### PR TITLE
feat: show cursor block in exec terminal display

### DIFF
--- a/internal/app/view_modes.go
+++ b/internal/app/view_modes.go
@@ -491,6 +491,10 @@ func (m Model) viewExecTerminal() string {
 				if g.Mode&1 != 0 { // reverse (attrReverse = 1)
 					style = style.Reverse(true)
 				}
+				// Render cursor block at the terminal's cursor position.
+				if x == cursor.X && y == cursor.Y {
+					style = style.Reverse(true)
+				}
 				line.WriteString(style.Render(string(ch)))
 			}
 			lines = append(lines, line.String())


### PR DESCRIPTION
Really simple commit to show cursor in the exec view:

<img width="159" height="111" alt="image" src="https://github.com/user-attachments/assets/f4bccd1a-d207-4fe1-b16a-fdafac2e5299" />
