### PR TITLE
feat: send arrow key sequences in DECCKM application in exec view

### DIFF
--- a/internal/app/ptyexec.go
+++ b/internal/app/ptyexec.go
@@ -122,7 +122,10 @@ func (m Model) handleExecKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Convert Bubbletea key to raw bytes for PTY.
-	raw := keyToBytes(msg)
+	// Pass the terminal's application cursor mode so arrow keys send the
+	// correct sequences (\x1bO vs \x1b[ depending on DECCKM state).
+	appCursor := m.execTerm != nil && m.execTerm.Mode()&vt10x.ModeAppCursor != 0
+	raw := keyToBytes(msg, appCursor)
 	if len(raw) > 0 {
 		_, _ = m.execPTY.Write(raw)
 	}
@@ -202,7 +205,7 @@ func startExecPTYReader(ptmx *os.File, term vt10x.Terminal, cmd *exec.Cmd, mu *s
 	}()
 }
 
-// keyBytesMap maps tea.KeyType to raw terminal byte sequences.
+// keyBytesMap maps tea.KeyType to raw terminal byte sequences (normal cursor mode).
 var keyBytesMap = map[tea.KeyType][]byte{
 	tea.KeyEnter:     {'\r'},
 	tea.KeyTab:       {'\t'},
@@ -243,10 +246,25 @@ var keyBytesMap = map[tea.KeyType][]byte{
 	tea.KeyCtrlZ:     {'\x1a'},
 }
 
+// keyBytesAppCursorMap overrides cursor-key sequences for application cursor
+// mode (DECCKM active): arrow keys send \x1bO_ instead of \x1b[_.
+var keyBytesAppCursorMap = map[tea.KeyType][]byte{
+	tea.KeyUp:    {'\x1b', 'O', 'A'},
+	tea.KeyDown:  {'\x1b', 'O', 'B'},
+	tea.KeyRight: {'\x1b', 'O', 'C'},
+	tea.KeyLeft:  {'\x1b', 'O', 'D'},
+}
+
 // keyToBytes converts a Bubbletea key message to raw terminal bytes.
-func keyToBytes(msg tea.KeyMsg) []byte {
+// appCursor should be true when the terminal has DECCKM active (ModeAppCursor).
+func keyToBytes(msg tea.KeyMsg, appCursor bool) []byte {
 	if msg.Type == tea.KeyRunes {
 		return []byte(string(msg.Runes))
+	}
+	if appCursor {
+		if b, ok := keyBytesAppCursorMap[msg.Type]; ok {
+			return b
+		}
 	}
 	if b, ok := keyBytesMap[msg.Type]; ok {
 		return b

--- a/internal/app/ptyexec_extra_test.go
+++ b/internal/app/ptyexec_extra_test.go
@@ -36,7 +36,7 @@ func TestKeyToBytesCtrlKeys(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := keyToBytes(tt.msg)
+			result := keyToBytes(tt.msg, false)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -44,7 +44,7 @@ func TestKeyToBytesCtrlKeys(t *testing.T) {
 
 func TestKeyToBytesMultiCharRunes(t *testing.T) {
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h', 'e', 'l', 'l', 'o'}}
-	result := keyToBytes(msg)
+	result := keyToBytes(msg, false)
 	assert.Equal(t, []byte("hello"), result)
 }
 
@@ -52,7 +52,7 @@ func TestKeyToBytesFallbackSingleChar(t *testing.T) {
 	// Simulate an unknown key type with a single-char string representation.
 	// This exercises the final fallback path.
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
-	result := keyToBytes(msg)
+	result := keyToBytes(msg, false)
 	assert.Equal(t, []byte("x"), result)
 }
 

--- a/internal/app/ptyexec_test.go
+++ b/internal/app/ptyexec_test.go
@@ -146,6 +146,33 @@ func TestKeyToBytesAppCursorMode(t *testing.T) {
 	}
 }
 
+// TestKeyToBytesAppCursorFallthrough verifies that when appCursor=true but the
+// key is not an arrow key, keyToBytes falls through to keyBytesMap and returns
+// the normal sequence (DECCKM only affects cursor keys).
+func TestKeyToBytesAppCursorFallthrough(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      tea.KeyMsg
+		expected []byte
+	}{
+		{name: "runes unchanged", msg: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}, expected: []byte("a")},
+		{name: "enter unchanged", msg: tea.KeyMsg{Type: tea.KeyEnter}, expected: []byte{'\r'}},
+		{name: "tab unchanged", msg: tea.KeyMsg{Type: tea.KeyTab}, expected: []byte{'\t'}},
+		{name: "home unchanged", msg: tea.KeyMsg{Type: tea.KeyHome}, expected: []byte{'\x1b', '[', 'H'}},
+		{name: "end unchanged", msg: tea.KeyMsg{Type: tea.KeyEnd}, expected: []byte{'\x1b', '[', 'F'}},
+		{name: "pgup unchanged", msg: tea.KeyMsg{Type: tea.KeyPgUp}, expected: []byte{'\x1b', '[', '5', '~'}},
+		{name: "pgdown unchanged", msg: tea.KeyMsg{Type: tea.KeyPgDown}, expected: []byte{'\x1b', '[', '6', '~'}},
+		{name: "delete unchanged", msg: tea.KeyMsg{Type: tea.KeyDelete}, expected: []byte{'\x1b', '[', '3', '~'}},
+		{name: "ctrl+c unchanged", msg: tea.KeyMsg{Type: tea.KeyCtrlC}, expected: []byte{'\x03'}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := keyToBytes(tt.msg, true)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestP4ExecKeyQ(t *testing.T) {
 	m := bp4()
 	m.mode = modeExec

--- a/internal/app/ptyexec_test.go
+++ b/internal/app/ptyexec_test.go
@@ -121,7 +121,26 @@ func TestKeyToBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := keyToBytes(tt.msg)
+			result := keyToBytes(tt.msg, false)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestKeyToBytesAppCursorMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      tea.KeyMsg
+		expected []byte
+	}{
+		{name: "up", msg: tea.KeyMsg{Type: tea.KeyUp}, expected: []byte{'\x1b', 'O', 'A'}},
+		{name: "down", msg: tea.KeyMsg{Type: tea.KeyDown}, expected: []byte{'\x1b', 'O', 'B'}},
+		{name: "right", msg: tea.KeyMsg{Type: tea.KeyRight}, expected: []byte{'\x1b', 'O', 'C'}},
+		{name: "left", msg: tea.KeyMsg{Type: tea.KeyLeft}, expected: []byte{'\x1b', 'O', 'D'}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := keyToBytes(tt.msg, true)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
Hey,

For now, in the exec view some applications like htop doesn't work properly with arrow keys.
This PR ensures arrow keys send the correct sequences when the terminal is in Application Cursor Mode (DECCKM).

Tell me what you think!

(used AI for this one)