### PR TITLE
feat: color palette update notifications (CSI 996/2031)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-/lft
+/lfk
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 
 - **460+ built-in color schemes** from [ghostty themes](https://github.com/ghostty-org/ghostty): Tokyonight, Catppuccin, Dracula, Nord, Rose Pine, Gruvbox, and many more. Transparent background support.
 - **Runtime theme switching**: Press `T` to preview and switch themes without restarting
+- **Auto dark/light mode**: configure a dark and a light scheme; lfk switches automatically when the OS appearance changes (requires CSI 996/2031 terminal support: Ghostty, kitty, Contour, …)
 - **Custom color themes** via config file (Tokyonight theme by default)
 - **Configurable keybindings** for direct actions
 - **Configurable search abbreviations**
@@ -417,7 +418,9 @@ Create `~/.config/lfk/config.yaml` to customize the application. All fields are 
 
 ```yaml
 # Color scheme (press T in-app to browse 460+ themes with live preview)
-colorscheme: catppuccin-mocha
+# Auto dark/light mode — Ghostty-style "dark:X,light:Y" syntax switches the
+# scheme when the OS appearance changes (CSI 996/2031; Ghostty, kitty >= 0.27, …)
+colorscheme: "dark:catppuccin-mocha,light:catppuccin-latte"
 
 # Use terminal's own background
 transparent_background: true

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -9,6 +9,23 @@
 #   rose-pine, gruvbox-dark, everforest-dark, one-half-dark, ayu-dark, nightfox
 colorscheme: tokyonight
 
+# ─── Auto Dark/Light Mode ─────────────────────────────────────────────────────
+# Use Ghostty-style "dark:X,light:Y" syntax in the colorscheme field to enable
+# automatic switching based on the OS appearance reported by the terminal
+# (CSI 996/2031 protocol). Supported terminals: Ghostty, kitty >= 0.27,
+# Contour, WezTerm (recent nightlies). Other terminals silently ignore the
+# sequences.
+#
+# On startup lfk sends CSI ?2031h (subscribe) + CSI ?996n (query current pref).
+# The terminal responds with dark (CSI ?997;1n) or light (CSI ?997;2n).
+# Any later OS appearance change triggers a real-time switch.
+#
+# Either side may be omitted; segment order does not matter; spaces in scheme
+# names are normalised to hyphens automatically.
+#
+# colorscheme: "dark:catppuccin-mocha,light:catppuccin-latte"
+# colorscheme: "dark:Rose Pine,light:Rose Pine Dawn"
+
 # ─── Transparent Background ───────────────────────────────────────────────────
 # Use the terminal's own background instead of the theme's background colors
 # for title bar and status bar. Selection highlights remain opaque.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -6,7 +6,7 @@ The configuration file is located at `~/.config/lfk/config.yaml`. All fields are
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `colorscheme` | string | `"tokyonight"` | Built-in color scheme name (460+ available). Press `T` in-app to browse. Custom `theme` overrides are applied on top. |
+| `colorscheme` | string | `"tokyonight"` | Built-in color scheme name (460+ available). Press `T` to browse. Supports dual-mode syntax for auto dark/light switching: `"dark:X,light:Y"`. Custom `theme` overrides are applied on top. |
 | `transparent_background` | bool | `false` | Use the terminal's own background for bars. Selection highlights remain opaque. |
 | `icons` | string | `"auto"` | Icon display mode. One of: `"auto"` (detects Nerd Font terminals; default), `"unicode"`, `"nerdfont"` (Material Design Icons; requires Nerd Font in terminal), `"simple"` (ASCII labels), `"emoji"`, or `"none"`. Unknown values fall back to `"unicode"`. Can be overridden at runtime by the `LFK_ICONS` environment variable. |
 | `log_path` | string | `"~/.local/share/lfk/lfk.log"` | Path to the application log file. |
@@ -26,6 +26,33 @@ The configuration file is located at `~/.config/lfk/config.yaml`. All fields are
 | `confirm_on_exit` | bool | `true` | Show quit confirmation when pressing `ctrl+c` on the last tab. Set to `false` to exit immediately. |
 | `scrolloff` | int | `5` | Number of lines to keep visible above/below the cursor when scrolling. Used by all views with cursor-based navigation. |
 | `mouse` | bool | `true` | Capture mouse input for click navigation, scroll, and tab switching. Set to `false` to allow native terminal text selection. Also available as `--no-mouse` CLI flag. |
+
+### Auto dark/light mode
+
+When `dark_colorscheme` and/or `light_colorscheme` are set, lfk subscribes to
+your terminal's operating system color-scheme preference via the standard
+CSI 2031/996 protocol:
+
+- On startup lfk sends `CSI ?2031h` (subscribe to notifications) and
+  `CSI ?996n` (request current preference).
+- The terminal responds with `CSI ?997;1n` (dark) or `CSI ?997;2n` (light).
+- Whenever the OS appearance changes, the terminal sends another notification
+  and lfk switches to the configured scheme in real time.
+
+**Supported terminals**: Ghostty, kitty ≥ 0.27, Contour, WezTerm (recent
+nightly builds). Other terminals silently ignore the sequences.
+
+```yaml
+# Example: dark → Catppuccin Mocha, light → Catppuccin Latte
+colorscheme: "dark:catppuccin-mocha,light:catppuccin-latte"
+
+# Spaces in scheme names are fine — they are normalised to hyphens internally:
+colorscheme: "dark:Rose Pine,light:Rose Pine Dawn"
+```
+
+When only one side is configured the other side performs no automatic switch.
+The `colorscheme` field still sets the default theme applied at startup; the
+dark/light schemes override it as soon as the terminal reports its preference.
 
 ### Icon mode auto-detection
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -29,9 +29,9 @@ The configuration file is located at `~/.config/lfk/config.yaml`. All fields are
 
 ### Auto dark/light mode
 
-When `dark_colorscheme` and/or `light_colorscheme` are set, lfk subscribes to
-your terminal's operating system color-scheme preference via the standard
-CSI 2031/996 protocol:
+When `colorscheme` uses the `dark:X,light:Y` dual-mode syntax (either segment
+may be omitted), lfk subscribes to your terminal's operating system
+color-scheme preference via the standard CSI 2031/996 protocol:
 
 - On startup lfk sends `CSI ?2031h` (subscribe to notifications) and
   `CSI ?996n` (request current preference).
@@ -51,8 +51,8 @@ colorscheme: "dark:Rose Pine,light:Rose Pine Dawn"
 ```
 
 When only one side is configured the other side performs no automatic switch.
-The `colorscheme` field still sets the default theme applied at startup; the
-dark/light schemes override it as soon as the terminal reports its preference.
+Plain (non-dual) `colorscheme` values continue to work as before and disable
+automatic dark/light switching entirely.
 
 ### Icon mode auto-detection
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1024,5 +1024,8 @@ func (m Model) Init() tea.Cmd {
 	if ui.ConfigTipsEnabled {
 		cmds = append(cmds, scheduleStartupTip())
 	}
+	if ui.ColorModeEnabled() {
+		cmds = append(cmds, ui.EnableColorModeCmd())
+	}
 	return tea.Batch(cmds...)
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -53,6 +53,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setStatusMessage("stderr: "+msg.message, true)
 		return m, tea.Batch(scheduleStatusClear(), m.waitForStderr())
 	default:
+		if dark, ok := ui.ParseColorModeMsg(msg); ok {
+			ui.SetColorMode(dark)
+			return m, nil
+		}
 		if mdl, cmd, ok := m.updateResourceMsg(msg); ok {
 			return mdl, cmd
 		}

--- a/internal/ui/colormode.go
+++ b/internal/ui/colormode.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"reflect"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// colorModeDarkSeq and colorModeLightSeq are the CSI ?997 sequences the
+// terminal sends in response to a CSI ?996n query or a CSI ?2031h
+// color-palette-update notification.
+var (
+	colorModeDarkSeq  = []byte("\x1b[?997;1n")
+	colorModeLightSeq = []byte("\x1b[?997;2n")
+)
+
+// ParseColorModeMsg inspects an arbitrary bubbletea message to determine
+// whether it is an unrecognized CSI sequence carrying a CSI ?997 dark/light
+// color-mode report (Color Palette Update Notifications protocol).
+//
+// bubbletea wraps unknown CSI sequences in an unexported named []byte type
+// (unknownCSISequenceMsg). We use reflection to reach the raw bytes and match
+// against the known sequences without importing that private type.
+// A named-type check (Name() != "") ensures plain []byte values are ignored.
+//
+// Returns (dark=true, true) for a dark-mode report, (dark=false, true) for a
+// light-mode report, and (_, false) when msg is unrelated.
+func ParseColorModeMsg(msg tea.Msg) (dark bool, ok bool) {
+	rv := reflect.ValueOf(msg)
+	rt := reflect.TypeOf(msg)
+	// Require a named slice-of-bytes (like unknownCSISequenceMsg), not plain []byte.
+	if rv.Kind() != reflect.Slice ||
+		rt.Elem().Kind() != reflect.Uint8 ||
+		rt.Name() == "" {
+		return false, false
+	}
+	b := rv.Bytes()
+	switch {
+	case bytes.Equal(b, colorModeDarkSeq):
+		return true, true
+	case bytes.Equal(b, colorModeLightSeq):
+		return false, true
+	}
+	return false, false
+}
+
+// EnableColorModeCmd returns a tea.Cmd that subscribes to Color Palette Update
+// Notifications (CSI ?2031h) and queries the current preference (CSI ?996n).
+// The terminal responds with CSI ?997;1n (dark) or CSI ?997;2n (light), which
+// bubbletea delivers as an unknownCSISequenceMsg parsed by ParseColorModeMsg.
+func EnableColorModeCmd() tea.Cmd {
+	return func() tea.Msg {
+		_, _ = fmt.Fprint(os.Stdout, ansi.SetModeLightDark+ansi.RequestLightDarkReport)
+		return nil
+	}
+}
+
+// DisableColorModeNotifications unsubscribes from Color Palette Update
+// Notifications by sending CSI ?2031l. Call this after the bubbletea program
+// exits so the terminal stops sending unsolicited CSI ?997 reports.
+func DisableColorModeNotifications() {
+	_, _ = fmt.Fprint(os.Stdout, ansi.ResetModeLightDark)
+}
+
+// SetColorMode applies ConfigDarkColorscheme (dark=true) or
+// ConfigLightColorscheme (dark=false) as the active color scheme.
+// No-op when the relevant scheme is not configured or is not a known built-in.
+func SetColorMode(dark bool) {
+	var schemeName string
+	if dark && ConfigDarkColorscheme != "" {
+		schemeName = ConfigDarkColorscheme
+	} else if !dark && ConfigLightColorscheme != "" {
+		schemeName = ConfigLightColorscheme
+	}
+	if schemeName == "" {
+		return
+	}
+	if scheme, ok := BuiltinSchemes()[schemeName]; ok {
+		ActiveSchemeName = schemeName
+		ApplyTheme(scheme)
+	}
+}
+
+// ColorModeEnabled reports whether Color Palette Update Notifications are
+// configured (i.e. at least one of the dark/light schemes is set).
+func ColorModeEnabled() bool {
+	return ConfigDarkColorscheme != "" || ConfigLightColorscheme != ""
+}

--- a/internal/ui/colormode_test.go
+++ b/internal/ui/colormode_test.go
@@ -181,6 +181,40 @@ func TestLoadConfig_DualColorscheme_DarkOnly(t *testing.T) {
 	require.Equal(t, "", ConfigLightColorscheme, "light scheme should be empty when not specified")
 }
 
+func TestApplyColorscheme_PlainSingleScheme(t *testing.T) {
+	orig := ActiveSchemeName
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ActiveSchemeName = orig
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+		ApplyTheme(DefaultTheme())
+	})
+	ConfigDarkColorscheme = ""
+	ConfigLightColorscheme = ""
+
+	theme := DefaultTheme()
+	applyColorscheme(&theme, configFile{Colorscheme: "dracula"})
+
+	assert.Equal(t, "dracula", ActiveSchemeName)
+	assert.Empty(t, ConfigDarkColorscheme, "dark scheme must stay unset for plain syntax")
+	assert.Empty(t, ConfigLightColorscheme, "light scheme must stay unset for plain syntax")
+}
+
+func TestApplyColorscheme_PlainSingleScheme_WithSpaces(t *testing.T) {
+	orig := ActiveSchemeName
+	t.Cleanup(func() {
+		ActiveSchemeName = orig
+		ApplyTheme(DefaultTheme())
+	})
+
+	theme := DefaultTheme()
+	applyColorscheme(&theme, configFile{Colorscheme: "Rose Pine"})
+
+	assert.Equal(t, "rose-pine", ActiveSchemeName, "spaces should normalise to hyphens for plain syntax")
+}
+
 func TestParseDualColorscheme(t *testing.T) {
 	cases := []struct {
 		input string

--- a/internal/ui/colormode_test.go
+++ b/internal/ui/colormode_test.go
@@ -1,0 +1,207 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unknownCSILike simulates the type bubbletea uses for unrecognized CSI
+// sequences: a named []byte type. We replicate the shape here so tests don't
+// depend on importing bubbletea's unexported type directly.
+type unknownCSILike []byte
+
+func TestParseColorModeMsg_Dark(t *testing.T) {
+	msg := unknownCSILike("\x1b[?997;1n")
+	dark, ok := ParseColorModeMsg(msg)
+	assert.True(t, ok, "CSI ?997;1n should be recognized as a color-mode report")
+	assert.True(t, dark, "CSI ?997;1n should report dark mode")
+}
+
+func TestParseColorModeMsg_Light(t *testing.T) {
+	msg := unknownCSILike("\x1b[?997;2n")
+	dark, ok := ParseColorModeMsg(msg)
+	assert.True(t, ok, "CSI ?997;2n should be recognized as a color-mode report")
+	assert.False(t, dark, "CSI ?997;2n should report light mode")
+}
+
+func TestParseColorModeMsg_Unrelated(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  interface{}
+	}{
+		{"string", "hello"},
+		{"int", 42},
+		{"nil", nil},
+		{"unknown CSI", unknownCSILike("\x1b[?997;3n")},
+		{"empty", unknownCSILike("")},
+		{"plain []byte", []byte("\x1b[?997;1n")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := ParseColorModeMsg(tc.msg)
+			assert.False(t, ok, "msg %q should not be recognized as a color-mode report", tc.name)
+		})
+	}
+}
+
+func TestSetColorMode_Dark(t *testing.T) {
+	orig := ActiveSchemeName
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ActiveSchemeName = orig
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+		ApplyTheme(DefaultTheme())
+	})
+
+	ConfigDarkColorscheme = "tokyonight-storm"
+	ConfigLightColorscheme = "tokyonight-day"
+
+	SetColorMode(true)
+	assert.Equal(t, "tokyonight-storm", ActiveSchemeName)
+}
+
+func TestSetColorMode_Light(t *testing.T) {
+	orig := ActiveSchemeName
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ActiveSchemeName = orig
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+		ApplyTheme(DefaultTheme())
+	})
+
+	ConfigDarkColorscheme = "tokyonight-storm"
+	ConfigLightColorscheme = "tokyonight-day"
+
+	SetColorMode(false)
+	assert.Equal(t, "tokyonight-day", ActiveSchemeName)
+}
+
+func TestSetColorMode_NoConfig(t *testing.T) {
+	orig := ActiveSchemeName
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ActiveSchemeName = orig
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+	})
+
+	ConfigDarkColorscheme = ""
+	ConfigLightColorscheme = ""
+
+	SetColorMode(true)
+	assert.Equal(t, orig, ActiveSchemeName, "scheme should not change when neither dark nor light is configured")
+}
+
+func TestSetColorMode_UnknownScheme(t *testing.T) {
+	orig := ActiveSchemeName
+	origDark := ConfigDarkColorscheme
+	t.Cleanup(func() {
+		ActiveSchemeName = orig
+		ConfigDarkColorscheme = origDark
+	})
+
+	ConfigDarkColorscheme = "nonexistent-scheme-xyz"
+	SetColorMode(true)
+	assert.Equal(t, orig, ActiveSchemeName, "scheme should not change for an unknown scheme name")
+}
+
+func TestColorModeEnabled(t *testing.T) {
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+	})
+
+	ConfigDarkColorscheme = ""
+	ConfigLightColorscheme = ""
+	assert.False(t, ColorModeEnabled())
+
+	ConfigDarkColorscheme = "dracula"
+	assert.True(t, ColorModeEnabled())
+
+	ConfigDarkColorscheme = ""
+	ConfigLightColorscheme = "tokyonight-day"
+	assert.True(t, ColorModeEnabled())
+}
+
+func TestLoadConfig_DualColorscheme(t *testing.T) {
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+	})
+
+	cfg := configFile{Colorscheme: "dark:Dracula,light:tokyonight-day"}
+	theme := DefaultTheme()
+	applyColorscheme(&theme, cfg)
+
+	require.Equal(t, "dracula", ConfigDarkColorscheme)
+	require.Equal(t, "tokyonight-day", ConfigLightColorscheme)
+}
+
+func TestLoadConfig_DualColorscheme_ReverseOrder(t *testing.T) {
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+	})
+
+	cfg := configFile{Colorscheme: "light:Rose Pine Dawn,dark:Rose Pine"}
+	theme := DefaultTheme()
+	applyColorscheme(&theme, cfg)
+
+	require.Equal(t, "rose-pine", ConfigDarkColorscheme)
+	require.Equal(t, "rose-pine-dawn", ConfigLightColorscheme)
+}
+
+func TestLoadConfig_DualColorscheme_DarkOnly(t *testing.T) {
+	origDark := ConfigDarkColorscheme
+	origLight := ConfigLightColorscheme
+	t.Cleanup(func() {
+		ConfigDarkColorscheme = origDark
+		ConfigLightColorscheme = origLight
+	})
+
+	ConfigLightColorscheme = "should-be-cleared"
+	cfg := configFile{Colorscheme: "dark:dracula"}
+	theme := DefaultTheme()
+	applyColorscheme(&theme, cfg)
+
+	require.Equal(t, "dracula", ConfigDarkColorscheme)
+	require.Equal(t, "", ConfigLightColorscheme, "light scheme should be empty when not specified")
+}
+
+func TestParseDualColorscheme(t *testing.T) {
+	cases := []struct {
+		input string
+		dark  string
+		light string
+		dual  bool
+	}{
+		{"dark:Rose Pine,light:Rose Pine Dawn", "rose-pine", "rose-pine-dawn", true},
+		{"light:Rose Pine Dawn,dark:Rose Pine", "rose-pine", "rose-pine-dawn", true},
+		{"dark:dracula", "dracula", "", true},
+		{"light:tokyonight-day", "", "tokyonight-day", true},
+		{"dracula", "", "", false},
+		{"", "", "", false},
+		{"dark: Dracula , light: tokyonight-day", "dracula", "tokyonight-day", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dark, light, dual := parseDualColorscheme(tc.input)
+			assert.Equal(t, tc.dual, dual, "isDual")
+			assert.Equal(t, tc.dark, dark, "dark")
+			assert.Equal(t, tc.light, light, "light")
+		})
+	}
+}

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -334,6 +334,14 @@ var ConfigMouse = true
 // the no_color config field, or the --no-color CLI flag.
 var ConfigNoColor bool
 
+// ConfigDarkColorscheme is the built-in scheme name applied when the terminal
+// reports dark mode. Populated by parsing the "dark:X" segment of colorscheme.
+var ConfigDarkColorscheme string
+
+// ConfigLightColorscheme is the built-in scheme name applied when the terminal
+// reports light mode. Populated by parsing the "light:X" segment of colorscheme.
+var ConfigLightColorscheme string
+
 // SetNoColor updates ConfigNoColor and rebuilds the active theme so style
 // globals reflect the new setting. No-op when the value is unchanged.
 func SetNoColor(v bool) {
@@ -345,7 +353,14 @@ func SetNoColor(v bool) {
 }
 
 type configFile struct {
-	// Colorscheme selects a built-in color scheme by name (e.g. "dracula", "nord").
+	// Colorscheme selects a built-in color scheme by name (e.g. "dracula",
+	// "nord"). Supports Ghostty-style dual-mode syntax to enable automatic
+	// dark/light switching via CSI 996/2031:
+	//
+	//   colorscheme: "dark:Rose Pine,light:Rose Pine Dawn"
+	//
+	// Either segment may be omitted. Without the prefix syntax the value is
+	// used as a plain scheme name and dark/light switching is disabled.
 	// Custom theme overrides in the "theme" section are applied on top.
 	Colorscheme   string            `json:"colorscheme" yaml:"colorscheme"`
 	Theme         Theme             `json:"theme" yaml:"theme"`
@@ -512,13 +527,61 @@ func loadConfigFile(configOverride string) (configFile, bool) {
 }
 
 // applyColorscheme selects a built-in colorscheme if specified in config.
+//
+// The colorscheme field supports two formats:
+//
+//  1. Plain name – "dracula"
+//     Applies the scheme and leaves dark/light switching disabled.
+//
+//  2. Ghostty-style dual-mode – "dark:Rose Pine,light:Rose Pine Dawn"
+//     Parses each comma-separated segment for a "dark:" or "light:" prefix.
+//     Both, one, or neither segment may be present; order does not matter.
+//     ConfigDarkColorscheme / ConfigLightColorscheme are set accordingly.
+//     No default scheme is applied immediately; the terminal's first CSI 997
+//     notification will trigger the initial switch.
 func applyColorscheme(theme *Theme, cfg configFile) {
-	if cfg.Colorscheme != "" {
-		if scheme, ok := BuiltinSchemes()[strings.ToLower(cfg.Colorscheme)]; ok {
-			*theme = scheme
-			ActiveSchemeName = strings.ToLower(cfg.Colorscheme)
+	if cfg.Colorscheme == "" {
+		return
+	}
+	dark, light, isDual := parseDualColorscheme(cfg.Colorscheme)
+	if isDual {
+		ConfigDarkColorscheme = dark
+		ConfigLightColorscheme = light
+		return
+	}
+	lower := normalizeScheme(cfg.Colorscheme)
+	if scheme, ok := BuiltinSchemes()[lower]; ok {
+		*theme = scheme
+		ActiveSchemeName = lower
+	}
+}
+
+// parseDualColorscheme parses a Ghostty-style "dark:X,light:Y" colorscheme
+// string. It returns the dark and light scheme names (normalized to lowercase
+// with spaces replaced by hyphens, matching built-in scheme map keys) and
+// isDual=true when the string contains at least one "dark:" or "light:" prefix.
+// Segment order and surrounding whitespace are both tolerated.
+func parseDualColorscheme(s string) (dark, light string, isDual bool) {
+	parts := strings.Split(s, ",")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		lower := strings.ToLower(p)
+		switch {
+		case strings.HasPrefix(lower, "dark:"):
+			dark = normalizeScheme(p[len("dark:"):])
+			isDual = true
+		case strings.HasPrefix(lower, "light:"):
+			light = normalizeScheme(p[len("light:"):])
+			isDual = true
 		}
 	}
+	return dark, light, isDual
+}
+
+// normalizeScheme converts a user-supplied scheme name to the lowercase,
+// hyphenated form used as keys in BuiltinSchemes (e.g. "Rose Pine" → "rose-pine").
+func normalizeScheme(s string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(s)), " ", "-")
 }
 
 // applyConfigOptions applies scalar config options (icons, terminal, tips, etc.).

--- a/main.go
+++ b/main.go
@@ -132,6 +132,9 @@ func runTUI(opts app.StartupOptions) error {
 	if !opts.NoMouse && ui.ConfigMouse {
 		progOpts = append(progOpts, tea.WithMouseCellMotion())
 	}
+	if ui.ColorModeEnabled() {
+		defer ui.DisableColorModeNotifications()
+	}
 	p := tea.NewProgram(m, progOpts...)
 
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
Implements the Color Palette Update Notifications protocol so lfk switches its color scheme automatically when the OS appearance changes, without restarting.

**Spec: https://contour-terminal.org/vt-extensions/color-palette-update-notifications/**

Config uses a Ghostty-style single-field syntax:

```
colorscheme: "dark:rose-pine,light:rose-pine-dawn"
```

Either segment may be omitted; order is irrelevant; spaces in scheme names are normalised to hyphens. Without the dark/light prefix syntax the field behaves exactly as before.

## Protocol:

- On startup lfk sends `CSI ?2031h` (subscribe to notifications) and `CSI ?996n` (query current preference).
- The terminal responds with `CSI ?997;1n` (dark) or `CSI ?997;2n` (light).
- bubbletea delivers these as unknownCSISequenceMsg values; ParseColorModeMsg uses reflection to read the bytes without importing the private type.
- SetColorMode applies ConfigDarkColorscheme or ConfigLightColorscheme.
- On exit `CSI ?2031l` unsubscribes from further notifications.

Supported terminals: Ghostty, kitty >= 0.27, Contour, WezTerm (recent nightlies). Others silently ignore the sequences.