### PR TITLE
feat: fuzzy match for command-bar value completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 - **Resource sorting** by name, age, or status
 - **Filter and search**: Filter with `f`, search with `/` -- supports substring, regex (auto-detected), and fuzzy (`~` prefix) modes
 - **Abbreviated search**: Type `pvc`, `hpa`, `deploy` etc. to jump to resource types
-- **Command bar** (`:`) with vertical dropdown autocomplete: resource jumps (`:pod`, `:dep`), built-in commands (`:ns`, `:ctx`, `:set`, `:sort`, `:export`), kubectl with `:k`/`:kubectl` prefix and flag/namespace completion, shell commands (`:!`)
+- **Command bar** (`:`) with vertical dropdown autocomplete: resource jumps (`:pod`, `:dep`), built-in commands (`:ns`, `:ctx`, `:set`, `:sort`, `:export`), kubectl with `:k`/`:kubectl` prefix and flag/namespace completion, shell commands (`:!`). Value positions (namespace, context, resource name, option, column, format) accept fuzzy matches; command names stay on prefix.
 - **Watch mode**: Auto-refresh resources every 2 seconds (enabled by default)
 - **Owner/controller navigation**: Jump to the owner of any resource with `o`
 - **Events view** with warnings-only filter toggle and duplicate-event grouping (`z`)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,7 +67,7 @@ Repeated completed tasks collapse with a `×N` suffix.
 :k describe pod nginx-abc
 ```
 
-Autocomplete offers subcommands, flags, resource types, and namespaces. Typing `:k` or `:kubectl` alone surfaces the subcommand list.
+Autocomplete offers subcommands, flags, resource types, and namespaces. Typing `:k` or `:kubectl` alone surfaces the subcommand list. Value positions (namespace, resource name, output format) accept fuzzy matches — exact > prefix > substring > subsequence — while command names themselves stay on prefix.
 
 ## Resource jumps
 

--- a/internal/app/commandbar_complete.go
+++ b/internal/app/commandbar_complete.go
@@ -174,15 +174,15 @@ func completeBuiltin(tokens []token, m *Model) []ui.Suggestion {
 				candidates = append(candidates, ns)
 			}
 		}
-		return filterSuggestionsTyped(candidates, prefix, "namespace")
+		return filterSuggestionsFuzzy(candidates, prefix, "namespace")
 	case "context":
-		return filterSuggestionsTyped(m.contextNames(), prefix, "context")
+		return filterSuggestionsFuzzy(m.contextNames(), prefix, "context")
 	case "set":
-		return filterSuggestionsTyped(setOptions(), prefix, "option")
+		return filterSuggestionsFuzzy(setOptions(), prefix, "option")
 	case "sort":
-		return filterSuggestionsTyped(ui.ActiveSortableColumns, prefix, "column")
+		return filterSuggestionsFuzzy(ui.ActiveSortableColumns, prefix, "column")
 	case "export":
-		return filterSuggestionsTyped([]string{"yaml", "json"}, prefix, "format")
+		return filterSuggestionsFuzzy([]string{"yaml", "json"}, prefix, "format")
 	default:
 		return nil
 	}
@@ -221,9 +221,9 @@ func completeKubectl(tokens []token, m *Model) []ui.Suggestion {
 		prevToken := strings.ToLower(effective[len(effective)-2].text)
 		switch prevToken {
 		case "-n", "--namespace":
-			return filterSuggestionsTyped(m.namespaceNames(), prefix, "namespace")
+			return filterSuggestionsFuzzy(m.namespaceNames(), prefix, "namespace")
 		case "-o", "--output":
-			return filterSuggestionsTyped(outputFormatsComplete(), prefix, "format")
+			return filterSuggestionsFuzzy(outputFormatsComplete(), prefix, "format")
 		}
 	}
 
@@ -257,7 +257,7 @@ func completeKubectl(tokens []token, m *Model) []ui.Suggestion {
 		// matches the currently viewed resource type (names are only available
 		// for the resource type currently loaded in the explorer).
 		names := resourceNamesForKubectl(m, effective)
-		return filterSuggestionsTyped(names, prefix, "name")
+		return filterSuggestionsFuzzy(names, prefix, "name")
 	}
 }
 
@@ -302,7 +302,7 @@ func (m *Model) generateCommandBarSuggestions() []ui.Suggestion {
 					candidates = append(candidates, ns)
 				}
 			}
-			return filterSuggestionsTyped(candidates, prefix, "namespace")
+			return filterSuggestionsFuzzy(candidates, prefix, "namespace")
 		}
 		// First token: still show matching resource types.
 		return completeResourceJump(input, m.resourceTypeItems())

--- a/internal/app/commandbar_fuzzy.go
+++ b/internal/app/commandbar_fuzzy.go
@@ -14,33 +14,40 @@ import (
 //
 // Tiers (case-insensitive):
 //   - Exact match:      10000
-//   - Prefix match:      5000 + (100 - len(text))       // shorter prefers
-//   - Substring match:   2000 + (100 - idx) - len(text) // earlier & shorter
-//   - Subsequence match:  500 + (100 - span)            // tighter prefers
+//   - Prefix match:      5000 + (100 - len(text))                 // shorter prefers
+//   - Substring match:   2000 + (100 - idx) + (100 - len(text))   // earlier & shorter
+//   - Subsequence match:  500 + (100 - span)                      // tighter prefers
 //
-// An empty query returns a small baseline score so every candidate is kept
-// while preserving alphabetical order.
+// An empty query returns a small baseline score so direct callers that score
+// individual candidates still match. filterSuggestionsFuzzy short-circuits
+// empty queries to preserve the candidate input order.
 func fuzzyScore(text, query string) int {
-	if query == "" {
+	return fuzzyScoreLower(text, strings.ToLower(query))
+}
+
+// fuzzyScoreLower is fuzzyScore with the query already lowercased. Hot-loop
+// callers should lowercase the query once and reuse this helper to avoid
+// repeated allocations per candidate.
+func fuzzyScoreLower(text, qLower string) int {
+	if qLower == "" {
 		return 1
 	}
 
 	t := strings.ToLower(text)
-	q := strings.ToLower(query)
 
-	if t == q {
+	if t == qLower {
 		return 10000
 	}
 
-	if strings.HasPrefix(t, q) {
+	if strings.HasPrefix(t, qLower) {
 		return 5000 + lengthBonus(len(t))
 	}
 
-	if idx := strings.Index(t, q); idx >= 0 {
+	if idx := strings.Index(t, qLower); idx >= 0 {
 		return 2000 + positionBonus(idx) + lengthBonus(len(t))
 	}
 
-	if span, ok := subsequenceSpan(t, q); ok {
+	if span, ok := subsequenceSpan(t, qLower); ok {
 		return 500 + positionBonus(span)
 	}
 
@@ -66,31 +73,35 @@ func positionBonus(n int) int {
 }
 
 // subsequenceSpan reports whether all query runes appear in text in order
-// (not necessarily contiguous) and returns the span from the first matched
-// rune to the last. Both inputs must already be lowercased.
+// (not necessarily contiguous) and returns the rune span from the first
+// matched rune to the last (inclusive). Both inputs must already be
+// lowercased.
 func subsequenceSpan(text, query string) (int, bool) {
 	if query == "" {
 		return 0, true
 	}
 
+	qr := []rune(query)
 	qi := 0
 	first := -1
 	last := -1
+	ti := 0
 
-	qr := []rune(query)
-	for i, r := range text {
+	for _, r := range text {
 		if qi >= len(qr) {
 			break
 		}
 
 		if r == qr[qi] {
 			if first == -1 {
-				first = i
+				first = ti
 			}
 
-			last = i
+			last = ti
 			qi++
 		}
+
+		ti++
 	}
 
 	if qi < len(qr) {
@@ -102,20 +113,34 @@ func subsequenceSpan(text, query string) (int, bool) {
 
 // filterSuggestionsFuzzy filters candidates by a fuzzy match against query
 // and sorts the results by score (descending) with alphabetical tiebreak.
+// Empty queries short-circuit to preserve the candidate input order so
+// upstream ordering (e.g. kubeconfig context order, default-namespace first)
+// survives until the user starts typing.
+//
 // Use this at value positions (namespace, context, resource name, option,
 // column, format). First-token command names stay on prefix via
 // filterSuggestionsTyped — a small curated list doesn't benefit from fuzzy
 // matching and would produce noisy results for short inputs.
 func filterSuggestionsFuzzy(candidates []string, query, category string) []ui.Suggestion {
+	if query == "" {
+		result := make([]ui.Suggestion, len(candidates))
+		for i, c := range candidates {
+			result[i] = ui.Suggestion{Text: c, Category: category}
+		}
+
+		return result
+	}
+
 	type scored struct {
 		s     ui.Suggestion
 		score int
 	}
 
+	qLower := strings.ToLower(query)
 	rs := make([]scored, 0, len(candidates))
 
 	for _, c := range candidates {
-		sc := fuzzyScore(c, query)
+		sc := fuzzyScoreLower(c, qLower)
 		if sc <= 0 {
 			continue
 		}

--- a/internal/app/commandbar_fuzzy.go
+++ b/internal/app/commandbar_fuzzy.go
@@ -1,0 +1,140 @@
+package app
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// fuzzyScore returns a match score for query against text. Higher is better;
+// 0 means no match. The scoring tiers are ordered so that a prefix match of
+// any candidate always outranks a substring match, which always outranks a
+// subsequence match, regardless of length bonuses within each tier.
+//
+// Tiers (case-insensitive):
+//   - Exact match:      10000
+//   - Prefix match:      5000 + (100 - len(text))       // shorter prefers
+//   - Substring match:   2000 + (100 - idx) - len(text) // earlier & shorter
+//   - Subsequence match:  500 + (100 - span)            // tighter prefers
+//
+// An empty query returns a small baseline score so every candidate is kept
+// while preserving alphabetical order.
+func fuzzyScore(text, query string) int {
+	if query == "" {
+		return 1
+	}
+
+	t := strings.ToLower(text)
+	q := strings.ToLower(query)
+
+	if t == q {
+		return 10000
+	}
+
+	if strings.HasPrefix(t, q) {
+		return 5000 + lengthBonus(len(t))
+	}
+
+	if idx := strings.Index(t, q); idx >= 0 {
+		return 2000 + positionBonus(idx) + lengthBonus(len(t))
+	}
+
+	if span, ok := subsequenceSpan(t, q); ok {
+		return 500 + positionBonus(span)
+	}
+
+	return 0
+}
+
+// lengthBonus prefers shorter candidates. Capped so it never crosses tiers.
+func lengthBonus(n int) int {
+	if n >= 100 {
+		return 0
+	}
+
+	return 100 - n
+}
+
+// positionBonus prefers smaller values (earlier position, tighter span).
+func positionBonus(n int) int {
+	if n >= 100 {
+		return 0
+	}
+
+	return 100 - n
+}
+
+// subsequenceSpan reports whether all query runes appear in text in order
+// (not necessarily contiguous) and returns the span from the first matched
+// rune to the last. Both inputs must already be lowercased.
+func subsequenceSpan(text, query string) (int, bool) {
+	if query == "" {
+		return 0, true
+	}
+
+	qi := 0
+	first := -1
+	last := -1
+
+	qr := []rune(query)
+	for i, r := range text {
+		if qi >= len(qr) {
+			break
+		}
+
+		if r == qr[qi] {
+			if first == -1 {
+				first = i
+			}
+
+			last = i
+			qi++
+		}
+	}
+
+	if qi < len(qr) {
+		return 0, false
+	}
+
+	return last - first + 1, true
+}
+
+// filterSuggestionsFuzzy filters candidates by a fuzzy match against query
+// and sorts the results by score (descending) with alphabetical tiebreak.
+// Use this at value positions (namespace, context, resource name, option,
+// column, format). First-token command names stay on prefix via
+// filterSuggestionsTyped — a small curated list doesn't benefit from fuzzy
+// matching and would produce noisy results for short inputs.
+func filterSuggestionsFuzzy(candidates []string, query, category string) []ui.Suggestion {
+	type scored struct {
+		s     ui.Suggestion
+		score int
+	}
+
+	rs := make([]scored, 0, len(candidates))
+
+	for _, c := range candidates {
+		sc := fuzzyScore(c, query)
+		if sc <= 0 {
+			continue
+		}
+
+		rs = append(rs, scored{ui.Suggestion{Text: c, Category: category}, sc})
+	}
+
+	sort.SliceStable(rs, func(i, j int) bool {
+		if rs[i].score != rs[j].score {
+			return rs[i].score > rs[j].score
+		}
+
+		return rs[i].s.Text < rs[j].s.Text
+	})
+
+	result := make([]ui.Suggestion, len(rs))
+	for i, r := range rs {
+		result[i] = r.s
+	}
+
+	return result
+}

--- a/internal/app/commandbar_fuzzy_test.go
+++ b/internal/app/commandbar_fuzzy_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFuzzyScore_EmptyQueryAllMatch(t *testing.T) {
+	assert.Positive(t, fuzzyScore("anything", ""), "empty query matches all")
+	assert.Positive(t, fuzzyScore("", ""), "empty against empty still matches")
+}
+
+func TestFuzzyScore_ExactBeatsPrefix(t *testing.T) {
+	exact := fuzzyScore("pod", "pod")
+	prefix := fuzzyScore("pods", "pod")
+	assert.Greater(t, exact, prefix, "exact should outrank prefix")
+}
+
+func TestFuzzyScore_PrefixBeatsSubstring(t *testing.T) {
+	prefix := fuzzyScore("production", "prod")
+	substring := fuzzyScore("my-prod-ns", "prod")
+	assert.Greater(t, prefix, substring, "prefix should outrank substring")
+}
+
+func TestFuzzyScore_SubstringBeatsSubsequence(t *testing.T) {
+	substring := fuzzyScore("kube-system", "system")
+	subseq := fuzzyScore("kube-system", "ksys")
+	assert.Greater(t, substring, subseq, "substring should outrank subsequence")
+}
+
+func TestFuzzyScore_Subsequence(t *testing.T) {
+	assert.Positive(t, fuzzyScore("kube-system", "ks"),
+		"subsequence 'ks' should match 'kube-system'")
+	assert.Positive(t, fuzzyScore("my-prod-cluster", "prod"),
+		"substring 'prod' should match 'my-prod-cluster'")
+}
+
+func TestFuzzyScore_NoMatch(t *testing.T) {
+	assert.Zero(t, fuzzyScore("default", "kube"),
+		"'kube' should not match 'default'")
+	assert.Zero(t, fuzzyScore("pod", "xyz"),
+		"'xyz' should not match 'pod'")
+}
+
+func TestFuzzyScore_TighterSpanWins(t *testing.T) {
+	tight := fuzzyScore("abcxy", "axy")
+	loose := fuzzyScore("axbcxxxxxy", "axy")
+	assert.Greater(t, tight, loose, "tighter subsequence span should rank higher")
+}
+
+func TestFuzzyScore_ShorterPrefixWins(t *testing.T) {
+	short := fuzzyScore("pod", "po")
+	long := fuzzyScore("podsecuritypolicy", "po")
+	assert.Greater(t, short, long, "shorter candidate should rank higher on prefix tie")
+}
+
+func TestFuzzyScore_CaseInsensitive(t *testing.T) {
+	assert.Equal(t, fuzzyScore("Pods", "pod"), fuzzyScore("pods", "POD"),
+		"matching should be case-insensitive")
+}
+
+func TestSubsequenceSpan(t *testing.T) {
+	span, ok := subsequenceSpan("kube-system", "ks")
+	assert.True(t, ok)
+	assert.Equal(t, 6, span, "'ks' spans from index 0 ('k') to 5 ('s'), length 6")
+
+	span, ok = subsequenceSpan("abc", "ac")
+	assert.True(t, ok)
+	assert.Equal(t, 3, span)
+
+	_, ok = subsequenceSpan("abc", "xyz")
+	assert.False(t, ok)
+
+	span, ok = subsequenceSpan("anything", "")
+	assert.True(t, ok)
+	assert.Zero(t, span)
+}
+
+func TestFilterSuggestionsFuzzy_Ranking(t *testing.T) {
+	cands := []string{"my-prod-cluster", "production", "prodigy", "staging"}
+	got := filterSuggestionsFuzzy(cands, "prod", "namespace")
+
+	assert.Len(t, got, 3, "'staging' should be excluded")
+	// production (prefix, shorter) should come before prodigy (prefix, shorter than production).
+	// But both are prefix matches; the tiebreak on length should put prodigy (7) > production (10).
+	// Then my-prod-cluster is substring.
+	texts := suggestionTexts(got)
+	assert.Equal(t, "my-prod-cluster", texts[len(texts)-1],
+		"substring match should rank below prefix matches")
+	assert.Contains(t, texts[:2], "production")
+	assert.Contains(t, texts[:2], "prodigy")
+}
+
+func TestFilterSuggestionsFuzzy_SubsequenceMatch(t *testing.T) {
+	cands := []string{"kube-system", "kube-public", "default", "production"}
+	got := filterSuggestionsFuzzy(cands, "ksys", "namespace")
+
+	texts := suggestionTexts(got)
+	assert.Contains(t, texts, "kube-system", "'ksys' should match 'kube-system' as subsequence")
+	assert.NotContains(t, texts, "default")
+}
+
+func TestFilterSuggestionsFuzzy_PreservesCategory(t *testing.T) {
+	got := filterSuggestionsFuzzy([]string{"yaml", "json"}, "", "format")
+	assert.Len(t, got, 2)
+	for _, s := range got {
+		assert.Equal(t, "format", s.Category)
+	}
+}
+
+func TestFilterSuggestionsFuzzy_AlphabeticalTiebreak(t *testing.T) {
+	// All three are exact-substring "foo" matches at the same position; with
+	// the same length they'll tie on score and should fall back to alphabetical.
+	cands := []string{"z-foo-1", "a-foo-1", "m-foo-1"}
+	got := filterSuggestionsFuzzy(cands, "foo", "namespace")
+
+	texts := suggestionTexts(got)
+	assert.Equal(t, []string{"a-foo-1", "m-foo-1", "z-foo-1"}, texts)
+}
+
+func TestFilterSuggestionsFuzzy_EmptyQueryKeepsAll(t *testing.T) {
+	cands := []string{"alpha", "beta", "gamma"}
+	got := filterSuggestionsFuzzy(cands, "", "option")
+	assert.Len(t, got, 3)
+}

--- a/internal/app/commandbar_fuzzy_test.go
+++ b/internal/app/commandbar_fuzzy_test.go
@@ -81,15 +81,11 @@ func TestFilterSuggestionsFuzzy_Ranking(t *testing.T) {
 	cands := []string{"my-prod-cluster", "production", "prodigy", "staging"}
 	got := filterSuggestionsFuzzy(cands, "prod", "namespace")
 
-	assert.Len(t, got, 3, "'staging' should be excluded")
-	// production (prefix, shorter) should come before prodigy (prefix, shorter than production).
-	// But both are prefix matches; the tiebreak on length should put prodigy (7) > production (10).
-	// Then my-prod-cluster is substring.
+	// 'staging' has no match. Among prefix matches, the length bonus puts the
+	// shorter candidate first: prodigy (7) > production (10). The substring
+	// match (my-prod-cluster) ranks below both prefix matches.
 	texts := suggestionTexts(got)
-	assert.Equal(t, "my-prod-cluster", texts[len(texts)-1],
-		"substring match should rank below prefix matches")
-	assert.Contains(t, texts[:2], "production")
-	assert.Contains(t, texts[:2], "prodigy")
+	assert.Equal(t, []string{"prodigy", "production", "my-prod-cluster"}, texts)
 }
 
 func TestFilterSuggestionsFuzzy_SubsequenceMatch(t *testing.T) {
@@ -122,5 +118,14 @@ func TestFilterSuggestionsFuzzy_AlphabeticalTiebreak(t *testing.T) {
 func TestFilterSuggestionsFuzzy_EmptyQueryKeepsAll(t *testing.T) {
 	cands := []string{"alpha", "beta", "gamma"}
 	got := filterSuggestionsFuzzy(cands, "", "option")
-	assert.Len(t, got, 3)
+	assert.Equal(t, []string{"alpha", "beta", "gamma"}, suggestionTexts(got),
+		"empty query preserves input order")
+}
+
+func TestFilterSuggestionsFuzzy_EmptyQueryPreservesNonAlphabeticalOrder(t *testing.T) {
+	// Simulate a kubeconfig where contexts arrive in usage order, not
+	// alphabetical. With an empty query the upstream order must survive.
+	cands := []string{"prod-east", "default", "prod-west", "staging"}
+	got := filterSuggestionsFuzzy(cands, "", "context")
+	assert.Equal(t, cands, suggestionTexts(got))
 }


### PR DESCRIPTION
Closes #27

## Summary

Second-token value completions in command mode now fuzzy-match instead of prefix-only. `:po prod` surfaces `my-prod-cluster`, `:ctx ksys` surfaces `kube-system`, and the same upgrade applies to every value position (namespace, context, resource name, `:set` option, `:sort` column, `:export` format, kubectl `-n` / `-o` / resource name).

First-token command names, flag names (`-f`, `--dry-run`…), kubectl subcommands, and resource-type completion **stay on prefix match** — the builtin command set is small and curated, and fuzzy would add noise for short inputs.

## Implementation

New file `internal/app/commandbar_fuzzy.go`:

- `fuzzyScore(text, query)` — tiered scoring:
  - Exact: 10000
  - Prefix: 5000 + length bonus (shorter wins)
  - Substring: 2000 + position bonus (earlier wins) + length bonus
  - Subsequence: 500 + span bonus (tighter wins)
  - Bonuses are capped so they never cross tiers
- `filterSuggestionsFuzzy` — drop-in replacement for `filterSuggestionsTyped`, sorts by score desc, alphabetical tiebreak
- `subsequenceSpan` — first-to-last span for the subsequence tier

`internal/app/commandbar_complete.go` call sites switched to fuzzy:

- `completeBuiltin`: `namespace`, `context`, `set`, `sort`, `export` (lines ~177-185)
- `completeKubectl`: `-n`/`--namespace` flag value, `-o`/`--output` flag value, resource name position (lines ~224, ~226, ~260)
- `generateCommandBarSuggestions` `cmdResourceJump` second-token namespace (line ~305)

`filterSuggestionsTyped` itself is unchanged and still used for first-token command names, flag names, and kubectl subcommands.

## Test plan

- [x] `go test ./...` — all passing (including 15 new tests in `commandbar_fuzzy_test.go` covering ranking tiers, tiebreaks, case-insensitivity, subsequence span math)
- [x] `go build -o lfk .` — clean
- [x] Reviewer: open app, type `:po <middle-substring-of-namespace>` and confirm the namespace appears in the dropdown
- [x] Reviewer: confirm first-token suggestions (`:n` → `namespace`/`ns`) still behave as before