### PR TITLE
fix: key namespace completion cache by context

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,6 +69,8 @@ Repeated completed tasks collapse with a `×N` suffix.
 
 Autocomplete offers subcommands, flags, resource types, and namespaces. Typing `:k` or `:kubectl` alone surfaces the subcommand list. Value positions (namespace, resource name, output format) accept fuzzy matches — exact > prefix > substring > subsequence — while command names themselves stay on prefix.
 
+Namespace suggestions come from a per-context cache warmed when the context is opened and refreshed on a 60s TTL. In-app mutations — `:k create ns`, `:k delete ns`, or a template apply — invalidate the cache immediately so new namespaces appear in completions without waiting for the TTL; changes made outside the TUI (CI, cloud console, `kubectl` in another shell) surface on the next refresh. The existing list stays visible during refreshes so completions never blank out.
+
 ## Resource jumps
 
 Type a resource name to navigate. Plural, singular, and kubectl abbreviations all work.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -750,9 +750,11 @@ type Model struct {
 	// Cached namespace names for command bar autocompletion, keyed by
 	// context name. Each tab may have its own nav.Context, so keying by
 	// context keeps completions correct when switching tabs or running
-	// `:ctx` within a tab without re-fetching a context's namespaces more
-	// than once.
-	cachedNamespaces map[string][]string
+	// `:ctx` within a tab. Entries carry a fetchedAt timestamp so the
+	// command bar can refresh them after namespaceCacheTTL without
+	// refetching on every open (stale-while-revalidate: the old entry
+	// stays visible while the refresh runs).
+	cachedNamespaces map[string]namespaceCacheEntry
 
 	// Async resource name cache for cross-namespace kubectl completion.
 	// Key: "context/namespace/resource" -> list of resource names.
@@ -971,6 +973,66 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	m.helpSearchInput.CharLimit = 100
 
 	return m
+}
+
+// namespaceCacheEntry holds the result of a namespace fetch plus the
+// time it completed. The fetchedAt timestamp lets the command bar
+// refresh stale entries without refetching on every open.
+type namespaceCacheEntry struct {
+	names     []string
+	fetchedAt time.Time
+}
+
+// namespaceCacheTTL is how long a cached namespace list stays fresh.
+// After this interval the command bar will trigger a background
+// refresh on next open so newly created namespaces show up in
+// completions without requiring an app restart. The stale entry stays
+// visible until the refresh lands (stale-while-revalidate), so the UI
+// never blinks between "has completions" and "empty".
+//
+// Actions that directly mutate namespaces (`:k create|delete ns ...`
+// and template applies) bypass the TTL via invalidateNamespaceCache,
+// so the common "I just made it" case is instant — the TTL is only a
+// backstop for changes made outside the TUI.
+const namespaceCacheTTL = 60 * time.Second
+
+// activeContext returns the kubectl context that queries on behalf of
+// the current tab should target. It prefers the tab-scoped nav.Context
+// and falls back to the client's current context; returns "" when the
+// client has not been initialised yet (e.g. in pre-startup tests) so
+// callers never panic on a nil client.
+func (m Model) activeContext() string {
+	if m.nav.Context != "" {
+		return m.nav.Context
+	}
+	if m.client != nil {
+		return m.client.CurrentContext()
+	}
+	return ""
+}
+
+// ensureNamespaceCacheFresh returns a command that refreshes the
+// namespace cache for the current context when the entry is missing,
+// empty, or older than namespaceCacheTTL; returns nil otherwise.
+// Context-open paths (drilling into a cluster, `:ctx`, bookmark
+// activation, session restore) batch it so the first `:` open in the
+// newly-opened context has completions ready without waiting for the
+// user's keystroke to trigger the fetch.
+func (m Model) ensureNamespaceCacheFresh() tea.Cmd {
+	entry, ok := m.cachedNamespaces[m.activeContext()]
+	if !ok || len(entry.names) == 0 || time.Since(entry.fetchedAt) > namespaceCacheTTL {
+		return m.loadNamespaces()
+	}
+	return nil
+}
+
+// invalidateNamespaceCache drops the cache entry for the current
+// context so the next command bar open triggers a fresh fetch. Called
+// after actions that mutate the cluster's namespace list (`:k create
+// ns`, `:k delete ns`, template applies) so the new state is reflected
+// in completions immediately instead of up to namespaceCacheTTL later.
+func (m *Model) invalidateNamespaceCache() {
+	delete(m.cachedNamespaces, m.activeContext())
 }
 
 // cancelAndReset cancels any in-flight API requests and creates a fresh

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -747,8 +747,12 @@ type Model struct {
 	commandBarPreview            string // ghost text shown dimmed after cursor (tab preview)
 	commandHistory               *commandHistory
 
-	// Cached namespace names for command bar autocompletion.
-	cachedNamespaces []string
+	// Cached namespace names for command bar autocompletion, keyed by
+	// context name. Each tab may have its own nav.Context, so keying by
+	// context keeps completions correct when switching tabs or running
+	// `:ctx` within a tab without re-fetching a context's namespaces more
+	// than once.
+	cachedNamespaces map[string][]string
 
 	// Async resource name cache for cross-namespace kubectl completion.
 	// Key: "context/namespace/resource" -> list of resource names.

--- a/internal/app/commandbar_complete.go
+++ b/internal/app/commandbar_complete.go
@@ -645,13 +645,12 @@ func (m *Model) contextNames() []string {
 // context keeps completions correct across tab switches and `:ctx`
 // changes within a tab. The cache is populated asynchronously when the
 // command bar opens for a context that isn't cached yet.
+//
+// A stale entry (older than namespaceCacheTTL) is still returned here
+// so completions remain visible while a background refresh runs; the
+// refresh is scheduled from handleKeyCommandBar.
 func (m *Model) namespaceNames() []string {
-	kctx := m.nav.Context
-	if kctx == "" && m.client != nil {
-		kctx = m.client.CurrentContext()
-	}
-
-	return m.cachedNamespaces[kctx]
+	return m.cachedNamespaces[m.activeContext()].names
 }
 
 // resourceNames returns unique resource names from the middle column.

--- a/internal/app/commandbar_complete.go
+++ b/internal/app/commandbar_complete.go
@@ -640,10 +640,18 @@ func (m *Model) contextNames() []string {
 	return names
 }
 
-// namespaceNames returns cached namespace names for completion.
-// The cache is populated asynchronously when the command bar opens.
+// namespaceNames returns cached namespace names for completion in the
+// current nav context. Each tab has its own nav.Context, so keying by
+// context keeps completions correct across tab switches and `:ctx`
+// changes within a tab. The cache is populated asynchronously when the
+// command bar opens for a context that isn't cached yet.
 func (m *Model) namespaceNames() []string {
-	return m.cachedNamespaces
+	kctx := m.nav.Context
+	if kctx == "" && m.client != nil {
+		kctx = m.client.CurrentContext()
+	}
+
+	return m.cachedNamespaces[kctx]
 }
 
 // resourceNames returns unique resource names from the middle column.

--- a/internal/app/commandbar_complete_test.go
+++ b/internal/app/commandbar_complete_test.go
@@ -4,12 +4,25 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
+
+// freshNsCache wraps plain context→names data as cache entries with a
+// current timestamp, so tests that only care about the contents don't
+// need to spell out the fetchedAt on every line.
+func freshNsCache(entries map[string][]string) map[string]namespaceCacheEntry {
+	out := make(map[string]namespaceCacheEntry, len(entries))
+	now := time.Now()
+	for ctx, names := range entries {
+		out[ctx] = namespaceCacheEntry{names: names, fetchedAt: now}
+	}
+	return out
+}
 
 // --- helpers ---
 
@@ -144,7 +157,7 @@ func TestCompleteBuiltin_NamespaceArg(t *testing.T) {
 		{text: "kube", start: 3, end: 7},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system", "production"}}
+	m.cachedNamespaces = freshNsCache(map[string][]string{"": {"default", "kube-system", "production"}})
 	got := completeBuiltin(tokens, &m)
 	assert.True(t, hasSuggestionCategory(got, "kube-system", "namespace"),
 		"should suggest 'kube-system' matching prefix 'kube'")
@@ -302,7 +315,7 @@ func TestCompleteKubectl_NamespaceFlag(t *testing.T) {
 		{text: "kube", start: 12, end: 16},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system", "kube-public"}}
+	m.cachedNamespaces = freshNsCache(map[string][]string{"": {"default", "kube-system", "kube-public"}})
 	got := completeKubectl(tokens, &m)
 	assert.True(t, hasSuggestionCategory(got, "kube-system", "namespace"),
 		"should suggest 'kube-system' after -n flag")
@@ -382,7 +395,7 @@ func TestGenerateSuggestions_ShellCommand(t *testing.T) {
 func TestGenerateSuggestions_BuiltinNamespace(t *testing.T) {
 	m := baseModelCov()
 	m.commandBarInput.Value = "ns kube"
-	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system", "production"}}
+	m.cachedNamespaces = freshNsCache(map[string][]string{"": {"default", "kube-system", "production"}})
 	got := m.generateCommandBarSuggestions()
 	assert.True(t, hasSuggestionCategory(got, "kube-system", "namespace"),
 		"should suggest 'kube-system' for 'ns kube'")
@@ -518,7 +531,7 @@ func TestCompleteKubectl_LongNamespaceFlag(t *testing.T) {
 		{text: "def", start: 21, end: 24},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system"}}
+	m.cachedNamespaces = freshNsCache(map[string][]string{"": {"default", "kube-system"}})
 	got := completeKubectl(tokens, &m)
 	assert.True(t, hasSuggestionCategory(got, "default", "namespace"),
 		"should suggest 'default' after --namespace flag")
@@ -555,7 +568,7 @@ func TestCompleteBuiltin_NamespaceEmptyPrefix(t *testing.T) {
 		{text: "", start: 10, end: 10},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system"}}
+	m.cachedNamespaces = freshNsCache(map[string][]string{"": {"default", "kube-system"}})
 	got := completeBuiltin(tokens, &m)
 	assert.Len(t, got, 2)
 	for _, s := range got {
@@ -565,10 +578,10 @@ func TestCompleteBuiltin_NamespaceEmptyPrefix(t *testing.T) {
 
 func TestNamespaceNames_ScopedByContext(t *testing.T) {
 	m := baseModelCov()
-	m.cachedNamespaces = map[string][]string{
+	m.cachedNamespaces = freshNsCache(map[string][]string{
 		"ctx-a": {"a-ns-1", "a-ns-2"},
 		"ctx-b": {"b-ns-1"},
-	}
+	})
 
 	m.nav.Context = "ctx-a"
 	assert.ElementsMatch(t, []string{"a-ns-1", "a-ns-2"}, m.namespaceNames(),
@@ -593,10 +606,10 @@ func TestCompleteBuiltin_NamespaceArg_PerContext(t *testing.T) {
 	}
 	m := baseModelCov()
 	m.nav.Context = "ctx-b"
-	m.cachedNamespaces = map[string][]string{
+	m.cachedNamespaces = freshNsCache(map[string][]string{
 		"ctx-a": {"kube-system", "kube-public"},
 		"ctx-b": {"default", "production"},
-	}
+	})
 
 	got := completeBuiltin(tokens, &m)
 	assert.False(t, hasSuggestion(got, "kube-system"),
@@ -615,10 +628,191 @@ func TestUpdateNamespacesLoaded_StoresUnderMessageContext(t *testing.T) {
 	result, _ := m.Update(namespacesLoadedMsg{context: "ctx-other", items: items})
 	rm := result.(Model)
 
-	assert.ElementsMatch(t, []string{"ns-x", "ns-y"}, rm.cachedNamespaces["ctx-other"],
+	assert.ElementsMatch(t, []string{"ns-x", "ns-y"}, rm.cachedNamespaces["ctx-other"].names,
 		"stored under the message's context, not the model's current nav.Context")
-	assert.Empty(t, rm.cachedNamespaces["ctx-current"],
+	_, hasCurrent := rm.cachedNamespaces["ctx-current"]
+	assert.False(t, hasCurrent,
 		"current context must not pick up values fetched for another context")
+}
+
+func TestUpdateNamespacesLoaded_StampsFetchedAt(t *testing.T) {
+	m := baseModelCov()
+	items := []model.Item{{Name: "ns-1"}}
+	before := time.Now()
+
+	result, _ := m.Update(namespacesLoadedMsg{context: "ctx-x", items: items})
+	rm := result.(Model)
+
+	entry := rm.cachedNamespaces["ctx-x"]
+	assert.Equal(t, []string{"ns-1"}, entry.names)
+	assert.False(t, entry.fetchedAt.Before(before),
+		"fetchedAt must be >= the time immediately before Update")
+	assert.Less(t, time.Since(entry.fetchedAt), time.Second,
+		"fetchedAt should be recent enough to register as fresh")
+}
+
+func TestActiveContext_PrefersNavContext(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Context = "tab-ctx"
+	// No client set; helper must not dereference it.
+	assert.Equal(t, "tab-ctx", m.activeContext())
+}
+
+func TestActiveContext_NilClientReturnsEmpty(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Context = ""
+	m.client = nil
+	assert.Equal(t, "", m.activeContext(),
+		"nil client with empty nav.Context must not panic")
+}
+
+func TestHandleKeyCommandBar_FreshCacheSkipsFetch(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.commandHistory = &commandHistory{cursor: -1}
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"test-ctx": {names: []string{"default"}, fetchedAt: time.Now()},
+	}
+	_, cmd := m.handleKeyCommandBar()
+	assert.Nil(t, cmd, "fresh cache entry must not trigger a background refresh")
+}
+
+func TestHandleKeyCommandBar_StaleCacheTriggersFetch(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.commandHistory = &commandHistory{cursor: -1}
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"test-ctx": {
+			names:     []string{"default"},
+			fetchedAt: time.Now().Add(-2 * namespaceCacheTTL),
+		},
+	}
+	_, cmd := m.handleKeyCommandBar()
+	assert.NotNil(t, cmd, "entry older than TTL must trigger a background refresh")
+}
+
+func TestHandleKeyCommandBar_MissingCacheTriggersFetch(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.commandHistory = &commandHistory{cursor: -1}
+	// No cachedNamespaces entry for test-ctx.
+	_, cmd := m.handleKeyCommandBar()
+	assert.NotNil(t, cmd, "missing entry must trigger a fetch")
+}
+
+func TestNamespaceNames_StaleEntryStillVisibleDuringRefresh(t *testing.T) {
+	// Stale-while-revalidate: a refresh will run in the background, but
+	// until it completes the existing entry must still be returned so
+	// command-bar completions never go blank on the 60s boundary.
+	m := baseModelCov()
+	m.nav.Context = "ctx-a"
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"ctx-a": {
+			names:     []string{"default", "legacy-ns"},
+			fetchedAt: time.Now().Add(-2 * namespaceCacheTTL),
+		},
+	}
+	assert.ElementsMatch(t, []string{"default", "legacy-ns"}, m.namespaceNames(),
+		"stale entry should still be shown until the refresh lands")
+}
+
+func TestEnsureNamespaceCacheFresh_FreshReturnsNil(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"test-ctx": {names: []string{"default"}, fetchedAt: time.Now()},
+	}
+	assert.Nil(t, m.ensureNamespaceCacheFresh(),
+		"fresh cache must not schedule a fetch on context-open paths")
+}
+
+func TestEnsureNamespaceCacheFresh_StaleReturnsFetch(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"test-ctx": {
+			names:     []string{"default"},
+			fetchedAt: time.Now().Add(-2 * namespaceCacheTTL),
+		},
+	}
+	assert.NotNil(t, m.ensureNamespaceCacheFresh(),
+		"stale entry must schedule a background refresh on context-open paths")
+}
+
+func TestEnsureNamespaceCacheFresh_MissingReturnsFetch(t *testing.T) {
+	m := baseModelWithFakeClient()
+	// No cache entry: opening this context must eagerly warm the cache.
+	assert.NotNil(t, m.ensureNamespaceCacheFresh())
+}
+
+func TestInvalidateNamespaceCache_DeletesCurrentContextOnly(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Context = "ctx-a"
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"ctx-a": {names: []string{"default"}, fetchedAt: time.Now()},
+		"ctx-b": {names: []string{"default"}, fetchedAt: time.Now()},
+	}
+
+	m.invalidateNamespaceCache()
+
+	_, stillHasA := m.cachedNamespaces["ctx-a"]
+	assert.False(t, stillHasA, "current-context entry must be removed so the next open refetches")
+	_, stillHasB := m.cachedNamespaces["ctx-b"]
+	assert.True(t, stillHasB, "other contexts must not be affected by a current-context invalidation")
+}
+
+func TestCommandAffectsNamespaces(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"create ns", []string{"create", "ns", "foo"}, true},
+		{"create namespace", []string{"create", "namespace", "foo"}, true},
+		{"delete ns", []string{"delete", "ns", "foo"}, true},
+		{"delete namespaces plural", []string{"delete", "namespaces", "foo"}, true},
+		{"replace ns", []string{"replace", "ns", "foo"}, true},
+		{"get pods", []string{"get", "pods"}, false},
+		{"get ns is read only", []string{"get", "ns"}, false},
+		{"create pod", []string{"create", "pod", "foo"}, false},
+		{"empty args", []string{}, false},
+		{"verb only", []string{"create"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, commandAffectsNamespaces(tc.args))
+		})
+	}
+}
+
+func TestUpdateActionResult_InvalidatesCacheOnSuccessFlag(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Context = "ctx-a"
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"ctx-a": {names: []string{"default"}, fetchedAt: time.Now()},
+	}
+
+	result, _ := m.updateActionResult(actionResultMsg{
+		message:                  "ok",
+		invalidateNamespaceCache: true,
+	})
+	rm := result.(Model)
+
+	_, still := rm.cachedNamespaces["ctx-a"]
+	assert.False(t, still, "successful action with invalidate flag must clear the current-context entry")
+}
+
+func TestUpdateActionResult_DoesNotInvalidateOnError(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Context = "ctx-a"
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		"ctx-a": {names: []string{"default"}, fetchedAt: time.Now()},
+	}
+
+	result, _ := m.updateActionResult(actionResultMsg{
+		err:                      assert.AnError,
+		invalidateNamespaceCache: true,
+	})
+	rm := result.(Model)
+
+	_, still := rm.cachedNamespaces["ctx-a"]
+	assert.True(t, still,
+		"failed action must not clear the cache even when the flag is set (the mutation never happened)")
 }
 
 func TestCompleteBuiltin_SortEmptyPrefix(t *testing.T) {

--- a/internal/app/commandbar_complete_test.go
+++ b/internal/app/commandbar_complete_test.go
@@ -144,7 +144,7 @@ func TestCompleteBuiltin_NamespaceArg(t *testing.T) {
 		{text: "kube", start: 3, end: 7},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = []string{"default", "kube-system", "production"}
+	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system", "production"}}
 	got := completeBuiltin(tokens, &m)
 	assert.True(t, hasSuggestionCategory(got, "kube-system", "namespace"),
 		"should suggest 'kube-system' matching prefix 'kube'")
@@ -302,7 +302,7 @@ func TestCompleteKubectl_NamespaceFlag(t *testing.T) {
 		{text: "kube", start: 12, end: 16},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = []string{"default", "kube-system", "kube-public"}
+	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system", "kube-public"}}
 	got := completeKubectl(tokens, &m)
 	assert.True(t, hasSuggestionCategory(got, "kube-system", "namespace"),
 		"should suggest 'kube-system' after -n flag")
@@ -382,7 +382,7 @@ func TestGenerateSuggestions_ShellCommand(t *testing.T) {
 func TestGenerateSuggestions_BuiltinNamespace(t *testing.T) {
 	m := baseModelCov()
 	m.commandBarInput.Value = "ns kube"
-	m.cachedNamespaces = []string{"default", "kube-system", "production"}
+	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system", "production"}}
 	got := m.generateCommandBarSuggestions()
 	assert.True(t, hasSuggestionCategory(got, "kube-system", "namespace"),
 		"should suggest 'kube-system' for 'ns kube'")
@@ -518,7 +518,7 @@ func TestCompleteKubectl_LongNamespaceFlag(t *testing.T) {
 		{text: "def", start: 21, end: 24},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = []string{"default", "kube-system"}
+	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system"}}
 	got := completeKubectl(tokens, &m)
 	assert.True(t, hasSuggestionCategory(got, "default", "namespace"),
 		"should suggest 'default' after --namespace flag")
@@ -555,12 +555,70 @@ func TestCompleteBuiltin_NamespaceEmptyPrefix(t *testing.T) {
 		{text: "", start: 10, end: 10},
 	}
 	m := baseModelCov()
-	m.cachedNamespaces = []string{"default", "kube-system"}
+	m.cachedNamespaces = map[string][]string{"": {"default", "kube-system"}}
 	got := completeBuiltin(tokens, &m)
 	assert.Len(t, got, 2)
 	for _, s := range got {
 		assert.Equal(t, "namespace", s.Category)
 	}
+}
+
+func TestNamespaceNames_ScopedByContext(t *testing.T) {
+	m := baseModelCov()
+	m.cachedNamespaces = map[string][]string{
+		"ctx-a": {"a-ns-1", "a-ns-2"},
+		"ctx-b": {"b-ns-1"},
+	}
+
+	m.nav.Context = "ctx-a"
+	assert.ElementsMatch(t, []string{"a-ns-1", "a-ns-2"}, m.namespaceNames(),
+		"nav.Context=ctx-a should read the ctx-a entry")
+
+	m.nav.Context = "ctx-b"
+	assert.ElementsMatch(t, []string{"b-ns-1"}, m.namespaceNames(),
+		"nav.Context=ctx-b should read the ctx-b entry, not leak from ctx-a")
+
+	m.nav.Context = "ctx-missing"
+	assert.Empty(t, m.namespaceNames(),
+		"unknown context should return nil so the command bar triggers a fresh load")
+}
+
+func TestCompleteBuiltin_NamespaceArg_PerContext(t *testing.T) {
+	// Cache holds entries for two contexts. Completing `:ns kube` under
+	// nav.Context=ctx-b must only see ctx-b's namespaces, even though
+	// ctx-a's cache contains a matching "kube-system".
+	tokens := []token{
+		{text: "ns", start: 0, end: 2},
+		{text: "kube", start: 3, end: 7},
+	}
+	m := baseModelCov()
+	m.nav.Context = "ctx-b"
+	m.cachedNamespaces = map[string][]string{
+		"ctx-a": {"kube-system", "kube-public"},
+		"ctx-b": {"default", "production"},
+	}
+
+	got := completeBuiltin(tokens, &m)
+	assert.False(t, hasSuggestion(got, "kube-system"),
+		"ctx-a's kube-system must not leak into ctx-b's completions")
+	assert.False(t, hasSuggestion(got, "kube-public"),
+		"ctx-a's kube-public must not leak into ctx-b's completions")
+}
+
+func TestUpdateNamespacesLoaded_StoresUnderMessageContext(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Context = "ctx-current"
+	items := []model.Item{{Name: "ns-x"}, {Name: "ns-y"}}
+
+	// A fetch issued for ctx-other completes; its result must be stored
+	// under ctx-other even though the tab has since moved to ctx-current.
+	result, _ := m.Update(namespacesLoadedMsg{context: "ctx-other", items: items})
+	rm := result.(Model)
+
+	assert.ElementsMatch(t, []string{"ns-x", "ns-y"}, rm.cachedNamespaces["ctx-other"],
+		"stored under the message's context, not the model's current nav.Context")
+	assert.Empty(t, rm.cachedNamespaces["ctx-current"],
+		"current context must not pick up values fetched for another context")
 }
 
 func TestCompleteBuiltin_SortEmptyPrefix(t *testing.T) {

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -152,7 +152,11 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 		}
 		m.nav.Context = arg
 		m.setStatusMessage(fmt.Sprintf("Context set to %s", arg), false)
-		return m, tea.Batch(m.loadResourceTypes(), scheduleStatusClear())
+		cmds := []tea.Cmd{m.loadResourceTypes(), scheduleStatusClear()}
+		if cmd := m.ensureNamespaceCacheFresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return m, tea.Batch(cmds...)
 
 	case "set":
 		return m.executeSetCommand(arg)
@@ -393,6 +397,10 @@ func (m Model) executeKubectlCommand(input string) tea.Cmd {
 		return nil
 	}
 
+	// Decide this BEFORE injectKubectlDefaults adds `--context` / `-n`
+	// so the positional-arg detection sees the user's original shape.
+	affectsNamespaces := commandAffectsNamespaces(args)
+
 	args = m.injectKubectlDefaults(args)
 
 	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl %s", strings.Join(args, " ")))
@@ -413,8 +421,34 @@ func (m Model) executeKubectlCommand(input string) tea.Cmd {
 	logger.Info("Running kubectl command", "cmd", shellCmd)
 
 	return tea.ExecProcess(c, func(err error) tea.Msg {
-		return actionResultMsg{err: err}
+		return actionResultMsg{err: err, invalidateNamespaceCache: affectsNamespaces}
 	})
+}
+
+// commandAffectsNamespaces reports whether a kubectl command (args
+// without the "kubectl"/"k" prefix) looks like it mutates the cluster's
+// Namespace list. Matches `create|delete|replace (ns|namespace|namespaces) ...`.
+// Read-only verbs (`get`, `describe`) are excluded so they don't force
+// an unnecessary cache refresh, and `apply -f <file>` is not inspected
+// (template applies invalidate unconditionally instead). False
+// positives only cost one extra GetNamespaces call, so the heuristic
+// favours breadth.
+func commandAffectsNamespaces(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	switch args[0] {
+	case "create", "delete", "replace":
+	default:
+		return false
+	}
+	for _, a := range args[1:] {
+		switch a {
+		case "ns", "namespace", "namespaces":
+			return true
+		}
+	}
+	return false
 }
 
 // injectKubectlDefaults scans the args for --context, -n/--namespace, and

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -644,7 +644,14 @@ func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
 			logger.Error("kubectl apply failed", "cmd", cmd.String(), "error", err, "output", string(output))
 			return actionResultMsg{err: fmt.Errorf("kubectl apply: %s", strings.TrimSpace(string(output)))}
 		}
-		return actionResultMsg{message: strings.TrimSpace(string(output))}
+		// Templates are rare and may create a Namespace (either directly
+		// via the "Namespace" template or an edited YAML that adds one),
+		// so always invalidate on success. Worst case is one extra
+		// GetNamespaces round-trip per template apply.
+		return actionResultMsg{
+			message:                  strings.TrimSpace(string(output)),
+			invalidateNamespaceCache: true,
+		}
 	}
 }
 

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -231,10 +231,10 @@ func (m Model) loadContainers(forPreview bool) tea.Cmd {
 }
 
 func (m Model) loadNamespaces() tea.Cmd {
-	kctx := m.nav.Context
-	if kctx == "" {
-		kctx = m.client.CurrentContext()
+	if m.client == nil {
+		return nil
 	}
+	kctx := m.activeContext()
 	// Use an independent context so namespace loading is never blocked or
 	// cancelled by in-flight resource requests.
 	return func() tea.Msg {

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -239,7 +239,7 @@ func (m Model) loadNamespaces() tea.Cmd {
 	// cancelled by in-flight resource requests.
 	return func() tea.Msg {
 		items, err := m.client.GetNamespaces(context.Background(), kctx)
-		return namespacesLoadedMsg{items: items, err: err}
+		return namespacesLoadedMsg{context: kctx, items: items, err: err}
 	}
 }
 

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -58,8 +58,9 @@ type resourceTreeLoadedMsg struct {
 }
 
 type namespacesLoadedMsg struct {
-	items []model.Item
-	err   error
+	context string
+	items   []model.Item
+	err     error
 }
 
 // yamlLoadedMsg delivers a full YAML document for the YAML view. The content

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -87,6 +87,11 @@ type previewYAMLLoadedMsg struct {
 type actionResultMsg struct {
 	message string
 	err     error
+	// invalidateNamespaceCache, when true on a successful action,
+	// drops the current context's namespace completion cache so the
+	// next command bar open reflects the mutation (e.g. `:k create
+	// ns`, `:k delete ns`, or a template apply).
+	invalidateNamespaceCache bool
 }
 
 // triggerCronJobMsg carries the result of triggering a CronJob.

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -836,14 +836,19 @@ func (m Model) updateNamespacesLoaded(msg namespacesLoadedMsg) (tea.Model, tea.C
 	// Cache namespace names for command bar autocompletion, keyed by the
 	// context the fetch was issued for. Keying avoids stale results when
 	// tabs / `:ctx` change nav.Context between the request and reply.
+	// Stamp fetchedAt so the next command bar open can decide whether
+	// the entry is still fresh or should trigger a background refresh.
 	if m.cachedNamespaces == nil {
-		m.cachedNamespaces = make(map[string][]string)
+		m.cachedNamespaces = make(map[string]namespaceCacheEntry)
 	}
 	names := make([]string, 0, len(msg.items))
 	for _, item := range msg.items {
 		names = append(names, item.Name)
 	}
-	m.cachedNamespaces[msg.context] = names
+	m.cachedNamespaces[msg.context] = namespaceCacheEntry{
+		names:     names,
+		fetchedAt: time.Now(),
+	}
 	if m.allNamespaces {
 		m.overlayCursor = 0
 	} else {
@@ -893,9 +898,16 @@ func (m Model) updateActionResult(msg actionResultMsg) (tea.Model, tea.Cmd) {
 	m.bulkMode = false
 	if msg.err != nil {
 		m.setErrorFromErr("Error: ", msg.err)
-	} else if msg.message != "" {
-		logger.Info("Action completed", "message", msg.message)
-		m.setStatusMessage(msg.message, false)
+	} else {
+		if msg.message != "" {
+			logger.Info("Action completed", "message", msg.message)
+			m.setStatusMessage(msg.message, false)
+		}
+		// Only invalidate when the action succeeded; a failed `create
+		// ns` or template apply did not actually mutate the cluster.
+		if msg.invalidateNamespaceCache {
+			m.invalidateNamespaceCache()
+		}
 	}
 	return m, tea.Batch(m.refreshCurrentLevel(), scheduleStatusClear())
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -833,11 +833,17 @@ func (m Model) updateNamespacesLoaded(msg namespacesLoadedMsg) (tea.Model, tea.C
 	m.err = nil
 	allNsItem := model.Item{Name: "All Namespaces", Status: "all"}
 	m.overlayItems = append([]model.Item{allNsItem}, msg.items...)
-	// Cache namespace names for command bar autocompletion.
-	m.cachedNamespaces = make([]string, 0, len(msg.items))
-	for _, item := range msg.items {
-		m.cachedNamespaces = append(m.cachedNamespaces, item.Name)
+	// Cache namespace names for command bar autocompletion, keyed by the
+	// context the fetch was issued for. Keying avoids stale results when
+	// tabs / `:ctx` change nav.Context between the request and reply.
+	if m.cachedNamespaces == nil {
+		m.cachedNamespaces = make(map[string][]string)
 	}
+	names := make([]string, 0, len(msg.items))
+	for _, item := range msg.items {
+		names = append(names, item.Name)
+	}
+	m.cachedNamespaces[msg.context] = names
 	if m.allNamespaces {
 		m.overlayCursor = 0
 	} else {

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -505,7 +505,11 @@ func (m Model) navigateToBookmark(bm model.Bookmark) (tea.Model, tea.Cmd) {
 	m.searchActive = false
 
 	m.setStatusMessage("Jumped to: "+bm.Name, false)
-	return m, tea.Batch(m.loadResources(false), scheduleStatusClear())
+	cmds := []tea.Cmd{m.loadResources(false), scheduleStatusClear()}
+	if cmd := m.ensureNamespaceCacheFresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	return m, tea.Batch(cmds...)
 }
 
 // restoreSession applies the pending session state after contexts have been loaded.
@@ -574,6 +578,9 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	if _, ok := m.discoveredResources[sess.Context]; !ok {
 		needsDiscovery = true
 		cmds = append(cmds, m.discoverAPIResources(sess.Context))
+	}
+	if cmd := m.ensureNamespaceCacheFresh(); cmd != nil {
+		cmds = append(cmds, cmd)
 	}
 
 	// If a resource type was saved, navigate deeper.

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -763,8 +763,14 @@ func (m Model) handleKeyCommandBar() (Model, tea.Cmd) {
 	m.commandBarSuggestions = nil
 	m.commandBarSelectedSuggestion = 0
 	m.commandHistory.reset()
-	// Eagerly populate namespace cache if empty.
-	if len(m.cachedNamespaces) == 0 {
+	// Eagerly populate the namespace cache for the current tab's context
+	// if nothing is cached for it yet. Different tabs / `:ctx` switches
+	// each need their own fetch since the cache is keyed by context name.
+	kctx := m.nav.Context
+	if kctx == "" && m.client != nil {
+		kctx = m.client.CurrentContext()
+	}
+	if len(m.cachedNamespaces[kctx]) == 0 {
 		return m, m.loadNamespaces()
 	}
 	return m, nil

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -763,17 +763,12 @@ func (m Model) handleKeyCommandBar() (Model, tea.Cmd) {
 	m.commandBarSuggestions = nil
 	m.commandBarSelectedSuggestion = 0
 	m.commandHistory.reset()
-	// Eagerly populate the namespace cache for the current tab's context
-	// if nothing is cached for it yet. Different tabs / `:ctx` switches
-	// each need their own fetch since the cache is keyed by context name.
-	kctx := m.nav.Context
-	if kctx == "" && m.client != nil {
-		kctx = m.client.CurrentContext()
-	}
-	if len(m.cachedNamespaces[kctx]) == 0 {
-		return m, m.loadNamespaces()
-	}
-	return m, nil
+	// Refresh the namespace cache if stale so namespaces created since
+	// the last fetch (inside or outside the TUI) surface in completions.
+	// The existing entry stays readable via namespaceNames() while the
+	// refresh is in flight, keeping completions non-blank across the
+	// TTL boundary.
+	return m, m.ensureNamespaceCacheFresh()
 }
 
 func (m Model) handleKeyColumnToggle() Model {

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -262,6 +262,9 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	if _, ok := m.discoveredResources[sel.Name]; !ok {
 		cmds = append(cmds, m.discoverAPIResources(sel.Name))
 	}
+	if cmd := m.ensureNamespaceCacheFresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	return m, tea.Batch(cmds...)
 }
 


### PR DESCRIPTION
Closes #29

## Summary

The command-bar namespace cache (`Model.cachedNamespaces`) is a flat `[]string` populated once on the first `:` keypress. Once filled, the empty-check at `update_keys.go:767` (`len(m.cachedNamespaces) == 0`) never triggers again — so every tab and every `:ctx` switch reads the first context's namespaces, even after `nav.Context` has moved.

This PR re-keys the cache by context name so each tab / context gets its own entry.

## Use cases fixed

### Two tabs, two clusters

1. Tab 1 on `ctx-a` → press `:` → fetches A's namespaces.
2. Open tab 2 on `ctx-b` → press `:` → type `:po <substring>`.
3. **Before:** dropdown shows A's namespaces (stale cache).
4. **After:** dropdown shows B's namespaces. Switching back to tab 1 reuses A's cached entry (no re-fetch).

### Single tab, `:ctx` switch

1. Cache fills for `ctx-a`.
2. Run `:ctx ctx-b` → `nav.Context` updates but the flat cache was never invalidated.
3. **Before:** `:po <substring>` filters over A's namespaces.
4. **After:** B's entry is missing, so `:` triggers a fetch for B, stored under its own key.

## Implementation

- `Model.cachedNamespaces` → `map[string][]string` (`app.go:751`).
- `namespacesLoadedMsg` gains a `context` field so async replies land under the context the fetch was issued for (guards against the tab moving during the fetch) (`messages.go:60`, `commands_load.go:242`).
- `updateNamespacesLoaded` stores under `msg.context`; lazy-inits the map (`update.go:837-846`).
- `namespaceNames()` returns `m.cachedNamespaces[m.nav.Context]`, falling back to `m.client.CurrentContext()` if nav hasn't moved off the root yet (`commandbar_complete.go:645-655`).
- `handleKeyCommandBar` empty-check becomes per-context (`update_keys.go:760-771`).

Matches the per-context keying already used by `discoveredResources` and `commandBarNameCache` — no new pattern introduced.

No clearing on context switch needed; previously-loaded contexts stay cached. No per-tab `TabState` copying needed; the map is cross-tab but per-context-correct.

## Caveats / follow-ups (out of scope for this PR)

- No TTL or invalidation. Namespaces created/deleted in-cluster after the first fetch won't appear until the app restarts. If that matters, a simple `:ctx` switch could force a refresh, or we could add a TTL / watch hook — happy to do that in a follow-up PR.

## Test plan

- [x] `go test ./...` — all passing, including 3 new tests:
  - `TestNamespaceNames_ScopedByContext` — per-context read is isolated
  - `TestCompleteBuiltin_NamespaceArg_PerContext` — no leak across contexts in the actual completion path
  - `TestUpdateNamespacesLoaded_StoresUnderMessageContext` — tab-moved-during-fetch race doesn't misroute the result
- [x] `go build -o lfk .` — clean
- [x] Reviewer: reproduce the two-tab case above on a real cluster and confirm B's namespaces appear, then tab back and confirm A's reappear without a re-fetch