### PR TITLE
chore: add flake.nix

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Pre-push hook: when a vX.Y.Z tag is being pushed, refuse the push if
+# flake.nix's baseVersion does not match the tag. This catches the same
+# mismatch the CI `verify-flake-version` job enforces, but locally and
+# before any bytes leave the machine — so you don't wait on a CI run
+# only to discover you forgot to run `make bump-version`.
+#
+# Stdin format (one line per ref being pushed):
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+
+set -eu
+
+flake_file="flake.nix"
+
+# If the flake isn't present, nothing to check.
+if [ ! -f "$flake_file" ]; then
+    exit 0
+fi
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Only care about version tags of the form refs/tags/vX.Y.Z[-suffix].
+    case "$local_ref" in
+        refs/tags/v[0-9]*) : ;;
+        *) continue ;;
+    esac
+
+    tag_name="${local_ref#refs/tags/}"
+    tag_version="${tag_name#v}"
+    # Strip pre-release suffix (-nightly, -rc, -beta, etc.) — compare base X.Y.Z.
+    base_tag="${tag_version%%-*}"
+
+    # Read the baseVersion from flake.nix at the tagged commit, so we validate
+    # what's actually being shipped (not the current working tree).
+    flake_version=$(git show "$local_sha:$flake_file" 2>/dev/null \
+        | grep -E '^\s*baseVersion\s*=' \
+        | sed -E 's/.*"([^"]+)".*/\1/' \
+        | head -n1 || true)
+
+    if [ -z "$flake_version" ]; then
+        echo "pre-push: warning: could not read baseVersion from $flake_file at $local_sha; skipping check for $tag_name" >&2
+        continue
+    fi
+
+    if [ "$base_tag" != "$flake_version" ]; then
+        cat >&2 <<EOF
+pre-push: refusing to push $tag_name
+  tag base version:    $base_tag
+  flake.nix baseVersion at $local_sha: $flake_version
+
+These must match. Recommended:
+  make release VERSION=$base_tag   # bumps flake.nix, commits, re-tags
+  git push && git push --tags
+
+Or manually:
+  git tag -d $tag_name
+  make bump-version VERSION=$base_tag
+  git add flake.nix && git commit -m "chore: bump version to v$base_tag"
+  git tag $tag_name
+  git push && git push --tags
+EOF
+        exit 1
+    fi
+done
+
+exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,34 @@ jobs:
             echo "nightly_date=" >> "$GITHUB_OUTPUT"
           fi
 
+  # Runs first (no needs) so a mismatched flake.nix fails the pipeline
+  # in seconds instead of waiting on build/test/lint/govulncheck.
+  verify-flake-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Verify flake.nix version matches tag
+        env:
+          TAG_REF: ${{ github.ref }}
+        run: |
+          TAG="${TAG_REF#refs/tags/}"
+          TAG_VERSION="${TAG#v}"
+          # Nightly/pre-release tags carry a suffix (e.g. 1.2.3-nightly.20260414);
+          # the flake version is the bare X.Y.Z.
+          BASE_TAG="${TAG_VERSION%%-*}"
+          FLAKE_VERSION=$(grep -E '^\s*baseVersion\s*=' flake.nix | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "Tag:   $BASE_TAG"
+          echo "Flake: $FLAKE_VERSION"
+          if [ "$BASE_TAG" != "$FLAKE_VERSION" ]; then
+            echo "::error::flake.nix baseVersion ($FLAKE_VERSION) does not match tag ($BASE_TAG)."
+            echo "::error::Run 'make release VERSION=$BASE_TAG' (or 'make bump-version') on the commit you want to tag, commit the change, then re-tag."
+            exit 1
+          fi
+
   build-and-test:
+    needs: [verify-flake-version]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,6 +87,7 @@ jobs:
         run: go test ./...
 
   lint:
+    needs: [verify-flake-version]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -76,6 +104,7 @@ jobs:
           version: latest
 
   govulncheck:
+    needs: [verify-flake-version]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -93,7 +122,7 @@ jobs:
         run: govulncheck ./...
 
   release:
-    needs: [detect, build-and-test, lint, govulncheck]
+    needs: [detect, build-and-test, lint, govulncheck, verify-flake-version]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,37 @@
-.PHONY: setup lint lint-fix test coverage build generate-themes sonar
+.PHONY: setup lint lint-fix test coverage build generate-themes sonar bump-version release
 
 setup:
 	git config core.hooksPath .githooks
+
+bump-version: ## Bump flake.nix baseVersion to $(VERSION) (usage: make bump-version VERSION=0.9.23)
+	@if [ -z "$(VERSION)" ]; then \
+		echo "usage: make bump-version VERSION=X.Y.Z"; exit 1; \
+	fi
+	@if ! echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "error: VERSION must be X.Y.Z (no leading v, no suffix); got: $(VERSION)"; exit 1; \
+	fi
+	@sed -i.bak -E 's/^(\s*baseVersion = )"[0-9]+\.[0-9]+\.[0-9]+";/\1"$(VERSION)";/' flake.nix && rm flake.nix.bak
+	@grep -n "baseVersion =" flake.nix
+
+release: setup ## Bump version, commit, and create tag in one step (usage: make release VERSION=0.9.23)
+	@if [ -z "$(VERSION)" ]; then \
+		echo "usage: make release VERSION=X.Y.Z"; exit 1; \
+	fi
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "error: working tree is not clean; commit or stash changes first"; \
+		git status --short; \
+		exit 1; \
+	fi
+	@if git rev-parse "v$(VERSION)" >/dev/null 2>&1; then \
+		echo "error: tag v$(VERSION) already exists"; exit 1; \
+	fi
+	@$(MAKE) --no-print-directory bump-version VERSION=$(VERSION)
+	@git add flake.nix
+	@git commit -m "chore: bump version to v$(VERSION)"
+	@git tag "v$(VERSION)"
+	@echo ""
+	@echo "Tag v$(VERSION) created. To publish:"
+	@echo "  git push && git push --tags"
 
 lint:
 	golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -143,6 +143,39 @@
 brew install janosmiko/tap/lfk
 ```
 
+### Nix (flake)
+
+Requires Nix ≥ 2.4 with flakes enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`).
+
+**Try without installing:**
+
+```bash
+nix run github:janosmiko/lfk
+# pinned to a release:
+nix run github:janosmiko/lfk/v0.9.22
+```
+
+**Install into your profile:**
+
+```bash
+nix profile install github:janosmiko/lfk
+# or a specific release:
+nix profile install github:janosmiko/lfk/v0.9.22
+```
+
+**Use as a flake input** (e.g. in a NixOS / home-manager config):
+
+```nix
+{
+  inputs.lfk.url = "github:janosmiko/lfk";
+
+  outputs = { self, nixpkgs, lfk, ... }: {
+    # ...
+    environment.systemPackages = [ lfk.packages.${system}.default ];
+  };
+}
+```
+
 ### Binary releases
 
 Download pre-built binaries from the [GitHub Releases](https://github.com/janosmiko/lfk/releases) page.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776864103,
+        "narHash": "sha256-osZwVCgGCfxrdi3W4x+zM31B60NvfDNe7oR3FPi+qyI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9cadaf6932b7c926e468f777549d57f04a7212da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "LFK is a lightning-fast, keyboard-focused, yazi-inspired terminal user interface for navigating and managing Kubernetes clusters. Built for speed and efficiency, it brings a three-column Miller columns layout with an owner-based resource hierarchy to your terminal.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          default = pkgs.buildGoModule {
+            pname = "lfk";
+            version = "v0.9.22";
+
+            src = ./.;
+
+            vendorHash = "sha256-mx5IuJLGtNx2WZUfF/TdubwOGCr0Wjy7s2zvzOXqyO0=";
+
+            meta = with pkgs.lib; {
+              description = "LFK is a lightning-fast Kubernetes navigator";
+              homepage = "https://github.com/janosmiko/lfk";
+              license = licenses.asl20;
+              maintainers = [ ];
+            };
+          };
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/lfk";
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,22 +16,44 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) lib;
+
+        # Single source of truth for the release version. Bumped by
+        # `make bump-version VERSION=X.Y.Z` before tagging; the release
+        # workflow verifies that this matches the pushed tag so the two
+        # can't drift. See docs/RELEASE.md for the full flow.
+        baseVersion = "0.9.24";
+        commit = self.shortRev or self.dirtyShortRev or "unknown";
+        version = "${baseVersion}-${commit}";
       in
       {
         packages = {
           default = pkgs.buildGoModule {
             pname = "lfk";
-            version = "v0.9.22";
+            inherit version;
 
             src = ./.;
 
             vendorHash = "sha256-mx5IuJLGtNx2WZUfF/TdubwOGCr0Wjy7s2zvzOXqyO0=";
 
-            meta = with pkgs.lib; {
+            subPackages = [ "." ];
+
+            # Matches the ldflag recipe documented in internal/version/version.go
+            # so `lfk --version` reports the flake-built version instead of "dev".
+            ldflags = [
+              "-s"
+              "-w"
+              "-X github.com/janosmiko/lfk/internal/version.Version=v${baseVersion}"
+              "-X github.com/janosmiko/lfk/internal/version.GitCommit=${commit}"
+            ];
+
+            enableParallelBuilding = true;
+
+            meta = {
               description = "LFK is a lightning-fast Kubernetes navigator";
               homepage = "https://github.com/janosmiko/lfk";
-              license = licenses.asl20;
-              maintainers = [ ];
+              license = lib.licenses.asl20;
+              mainProgram = "lfk";
             };
           };
         };


### PR DESCRIPTION
## Summary

Allow nix users to install or run lfk using flakes

example by doing : `nix run github:janosmiko/lfk`
or `nix run .`
or reference this repository as input in any flake.nix :

```nix
# flake.nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/master";
    lfk.url = "github:janosmiko/lfk";
  };
}
```

## Type of change

- [ ] feat: new user-facing feature
- [ ] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [x] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

<!-- e.g. Closes #123 -->

## Changes

<!-- Bullet list of the key changes. -->

-

## Testing

<!-- How did you verify this works? Include the cluster / terminal you tested against when relevant. -->

- [ ] `go build ./...` succeeds
- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [ ] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->
