### PR TITLE
fix: cancel log streams on tab close and quit

### DIFF
--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -124,6 +124,16 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 
 	switch canonical {
 	case "quit":
+		// Mirror the cleanup the other quit paths (closeTabOrQuit,
+		// handleQuitConfirmOverlayKey) perform before tea.Quit so that
+		// kubectl log streams started from any tab don't outlive the
+		// process. Without this, `:q` / `:q!` / `:quit` leaks the
+		// kubectl subprocess and its reader goroutine — issue #48.
+		if m.portForwardMgr != nil {
+			m.portForwardMgr.StopAll()
+		}
+		m.cancelAllTabLogStreams()
+		m.saveCurrentSession()
 		return m, tea.Quit
 
 	case "namespace":

--- a/internal/app/tab_close_cancel_test.go
+++ b/internal/app/tab_close_cancel_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// recordCancelFn returns a context.CancelFunc-shaped closure that pushes a
+// label onto the supplied slice when invoked. Lets tests assert which cancel
+// funcs were actually called without depending on real contexts/subprocesses.
+func recordCancelFn(label string, log *[]string) func() {
+	return func() { *log = append(*log, label) }
+}
+
+// modelWithLogCancels builds a 3-tab Model where the active tab has both
+// stream and history cancels populated, and each inactive tab has its
+// per-tab logCancel populated. (TabState only carries logCancel today;
+// logHistoryCancel lives only on Model — see app.go.) Mirrors the real
+// shape after a user has streamed logs in several tabs and switched
+// between them.
+func modelWithLogCancels(t *testing.T, calls *[]string) Model {
+	t.Helper()
+	tabs := []TabState{
+		{
+			nav:       model.NavigationState{Context: "prod", Level: model.LevelResources},
+			logCancel: recordCancelFn("tab0-stream", calls),
+		},
+		{
+			nav:       model.NavigationState{Context: "staging", Level: model.LevelResources},
+			logCancel: recordCancelFn("tab1-stream", calls),
+		},
+		{
+			nav:       model.NavigationState{Context: "dev", Level: model.LevelResources},
+			logCancel: recordCancelFn("tab2-stream", calls),
+		},
+	}
+	return Model{
+		tabs:               tabs,
+		activeTab:          1,
+		nav:                tabs[1].nav,
+		logCancel:          recordCancelFn("active-stream", calls),
+		logHistoryCancel:   recordCancelFn("active-history", calls),
+		width:              120,
+		height:             30,
+		mode:               modeExplorer,
+		selectedItems:      make(map[string]bool),
+		cursorMemory:       make(map[string]int),
+		itemCache:          make(map[string][]model.Item),
+		yamlCollapsed:      make(map[string]bool),
+		selectedNamespaces: make(map[string]bool),
+		selectionAnchor:    -1,
+	}
+}
+
+// --- cancelAllTabLogStreams: covers active + all per-tab cancels ---
+
+func TestCancelAllTabLogStreams_CancelsEveryStreamAndHistory(t *testing.T) {
+	var calls []string
+	m := modelWithLogCancels(t, &calls)
+
+	m.cancelAllTabLogStreams()
+
+	// Every cancel func should have fired exactly once. The order is not
+	// load-bearing, just the set.
+	assert.ElementsMatch(t,
+		[]string{
+			"active-stream", "active-history",
+			"tab0-stream",
+			"tab1-stream",
+			"tab2-stream",
+		},
+		calls,
+		"cancelAllTabLogStreams must cancel active stream + history AND every per-tab logCancel")
+
+	// All cancel pointers must be nil after calling so a second invocation
+	// is a no-op (idempotent).
+	assert.Nil(t, m.logCancel)
+	assert.Nil(t, m.logHistoryCancel)
+	for i := range m.tabs {
+		assert.Nilf(t, m.tabs[i].logCancel, "tab %d logCancel must be nil after helper", i)
+	}
+}
+
+func TestCancelAllTabLogStreams_IsIdempotent(t *testing.T) {
+	var calls []string
+	m := modelWithLogCancels(t, &calls)
+
+	m.cancelAllTabLogStreams()
+	m.cancelAllTabLogStreams() // second call must not double-fire any cancel
+
+	assert.Len(t, calls, 5, "second invocation must not re-fire any cancel")
+}
+
+// --- :quit / :q command-bar path must cancel log streams ---
+
+func TestQuitBuiltinCommandCancelsAllLogStreams(t *testing.T) {
+	tests := []string{"quit", "q", "q!"}
+	for _, cmd := range tests {
+		t.Run(cmd, func(t *testing.T) {
+			var calls []string
+			m := modelWithLogCancels(t, &calls)
+
+			_, teaCmd := m.executeBuiltinCommand(cmd)
+
+			assert.NotNil(t, teaCmd, ":%s should return a tea.Quit command", cmd)
+			// Whatever the order, every stream/history cancel must have fired.
+			assert.ElementsMatch(t,
+				[]string{
+					"active-stream", "active-history",
+					"tab0-stream",
+					"tab1-stream",
+					"tab2-stream",
+				},
+				calls,
+				":%s must cancel every active and per-tab log stream and history fetch — issue #48 leak path", cmd)
+		})
+	}
+}
+
+// --- Tab-close branch only cancels the closing tab's streams ---
+// Closing ONE tab when multiple exist must not kill streams in the OTHER
+// tabs. The user only asked to close one tab — sibling streams continue.
+
+func TestCloseTabOrQuit_LeavesOtherTabsStreamsRunning(t *testing.T) {
+	var calls []string
+	m := modelWithLogCancels(t, &calls)
+	// activeTab is 1 (staging). Closing it must cancel ONLY the active
+	// tab's cancels, not tab 0 or tab 2.
+
+	_, _ = m.closeTabOrQuit()
+
+	assert.ElementsMatch(t,
+		[]string{"active-stream", "active-history"},
+		calls,
+		"tab close must cancel only the active tab's stream + history; sibling tabs keep streaming")
+}
+
+// --- Single-tab quit path (no confirm) cancels everything ---
+
+func TestCloseTabOrQuit_NoConfirmQuitCancelsAllStreams(t *testing.T) {
+	orig := ui.ConfigConfirmOnExit
+	ui.ConfigConfirmOnExit = false
+	t.Cleanup(func() { ui.ConfigConfirmOnExit = orig })
+
+	var calls []string
+	m := Model{
+		tabs: []TabState{{
+			nav:       model.NavigationState{Context: "prod", Level: model.LevelResources},
+			logCancel: recordCancelFn("tab0-stream", &calls),
+		}},
+		activeTab:          0,
+		nav:                model.NavigationState{Context: "prod", Level: model.LevelResources},
+		logCancel:          recordCancelFn("active-stream", &calls),
+		logHistoryCancel:   recordCancelFn("active-history", &calls),
+		width:              120,
+		height:             30,
+		selectedItems:      make(map[string]bool),
+		cursorMemory:       make(map[string]int),
+		itemCache:          make(map[string][]model.Item),
+		yamlCollapsed:      make(map[string]bool),
+		selectedNamespaces: make(map[string]bool),
+	}
+
+	_, teaCmd := m.closeTabOrQuit()
+	assert.NotNil(t, teaCmd, "single-tab close with confirm-off must return tea.Quit")
+	assert.ElementsMatch(t,
+		[]string{
+			"active-stream", "active-history",
+			"tab0-stream",
+		},
+		calls,
+		"no-confirm quit must cancel everything (active + per-tab)")
+}

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -1308,10 +1308,35 @@ func (m Model) refreshCurrentLevel() tea.Cmd {
 	return nil
 }
 
+func (m *Model) cancelAllTabLogStreams() {
+	if m.logCancel != nil {
+		m.logCancel()
+		m.logCancel = nil
+	}
+	if m.logHistoryCancel != nil {
+		m.logHistoryCancel()
+		m.logHistoryCancel = nil
+	}
+	for i := range m.tabs {
+		if m.tabs[i].logCancel != nil {
+			m.tabs[i].logCancel()
+			m.tabs[i].logCancel = nil
+		}
+	}
+}
+
 // closeTabOrQuit closes the current tab if multiple tabs are open,
 // otherwise quits the application (with optional confirmation).
 func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 	if len(m.tabs) > 1 {
+		if m.logCancel != nil {
+			m.logCancel()
+			m.logCancel = nil
+		}
+		if m.logHistoryCancel != nil {
+			m.logHistoryCancel()
+			m.logHistoryCancel = nil
+		}
 		m.tabs = append(m.tabs[:m.activeTab], m.tabs[m.activeTab+1:]...)
 		if m.activeTab > 0 {
 			m.activeTab--
@@ -1334,6 +1359,7 @@ func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 	if m.portForwardMgr != nil {
 		m.portForwardMgr.StopAll()
 	}
+	m.cancelAllTabLogStreams()
 	m.saveCurrentSession()
 	return m, tea.Quit
 }

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -1308,7 +1308,11 @@ func (m Model) refreshCurrentLevel() tea.Cmd {
 	return nil
 }
 
-func (m *Model) cancelAllTabLogStreams() {
+// cancelActiveTabLogStreams cancels the live (Model-level) log stream
+// and history-fetch contexts. Used by tab-close paths so the closing
+// tab's kubectl subprocess + reader goroutine exit immediately, while
+// sibling tabs' streams (held in TabState.logCancel) keep running.
+func (m *Model) cancelActiveTabLogStreams() {
 	if m.logCancel != nil {
 		m.logCancel()
 		m.logCancel = nil
@@ -1317,6 +1321,14 @@ func (m *Model) cancelAllTabLogStreams() {
 		m.logHistoryCancel()
 		m.logHistoryCancel = nil
 	}
+}
+
+// cancelAllTabLogStreams cancels every log stream owned by the Model:
+// the active tab's stream + history (held on Model) and every inactive
+// tab's stream (held in TabState.logCancel). Used by quit paths so no
+// kubectl subprocess or reader goroutine outlives the lfk process.
+func (m *Model) cancelAllTabLogStreams() {
+	m.cancelActiveTabLogStreams()
 	for i := range m.tabs {
 		if m.tabs[i].logCancel != nil {
 			m.tabs[i].logCancel()
@@ -1329,14 +1341,7 @@ func (m *Model) cancelAllTabLogStreams() {
 // otherwise quits the application (with optional confirmation).
 func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 	if len(m.tabs) > 1 {
-		if m.logCancel != nil {
-			m.logCancel()
-			m.logCancel = nil
-		}
-		if m.logHistoryCancel != nil {
-			m.logHistoryCancel()
-			m.logHistoryCancel = nil
-		}
+		m.cancelActiveTabLogStreams()
 		m.tabs = append(m.tabs[:m.activeTab], m.tabs[m.activeTab+1:]...)
 		if m.activeTab > 0 {
 			m.activeTab--

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -327,6 +327,14 @@ func (m Model) handleExplorerEsc() (tea.Model, tea.Cmd) {
 	}
 	if m.nav.Level == model.LevelClusters {
 		if len(m.tabs) > 1 {
+			if m.logCancel != nil {
+				m.logCancel()
+				m.logCancel = nil
+			}
+			if m.logHistoryCancel != nil {
+				m.logHistoryCancel()
+				m.logHistoryCancel = nil
+			}
 			m.tabs = append(m.tabs[:m.activeTab], m.tabs[m.activeTab+1:]...)
 			if m.activeTab > 0 {
 				m.activeTab--
@@ -338,6 +346,7 @@ func (m Model) handleExplorerEsc() (tea.Model, tea.Cmd) {
 			}
 			return m, m.loadPreview()
 		}
+		m.cancelAllTabLogStreams()
 		return m, tea.Quit
 	}
 	return m.navigateParent()

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -327,14 +327,7 @@ func (m Model) handleExplorerEsc() (tea.Model, tea.Cmd) {
 	}
 	if m.nav.Level == model.LevelClusters {
 		if len(m.tabs) > 1 {
-			if m.logCancel != nil {
-				m.logCancel()
-				m.logCancel = nil
-			}
-			if m.logHistoryCancel != nil {
-				m.logHistoryCancel()
-				m.logHistoryCancel = nil
-			}
+			m.cancelActiveTabLogStreams()
 			m.tabs = append(m.tabs[:m.activeTab], m.tabs[m.activeTab+1:]...)
 			if m.activeTab > 0 {
 				m.activeTab--

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -1086,6 +1086,7 @@ func (m Model) handleQuitConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		if m.portForwardMgr != nil {
 			m.portForwardMgr.StopAll()
 		}
+		m.cancelAllTabLogStreams()
 		m.saveCurrentSession()
 		return m, tea.Quit
 	case "n", "N", "esc", "q":


### PR DESCRIPTION
## Summary

Closing a tab — or quitting lfk — while the log viewer has an active stream leaks both the `kubectl logs -f` subprocess and the goroutine reading from it. The kubectl subprocess is tied to `ctx` via `exec.CommandContext` in `startLogStream`, but `ctx` derives from `context.Background()`, so the only way to stop it is the cancel func stored in `m.logCancel` / `TabState.logCancel`. Four lifecycle paths skipped that cancel:

- `closeTabOrQuit` tab-close branch (`internal/app/update_actions.go`)
- `handleExplorerEsc` duplicate close path (`internal/app/update_keys.go`)
- `closeTabOrQuit` no-confirm quit branch (`internal/app/update_actions.go`)
- `handleQuitConfirmOverlayKey` (`internal/app/update_overlays.go`)

This PR adds a small `cancelAllTabLogStreams()` helper that cancels both the active tab's live cancels (held on the Model) and the per-tab cancels held in `TabState`, then wires it (and the per-tab live-cancel pattern) into all four sites.

## Type of change

- [ ] feat: new user-facing feature
- [x] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

Closes #48

## Changes

- New `(*Model).cancelAllTabLogStreams()` helper in `update_actions.go` that cancels `m.logCancel`, `m.logHistoryCancel`, and every `TabState.logCancel` in `m.tabs`.
- `closeTabOrQuit` (canonical) — cancel the active tab's `logCancel` / `logHistoryCancel` before the slice splice; call `cancelAllTabLogStreams()` on the no-confirm quit branch.
- `handleExplorerEsc` (the duplicated tab-close path triggered by `Esc` from cluster level) — same cancel-before-splice + `cancelAllTabLogStreams()` on the last-tab quit branch.
- `handleQuitConfirmOverlayKey` — call `cancelAllTabLogStreams()` before `tea.Quit`.

## Testing

Verified on macOS 14.8.2 against a live cluster (kubectl v1.34.1).

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (`golangci-lint 2.11.4`, `--fix` reported `0 issues.`)
- [x] Manually verified against a real cluster (when behavior changed)

**Repro / verification recipe** (the same recipe used to confirm the leak before the fix):

1. Start lfk against any cluster.
2. In another terminal: `pgrep -af "kubectl logs"` — should be 0.
3. In lfk: navigate to a pod, open log viewer (Enter), confirm logs are streaming.
4. Open a second tab, switch back to the log tab.
5. `Ctrl+C` to close the log tab.
6. `pgrep -af "kubectl logs"` — was 1 (leaked) before this change, now 0.
7. Repeated for the multi-tab quit path: open three tabs each streaming logs from a different pod, press `q`, confirm with Enter — all three kubectl subprocesses now exit immediately.

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

N/A — no UI changes.
