### PR TITLE
feat: persistent up/down history for / and f search/filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ All search and filter inputs support three modes, auto-detected from the query s
 
 **Clipboard paste**: All search, filter, and command bar inputs accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). Multiline paste shows a confirmation dialog.
 
+**Recall previous queries**: While the `f` filter or `/` search input is open, press `Up` / `Down` to cycle through previous queries. `/` and `f` share one history (the matcher and matched fields are identical between them), kept separate from the `:` command bar. Both persist across sessions under `$XDG_STATE_HOME/lfk/` (default `~/.local/state/lfk/`) — `query-history` for `/` and `f`, `history` for the command bar.
+
 ## Contributing
 
 Contributions are welcome! Here is how to get started.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -59,11 +59,14 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `f` | Start filter mode (filter items in current view) |
 | `/` | Start search mode (search and jump to match) |
 | `Tab` | Inside `/` or `f`: toggle broad mode — also matches against column values (annotations, labels, finalizers, CRD printer columns, custom user columns). Prompt shows `filter (all):` / `search (all):` while on. Resets on Enter/Esc. |
+| `Up` / `Down` | Inside `/` or `f`: cycle through previous queries (shared persistent history). |
 | `n` | Jump to next search match |
 | `N` | Jump to previous search match |
 | `Esc` | Clear filter / cancel search |
 
 Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
+
+`/` and `f` share one persistent history at `$XDG_STATE_HOME/lfk/query-history` (default `~/.local/state/lfk/query-history`) — both inputs accept the same query syntax and match against the same fields, so a query confirmed in one mode is recallable from the other. The `:` command bar keeps its own `history` file because its inputs are kubectl-shaped commands rather than resource-name queries.
 
 ## Actions
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -797,6 +797,7 @@ type Model struct {
 	commandBarSelectedSuggestion int
 	commandBarPreview            string // ghost text shown dimmed after cursor (tab preview)
 	commandHistory               *commandHistory
+	queryHistory                 *commandHistory // shared by explorer / search and f filter
 
 	// Cached namespace names for command bar autocompletion, keyed by
 	// context name. Each tab may have its own nav.Context, so keying by
@@ -959,6 +960,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		pendingSession:      loadSession(),
 		pendingPortForwards: loadPortForwardState(),
 		commandHistory:      loadCommandHistory(),
+		queryHistory:        loadInputHistory(historyFileQuery),
 		pinnedState:         pinnedSt,
 		namespace:           defaultNS,
 		spinner:             s,

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -8,16 +8,36 @@ import (
 
 const maxHistoryEntries = 500
 
-// commandHistory manages persistent shell command history for the command bar.
+// Filenames for the persistent input histories under $XDG_STATE_HOME/lfk/.
+// `/` (search) and `f` (filter) share one file: the query syntax and matched
+// fields are identical between the two, only the action on a match differs
+// (jump vs. narrow), so users want to recall the same query regardless of
+// which mode they re-enter. The `:` command bar stays separate because its
+// inputs are kubectl-shaped commands, not resource-name queries.
+const (
+	historyFileCommand = "history"
+	historyFileQuery   = "query-history"
+)
+
+// commandHistory manages a persistent ring of recent text-input entries.
+// Used by the command bar and (per filename) the explorer search and
+// filter inputs.
 type commandHistory struct {
-	entries []string
-	cursor  int    // -1 means "not browsing history" (typing new command)
-	draft   string // saves what the user was typing before browsing history
+	entries  []string
+	cursor   int    // -1 means "not browsing history" (typing new command)
+	draft    string // saves what the user was typing before browsing history
+	filename string // file under $XDG_STATE_HOME/lfk/; empty = command bar (back-compat)
 }
 
-// historyFilePath returns the path to the command history file.
+// historyFilePath returns the path to the command bar history file.
 // Uses $XDG_STATE_HOME/lfk/history (defaults to ~/.local/state/lfk/history).
 func historyFilePath() string {
+	return historyFilePathFor(historyFileCommand)
+}
+
+// historyFilePathFor returns the path to the named history file. Returns
+// "" when the home directory cannot be resolved.
+func historyFilePathFor(name string) string {
 	stateDir := os.Getenv("XDG_STATE_HOME")
 	if stateDir == "" {
 		home, err := os.UserHomeDir()
@@ -26,13 +46,20 @@ func historyFilePath() string {
 		}
 		stateDir = filepath.Join(home, ".local", "state")
 	}
-	return filepath.Join(stateDir, "lfk", "history")
+	return filepath.Join(stateDir, "lfk", name)
 }
 
-// loadCommandHistory reads command history from disk and returns a new commandHistory.
+// loadCommandHistory reads command bar history from disk.
 func loadCommandHistory() *commandHistory {
-	h := &commandHistory{cursor: -1}
-	path := historyFilePath()
+	return loadInputHistory(historyFileCommand)
+}
+
+// loadInputHistory reads the named history file from disk and returns a new
+// commandHistory bound to that filename. The filename is used by save() so
+// every loaded instance writes back to the file it came from.
+func loadInputHistory(name string) *commandHistory {
+	h := &commandHistory{cursor: -1, filename: name}
+	path := historyFilePathFor(name)
 	if path == "" {
 		return h
 	}
@@ -54,8 +81,12 @@ func loadCommandHistory() *commandHistory {
 }
 
 // add appends a command to the history. Empty commands and consecutive
-// duplicates are ignored.
+// duplicates are ignored. Nil receiver is a no-op so test models that
+// don't initialize history don't panic.
 func (h *commandHistory) add(cmd string) {
+	if h == nil {
+		return
+	}
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return
@@ -71,9 +102,16 @@ func (h *commandHistory) add(cmd string) {
 	}
 }
 
-// save writes the current history entries to disk.
+// save writes the current history entries to disk. Nil receiver no-op.
 func (h *commandHistory) save() {
-	path := historyFilePath()
+	if h == nil {
+		return
+	}
+	name := h.filename
+	if name == "" {
+		name = historyFileCommand
+	}
+	path := historyFilePathFor(name)
 	if path == "" {
 		return
 	}
@@ -87,8 +125,9 @@ func (h *commandHistory) save() {
 // up navigates to the previous (older) history entry.
 // On the first call, it saves the current input as a draft.
 // Returns the history entry to display in the command bar.
+// Nil receiver returns currentInput unchanged.
 func (h *commandHistory) up(currentInput string) string {
-	if len(h.entries) == 0 {
+	if h == nil || len(h.entries) == 0 {
 		return currentInput
 	}
 	if h.cursor == -1 {
@@ -104,7 +143,11 @@ func (h *commandHistory) up(currentInput string) string {
 // down navigates to the next (newer) history entry.
 // If at the end of history, restores the saved draft.
 // Returns the text to display in the command bar.
+// Nil receiver returns "".
 func (h *commandHistory) down() string {
+	if h == nil {
+		return ""
+	}
 	if h.cursor == -1 {
 		return h.draft
 	}
@@ -117,7 +160,11 @@ func (h *commandHistory) down() string {
 }
 
 // reset resets the cursor position, clearing any history browsing state.
+// Nil receiver no-op.
 func (h *commandHistory) reset() {
+	if h == nil {
+		return
+	}
 	h.cursor = -1
 	h.draft = ""
 }

--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -252,3 +252,67 @@ func TestCovCommandHistorySaveLoad(t *testing.T) {
 	assert.Equal(t, "test command 1", h2.entries[0])
 	assert.Equal(t, "test command 2", h2.entries[1])
 }
+
+// --- loadInputHistory: per-name files stay isolated ---
+
+// TestLoadInputHistoryIsolatesQueryFromCommand pins the one separation
+// that still matters after `/` and `f` were merged into a single
+// query-history: kubectl-shaped `:` command bar entries must not appear
+// when recalling `/`/`f` queries. Without isolation, pressing Up in `/`
+// would surface ":get pods" as a suggested resource-name pattern.
+func TestLoadInputHistoryIsolatesQueryFromCommand(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	qh := loadInputHistory(historyFileQuery)
+	qh.add("nginx")
+	qh.save()
+
+	ch := loadCommandHistory()
+	ch.add(":get pods")
+	ch.save()
+
+	// Reload from disk and verify no cross-contamination between the two
+	// distinct files.
+	gotQuery := loadInputHistory(historyFileQuery)
+	gotCmd := loadCommandHistory()
+
+	assert.Equal(t, []string{"nginx"}, gotQuery.entries)
+	assert.Equal(t, []string{":get pods"}, gotCmd.entries)
+}
+
+// TestSavePreservesFilenameAcrossSaves verifies a loaded instance keeps
+// writing back to the same file, rather than silently defaulting to
+// "history" after the first save.
+func TestSavePreservesFilenameAcrossSaves(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	h := loadInputHistory(historyFileQuery)
+	h.add("first")
+	h.save()
+	h.add("second")
+	h.save()
+
+	// File must exist at the query-history path, NOT at "history".
+	_, err := os.Stat(filepath.Join(tmp, "lfk", historyFileQuery))
+	require.NoError(t, err, "query-history file must exist after save")
+
+	_, err = os.Stat(filepath.Join(tmp, "lfk", historyFileCommand))
+	assert.Error(t, err, "command history file must NOT be created by query saves")
+}
+
+// --- nil-safe methods ---
+
+// Nil receiver tolerance lets test models that don't initialize history
+// pointers exercise the filter/search Enter/Esc paths without panicking.
+// This mirrors how the rest of the Model fields are partially-init in
+// test factories — a regression here would fail dozens of tests at once.
+func TestCommandHistoryNilSafe(t *testing.T) {
+	var h *commandHistory
+
+	assert.NotPanics(t, func() { h.add("anything") })
+	assert.NotPanics(t, func() { h.save() })
+	assert.NotPanics(t, func() { h.reset() })
+	assert.Equal(t, "draft", h.up("draft"))
+	assert.Empty(t, h.down())
+}

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -625,6 +625,14 @@ func keyMsg(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyHome}
 	case "end":
 		return tea.KeyMsg{Type: tea.KeyEnd}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
 	default:
 		if len(s) == 1 {
 			return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -785,6 +785,7 @@ func (m Model) handleKeyFilter() Model {
 	m.filterText = ""
 	m.setCursor(0)
 	m.clampCursor()
+	m.queryHistory.reset()
 	return m
 }
 
@@ -793,6 +794,7 @@ func (m Model) handleKeySearch() Model {
 	m.searchBroadMode = false // each fresh search session starts in name-only
 	m.searchInput.Clear()
 	m.searchPrevCursor = m.cursor()
+	m.queryHistory.reset()
 	return m
 }
 

--- a/internal/app/update_search.go
+++ b/internal/app/update_search.go
@@ -352,6 +352,11 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = m.filterInput.Value
 			m.setCursor(0)
 			m.clampCursor()
+			// Editing a recalled entry leaves history navigation: the
+			// edited text becomes the new draft, so a later Down past
+			// newest restores the edits, not the original pre-recall
+			// draft.
+			m.queryHistory.reset()
 		}
 		return m, nil
 	case "ctrl+w":
@@ -359,12 +364,14 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filterText = m.filterInput.Value
 		m.setCursor(0)
 		m.clampCursor()
+		m.queryHistory.reset()
 		return m, nil
 	case "ctrl+u":
 		m.filterInput.DeleteLine()
 		m.filterText = m.filterInput.Value
 		m.setCursor(0)
 		m.clampCursor()
+		m.queryHistory.reset()
 		return m, nil
 	case "ctrl+a":
 		m.filterInput.Home()
@@ -387,6 +394,7 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = m.filterInput.Value
 			m.setCursor(0)
 			m.clampCursor()
+			m.queryHistory.reset()
 		}
 		return m, nil
 	}
@@ -450,15 +458,20 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(m.searchInput.Value) > 0 {
 			m.searchInput.Backspace()
 			m.jumpToSearchMatch(0)
+			// Editing a recalled entry leaves history navigation; see
+			// the analogous comment in handleFilterKey for rationale.
+			m.queryHistory.reset()
 		}
 		return m, nil
 	case "ctrl+w":
 		m.searchInput.DeleteWord()
 		m.jumpToSearchMatch(0)
+		m.queryHistory.reset()
 		return m, nil
 	case "ctrl+u":
 		m.searchInput.DeleteLine()
 		m.jumpToSearchMatch(0)
+		m.queryHistory.reset()
 		return m, nil
 	case "ctrl+a":
 		m.searchInput.Home()
@@ -485,6 +498,7 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(key) == 1 && key[0] >= 32 && key[0] < 127 {
 			m.searchInput.Insert(key)
 			m.jumpToSearchMatch(0)
+			m.queryHistory.reset()
 		}
 		return m, nil
 	}

--- a/internal/app/update_search.go
+++ b/internal/app/update_search.go
@@ -307,6 +307,8 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// input starts via handleKeyFilter.
 		m.setCursor(0)
 		m.clampCursor()
+		m.queryHistory.add(m.filterInput.Value)
+		m.queryHistory.save()
 		// The cursor now points at the first filter match — a different
 		// item than before. Without invalidation the right pane keeps
 		// rendering the previous selection's rightItems (and skips the
@@ -324,6 +326,18 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.clampCursor()
 		m.invalidatePreviewForCursorChange()
 		return m, m.loadPreview()
+	case "up":
+		m.filterInput.Set(m.queryHistory.up(m.filterInput.Value))
+		m.filterText = m.filterInput.Value
+		m.setCursor(0)
+		m.clampCursor()
+		return m, nil
+	case "down":
+		m.filterInput.Set(m.queryHistory.down())
+		m.filterText = m.filterInput.Value
+		m.setCursor(0)
+		m.clampCursor()
+		return m, nil
 	case "tab":
 		// Toggle broad mode: also match against column values
 		// (annotations, labels, finalizers, CRD printer columns, ...).
@@ -398,6 +412,8 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Keep searchBroadMode as-is so n/N (jumpToSearchMatch reads
 		// this flag) stay in the same scope as the just-confirmed query.
 		// Reset on Esc or when a new search starts via handleKeySearch.
+		m.queryHistory.add(m.searchInput.Value)
+		m.queryHistory.save()
 		m.syncExpandedGroup()
 		// Confirming the search lands the cursor on a different item than
 		// when search started. Invalidate so the right pane drops the
@@ -417,6 +433,14 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// so the preview must invalidate here too.
 		m.invalidatePreviewForCursorChange()
 		return m, m.loadPreview()
+	case "up":
+		m.searchInput.Set(m.queryHistory.up(m.searchInput.Value))
+		m.jumpToSearchMatch(0)
+		return m, nil
+	case "down":
+		m.searchInput.Set(m.queryHistory.down())
+		m.jumpToSearchMatch(0)
+		return m, nil
 	case "tab":
 		// Toggle broad mode: searchMatchesItem also walks column values.
 		m.searchBroadMode = !m.searchBroadMode

--- a/internal/app/update_search_test.go
+++ b/internal/app/update_search_test.go
@@ -5,6 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
@@ -630,6 +631,110 @@ func TestHandleKeySearchResetsHistoryCursor(t *testing.T) {
 
 	assert.Equal(t, -1, rm.queryHistory.cursor)
 	assert.Empty(t, rm.queryHistory.draft)
+}
+
+// TestHandleFilterKeyEditAfterRecallPreservesEdits pins the fix for the
+// "edits to a recalled query are silently dropped" UX bug. Sequence:
+// type a draft, Up to recall an entry, edit the recalled text, Down past
+// the newest entry. The expected behavior is that Down restores the
+// edited text — not the pre-recall draft. Without resetting the cursor
+// on a typing keystroke, the history navigation state lingers and the
+// edits get overwritten.
+func TestHandleFilterKeyEditAfterRecallPreservesEdits(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("default")
+	m.filterActive = true
+	m.filterInput.Set("ngi")
+
+	// Up: recall "default", original draft "ngi" is saved.
+	result, _ := m.handleFilterKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "default", m.filterInput.Value)
+
+	// User edits the recalled text by typing one character. This should
+	// "leave" history navigation — cursor reset, original draft cleared.
+	result, _ = m.handleFilterKey(keyMsg("x"))
+	m = result.(Model)
+	assert.Equal(t, "defaultx", m.filterInput.Value)
+	assert.Equal(t, -1, m.queryHistory.cursor, "typing must reset history cursor")
+
+	// Up again now saves "defaultx" as the new draft and jumps to the
+	// most-recent entry.
+	result, _ = m.handleFilterKey(keyMsg("up"))
+	m = result.(Model)
+	assert.Equal(t, "default", m.filterInput.Value)
+
+	// Down past newest must restore the edited text, not "ngi".
+	result, _ = m.handleFilterKey(keyMsg("down"))
+	m = result.(Model)
+	assert.Equal(t, "defaultx", m.filterInput.Value)
+}
+
+// TestHandleFilterKeyBackspaceAfterRecallResetsHistory: backspace is
+// also an edit and must reset the history cursor. Same rationale as
+// TestHandleFilterKeyEditAfterRecallPreservesEdits.
+func TestHandleFilterKeyBackspaceAfterRecallResetsHistory(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("default")
+	m.filterActive = true
+	m.filterInput.Set("ngi")
+
+	result, _ := m.handleFilterKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "default", m.filterInput.Value)
+
+	result, _ = m.handleFilterKey(keyMsg("backspace"))
+	m = result.(Model)
+	assert.Equal(t, "defaul", m.filterInput.Value)
+	assert.Equal(t, -1, m.queryHistory.cursor, "backspace must reset history cursor")
+}
+
+// TestHandleSearchKeyEditAfterRecallPreservesEdits is the / search
+// counterpart to the filter test.
+func TestHandleSearchKeyEditAfterRecallPreservesEdits(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("redis")
+	m.searchActive = true
+	m.searchInput.Set("ngi")
+
+	result, _ := m.handleSearchKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "redis", m.searchInput.Value)
+
+	result, _ = m.handleSearchKey(keyMsg("x"))
+	m = result.(Model)
+	assert.Equal(t, "redisx", m.searchInput.Value)
+	assert.Equal(t, -1, m.queryHistory.cursor, "typing must reset history cursor")
+
+	result, _ = m.handleSearchKey(keyMsg("up"))
+	m = result.(Model)
+	assert.Equal(t, "redis", m.searchInput.Value)
+
+	result, _ = m.handleSearchKey(keyMsg("down"))
+	m = result.(Model)
+	assert.Equal(t, "redisx", m.searchInput.Value)
+}
+
+// TestHandleSearchKeyBackspaceAfterRecallResetsHistory: backspace must
+// also reset history navigation in / search mode.
+func TestHandleSearchKeyBackspaceAfterRecallResetsHistory(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("redis")
+	m.searchActive = true
+	m.searchInput.Set("ngi")
+
+	result, _ := m.handleSearchKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "redis", m.searchInput.Value)
+
+	result, _ = m.handleSearchKey(keyMsg("backspace"))
+	m = result.(Model)
+	assert.Equal(t, "redi", m.searchInput.Value)
+	assert.Equal(t, -1, m.queryHistory.cursor, "backspace must reset history cursor")
 }
 
 func TestCovHandleFilterKeyEnter(t *testing.T) {

--- a/internal/app/update_search_test.go
+++ b/internal/app/update_search_test.go
@@ -483,6 +483,155 @@ func TestPush4HandleSearchKeyEnter(t *testing.T) {
 	assert.False(t, rm.searchActive)
 }
 
+// --- search/filter history navigation (up/down) ---
+
+// TestHandleFilterKeyUpRecallsHistory exercises the user-facing feature:
+// pressing Up while the filter input is open replaces the input with the
+// most-recent persisted query. Primary acceptance test for query recall.
+func TestHandleFilterKeyUpRecallsHistory(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("kube-system")
+	m.queryHistory.add("default")
+	m.filterActive = true
+
+	result, _ := m.handleFilterKey(keyMsg("up"))
+	rm := result.(Model)
+
+	// Most recent entry surfaces first; filterText must mirror the input
+	// so visibleMiddleItems narrows immediately, not on the next keystroke.
+	assert.Equal(t, "default", rm.filterInput.Value)
+	assert.Equal(t, "default", rm.filterText)
+}
+
+// TestHandleFilterKeyUpDownCycles walks the full up/up/down sequence to
+// pin the cycling semantics: Up moves to older entries, Down moves
+// toward newer + finally restores the draft when past the newest.
+func TestHandleFilterKeyUpDownCycles(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("first")
+	m.queryHistory.add("second")
+	m.filterActive = true
+	m.filterInput.Set("partial-typed")
+
+	// Up: most recent → "second", original input saved as draft.
+	result, _ := m.handleFilterKey(keyMsg("up"))
+	m = result.(Model)
+	assert.Equal(t, "second", m.filterInput.Value)
+
+	// Up again: older → "first".
+	result, _ = m.handleFilterKey(keyMsg("up"))
+	m = result.(Model)
+	assert.Equal(t, "first", m.filterInput.Value)
+
+	// Down: back toward newer → "second".
+	result, _ = m.handleFilterKey(keyMsg("down"))
+	m = result.(Model)
+	assert.Equal(t, "second", m.filterInput.Value)
+
+	// Down past newest: draft restored.
+	result, _ = m.handleFilterKey(keyMsg("down"))
+	m = result.(Model)
+	assert.Equal(t, "partial-typed", m.filterInput.Value)
+}
+
+// TestHandleFilterKeyEnterPersistsToHistory pins the contract that
+// Enter both confirms the filter AND records it for next session — the
+// "people search the same things" motivation for persistence.
+func TestHandleFilterKeyEnterPersistsToHistory(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.filterActive = true
+	m.filterInput.Set("nginx")
+
+	result, _ := m.handleFilterKey(keyMsg("enter"))
+	rm := result.(Model)
+
+	assert.Equal(t, []string{"nginx"}, rm.queryHistory.entries)
+}
+
+// TestHandleSearchKeyUpRecallsHistory is the analogue for the / search
+// path: Up replaces the search input with the most-recent saved query.
+func TestHandleSearchKeyUpRecallsHistory(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("redis")
+	m.queryHistory.add("nginx")
+	m.searchActive = true
+
+	result, _ := m.handleSearchKey(keyMsg("up"))
+	rm := result.(Model)
+
+	assert.Equal(t, "nginx", rm.searchInput.Value)
+}
+
+// TestHandleSearchKeyEnterPersistsToHistory pins the / search Enter
+// path: confirming a search saves it for recall in a later session.
+func TestHandleSearchKeyEnterPersistsToHistory(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.searchActive = true
+	m.searchInput.Set("payments")
+
+	result, _ := m.handleSearchKey(keyMsg("enter"))
+	rm := result.(Model)
+
+	assert.Equal(t, []string{"payments"}, rm.queryHistory.entries)
+}
+
+// TestSearchAndFilterShareHistory pins the design decision that `/` and
+// `f` write to and read from a single shared history. A query confirmed
+// in one mode must be recallable from the other — without this, users
+// who happen to remember "I typed nginx as a search" vs. "as a filter"
+// see different recall results, which was the awkwardness the merge was
+// meant to remove.
+func TestSearchAndFilterShareHistory(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+
+	// Confirm a query in filter mode.
+	m.filterActive = true
+	m.filterInput.Set("nginx")
+	result, _ := m.handleFilterKey(keyMsg("enter"))
+	m = result.(Model)
+
+	// Now switch to search mode and press Up — must recall the filter
+	// query. Validates a single shared store backs both inputs.
+	m.searchActive = true
+	m.searchInput.Clear()
+	result, _ = m.handleSearchKey(keyMsg("up"))
+	rm := result.(Model)
+
+	assert.Equal(t, "nginx", rm.searchInput.Value, "search must recall a query confirmed in filter mode")
+}
+
+// TestHandleKeyFilterResetsHistoryCursor guards the "fresh session"
+// invariant: opening the filter with `f` resets the history cursor so
+// the first Up always starts from the newest entry, not from wherever
+// a prior session left off.
+func TestHandleKeyFilterResetsHistoryCursor(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: 0, draft: "stale"}
+
+	rm := m.handleKeyFilter()
+
+	assert.Equal(t, -1, rm.queryHistory.cursor)
+	assert.Empty(t, rm.queryHistory.draft)
+}
+
+// TestHandleKeySearchResetsHistoryCursor mirrors the filter case for
+// the / search entry point.
+func TestHandleKeySearchResetsHistoryCursor(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: 2, draft: "stale"}
+
+	rm := m.handleKeySearch()
+
+	assert.Equal(t, -1, rm.queryHistory.cursor)
+	assert.Empty(t, rm.queryHistory.draft)
+}
+
 func TestCovHandleFilterKeyEnter(t *testing.T) {
 	m := baseModelCov()
 	m.cursors = [5]int{}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -64,6 +64,7 @@ func helpSections() []helpSection {
 				{kb.Help + " / F1", "Toggle help screen"},
 				{kb.Filter, "Filter items (~prefix: fuzzy, regex auto-detected, \\prefix: literal)"},
 				{kb.Search, "Search and jump to match (~fuzzy, regex auto, \\literal)"},
+				{"", "Up/Down inside filter or search recalls previous queries (shared, persistent across sessions)."},
 				{"", "Paste from clipboard: Cmd+V (macOS) / Ctrl+Shift+V (Linux). Multiline asks to confirm."},
 				{kb.NextMatch, "Next search match"},
 				{kb.PrevMatch, "Previous search match"},


### PR DESCRIPTION
## Summary

Adds persistent Up/Down history navigation to the `/` search and `f` filter inputs, mirroring the affordance the `:` command bar already has. Closes the gap where users re-type the same namespace prefixes, label patterns, and pod-name fragments every time lfk starts.

## Type of change

- [x] feat: new user-facing feature

## Related issue

Closes #54

## Changes

- New shared history (`m.queryHistory`) backs both `/` and `f`. One file because both inputs accept the same query syntax and match the same fields — a query confirmed in one mode is recallable from the other.
- Persists to `$XDG_STATE_HOME/lfk/query-history` (default `~/.local/state/lfk/query-history`). The existing `:` command bar `history` file is unchanged.
- `internal/app/history.go`: generalized `loadCommandHistory`/`historyFilePath` into `loadInputHistory(name)` / `historyFilePathFor(name)`, with a `filename` field on the struct so each loaded instance writes back to its own file. Methods made nil-safe so partially-init test models don't panic.
- `internal/app/update_search.go`: added `up`/`down` cases to `handleFilterKey` and `handleSearchKey`; Enter calls `add` + `save`.
- `internal/app/update_keys.go`: `handleKeyFilter` and `handleKeySearch` reset the cursor on entry so the first Up always starts from the newest entry.
- 7 new tests including `TestSearchAndFilterShareHistory` which pins the share invariant: a query confirmed in filter mode is recalled by Up in search mode.
- README, `docs/keybindings.md`, and the in-app help screen updated.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->