### PR TITLE
perf(explorer): debounce preview load on cursor moves

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -558,6 +558,8 @@ type Model struct {
 	// they were created with and are discarded if it no longer matches.
 	requestGen uint64
 
+	previewDebounceGen uint64
+
 	// Context cancellation for in-flight API requests. Cancelled on every
 	// navigation change so stale requests are aborted early instead of
 	// running to completion.

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -75,6 +75,14 @@ func scheduleWatchTick(interval time.Duration) tea.Cmd {
 	})
 }
 
+const previewDebounceDelay = 300 * time.Millisecond
+
+func schedulePreviewDebounce(gen uint64) tea.Cmd {
+	return tea.Tick(previewDebounceDelay, func(_ time.Time) tea.Msg {
+		return previewDebounceTickMsg{gen: gen}
+	})
+}
+
 // scheduleDescribeRefresh returns a command that sends a describeRefreshTickMsg after 2 seconds.
 func scheduleDescribeRefresh() tea.Cmd {
 	return tea.Tick(2*time.Second, func(_ time.Time) tea.Msg {

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -1099,7 +1100,7 @@ func TestCov80MoveCursorUpFromZero(t *testing.T) {
 	result, cmd := m.moveCursor(-1)
 	rm := result.(Model)
 	assert.Equal(t, 0, rm.cursor())
-	assert.NotNil(t, cmd) // loadPreview
+	assert.NotNil(t, cmd)
 }
 
 func TestCov80MoveCursorDownPastEnd(t *testing.T) {
@@ -1259,6 +1260,59 @@ func TestMoveCursorBumpsRequestGenAndDiscardsStalePreview(t *testing.T) {
 	am := after.(Model)
 	assert.True(t, am.loading, "stale preview must not clear loading flag")
 	assert.Nil(t, am.rightItems, "stale preview must not populate rightItems")
+}
+
+func TestMoveCursorDoesNotCancelInFlightReqCtx(t *testing.T) {
+	m := basePush80Model()
+	m.reqCtx, m.reqCancel = context.WithCancel(context.Background())
+	oldCtx := m.reqCtx
+	m.setCursor(0)
+
+	result, _ := m.moveCursor(1)
+	rm := result.(Model)
+
+	assert.NoError(t, oldCtx.Err())
+	assert.Equal(t, oldCtx, rm.reqCtx)
+}
+
+func TestMoveCursorDebounceCoalescesRapidBursts(t *testing.T) {
+	m := basePush80Model()
+	m.middleItems = []model.Item{
+		{Name: "pod-1", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-2", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-3", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-4", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-5", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-6", Namespace: "default", Kind: "Pod"},
+	}
+	m.setCursor(0)
+
+	startGen := m.previewDebounceGen
+	scheduledGens := make([]uint64, 0, 5)
+	for range 5 {
+		result, cmd := m.moveCursor(1)
+		m = result.(Model)
+		require.NotNil(t, cmd)
+		msg := cmd()
+		tick, ok := msg.(previewDebounceTickMsg)
+		require.True(t, ok)
+		scheduledGens = append(scheduledGens, tick.gen)
+	}
+
+	assert.Equal(t, startGen+5, m.previewDebounceGen)
+	for i := 1; i < len(scheduledGens); i++ {
+		assert.Greater(t, scheduledGens[i], scheduledGens[i-1])
+	}
+
+	for _, staleGen := range scheduledGens[:4] {
+		_, cmd := m.Update(previewDebounceTickMsg{gen: staleGen})
+		assert.Nilf(t, cmd, "stale gen %d must be dropped (current %d)", staleGen, m.previewDebounceGen)
+	}
+
+	finalGen := scheduledGens[4]
+	require.Equal(t, m.previewDebounceGen, finalGen)
+	_, cmd := m.Update(previewDebounceTickMsg{gen: finalGen})
+	assert.NotNil(t, cmd)
 }
 
 func TestCov80MoveCursorEmptyItems(t *testing.T) {

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -1288,31 +1288,29 @@ func TestMoveCursorDebounceCoalescesRapidBursts(t *testing.T) {
 	m.setCursor(0)
 
 	startGen := m.previewDebounceGen
-	scheduledGens := make([]uint64, 0, 5)
 	for range 5 {
 		result, cmd := m.moveCursor(1)
 		m = result.(Model)
-		require.NotNil(t, cmd)
-		msg := cmd()
-		tick, ok := msg.(previewDebounceTickMsg)
-		require.True(t, ok)
-		scheduledGens = append(scheduledGens, tick.gen)
+		require.NotNil(t, cmd, "moveCursor must return a debounce cmd")
 	}
 
 	assert.Equal(t, startGen+5, m.previewDebounceGen)
-	for i := 1; i < len(scheduledGens); i++ {
-		assert.Greater(t, scheduledGens[i], scheduledGens[i-1])
-	}
 
-	for _, staleGen := range scheduledGens[:4] {
+	for staleGen := startGen + 1; staleGen < m.previewDebounceGen; staleGen++ {
 		_, cmd := m.Update(previewDebounceTickMsg{gen: staleGen})
 		assert.Nilf(t, cmd, "stale gen %d must be dropped (current %d)", staleGen, m.previewDebounceGen)
 	}
 
-	finalGen := scheduledGens[4]
-	require.Equal(t, m.previewDebounceGen, finalGen)
-	_, cmd := m.Update(previewDebounceTickMsg{gen: finalGen})
-	assert.NotNil(t, cmd)
+	_, cmd := m.Update(previewDebounceTickMsg{gen: m.previewDebounceGen})
+	assert.NotNil(t, cmd, "current gen must trigger preview load")
+}
+
+func TestSchedulePreviewDebounceCarriesGen(t *testing.T) {
+	cmd := schedulePreviewDebounce(42)
+	require.NotNil(t, cmd)
+	tick, ok := cmd().(previewDebounceTickMsg)
+	require.True(t, ok)
+	assert.Equal(t, uint64(42), tick.gen)
 }
 
 func TestCov80MoveCursorEmptyItems(t *testing.T) {

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -129,6 +129,8 @@ type startupTipMsg struct{ tip string }
 // watchTickMsg triggers a periodic refresh in watch mode.
 type watchTickMsg struct{}
 
+type previewDebounceTickMsg struct{ gen uint64 }
+
 // describeRefreshTickMsg triggers a periodic refresh in the describe viewer.
 type describeRefreshTickMsg struct{}
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1234,6 +1234,9 @@ func (m Model) updateWatchTick(msg watchTickMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// dispatchNavigationTick fans out tick messages whose handlers belong with
+// cursor/navigation state. Kept as a wrapper so updateResourceMsg's switch
+// stays under the gocyclo threshold (see .golangci config).
 func (m Model) dispatchNavigationTick(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case watchTickMsg:
@@ -1249,7 +1252,6 @@ func (m Model) updatePreviewDebounceTick(msg previewDebounceTickMsg) (tea.Model,
 		return m, nil
 	}
 	if m.mapView {
-		m.resourceTree = nil
 		return m, tea.Batch(m.loadPreview(), m.loadResourceTree())
 	}
 	return m, m.loadPreview()

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -119,8 +119,8 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case startupTipMsg:
 		mdl, cmd := m.updateStartupTip(msg)
 		return mdl, cmd, true
-	case watchTickMsg:
-		mdl, cmd := m.updateWatchTick(msg)
+	case watchTickMsg, previewDebounceTickMsg:
+		mdl, cmd := m.dispatchNavigationTick(msg)
 		return mdl, cmd, true
 	case podSelectMsg:
 		mdl, cmd := m.updatePodSelect(msg)
@@ -1232,6 +1232,27 @@ func (m Model) updateWatchTick(msg watchTickMsg) (tea.Model, tea.Cmd) {
 	cmd := tea.Batch(m.refreshCurrentLevel(), scheduleWatchTick(m.watchInterval))
 	m.suppressBgtasks = false
 	return m, cmd
+}
+
+func (m Model) dispatchNavigationTick(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case watchTickMsg:
+		return m.updateWatchTick(msg)
+	case previewDebounceTickMsg:
+		return m.updatePreviewDebounceTick(msg)
+	}
+	return m, nil
+}
+
+func (m Model) updatePreviewDebounceTick(msg previewDebounceTickMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.previewDebounceGen {
+		return m, nil
+	}
+	if m.mapView {
+		m.resourceTree = nil
+		return m, tea.Batch(m.loadPreview(), m.loadResourceTree())
+	}
+	return m, m.loadPreview()
 }
 
 func (m Model) updatePodSelect(msg podSelectMsg) (tea.Model, tea.Cmd) {

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -52,9 +52,6 @@ func (m Model) moveCursor(delta int) (tea.Model, tea.Cmd) {
 	}
 
 	m.invalidatePreviewForCursorChange()
-	if m.mapView {
-		m.resourceTree = nil
-	}
 	return m, schedulePreviewDebounce(m.previewDebounceGen)
 }
 
@@ -72,6 +69,7 @@ func (m *Model) invalidatePreviewForCursorChange() {
 	m.rightItems = nil
 	m.previewYAML = ""
 	m.previewScroll = 0
+	m.resourceTree = nil
 	m.loading = true
 	m.previewLoading = true
 }

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -52,12 +52,10 @@ func (m Model) moveCursor(delta int) (tea.Model, tea.Cmd) {
 	}
 
 	m.invalidatePreviewForCursorChange()
-	// Reload resource map if active.
 	if m.mapView {
 		m.resourceTree = nil
-		return m, tea.Batch(m.loadPreview(), m.loadResourceTree())
 	}
-	return m, m.loadPreview()
+	return m, schedulePreviewDebounce(m.previewDebounceGen)
 }
 
 // invalidatePreviewForCursorChange resets the right-column state and bumps
@@ -65,8 +63,12 @@ func (m Model) moveCursor(delta int) (tea.Model, tea.Cmd) {
 // position is discarded by its message handler instead of being applied to
 // the wrong selection (which causes stale items to appear, followed by a
 // brief "No resources found" flash before the new load returns).
+//
+// Does not cancel reqCtx: cancelling on cursor moves storms Bubble Tea's
+// msg channel with context.Canceled deliveries that crowd out KeyMsgs.
 func (m *Model) invalidatePreviewForCursorChange() {
 	m.requestGen++
+	m.previewDebounceGen++
 	m.rightItems = nil
 	m.previewYAML = ""
 	m.previewScroll = 0


### PR DESCRIPTION
Fixes #58.

## Summary

Holding `j`/`k` triggers autorepeat faster than preview loads can complete, so each keypress fans out a new request (containers + metrics + events) to the apiserver. During scroll bursts, most of these requests are wasted—all but the final one—resulting in unnecessary apiserver load and a backlog of response messages that degrades cursor responsiveness.

This PR debounces preview dispatch so a burst of inputs (e.g., 5× `j`) coalesces into a single fetch ~300 ms after the cursor settles, instead of issuing multiple concurrent fan-outs.

---

## What changes

Preview dispatch is deferred via a `tea.Tick` carrying a generation token. Only the most recent token (matching `m.previewDebounceGen`) is honored, so intermediate ticks from a held-key burst are dropped.

Cursor movement remains synchronous—only the preview load is debounced:
- Single `j`: cursor moves immediately; preview appears after the debounce window
- Rapid burst (e.g., 5× `j`): one preview load after the cursor settles

The debounce is set to 300 ms. On macOS, `InitialKeyRepeat` is typically ~225 ms, so the first scheduled tick during a hold is invalidated by the first autorepeat event. This prevents any fetches from firing mid-burst.

---

## Why no `cancelAndReset()` on cursor moves

An earlier version cancelled `reqCtx` on every cursor move to abort in-flight requests. While correct in isolation, this caused cursor stalls in practice.

Each cancellation generates a `context.Canceled` message from every in-flight request. At ~30 Hz autorepeat, these messages accumulate in Bubble Tea’s central channel and crowd out `KeyMsg`s, blocking cursor updates after a few presses.

Instead, this implementation relies on the generation check to discard stale responses. This ensures correctness without introducing message pressure. A comment in `invalidatePreviewForCursorChange` documents this to prevent reintroducing cancellation later.

---

## Effect

- 5× `j` burst → 1 preview fetch after settle (previously 5 concurrent)
- Eliminates response backlog during rapid cursor movement

---

## Test plan

- [x] `go test ./...` clean  
- [x] `golangci-lint run ./...` clean  
- [x] Pre-commit hook passed  

Manual:
- [x] Single `j` → cursor advances immediately; preview appears ~300 ms later  
- [x] Rapid 5× `j` → one fetch fires after release (not mid-burst)  
- [x] `Page Down` / search-confirm still trigger immediate loads (bypass debounce)  

Regression tests:
- [x] `TestMoveCursorDoesNotCancelInFlightReqCtx` — ensures cancellation is not reintroduced  
- [x] `TestMoveCursorDebounceCoalescesRapidBursts` — verifies burst coalescing (only final tick dispatches `loadPreview`)  
