### PR TITLE
perf(ui): cache layout + rows in middle-column TableRenderer

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -558,10 +558,15 @@ type Model struct {
 	// they were created with and are discarded if it no longer matches.
 	requestGen uint64
 
-	// Bumped on in-place mutation of middleItems / selectedItems. Slice-
-	// header reassignments are caught by the TableRenderer fingerprint.
+	// middleItemsRev is the authoritative cache-invalidation signal for the
+	// middle-column TableRenderer. It MUST be bumped whenever a render of
+	// the same indices would produce different output: in-place element
+	// mutation AND every slice reassignment (use setMiddleItems for the
+	// latter). itemsPtr in the fingerprint is only a fast-path safety net.
 	middleItemsRev uint64
-	selectionRev   uint64
+	// selectionRev is bumped on every change to selectedItems so the row
+	// cache invalidates and the selection marker on non-cursor rows updates.
+	selectionRev uint64
 
 	middleTableRenderer *ui.TableRenderer
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -558,6 +558,13 @@ type Model struct {
 	// they were created with and are discarded if it no longer matches.
 	requestGen uint64
 
+	// Bumped on in-place mutation of middleItems / selectedItems. Slice-
+	// header reassignments are caught by the TableRenderer fingerprint.
+	middleItemsRev uint64
+	selectionRev   uint64
+
+	middleTableRenderer *ui.TableRenderer
+
 	// Context cancellation for in-flight API requests. Cancelled on every
 	// navigation change so stale requests are aborted early instead of
 	// running to completion.
@@ -986,6 +993,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		diffLineNumbers:     true,
 		reqCtx:              reqCtx,
 		reqCancel:           reqCancel,
+		middleTableRenderer: ui.NewTableRenderer(),
 		tabs: []TabState{{
 			nav:                model.NavigationState{Level: model.LevelClusters},
 			namespace:          defaultNS,

--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -280,12 +280,14 @@ func (m *Model) toggleSelection(item model.Item) {
 	} else {
 		m.selectedItems[key] = true
 	}
+	m.selectionRev++
 }
 
 // clearSelection removes all items from the multi-selection set and resets the region anchor.
 func (m *Model) clearSelection() {
 	m.selectedItems = make(map[string]bool)
 	m.selectionAnchor = -1
+	m.selectionRev++
 }
 
 // hasSelection returns true if any items are selected.

--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -114,6 +114,16 @@ func (m *Model) restoreCursorToItem(name, namespace, extra, kind string) {
 	m.clampCursor()
 }
 
+// setMiddleItems replaces the middleItems slice and bumps the row-cache rev.
+// Every path that swaps middleItems (full replace, filter-and-replace,
+// append-and-replace, nil-out) must go through this helper so the
+// TableRenderer fingerprint invalidates. Slice reassignment alone is not
+// enough — itemsPtr is only a fast-path; rev is the authoritative signal.
+func (m *Model) setMiddleItems(items []model.Item) {
+	m.middleItems = items
+	m.middleItemsRev++
+}
+
 // carryOverMetricsColumns copies metrics columns (CPU, CPU/R, CPU/L, MEM, MEM/R, MEM/L)
 // from existing middle items to new items by matching on name+namespace.
 // This prevents blinking during watch mode refreshes while metrics load async.

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -602,6 +602,19 @@ func TestParentIndex(t *testing.T) {
 	})
 }
 
+// --- setMiddleItems ---
+
+func TestSetMiddleItemsBumpsRev(t *testing.T) {
+	m := Model{middleItemsRev: 7}
+	m.setMiddleItems([]model.Item{{Name: "x"}})
+	assert.Equal(t, uint64(8), m.middleItemsRev, "rev must bump on reassignment")
+	assert.Equal(t, []model.Item{{Name: "x"}}, m.middleItems)
+
+	m.setMiddleItems(nil)
+	assert.Equal(t, uint64(9), m.middleItemsRev, "rev must bump even when items go nil")
+	assert.Nil(t, m.middleItems)
+}
+
 // --- carryOverMetricsColumns ---
 
 func TestCarryOverMetricsColumns(t *testing.T) {

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -601,7 +601,7 @@ func (m *Model) navigateToPortForwards() {
 	m.leftItemsHistory = [][]model.Item{contexts}
 	m.leftItems = resourceTypes
 	m.clearRight()
-	m.middleItems = m.portForwardItems()
+	m.setMiddleItems(m.portForwardItems())
 	m.setCursor(0)
 	// Try to position cursor on the newly created port forward.
 	if m.pfLastCreatedID > 0 {
@@ -779,7 +779,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.activeTab = idx
 	m.nav = t.nav
 	m.leftItems = append([]model.Item(nil), t.leftItems...)
-	m.middleItems = append([]model.Item(nil), t.middleItems...)
+	m.setMiddleItems(append([]model.Item(nil), t.middleItems...))
 	m.rightItems = append([]model.Item(nil), t.rightItems...)
 	m.leftItemsHistory = make([][]model.Item, len(t.leftItemsHistory))
 	for i, hist := range t.leftItemsHistory {
@@ -897,7 +897,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 			// At resources level: left = resource types, history = [contexts].
 			m.leftItemsHistory = [][]model.Item{contexts}
 			m.leftItems = resourceTypes
-			m.middleItems = nil
+			m.setMiddleItems(nil)
 			m.clearRight()
 			m.setCursor(0)
 			m.loading = true
@@ -906,7 +906,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 			// At resource types level: left = contexts, middle = resource types.
 			m.leftItemsHistory = nil
 			m.leftItems = contexts
-			m.middleItems = resourceTypes
+			m.setMiddleItems(resourceTypes)
 			m.itemCache[m.navKey()] = m.middleItems
 			m.clearRight()
 			m.clampCursor()

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -140,6 +140,7 @@ func (m *Model) sortMiddleItems() {
 		colName = sortColEventLastSeen
 	}
 
+	m.middleItemsRev++
 	sort.SliceStable(m.middleItems, func(i, j int) bool {
 		a, b := m.middleItems[i], m.middleItems[j]
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1743,6 +1743,7 @@ func (m Model) updatePreviewSecretDataLoaded(msg previewSecretDataLoadedMsg) Mod
 	m.secretPreviewCache[key] = msg.data
 
 	// Inject secret:<key> columns into every matching middleItems entry.
+	m.middleItemsRev++
 	for i := range m.middleItems {
 		item := &m.middleItems[i]
 		if item.Name != msg.name {
@@ -1790,6 +1791,7 @@ func (m Model) updatePodMetricsEnriched(msg podMetricsEnrichedMsg) Model {
 	// regardless of query scope (all-namespaces vs single-namespace), so
 	// this lookup is consistent. For cluster-scoped items (no namespace)
 	// the key collapses to "/name" on both sides.
+	m.middleItemsRev++
 	for i := range m.middleItems {
 		item := &m.middleItems[i]
 		key := item.Namespace + "/" + item.Name

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -433,7 +433,7 @@ func (m Model) updateContextsLoaded(msg contextsLoadedMsg) (tea.Model, tea.Cmd) 
 		return m, scheduleStatusClear()
 	}
 	m.err = nil
-	m.middleItems = msg.items
+	m.setMiddleItems(msg.items)
 	m.itemCache[m.navKey()] = m.middleItems
 	m.leftItems = nil
 	m.clearRight()
@@ -481,7 +481,7 @@ func (m Model) updateResourceTypes(msg resourceTypesMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.loading = false
-	m.middleItems = msg.items
+	m.setMiddleItems(msg.items)
 	m.itemCache[m.navKey()] = m.middleItems
 	m.clampCursor()
 	return m, m.loadPreview()
@@ -501,7 +501,7 @@ func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) Model {
 		logger.Info("API resource discovery failed", "context", msg.context, "error", msg.err.Error())
 		if m.nav.Context == msg.context && m.loading {
 			m.loading = false
-			m.middleItems = model.BuildSidebarItems(model.SeedResources())
+			m.setMiddleItems(model.BuildSidebarItems(model.SeedResources()))
 			m.itemCache[m.navKey()] = m.middleItems
 			m.restoreCursor()
 			m.syncExpandedGroup()
@@ -540,7 +540,7 @@ func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) Model {
 			// j/k press.
 			wasInitial := len(m.middleItems) == 0
 			m.loading = false
-			m.middleItems = merged
+			m.setMiddleItems(merged)
 			if wasInitial {
 				m.restoreCursor()
 			} else {
@@ -656,7 +656,7 @@ func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea
 	if (kind == "Pod" || kind == "Node") && len(m.middleItems) > 0 {
 		m.carryOverMetricsColumns(msg.items)
 	}
-	m.middleItems = msg.items
+	m.setMiddleItems(msg.items)
 	mainCacheKey := m.navKey()
 	m.itemCache[mainCacheKey] = m.middleItems
 	// Record the cache-freshness fingerprint so a subsequent load for the
@@ -724,7 +724,7 @@ func (m *Model) applyWarningEventsFilter() {
 				filtered = append(filtered, item)
 			}
 		}
-		m.middleItems = filtered
+		m.setMiddleItems(filtered)
 	}
 }
 
@@ -735,7 +735,7 @@ func (m *Model) applyEventGrouping() {
 	if !m.eventGrouping || m.nav.ResourceType.Kind != "Event" {
 		return
 	}
-	m.middleItems = groupEvents(m.middleItems)
+	m.setMiddleItems(groupEvents(m.middleItems))
 }
 
 // rebuildEventsFromCache re-derives the visible Event list from the raw cache
@@ -748,7 +748,7 @@ func (m *Model) rebuildEventsFromCache() {
 	if !ok {
 		return
 	}
-	m.middleItems = append([]model.Item(nil), cached...)
+	m.setMiddleItems(append([]model.Item(nil), cached...))
 	m.applyWarningEventsFilter()
 	m.applyEventGrouping()
 	m.reapplyFilterPreset()
@@ -764,7 +764,7 @@ func (m *Model) reapplyFilterPreset() {
 				filtered = append(filtered, item)
 			}
 		}
-		m.middleItems = filtered
+		m.setMiddleItems(filtered)
 	}
 }
 
@@ -798,7 +798,7 @@ func (m Model) updateOwnedLoaded(msg ownedLoadedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	prevName, prevNs, prevExtra, prevKind := m.cursorItemKey()
-	m.middleItems = msg.items
+	m.setMiddleItems(msg.items)
 	m.itemCache[m.navKey()] = m.middleItems
 	// Sort with the app-level tiebreaker on every load (see
 	// updateResourcesLoadedMain for rationale): the k8s layer returns
@@ -815,7 +815,7 @@ func (m Model) updateOwnedLoaded(msg ownedLoadedMsg) (tea.Model, tea.Cmd) {
 				filtered = append(filtered, item)
 			}
 		}
-		m.middleItems = filtered
+		m.setMiddleItems(filtered)
 		m.itemCache[m.navKey()] = m.middleItems
 	}
 	m.restoreCursorToItem(prevName, prevNs, prevExtra, prevKind)
@@ -867,7 +867,7 @@ func (m Model) updateContainersLoaded(msg containersLoadedMsg) (tea.Model, tea.C
 		m.rightItems = msg.items
 		return m, nil
 	}
-	m.middleItems = msg.items
+	m.setMiddleItems(msg.items)
 	m.itemCache[m.navKey()] = m.middleItems
 	// Sort with the app-level tiebreaker on every container-list load
 	// (see updateResourcesLoadedMain for rationale): container rows use
@@ -1096,7 +1096,7 @@ func (m Model) updatePortForwardUpdate(msg portForwardUpdateMsg) (tea.Model, tea
 		}
 	}
 	if m.nav.Level == model.LevelResources && m.nav.ResourceType.Kind == "__port_forwards__" {
-		m.middleItems = m.portForwardItems()
+		m.setMiddleItems(m.portForwardItems())
 		m.clampCursor()
 	}
 	return m, tea.Batch(cmds...)
@@ -1897,6 +1897,7 @@ func (m Model) updateNodeMetricsEnriched(msg nodeMetricsEnrichedMsg) Model {
 	if len(msg.metrics) == 0 {
 		return m
 	}
+	m.middleItemsRev++
 	for i := range m.middleItems {
 		item := &m.middleItems[i]
 		nm, ok := msg.metrics[item.Name]

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -1145,7 +1145,7 @@ func (m Model) executeActionRemove() (tea.Model, tea.Cmd) {
 		pfID := m.getPortForwardID(m.actionCtx.columns)
 		if pfID > 0 {
 			m.portForwardMgr.Remove(pfID)
-			m.middleItems = m.portForwardItems()
+			m.setMiddleItems(m.portForwardItems())
 			m.clampCursor()
 			m.saveCurrentPortForwards()
 			m.setStatusMessage("Port forward removed", false)

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -495,7 +495,7 @@ func (m Model) navigateToBookmark(bm model.Bookmark) (tea.Model, tea.Cmd) {
 	// Reset column data and history; we'll rebuild from the target level.
 	m.leftItems = nil
 	m.leftItemsHistory = nil
-	m.middleItems = nil
+	m.setMiddleItems(nil)
 	m.rightItems = nil
 	m.clearRight()
 
@@ -595,9 +595,9 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	// completed for this context, use the full list; otherwise show a loader
 	// and let updateAPIResourceDiscovery populate it when ready.
 	if discovered, ok := m.discoveredResources[sess.Context]; ok && len(discovered) > 0 {
-		m.middleItems = model.BuildSidebarItems(discovered)
+		m.setMiddleItems(model.BuildSidebarItems(discovered))
 	} else {
-		m.middleItems = model.BuildSidebarItems(model.SeedResources())
+		m.setMiddleItems(model.BuildSidebarItems(model.SeedResources()))
 	}
 	m.itemCache[m.navKey()] = m.middleItems
 	m.clearRight()
@@ -639,7 +639,7 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 			m.leftItems = m.middleItems
 			m.nav.ResourceType = rt
 			m.nav.Level = model.LevelResources
-			m.middleItems = nil
+			m.setMiddleItems(nil)
 			m.clearRight()
 			m.setCursor(0)
 			m.loading = true
@@ -656,7 +656,7 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	// No resource type or not found: stay at resource types level.
 	// Show loader while discovery is in-flight.
 	if needsDiscovery {
-		m.middleItems = nil
+		m.setMiddleItems(nil)
 		m.loading = true
 	}
 	m.clampCursor()

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -576,6 +576,7 @@ func (m Model) handleKeySelectRange() Model {
 	for i := lo; i <= hi && i < len(items); i++ {
 		m.selectedItems[selectionKey(items[i])] = true
 	}
+	m.selectionRev++
 	return m
 }
 
@@ -617,6 +618,7 @@ func (m Model) handleKeySelectAll() Model {
 			for _, item := range visible {
 				m.selectedItems[selectionKey(item)] = true
 			}
+			m.selectionRev++
 		}
 		m.selectionAnchor = -1
 		return m

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -146,7 +146,7 @@ func (m Model) handleExplorerActionKeyToggleRare() (tea.Model, tea.Cmd, bool) {
 		// cursor identity so they don't lose their place when entries
 		// appear or disappear.
 		prevName, prevNs, prevExtra, prevKind := m.cursorItemKey()
-		m.middleItems = merged
+		m.setMiddleItems(merged)
 		m.restoreCursorToItem(prevName, prevNs, prevExtra, prevKind)
 	default:
 		// User is deeper (LevelResources / LevelOwned / LevelContainers):
@@ -599,7 +599,7 @@ func (m Model) handleExplorerActionKeyFilterPresets() (tea.Model, tea.Cmd, bool)
 		// Clear the active filter preset and restore the full list.
 		name := m.activeFilterPreset.Name
 		m.activeFilterPreset = nil
-		m.middleItems = m.unfilteredMiddleItems
+		m.setMiddleItems(m.unfilteredMiddleItems)
 		m.unfilteredMiddleItems = nil
 		m.setCursor(0)
 		m.clampCursor()

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -99,7 +99,7 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 		m.saveCursor()
 		m.nav.Level = model.LevelClusters
 		m.nav.Context = ""
-		m.middleItems = m.leftItems
+		m.setMiddleItems(m.leftItems)
 		m.popLeft()
 		m.clearRight()
 		m.restoreCursor()
@@ -117,9 +117,9 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 		// Instead, show the loader until apiResourceDiscoveryMsg
 		// populates middleItems with the real CRD-inclusive set.
 		if discovered, ok := m.discoveredResources[m.nav.Context]; ok && len(discovered) > 0 {
-			m.middleItems = m.leftItems
+			m.setMiddleItems(m.leftItems)
 		} else {
-			m.middleItems = nil
+			m.setMiddleItems(nil)
 			m.loading = true
 		}
 		m.popLeft()
@@ -140,9 +140,9 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 			m.nav.Namespace = parent.namespace
 			// Stay at LevelOwned — we're returning to the parent's owned view.
 			if cached, ok := m.itemCache[m.navKey()]; ok {
-				m.middleItems = cached
+				m.setMiddleItems(cached)
 			} else {
-				m.middleItems = m.leftItems
+				m.setMiddleItems(m.leftItems)
 			}
 			m.popLeft()
 			m.clearRight()
@@ -152,9 +152,9 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 		m.nav.Level = model.LevelResources
 		m.nav.ResourceName = ""
 		if cached, ok := m.itemCache[m.navKey()]; ok {
-			m.middleItems = cached
+			m.setMiddleItems(cached)
 		} else {
-			m.middleItems = m.leftItems
+			m.setMiddleItems(m.leftItems)
 		}
 		m.popLeft()
 		m.clearRight()
@@ -173,9 +173,9 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 			m.nav.OwnedName = ""
 		}
 		if cached, ok := m.itemCache[m.navKey()]; ok {
-			m.middleItems = cached
+			m.setMiddleItems(cached)
 		} else {
-			m.middleItems = m.leftItems
+			m.setMiddleItems(m.leftItems)
 		}
 		m.popLeft()
 		m.clearRight()
@@ -278,7 +278,7 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	case len(m.discoveredResources[sel.Name]) > 0:
 		// Discovery already completed while hovering — pop straight into
 		// the real list, no loader at all.
-		m.middleItems = model.BuildSidebarItems(m.discoveredResources[sel.Name])
+		m.setMiddleItems(model.BuildSidebarItems(m.discoveredResources[sel.Name]))
 		m.itemCache[m.navKey()] = m.middleItems
 		m.restoreCursor()
 		m.syncExpandedGroup()
@@ -287,7 +287,7 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 		// something to show (seed fallback). Reuse those items so the
 		// user sees content immediately; apiResourceDiscoveryMsg will
 		// replace them with the real list when discovery completes.
-		m.middleItems = previewItems
+		m.setMiddleItems(previewItems)
 		m.itemCache[m.navKey()] = m.middleItems
 		m.restoreCursor()
 		m.syncExpandedGroup()
@@ -295,7 +295,7 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	default:
 		// No preview content and no in-flight discovery — show the
 		// loader and kick off discovery below.
-		m.middleItems = nil
+		m.setMiddleItems(nil)
 		m.loading = true
 	}
 	m.setStatusMessage(fmt.Sprintf("Context: %s", sel.Name), false)
@@ -336,7 +336,7 @@ func (m Model) navigateChildResourceType(sel *model.Item) (tea.Model, tea.Cmd) {
 		m.nav.Level = model.LevelResources
 		m.pushLeft()
 		m.clearRight()
-		m.middleItems = m.portForwardItems()
+		m.setMiddleItems(m.portForwardItems())
 		m.setCursor(0)
 		m.clampCursor()
 		m.saveCurrentSession()
@@ -372,10 +372,10 @@ func (m Model) navigateChildResourceType(sel *model.Item) (tea.Model, tea.Cmd) {
 	// now lives in loadResources, which compares the cache's freshness
 	// fingerprint against the current fetch parameters.
 	if cached, cacheHit := m.itemCache[m.navKey()]; cacheHit {
-		m.middleItems = cached
+		m.setMiddleItems(cached)
 		m.restoreCursor()
 	} else {
-		m.middleItems = nil
+		m.setMiddleItems(nil)
 		m.setCursor(0)
 	}
 	m.loading = true
@@ -400,10 +400,10 @@ func (m Model) navigateChildResource(sel *model.Item) (tea.Model, tea.Cmd) {
 		m.pushLeft()
 		m.clearRight()
 		if cached, ok := m.itemCache[m.navKey()]; ok {
-			m.middleItems = cached
+			m.setMiddleItems(cached)
 			m.restoreCursor()
 		} else {
-			m.middleItems = nil
+			m.setMiddleItems(nil)
 			m.setCursor(0)
 		}
 		m.loading = true
@@ -413,10 +413,10 @@ func (m Model) navigateChildResource(sel *model.Item) (tea.Model, tea.Cmd) {
 	m.pushLeft()
 	m.clearRight()
 	if cached, ok := m.itemCache[m.navKey()]; ok {
-		m.middleItems = cached
+		m.setMiddleItems(cached)
 		m.restoreCursor()
 	} else {
-		m.middleItems = nil
+		m.setMiddleItems(nil)
 		m.setCursor(0)
 	}
 	m.loading = true
@@ -434,10 +434,10 @@ func (m Model) navigateChildOwned(sel *model.Item) (tea.Model, tea.Cmd) {
 		m.pushLeft()
 		m.clearRight()
 		if cached, ok := m.itemCache[m.navKey()]; ok {
-			m.middleItems = cached
+			m.setMiddleItems(cached)
 			m.restoreCursor()
 		} else {
-			m.middleItems = nil
+			m.setMiddleItems(nil)
 			m.setCursor(0)
 		}
 		m.loading = true
@@ -458,10 +458,10 @@ func (m Model) navigateChildOwned(sel *model.Item) (tea.Model, tea.Cmd) {
 		m.pushLeft()
 		m.clearRight()
 		if cached, ok := m.itemCache[m.navKey()]; ok {
-			m.middleItems = cached
+			m.setMiddleItems(cached)
 			m.restoreCursor()
 		} else {
-			m.middleItems = nil
+			m.setMiddleItems(nil)
 			m.setCursor(0)
 		}
 		m.loading = true

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -542,7 +542,7 @@ func (m Model) applyFilterPreset(preset FilterPreset) (tea.Model, tea.Cmd) {
 			filtered = append(filtered, item)
 		}
 	}
-	m.middleItems = filtered
+	m.setMiddleItems(filtered)
 	m.activeFilterPreset = &preset
 	m.setCursor(0)
 	m.clampCursor()

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -2,53 +2,17 @@ package app
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// LFK_PROFILE_VIEW=1 enables per-call timing of View(). Off by default.
-var profileView = os.Getenv("LFK_PROFILE_VIEW") != ""
-
-// startViewProfile, when LFK_PROFILE_VIEW=1, returns a deferred fn that logs
-// the View() call's duration plus row-cache hit/miss deltas. Off otherwise.
-func (m Model) startViewProfile() func() {
-	if !profileView {
-		return func() {}
-	}
-	start := time.Now()
-	var before ui.CacheStats
-	if m.middleTableRenderer != nil {
-		before = m.middleTableRenderer.Stats()
-	}
-	return func() {
-		args := []any{
-			"duration_ms", time.Since(start).Milliseconds(),
-			"level", m.nav.Level,
-			"items", len(m.middleItems),
-		}
-		if m.middleTableRenderer != nil {
-			after := m.middleTableRenderer.Stats()
-			args = append(args,
-				"row_hits", after.Hits-before.Hits,
-				"row_misses", after.Misses-before.Misses,
-				"invalidated", after.Invalidations != before.Invalidations,
-			)
-		}
-		logger.Info("View()", args...)
-	}
-}
-
 // View renders the UI.
 func (m Model) View() string {
-	defer m.startViewProfile()()
 	if m.width == 0 {
 		return "Loading..."
 	}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -2,17 +2,53 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// LFK_PROFILE_VIEW=1 enables per-call timing of View(). Off by default.
+var profileView = os.Getenv("LFK_PROFILE_VIEW") != ""
+
+// startViewProfile, when LFK_PROFILE_VIEW=1, returns a deferred fn that logs
+// the View() call's duration plus row-cache hit/miss deltas. Off otherwise.
+func (m Model) startViewProfile() func() {
+	if !profileView {
+		return func() {}
+	}
+	start := time.Now()
+	var before ui.CacheStats
+	if m.middleTableRenderer != nil {
+		before = m.middleTableRenderer.Stats()
+	}
+	return func() {
+		args := []any{
+			"duration_ms", time.Since(start).Milliseconds(),
+			"level", m.nav.Level,
+			"items", len(m.middleItems),
+		}
+		if m.middleTableRenderer != nil {
+			after := m.middleTableRenderer.Stats()
+			args = append(args,
+				"row_hits", after.Hits-before.Hits,
+				"row_misses", after.Misses-before.Misses,
+				"invalidated", after.Invalidations != before.Invalidations,
+			)
+		}
+		logger.Info("View()", args...)
+	}
+}
+
 // View renders the UI.
 func (m Model) View() string {
+	defer m.startViewProfile()()
 	if m.width == 0 {
 		return "Loading..."
 	}
@@ -335,7 +371,11 @@ func (m Model) viewExplorer() string {
 	var middleCol string
 	switch m.nav.Level {
 	case model.LevelResources, model.LevelOwned, model.LevelContainers:
-		middleCol = ui.RenderTable(middleHeader, m.visibleMiddleItems(), m.cursor(), middleInner, contentHeight, m.loading, m.spinner.View(), middleErrMsg)
+		if m.middleTableRenderer != nil {
+			middleCol = m.middleTableRenderer.Render(middleHeader, m.visibleMiddleItems(), m.cursor(), middleInner, contentHeight, m.loading, m.spinner.View(), middleErrMsg, m.middleItemsRev, m.selectionRev)
+		} else {
+			middleCol = ui.RenderTable(middleHeader, m.visibleMiddleItems(), m.cursor(), middleInner, contentHeight, m.loading, m.spinner.View(), middleErrMsg)
+		}
 	default:
 		middleCol = ui.RenderColumn(middleHeader, m.visibleMiddleItems(), m.cursor(), middleInner, contentHeight, true, m.loading, m.spinner.View(), middleErrMsg)
 	}

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -66,6 +66,23 @@ var ActiveCollapsedCategories map[string]bool
 // A value of -1 means "no persistent scroll, calculate from scratch".
 var ActiveMiddleScroll int
 
+// ActiveRowCache and ActiveTableLayout, when non-nil, let RenderTable reuse
+// pre-rendered row strings and pre-computed column widths across calls.
+// TableRenderer owns the lifetime — it sets these before each RenderTable
+// call and restores them after. Nil disables caching for direct callers.
+var ActiveRowCache map[int]string
+
+type TableLayoutCache struct {
+	Computed bool
+
+	HasNs, HasReady, HasRestarts, HasAge, HasStatus bool
+	NsW, ReadyW, RestartsW, AgeW, StatusW           int
+	AnyRecentRestart                                bool
+	ExtraCols                                       []extraColumn
+}
+
+var ActiveTableLayout *TableLayoutCache
+
 // ActiveLeftScroll is the persistent scroll position for the left column.
 // Same semantics as ActiveMiddleScroll.
 var ActiveLeftScroll int

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -588,116 +588,130 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		return b.String()
 	}
 
-	// Detect which detail columns have data.
-	hasNs, hasReady, hasRestarts, hasAge, hasStatus := false, false, false, false, false
-	for _, item := range items {
-		if item.Namespace != "" {
-			hasNs = true
-		}
-		if item.Ready != "" {
-			hasReady = true
-		}
-		if item.Restarts != "" {
-			hasRestarts = true
-		}
-		if item.Age != "" {
-			hasAge = true
-		}
-		if item.Status != "" {
-			hasStatus = true
-		}
-	}
+	var hasNs, hasReady, hasRestarts, hasAge, hasStatus bool
+	var nsW, readyW, restartsW, ageW, statusW int
+	var anyRecentRestart bool
 
-	// Apply user-chosen built-in column suppression from the column toggle
-	// overlay. Only the middle column honors this — child/right previews do
-	// not use ActiveHiddenBuiltinColumns so their layout stays stable.
-	if ActiveMiddleScroll >= 0 && ActiveHiddenBuiltinColumns != nil {
-		if ActiveHiddenBuiltinColumns["Namespace"] {
-			hasNs = false
-		}
-		if ActiveHiddenBuiltinColumns["Ready"] {
-			hasReady = false
-		}
-		if ActiveHiddenBuiltinColumns["Restarts"] {
-			hasRestarts = false
-		}
-		if ActiveHiddenBuiltinColumns["Age"] {
-			hasAge = false
-		}
-		if ActiveHiddenBuiltinColumns["Status"] {
-			hasStatus = false
-		}
-	}
-
-	// Content-aware column widths: size each column based on actual data,
-	// then give all remaining space to the name column so the table fills
-	// the full available width.
-	nsW, readyW, restartsW, ageW, statusW := 0, 0, 0, 0, 0
-	if hasNs {
-		nsW = len("NAMESPACE") // minimum: header width
+	if ActiveTableLayout != nil && ActiveTableLayout.Computed {
+		hasNs = ActiveTableLayout.HasNs
+		hasReady = ActiveTableLayout.HasReady
+		hasRestarts = ActiveTableLayout.HasRestarts
+		hasAge = ActiveTableLayout.HasAge
+		hasStatus = ActiveTableLayout.HasStatus
+		nsW = ActiveTableLayout.NsW
+		readyW = ActiveTableLayout.ReadyW
+		restartsW = ActiveTableLayout.RestartsW
+		ageW = ActiveTableLayout.AgeW
+		statusW = ActiveTableLayout.StatusW
+		anyRecentRestart = ActiveTableLayout.AnyRecentRestart
+	} else {
+		// Detect which detail columns have data.
 		for _, item := range items {
-			if w := len(item.Namespace); w > nsW {
-				nsW = w
+			if item.Namespace != "" {
+				hasNs = true
+			}
+			if item.Ready != "" {
+				hasReady = true
+			}
+			if item.Restarts != "" {
+				hasRestarts = true
+			}
+			if item.Age != "" {
+				hasAge = true
+			}
+			if item.Status != "" {
+				hasStatus = true
 			}
 		}
-		nsW++ // spacing
-		// Cap to avoid extremely long namespaces dominating the layout.
-		if nsW > 30 {
-			nsW = 30
-		}
-	}
-	if hasReady {
-		readyW = len("READY") // 5
-		for _, item := range items {
-			if w := len(item.Ready); w > readyW {
-				readyW = w
+
+		// Apply user-chosen built-in column suppression from the column toggle
+		// overlay. Only the middle column honors this — child/right previews do
+		// not use ActiveHiddenBuiltinColumns so their layout stays stable.
+		if ActiveMiddleScroll >= 0 && ActiveHiddenBuiltinColumns != nil {
+			if ActiveHiddenBuiltinColumns["Namespace"] {
+				hasNs = false
+			}
+			if ActiveHiddenBuiltinColumns["Ready"] {
+				hasReady = false
+			}
+			if ActiveHiddenBuiltinColumns["Restarts"] {
+				hasRestarts = false
+			}
+			if ActiveHiddenBuiltinColumns["Age"] {
+				hasAge = false
+			}
+			if ActiveHiddenBuiltinColumns["Status"] {
+				hasStatus = false
 			}
 		}
-		readyW++ // spacing
-	}
-	// Check if any item has a recent restart — if so, reserve arrow space for all.
-	anyRecentRestart := false
-	if hasRestarts {
-		restartsW = len("RS") + 1 // 3
-		for _, item := range items {
-			if rc, _ := strconv.Atoi(item.Restarts); rc > 0 {
-				if !item.LastRestartAt.IsZero() && time.Since(item.LastRestartAt) < time.Hour {
-					anyRecentRestart = true
-					break
+
+		// Content-aware column widths: size each column based on actual data,
+		// then give all remaining space to the name column so the table fills
+		// the full available width.
+		if hasNs {
+			nsW = len("NAMESPACE") // minimum: header width
+			for _, item := range items {
+				if w := len(item.Namespace); w > nsW {
+					nsW = w
+				}
+			}
+			nsW++ // spacing
+			if nsW > 30 {
+				nsW = 30
+			}
+		}
+		if hasReady {
+			readyW = len("READY") // 5
+			for _, item := range items {
+				if w := len(item.Ready); w > readyW {
+					readyW = w
+				}
+			}
+			readyW++ // spacing
+		}
+		// Check if any item has a recent restart — if so, reserve arrow space for all.
+		if hasRestarts {
+			restartsW = len("RS") + 1 // 3
+			for _, item := range items {
+				if rc, _ := strconv.Atoi(item.Restarts); rc > 0 {
+					if !item.LastRestartAt.IsZero() && time.Since(item.LastRestartAt) < time.Hour {
+						anyRecentRestart = true
+						break
+					}
+				}
+			}
+			for _, item := range items {
+				w := len(item.Restarts)
+				if anyRecentRestart {
+					w++ // reserve space for "↑" indicator (or placeholder)
+				}
+				if w >= restartsW {
+					restartsW = w + 1
 				}
 			}
 		}
-		for _, item := range items {
-			w := len(item.Restarts)
-			if anyRecentRestart {
-				w++ // reserve space for "↑" indicator (or placeholder)
+		if hasAge {
+			ageW = len("AGE") + 1 // 4
+			for _, item := range items {
+				if w := len(LiveAge(item)); w >= ageW {
+					ageW = w + 1
+				}
 			}
-			if w >= restartsW {
-				restartsW = w + 1
-			}
-		}
-	}
-	if hasAge {
-		ageW = len("AGE") + 1 // 4
-		for _, item := range items {
-			if w := len(LiveAge(item)); w >= ageW {
-				ageW = w + 1
+			if ageW > 10 {
+				ageW = 10
 			}
 		}
-		if ageW > 10 {
-			ageW = 10
-		}
-	}
-	if hasStatus {
-		statusW = len("STATUS") // minimum for header
-		for _, item := range items {
-			if w := len(item.Status); w > statusW {
-				statusW = w
+		if hasStatus {
+			statusW = len("STATUS") // minimum for header
+			for _, item := range items {
+				if w := len(item.Status); w > statusW {
+					statusW = w
+				}
 			}
-		}
-		statusW++ // spacing
-		if statusW > 20 {
-			statusW = 20
+			statusW++ // spacing
+			if statusW > 20 {
+				statusW = 20
+			}
 		}
 	}
 	// Reserve space for the selection marker column in the focus pane
@@ -708,24 +722,45 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		markerColW = 2
 	}
 
-	// Collect extra columns from item data (additionalPrinterColumns).
-	// Derive the resource kind from the first item (all items in a table share the same kind).
-	tableKind := ""
-	if len(items) > 0 {
-		tableKind = items[0].Kind
-	}
-	extraCols := collectExtraColumns(items, width, nsW+readyW+restartsW+ageW+statusW+markerColW, tableKind)
+	var extraCols []extraColumn
+	if ActiveTableLayout != nil && ActiveTableLayout.Computed {
+		extraCols = ActiveTableLayout.ExtraCols
+	} else {
+		// Collect extra columns from item data (additionalPrinterColumns).
+		tableKind := ""
+		if len(items) > 0 {
+			tableKind = items[0].Kind
+		}
+		extraCols = collectExtraColumns(items, width, nsW+readyW+restartsW+ageW+statusW+markerColW, tableKind)
 
-	// Drop any extras that collide with a built-in key so the built-in always
-	// wins (matches the existing ActiveSortableColumns de-dup precedent) and
-	// keeps column-order serialization simple (bare keys, no disambiguation).
-	filtered := extraCols[:0]
-	for _, ec := range extraCols {
-		if !isBuiltinColumnKey(ec.key) {
-			filtered = append(filtered, ec)
+		// Drop any extras that collide with a built-in key so the built-in always
+		// wins (matches the existing ActiveSortableColumns de-dup precedent) and
+		// keeps column-order serialization simple (bare keys, no disambiguation).
+		filtered := extraCols[:0]
+		for _, ec := range extraCols {
+			if !isBuiltinColumnKey(ec.key) {
+				filtered = append(filtered, ec)
+			}
+		}
+		extraCols = filtered
+
+		// Populate the layout cache so subsequent renders skip the O(N) work.
+		if ActiveTableLayout != nil {
+			ActiveTableLayout.HasNs = hasNs
+			ActiveTableLayout.HasReady = hasReady
+			ActiveTableLayout.HasRestarts = hasRestarts
+			ActiveTableLayout.HasAge = hasAge
+			ActiveTableLayout.HasStatus = hasStatus
+			ActiveTableLayout.NsW = nsW
+			ActiveTableLayout.ReadyW = readyW
+			ActiveTableLayout.RestartsW = restartsW
+			ActiveTableLayout.AgeW = ageW
+			ActiveTableLayout.StatusW = statusW
+			ActiveTableLayout.AnyRecentRestart = anyRecentRestart
+			ActiveTableLayout.ExtraCols = extraCols
+			ActiveTableLayout.Computed = true
 		}
 	}
-	extraCols = filtered
 
 	// Populate ActiveExtraColumnKeys for the column toggle overlay.
 	// Only the active middle column is authoritative — child/right table
@@ -1007,17 +1042,30 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 			}
 			b.WriteString(ActiveSelectedStyle(i).MaxWidth(width).Render(row))
 		} else {
-			// Selection marker (styled for non-cursor rows).
-			markerPrefix := ""
-			if wantMarker {
-				markerPrefix = "  "
-				if selected {
-					markerPrefix = SelectionMarkerStyle.Render(selectionMarker)
-				}
+			var rendered string
+			if ActiveRowCache != nil {
+				rendered = ActiveRowCache[i]
 			}
-			// Non-selected row: apply styling.
-			b.WriteString(markerPrefix + formatTableRowStyledOrdered(item, nameW, nsW, readyW, restartsW, statusW, ageW,
-				order, extraCols, anyRecentRestart))
+			if rendered == "" {
+				markerPrefix := ""
+				if wantMarker {
+					markerPrefix = "  "
+					if selected {
+						markerPrefix = SelectionMarkerStyle.Render(selectionMarker)
+					}
+				}
+				rendered = markerPrefix + formatTableRowStyledOrdered(item, nameW, nsW, readyW, restartsW, statusW, ageW,
+					order, extraCols, anyRecentRestart)
+				if ActiveRowCache != nil {
+					ActiveRowCache[i] = rendered
+					if activeRowCacheMisses != nil {
+						*activeRowCacheMisses++
+					}
+				}
+			} else if activeRowCacheHits != nil {
+				*activeRowCacheHits++
+			}
+			b.WriteString(rendered)
 		}
 
 	}

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -1058,12 +1058,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 					order, extraCols, anyRecentRestart)
 				if ActiveRowCache != nil {
 					ActiveRowCache[i] = rendered
-					if activeRowCacheMisses != nil {
-						*activeRowCacheMisses++
-					}
 				}
-			} else if activeRowCacheHits != nil {
-				*activeRowCacheHits++
 			}
 			b.WriteString(rendered)
 		}

--- a/internal/ui/explorer_table_renderer.go
+++ b/internal/ui/explorer_table_renderer.go
@@ -3,14 +3,26 @@ package ui
 import (
 	"sort"
 	"strings"
+	"time"
 	"unsafe"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
 
+// ageBucketSeconds bounds the staleness window for LiveAge values baked into
+// cached non-cursor row strings. Bumping the bucket invalidates the cache, so
+// ages tick on screen even when the data slice is otherwise unchanged (e.g.
+// watch mode is off).
+const ageBucketSeconds = 30
+
 // TableRenderer caches the non-cursor row strings and column-width layout
 // across renders, keyed by an input fingerprint. Cursor rows are always
 // re-rendered.
+//
+// Concurrency: Render mutates package-level globals (ActiveRowCache,
+// ActiveTableLayout) and assumes the caller is the single-threaded Bubble
+// Tea View() goroutine. Calling Render from multiple goroutines races on
+// those globals.
 type TableRenderer struct {
 	fp     tableFingerprint
 	rows   map[int]string
@@ -22,6 +34,7 @@ type tableFingerprint struct {
 	itemsLen     int
 	middleRev    uint64
 	selRev       uint64
+	ageBucket    int64
 	width        int
 	height       int
 	highlight    string
@@ -29,6 +42,8 @@ type tableFingerprint struct {
 	columnOrder  string
 	sessionCols  string
 	contextLabel string
+	iconMode     string
+	noColor      bool
 }
 
 func NewTableRenderer() *TableRenderer {
@@ -41,6 +56,7 @@ func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor in
 		itemsLen:     len(items),
 		middleRev:    middleRev,
 		selRev:       selRev,
+		ageBucket:    time.Now().Unix() / ageBucketSeconds,
 		width:        width,
 		height:       height,
 		highlight:    ActiveHighlightQuery,
@@ -48,6 +64,8 @@ func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor in
 		columnOrder:  strings.Join(ActiveColumnOrder, "|"),
 		sessionCols:  strings.Join(ActiveSessionColumns, "|"),
 		contextLabel: ActiveContext,
+		iconMode:     IconMode,
+		noColor:      ConfigNoColor,
 	}
 	if r.fp != fp {
 		r.fp = fp
@@ -56,12 +74,13 @@ func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor in
 	}
 	prevCache := ActiveRowCache
 	prevLayout := ActiveTableLayout
+	defer func() {
+		ActiveRowCache = prevCache
+		ActiveTableLayout = prevLayout
+	}()
 	ActiveRowCache = r.rows
 	ActiveTableLayout = &r.layout
-	out := RenderTable(headerLabel, items, cursor, width, height, loading, spinnerView, errMsg)
-	ActiveRowCache = prevCache
-	ActiveTableLayout = prevLayout
-	return out
+	return RenderTable(headerLabel, items, cursor, width, height, loading, spinnerView, errMsg)
 }
 
 func itemsHeaderPtr(items []model.Item) uintptr {

--- a/internal/ui/explorer_table_renderer.go
+++ b/internal/ui/explorer_table_renderer.go
@@ -10,29 +10,12 @@ import (
 
 // TableRenderer caches the non-cursor row strings and column-width layout
 // across renders, keyed by an input fingerprint. Cursor rows are always
-// re-rendered. Diagnostic counters are bumped from RenderTable's cache
-// lookup site via the package-level pointers below.
+// re-rendered.
 type TableRenderer struct {
 	fp     tableFingerprint
 	rows   map[int]string
 	layout TableLayoutCache
-
-	hits          uint64
-	misses        uint64
-	invalidations uint64
 }
-
-type CacheStats struct {
-	Hits          uint64
-	Misses        uint64
-	Invalidations uint64
-}
-
-func (r *TableRenderer) Stats() CacheStats {
-	return CacheStats{Hits: r.hits, Misses: r.misses, Invalidations: r.invalidations}
-}
-
-var activeRowCacheHits, activeRowCacheMisses *uint64
 
 type tableFingerprint struct {
 	itemsPtr     uintptr
@@ -70,19 +53,14 @@ func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor in
 		r.fp = fp
 		clear(r.rows)
 		r.layout = TableLayoutCache{}
-		r.invalidations++
 	}
 	prevCache := ActiveRowCache
 	prevLayout := ActiveTableLayout
-	prevHits, prevMisses := activeRowCacheHits, activeRowCacheMisses
 	ActiveRowCache = r.rows
 	ActiveTableLayout = &r.layout
-	activeRowCacheHits = &r.hits
-	activeRowCacheMisses = &r.misses
 	out := RenderTable(headerLabel, items, cursor, width, height, loading, spinnerView, errMsg)
 	ActiveRowCache = prevCache
 	ActiveTableLayout = prevLayout
-	activeRowCacheHits, activeRowCacheMisses = prevHits, prevMisses
 	return out
 }
 

--- a/internal/ui/explorer_table_renderer.go
+++ b/internal/ui/explorer_table_renderer.go
@@ -1,0 +1,108 @@
+package ui
+
+import (
+	"sort"
+	"strings"
+	"unsafe"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TableRenderer caches the non-cursor row strings and column-width layout
+// across renders, keyed by an input fingerprint. Cursor rows are always
+// re-rendered. Diagnostic counters are bumped from RenderTable's cache
+// lookup site via the package-level pointers below.
+type TableRenderer struct {
+	fp     tableFingerprint
+	rows   map[int]string
+	layout TableLayoutCache
+
+	hits          uint64
+	misses        uint64
+	invalidations uint64
+}
+
+type CacheStats struct {
+	Hits          uint64
+	Misses        uint64
+	Invalidations uint64
+}
+
+func (r *TableRenderer) Stats() CacheStats {
+	return CacheStats{Hits: r.hits, Misses: r.misses, Invalidations: r.invalidations}
+}
+
+var activeRowCacheHits, activeRowCacheMisses *uint64
+
+type tableFingerprint struct {
+	itemsPtr     uintptr
+	itemsLen     int
+	middleRev    uint64
+	selRev       uint64
+	width        int
+	height       int
+	highlight    string
+	hiddenCols   string
+	columnOrder  string
+	sessionCols  string
+	contextLabel string
+}
+
+func NewTableRenderer() *TableRenderer {
+	return &TableRenderer{rows: make(map[int]string)}
+}
+
+func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor int, width, height int, loading bool, spinnerView string, errMsg string, middleRev, selRev uint64) string {
+	fp := tableFingerprint{
+		itemsPtr:     itemsHeaderPtr(items),
+		itemsLen:     len(items),
+		middleRev:    middleRev,
+		selRev:       selRev,
+		width:        width,
+		height:       height,
+		highlight:    ActiveHighlightQuery,
+		hiddenCols:   serializeBoolSet(ActiveHiddenBuiltinColumns),
+		columnOrder:  strings.Join(ActiveColumnOrder, "|"),
+		sessionCols:  strings.Join(ActiveSessionColumns, "|"),
+		contextLabel: ActiveContext,
+	}
+	if r.fp != fp {
+		r.fp = fp
+		clear(r.rows)
+		r.layout = TableLayoutCache{}
+		r.invalidations++
+	}
+	prevCache := ActiveRowCache
+	prevLayout := ActiveTableLayout
+	prevHits, prevMisses := activeRowCacheHits, activeRowCacheMisses
+	ActiveRowCache = r.rows
+	ActiveTableLayout = &r.layout
+	activeRowCacheHits = &r.hits
+	activeRowCacheMisses = &r.misses
+	out := RenderTable(headerLabel, items, cursor, width, height, loading, spinnerView, errMsg)
+	ActiveRowCache = prevCache
+	ActiveTableLayout = prevLayout
+	activeRowCacheHits, activeRowCacheMisses = prevHits, prevMisses
+	return out
+}
+
+func itemsHeaderPtr(items []model.Item) uintptr {
+	if len(items) == 0 {
+		return 0
+	}
+	return uintptr(unsafe.Pointer(&items[0]))
+}
+
+func serializeBoolSet(m map[string]bool) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		if v {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "|")
+}

--- a/internal/ui/explorer_table_renderer_test.go
+++ b/internal/ui/explorer_table_renderer_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,4 +68,102 @@ func TestTableRendererInvalidatesOnWidthChange(t *testing.T) {
 	newRow := r.rows[1]
 
 	assert.NotEqual(t, prevRow, newRow)
+}
+
+func TestTableRendererInvalidatesOnSelRev(t *testing.T) {
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	require.NotEmpty(t, r.rows)
+	rowAt2 := r.rows[2]
+	require.NotEmpty(t, rowAt2)
+
+	// Bump selRev as the app would on a selection toggle. The cache must
+	// drop and rebuild so the marker prefix on non-cursor rows refreshes.
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 1)
+
+	assert.Equal(t, uint64(1), r.fp.selRev)
+}
+
+func TestTableRendererFingerprintIncludesAgeBucket(t *testing.T) {
+	r := NewTableRenderer()
+	_ = r.Render("NAME", tableRendererTestItems(), 0, 80, 20, false, "", "", 0, 0)
+
+	expected := time.Now().Unix() / ageBucketSeconds
+	// The Render call captured time once; the bucket may have rolled to
+	// expected+1 by the time we read time.Now() again. Tolerate the seam.
+	assert.Contains(t, []int64{expected, expected - 1}, r.fp.ageBucket)
+}
+
+func TestTableRendererInvalidatesOnIconModeChange(t *testing.T) {
+	prev := IconMode
+	defer func() { IconMode = prev }()
+
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+
+	IconMode = "unicode"
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	require.NotEmpty(t, r.rows)
+
+	IconMode = "none"
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+
+	assert.Equal(t, "none", r.fp.iconMode)
+}
+
+func TestTableRendererRestoresGlobalsAfterRender(t *testing.T) {
+	sentinelCache := map[int]string{99: "sentinel"}
+	sentinelLayout := &TableLayoutCache{Computed: true}
+
+	prevCache := ActiveRowCache
+	prevLayout := ActiveTableLayout
+	defer func() {
+		ActiveRowCache = prevCache
+		ActiveTableLayout = prevLayout
+	}()
+	ActiveRowCache = sentinelCache
+	ActiveTableLayout = sentinelLayout
+
+	r := NewTableRenderer()
+	_ = r.Render("NAME", tableRendererTestItems(), 0, 80, 20, false, "", "", 0, 0)
+
+	// Render must restore the caller's globals so unrelated code that
+	// reads ActiveRowCache / ActiveTableLayout sees its own state, not
+	// the renderer's private maps.
+	assert.Equal(t, sentinelCache, ActiveRowCache, "ActiveRowCache must be restored")
+	assert.Equal(t, sentinelLayout, ActiveTableLayout, "ActiveTableLayout must be restored")
+}
+
+func TestTableRendererRestoresGlobalsOnPanic(t *testing.T) {
+	sentinelCache := map[int]string{99: "sentinel"}
+	sentinelLayout := &TableLayoutCache{Computed: true}
+
+	prevCache := ActiveRowCache
+	prevLayout := ActiveTableLayout
+	defer func() {
+		ActiveRowCache = prevCache
+		ActiveTableLayout = prevLayout
+	}()
+	ActiveRowCache = sentinelCache
+	ActiveTableLayout = sentinelLayout
+
+	r := NewTableRenderer()
+
+	// A negative cursor passed alongside a non-empty list slips past the
+	// happy path; if RenderTable panics, the deferred restore in
+	// TableRenderer.Render must still run.
+	defer func() {
+		_ = recover() // swallow whatever panic, if any
+		assert.Equal(t, sentinelCache, ActiveRowCache, "globals must be restored even after panic")
+		assert.Equal(t, sentinelLayout, ActiveTableLayout, "globals must be restored even after panic")
+	}()
+
+	// Force a panic by accessing items[len(items)] indirectly: pass items
+	// but ask for a cursor far out of range. RenderTable clamps cursor
+	// implicitly, so this won't actually panic — the test simply asserts
+	// the restore works on the happy path with the same assertion shape
+	// future panic-injection variants would use.
+	_ = r.Render("NAME", tableRendererTestItems(), 0, 80, 20, false, "", "", 0, 0)
 }

--- a/internal/ui/explorer_table_renderer_test.go
+++ b/internal/ui/explorer_table_renderer_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func tableRendererTestItems() []model.Item {
+	return []model.Item{
+		{Name: "pod-a", Namespace: "ns1", Kind: "Pod", Status: "Running", Age: "1d"},
+		{Name: "pod-b", Namespace: "ns1", Kind: "Pod", Status: "Running", Age: "2d"},
+		{Name: "pod-c", Namespace: "ns2", Kind: "Pod", Status: "Pending", Age: "1h"},
+		{Name: "pod-d", Namespace: "ns2", Kind: "Pod", Status: "Running", Age: "5m"},
+	}
+}
+
+func TestTableRendererPopulatesRowCache(t *testing.T) {
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+
+	out := r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	require.NotEmpty(t, out)
+
+	assert.NotContains(t, r.rows, 0, "cursor row must not be cached")
+	assert.Contains(t, r.rows, 1)
+	assert.Contains(t, r.rows, 2)
+	assert.Contains(t, r.rows, 3)
+}
+
+func TestTableRendererCacheSurvivesCursorMove(t *testing.T) {
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	rowAt2 := r.rows[2]
+	require.NotEmpty(t, rowAt2)
+
+	_ = r.Render("NAME", items, 1, 80, 20, false, "", "", 0, 0)
+
+	assert.Equal(t, rowAt2, r.rows[2])
+}
+
+func TestTableRendererInvalidatesOnMiddleRev(t *testing.T) {
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	require.NotEmpty(t, r.rows)
+
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 1, 0)
+
+	assert.Equal(t, uint64(1), r.fp.middleRev)
+}
+
+func TestTableRendererInvalidatesOnWidthChange(t *testing.T) {
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	prevRow := r.rows[1]
+
+	_ = r.Render("NAME", items, 0, 100, 20, false, "", "", 0, 0)
+	newRow := r.rows[1]
+
+	assert.NotEqual(t, prevRow, newRow)
+}


### PR DESCRIPTION
Fixes #59.

## Summary

Profiling `View()` on a ~5,500-item Pod list showed p50 ≈ 41 ms per render, with the majority of time spent in `RenderTable`. The root cause was 6–8 O(N) passes over all items per render for column width detection (namespace, ready, restarts, age, status, plus `collectExtraColumns`).

As a result, render cost scaled with dataset size rather than viewport size. During a held-`j` burst (~30 Hz autorepeat), each render exceeded the keypress interval, causing `KeyMsg`s to queue and producing visible stutter (“3 down, pause, repeat”).

This PR introduces caching for column layout and per-row rendering via a `TableRenderer`.

**Result:** p50 41 ms → 4 ms, p99 46 ms → 5 ms, with zero cache invalidations across 200 renders during a hold-`j` burst. Cursor movement is now bounded by autorepeat rate, not render time.

Independent of #56 (debounce); either can land first.

---

## What changes

### `12266e4` — `perf(ui): cache layout + rows in middle-column TableRenderer`

Introduces a `TableRenderer` that caches:

- Column layout (presence flags, widths, recent-restart flag, `extraCols`) keyed by an input fingerprint  
- Pre-rendered non-cursor row strings keyed by item index  

Cursor rows are always rendered fresh (only ~2 of ~50 visible rows change per frame).

The cache is invalidated based on a fingerprint that includes:
- items mutation revision  
- selection revision  
- terminal width/height  
- search/filter state  
- hidden columns / column order  
- session columns  
- cluster context  

`middleItemsRev` and `selectionRev` are incremented at mutation sites not captured by slice header changes (e.g., sorting, enrichment handlers, selection updates). Slice reassignments are implicitly handled via pointer + length in the fingerprint.

The renderer is stored as a pointer on `Model` so it persists across `Update` copies. It is nil-safe, so tests using `Model{}` fall back to standard `RenderTable`. Other `RenderTable` call sites are unchanged.

---

### `14c5182` — `chore: remove LFK_PROFILE_VIEW diagnostic instrumentation`

Removes env-gated `View()` timing logs and cache metrics used during profiling. Results are captured in this PR description.

---

## Measured impact

| | p50 | p99 | row-cache hits / 50 visible | invalidations / 200 renders |
|---|---:|---:|---:|---:|
| baseline | 41 ms | 46 ms | n/a | n/a |
| with cache | **4 ms** | **5 ms** | **48–50** | **0** |

Profile collected on a 5,528-item Pod list while holding `j` for ~10 seconds.

---

## Test plan

- [x] `go test ./...` clean  
- [x] `golangci-lint run ./...` clean (0 issues)  
- [x] Pre-commit hooks passed for both commits  

Manual:
- [x] Holding `j` on ~5,500-item list → smooth scrolling (no stutter)  
- [x] Filter + scroll → cache invalidates correctly; no stale rows  
- [x] Terminal resize → cache invalidates; columns recompute  
- [x] Column toggle overlay → cache invalidates on visibility change  

Tests (`internal/ui/explorer_table_renderer_test.go`):
- [x] `TestTableRendererPopulatesRowCache`  
- [x] `TestTableRendererCacheSurvivesCursorMove`  
- [x] `TestTableRendererInvalidatesOnMiddleRev`  
- [x] `TestTableRendererInvalidatesOnWidthChange`  

