### PR TITLE
fix(logs): clamp rune-slice index in log search to prevent panic

### DIFF
--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -348,7 +348,8 @@ func (m *Model) findNextLogMatchForward(rawQuery string, start int) {
 		dl := m.logDisplayLine(start)
 		runes := []rune(dl)
 		// Clamp: logVisualCurCol carries the column from a previously
-		// focused line and may exceed this line's rune length.
+		// focused line and may exceed this line's rune length. Forward
+		// uses +1 because the search starts after (not at) the cursor.
 		end := min(m.logVisualCurCol+1, len(runes))
 		curBytePos := len(string(runes[:end]))
 		if curBytePos < len(dl) {
@@ -376,8 +377,8 @@ func (m *Model) findNextLogMatchBackward(rawQuery string, start int) {
 	if start >= 0 && start < len(m.logLines) {
 		dl := m.logDisplayLine(start)
 		runes := []rune(dl)
-		// Clamp: logVisualCurCol carries the column from a previously
-		// focused line and may exceed this line's rune length.
+		// Clamp: logVisualCurCol may exceed this line's rune length;
+		// backward search ends at (excluding) the cursor.
 		end := min(m.logVisualCurCol, len(runes))
 		curBytePos := len(string(runes[:end]))
 		if curBytePos > 0 {

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -346,7 +346,11 @@ func (m *Model) findNextLogMatchForward(rawQuery string, start int) {
 	// Check for another match on the current line after the cursor.
 	if start >= 0 && start < len(m.logLines) {
 		dl := m.logDisplayLine(start)
-		curBytePos := len(string([]rune(dl)[:m.logVisualCurCol+1]))
+		runes := []rune(dl)
+		// Clamp: logVisualCurCol carries the column from a previously
+		// focused line and may exceed this line's rune length.
+		end := min(m.logVisualCurCol+1, len(runes))
+		curBytePos := len(string(runes[:end]))
 		if curBytePos < len(dl) {
 			col := ui.FindColumnInLine(dl[curBytePos:], rawQuery)
 			if col >= 0 {
@@ -371,7 +375,11 @@ func (m *Model) findNextLogMatchBackward(rawQuery string, start int) {
 	// Check for a match on the current line before the cursor.
 	if start >= 0 && start < len(m.logLines) {
 		dl := m.logDisplayLine(start)
-		curBytePos := len(string([]rune(dl)[:m.logVisualCurCol]))
+		runes := []rune(dl)
+		// Clamp: logVisualCurCol carries the column from a previously
+		// focused line and may exceed this line's rune length.
+		end := min(m.logVisualCurCol, len(runes))
+		curBytePos := len(string(runes[:end]))
 		if curBytePos > 0 {
 			lastCol := findLastMatchInStr(dl[:curBytePos], rawQuery)
 			if lastCol >= 0 {

--- a/internal/app/update_logs_test.go
+++ b/internal/app/update_logs_test.go
@@ -134,6 +134,36 @@ func TestFindNextLogMatch(t *testing.T) {
 		assert.Equal(t, 0, m.logCursor)
 	})
 
+	t.Run("does not panic on multi-byte rune lines when cursor col exceeds rune count", func(t *testing.T) {
+		// The bug is fundamentally about rune vs byte length divergence:
+		// `[]rune(line)[:n]` panics when n > len(runes). Multi-byte content
+		// (e.g. `こんにちは` is 5 runes / 15 bytes) exercises the rune path
+		// distinct from len(line). Verify both forward and backward.
+		m := Model{
+			height:          30,
+			width:           80,
+			tabs:            []TabState{{}},
+			logLines:        []string{"こんにちは", "info: target here"},
+			logSearchQuery:  "target",
+			logCursor:       0,
+			logVisualCurCol: 900, // far beyond 5 runes
+		}
+		assert.NotPanics(t, func() { m.findNextLogMatch(true) })
+		assert.Equal(t, 1, m.logCursor)
+
+		m2 := Model{
+			height:          30,
+			width:           80,
+			tabs:            []TabState{{}},
+			logLines:        []string{"info: target here", "こんにちは"},
+			logSearchQuery:  "target",
+			logCursor:       1,
+			logVisualCurCol: 900,
+		}
+		assert.NotPanics(t, func() { m2.findNextLogMatch(false) })
+		assert.Equal(t, 0, m2.logCursor)
+	})
+
 	t.Run("disables log follow on match", func(t *testing.T) {
 		m := Model{
 			height:         30,

--- a/internal/app/update_logs_test.go
+++ b/internal/app/update_logs_test.go
@@ -101,6 +101,39 @@ func TestFindNextLogMatch(t *testing.T) {
 		assert.Equal(t, 1, m.logCursor)
 	})
 
+	t.Run("forward does not panic when cursor col exceeds line length", func(t *testing.T) {
+		// Regression: logVisualCurCol carries over from a previously
+		// focused long line. When `n` triggers a forward search and the
+		// current (start) line is shorter than logVisualCurCol+1, the
+		// rune-slice indexing must not panic.
+		m := Model{
+			height:          30,
+			width:           80,
+			tabs:            []TabState{{}},
+			logLines:        []string{"short", "info: target here"},
+			logSearchQuery:  "target",
+			logCursor:       0,
+			logVisualCurCol: 900, // far beyond "short"
+		}
+		assert.NotPanics(t, func() { m.findNextLogMatch(true) })
+		assert.Equal(t, 1, m.logCursor)
+	})
+
+	t.Run("backward does not panic when cursor col exceeds line length", func(t *testing.T) {
+		// Same regression for the backward path (N / shift-n).
+		m := Model{
+			height:          30,
+			width:           80,
+			tabs:            []TabState{{}},
+			logLines:        []string{"info: target here", "short"},
+			logSearchQuery:  "target",
+			logCursor:       1,
+			logVisualCurCol: 900, // far beyond "short"
+		}
+		assert.NotPanics(t, func() { m.findNextLogMatch(false) })
+		assert.Equal(t, 0, m.logCursor)
+	})
+
 	t.Run("disables log follow on match", func(t *testing.T) {
 		m := Model{
 			height:         30,

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -647,9 +647,14 @@ func (m *Model) yamlNextIntraLineMatch(forward bool) bool {
 	}
 	line := visibleLines[m.yamlCursor]
 
+	runes := []rune(line)
 	if forward {
 		// Search for a match after the current cursor position.
-		curBytePos := len(string([]rune(line)[:m.yamlVisualCurCol+1]))
+		// Clamp: yamlVisualCurCol carries the column from a previously
+		// focused line and may exceed this line's rune length. Forward
+		// uses +1 because the search starts after (not at) the cursor.
+		end := min(m.yamlVisualCurCol+1, len(runes))
+		curBytePos := len(string(runes[:end]))
 		if curBytePos < len(line) {
 			remainder := line[curBytePos:]
 			col := ui.FindColumnInLine(remainder, rawQuery)
@@ -660,7 +665,10 @@ func (m *Model) yamlNextIntraLineMatch(forward bool) bool {
 		}
 	} else {
 		// Search for a match before the current cursor position.
-		curBytePos := len(string([]rune(line)[:m.yamlVisualCurCol]))
+		// Clamp: yamlVisualCurCol may exceed this line's rune length;
+		// backward search ends at (excluding) the cursor.
+		end := min(m.yamlVisualCurCol, len(runes))
+		curBytePos := len(string(runes[:end]))
 		if curBytePos > 0 {
 			prefix := line[:curBytePos]
 			// For backward search, find the last match in the prefix.

--- a/internal/app/update_yaml_test.go
+++ b/internal/app/update_yaml_test.go
@@ -215,3 +215,38 @@ func TestYAMLScrollToMatchFolded(t *testing.T) {
 		assert.Equal(t, 0, m.yamlCursor) // unchanged
 	})
 }
+
+// --- yamlNextIntraLineMatch ---
+
+func TestYamlNextIntraLineMatch(t *testing.T) {
+	t.Run("forward does not panic when cursor col exceeds line length", func(t *testing.T) {
+		// Regression: yamlVisualCurCol carries over from a previously
+		// focused long line. When `n` triggers an intra-line search and
+		// the current line is shorter than yamlVisualCurCol+1, the
+		// rune-slice indexing must not panic.
+		m := Model{
+			yamlContent:      "short\nfoo: target here",
+			yamlCursor:       0,
+			yamlVisualCurCol: 900, // far beyond "short"
+			yamlSearchText:   TextInput{Value: "target"},
+			yamlCollapsed:    map[string]bool{},
+		}
+		var found bool
+		assert.NotPanics(t, func() { found = m.yamlNextIntraLineMatch(true) })
+		assert.False(t, found, "no match expected on the short current line")
+	})
+
+	t.Run("backward does not panic when cursor col exceeds line length", func(t *testing.T) {
+		// Same regression for the backward path (N / shift-n).
+		m := Model{
+			yamlContent:      "foo: target here\nshort",
+			yamlCursor:       1,
+			yamlVisualCurCol: 900, // far beyond "short"
+			yamlSearchText:   TextInput{Value: "target"},
+			yamlCollapsed:    map[string]bool{},
+		}
+		var found bool
+		assert.NotPanics(t, func() { found = m.yamlNextIntraLineMatch(false) })
+		assert.False(t, found, "no match expected on the short current line")
+	})
+}


### PR DESCRIPTION
## Summary

Log-viewer search panicked with `slice bounds out of range [:N] with capacity M` when the cursor's sticky horizontal column (carried over from a previous longer line, vim-style) exceeded the rune length of the current line. Encountered while reading pod logs in wrap mode and triggering search/`n`/`N` after navigating across lines of differing lengths.

## Type of change

- [x] fix: bug fix

## Related issue

<!-- none -->

## Changes

- `findNextLogMatchForward` / `findNextLogMatchBackward`: extract `[]rune(dl)` once and clamp the slice end to `len(runes)` before computing `curBytePos`.
- When the cursor column is past the end of the current line, forward search now skips the on-line check and falls through to the next-line scan; backward search treats the entire line as "before the cursor" (rightmost-match search of the full line). Both behaviours match the user-visible search semantics.
- Add two regression subtests in `TestFindNextLogMatch` (forward + backward) with `logVisualCurCol` set far beyond the line's rune length. Verified each test panics on the unfixed code and passes after the fix.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (pre-commit hook)
- [x] Manually verified panic was triggered by sticky cursor column carryover during log search

## Checklist

- [x] Commits follow conventional commit style
- [x] No README / docs change required (internal bug fix, no user-visible behaviour change beyond not crashing)
- [x] No keybinding change
- [x] No secrets, tokens, or personal data in diffs
- [x] PR is opened from a feature branch on the fork