### PR TITLE
feat(ui): add structured preview side panel to log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
 - **YAML preview** in the right column with syntax highlighting
 - **Full-screen YAML viewer** with scrollable output, search, section folding (`Tab`/`z`), and in-place editing
 - **Resource details** summary in split preview (toggle with `Shift+P`)
-- **Inline log viewer** with streaming, search, line numbers, word wrap, follow mode, timestamps toggle, previous container logs, container filter, tail-first loading, line jump, and automatic reconnect across init-container transitions (stays attached as each init container finishes and the next one starts)
+- **Inline log viewer** with streaming, search, line numbers, word wrap, follow mode, timestamps toggle, previous container logs, container filter, tail-first loading, line jump, structured preview pane (`P`: parses the selected line as JSON or logfmt, falls back to plain text), and automatic reconnect across init-container transitions (stays attached as each init container finishes and the next one starts)
 - **Inline describe view** with scrollable output
 - **Secret viewing/editing** with decode toggle (`Ctrl+S`) and dedicated editor (`e`)
 - **Embedded terminal** (PTY mode) for exec and shell with tab switching — PTY keeps running in background when switching tabs

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -229,6 +229,7 @@ my namespace" mode.
 | `s` | Toggle timestamps |
 | `p` | Toggle pod/container prefixes |
 | `P` | Toggle structured preview side panel (JSON / logfmt / plain text) |
+| `J` / `K` | Scroll the preview side panel down / up (one row, no-op when panel is hidden) |
 | `c` | Toggle previous container logs |
 | `/` | Search in logs |
 | `n` / `N` | Next / previous search match |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -228,6 +228,7 @@ my namespace" mode.
 | `#` | Toggle line numbers |
 | `s` | Toggle timestamps |
 | `p` | Toggle pod/container prefixes |
+| `P` | Toggle structured preview side panel (JSON / logfmt / plain text) |
 | `c` | Toggle previous container logs |
 | `/` | Search in logs |
 | `n` / `N` | Next / previous search match |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -437,6 +437,7 @@ type Model struct {
 	logLineNumbers    bool               // show line numbers
 	logTimestamps     bool               // show timestamps (--timestamps)
 	logHidePrefixes   bool               // hide [pod/name/container] prefixes
+	logPreviewVisible bool               // show structured preview side panel
 	logPrevious       bool               // show previous container logs (--previous)
 	logIsMulti        bool               // multi-log stream (for restart)
 	logMultiItems     []model.Item       // items for multi-log restart

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -438,6 +438,7 @@ type Model struct {
 	logTimestamps     bool               // show timestamps (--timestamps)
 	logHidePrefixes   bool               // hide [pod/name/container] prefixes
 	logPreviewVisible bool               // show structured preview side panel
+	logPreviewScroll  int                // body-row offset within the preview pane (J/K)
 	logPrevious       bool               // show previous container logs (--previous)
 	logIsMulti        bool               // multi-log stream (for restart)
 	logMultiItems     []model.Item       // items for multi-log restart

--- a/internal/app/commands_logs_preview.go
+++ b/internal/app/commands_logs_preview.go
@@ -1,0 +1,56 @@
+package app
+
+// logPreviewMinTotalWidth is the minimum terminal width at which the log
+// preview side panel is rendered. Below this the toggle stays armed but the
+// panel is hidden so the log stream itself remains readable.
+const logPreviewMinTotalWidth = 80
+
+// splitLogPreviewWidth divides the available terminal width between the log
+// viewer and the preview side panel. Returns (logWidth, previewWidth=0) when
+// the terminal is too narrow to host both.
+func splitLogPreviewWidth(total int) (int, int) {
+	if total < logPreviewMinTotalWidth {
+		return total, 0
+	}
+	previewW := total * 2 / 5
+	switch {
+	case previewW < 30:
+		previewW = 30
+	case previewW > 80:
+		previewW = 80
+	}
+	logW := total - previewW
+	if logW < 50 {
+		logW = 50
+		previewW = total - logW
+	}
+	return logW, previewW
+}
+
+// logEffectiveWidth is the width the log viewer is actually rendered at,
+// accounting for the optional preview side panel. Used by wrap-math helpers
+// so cursor visibility and follow-mode pinning stay in sync with the renderer.
+func (m *Model) logEffectiveWidth() int {
+	if !m.logPreviewVisible {
+		return m.width
+	}
+	logW, previewW := splitLogPreviewWidth(m.width)
+	if previewW == 0 {
+		return m.width
+	}
+	return logW
+}
+
+// logPreviewLine returns the log line currently targeted by the preview pane.
+// The cursor is the source of truth; when it is unset (initial state, no
+// stream yet) we fall back to the most recent line.
+func (m *Model) logPreviewLine() string {
+	if len(m.logLines) == 0 {
+		return ""
+	}
+	idx := m.logCursor
+	if idx < 0 || idx >= len(m.logLines) {
+		idx = len(m.logLines) - 1
+	}
+	return m.logLines[idx]
+}

--- a/internal/app/commands_logs_preview_test.go
+++ b/internal/app/commands_logs_preview_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 func TestSplitLogPreviewWidth(t *testing.T) {
@@ -125,4 +127,134 @@ func TestViewLogsHidesPreviewWhenTerminalTooNarrow(t *testing.T) {
 	}
 	out := m.viewLogs()
 	assert.NotContains(t, out, "PREVIEW", "panel must be suppressed when terminal is too narrow")
+}
+
+// scrollOverflowJSON in the app package mirrors the one in internal/ui:
+// a JSON line whose pretty-printed body easily exceeds a small height so
+// scroll math can be exercised deterministically.
+const scrollOverflowJSON = `{"a":"1","b":"2","c":"3","d":"4","e":"5","f":"6","g":"7","h":"8"}`
+
+func TestLogKeyJCapitalScrollsPreviewDown(t *testing.T) {
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{scrollOverflowJSON},
+		logCursor:         0,
+		logPreviewVisible: true,
+		tabs:              []TabState{{}},
+		width:             140,
+		height:            10, // small enough to force preview overflow
+		logTitle:          "Logs",
+	}
+	ret, _ := m.handleLogKey(runeKey('J'))
+	scrolled := ret.(Model)
+	assert.Equal(t, 1, scrolled.logPreviewScroll, "J should advance preview scroll by 1")
+}
+
+func TestLogKeyKCapitalScrollsPreviewUp(t *testing.T) {
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{scrollOverflowJSON},
+		logCursor:         0,
+		logPreviewVisible: true,
+		logPreviewScroll:  3,
+		tabs:              []TabState{{}},
+		width:             140,
+		height:            10,
+		logTitle:          "Logs",
+	}
+	ret, _ := m.handleLogKey(runeKey('K'))
+	scrolled := ret.(Model)
+	assert.Equal(t, 2, scrolled.logPreviewScroll, "K should rewind preview scroll by 1")
+}
+
+func TestLogKeyJCapitalNoOpWhenPreviewHidden(t *testing.T) {
+	// J must not consume the key when preview is off. handleLogActionKey
+	// returning ok=false means the dispatcher leaves m unchanged at the
+	// outer handleLogKey level. We confirm scroll stays 0.
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{scrollOverflowJSON},
+		logCursor:         0,
+		logPreviewVisible: false,
+		tabs:              []TabState{{}},
+		width:             140,
+		height:            10,
+		logTitle:          "Logs",
+	}
+	ret, _ := m.handleLogKey(runeKey('J'))
+	after := ret.(Model)
+	assert.Equal(t, 0, after.logPreviewScroll, "J must not scroll preview when preview is hidden")
+}
+
+func TestLogKeyJCapitalClampsAtMax(t *testing.T) {
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{scrollOverflowJSON},
+		logCursor:         0,
+		logPreviewVisible: true,
+		tabs:              []TabState{{}},
+		width:             140,
+		height:            10,
+		logTitle:          "Logs",
+	}
+	// Press J many more times than the body has rows.
+	for range 100 {
+		ret, _ := m.handleLogKey(runeKey('J'))
+		m = ret.(Model)
+	}
+	_, previewW := splitLogPreviewWidth(m.width)
+	wantMax := ui.LogPreviewMaxScroll(m.logPreviewLine(), previewW, m.logViewHeight())
+	assert.Equal(t, wantMax, m.logPreviewScroll, "J spam must clamp at LogPreviewMaxScroll")
+}
+
+func TestLogKeyKCapitalClampsAtZero(t *testing.T) {
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{scrollOverflowJSON},
+		logCursor:         0,
+		logPreviewVisible: true,
+		logPreviewScroll:  0,
+		tabs:              []TabState{{}},
+		width:             140,
+		height:            10,
+		logTitle:          "Logs",
+	}
+	ret, _ := m.handleLogKey(runeKey('K'))
+	after := ret.(Model)
+	assert.Equal(t, 0, after.logPreviewScroll, "K at scroll 0 must not go negative")
+}
+
+func TestEnsureLogCursorVisibleResetsPreviewScroll(t *testing.T) {
+	// Whenever the cursor moves the previewed line changes, so any prior
+	// scroll offset is stale and must be cleared. ensureLogCursorVisible
+	// is the chokepoint every cursor handler funnels through.
+	m := Model{
+		logLines:         []string{"a", "b", "c"},
+		logCursor:        2,
+		logPreviewScroll: 5,
+		width:            120,
+		height:           20,
+	}
+	m.ensureLogCursorVisible()
+	assert.Equal(t, 0, m.logPreviewScroll, "ensureLogCursorVisible must reset preview scroll")
+}
+
+func TestLogKeyJLowercaseResetsPreviewScroll(t *testing.T) {
+	// Behavioral guarantee that the scroll-reset path is wired up: pressing
+	// lowercase j (cursor down) must reset any preview scroll because the
+	// cursor lands on a different line whose preview is unrelated.
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{"first line", "second line"},
+		logCursor:         0,
+		logPreviewVisible: true,
+		logPreviewScroll:  4,
+		tabs:              []TabState{{}},
+		width:             140,
+		height:            20,
+		logTitle:          "Logs",
+	}
+	ret, _ := m.handleLogKey(runeKey('j'))
+	after := ret.(Model)
+	assert.Equal(t, 0, after.logPreviewScroll, "lowercase j must reset preview scroll via ensureLogCursorVisible")
 }

--- a/internal/app/commands_logs_preview_test.go
+++ b/internal/app/commands_logs_preview_test.go
@@ -203,7 +203,10 @@ func TestLogKeyJCapitalClampsAtMax(t *testing.T) {
 		m = ret.(Model)
 	}
 	_, previewW := splitLogPreviewWidth(m.width)
-	wantMax := ui.LogPreviewMaxScroll(m.logPreviewLine(), previewW, m.logViewHeight())
+	// Mirror the handler: maxScroll is computed from the inner content
+	// height (logContentHeight), and LogPreviewMaxScroll's height arg is
+	// the outer panel size, so add 2 for the border.
+	wantMax := ui.LogPreviewMaxScroll(m.logPreviewLine(), previewW, m.logContentHeight()+2)
 	assert.Equal(t, wantMax, m.logPreviewScroll, "J spam must clamp at LogPreviewMaxScroll")
 }
 
@@ -237,6 +240,48 @@ func TestEnsureLogCursorVisibleResetsPreviewScroll(t *testing.T) {
 	}
 	m.ensureLogCursorVisible()
 	assert.Equal(t, 0, m.logPreviewScroll, "ensureLogCursorVisible must reset preview scroll")
+}
+
+func TestScrollToMaxRevealsLastBodyRowInRenderedView(t *testing.T) {
+	// Regression: the J handler computes maxScroll from m.logContentHeight()
+	// because m.logViewHeight() depends on View()'s mutation of m.height
+	// for the app title bar (and optional tab bar). Using the wrong height
+	// makes maxScroll 1-2 short and hides the last body rows from the user.
+	//
+	// This test mirrors the user-visible flow: build a body that overflows,
+	// spam J to reach max, then assert the last body line appears in the
+	// rendered viewLogs output. View() reduces m.height by 1 before
+	// dispatching, so we mimic that reduction in the test setup so viewLogs
+	// sees the same height the real app pipeline would give it.
+	const sentinel = "END_OF_BODY_MARKER"
+	// Many fields so body line count exceeds the panel height regardless
+	// of which side of the off-by-one bug we're on.
+	jsonLine := `{"a":"1","b":"2","c":"3","d":"4","e":"5","f":"6","g":"7","h":"8","i":"9","j":"10","k":"11","l":"12","m":"13","n":"14","o":"15","p":"16","q":"17","r":"18","s":"19","t":"20","u":"21","v":"22","w":"23","x":"24","y":"25","z_last_field":"` + sentinel + `"}`
+	terminalH := 16
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{jsonLine},
+		logCursor:         0,
+		logPreviewVisible: true,
+		tabs:              []TabState{{}}, // single tab → no tab bar
+		width:             140,
+		height:            terminalH, // Update-context: untouched terminal height
+		logTitle:          "Logs",
+	}
+	// Spam J more times than there could possibly be body rows so we land
+	// at whatever maxScroll the handler considers final.
+	for range 100 {
+		ret, _ := m.handleLogKey(runeKey('J'))
+		m = ret.(Model)
+	}
+	// Render viewLogs the same way View() would: with m.height reduced by
+	// 1 for the app title bar.
+	m.height = terminalH - 1
+	out := m.viewLogs()
+	assert.Contains(t, out, sentinel,
+		"after spamming J the last body row must be visible in viewLogs output; "+
+			"if maxScroll is computed against the wrong height the handler stops "+
+			"short and the user sees the bottom of the body clipped off-screen")
 }
 
 func TestLogKeyJLowercaseResetsPreviewScroll(t *testing.T) {

--- a/internal/app/commands_logs_preview_test.go
+++ b/internal/app/commands_logs_preview_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitLogPreviewWidth(t *testing.T) {
+	cases := []struct {
+		name              string
+		total             int
+		wantLog, wantPrev int
+	}{
+		{"narrow disables panel", 60, 60, 0},
+		{"borderline disables panel", 79, 79, 0},
+		{"baseline 80 splits to floor", 80, 50, 30},
+		{"medium 120 hits 40 percent", 120, 72, 48},
+		{"wide caps preview at 80", 250, 170, 80},
+		{"width 100 keeps natural split", 100, 60, 40},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLog, gotPrev := splitLogPreviewWidth(tc.total)
+			assert.Equal(t, tc.wantLog, gotLog, "logWidth")
+			assert.Equal(t, tc.wantPrev, gotPrev, "previewWidth")
+			if gotPrev > 0 {
+				assert.Equal(t, tc.total, gotLog+gotPrev, "split must sum to total")
+			}
+		})
+	}
+}
+
+func TestLogEffectiveWidthRespectsPreview(t *testing.T) {
+	m := Model{width: 200}
+	assert.Equal(t, 200, m.logEffectiveWidth(), "preview off: full width")
+
+	m.logPreviewVisible = true
+	logW, prevW := splitLogPreviewWidth(200)
+	assert.Equal(t, logW, m.logEffectiveWidth(), "preview on: log column width")
+	assert.Greater(t, prevW, 0, "expected non-zero preview width at width 200")
+
+	m.width = 60
+	assert.Equal(t, 60, m.logEffectiveWidth(), "narrow terminal: preview hidden, full width")
+}
+
+func TestLogPreviewLine(t *testing.T) {
+	m := Model{logLines: nil}
+	assert.Equal(t, "", m.logPreviewLine(), "empty buffer returns empty")
+
+	m.logLines = []string{"first", "second", "third"}
+	m.logCursor = 1
+	assert.Equal(t, "second", m.logPreviewLine(), "cursor in range returns its line")
+
+	m.logCursor = -1
+	assert.Equal(t, "third", m.logPreviewLine(), "unset cursor falls back to last line")
+
+	m.logCursor = 99
+	assert.Equal(t, "third", m.logPreviewLine(), "out-of-range cursor falls back to last line")
+}
+
+func TestLogKeyPCapitalTogglesPreview(t *testing.T) {
+	m := Model{
+		mode:     modeLogs,
+		logLines: []string{`{"level":"info","msg":"hi"}`},
+		tabs:     []TabState{{}},
+		width:    120,
+		height:   40,
+	}
+	assert.False(t, m.logPreviewVisible)
+
+	ret, _ := m.handleLogKey(runeKey('P'))
+	on := ret.(Model)
+	assert.True(t, on.logPreviewVisible, "P should turn preview on")
+
+	ret2, _ := on.handleLogKey(runeKey('P'))
+	off := ret2.(Model)
+	assert.False(t, off.logPreviewVisible, "second P should turn preview off")
+}
+
+func TestLogKeyPLowercaseStillTogglesPrefixesOnly(t *testing.T) {
+	// Regression guard: lowercase p must remain bound to the prefix toggle
+	// and must not affect the new preview state.
+	m := Model{
+		mode:     modeLogs,
+		logLines: []string{"[pod/x/y] line"},
+		tabs:     []TabState{{}},
+		width:    120,
+		height:   40,
+	}
+	ret, _ := m.handleLogKey(runeKey('p'))
+	result := ret.(Model)
+	assert.True(t, result.logHidePrefixes, "lowercase p toggles prefixes")
+	assert.False(t, result.logPreviewVisible, "lowercase p must not affect preview")
+}
+
+func TestViewLogsRendersPreviewWhenVisible(t *testing.T) {
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{`{"level":"info","msg":"served","port":8080}`},
+		logCursor:         0,
+		logPreviewVisible: true,
+		tabs:              []TabState{{}},
+		width:             140,
+		height:            30,
+		logTitle:          "Logs",
+	}
+	out := m.viewLogs()
+	// The PREVIEW header and the JSON-detection label should appear once
+	// the side panel is rendered.
+	assert.Contains(t, out, "PREVIEW")
+	assert.Contains(t, out, "JSON")
+}
+
+func TestViewLogsHidesPreviewWhenTerminalTooNarrow(t *testing.T) {
+	m := Model{
+		mode:              modeLogs,
+		logLines:          []string{`{"level":"info"}`},
+		logCursor:         0,
+		logPreviewVisible: true, // armed but width < 80 so panel must be suppressed
+		tabs:              []TabState{{}},
+		width:             60,
+		height:            30,
+		logTitle:          "Logs",
+	}
+	out := m.viewLogs()
+	assert.NotContains(t, out, "PREVIEW", "panel must be suppressed when terminal is too narrow")
+}

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -142,6 +142,9 @@ func (m Model) handleLogActionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	case "p":
 		ret := m.handleLogKeyP()
 		return ret, nil, true
+	case "P":
+		ret := m.handleLogKeyP2()
+		return ret, nil, true
 	case "#":
 		ret := m.handleLogKeyHash()
 		return ret, nil, true
@@ -782,6 +785,15 @@ func (m Model) handleLogKeyN2() Model {
 func (m Model) handleLogKeyP() Model {
 	m.logLineInput = ""
 	m.logHidePrefixes = !m.logHidePrefixes
+	return m
+}
+
+func (m Model) handleLogKeyP2() Model {
+	m.logLineInput = ""
+	m.logPreviewVisible = !m.logPreviewVisible
+	// Effective viewer width changes when the panel toggles, so wrap-aware
+	// scroll/skip values need recomputing for the new geometry.
+	m.ensureLogCursorVisible()
 	return m
 }
 

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -145,6 +145,18 @@ func (m Model) handleLogActionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	case "P":
 		ret := m.handleLogKeyP2()
 		return ret, nil, true
+	case "J":
+		if !m.logPreviewVisible {
+			return m, nil, false
+		}
+		ret := m.handleLogKeyJ2()
+		return ret, nil, true
+	case "K":
+		if !m.logPreviewVisible {
+			return m, nil, false
+		}
+		ret := m.handleLogKeyK2()
+		return ret, nil, true
 	case "#":
 		ret := m.handleLogKeyHash()
 		return ret, nil, true
@@ -791,9 +803,35 @@ func (m Model) handleLogKeyP() Model {
 func (m Model) handleLogKeyP2() Model {
 	m.logLineInput = ""
 	m.logPreviewVisible = !m.logPreviewVisible
+	m.logPreviewScroll = 0
 	// Effective viewer width changes when the panel toggles, so wrap-aware
 	// scroll/skip values need recomputing for the new geometry.
 	m.ensureLogCursorVisible()
+	return m
+}
+
+// handleLogKeyJ2 scrolls the structured preview pane down by one body row.
+// Caller is responsible for checking m.logPreviewVisible — this only runs
+// when the panel is on, so it is safe to assume a valid preview width.
+func (m Model) handleLogKeyJ2() Model {
+	m.logLineInput = ""
+	_, previewW := splitLogPreviewWidth(m.width)
+	if previewW == 0 {
+		return m
+	}
+	maxScroll := ui.LogPreviewMaxScroll(m.logPreviewLine(), previewW, m.logViewHeight())
+	if m.logPreviewScroll < maxScroll {
+		m.logPreviewScroll++
+	}
+	return m
+}
+
+// handleLogKeyK2 scrolls the structured preview pane up by one body row.
+func (m Model) handleLogKeyK2() Model {
+	m.logLineInput = ""
+	if m.logPreviewScroll > 0 {
+		m.logPreviewScroll--
+	}
 	return m
 }
 

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -819,7 +819,15 @@ func (m Model) handleLogKeyJ2() Model {
 	if previewW == 0 {
 		return m
 	}
-	maxScroll := ui.LogPreviewMaxScroll(m.logPreviewLine(), previewW, m.logViewHeight())
+	// LogPreviewMaxScroll's `height` arg is the outer panel height — it
+	// subtracts 2 internally for the border to reach the inner content
+	// height. logContentHeight already gives that inner height (it
+	// accounts for the View()-time app title / tab bar reductions that
+	// m.logViewHeight() can't see from Update context), so add 2 to map
+	// back. Using logViewHeight here would over-count by 1 (or 2 with
+	// tabs) and clip the last body rows off the user's viewport.
+	previewH := m.logContentHeight() + 2
+	maxScroll := ui.LogPreviewMaxScroll(m.logPreviewLine(), previewW, previewH)
 	if m.logPreviewScroll < maxScroll {
 		m.logPreviewScroll++
 	}

--- a/internal/app/view_modes.go
+++ b/internal/app/view_modes.go
@@ -30,7 +30,7 @@ func (m Model) viewLogs() string {
 	logView := ui.RenderLogViewer(m.logLines, m.logScroll, logWidth, viewH, m.logFollow, m.logWrap, m.logLineNumbers, m.logTimestamps, m.logPrevious, m.logHidePrefixes, m.logTitle, m.logSearchQuery, m.logSearchInput.Value, m.logSearchActive, canSwitchPod, canFilterContainers, m.logHasMoreHistory, m.logLoadingHistory, statusMsg, statusIsErr, m.logCursor, m.logVisualMode, m.logVisualStart, m.logVisualType, m.logVisualCol, m.logVisualCurCol, m.logWrapTopSkip)
 
 	if previewWidth > 0 {
-		preview := ui.RenderLogPreviewPane(m.logPreviewLine(), previewWidth, viewH)
+		preview := ui.RenderLogPreviewPane(m.logPreviewLine(), previewWidth, viewH, m.logPreviewScroll)
 		return lipgloss.JoinHorizontal(lipgloss.Top, logView, preview)
 	}
 	return logView
@@ -304,6 +304,12 @@ func (m *Model) clampLogScroll() {
 // classic source-line scrolloff. logFollow always wins: it snaps to the
 // (maxScroll, topSkip) pair that pins the most recent sub-line to the bottom.
 func (m *Model) ensureLogCursorVisible() {
+	// Cursor movement implies the previewed line just changed (or is about
+	// to), so any prior preview scroll is now relative to stale content.
+	// Resetting here covers j/k/ctrl+d/u/ctrl+f/b/G/g/search-next as well
+	// as the toggle, which all reach this function.
+	m.logPreviewScroll = 0
+
 	if m.logCursor < 0 {
 		return
 	}

--- a/internal/app/view_modes.go
+++ b/internal/app/view_modes.go
@@ -20,7 +20,20 @@ func (m Model) viewLogs() string {
 		statusMsg = m.statusMessage
 		statusIsErr = m.statusMessageErr
 	}
-	return ui.RenderLogViewer(m.logLines, m.logScroll, m.width, viewH, m.logFollow, m.logWrap, m.logLineNumbers, m.logTimestamps, m.logPrevious, m.logHidePrefixes, m.logTitle, m.logSearchQuery, m.logSearchInput.Value, m.logSearchActive, canSwitchPod, canFilterContainers, m.logHasMoreHistory, m.logLoadingHistory, statusMsg, statusIsErr, m.logCursor, m.logVisualMode, m.logVisualStart, m.logVisualType, m.logVisualCol, m.logVisualCurCol, m.logWrapTopSkip)
+
+	logWidth := m.width
+	previewWidth := 0
+	if m.logPreviewVisible {
+		logWidth, previewWidth = splitLogPreviewWidth(m.width)
+	}
+
+	logView := ui.RenderLogViewer(m.logLines, m.logScroll, logWidth, viewH, m.logFollow, m.logWrap, m.logLineNumbers, m.logTimestamps, m.logPrevious, m.logHidePrefixes, m.logTitle, m.logSearchQuery, m.logSearchInput.Value, m.logSearchActive, canSwitchPod, canFilterContainers, m.logHasMoreHistory, m.logLoadingHistory, statusMsg, statusIsErr, m.logCursor, m.logVisualMode, m.logVisualStart, m.logVisualType, m.logVisualCol, m.logVisualCurCol, m.logWrapTopSkip)
+
+	if previewWidth > 0 {
+		preview := ui.RenderLogPreviewPane(m.logPreviewLine(), previewWidth, viewH)
+		return lipgloss.JoinHorizontal(lipgloss.Top, logView, preview)
+	}
+	return logView
 }
 
 func (m Model) viewDescribe() string {
@@ -424,9 +437,11 @@ func (m *Model) logMaxScrollAndSkip() (int, int) {
 
 // logWrapAvailWidth returns the per-line content width used when computing
 // wrap counts. Mirrors the logviewer's renderWrappedLines availWidth math
-// (border + padding + cursor gutter + line-number gutter).
+// (border + padding + cursor gutter + line-number gutter). Uses the
+// effective viewer width so wrap math stays correct when the preview pane
+// is open and the log column has been narrowed.
 func (m *Model) logWrapAvailWidth() int {
-	contentWidth := max(m.width-4, 10)
+	contentWidth := max(m.logEffectiveWidth()-4, 10)
 	lineNumWidth := 0
 	if m.logLineNumbers && len(m.logLines) > 0 {
 		lineNumWidth = len(fmt.Sprintf("%d", len(m.logLines))) + 1

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -342,6 +342,7 @@ func helpSections() []helpSection {
 				{"#", "Toggle line numbers"},
 				{"s", "Toggle timestamps"},
 				{"p", "Toggle pod/container prefixes"},
+				{"P", "Toggle structured preview side panel (JSON / logfmt / text)"},
 				{"c", "Toggle previous container logs"},
 				{"/", "Search in logs"},
 				{"n", "Next search match"},

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -343,6 +343,7 @@ func helpSections() []helpSection {
 				{"s", "Toggle timestamps"},
 				{"p", "Toggle pod/container prefixes"},
 				{"P", "Toggle structured preview side panel (JSON / logfmt / text)"},
+				{"J/K", "Scroll preview side panel down/up (when visible)"},
 				{"c", "Toggle previous container logs"},
 				{"/", "Search in logs"},
 				{"n", "Next search match"},

--- a/internal/ui/logpreview.go
+++ b/internal/ui/logpreview.go
@@ -1,0 +1,294 @@
+package ui
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// LogPreviewKind identifies how the previewed log line was parsed.
+type LogPreviewKind int
+
+const (
+	LogPreviewText LogPreviewKind = iota
+	LogPreviewJSON
+	LogPreviewLogfmt
+)
+
+// LogPreviewField is a single key/value pair extracted from a structured log line.
+type LogPreviewField struct {
+	Key   string
+	Value string
+}
+
+// ParsedLogPreview holds the result of parsing a single log line for preview.
+type ParsedLogPreview struct {
+	Kind   LogPreviewKind
+	Prefix string // pod/container bracket prefix, e.g. "[pod/foo/bar]" or ""
+	Time   string // RFC3339Nano timestamp prefix, or ""
+	Body   string // raw line with prefix and timestamp stripped
+	Fields []LogPreviewField
+}
+
+// ParseLogLine extracts the optional pod prefix and timestamp, then tries
+// JSON and logfmt parsing in order. Falls back to plain text when neither
+// matches. Parsing is intentionally cheap and never panics.
+func ParseLogLine(line string) ParsedLogPreview {
+	p := ParsedLogPreview{Kind: LogPreviewText, Body: line}
+	rest := line
+	if len(rest) > 0 && rest[0] == '[' {
+		if i := strings.Index(rest, "] "); i > 0 {
+			p.Prefix = rest[:i+1]
+			rest = rest[i+2:]
+		}
+	}
+	if t, after, ok := splitLeadingTimestamp(rest); ok {
+		p.Time = t
+		rest = after
+	}
+	p.Body = rest
+
+	trimmed := strings.TrimSpace(rest)
+	if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' {
+		if fields, ok := parseJSONFields(trimmed); ok {
+			p.Kind = LogPreviewJSON
+			p.Fields = fields
+			return p
+		}
+	}
+	if fields, ok := parseLogfmtFields(rest); ok {
+		p.Kind = LogPreviewLogfmt
+		p.Fields = fields
+		return p
+	}
+	return p
+}
+
+// splitLeadingTimestamp returns the leading RFC3339Nano timestamp and the
+// remainder, or ("", s, false) when s does not start with a timestamp.
+// Mirrors the detection in stripTimestampRaw.
+func splitLeadingTimestamp(s string) (string, string, bool) {
+	if len(s) < 21 || s[4] != '-' || s[10] != 'T' {
+		return "", s, false
+	}
+	spaceIdx := strings.IndexByte(s, ' ')
+	if spaceIdx < 20 || spaceIdx > 35 {
+		return "", s, false
+	}
+	return s[:spaceIdx], s[spaceIdx+1:], true
+}
+
+func parseJSONFields(s string) ([]LogPreviewField, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		return nil, false
+	}
+	if len(raw) == 0 {
+		return nil, false
+	}
+	keys := make([]string, 0, len(raw))
+	for k := range raw {
+		keys = append(keys, k)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		ri, rj := jsonKeyRank(keys[i]), jsonKeyRank(keys[j])
+		if ri != rj {
+			return ri < rj
+		}
+		return keys[i] < keys[j]
+	})
+	fields := make([]LogPreviewField, 0, len(keys))
+	for _, k := range keys {
+		fields = append(fields, LogPreviewField{Key: k, Value: jsonValueString(raw[k])})
+	}
+	return fields, true
+}
+
+// jsonKeyRank orders well-known structured-logging keys ahead of arbitrary
+// fields so the most useful information sits at the top of the panel.
+func jsonKeyRank(k string) int {
+	switch strings.ToLower(k) {
+	case "time", "timestamp", "ts", "@timestamp":
+		return 0
+	case "level", "lvl", "severity":
+		return 1
+	case "msg", "message":
+		return 2
+	case "logger", "caller", "source":
+		return 3
+	case "error", "err":
+		return 4
+	}
+	return 100
+}
+
+func jsonValueString(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err == nil {
+		b, err := json.MarshalIndent(v, "", "  ")
+		if err == nil {
+			return string(b)
+		}
+	}
+	return string(raw)
+}
+
+// logfmtPair matches `key=bareword` and `key="quoted value"` pairs. Keys are
+// alphanumeric plus _ . - to cover the common ecosystem (logfmt, klog, slog).
+var logfmtPair = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_.\-]*)=(?:"((?:[^"\\]|\\.)*)"|([^\s"]+))`)
+
+func parseLogfmtFields(s string) ([]LogPreviewField, bool) {
+	matches := logfmtPair.FindAllStringSubmatch(s, -1)
+	// Require at least 2 distinct pairs to count as logfmt — a single
+	// `foo=bar` token is too easy to hit on free-form text.
+	if len(matches) < 2 {
+		return nil, false
+	}
+	fields := make([]LogPreviewField, 0, len(matches))
+	for _, m := range matches {
+		v := m[2]
+		if v == "" {
+			v = m[3]
+		}
+		fields = append(fields, LogPreviewField{Key: m[1], Value: v})
+	}
+	return fields, true
+}
+
+// RenderLogPreviewPane renders a side panel showing the parsed view of a
+// single log line. Output is exactly width columns wide and height+2 rows
+// tall (matching RenderLogViewer's title + body + footer layout) so it can
+// be JoinHorizontal'd next to the main log view.
+func RenderLogPreviewPane(line string, width, height int) string {
+	if width < 10 {
+		width = 10
+	}
+	if height < 3 {
+		height = 3
+	}
+	parsed := ParseLogLine(line)
+
+	titleText := " PREVIEW "
+	switch parsed.Kind {
+	case LogPreviewJSON:
+		titleText += HelpKeyStyle.Render("[JSON]")
+	case LogPreviewLogfmt:
+		titleText += HelpKeyStyle.Render("[LOGFMT]")
+	default:
+		titleText += HelpKeyStyle.Render("[TEXT]")
+	}
+	titleBar := FillLinesBg(
+		TitleStyle.Width(width).MaxWidth(width).MaxHeight(1).Render(titleText),
+		width, BarBg)
+
+	contentHeight := max(height-2, 1)
+	contentWidth := max(width-4, 10) // border 2 + padding 2
+
+	bodyLines := buildPreviewBody(parsed, contentWidth)
+
+	if len(bodyLines) > contentHeight {
+		bodyLines = bodyLines[:contentHeight]
+	}
+	for len(bodyLines) < contentHeight {
+		bodyLines = append(bodyLines, "")
+	}
+
+	bodyContent := strings.Join(bodyLines, "\n")
+	bodyContent = FillLinesBg(bodyContent, contentWidth, BaseBg)
+	body := FullscreenBorderStyle(width, contentHeight).Render(bodyContent)
+
+	// Empty status bar keeps the panel's row count aligned with the log
+	// viewer's title + body + footer layout so JoinHorizontal stays clean.
+	// The P binding is already shown in the main log hint bar.
+	footer := StatusBarBgStyle.Width(width).MaxWidth(width).MaxHeight(1).Render("")
+
+	return lipgloss.JoinVertical(lipgloss.Left, titleBar, body, footer)
+}
+
+func buildPreviewBody(parsed ParsedLogPreview, contentWidth int) []string {
+	if parsed.Prefix == "" && parsed.Time == "" && parsed.Body == "" && len(parsed.Fields) == 0 {
+		return []string{DimStyle.Render("(no log line selected)")}
+	}
+	var lines []string
+	if parsed.Prefix != "" {
+		lines = append(lines, DimStyle.Render("source ")+parsed.Prefix)
+	}
+	if parsed.Time != "" {
+		lines = append(lines, DimStyle.Render("time   ")+parsed.Time)
+	}
+	if (parsed.Prefix != "" || parsed.Time != "") && (len(parsed.Fields) > 0 || parsed.Body != "") {
+		lines = append(lines, "")
+	}
+	if len(parsed.Fields) > 0 {
+		lines = append(lines, renderPreviewFields(parsed.Fields, contentWidth)...)
+		return lines
+	}
+	body := strings.TrimSpace(parsed.Body)
+	if body == "" {
+		lines = append(lines, DimStyle.Render("(empty)"))
+		return lines
+	}
+	for src := range strings.SplitSeq(body, "\n") {
+		lines = append(lines, wrapLine(sanitizeLogLine(src, ConfigLogRenderAnsi), contentWidth)...)
+	}
+	return lines
+}
+
+func renderPreviewFields(fields []LogPreviewField, width int) []string {
+	keyWidth := 0
+	for _, f := range fields {
+		if l := len([]rune(f.Key)); l > keyWidth {
+			keyWidth = l
+		}
+	}
+	if keyWidth > 18 {
+		keyWidth = 18
+	}
+	keyStyle := lipgloss.NewStyle().Foreground(ThemeColor(ColorPrimary)).Bold(true)
+	sepStyle := DimStyle
+	prefixCells := keyWidth + 3 // " : " separator
+	availForValue := max(width-prefixCells, 10)
+
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		key, keyDisplayLen := truncateKeyForPreview(f.Key, keyWidth)
+		prefix := keyStyle.Render(key) + strings.Repeat(" ", keyWidth-keyDisplayLen) + sepStyle.Render(" : ")
+		first := true
+		for line := range strings.SplitSeq(f.Value, "\n") {
+			chunks := wrapLine(sanitizeLogLine(line, ConfigLogRenderAnsi), availForValue)
+			if len(chunks) == 0 {
+				chunks = []string{""}
+			}
+			for _, chunk := range chunks {
+				if first {
+					out = append(out, prefix+chunk)
+					first = false
+				} else {
+					out = append(out, strings.Repeat(" ", prefixCells)+chunk)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// truncateKeyForPreview clamps a key to at most keyWidth runes, appending an
+// ellipsis when truncation occurs so the user can tell the displayed key has
+// been shortened. Returns the rendered key and its rune count for padding.
+func truncateKeyForPreview(key string, keyWidth int) (string, int) {
+	runes := []rune(key)
+	if len(runes) <= keyWidth {
+		return key, len(runes)
+	}
+	if keyWidth <= 1 {
+		return "…", 1
+	}
+	return string(runes[:keyWidth-1]) + "…", keyWidth
+}

--- a/internal/ui/logpreview.go
+++ b/internal/ui/logpreview.go
@@ -69,7 +69,8 @@ func ParseLogLine(line string) ParsedLogPreview {
 
 // splitLeadingTimestamp returns the leading RFC3339Nano timestamp and the
 // remainder, or ("", s, false) when s does not start with a timestamp.
-// Mirrors the detection in stripTimestampRaw.
+// This is the canonical primitive; stripTimestampRaw delegates to it.
+// Minimum length: "2024-01-15T10:30:00Z " = 21 chars.
 func splitLeadingTimestamp(s string) (string, string, bool) {
 	if len(s) < 21 || s[4] != '-' || s[10] != 'T' {
 		return "", s, false

--- a/internal/ui/logpreview.go
+++ b/internal/ui/logpreview.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -166,8 +167,11 @@ func parseLogfmtFields(s string) ([]LogPreviewField, bool) {
 // RenderLogPreviewPane renders a side panel showing the parsed view of a
 // single log line. Output is exactly width columns wide and height+2 rows
 // tall (matching RenderLogViewer's title + body + footer layout) so it can
-// be JoinHorizontal'd next to the main log view.
-func RenderLogPreviewPane(line string, width, height int) string {
+// be JoinHorizontal'd next to the main log view. scroll is the number of
+// body rows to skip from the top; it is clamped to [0, max] internally so
+// callers can pass an unclamped value and rely on LogPreviewMaxScroll for
+// the upper bound when they need it (e.g. to gate key handlers).
+func RenderLogPreviewPane(line string, width, height, scroll int) string {
 	if width < 10 {
 		width = 10
 	}
@@ -175,6 +179,16 @@ func RenderLogPreviewPane(line string, width, height int) string {
 		height = 3
 	}
 	parsed := ParseLogLine(line)
+
+	contentHeight := max(height-2, 1)
+	contentWidth := max(width-4, 10) // border 2 + padding 2
+
+	bodyLines := buildPreviewBody(parsed, contentWidth)
+	totalLines := len(bodyLines)
+	scroll = clampPreviewScroll(scroll, totalLines, contentHeight)
+	if scroll > 0 {
+		bodyLines = bodyLines[scroll:]
+	}
 
 	titleText := " PREVIEW "
 	switch parsed.Kind {
@@ -185,14 +199,14 @@ func RenderLogPreviewPane(line string, width, height int) string {
 	default:
 		titleText += HelpKeyStyle.Render("[TEXT]")
 	}
+	if totalLines > contentHeight {
+		// Show "topVisibleRow/totalRows" so the user can see how far they
+		// have scrolled and how much body content is still hidden.
+		titleText += "  " + DimStyle.Render(scrollPositionLabel(scroll, totalLines))
+	}
 	titleBar := FillLinesBg(
 		TitleStyle.Width(width).MaxWidth(width).MaxHeight(1).Render(titleText),
 		width, BarBg)
-
-	contentHeight := max(height-2, 1)
-	contentWidth := max(width-4, 10) // border 2 + padding 2
-
-	bodyLines := buildPreviewBody(parsed, contentWidth)
 
 	if len(bodyLines) > contentHeight {
 		bodyLines = bodyLines[:contentHeight]
@@ -207,10 +221,44 @@ func RenderLogPreviewPane(line string, width, height int) string {
 
 	// Empty status bar keeps the panel's row count aligned with the log
 	// viewer's title + body + footer layout so JoinHorizontal stays clean.
-	// The P binding is already shown in the main log hint bar.
+	// The P / J / K bindings are advertised in the main log hint bar.
 	footer := StatusBarBgStyle.Width(width).MaxWidth(width).MaxHeight(1).Render("")
 
 	return lipgloss.JoinVertical(lipgloss.Left, titleBar, body, footer)
+}
+
+// LogPreviewMaxScroll returns the largest valid scroll offset for
+// RenderLogPreviewPane given the same line and dimensions. Callers use this
+// to clamp scroll-down handlers without re-rendering.
+func LogPreviewMaxScroll(line string, width, height int) int {
+	if width < 10 {
+		width = 10
+	}
+	if height < 3 {
+		height = 3
+	}
+	parsed := ParseLogLine(line)
+	contentHeight := max(height-2, 1)
+	contentWidth := max(width-4, 10)
+	bodyLines := buildPreviewBody(parsed, contentWidth)
+	return max(0, len(bodyLines)-contentHeight)
+}
+
+func clampPreviewScroll(scroll, total, contentHeight int) int {
+	if scroll < 0 {
+		return 0
+	}
+	maxScroll := max(0, total-contentHeight)
+	if scroll > maxScroll {
+		return maxScroll
+	}
+	return scroll
+}
+
+func scrollPositionLabel(scroll, total int) string {
+	// scroll is 0-based row index of the top visible row. Show 1-based to
+	// match how editors present line counters.
+	return fmt.Sprintf("%d/%d", scroll+1, total)
 }
 
 func buildPreviewBody(parsed ParsedLogPreview, contentWidth int) []string {

--- a/internal/ui/logpreview_test.go
+++ b/internal/ui/logpreview_test.go
@@ -35,6 +35,68 @@ func TestParseLogLine_JSON(t *testing.T) {
 	}
 }
 
+func TestJSONKeyRank(t *testing.T) {
+	cases := []struct {
+		key  string
+		want int
+	}{
+		// Time bucket.
+		{"time", 0},
+		{"timestamp", 0},
+		{"ts", 0},
+		{"@timestamp", 0},
+		// Level bucket.
+		{"level", 1},
+		{"lvl", 1},
+		{"severity", 1},
+		// Message bucket.
+		{"msg", 2},
+		{"message", 2},
+		// Source bucket.
+		{"logger", 3},
+		{"caller", 3},
+		{"source", 3},
+		// Error bucket.
+		{"error", 4},
+		{"err", 4},
+		// Case-insensitive matching for any of the above.
+		{"LEVEL", 1},
+		{"Msg", 2},
+		{"@TimeStamp", 0},
+		// Anything else falls into the catch-all bucket.
+		{"port", 100},
+		{"trace_id", 100},
+		{"", 100},
+	}
+	for _, tc := range cases {
+		if got := jsonKeyRank(tc.key); got != tc.want {
+			t.Errorf("jsonKeyRank(%q) = %d, want %d", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestParseLogLine_JSONFieldOrderUsesAliases(t *testing.T) {
+	// Mixed aliases must produce the canonical rank order:
+	// time(0) < level(1) < msg(2) < logger(3) < error(4) < others(100).
+	p := ParseLogLine(`{"trace_id":"x","err":"boom","caller":"main.go:1","lvl":"info","message":"hi","@timestamp":"now"}`)
+	if p.Kind != LogPreviewJSON {
+		t.Fatalf("kind = %v, want JSON", p.Kind)
+	}
+	gotKeys := make([]string, len(p.Fields))
+	for i, f := range p.Fields {
+		gotKeys[i] = f.Key
+	}
+	wantKeys := []string{"@timestamp", "lvl", "message", "caller", "err", "trace_id"}
+	if len(gotKeys) != len(wantKeys) {
+		t.Fatalf("got %d fields, want %d", len(gotKeys), len(wantKeys))
+	}
+	for i := range wantKeys {
+		if gotKeys[i] != wantKeys[i] {
+			t.Errorf("field[%d] = %q, want %q (full order: %v)", i, gotKeys[i], wantKeys[i], gotKeys)
+		}
+	}
+}
+
 func TestParseLogLine_JSONNested(t *testing.T) {
 	p := ParseLogLine(`{"event":{"name":"x","count":3}}`)
 	if p.Kind != LogPreviewJSON {

--- a/internal/ui/logpreview_test.go
+++ b/internal/ui/logpreview_test.go
@@ -1,0 +1,232 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseLogLine_PlainText(t *testing.T) {
+	p := ParseLogLine("just a plain log line with no structure")
+	if p.Kind != LogPreviewText {
+		t.Fatalf("kind = %v, want Text", p.Kind)
+	}
+	if p.Prefix != "" || p.Time != "" {
+		t.Fatalf("prefix/time should be empty, got %q / %q", p.Prefix, p.Time)
+	}
+	if len(p.Fields) != 0 {
+		t.Fatalf("plain text should have no fields, got %v", p.Fields)
+	}
+}
+
+func TestParseLogLine_JSON(t *testing.T) {
+	p := ParseLogLine(`{"level":"info","msg":"server started","port":8080}`)
+	if p.Kind != LogPreviewJSON {
+		t.Fatalf("kind = %v, want JSON", p.Kind)
+	}
+	if len(p.Fields) != 3 {
+		t.Fatalf("want 3 fields, got %d (%v)", len(p.Fields), p.Fields)
+	}
+	// Common keys are ranked: level (1), msg (2), then alphabetical.
+	if p.Fields[0].Key != "level" || p.Fields[1].Key != "msg" || p.Fields[2].Key != "port" {
+		t.Fatalf("field order wrong: %v", p.Fields)
+	}
+	if p.Fields[2].Value != "8080" {
+		t.Fatalf("port value = %q, want 8080", p.Fields[2].Value)
+	}
+}
+
+func TestParseLogLine_JSONNested(t *testing.T) {
+	p := ParseLogLine(`{"event":{"name":"x","count":3}}`)
+	if p.Kind != LogPreviewJSON {
+		t.Fatalf("kind = %v, want JSON", p.Kind)
+	}
+	if !strings.Contains(p.Fields[0].Value, "name") {
+		t.Fatalf("nested value should pretty-print object, got %q", p.Fields[0].Value)
+	}
+}
+
+func TestParseLogLine_Logfmt(t *testing.T) {
+	p := ParseLogLine(`level=info msg="server started" port=8080`)
+	if p.Kind != LogPreviewLogfmt {
+		t.Fatalf("kind = %v, want Logfmt", p.Kind)
+	}
+	if len(p.Fields) != 3 {
+		t.Fatalf("want 3 fields, got %d", len(p.Fields))
+	}
+	if p.Fields[1].Key != "msg" || p.Fields[1].Value != "server started" {
+		t.Fatalf("quoted field wrong: %+v", p.Fields[1])
+	}
+}
+
+func TestParseLogLine_LogfmtNeedsTwoPairs(t *testing.T) {
+	// A single foo=bar in free-form text must not promote to logfmt.
+	p := ParseLogLine("starting service config=prod")
+	if p.Kind != LogPreviewText {
+		t.Fatalf("kind = %v, want Text (single pair)", p.Kind)
+	}
+}
+
+func TestParseLogLine_PodPrefix(t *testing.T) {
+	p := ParseLogLine(`[pod/api/server] {"level":"info","msg":"hi"}`)
+	if p.Prefix != "[pod/api/server]" {
+		t.Fatalf("prefix = %q, want [pod/api/server]", p.Prefix)
+	}
+	if p.Kind != LogPreviewJSON {
+		t.Fatalf("kind = %v, want JSON after prefix strip", p.Kind)
+	}
+}
+
+func TestParseLogLine_Timestamp(t *testing.T) {
+	p := ParseLogLine(`2024-01-15T10:30:00.123456789Z hello world`)
+	if p.Time == "" {
+		t.Fatalf("expected timestamp to be extracted")
+	}
+	if !strings.HasPrefix(p.Time, "2024-01-15T") {
+		t.Fatalf("timestamp = %q", p.Time)
+	}
+	if p.Body != "hello world" {
+		t.Fatalf("body after timestamp = %q", p.Body)
+	}
+}
+
+func TestParseLogLine_PrefixAndTimestampAndJSON(t *testing.T) {
+	p := ParseLogLine(`[pod/api/server] 2024-01-15T10:30:00.000000000Z {"level":"warn","msg":"slow"}`)
+	if p.Prefix != "[pod/api/server]" {
+		t.Fatalf("prefix = %q", p.Prefix)
+	}
+	if p.Time == "" {
+		t.Fatalf("time empty")
+	}
+	if p.Kind != LogPreviewJSON {
+		t.Fatalf("kind = %v, want JSON", p.Kind)
+	}
+	if p.Fields[0].Key != "level" {
+		t.Fatalf("first field = %q, want level", p.Fields[0].Key)
+	}
+}
+
+func TestParseLogLine_MalformedJSON(t *testing.T) {
+	p := ParseLogLine(`{not valid json}`)
+	if p.Kind == LogPreviewJSON {
+		t.Fatalf("malformed JSON should not parse as JSON")
+	}
+}
+
+func TestParseLogLine_EmptyJSON(t *testing.T) {
+	p := ParseLogLine(`{}`)
+	if p.Kind == LogPreviewJSON {
+		t.Fatalf("empty JSON object should fall through to text")
+	}
+}
+
+func TestRenderLogPreviewPane_Dimensions(t *testing.T) {
+	out := RenderLogPreviewPane(`{"level":"info","msg":"hi"}`, 40, 20)
+	lines := strings.Split(out, "\n")
+	// Title (1) + border-wrapped body (height-2 + 2 border lines = height) + footer (1) = height + 2.
+	want := 22
+	if len(lines) != want {
+		t.Fatalf("rendered %d lines, want %d", len(lines), want)
+	}
+}
+
+func TestRenderLogPreviewPane_EmptyLine(t *testing.T) {
+	out := RenderLogPreviewPane("", 40, 10)
+	if !strings.Contains(out, "no log line selected") {
+		t.Fatalf("expected empty-state hint, got: %s", out)
+	}
+}
+
+func TestRenderLogPreviewPane_KindLabel(t *testing.T) {
+	jsonOut := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10)
+	if !strings.Contains(jsonOut, "JSON") {
+		t.Fatalf("JSON label missing: %s", jsonOut)
+	}
+	logfmtOut := RenderLogPreviewPane(`a=b c=d`, 40, 10)
+	if !strings.Contains(logfmtOut, "LOGFMT") {
+		t.Fatalf("LOGFMT label missing: %s", logfmtOut)
+	}
+	textOut := RenderLogPreviewPane(`free form`, 40, 10)
+	if !strings.Contains(textOut, "TEXT") {
+		t.Fatalf("TEXT label missing: %s", textOut)
+	}
+}
+
+func TestRenderLogPreviewPane_NarrowDoesNotPanic(t *testing.T) {
+	// Tiny dimensions must clamp gracefully.
+	_ = RenderLogPreviewPane("hello", 1, 1)
+}
+
+func TestRenderLogPreviewPane_FooterHasNoLegend(t *testing.T) {
+	// The P binding is shown in the main log hint bar; the preview footer
+	// must not duplicate it.
+	out := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10)
+	if strings.Contains(out, "close preview") {
+		t.Fatalf("preview footer should not repeat the P legend: %s", out)
+	}
+}
+
+func TestTruncateKeyForPreview(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		width     int
+		wantKey   string
+		wantWidth int
+	}{
+		{"short ascii fits", "level", 10, "level", 5},
+		{"exact fit", "abcde", 5, "abcde", 5},
+		{"truncates with ellipsis", "extremely_long_key_name", 18, "extremely_long_ke…", 18},
+		{"single-cell width degrades to ellipsis only", "abc", 1, "…", 1},
+		{"multibyte counted in runes", "αβγδε", 4, "αβγ…", 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotKey, gotWidth := truncateKeyForPreview(tc.in, tc.width)
+			if gotKey != tc.wantKey {
+				t.Fatalf("key = %q, want %q", gotKey, tc.wantKey)
+			}
+			if gotWidth != tc.wantWidth {
+				t.Fatalf("width = %d, want %d", gotWidth, tc.wantWidth)
+			}
+		})
+	}
+}
+
+func TestRenderLogPreviewPane_TruncatedKeyShowsEllipsis(t *testing.T) {
+	out := RenderLogPreviewPane(`{"extremely_long_key_name":"v","b":"c"}`, 40, 10)
+	if !strings.Contains(out, "…") {
+		t.Fatalf("expected ellipsis on truncated key, got: %s", out)
+	}
+}
+
+func TestRenderLogPreviewPane_SanitizesControlChars(t *testing.T) {
+	// A JSON value containing an embedded ESC + non-SGR CSI must be
+	// scrubbed so the panel layout cannot be corrupted by producer output.
+	// (ConfigLogRenderAnsi defaults to false during tests.)
+	in := "{\"msg\":\"before\x1b[2Jafter\"}"
+	out := RenderLogPreviewPane(in, 60, 10)
+	if strings.Contains(out, "\x1b[2J") {
+		t.Fatalf("preview must scrub raw CSI sequences from values, got: %q", out)
+	}
+}
+
+func TestRenderLogPreviewPane_SanitizesPlainTextBody(t *testing.T) {
+	out := RenderLogPreviewPane("plain\x00body", 40, 10)
+	if strings.Contains(out, "\x00") {
+		t.Fatalf("preview must scrub NUL bytes from plain-text body")
+	}
+}
+
+func TestRenderLogPreviewPane_NestedJSONKeepsLineBreaks(t *testing.T) {
+	in := `{"event":{"type":"order","actor":{"id":"u1","role":"admin"}}}`
+	out := RenderLogPreviewPane(in, 80, 20)
+	if strings.Contains(out, "�") {
+		t.Fatalf("nested JSON value must not contain replacement chars; got:\n%s", out)
+	}
+	// Pretty-printed nested keys should be visible on their own lines.
+	for _, want := range []string{`"type"`, `"actor"`, `"id"`, `"role"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("nested key %s missing from preview output:\n%s", want, out)
+		}
+	}
+}

--- a/internal/ui/logpreview_test.go
+++ b/internal/ui/logpreview_test.go
@@ -182,7 +182,7 @@ func TestParseLogLine_EmptyJSON(t *testing.T) {
 }
 
 func TestRenderLogPreviewPane_Dimensions(t *testing.T) {
-	out := RenderLogPreviewPane(`{"level":"info","msg":"hi"}`, 40, 20)
+	out := RenderLogPreviewPane(`{"level":"info","msg":"hi"}`, 40, 20, 0)
 	lines := strings.Split(out, "\n")
 	// Title (1) + border-wrapped body (height-2 + 2 border lines = height) + footer (1) = height + 2.
 	want := 22
@@ -192,22 +192,22 @@ func TestRenderLogPreviewPane_Dimensions(t *testing.T) {
 }
 
 func TestRenderLogPreviewPane_EmptyLine(t *testing.T) {
-	out := RenderLogPreviewPane("", 40, 10)
+	out := RenderLogPreviewPane("", 40, 10, 0)
 	if !strings.Contains(out, "no log line selected") {
 		t.Fatalf("expected empty-state hint, got: %s", out)
 	}
 }
 
 func TestRenderLogPreviewPane_KindLabel(t *testing.T) {
-	jsonOut := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10)
+	jsonOut := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10, 0)
 	if !strings.Contains(jsonOut, "JSON") {
 		t.Fatalf("JSON label missing: %s", jsonOut)
 	}
-	logfmtOut := RenderLogPreviewPane(`a=b c=d`, 40, 10)
+	logfmtOut := RenderLogPreviewPane(`a=b c=d`, 40, 10, 0)
 	if !strings.Contains(logfmtOut, "LOGFMT") {
 		t.Fatalf("LOGFMT label missing: %s", logfmtOut)
 	}
-	textOut := RenderLogPreviewPane(`free form`, 40, 10)
+	textOut := RenderLogPreviewPane(`free form`, 40, 10, 0)
 	if !strings.Contains(textOut, "TEXT") {
 		t.Fatalf("TEXT label missing: %s", textOut)
 	}
@@ -215,13 +215,93 @@ func TestRenderLogPreviewPane_KindLabel(t *testing.T) {
 
 func TestRenderLogPreviewPane_NarrowDoesNotPanic(t *testing.T) {
 	// Tiny dimensions must clamp gracefully.
-	_ = RenderLogPreviewPane("hello", 1, 1)
+	_ = RenderLogPreviewPane("hello", 1, 1, 0)
+}
+
+// scrollOverflowJSON is a JSON line whose pretty-printed body easily
+// exceeds a small height so we can drive scroll behavior deterministically.
+const scrollOverflowJSON = `{"a":"1","b":"2","c":"3","d":"4","e":"5","f":"6","g":"7","h":"8"}`
+
+func TestLogPreviewMaxScroll(t *testing.T) {
+	// Tall enough that everything fits — no scrolling possible.
+	if got := LogPreviewMaxScroll(scrollOverflowJSON, 60, 30); got != 0 {
+		t.Errorf("max scroll on tall pane = %d, want 0", got)
+	}
+	// Same content, short pane — must report a positive bound.
+	if got := LogPreviewMaxScroll(scrollOverflowJSON, 60, 5); got <= 0 {
+		t.Errorf("max scroll on short pane = %d, want > 0", got)
+	}
+	// Empty line: empty-state placeholder is one row, never overflows.
+	if got := LogPreviewMaxScroll("", 40, 10); got != 0 {
+		t.Errorf("max scroll on empty line = %d, want 0", got)
+	}
+	// Defensive: tiny width/height clamps internally without panicking and
+	// still returns a non-negative bound.
+	if got := LogPreviewMaxScroll(scrollOverflowJSON, 1, 1); got < 0 {
+		t.Errorf("max scroll on tiny pane = %d, want >= 0", got)
+	}
+}
+
+func TestRenderLogPreviewPane_ScrollHidesEarlierRows(t *testing.T) {
+	// Render the same content at scroll 0 vs scroll 2. The first body
+	// row at scroll 0 must not appear in the scroll-2 output.
+	at0 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0)
+	at2 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 2)
+	if at0 == at2 {
+		t.Fatal("scrolled and unscrolled output should differ")
+	}
+	// "a" is the alphabetically-first non-ranked key; with the rank-then-
+	// alpha sort it sits on the first body row at scroll 0.
+	firstRowToken := " a "
+	if !strings.Contains(at0, firstRowToken) {
+		t.Fatalf("expected first body row token %q in scroll=0 output:\n%s", firstRowToken, at0)
+	}
+	if strings.Contains(at2, firstRowToken) {
+		t.Fatalf("scroll=2 output should not contain first row token %q:\n%s", firstRowToken, at2)
+	}
+}
+
+func TestRenderLogPreviewPane_ScrollClampsToMax(t *testing.T) {
+	// Scroll past the end clamps; output must equal what render at the
+	// computed maxScroll produces.
+	maxScroll := LogPreviewMaxScroll(scrollOverflowJSON, 60, 5)
+	atMax := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, maxScroll)
+	atOverflow := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, maxScroll+10)
+	if atMax != atOverflow {
+		t.Fatal("scroll beyond max should clamp and produce identical output")
+	}
+}
+
+func TestRenderLogPreviewPane_NegativeScrollClampsToZero(t *testing.T) {
+	at0 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0)
+	atNeg := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, -5)
+	if at0 != atNeg {
+		t.Fatal("negative scroll should clamp to 0 and produce identical output")
+	}
+}
+
+func TestRenderLogPreviewPane_TitleShowsPositionWhenScrollable(t *testing.T) {
+	// Short pane → overflow → "N/M" position label appears in the title.
+	out := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0)
+	if !strings.Contains(out, "1/") {
+		t.Fatalf("expected position label like '1/N' in scrollable output:\n%s", out)
+	}
+}
+
+func TestRenderLogPreviewPane_NoPositionLabelWhenContentFits(t *testing.T) {
+	// Tall pane → no overflow → no position label.
+	out := RenderLogPreviewPane(`{"a":"1","b":"2"}`, 60, 30, 0)
+	for _, frag := range []string{"1/", "2/", "3/"} {
+		if strings.Contains(out, frag) {
+			t.Fatalf("non-scrollable pane should not show position label %q:\n%s", frag, out)
+		}
+	}
 }
 
 func TestRenderLogPreviewPane_FooterHasNoLegend(t *testing.T) {
 	// The P binding is shown in the main log hint bar; the preview footer
 	// must not duplicate it.
-	out := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10)
+	out := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10, 0)
 	if strings.Contains(out, "close preview") {
 		t.Fatalf("preview footer should not repeat the P legend: %s", out)
 	}
@@ -255,7 +335,7 @@ func TestTruncateKeyForPreview(t *testing.T) {
 }
 
 func TestRenderLogPreviewPane_TruncatedKeyShowsEllipsis(t *testing.T) {
-	out := RenderLogPreviewPane(`{"extremely_long_key_name":"v","b":"c"}`, 40, 10)
+	out := RenderLogPreviewPane(`{"extremely_long_key_name":"v","b":"c"}`, 40, 10, 0)
 	if !strings.Contains(out, "…") {
 		t.Fatalf("expected ellipsis on truncated key, got: %s", out)
 	}
@@ -266,14 +346,14 @@ func TestRenderLogPreviewPane_SanitizesControlChars(t *testing.T) {
 	// scrubbed so the panel layout cannot be corrupted by producer output.
 	// (ConfigLogRenderAnsi defaults to false during tests.)
 	in := "{\"msg\":\"before\x1b[2Jafter\"}"
-	out := RenderLogPreviewPane(in, 60, 10)
+	out := RenderLogPreviewPane(in, 60, 10, 0)
 	if strings.Contains(out, "\x1b[2J") {
 		t.Fatalf("preview must scrub raw CSI sequences from values, got: %q", out)
 	}
 }
 
 func TestRenderLogPreviewPane_SanitizesPlainTextBody(t *testing.T) {
-	out := RenderLogPreviewPane("plain\x00body", 40, 10)
+	out := RenderLogPreviewPane("plain\x00body", 40, 10, 0)
 	if strings.Contains(out, "\x00") {
 		t.Fatalf("preview must scrub NUL bytes from plain-text body")
 	}
@@ -281,7 +361,7 @@ func TestRenderLogPreviewPane_SanitizesPlainTextBody(t *testing.T) {
 
 func TestRenderLogPreviewPane_NestedJSONKeepsLineBreaks(t *testing.T) {
 	in := `{"event":{"type":"order","actor":{"id":"u1","role":"admin"}}}`
-	out := RenderLogPreviewPane(in, 80, 20)
+	out := RenderLogPreviewPane(in, 80, 20, 0)
 	if strings.Contains(out, "�") {
 		t.Fatalf("nested JSON value must not contain replacement chars; got:\n%s", out)
 	}

--- a/internal/ui/logpreview_test.go
+++ b/internal/ui/logpreview_test.go
@@ -280,6 +280,25 @@ func TestRenderLogPreviewPane_NegativeScrollClampsToZero(t *testing.T) {
 	}
 }
 
+func TestRenderLogPreviewPane_AtMaxScrollLastBodyRowIsVisible(t *testing.T) {
+	// Regression: scrolling to max must actually reveal the last body row.
+	// We pick a key (z_last_bucket) that ranks at the catch-all 100 bucket
+	// AND sorts alphabetically last, so we know which token must appear.
+	json := `{"a":"1","b":"2","c":"3","d":"4","e":"5","f":"6","g":"7","z_last_bucket":"END"}`
+	width, height := 60, 5
+	maxScroll := LogPreviewMaxScroll(json, width, height)
+	if maxScroll == 0 {
+		t.Fatal("test setup error: pick dimensions/content that overflow")
+	}
+	out := RenderLogPreviewPane(json, width, height, maxScroll)
+	if !strings.Contains(out, "z_last_bucket") {
+		t.Fatalf("at max scroll the last body row (key 'z_last_bucket') must be visible:\n%s", out)
+	}
+	if !strings.Contains(out, "END") {
+		t.Fatalf("at max scroll the value 'END' of the last body row must be visible:\n%s", out)
+	}
+}
+
 func TestRenderLogPreviewPane_TitleShowsPositionWhenScrollable(t *testing.T) {
 	// Short pane → overflow → "N/M" position label appears in the title.
 	out := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0)

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -414,22 +414,12 @@ func StripTimestamp(line string) string {
 }
 
 // stripTimestampRaw removes a leading RFC3339Nano timestamp from a string.
+// Delegates to splitLeadingTimestamp so detection rules stay in one place.
 func stripTimestampRaw(s string) string {
-	// Quick check: RFC3339Nano timestamps start with a digit and contain 'T'.
-	// Minimum length: "2024-01-15T10:30:00Z " = 21 chars.
-	if len(s) < 21 || s[4] != '-' {
-		return s
+	if _, rest, ok := splitLeadingTimestamp(s); ok {
+		return rest
 	}
-	// Find the space after the timestamp.
-	spaceIdx := strings.IndexByte(s, ' ')
-	if spaceIdx < 20 || spaceIdx > 35 {
-		return s
-	}
-	// Verify it looks like a timestamp (contains 'T' between date and time).
-	if s[10] != 'T' {
-		return s
-	}
-	return s[spaceIdx+1:]
+	return s
 }
 
 // podPrefixColors is a palette of distinct colors for pod/container log prefixes.

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -190,6 +190,7 @@ func renderLogFooter(width int, statusMsg string, statusIsErr, searchActive bool
 		{Key: "s", Desc: "timestamps"},
 		{Key: "p", Desc: "prefixes"},
 		{Key: "P", Desc: "preview"},
+		{Key: "J/K", Desc: "preview scroll"},
 		{Key: "c", Desc: "previous"},
 		{Key: "v/V/ctrl+v", Desc: "select"},
 		{Key: "/", Desc: "search"},

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -189,6 +189,7 @@ func renderLogFooter(width int, statusMsg string, statusIsErr, searchActive bool
 		{Key: "#", Desc: "line#"},
 		{Key: "s", Desc: "timestamps"},
 		{Key: "p", Desc: "prefixes"},
+		{Key: "P", Desc: "preview"},
 		{Key: "c", Desc: "previous"},
 		{Key: "v/V/ctrl+v", Desc: "select"},
 		{Key: "/", Desc: "search"},


### PR DESCRIPTION
## Summary

Adds a `P` keybinding in the log viewer that toggles a side panel showing the cursor-selected log line as a structured key/value view. The panel parses the line as JSON, then logfmt, then falls back to plain text. Well-known fields (`level`, `msg`, `error`, `time`, `logger`) are ranked first; everything else follows alphabetically. The streaming hot path is untouched — parsing happens on render only, never on append.

## Type of change

- [x] feat: new user-facing feature

## Related issue

N/A

## Changes

- New `P` keybinding wired through `handleLogActionKey` to toggle a `logPreviewVisible` flag; `ensureLogCursorVisible` runs after the toggle so wrap math reflects the new geometry.
- New `internal/ui/logpreview.go`: `ParseLogLine` (JSON → logfmt → plain text cascade) and `RenderLogPreviewPane` (bordered side panel matching the log viewer's title + body + footer row count).
- New `internal/app/commands_logs_preview.go`: `splitLogPreviewWidth` (40% panel, capped 30–80, log column floored at 50, hidden under 80 cols), `logEffectiveWidth`, `logPreviewLine` (cursor with last-line fallback).
- `viewLogs` `JoinHorizontal`s the log view and preview when armed; `logWrapAvailWidth` reads `logEffectiveWidth()` so cursor visibility, follow mode, and wrap pinning stay in sync at the narrower width.
- Field values run through the existing `sanitizeLogLine` so embedded control bytes can't corrupt the panel. `\n` separators in nested-JSON `MarshalIndent` output are preserved (sanitize is applied per-line, not pre-split).
- Long keys truncated with `…`; rune-aware padding so multibyte keys align cleanly.
- Lowercase `p` (toggle pod/container prefixes) is unchanged — covered by a regression test.
- Documented in `docs/keybindings.md`, `internal/ui/help.go`, the in-viewer hint bar, and the README feature list.

### Known limitation (deferred)

When a parsed line has more body lines than the panel's content area, the bottom rows are silently truncated. The panel is not scrollable and there is no indicator additional content is there. Possibly address in future change.

Another thought is to have an enter feature on the raw log which will actually show the entire log in its own view (similar to YAML). It can offer similar features like expand/collapse per nested json key, go to lines, etc.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster

### Manual verification

Tested against a single-node `kind` cluster with five emitter deployments covering each parser path and stressing wrap behavior on long values:

```bash
kind create cluster --name lfk-test
kubectl apply -f log-demo.yaml
kubectl apply -f log-demo-long.yaml
./lfk            # context kind-lfk-test → namespace log-demo → pod → L → P
```

What was verified:

- **`json-emitter`** — flat JSON: `level` / `msg` ranked first, values displayed verbatim.
- **`nested-json-emitter`** — JSON with nested `event{...}` and `tags[...]`: pretty-printed with indentation, newlines preserved (regression: an earlier revision replaced `\n` with U+FFFD because `sanitizeLogLine` was applied before the per-line split).
- **`logfmt-emitter`** — quoted-value handling; unquoted values whitespace-bounded.
- **`plain-emitter`** — shown verbatim with wrap.
- **`long-msg-emitter`** — long `msg` (200–350 chars including a Go panic stack fragment) wraps onto multiple lines with continuation indented under the value column.
- **`huge-line-emitter`** — 17-field JSON, ~640 bytes per line: panel stays readable while the main viewer scrolls horizontally.
- Toggle while following: panel keeps tailing the new last line.
- Terminal narrower than 80 cols: panel auto-hides; widening restores it.
- Lowercase `p` and uppercase `P` are independent (regression test).

<details>
<summary>log-demo.yaml — JSON, nested JSON, logfmt, plain text</summary>

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: log-demo
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: json-emitter
  namespace: log-demo
  labels: { app: json-emitter }
spec:
  replicas: 1
  selector: { matchLabels: { app: json-emitter } }
  template:
    metadata:
      labels: { app: json-emitter }
    spec:
      containers:
        - name: emitter
          image: busybox:1.36
          command:
            - /bin/sh
            - -c
            - |
              i=0
              while true; do
                i=$((i+1))
                level=info
                [ $((i % 7)) -eq 0 ] && level=warn
                [ $((i % 13)) -eq 0 ] && level=error
                ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                printf '{"ts":"%s","level":"%s","logger":"http","msg":"served request","method":"GET","path":"/api/users/%d","status":200,"duration_ms":%d,"client_ip":"10.0.0.%d","trace_id":"abc%d"}\n' "$ts" "$level" "$i" "$((i * 3 % 250))" "$((i % 250))" "$i"
                sleep 1
              done
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: logfmt-emitter
  namespace: log-demo
  labels: { app: logfmt-emitter }
spec:
  replicas: 1
  selector: { matchLabels: { app: logfmt-emitter } }
  template:
    metadata:
      labels: { app: logfmt-emitter }
    spec:
      containers:
        - name: emitter
          image: busybox:1.36
          command:
            - /bin/sh
            - -c
            - |
              i=0
              while true; do
                i=$((i+1))
                level=info
                [ $((i % 5)) -eq 0 ] && level=warn
                [ $((i % 11)) -eq 0 ] && level=error
                ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                printf 'ts=%s level=%s component=worker msg="job complete" job_id=%d queue=ingest duration=%dms attempts=%d\n' "$ts" "$level" "$i" "$((i * 7 % 500))" "$((i % 4 + 1))"
                sleep 1
              done
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: plain-emitter
  namespace: log-demo
  labels: { app: plain-emitter }
spec:
  replicas: 1
  selector: { matchLabels: { app: plain-emitter } }
  template:
    metadata:
      labels: { app: plain-emitter }
    spec:
      containers:
        - name: emitter
          image: busybox:1.36
          command:
            - /bin/sh
            - -c
            - |
              i=0
              while true; do
                i=$((i+1))
                echo "[$(date -u +%H:%M:%S)] processing batch $i with $((i * 2)) records"
                sleep 1
              done
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nested-json-emitter
  namespace: log-demo
  labels: { app: nested-json-emitter }
spec:
  replicas: 1
  selector: { matchLabels: { app: nested-json-emitter } }
  template:
    metadata:
      labels: { app: nested-json-emitter }
    spec:
      containers:
        - name: emitter
          image: busybox:1.36
          command:
            - /bin/sh
            - -c
            - |
              i=0
              while true; do
                i=$((i+1))
                ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                printf '{"ts":"%s","level":"info","msg":"event received","event":{"type":"order.created","order":{"id":%d,"items":%d,"total_cents":%d},"actor":{"id":"user-%d","role":"customer"}},"tags":["billing","async"]}\n' "$ts" "$i" "$((i % 5 + 1))" "$((i * 199 % 100000))" "$((i % 50))"
                sleep 1
              done
```
</details>

<details>
<summary>log-demo-long.yaml — long-msg and huge-line stressors</summary>

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: long-msg-emitter
  namespace: log-demo
  labels: { app: long-msg-emitter }
spec:
  replicas: 1
  selector: { matchLabels: { app: long-msg-emitter } }
  template:
    metadata:
      labels: { app: long-msg-emitter }
    spec:
      containers:
        - name: emitter
          image: busybox:1.36
          command:
            - /bin/sh
            - -c
            - |
              i=0
              while true; do
                i=$((i+1))
                ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                # Three flavors so each preview shows different long msg shapes.
                case $((i % 3)) in
                  0)
                    msg="Failed to reconcile resource after 5 retries: the upstream API returned 503 Service Unavailable while the controller was attempting to patch the status subresource of pod default/api-server-7c9d4b6f5-x8z2k; this typically indicates the apiserver is overloaded or experiencing partial outage, please check kube-apiserver logs and consider increasing client-go QPS/Burst limits"
                    ;;
                  1)
                    msg="panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4ab12c] goroutine 142 [running]: main.(*Server).handleRequest(0xc000180000, 0xc0001a8000, 0xc00012a0e0) /src/server/handler.go:248 +0x4cc net/http.HandlerFunc.ServeHTTP(0x7c2480, 0xc000180000, 0x9d8e80, 0xc00012a0e0)"
                    ;;
                  *)
                    msg="processed batch of 1247 events in 3.482s (avg 2.79ms/event, p50=1.8ms p95=8.4ms p99=22.1ms max=187ms), retried 12 events due to transient downstream timeouts, dropped 3 events that exceeded the maximum retry budget after 5 attempts each"
                    ;;
                esac
                printf '{"ts":"%s","level":"error","logger":"controller","msg":"%s","attempt":%d,"trace_id":"trace-%d"}\n' "$ts" "$msg" "$((i % 5 + 1))" "$i"
                sleep 1
              done
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: huge-line-emitter
  namespace: log-demo
  labels: { app: huge-line-emitter }
spec:
  replicas: 1
  selector: { matchLabels: { app: huge-line-emitter } }
  template:
    metadata:
      labels: { app: huge-line-emitter }
    spec:
      containers:
        - name: emitter
          image: busybox:1.36
          command:
            - /bin/sh
            - -c
            - |
              i=0
              while true; do
                i=$((i+1))
                ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                # Many fields → very wide overall line; tests that the main
                # viewer's horizontal scroll/wrap works while preview shows
                # the same data as readable rows.
                printf '{"ts":"%s","level":"info","logger":"http.access","msg":"request handled","method":"POST","path":"/api/v2/organizations/acme-corp/workspaces/production/pipelines/etl-daily/runs","status":201,"duration_ms":%d,"client_ip":"203.0.113.%d","user_agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"req-%d-abcdef0123456789","tenant_id":"tenant-%d","user_id":"user-%d","session_id":"sess-%d-fedcba9876543210","forwarded_for":"10.0.0.%d, 172.16.0.%d","referer":"https://app.example.com/dashboard/workspaces/production","content_length":%d,"response_bytes":%d}\n' "$ts" "$((i * 13 % 800))" "$((i % 250))" "$i" "$((i % 99))" "$((i % 50))" "$i" "$((i % 250))" "$((i % 250))" "$((i * 7))" "$((i * 23))"
                sleep 1
              done
```
</details>

## Checklist

- [x] Commits follow conventional commit style (`feat:`)
- [x] README / `docs/` updated
- [x] `docs/keybindings.md` and the in-app help screen updated
- [x] No secrets, tokens, or personal data included
- [x] PR opened from a feature branch on my fork

## Screenshots / recordings

<img width="1906" height="1047" alt="image" src="https://github.com/user-attachments/assets/774aa2ee-0c4a-4928-a9ca-a14ccdb0c51f" />
