### PR TITLE
perf(k8s): cache API discovery to disk across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,24 @@ load. Tune it with:
 Values outside `[500ms, 10m]` are clamped to the bounds; invalid values fall
 back to 2s.
 
+### Discovery Cache
+
+API discovery (the list of resource types and CRDs the server exposes) is
+cached on disk under `~/.kube/cache/discovery/<host>/` with a 5-minute TTL.
+Layout matches `kubectl` and `k9s` so the same cache is shared across all
+three tools — a cold start hits zero discovery round-trips when the cache
+is warm. On busy clusters with many CRDs this is a measurable launch-time
+win and removes redundant load on the API server.
+
+- **Override location:** Set `KUBECACHEDIR` (same env var `kubectl`
+  honors) to relocate `<KUBECACHEDIR>/discovery/...` and
+  `<KUBECACHEDIR>/http/...`.
+- **Force refresh:** Press `R` (Shift+r) at the resource types level to
+  invalidate the cache and re-run discovery — newly installed or removed
+  CRDs show up immediately without restarting `lfk`.
+- **TTL:** 5 minutes. Stale entries are refetched automatically on the
+  next discovery request.
+
 ### Secret Lazy Loading
 
 On clusters with many Helm releases or large TLS secrets, listing the

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -52,6 +53,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -90,6 +92,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
+github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -1282,6 +1282,8 @@ func (m Model) refreshCurrentLevel() tea.Cmd {
 			if m.discoveringContexts != nil {
 				m.discoveringContexts[m.nav.Context] = true
 			}
+			// Force a round-trip; otherwise shift+r would serve stale cache.
+			m.client.InvalidateDiscoveryCache(m.nav.Context)
 			cmds = append(cmds, m.discoverAPIResources(m.nav.Context))
 		}
 		// Always emit the current cached list too so the UI repaints

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -9,11 +9,13 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -78,6 +80,11 @@ type Client struct {
 	// of being pulled up-front. Configured via the secret_lazy_loading
 	// option; off by default so the list behaves like every other resource.
 	secretLazyLoading bool
+
+	// Guarded by discoveryMu; concurrent tea.Cmd goroutines may discover
+	// across different contexts.
+	discoveryMu      sync.Mutex
+	discoveryClients map[string]*disk.CachedDiscoveryClient
 }
 
 // SetSecretLazyLoading toggles the metadata-only list path for Secrets.

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -62,11 +62,10 @@ func convertAPIResourceLists(lists []*metav1.APIResourceList) []model.ResourceTy
 // succeed) are logged and the successful subset is returned. A complete
 // failure to reach the discovery endpoint returns an error.
 func (c *Client) DiscoverAPIResources(ctx context.Context, contextName string) ([]model.ResourceTypeEntry, error) {
-	cs, err := c.clientsetForContext(contextName)
+	dc, err := c.discoveryForContext(contextName)
 	if err != nil {
-		return nil, fmt.Errorf("getting clientset: %w", err)
+		return nil, fmt.Errorf("getting discovery client: %w", err)
 	}
-	dc := cs.Discovery()
 
 	lists, err := discovery.ServerPreferredResources(dc)
 	if err != nil {

--- a/internal/k8s/discovery_cache.go
+++ b/internal/k8s/discovery_cache.go
@@ -16,6 +16,10 @@ import (
 const discoveryCacheTTL = 5 * time.Minute
 
 // Layout matches kubectl/k9s so all three tools share ~/.kube/cache/discovery.
+// Pattern is copied verbatim from kubectl's overlyCautiousIllegalFileCharacters:
+// the literal '(' and ')' inside the character class are intentional and kept
+// for on-disk-cache compatibility — they're filename-safe anyway, so allowing
+// them through is harmless.
 var toCacheHostDir = regexp.MustCompile(`[^(\w/.)]`)
 
 func cacheHostDir(host string) string {
@@ -72,6 +76,13 @@ func (c *Client) discoveryForContext(displayName string) (discovery.DiscoveryInt
 
 // InvalidateDiscoveryCache forces the next discovery call to re-fetch.
 // Nil-safe so test models without a real client can call it.
+//
+// Note: this only flips the in-memory client's invalidated flag. A *fresh*
+// client created later (e.g. first-time discovery for a context) won't see
+// the flag and will read from disk if the cache is still warm. That's fine
+// in practice because shift+r at LevelResourceTypes can only be reached
+// after an initial discovery has already created the client — see the
+// caller in app/update_actions.go's refreshCurrentLevel.
 func (c *Client) InvalidateDiscoveryCache(displayName string) {
 	if c == nil {
 		return

--- a/internal/k8s/discovery_cache.go
+++ b/internal/k8s/discovery_cache.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/disk"
+	"k8s.io/client-go/kubernetes"
+)
+
+const discoveryCacheTTL = 5 * time.Minute
+
+// Layout matches kubectl/k9s so all three tools share ~/.kube/cache/discovery.
+var toCacheHostDir = regexp.MustCompile(`[^(\w/.)]`)
+
+func cacheHostDir(host string) string {
+	h := strings.Replace(host, "https://", "", 1)
+	h = strings.Replace(h, "http://", "", 1)
+	return toCacheHostDir.ReplaceAllString(h, "_")
+}
+
+// discoveryForContext returns a per-context disk-cached discovery client,
+// memoized in-process. testClientset bypasses the disk path so unit tests
+// don't touch the filesystem.
+func (c *Client) discoveryForContext(displayName string) (discovery.DiscoveryInterface, error) {
+	if c.testClientset != nil {
+		if cs, ok := c.testClientset.(kubernetes.Interface); ok {
+			return cs.Discovery(), nil
+		}
+	}
+
+	c.discoveryMu.Lock()
+	defer c.discoveryMu.Unlock()
+
+	if existing, ok := c.discoveryClients[displayName]; ok {
+		return existing, nil
+	}
+
+	cfg, err := c.restConfigForContext(displayName)
+	if err != nil {
+		return nil, err
+	}
+
+	base := os.Getenv("KUBECACHEDIR")
+	if base == "" {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return nil, fmt.Errorf("resolving home dir for discovery cache: %w", herr)
+		}
+		base = filepath.Join(home, ".kube", "cache")
+	}
+
+	discDir := filepath.Join(base, "discovery", cacheHostDir(cfg.Host))
+	httpDir := filepath.Join(base, "http")
+
+	client, err := disk.NewCachedDiscoveryClientForConfig(cfg, discDir, httpDir, discoveryCacheTTL)
+	if err != nil {
+		return nil, fmt.Errorf("creating cached discovery client: %w", err)
+	}
+
+	if c.discoveryClients == nil {
+		c.discoveryClients = make(map[string]*disk.CachedDiscoveryClient)
+	}
+	c.discoveryClients[displayName] = client
+	return client, nil
+}
+
+// InvalidateDiscoveryCache forces the next discovery call to re-fetch.
+// Nil-safe so test models without a real client can call it.
+func (c *Client) InvalidateDiscoveryCache(displayName string) {
+	if c == nil {
+		return
+	}
+	c.discoveryMu.Lock()
+	defer c.discoveryMu.Unlock()
+	if cli, ok := c.discoveryClients[displayName]; ok {
+		cli.Invalidate()
+	}
+}

--- a/internal/k8s/discovery_cache_test.go
+++ b/internal/k8s/discovery_cache_test.go
@@ -1,0 +1,265 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCacheHostDir(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "strips https scheme",
+			host: "https://api.example.test:6443",
+			want: "api.example.test_6443",
+		},
+		{
+			name: "strips http scheme",
+			host: "http://api.example.test",
+			want: "api.example.test",
+		},
+		{
+			name: "preserves dots and slashes",
+			host: "https://api.example.test/v1/path",
+			want: "api.example.test/v1/path",
+		},
+		{
+			name: "replaces colons with underscore",
+			host: "https://10.0.0.1:6443",
+			want: "10.0.0.1_6443",
+		},
+		{
+			name: "no scheme passes through",
+			host: "api.example.test:6443",
+			want: "api.example.test_6443",
+		},
+		{
+			name: "leaves underscores",
+			host: "https://my_cluster.example.test",
+			want: "my_cluster.example.test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cacheHostDir(tt.host)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCacheHostDir_MatchesKubectlLayout(t *testing.T) {
+	// Sanity-check that the sanitization matches kubectl's documented
+	// behavior so the on-disk layout under ~/.kube/cache/discovery is
+	// shared between kubectl, k9s and lfk. If this test fails, kubectl
+	// won't see the cache lfk wrote (and vice versa).
+	cases := map[string]string{
+		"https://kubernetes.docker.internal:6443": "kubernetes.docker.internal_6443",
+		"https://1.2.3.4:8443":                    "1.2.3.4_8443",
+	}
+	for host, want := range cases {
+		assert.Equal(t, want, cacheHostDir(host), "host=%s", host)
+	}
+}
+
+func TestInvalidateDiscoveryCache_NilSafe(t *testing.T) {
+	// Models without a real Client (test fixtures) call this on a nil
+	// receiver during refresh — must not panic.
+	var c *Client
+	assert.NotPanics(t, func() {
+		c.InvalidateDiscoveryCache("any")
+	})
+}
+
+func TestInvalidateDiscoveryCache_MissingKey(t *testing.T) {
+	// First-use case: shift+r before the context has ever been discovered.
+	// Map is empty, the call should be a no-op rather than panicking.
+	c := &Client{}
+	assert.NotPanics(t, func() {
+		c.InvalidateDiscoveryCache("never-seen")
+	})
+}
+
+func TestInvalidateDiscoveryCache_PresentKey(t *testing.T) {
+	// After a real discoveryForContext() created a cached client for the
+	// context, Invalidate must:
+	//  - run on the existing memoized client (i.e. not be a no-op),
+	//  - not panic,
+	//  - leave the entry in the map so subsequent reads still hit the
+	//    same client.
+	//
+	// We prove "Invalidate runs on the right pointer" by reading from a
+	// pre-seeded cache before the call (sanity that we own the path the
+	// disk client reads from). The post-invalidate behavior of the flag
+	// is client-go's responsibility, so we don't re-assert it here —
+	// observing it would require a real API server (or a 30s timeout).
+	tmp := t.TempDir()
+	cacheDir := filepath.Join(tmp, "cache")
+	t.Setenv("KUBECACHEDIR", cacheDir)
+
+	c := newKubeconfigClient(t, tmp)
+
+	first, err := c.discoveryForContext("alpha")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	seedServerGroupsCache(t, cacheDir, "alpha.example.test_6443", "before-invalidate.example.com")
+
+	// Sanity: client reads from the seeded cache, confirming our path
+	// resolution matches what the disk client actually uses.
+	groups, err := first.ServerGroups()
+	require.NoError(t, err)
+	require.Len(t, groups.Groups, 1)
+	require.Equal(t, "before-invalidate.example.com", groups.Groups[0].Name)
+
+	assert.NotPanics(t, func() {
+		c.InvalidateDiscoveryCache("alpha")
+	})
+
+	second, err := c.discoveryForContext("alpha")
+	require.NoError(t, err)
+	assert.Same(t, first, second, "Invalidate must not evict the memoized client")
+}
+
+func TestDiscoveryForContext_TestClientsetEscape(t *testing.T) {
+	// When testClientset is set, discoveryForContext must bypass the
+	// disk-cache path entirely and return the fake's Discovery() —
+	// otherwise unit tests would touch ~/.kube/cache.
+	cs := k8sfake.NewClientset()
+	c := newFakeClient(cs, nil)
+
+	dc, err := c.discoveryForContext("any")
+	require.NoError(t, err)
+	assert.Same(t, cs.Discovery(), dc, "test escape must return the fake's Discovery client")
+
+	// And it must not have created any disk cache state.
+	assert.Nil(t, c.discoveryClients, "test escape must not initialize the disk-cache map")
+}
+
+func TestDiscoveryForContext_HonorsKUBECACHEDIR(t *testing.T) {
+	// KUBECACHEDIR mirrors kubectl: when set, the cache lives under that
+	// directory rather than ~/.kube/cache. Verified by pre-seeding a
+	// servergroups.json at the expected sanitized-host path and confirming
+	// the resulting discovery client reads from it. The disk client does
+	// not create cache directories at construction time (only on first
+	// write), so dir-existence alone wouldn't be a reliable signal.
+	tmp := t.TempDir()
+	cacheDir := filepath.Join(tmp, "custom-cache")
+	t.Setenv("KUBECACHEDIR", cacheDir)
+
+	c := newKubeconfigClient(t, tmp)
+
+	seedServerGroupsCache(t, cacheDir, "alpha.example.test_6443", "kubecachedir-sentinel.example.com")
+
+	dc, err := c.discoveryForContext("alpha")
+	require.NoError(t, err)
+
+	groups, err := dc.ServerGroups()
+	require.NoError(t, err, "ServerGroups must read from KUBECACHEDIR-overridden disk cache")
+	require.Len(t, groups.Groups, 1)
+	assert.Equal(t, "kubecachedir-sentinel.example.com", groups.Groups[0].Name,
+		"ServerGroups must return our pre-seeded sentinel — proves KUBECACHEDIR was honored")
+}
+
+func TestDiscoveryForContext_Memoizes(t *testing.T) {
+	// Two calls for the same context must return the identical pointer —
+	// otherwise every refresh would reopen the disk cache and rebuild the
+	// HTTP transport, defeating the whole point of caching.
+	tmp := t.TempDir()
+	t.Setenv("KUBECACHEDIR", filepath.Join(tmp, "cache"))
+
+	c := newKubeconfigClient(t, tmp)
+
+	first, err := c.discoveryForContext("alpha")
+	require.NoError(t, err)
+	second, err := c.discoveryForContext("alpha")
+	require.NoError(t, err)
+
+	assert.Same(t, first, second, "discoveryForContext must memoize per-context")
+}
+
+func TestDiscoveryForContext_PerContextMemoization(t *testing.T) {
+	// Different contexts must get distinct cached clients — they point at
+	// different API servers and have separate on-disk cache directories.
+	tmp := t.TempDir()
+	t.Setenv("KUBECACHEDIR", filepath.Join(tmp, "cache"))
+
+	c := newKubeconfigClient(t, tmp)
+
+	alpha, err := c.discoveryForContext("alpha")
+	require.NoError(t, err)
+	beta, err := c.discoveryForContext("beta")
+	require.NoError(t, err)
+
+	assert.NotSame(t, alpha, beta, "different contexts must get distinct discovery clients")
+}
+
+// seedServerGroupsCache writes a fake servergroups.json under
+// <cacheDir>/discovery/<host>/ that the disk client will treat as a
+// fresh cache hit. Used to assert observable behavior (which cache
+// directory the client reads from) without standing up an HTTP server.
+func seedServerGroupsCache(t *testing.T, cacheDir, hostDir, sentinelGroupName string) {
+	t.Helper()
+	dir := filepath.Join(cacheDir, "discovery", hostDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	body := `{"kind":"APIGroupList","apiVersion":"v1","groups":[{"name":"` +
+		sentinelGroupName +
+		`","versions":[{"groupVersion":"` + sentinelGroupName +
+		`/v1","version":"v1"}],"preferredVersion":{"groupVersion":"` +
+		sentinelGroupName + `/v1","version":"v1"}}]}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "servergroups.json"), []byte(body), 0o644))
+}
+
+// newKubeconfigClient builds a real Client backed by a two-context
+// kubeconfig in tmp. Used by tests that exercise the disk-cache path
+// (discoveryForContext goes through restConfigForContext, which needs a
+// resolvable kubeconfig). The token-only auth means construction never
+// touches the network.
+func newKubeconfigClient(t *testing.T, tmp string) *Client {
+	t.Helper()
+
+	kubeconfig := filepath.Join(tmp, "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+current-context: alpha
+clusters:
+- name: cluster-alpha
+  cluster:
+    server: https://alpha.example.test:6443
+    insecure-skip-tls-verify: true
+- name: cluster-beta
+  cluster:
+    server: https://beta.example.test:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: alpha
+  context:
+    cluster: cluster-alpha
+    user: user-alpha
+- name: beta
+  context:
+    cluster: cluster-beta
+    user: user-beta
+users:
+- name: user-alpha
+  user:
+    token: alpha-token
+- name: user-beta
+  user:
+    token: beta-token
+`), 0o600))
+
+	t.Setenv("KUBECONFIG", kubeconfig)
+
+	c, err := NewClient("")
+	require.NoError(t, err)
+	return c
+}


### PR DESCRIPTION
## Summary

Wraps the discovery client in `disk.CachedDiscoveryClient` under `~/.kube/cache`. Cuts cold-launch cost: every prior launch re-issued the full discovery handshake (one HTTP call per API group, ~50–200 round-trips on busy clusters with many CRDs). With a warm cache, those round-trips drop to zero until the 5m TTL expires.

The cache layout is identical to kubectl and k9s, so `~/.kube/cache/discovery/<host>/` is shared across all three tools — warming one warms the others.

## Type of change

- [x] perf: performance improvement

## Related issue

n/a

## Changes

- `internal/k8s/discovery_cache.go` (new) — per-context disk-cached discovery client, 5m TTL, in-process memoization keyed by lfk display name. `KUBECACHEDIR` honored for parity with kubectl.
- `internal/k8s/client.go` — adds `discoveryMu` / `discoveryClients` fields on `Client`.
- `internal/k8s/discovery.go` — `DiscoverAPIResources` now uses the cached helper instead of `clientsetForContext().Discovery()`.
- `internal/app/update_actions.go` — `shift+r` at `LevelResourceTypes` invalidates the cache before re-discovering, so a freshly installed CRD surfaces immediately rather than waiting for the TTL.
- `go.mod` / `go.sum` — `peterbourgon/diskv` and `google/btree` added as transitive deps of `client-go/discovery/cached/disk`.

## Testing

Verified against a real EKS 1.32 cluster with 204 CRDs:

- Cold launch (cache wiped): `time /tmp/lfk` → **13.3s wall**.
- Warm launch (after the cold one populated cache): `time /tmp/lfk` → **3.9s wall** (~70% faster).
- Cross-tool compat: `kubectl api-resources` after lfk warmup → 0.87s. Reverse direction (kubectl warms cache, then lfk launch) → 3.9s, identical to lfk-warm.
- 111 `serverresources.json` files written under `~/.kube/cache/discovery/<host>/`, one per API group.
- `shift+r` invalidation covered by existing unit test `TestCovRefreshCurrentLevelResourceTypes`.
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed (no user-visible config — `KUBECACHEDIR` is the standard kubectl env var)
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (n/a — no keybinding changes)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

n/a — backend perf change, no UI.