### PR TITLE
fix(ui): drop x:actions hint on the kubeconfig list

### DIFF
--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -259,14 +259,20 @@ func (m Model) statusBar() string {
 			{Key: kb.Enter, Desc: "view"},
 			{Key: kb.NamespaceSelector, Desc: "namespace"},
 			{Key: kb.AllNamespaces, Desc: "all-ns"},
-			{Key: kb.ActionMenu, Desc: "actions"},
-			{Key: kb.CreateTemplate, Desc: "create"},
-			{Key: kb.SortNext + "/" + kb.SortPrev, Desc: "sort"},
-			{Key: kb.Filter, Desc: "filter"},
-			{Key: kb.SetMark + "/" + kb.OpenMarks, Desc: "marks"},
-			{Key: kb.Help, Desc: "help"},
-			{Key: "q", Desc: "quit"},
 		}
+		// The action menu has no entries at the kubeconfig list level, so
+		// hide the hint there to avoid advertising a no-op key.
+		if m.nav.Level != model.LevelClusters {
+			hintEntries = append(hintEntries, ui.HintEntry{Key: kb.ActionMenu, Desc: "actions"})
+		}
+		hintEntries = append(hintEntries,
+			ui.HintEntry{Key: kb.CreateTemplate, Desc: "create"},
+			ui.HintEntry{Key: kb.SortNext + "/" + kb.SortPrev, Desc: "sort"},
+			ui.HintEntry{Key: kb.Filter, Desc: "filter"},
+			ui.HintEntry{Key: kb.SetMark + "/" + kb.OpenMarks, Desc: "marks"},
+			ui.HintEntry{Key: kb.Help, Desc: "help"},
+			ui.HintEntry{Key: "q", Desc: "quit"},
+		)
 		// Add context-specific hints for Events resource type.
 		hintEntries = m.appendEventsHintEntries(hintEntries)
 	}

--- a/internal/app/view_status_extra_test.go
+++ b/internal/app/view_status_extra_test.go
@@ -205,6 +205,36 @@ func TestStatusBarDashboardHints(t *testing.T) {
 	assert.Contains(t, stripped, "namespace")
 }
 
+// --- statusBar: cluster-list hints omit "actions" ---
+
+func TestStatusBarClusterListOmitsActionsHint(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelClusters},
+		middleItems:   []model.Item{{Name: "ctx-a"}},
+		width:         200,
+		height:        40,
+		tabs:          []TabState{{}},
+		selectedItems: make(map[string]bool),
+	}
+	stripped := stripANSI(m.statusBar())
+	assert.NotContains(t, stripped, "actions")
+	assert.Contains(t, stripped, "create")
+	assert.Contains(t, stripped, "filter")
+}
+
+func TestStatusBarResourceListShowsActionsHint(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelResources},
+		middleItems:   []model.Item{{Name: "pod"}},
+		width:         200,
+		height:        40,
+		tabs:          []TabState{{}},
+		selectedItems: make(map[string]bool),
+	}
+	stripped := stripANSI(m.statusBar())
+	assert.Contains(t, stripped, "actions")
+}
+
 // --- statusBar: small width ---
 
 func TestStatusBarSmallWidth(t *testing.T) {


### PR DESCRIPTION
## Summary

On the kubeconfig (cluster) list, the hint bar advertised `x: actions` but pressing `x` did nothing — `openActionMenu` early-exits at `LevelClusters` because `selectedResourceKind()` only returns a kind for resource/owned/container levels. This drops that hint at `LevelClusters` so we don't advertise a no-op key.

## Type of change

- [x] fix: bug fix

## Related issue

n/a

## Changes

- `internal/app/view_status.go`: skip the `x: actions` hint entry when `m.nav.Level == LevelClusters`.
- `internal/app/view_status_extra_test.go`: add two tests locking in the behavior (cluster list hides `actions`, resource list still shows it).

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (via pre-commit hook)
- [x] Manually verified against a real cluster

## Checklist

- [x] Commits follow conventional commit style
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

n/a