### PR TITLE
fix(ui): auto-apply single result when committing namespace filter

### DIFF
--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -533,15 +533,19 @@ func (m *Model) filteredLogPodItems() []model.Item {
 }
 
 // filteredLogContainerItems returns overlay items matching the current log container filter.
+//
+// The "All Containers" virtual row is filtered by name like every other
+// entry — keeping it pinned would clutter the narrowed list and break the
+// muscle-memory consistency with the namespace and log pod selectors.
+// Users can still reach all-containers by clearing the filter.
 func (m *Model) filteredLogContainerItems() []model.Item {
 	if m.logContainerFilterText == "" {
 		return m.overlayItems
 	}
 	rawQuery := m.logContainerFilterText
-	var filtered []model.Item
+	filtered := []model.Item{}
 	for _, item := range m.overlayItems {
-		// Always include the "All Containers" virtual item.
-		if item.Status == "all" || ui.MatchLine(item.Name, rawQuery) {
+		if ui.MatchLine(item.Name, rawQuery) {
 			filtered = append(filtered, item)
 		}
 	}

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -889,12 +889,22 @@ func TestFilteredLogContainerItems(t *testing.T) {
 		assert.Len(t, result, 3)
 	})
 
-	t.Run("filter matches plus always includes All Containers", func(t *testing.T) {
+	// Filter applies to the All Containers virtual row like every other entry,
+	// matching the namespace and log pod selectors. Keeping it always-visible
+	// clutters the filtered list and breaks the muscle-memory consistency
+	// across selectors.
+	t.Run("filter excludes All Containers when name does not match", func(t *testing.T) {
 		m.logContainerFilterText = "nginx"
 		result := m.filteredLogContainerItems()
-		assert.Len(t, result, 2)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "nginx", result[0].Name)
+	})
+
+	t.Run("filter matches All Containers by name", func(t *testing.T) {
+		m.logContainerFilterText = "All"
+		result := m.filteredLogContainerItems()
+		assert.Len(t, result, 1)
 		assert.Equal(t, "All Containers", result[0].Name)
-		assert.Equal(t, "nginx", result[1].Name)
 	})
 }
 

--- a/internal/app/template_filter_test.go
+++ b/internal/app/template_filter_test.go
@@ -155,7 +155,32 @@ func TestTemplateFilterModeEscExitsAndClears(t *testing.T) {
 
 // --- handleTemplateFilterMode: enter confirms filter ---
 
-func TestTemplateFilterModeEnterConfirms(t *testing.T) {
+// "config" matches two sample templates (ConfigMap, Secret), so Enter must
+// keep the legacy behavior: exit filter mode and preserve the filter text so
+// the user can navigate the narrowed list. Auto-applying would be a guess.
+func TestTemplateFilterModeEnterConfirmsWithMultipleResults(t *testing.T) {
+	m := Model{
+		overlay:            overlayTemplates,
+		templateItems:      sampleTemplates(),
+		templateSearchMode: true,
+		templateFilter:     TextInput{Value: "config"},
+		templateCursor:     0,
+		tabs:               []TabState{{}},
+		width:              80,
+		height:             40,
+	}
+	ret, cmd := m.handleTemplateFilterMode(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+	assert.False(t, result.templateSearchMode)
+	assert.Equal(t, overlayTemplates, result.overlay, "overlay must stay open")
+	// Filter text is preserved after enter
+	assert.Equal(t, "config", result.templateFilter.Value)
+	assert.Nil(t, cmd, "no command must be issued when more than one match")
+}
+
+// Filter narrows to a single template: Enter must apply it and close the
+// overlay so the user does not have to press Enter again on a one-row list.
+func TestTemplateFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
 	m := Model{
 		overlay:            overlayTemplates,
 		templateItems:      sampleTemplates(),
@@ -166,11 +191,12 @@ func TestTemplateFilterModeEnterConfirms(t *testing.T) {
 		width:              80,
 		height:             40,
 	}
-	ret, _ := m.handleTemplateFilterMode(specialKey(tea.KeyEnter))
+	ret, cmd := m.handleTemplateFilterMode(specialKey(tea.KeyEnter))
 	result := ret.(Model)
 	assert.False(t, result.templateSearchMode)
-	// Filter text is preserved after enter
-	assert.Equal(t, "deploy", result.templateFilter.Value)
+	assert.Equal(t, overlayNone, result.overlay, "overlay must close")
+	assert.Empty(t, result.templateFilter.Value, "filter must be cleared after commit")
+	assert.NotNil(t, cmd, "applyTemplate command must be returned")
 }
 
 // --- handleTemplateFilterMode: ctrl+w deletes word ---

--- a/internal/app/update_overlays_logs.go
+++ b/internal/app/update_overlays_logs.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -117,37 +118,8 @@ func (m Model) handleLogPodSelectOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		return m, nil
 	case "enter":
 		if m.overlayCursor >= 0 && m.overlayCursor < len(items) {
-			sel := items[m.overlayCursor]
-			m.overlay = overlayNone
-			m.pendingAction = ""
-			m.logSavedPodName = ""
-			m.logPodFilterText = ""
-			m.logPodFilterActive = false
-			m.logSelectedContainers = nil
-			m.logContainers = nil
-			m.logLines = nil
-			m.logScroll = 0
-			m.logTailLines = ui.ConfigLogTailLines
-			m.logHasMoreHistory = true
-			m.logLoadingHistory = false
-
-			if sel.Status == "all" {
-				// "All Pods" selected: stream all pods using the parent resource.
-				m.actionCtx.kind = m.logParentKind
-				m.actionCtx.name = m.logParentName
-				m.actionCtx.containerName = ""
-				m.logTitle = fmt.Sprintf("Logs: %s/%s (all pods)", m.actionNamespace(), m.logParentName)
-			} else {
-				// Specific pod selected.
-				m.actionCtx.name = sel.Name
-				m.actionCtx.kind = "Pod"
-				if sel.Namespace != "" {
-					m.actionCtx.namespace = sel.Namespace
-				}
-				m.actionCtx.containerName = ""
-				m.logTitle = fmt.Sprintf("Logs: %s/%s", m.actionNamespace(), m.actionCtx.name)
-			}
-			return m, m.startLogStream()
+			cmd := m.applyLogPodSelection(items[m.overlayCursor])
+			return m, cmd
 		}
 		return m, nil
 	case "/":
@@ -170,6 +142,43 @@ func (m Model) handleLogPodSelectOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		return m.closeTabOrQuit()
 	}
 	return m, nil
+}
+
+// applyLogPodSelection switches the log viewer to the given pod selection
+// and returns a fresh log stream command. Shared by the normal-mode Enter
+// handler and the filter-mode single-result fast-path so both commit
+// paths stay in lockstep.
+func (m *Model) applyLogPodSelection(sel model.Item) tea.Cmd {
+	m.overlay = overlayNone
+	m.pendingAction = ""
+	m.logSavedPodName = ""
+	m.logPodFilterText = ""
+	m.logPodFilterActive = false
+	m.logSelectedContainers = nil
+	m.logContainers = nil
+	m.logLines = nil
+	m.logScroll = 0
+	m.logTailLines = ui.ConfigLogTailLines
+	m.logHasMoreHistory = true
+	m.logLoadingHistory = false
+
+	if sel.Status == "all" {
+		// "All Pods" selected: stream all pods using the parent resource.
+		m.actionCtx.kind = m.logParentKind
+		m.actionCtx.name = m.logParentName
+		m.actionCtx.containerName = ""
+		m.logTitle = fmt.Sprintf("Logs: %s/%s (all pods)", m.actionNamespace(), m.logParentName)
+	} else {
+		// Specific pod selected.
+		m.actionCtx.name = sel.Name
+		m.actionCtx.kind = "Pod"
+		if sel.Namespace != "" {
+			m.actionCtx.namespace = sel.Namespace
+		}
+		m.actionCtx.containerName = ""
+		m.logTitle = fmt.Sprintf("Logs: %s/%s", m.actionNamespace(), m.actionCtx.name)
+	}
+	return m.startLogStream()
 }
 
 // handleLogPodFilterMode handles keyboard input while the pod selector filter is active.
@@ -196,6 +205,15 @@ func (m Model) handleLogPodFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case filterAccept:
 		m.logPodFilterActive = false
 		m.overlayCursor = 0
+		// When the filter narrows to a single pod, Enter is unambiguous:
+		// apply it and start streaming. Without this, the user has to press
+		// Enter twice (once to leave filter mode, once to commit) on a
+		// one-row list.
+		items := m.filteredLogPodItems()
+		if len(items) == 1 {
+			cmd := m.applyLogPodSelection(items[0])
+			return m, cmd
+		}
 		return m, nil
 	case filterClose:
 		return m.closeTabOrQuit()

--- a/internal/app/update_overlays_logs.go
+++ b/internal/app/update_overlays_logs.go
@@ -376,6 +376,25 @@ func (m Model) handleLogContainerFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 	case filterAccept:
 		m.logContainerFilterActive = false
 		m.overlayCursor = 0
+		// When the filter narrows to a single container and the user hasn't
+		// been Space-toggling selections, Enter is unambiguous: apply that
+		// container and restart the stream. Multi-select via Space is
+		// preserved: if the user already toggled selections, Enter still
+		// just exits filter mode without replacing them.
+		if !m.logContainerSelectionModified {
+			items := m.filteredLogContainerItems()
+			if len(items) == 1 {
+				if items[0].Status == "all" {
+					m.logSelectedContainers = nil
+				} else {
+					m.logSelectedContainers = []string{items[0].Name}
+				}
+				m.overlay = overlayNone
+				m.logContainerFilterText = ""
+				cmd := m.restartLogStreamForContainerFilter()
+				return m, cmd
+			}
+		}
 		return m, nil
 	case filterClose:
 		return m.closeTabOrQuit()

--- a/internal/app/update_overlays_logs_test.go
+++ b/internal/app/update_overlays_logs_test.go
@@ -245,6 +245,78 @@ func TestCovLogContainerSelectEnterModified(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+// Filter narrows to a single container: Enter must apply it and close the
+// overlay so the user does not have to press Enter again on a one-row list.
+func TestLogContainerFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayLogContainerSelect
+	m.logContainers = []string{"main", "sidecar", "init"}
+	m.overlayItems = logContainerOverlayItems(m.logContainers)
+	m.logContainerFilterActive = true
+	m.logContainerFilterText = "side"
+	result, cmd := m.handleLogContainerFilterMode(keyMsg("enter"))
+	rm := result.(Model)
+	assert.False(t, rm.logContainerFilterActive)
+	assert.Equal(t, overlayNone, rm.overlay, "overlay must close")
+	assert.Equal(t, []string{"sidecar"}, rm.logSelectedContainers, "sole filter match must be applied")
+	assert.Empty(t, rm.logContainerFilterText, "filter text must be cleared after commit")
+	assert.NotNil(t, cmd, "restart log stream command must be returned")
+}
+
+// Two filtered container results: Enter must keep the legacy behavior —
+// exit filter mode and let the user pick. Auto-applying would be a guess.
+func TestLogContainerFilterModeEnterPreservesMultipleResults(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayLogContainerSelect
+	m.logContainers = []string{"web-main", "web-side", "init"}
+	m.overlayItems = logContainerOverlayItems(m.logContainers)
+	m.logContainerFilterActive = true
+	m.logContainerFilterText = "web"
+	result, cmd := m.handleLogContainerFilterMode(keyMsg("enter"))
+	rm := result.(Model)
+	assert.False(t, rm.logContainerFilterActive)
+	assert.Equal(t, overlayLogContainerSelect, rm.overlay, "overlay must stay open")
+	assert.Equal(t, "web", rm.logContainerFilterText, "filter text must be preserved")
+	assert.Nil(t, cmd, "no command must be issued when more than one match")
+}
+
+// User has been Space-toggling container selections then opens filter to
+// refine. Even if the filter narrows to one result, do not silently
+// replace their in-progress multi-selection.
+func TestLogContainerFilterModeEnterPreservesMultiSelect(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayLogContainerSelect
+	m.logContainers = []string{"main", "sidecar", "init"}
+	m.overlayItems = logContainerOverlayItems(m.logContainers)
+	m.logContainerSelectionModified = true
+	m.logSelectedContainers = []string{"main"}
+	m.logContainerFilterActive = true
+	m.logContainerFilterText = "side"
+	result, cmd := m.handleLogContainerFilterMode(keyMsg("enter"))
+	rm := result.(Model)
+	assert.False(t, rm.logContainerFilterActive)
+	assert.Equal(t, overlayLogContainerSelect, rm.overlay, "overlay must stay open")
+	assert.Equal(t, []string{"main"}, rm.logSelectedContainers, "Space-toggled selection must survive")
+	assert.Nil(t, cmd, "no command must be issued during in-progress multi-select")
+}
+
+// Filter narrows to the "All Containers" virtual row only: fast-path must
+// reset to the all-containers stream (logSelectedContainers = nil).
+func TestLogContainerFilterModeEnterAutoSelectsSoleAllContainersResult(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayLogContainerSelect
+	m.logContainers = []string{"main"}
+	m.overlayItems = logContainerOverlayItems(m.logContainers)
+	m.logSelectedContainers = []string{"main"}
+	m.logContainerFilterActive = true
+	m.logContainerFilterText = "All"
+	result, cmd := m.handleLogContainerFilterMode(keyMsg("enter"))
+	rm := result.(Model)
+	assert.Equal(t, overlayNone, rm.overlay)
+	assert.Nil(t, rm.logSelectedContainers, "sole 'All Containers' match must reset to all")
+	assert.NotNil(t, cmd)
+}
+
 func TestCovLogContainerSelectSlash(t *testing.T) {
 	m := baseModelBoost2()
 	result, _ := m.handleLogContainerSelectOverlayKey(keyMsg("/"))

--- a/internal/app/update_overlays_logs_test.go
+++ b/internal/app/update_overlays_logs_test.go
@@ -348,6 +348,68 @@ func TestCovLogPodSelectEnterSpecificPod(t *testing.T) {
 	assert.Equal(t, "pod-1", rm.actionCtx.name)
 }
 
+// Filter narrows to a single pod: Enter must apply it and close the
+// overlay so the user does not have to press Enter again on a one-row list.
+func TestLogPodFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayLogPodSelect
+	m.overlayItems = []model.Item{
+		{Name: "All Pods", Status: "all"},
+		{Name: "kube-proxy-abc", Namespace: "kube-system"},
+		{Name: "etcd-main", Namespace: "kube-system"},
+	}
+	m.logPodFilterActive = true
+	m.logPodFilterText = "kube-proxy"
+	result, cmd := m.handleLogPodFilterMode(keyMsg("enter"))
+	rm := result.(Model)
+	assert.False(t, rm.logPodFilterActive)
+	assert.Equal(t, overlayNone, rm.overlay, "overlay must close")
+	assert.Equal(t, "kube-proxy-abc", rm.actionCtx.name, "sole filter match must be applied")
+	assert.Empty(t, rm.logPodFilterText, "filter text must be cleared after commit")
+	assert.NotNil(t, cmd, "startLogStream command must be returned")
+}
+
+// Two filtered pod results: Enter must keep the legacy behavior — exit
+// filter mode and let the user pick. Auto-applying would be a guess.
+func TestLogPodFilterModeEnterPreservesMultipleResults(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayLogPodSelect
+	m.overlayItems = []model.Item{
+		{Name: "All Pods", Status: "all"},
+		{Name: "kube-proxy-1"},
+		{Name: "kube-proxy-2"},
+	}
+	m.logPodFilterActive = true
+	m.logPodFilterText = "kube"
+	result, cmd := m.handleLogPodFilterMode(keyMsg("enter"))
+	rm := result.(Model)
+	assert.False(t, rm.logPodFilterActive)
+	assert.Equal(t, overlayLogPodSelect, rm.overlay, "overlay must stay open")
+	assert.Equal(t, "kube", rm.logPodFilterText, "filter text must be preserved")
+	assert.Nil(t, cmd, "no command must be issued when more than one match")
+}
+
+// Filter narrows to the "All Pods" virtual row only: fast-path must apply
+// the all-pods stream (kind/name from logParentKind/logParentName).
+func TestLogPodFilterModeEnterAutoSelectsSoleAllPodsResult(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayLogPodSelect
+	m.logParentKind = "Deployment"
+	m.logParentName = "my-deploy"
+	m.overlayItems = []model.Item{
+		{Name: "All Pods", Status: "all"},
+		{Name: "kube-proxy-1"},
+	}
+	m.logPodFilterActive = true
+	m.logPodFilterText = "All"
+	result, cmd := m.handleLogPodFilterMode(keyMsg("enter"))
+	rm := result.(Model)
+	assert.Equal(t, overlayNone, rm.overlay)
+	assert.Equal(t, "Deployment", rm.actionCtx.kind)
+	assert.Equal(t, "my-deploy", rm.actionCtx.name)
+	assert.NotNil(t, cmd)
+}
+
 func TestCovLogPodSelectSlash(t *testing.T) {
 	m := baseModelBoost2()
 	result, _ := m.handleLogPodSelectOverlayKey(keyMsg("/"))

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -187,6 +187,31 @@ func (m Model) handleNamespaceFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case filterAccept:
 		m.nsFilterMode = false
 		m.overlayCursor = 0
+		// When the filter narrows to a single result and the user hasn't
+		// been multi-selecting with Space, Enter is unambiguous: apply
+		// that result and close. Without this, the user has to press
+		// Enter twice (once to leave filter mode, once to commit) on a
+		// list that has only one row — the second Enter is busy work.
+		if !m.nsSelectionModified {
+			items := m.filteredOverlayItems()
+			if len(items) == 1 {
+				if items[0].Status == "all" {
+					m.selectedNamespaces = nil
+					m.allNamespaces = true
+				} else {
+					ns := items[0].Name
+					m.selectedNamespaces = map[string]bool{ns: true}
+					m.namespace = ns
+					m.allNamespaces = false
+				}
+				m.overlay = overlayNone
+				m.overlayFilter.Clear()
+				m.saveCurrentSession()
+				m.cancelAndReset()
+				m.requestGen++
+				return m, m.refreshCurrentLevel()
+			}
+		}
 		return m, nil
 	case filterClose:
 		return m.closeTabOrQuit()

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -693,7 +693,24 @@ func (m Model) handleColorschemeFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.schemeFilterMode = false
 		m.schemeCursor = 0
 		ui.ResetOverlaySchemeScroll()
-		m.previewSchemeAtCursor(m.filteredSchemeNames())
+		filtered := m.filteredSchemeNames()
+		// When the filter narrows to a single scheme, Enter is unambiguous:
+		// commit it and close. The live preview already applied the theme on
+		// each keystroke; here we lock it in with a status message so the
+		// user does not have to press Enter again on a one-row list.
+		if len(filtered) == 1 {
+			name := filtered[0]
+			schemes := ui.BuiltinSchemes()
+			if theme, ok := schemes[name]; ok {
+				ui.ApplyTheme(theme)
+				ui.ActiveSchemeName = name
+				m.setStatusMessage("Color scheme: "+name, false)
+			}
+			m.overlay = overlayNone
+			m.schemeFilter.Clear()
+			return m, scheduleStatusClear()
+		}
+		m.previewSchemeAtCursor(filtered)
 		return m, nil
 	case filterClose:
 		return m.closeTabOrQuit()

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -320,6 +320,16 @@ func (m Model) handleTemplateFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case filterAccept:
 		m.templateSearchMode = false
+		// When the filter narrows to a single template, Enter is unambiguous:
+		// apply it and close. Without this, the user has to press Enter twice
+		// (once to leave filter mode, once to commit) on a one-row list.
+		filtered := m.filteredTemplates()
+		if len(filtered) == 1 {
+			tmpl := filtered[0]
+			m.overlay = overlayNone
+			m.templateFilter.Clear()
+			return m, m.applyTemplate(tmpl)
+		}
 		return m, nil
 	case filterClose:
 		return m.closeTabOrQuit()

--- a/internal/app/update_overlays_selectors_extra_test.go
+++ b/internal/app/update_overlays_selectors_extra_test.go
@@ -219,6 +219,90 @@ func TestNamespaceFilterModeEnterCommits(t *testing.T) {
 	// Filter text is preserved after enter
 }
 
+// Filter narrows the list to a single concrete namespace: Enter must apply
+// it and close the overlay so the user does not have to press Enter again
+// on a one-row list.
+func TestNamespaceFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
+	items := []model.Item{
+		{Name: "All Namespaces", Status: "all"},
+		{Name: "default"},
+		{Name: "kube-system"},
+	}
+	m := Model{
+		overlay:       overlayNamespace,
+		nsFilterMode:  true,
+		overlayItems:  items,
+		overlayFilter: TextInput{Value: "kube"},
+		allNamespaces: true,
+		tabs:          []TabState{{}},
+		width:         80,
+		height:        40,
+	}
+	ret, cmd := m.handleNamespaceFilterMode(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+	assert.False(t, result.nsFilterMode)
+	assert.Equal(t, overlayNone, result.overlay)
+	assert.Equal(t, "kube-system", result.namespace)
+	assert.True(t, result.selectedNamespaces["kube-system"])
+	assert.False(t, result.allNamespaces)
+	assert.NotNil(t, cmd)
+}
+
+// Two filtered results: Enter must keep the legacy behavior — exit filter
+// mode and let the user pick. Auto-applying would be a guess.
+func TestNamespaceFilterModeEnterDoesNotAutoApplyMultipleResults(t *testing.T) {
+	items := []model.Item{
+		{Name: "All Namespaces", Status: "all"},
+		{Name: "kube-system"},
+		{Name: "kube-public"},
+	}
+	m := Model{
+		overlay:       overlayNamespace,
+		nsFilterMode:  true,
+		overlayItems:  items,
+		overlayFilter: TextInput{Value: "kube"},
+		allNamespaces: true,
+		tabs:          []TabState{{}},
+		width:         80,
+		height:        40,
+	}
+	ret, _ := m.handleNamespaceFilterMode(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+	assert.False(t, result.nsFilterMode)
+	assert.Equal(t, overlayNamespace, result.overlay)
+	assert.Empty(t, result.selectedNamespaces)
+	assert.True(t, result.allNamespaces)
+}
+
+// User has been Space-toggling selections and then opens filter to refine.
+// Even if the filter narrows to one result, do not silently replace their
+// in-progress multi-selection — they pressed Enter to exit filter mode,
+// not to abandon the selections they already made.
+func TestNamespaceFilterModeEnterPreservesMultiSelect(t *testing.T) {
+	items := []model.Item{
+		{Name: "All Namespaces", Status: "all"},
+		{Name: "default"},
+		{Name: "kube-system"},
+	}
+	m := Model{
+		overlay:             overlayNamespace,
+		nsFilterMode:        true,
+		nsSelectionModified: true,
+		selectedNamespaces:  map[string]bool{"default": true},
+		overlayItems:        items,
+		overlayFilter:       TextInput{Value: "kube"},
+		tabs:                []TabState{{}},
+		width:               80,
+		height:              40,
+	}
+	ret, _ := m.handleNamespaceFilterMode(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+	assert.False(t, result.nsFilterMode)
+	assert.Equal(t, overlayNamespace, result.overlay)
+	assert.True(t, result.selectedNamespaces["default"], "existing Space-toggled selection must survive")
+	assert.False(t, result.selectedNamespaces["kube-system"], "single filter match must not be auto-applied during multi-select")
+}
+
 func TestNamespaceFilterModeTyping(t *testing.T) {
 	m := Model{
 		overlay:       overlayNamespace,

--- a/internal/app/update_overlays_selectors_extra_test.go
+++ b/internal/app/update_overlays_selectors_extra_test.go
@@ -950,3 +950,52 @@ func TestColorschemeFilterModeEnterCommits(t *testing.T) {
 	result := ret.(Model)
 	assert.False(t, result.schemeFilterMode)
 }
+
+// Filter narrows to a single scheme: Enter must apply it and close the
+// overlay so the user does not have to press Enter again on a one-row list.
+func TestColorschemeFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
+	entries := []ui.SchemeEntry{
+		{Name: "Dark Themes", IsHeader: true},
+		{Name: "dracula"},
+		{Name: "gruvbox-dark"},
+	}
+	m := Model{
+		overlay:          overlayColorscheme,
+		schemeEntries:    entries,
+		schemeFilterMode: true,
+		schemeFilter:     TextInput{Value: "drac"},
+		tabs:             []TabState{{}},
+		width:            80,
+		height:           40,
+	}
+	ret, cmd := m.handleColorschemeFilterMode(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+	assert.False(t, result.schemeFilterMode)
+	assert.Equal(t, overlayNone, result.overlay, "overlay must close")
+	assert.Empty(t, result.schemeFilter.Value, "filter must be cleared after commit")
+	assert.NotNil(t, cmd, "scheduleStatusClear command must be returned")
+}
+
+// Two filtered results: Enter must keep the legacy behavior — exit filter
+// mode and let the user pick. Auto-applying would be a guess.
+func TestColorschemeFilterModeEnterPreservesMultipleResults(t *testing.T) {
+	entries := []ui.SchemeEntry{
+		{Name: "Dark Themes", IsHeader: true},
+		{Name: "gruvbox-dark"},
+		{Name: "gruvbox-darkhard"},
+	}
+	m := Model{
+		overlay:          overlayColorscheme,
+		schemeEntries:    entries,
+		schemeFilterMode: true,
+		schemeFilter:     TextInput{Value: "gruv"},
+		tabs:             []TabState{{}},
+		width:            80,
+		height:           40,
+	}
+	ret, _ := m.handleColorschemeFilterMode(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+	assert.False(t, result.schemeFilterMode)
+	assert.Equal(t, overlayColorscheme, result.overlay, "overlay must stay open")
+	assert.Equal(t, "gruv", result.schemeFilter.Value, "filter must be preserved")
+}


### PR DESCRIPTION
## Summary

When the namespace selector's filter narrows results to a single match, Enter now applies that namespace and closes the overlay instead of dropping into navigation mode on a one-row list.

## Type of change

- [x] fix: bug fix

## Related issue

N/A

## Changes

- `handleNamespaceFilterMode`: on `filterAccept`, if the filtered list has exactly one item and the user has not been Space-toggling, apply that item and close the overlay.
- Handles the `all` virtual row too (sole match flips to all-namespaces mode).
- Preserves in-progress multi-select: when `nsSelectionModified` is true, Enter still just exits filter mode.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (via pre-commit hook)
- [x] Manually verified against a real cluster

New unit tests:
- `TestNamespaceFilterModeEnterAutoSelectsSoleResult`
- `TestNamespaceFilterModeEnterDoesNotAutoApplyMultipleResults`
- `TestNamespaceFilterModeEnterPreservesMultiSelect`

## Checklist

- [x] Commits follow conventional commit style
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)
