### PR TITLE
fix(ui): show full hotkey hint bar with log preview on (#71)

### DIFF
--- a/internal/app/commands_logs_preview_test.go
+++ b/internal/app/commands_logs_preview_test.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/janosmiko/lfk/internal/ui"
@@ -282,6 +284,56 @@ func TestScrollToMaxRevealsLastBodyRowInRenderedView(t *testing.T) {
 		"after spamming J the last body row must be visible in viewLogs output; "+
 			"if maxScroll is computed against the wrong height the handler stops "+
 			"short and the user sees the bottom of the body clipped off-screen")
+}
+
+// TestViewLogs_PreviewVisible_HotkeyHintFullWidth is the regression test for
+// issue #71: when the log preview side panel is on, the bottom hotkey hint bar
+// gets clipped because it is rendered inside the (narrower) log column instead
+// of spanning the full terminal width. The fix renders the hint bar across
+// the entire viewLogs() output below the JoinHorizontal'd panes.
+func TestViewLogs_PreviewVisible_HotkeyHintFullWidth(t *testing.T) {
+	const terminalW = 300
+	base := Model{
+		mode:     modeLogs,
+		logLines: []string{"sample log line"},
+		tabs:     []TabState{{}},
+		width:    terminalW,
+		height:   30 - 1, // mimic View()'s app title decrement
+		logTitle: "Logs",
+	}
+	off := base
+	off.logPreviewVisible = false
+	on := base
+	on.logPreviewVisible = true
+
+	outOff := off.viewLogs()
+	outOn := on.viewLogs()
+
+	// Pick a hint near the END of the bar — this only fits when the bar is
+	// rendered at the full terminal width, not at the narrower logWidth.
+	const lateHint = "save all"
+
+	// Sanity check: the test depends on this hint fitting at full width.
+	if !strings.Contains(outOff, lateHint) {
+		t.Skipf("baseline hint set changed: %q no longer fits at width=%d; "+
+			"adjust the test or the hint set", lateHint, terminalW)
+	}
+
+	assert.Contains(t, outOn, lateHint,
+		"with preview on, late hotkey hints must remain visible — the hint bar "+
+			"must span m.width, not the narrower logWidth (issue #71)")
+
+	// Belt and braces: the bottom line of the rendered output must be exactly
+	// terminalW visual cells. Both with and without preview.
+	bottomOff := lastLine(outOff)
+	bottomOn := lastLine(outOn)
+	assert.Equal(t, terminalW, ansi.StringWidth(bottomOff), "footer width without preview")
+	assert.Equal(t, terminalW, ansi.StringWidth(bottomOn), "footer width with preview")
+}
+
+func lastLine(s string) string {
+	lines := strings.Split(s, "\n")
+	return lines[len(lines)-1]
 }
 
 func TestLogKeyJLowercaseResetsPreviewScroll(t *testing.T) {

--- a/internal/app/view_modes.go
+++ b/internal/app/view_modes.go
@@ -27,11 +27,19 @@ func (m Model) viewLogs() string {
 		logWidth, previewWidth = splitLogPreviewWidth(m.width)
 	}
 
-	logView := ui.RenderLogViewer(m.logLines, m.logScroll, logWidth, viewH, m.logFollow, m.logWrap, m.logLineNumbers, m.logTimestamps, m.logPrevious, m.logHidePrefixes, m.logTitle, m.logSearchQuery, m.logSearchInput.Value, m.logSearchActive, canSwitchPod, canFilterContainers, m.logHasMoreHistory, m.logLoadingHistory, statusMsg, statusIsErr, m.logCursor, m.logVisualMode, m.logVisualStart, m.logVisualType, m.logVisualCol, m.logVisualCurCol, m.logWrapTopSkip)
+	// When the preview pane is visible the hotkey hint bar is rendered once
+	// across the full terminal width below the JoinHorizontal'd panes, so each
+	// pane omits its internal footer (issue #71). Otherwise the log viewer
+	// keeps its built-in footer for the standalone (no-preview) layout.
+	omitInnerFooter := previewWidth > 0
+
+	logView := ui.RenderLogViewer(m.logLines, m.logScroll, logWidth, viewH, m.logFollow, m.logWrap, m.logLineNumbers, m.logTimestamps, m.logPrevious, m.logHidePrefixes, m.logTitle, m.logSearchQuery, m.logSearchInput.Value, m.logSearchActive, canSwitchPod, canFilterContainers, m.logHasMoreHistory, m.logLoadingHistory, statusMsg, statusIsErr, m.logCursor, m.logVisualMode, m.logVisualStart, m.logVisualType, m.logVisualCol, m.logVisualCurCol, m.logWrapTopSkip, omitInnerFooter)
 
 	if previewWidth > 0 {
-		preview := ui.RenderLogPreviewPane(m.logPreviewLine(), previewWidth, viewH, m.logPreviewScroll)
-		return lipgloss.JoinHorizontal(lipgloss.Top, logView, preview)
+		preview := ui.RenderLogPreviewPane(m.logPreviewLine(), previewWidth, viewH, m.logPreviewScroll, true)
+		panes := lipgloss.JoinHorizontal(lipgloss.Top, logView, preview)
+		footer := ui.RenderLogFooter(m.width, statusMsg, statusIsErr, m.logSearchActive, m.logSearchInput.Value, m.logSearchQuery, m.logVisualMode, canSwitchPod, canFilterContainers)
+		return lipgloss.JoinVertical(lipgloss.Left, panes, footer)
 	}
 	return logView
 }

--- a/internal/ui/logpreview.go
+++ b/internal/ui/logpreview.go
@@ -529,7 +529,12 @@ func parseLogfmtFields(s string) ([]LogPreviewField, bool) {
 // body rows to skip from the top; it is clamped to [0, max] internally so
 // callers can pass an unclamped value and rely on LogPreviewMaxScroll for
 // the upper bound when they need it (e.g. to gate key handlers).
-func RenderLogPreviewPane(line string, width, height, scroll int) string {
+//
+// omitFooter, when true, suppresses the empty status-bar padding row at the
+// bottom so the caller can JoinVertical a full-width footer below the
+// JoinHorizontal'd panes (see RenderLogFooter and issue #71). The output is
+// one row shorter than the default rendering when omitFooter=true.
+func RenderLogPreviewPane(line string, width, height, scroll int, omitFooter bool) string {
 	if width < 10 {
 		width = 10
 	}
@@ -588,6 +593,10 @@ func RenderLogPreviewPane(line string, width, height, scroll int) string {
 	bodyContent := strings.Join(bodyLines, "\n")
 	bodyContent = FillLinesBg(bodyContent, contentWidth, BaseBg)
 	body := FullscreenBorderStyle(width, contentHeight).Render(bodyContent)
+
+	if omitFooter {
+		return lipgloss.JoinVertical(lipgloss.Left, titleBar, body)
+	}
 
 	// Empty status bar keeps the panel's row count aligned with the log
 	// viewer's title + body + footer layout so JoinHorizontal stays clean.

--- a/internal/ui/logpreview_test.go
+++ b/internal/ui/logpreview_test.go
@@ -182,7 +182,7 @@ func TestParseLogLine_EmptyJSON(t *testing.T) {
 }
 
 func TestRenderLogPreviewPane_Dimensions(t *testing.T) {
-	out := RenderLogPreviewPane(`{"level":"info","msg":"hi"}`, 40, 20, 0)
+	out := RenderLogPreviewPane(`{"level":"info","msg":"hi"}`, 40, 20, 0, false)
 	lines := strings.Split(out, "\n")
 	// Title (1) + border-wrapped body (height-2 + 2 border lines = height) + footer (1) = height + 2.
 	want := 22
@@ -192,22 +192,22 @@ func TestRenderLogPreviewPane_Dimensions(t *testing.T) {
 }
 
 func TestRenderLogPreviewPane_EmptyLine(t *testing.T) {
-	out := RenderLogPreviewPane("", 40, 10, 0)
+	out := RenderLogPreviewPane("", 40, 10, 0, false)
 	if !strings.Contains(out, "no log line selected") {
 		t.Fatalf("expected empty-state hint, got: %s", out)
 	}
 }
 
 func TestRenderLogPreviewPane_KindLabel(t *testing.T) {
-	jsonOut := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10, 0)
+	jsonOut := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10, 0, false)
 	if !strings.Contains(jsonOut, "JSON") {
 		t.Fatalf("JSON label missing: %s", jsonOut)
 	}
-	logfmtOut := RenderLogPreviewPane(`a=b c=d`, 40, 10, 0)
+	logfmtOut := RenderLogPreviewPane(`a=b c=d`, 40, 10, 0, false)
 	if !strings.Contains(logfmtOut, "LOGFMT") {
 		t.Fatalf("LOGFMT label missing: %s", logfmtOut)
 	}
-	textOut := RenderLogPreviewPane(`free form`, 40, 10, 0)
+	textOut := RenderLogPreviewPane(`free form`, 40, 10, 0, false)
 	if !strings.Contains(textOut, "TEXT") {
 		t.Fatalf("TEXT label missing: %s", textOut)
 	}
@@ -215,7 +215,7 @@ func TestRenderLogPreviewPane_KindLabel(t *testing.T) {
 
 func TestRenderLogPreviewPane_NarrowDoesNotPanic(t *testing.T) {
 	// Tiny dimensions must clamp gracefully.
-	_ = RenderLogPreviewPane("hello", 1, 1, 0)
+	_ = RenderLogPreviewPane("hello", 1, 1, 0, false)
 }
 
 // scrollOverflowJSON is a JSON line whose pretty-printed body easily
@@ -245,8 +245,8 @@ func TestLogPreviewMaxScroll(t *testing.T) {
 func TestRenderLogPreviewPane_ScrollHidesEarlierRows(t *testing.T) {
 	// Render the same content at scroll 0 vs scroll 2. The first body
 	// row at scroll 0 must not appear in the scroll-2 output.
-	at0 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0)
-	at2 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 2)
+	at0 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0, false)
+	at2 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 2, false)
 	if at0 == at2 {
 		t.Fatal("scrolled and unscrolled output should differ")
 	}
@@ -265,16 +265,16 @@ func TestRenderLogPreviewPane_ScrollClampsToMax(t *testing.T) {
 	// Scroll past the end clamps; output must equal what render at the
 	// computed maxScroll produces.
 	maxScroll := LogPreviewMaxScroll(scrollOverflowJSON, 60, 5)
-	atMax := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, maxScroll)
-	atOverflow := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, maxScroll+10)
+	atMax := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, maxScroll, false)
+	atOverflow := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, maxScroll+10, false)
 	if atMax != atOverflow {
 		t.Fatal("scroll beyond max should clamp and produce identical output")
 	}
 }
 
 func TestRenderLogPreviewPane_NegativeScrollClampsToZero(t *testing.T) {
-	at0 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0)
-	atNeg := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, -5)
+	at0 := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0, false)
+	atNeg := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, -5, false)
 	if at0 != atNeg {
 		t.Fatal("negative scroll should clamp to 0 and produce identical output")
 	}
@@ -290,7 +290,7 @@ func TestRenderLogPreviewPane_AtMaxScrollLastBodyRowIsVisible(t *testing.T) {
 	if maxScroll == 0 {
 		t.Fatal("test setup error: pick dimensions/content that overflow")
 	}
-	out := RenderLogPreviewPane(json, width, height, maxScroll)
+	out := RenderLogPreviewPane(json, width, height, maxScroll, false)
 	if !strings.Contains(out, "z_last_bucket") {
 		t.Fatalf("at max scroll the last body row (key 'z_last_bucket') must be visible:\n%s", out)
 	}
@@ -301,7 +301,7 @@ func TestRenderLogPreviewPane_AtMaxScrollLastBodyRowIsVisible(t *testing.T) {
 
 func TestRenderLogPreviewPane_TitleShowsPositionWhenScrollable(t *testing.T) {
 	// Short pane → overflow → "N/M" position label appears in the title.
-	out := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0)
+	out := RenderLogPreviewPane(scrollOverflowJSON, 60, 5, 0, false)
 	if !strings.Contains(out, "1/") {
 		t.Fatalf("expected position label like '1/N' in scrollable output:\n%s", out)
 	}
@@ -309,7 +309,7 @@ func TestRenderLogPreviewPane_TitleShowsPositionWhenScrollable(t *testing.T) {
 
 func TestRenderLogPreviewPane_NoPositionLabelWhenContentFits(t *testing.T) {
 	// Tall pane → no overflow → no position label.
-	out := RenderLogPreviewPane(`{"a":"1","b":"2"}`, 60, 30, 0)
+	out := RenderLogPreviewPane(`{"a":"1","b":"2"}`, 60, 30, 0, false)
 	for _, frag := range []string{"1/", "2/", "3/"} {
 		if strings.Contains(out, frag) {
 			t.Fatalf("non-scrollable pane should not show position label %q:\n%s", frag, out)
@@ -320,7 +320,7 @@ func TestRenderLogPreviewPane_NoPositionLabelWhenContentFits(t *testing.T) {
 func TestRenderLogPreviewPane_FooterHasNoLegend(t *testing.T) {
 	// The P binding is shown in the main log hint bar; the preview footer
 	// must not duplicate it.
-	out := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10, 0)
+	out := RenderLogPreviewPane(`{"a":"b","c":"d"}`, 40, 10, 0, false)
 	if strings.Contains(out, "close preview") {
 		t.Fatalf("preview footer should not repeat the P legend: %s", out)
 	}
@@ -354,7 +354,7 @@ func TestTruncateKeyForPreview(t *testing.T) {
 }
 
 func TestRenderLogPreviewPane_TruncatedKeyShowsEllipsis(t *testing.T) {
-	out := RenderLogPreviewPane(`{"extremely_long_key_name":"v","b":"c"}`, 40, 10, 0)
+	out := RenderLogPreviewPane(`{"extremely_long_key_name":"v","b":"c"}`, 40, 10, 0, false)
 	if !strings.Contains(out, "…") {
 		t.Fatalf("expected ellipsis on truncated key, got: %s", out)
 	}
@@ -365,14 +365,14 @@ func TestRenderLogPreviewPane_SanitizesControlChars(t *testing.T) {
 	// scrubbed so the panel layout cannot be corrupted by producer output.
 	// (ConfigLogRenderAnsi defaults to false during tests.)
 	in := "{\"msg\":\"before\x1b[2Jafter\"}"
-	out := RenderLogPreviewPane(in, 60, 10, 0)
+	out := RenderLogPreviewPane(in, 60, 10, 0, false)
 	if strings.Contains(out, "\x1b[2J") {
 		t.Fatalf("preview must scrub raw CSI sequences from values, got: %q", out)
 	}
 }
 
 func TestRenderLogPreviewPane_SanitizesPlainTextBody(t *testing.T) {
-	out := RenderLogPreviewPane("plain\x00body", 40, 10, 0)
+	out := RenderLogPreviewPane("plain\x00body", 40, 10, 0, false)
 	if strings.Contains(out, "\x00") {
 		t.Fatalf("preview must scrub NUL bytes from plain-text body")
 	}
@@ -380,7 +380,7 @@ func TestRenderLogPreviewPane_SanitizesPlainTextBody(t *testing.T) {
 
 func TestRenderLogPreviewPane_NestedJSONKeepsLineBreaks(t *testing.T) {
 	in := `{"event":{"type":"order","actor":{"id":"u1","role":"admin"}}}`
-	out := RenderLogPreviewPane(in, 80, 20, 0)
+	out := RenderLogPreviewPane(in, 80, 20, 0, false)
 	if strings.Contains(out, "�") {
 		t.Fatalf("nested JSON value must not contain replacement chars; got:\n%s", out)
 	}
@@ -530,7 +530,7 @@ func TestParseLogLine_Klog_BeatsLogfmtForMessageBody(t *testing.T) {
 
 func TestRenderLogPreviewPane_KlogTitleIndicator(t *testing.T) {
 	in := `W0415 12:40:18.037168       1 mount_helper_common.go:142] Warning: x`
-	out := RenderLogPreviewPane(in, 80, 20, 0)
+	out := RenderLogPreviewPane(in, 80, 20, 0, false)
 	if !strings.Contains(out, "[KLOG]") {
 		t.Fatalf("expected [KLOG] kind indicator in title; got:\n%s", out)
 	}
@@ -689,7 +689,7 @@ func TestParseLogLine_Zap_TooManyTabSegmentsRejected(t *testing.T) {
 
 func TestRenderLogPreviewPane_ZapTitleIndicator(t *testing.T) {
 	in := "[pod/x/manager] 2026-04-27T16:06:59Z\tINFO\tsetup\tstarting manager"
-	out := RenderLogPreviewPane(in, 80, 20, 0)
+	out := RenderLogPreviewPane(in, 80, 20, 0, false)
 	if !strings.Contains(out, "[ZAP]") {
 		t.Fatalf("expected [ZAP] kind indicator in title; got:\n%s", out)
 	}
@@ -809,7 +809,7 @@ func TestParseLogLine_Nginx_BeatsLogfmtForQuerystringPairs(t *testing.T) {
 
 func TestRenderLogPreviewPane_NginxTitleIndicator(t *testing.T) {
 	in := `192.168.1.1 - - [15/Jan/2024:10:30:00 +0000] "GET /api HTTP/1.1" 200 1234 "-" "curl/8"`
-	out := RenderLogPreviewPane(in, 100, 20, 0)
+	out := RenderLogPreviewPane(in, 100, 20, 0, false)
 	if !strings.Contains(out, "[NGINX]") {
 		t.Fatalf("expected [NGINX] kind indicator in title; got:\n%s", out)
 	}
@@ -945,7 +945,7 @@ func TestParseLogLine_Envoy_BeatsLogfmtForQuerystringPairs(t *testing.T) {
 
 func TestRenderLogPreviewPane_EnvoyTitleIndicator(t *testing.T) {
 	in := `[2024-01-15T10:30:00.000Z] "GET /api HTTP/1.1" 200 - 0 1234 5 4 "192.168.1.1" "curl/8" "rid" "host" "10.0.0.5:8080"`
-	out := RenderLogPreviewPane(in, 120, 25, 0)
+	out := RenderLogPreviewPane(in, 120, 25, 0, false)
 	if !strings.Contains(out, "[ENVOY]") {
 		t.Fatalf("expected [ENVOY] kind indicator in title; got:\n%s", out)
 	}
@@ -1075,7 +1075,7 @@ func TestParseLogLine_Java_RejectsNonJava(t *testing.T) {
 
 func TestRenderLogPreviewPane_JavaTitleIndicator(t *testing.T) {
 	in := `2024-01-15T10:30:00.123+00:00  INFO 12345 --- [main] c.e.MyService : Server started on port 8080`
-	out := RenderLogPreviewPane(in, 100, 20, 0)
+	out := RenderLogPreviewPane(in, 100, 20, 0, false)
 	if !strings.Contains(out, "[JAVA]") {
 		t.Fatalf("expected [JAVA] kind indicator in title; got:\n%s", out)
 	}
@@ -1171,7 +1171,7 @@ func TestParseLogLine_Postgres_RejectsNonPostgres(t *testing.T) {
 
 func TestRenderLogPreviewPane_PostgresTitleIndicator(t *testing.T) {
 	in := `2024-01-15 10:30:00.123 UTC [1234] ERROR:  relation "foo" does not exist`
-	out := RenderLogPreviewPane(in, 100, 20, 0)
+	out := RenderLogPreviewPane(in, 100, 20, 0, false)
 	if !strings.Contains(out, "[POSTGRES]") {
 		t.Fatalf("expected [POSTGRES] kind indicator in title; got:\n%s", out)
 	}

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -15,9 +15,18 @@ var LogSearchHighlightStyle = lipgloss.NewStyle().
 	Bold(true)
 
 // RenderLogViewer renders the full-screen log viewer.
-func RenderLogViewer(lines []string, scroll, width, height int, follow, wrap, lineNumbers, timestamps, previous, hidePrefixes bool, title, searchQuery, searchInput string, searchActive, canSwitchPod, canFilterContainers, hasMoreHistory, loadingHistory bool, statusMsg string, statusIsErr bool, cursor int, visualMode bool, visualStart int, visualType rune, visualCol, visualCurCol, wrapTopSkip int) string {
+//
+// omitFooter, when true, suppresses the internal hotkey hint bar so the caller
+// can render a full-terminal-width footer below a JoinHorizontal'd composition
+// (e.g. with the side preview pane). The output is one row shorter than the
+// default rendering. Callers that pass omitFooter=true must render their own
+// footer via RenderLogFooter.
+func RenderLogViewer(lines []string, scroll, width, height int, follow, wrap, lineNumbers, timestamps, previous, hidePrefixes bool, title, searchQuery, searchInput string, searchActive, canSwitchPod, canFilterContainers, hasMoreHistory, loadingHistory bool, statusMsg string, statusIsErr bool, cursor int, visualMode bool, visualStart int, visualType rune, visualCol, visualCurCol, wrapTopSkip int, omitFooter bool) string {
 	titleBar := renderLogTitleBar(title, lines, width, follow, wrap, lineNumbers, timestamps, previous, hidePrefixes, visualMode, visualType, loadingHistory, searchQuery)
-	footer := renderLogFooter(width, statusMsg, statusIsErr, searchActive, searchInput, searchQuery, visualMode, canSwitchPod, canFilterContainers)
+	var footer string
+	if !omitFooter {
+		footer = RenderLogFooter(width, statusMsg, statusIsErr, searchActive, searchInput, searchQuery, visualMode, canSwitchPod, canFilterContainers)
+	}
 
 	// Content area: subtract border top + bottom (2 lines).
 	contentHeight := max(height-2, 1)
@@ -119,6 +128,9 @@ func RenderLogViewer(lines []string, scroll, width, height int, follow, wrap, li
 	borderStyle := FullscreenBorderStyle(width, contentHeight)
 	body := borderStyle.Render(bodyContent)
 
+	if omitFooter {
+		return lipgloss.JoinVertical(lipgloss.Left, titleBar, body)
+	}
 	return lipgloss.JoinVertical(lipgloss.Left, titleBar, body, footer)
 }
 
@@ -170,13 +182,17 @@ func renderLogTitleBar(title string, lines []string, width int, follow, wrap, li
 	return FillLinesBg(TitleStyle.Width(width).MaxWidth(width).MaxHeight(1).Render(titleText), width, BarBg)
 }
 
-// renderLogFooter builds the footer bar for the log viewer.
+// RenderLogFooter builds the footer bar for the log viewer.
 //
 // searchQuery is the *committed* search query (empty until the user presses
 // enter on the search prompt). The n/N next/prev hint is only surfaced once
 // a query has been committed \u2014 advertising it on a fresh viewer with no
 // search would be a no-op chord and a confusing claim.
-func renderLogFooter(width int, statusMsg string, statusIsErr, searchActive bool, searchInput, searchQuery string, visualMode, canSwitchPod, canFilterContainers bool) string {
+//
+// Exported so callers can render the footer at a wider terminal width than the
+// log column itself (e.g. when the side preview pane is on and the hint bar
+// must span the full screen below the JoinHorizontal'd panes \u2014 issue #71).
+func RenderLogFooter(width int, statusMsg string, statusIsErr, searchActive bool, searchInput, searchQuery string, visualMode, canSwitchPod, canFilterContainers bool) string {
 	if statusMsg != "" {
 		style := HelpKeyStyle
 		if statusIsErr {

--- a/internal/ui/logviewer_render_test.go
+++ b/internal/ui/logviewer_render_test.go
@@ -80,7 +80,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"my-pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "my-pod")
 		assert.Contains(t, result, "log entry 1")
@@ -94,7 +94,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "FOLLOW")
 	})
@@ -106,7 +106,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "WRAP")
 	})
@@ -118,7 +118,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "LINE#")
 	})
@@ -130,7 +130,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "TIMESTAMPS")
 	})
@@ -142,7 +142,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "PREVIOUS")
 	})
@@ -154,7 +154,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "error", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "/error")
 	})
@@ -166,7 +166,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "err",
 			true, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "err")
 		assert.Contains(t, result, "enter:apply")
@@ -179,7 +179,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"Saved to file", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "Saved to file")
 	})
@@ -191,7 +191,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			0, true, 0, 'V', 0, 0, 0,
+			0, true, 0, 'V', 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "VISUAL LINE")
 	})
@@ -203,7 +203,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			0, true, 0, 'v', 0, 0, 0,
+			0, true, 0, 'v', 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "VISUAL")
 	})
@@ -215,7 +215,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			0, true, 0, 'B', 0, 0, 0,
+			0, true, 0, 'B', 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "VISUAL BLOCK")
 	})
@@ -227,7 +227,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "pod")
 		assert.Contains(t, result, "0 lines")
@@ -240,7 +240,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, true,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "LOADING HISTORY")
 	})
@@ -253,7 +253,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, true, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "switch pod")
 	})
@@ -265,7 +265,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, true, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "containers")
 	})
@@ -278,7 +278,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "WRAP")
 		// The long line should be visible (at least part of it).
@@ -293,7 +293,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		// "/" search hint must still be there; "n/N" must not.
 		assert.Contains(t, result, "search")
@@ -308,7 +308,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "error", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "n/N")
 		assert.Contains(t, result, "next/prev")
@@ -323,7 +323,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "error", "err",
 			true, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		assert.Contains(t, result, "enter:apply")
 		assert.NotContains(t, result, "n/N")
@@ -350,7 +350,7 @@ func TestRenderLogViewer(t *testing.T) {
 			"pod", "", "",
 			false, false, false, false, false,
 			"", false,
-			-1, false, 0, 0, 0, 0, 0,
+			-1, false, 0, 0, 0, 0, 0, false,
 		)
 		// Layout: title (1) + bordered body (contentHeight+2 = height) +
 		// footer (1) = height + 2 rows total. lipgloss re-wrapping a


### PR DESCRIPTION
## Summary

When the log preview side panel is visible the hotkey hint bar was rendered inside the narrower log column, clipping the late entries ("123G goto", "S save", "ctrl+s save all", and the "switch pod / containers" affordance). The bar now spans the full terminal width below the JoinHorizontal'd panes.

The renderers gain an `omitFooter` flag so callers can compose a shared full-width footer; `RenderLogFooter` is exported for the same reason. The existing standalone (no-preview) layout is unchanged.

## Type of change

- [x] fix: bug fix

## Related issue

Closes #71

## Changes

- Fix clipping of hint bar when the log preview is enable

## Testing

<!-- How did you verify this works? Include the cluster / terminal you tested against when relevant. -->

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->
