### PR TITLE
perf(discovery): stale-while-revalidate cache under ~/.kube/cache/discovery

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -651,6 +651,14 @@ type Model struct {
 	// updateAPIResourceDiscovery when the result arrives.
 	discoveringContexts map[string]bool
 
+	// Contexts whose discoveredResources entries have been refreshed
+	// (i.e. live-fetched) during this session. NewModel prefills
+	// discoveredResources from the on-disk discovery cache for instant
+	// first paint, so the bare presence of an entry no longer implies
+	// "fresh" — this flag is the source of truth for stale-while-revalidate
+	// gating in the lazy discovery triggers.
+	discoveryRefreshedContexts map[string]bool
+
 	// bookmarkAwaitingDiscovery holds a bookmark whose target resource type
 	// can't be resolved yet because API discovery for the effective context
 	// hasn't completed (typical at session restore — the seed list resolves
@@ -994,40 +1002,41 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	reqCtx, reqCancel := context.WithCancel(context.Background())
 	pinnedSt := loadPinnedState()
 	m := Model{
-		client:              client,
-		nav:                 model.NavigationState{Level: model.LevelClusters},
-		bookmarks:           loadBookmarks(),
-		pendingSession:      loadSession(),
-		pendingPortForwards: loadPortForwardState(),
-		commandHistory:      loadCommandHistory(),
-		queryHistory:        loadInputHistory(historyFileQuery),
-		pinnedState:         pinnedSt,
-		namespace:           defaultNS,
-		spinner:             s,
-		watchInterval:       watchInterval,
-		splitPreview:        true,
-		allNamespaces:       true,
-		watchMode:           true,
-		sortColumnName:      sortColDefault,
-		sortAscending:       true,
-		cursorMemory:        make(map[string]int),
-		itemCache:           make(map[string][]model.Item),
-		cacheFingerprints:   make(map[string]string),
-		selectedItems:       make(map[string]bool),
-		selectionAnchor:     -1,
-		yamlCollapsed:       make(map[string]bool),
-		discoveredResources: make(map[string][]model.ResourceTypeEntry),
-		discoveringContexts: make(map[string]bool),
-		secretPreviewCache:  make(map[string]*model.SecretData),
-		allGroupsExpanded:   true,
-		warningEventsOnly:   true,
-		eventGrouping:       true,
-		logPreviewVisible:   true,
-		bgtasks:             bgtasks.New(bgtasks.DefaultThreshold),
-		diffLineNumbers:     true,
-		reqCtx:              reqCtx,
-		reqCancel:           reqCancel,
-		middleTableRenderer: ui.NewTableRenderer(),
+		client:                     client,
+		nav:                        model.NavigationState{Level: model.LevelClusters},
+		bookmarks:                  loadBookmarks(),
+		pendingSession:             loadSession(),
+		pendingPortForwards:        loadPortForwardState(),
+		commandHistory:             loadCommandHistory(),
+		queryHistory:               loadInputHistory(historyFileQuery),
+		pinnedState:                pinnedSt,
+		namespace:                  defaultNS,
+		spinner:                    s,
+		watchInterval:              watchInterval,
+		splitPreview:               true,
+		allNamespaces:              true,
+		watchMode:                  true,
+		sortColumnName:             sortColDefault,
+		sortAscending:              true,
+		cursorMemory:               make(map[string]int),
+		itemCache:                  make(map[string][]model.Item),
+		cacheFingerprints:          make(map[string]string),
+		selectedItems:              make(map[string]bool),
+		selectionAnchor:            -1,
+		yamlCollapsed:              make(map[string]bool),
+		discoveredResources:        make(map[string][]model.ResourceTypeEntry),
+		discoveringContexts:        make(map[string]bool),
+		secretPreviewCache:         make(map[string]*model.SecretData),
+		discoveryRefreshedContexts: make(map[string]bool),
+		allGroupsExpanded:          true,
+		warningEventsOnly:          true,
+		eventGrouping:              true,
+		logPreviewVisible:          true,
+		bgtasks:                    bgtasks.New(bgtasks.DefaultThreshold),
+		diffLineNumbers:            true,
+		reqCtx:                     reqCtx,
+		reqCancel:                  reqCancel,
+		middleTableRenderer:        ui.NewTableRenderer(),
 		tabs: []TabState{{
 			nav:                model.NavigationState{Level: model.LevelClusters},
 			namespace:          defaultNS,
@@ -1049,6 +1058,22 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		activeTab:      0,
 		execMu:         &sync.Mutex{},
 		portForwardMgr: k8s.NewPortForwardManager(),
+	}
+
+	// Stale-while-revalidate: seed discoveredResources from the on-disk
+	// snapshot so the sidebar paints instantly on first frame instead of
+	// waiting for a live discovery roundtrip. The lazy-trigger sites still
+	// fire fresh discovery (gated by m.discoveryRefreshedContexts), so the
+	// cached values are replaced as soon as the live result lands.
+	if cache := loadDiscoveryCache(); cache != nil {
+		pseudo := model.PseudoResources()
+		for ctx, snap := range cache.Contexts {
+			cached := modelEntriesFromDiscoveryCache(snap.Entries)
+			merged := make([]model.ResourceTypeEntry, 0, len(pseudo)+len(cached))
+			merged = append(merged, pseudo...)
+			merged = append(merged, cached...)
+			m.discoveredResources[ctx] = merged
+		}
 	}
 
 	// When CLI flags are provided, replace the file-loaded session with a

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1060,18 +1060,18 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		portForwardMgr: k8s.NewPortForwardManager(),
 	}
 
-	// Stale-while-revalidate: seed discoveredResources from the on-disk
-	// snapshot so the sidebar paints instantly on first frame instead of
-	// waiting for a live discovery roundtrip. The lazy-trigger sites still
-	// fire fresh discovery (gated by m.discoveryRefreshedContexts), so the
-	// cached values are replaced as soon as the live result lands.
-	if cache := loadDiscoveryCache(); cache != nil {
+	// Stale-while-revalidate: seed discoveredResources from the per-host
+	// snapshots under ~/.kube/cache/discovery/<host>/lfk-enriched.yaml so
+	// the sidebar paints instantly on first frame instead of waiting for a
+	// live discovery roundtrip. The lazy-trigger sites still fire fresh
+	// discovery (gated by m.discoveryRefreshedContexts), so the cached
+	// values are replaced as soon as the live result lands.
+	if cached := loadAllDiscoveryCaches(client); cached != nil {
 		pseudo := model.PseudoResources()
-		for ctx, snap := range cache.Contexts {
-			cached := modelEntriesFromDiscoveryCache(snap.Entries)
-			merged := make([]model.ResourceTypeEntry, 0, len(pseudo)+len(cached))
+		for ctx, entries := range cached {
+			merged := make([]model.ResourceTypeEntry, 0, len(pseudo)+len(entries))
 			merged = append(merged, pseudo...)
-			merged = append(merged, cached...)
+			merged = append(merged, entries...)
 			m.discoveredResources[ctx] = merged
 		}
 	}

--- a/internal/app/commands_load_preview.go
+++ b/internal/app/commands_load_preview.go
@@ -59,23 +59,26 @@ func (m Model) loadPreviewClusters(sel *model.Item) tea.Cmd {
 	}
 	if discovered := m.discoveredResources[hoveredCtx]; len(discovered) > 0 {
 		items := model.BuildSidebarItems(discovered)
-		return func() tea.Msg {
+		// If the discovered slice came from the disk cache (prefilled at
+		// startup) and discovery hasn't run live yet this session, we
+		// still want to kick one off behind the cached view — the user
+		// gets instant paint plus an asynchronous refresh.
+		var cmds []tea.Cmd
+		cmds = append(cmds, func() tea.Msg {
 			return resourceTypesMsg{items: items}
+		})
+		if m.shouldFireDiscoveryFor(hoveredCtx) {
+			m.markDiscoveryStarted(hoveredCtx)
+			cmds = append(cmds, m.discoverAPIResources(hoveredCtx))
 		}
+		return tea.Batch(cmds...)
 	}
 	// Clear rightItems so renderRightClusters falls into its loader branch.
 	cmds := []tea.Cmd{func() tea.Msg {
 		return resourceTypesMsg{items: nil}
 	}}
-	if !m.discoveringContexts[hoveredCtx] {
-		// discoveringContexts is a reference-type map, so writing here
-		// propagates back through the value receiver to the Update
-		// handler. The map is created in NewModel; if it is nil we skip
-		// the dedup rather than panic — callers in tests may not
-		// initialize it, but production always does.
-		if m.discoveringContexts != nil {
-			m.discoveringContexts[hoveredCtx] = true
-		}
+	if m.shouldFireDiscoveryFor(hoveredCtx) {
+		m.markDiscoveryStarted(hoveredCtx)
 		cmds = append(cmds, m.discoverAPIResources(hoveredCtx))
 	}
 	return tea.Batch(cmds...)

--- a/internal/app/commands_load_preview_clusters_test.go
+++ b/internal/app/commands_load_preview_clusters_test.go
@@ -30,16 +30,41 @@ func TestLoadPreviewClusters_UncachedTriggersDiscoveryAndClearsRightItems(t *tes
 		"must mark the hovered context as discovering to dedupe subsequent hovers")
 }
 
-// When the hovered context already has discovered resources, we emit them
-// directly and do NOT re-trigger discovery — important so repeated cursoring
-// through already-visited contexts doesn't keep re-auth'ing.
-func TestLoadPreviewClusters_CachedDoesNotTriggerDiscovery(t *testing.T) {
+// When the hovered context has discovered resources from a previous session
+// (cache prefill) we emit them immediately for instant paint AND fire a
+// fresh discovery behind the scenes (stale-while-revalidate). Once that
+// session-fresh discovery has completed, repeated hovers must not re-fire —
+// otherwise cursoring through already-visited contexts would keep re-auth'ing.
+func TestLoadPreviewClusters_CachedFiresRevalidationOnFirstHover(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m.nav.Level = model.LevelClusters
 	m.nav.Context = ""
 	m.discoveredResources["visited-ctx"] = []model.ResourceTypeEntry{
 		{DisplayName: "Pods", Kind: "Pod", APIVersion: "v1", Resource: "pods"},
 	}
+	m = withMiddleItem(m, model.Item{Name: "visited-ctx"})
+
+	cmd := m.loadPreview()
+	require.NotNil(t, cmd)
+	// The cached items must still be emitted so the right pane paints
+	// immediately. shouldFireDiscoveryFor returns true here because no
+	// session-fresh discovery has run, so a Batch (cached emit + discovery)
+	// is expected — drain it and verify the resourceTypesMsg is in flight.
+	assert.True(t, m.discoveringContexts["visited-ctx"],
+		"first hover of a cache-prefilled context must trigger background revalidation")
+}
+
+// After this session has already done a live discovery for the context,
+// further hovers must not re-fire — that's the dedup the OIDC-auth-loop
+// regression test is guarding against.
+func TestLoadPreviewClusters_CachedSkipsAfterSessionRefresh(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.nav.Level = model.LevelClusters
+	m.nav.Context = ""
+	m.discoveredResources["visited-ctx"] = []model.ResourceTypeEntry{
+		{DisplayName: "Pods", Kind: "Pod", APIVersion: "v1", Resource: "pods"},
+	}
+	m.discoveryRefreshedContexts["visited-ctx"] = true
 	m = withMiddleItem(m, model.Item{Name: "visited-ctx"})
 
 	cmd := m.loadPreview()
@@ -51,7 +76,7 @@ func TestLoadPreviewClusters_CachedDoesNotTriggerDiscovery(t *testing.T) {
 	assert.False(t, rmsg.seeded,
 		"discovered entries must not be tagged seeded")
 	assert.False(t, m.discoveringContexts["visited-ctx"],
-		"already-discovered context must not be marked discovering")
+		"context already refreshed this session must not be marked discovering again")
 }
 
 // If discovery is already in-flight for the hovered context, don't fire a

--- a/internal/app/discovery_cache.go
+++ b/internal/app/discovery_cache.go
@@ -1,0 +1,273 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// discoveryCacheSchemaVersion bumps whenever the on-disk shape changes.
+// loadDiscoveryCache rejects unknown versions so older binaries don't trip
+// on a forward-incompat write from a newer one — the worst case is one
+// extra discovery roundtrip on first launch after upgrade.
+const discoveryCacheSchemaVersion = 1
+
+// DiscoveryCacheEntry is the serialized form of a single ResourceTypeEntry.
+// It mirrors model.ResourceTypeEntry but carries explicit JSON tags so the
+// YAML shape stays stable across renames in the domain type.
+type DiscoveryCacheEntry struct {
+	DisplayName    string              `json:"display_name,omitempty"`
+	Kind           string              `json:"kind"`
+	APIGroup       string              `json:"api_group"`
+	APIVersion     string              `json:"api_version"`
+	Resource       string              `json:"resource"`
+	Namespaced     bool                `json:"namespaced,omitempty"`
+	RequiresCRD    bool                `json:"requires_crd,omitempty"`
+	Deprecated     bool                `json:"deprecated,omitempty"`
+	DeprecationMsg string              `json:"deprecation_msg,omitempty"`
+	Verbs          []string            `json:"verbs,omitempty"`
+	PrinterColumns []DiscoveryCacheCol `json:"printer_columns,omitempty"`
+	Icon           DiscoveryCacheIcon  `json:"icon,omitzero"`
+}
+
+// DiscoveryCacheCol mirrors model.PrinterColumn with explicit JSON tags.
+type DiscoveryCacheCol struct {
+	Name     string `json:"name"`
+	Type     string `json:"type,omitempty"`
+	JSONPath string `json:"json_path,omitempty"`
+}
+
+// DiscoveryCacheIcon mirrors model.Icon with explicit JSON tags.
+type DiscoveryCacheIcon struct {
+	Unicode  string `json:"unicode,omitempty"`
+	Simple   string `json:"simple,omitempty"`
+	Emoji    string `json:"emoji,omitempty"`
+	NerdFont string `json:"nerd_font,omitempty"`
+}
+
+// DiscoveryCacheContext is the per-context block — a snapshot of the API
+// resources the cluster reported, plus the wall-clock time of capture.
+type DiscoveryCacheContext struct {
+	UpdatedAt time.Time             `json:"updated_at"`
+	Entries   []DiscoveryCacheEntry `json:"entries"`
+}
+
+// DiscoveryCacheState is the top-level on-disk document.
+type DiscoveryCacheState struct {
+	SchemaVersion int                              `json:"schema_version"`
+	Contexts      map[string]DiscoveryCacheContext `json:"contexts,omitempty"`
+}
+
+// discoveryCacheFilePath returns the path to the discovery cache file.
+// Uses the same XDG state directory as session.yaml so cleanup tools that
+// already understand lfk's state dir cover it without extra config.
+func discoveryCacheFilePath() string {
+	stateDir := os.Getenv("XDG_STATE_HOME")
+	if stateDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		stateDir = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateDir, "lfk", "discovery-cache.yaml")
+}
+
+// loadDiscoveryCache reads the cache file. Returns nil on any failure —
+// missing file, corrupt YAML, unknown schema. Callers fall through to a
+// live discovery, so a nil result is recoverable.
+func loadDiscoveryCache() *DiscoveryCacheState {
+	path := discoveryCacheFilePath()
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var s DiscoveryCacheState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		logger.Warn("Discovery cache is corrupt; ignoring", "error", err, "path", path)
+		return nil
+	}
+	if s.SchemaVersion != discoveryCacheSchemaVersion {
+		logger.Info("Discovery cache schema version mismatch; ignoring",
+			"got", s.SchemaVersion, "want", discoveryCacheSchemaVersion)
+		return nil
+	}
+	if s.Contexts == nil {
+		s.Contexts = make(map[string]DiscoveryCacheContext)
+	}
+	return &s
+}
+
+// saveDiscoveryCache writes the full cache document atomically (write to a
+// sibling .tmp then rename) so a crash mid-write can't leave a half-written
+// file that loadDiscoveryCache would discard.
+func saveDiscoveryCache(state DiscoveryCacheState) error {
+	path := discoveryCacheFilePath()
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	state.SchemaVersion = discoveryCacheSchemaVersion
+	data, err := yaml.Marshal(state)
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// updateDiscoveryCacheContext is the single mutator: it loads the current
+// state (or starts an empty one), replaces a context's entry list with
+// `entries`, and writes the result back to disk. Other contexts in the file
+// are preserved untouched so cluster-level updates don't trash unrelated
+// snapshots.
+func updateDiscoveryCacheContext(contextName string, entries []model.ResourceTypeEntry) error {
+	if contextName == "" {
+		return nil
+	}
+	state := loadDiscoveryCache()
+	if state == nil {
+		state = &DiscoveryCacheState{
+			SchemaVersion: discoveryCacheSchemaVersion,
+			Contexts:      make(map[string]DiscoveryCacheContext),
+		}
+	}
+	if state.Contexts == nil {
+		state.Contexts = make(map[string]DiscoveryCacheContext)
+	}
+	state.Contexts[contextName] = DiscoveryCacheContext{
+		UpdatedAt: time.Now().UTC(),
+		Entries:   discoveryCacheEntriesFromModel(entries),
+	}
+	return saveDiscoveryCache(*state)
+}
+
+// discoveryCacheEntriesFromModel converts the model's domain types to the
+// cache's serialization types. The cache deliberately does not store
+// pseudo-resources (helm releases, port forwards) — those are prepended at
+// runtime by updateAPIResourceDiscovery and may evolve independently of
+// disk format.
+func discoveryCacheEntriesFromModel(entries []model.ResourceTypeEntry) []DiscoveryCacheEntry {
+	out := make([]DiscoveryCacheEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, DiscoveryCacheEntry{
+			DisplayName:    e.DisplayName,
+			Kind:           e.Kind,
+			APIGroup:       e.APIGroup,
+			APIVersion:     e.APIVersion,
+			Resource:       e.Resource,
+			Namespaced:     e.Namespaced,
+			RequiresCRD:    e.RequiresCRD,
+			Deprecated:     e.Deprecated,
+			DeprecationMsg: e.DeprecationMsg,
+			Verbs:          append([]string(nil), e.Verbs...),
+			PrinterColumns: discoveryCacheColsFromModel(e.PrinterColumns),
+			Icon: DiscoveryCacheIcon{
+				Unicode:  e.Icon.Unicode,
+				Simple:   e.Icon.Simple,
+				Emoji:    e.Icon.Emoji,
+				NerdFont: e.Icon.NerdFont,
+			},
+		})
+	}
+	return out
+}
+
+func discoveryCacheColsFromModel(cols []model.PrinterColumn) []DiscoveryCacheCol {
+	if len(cols) == 0 {
+		return nil
+	}
+	out := make([]DiscoveryCacheCol, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, DiscoveryCacheCol{Name: c.Name, Type: c.Type, JSONPath: c.JSONPath})
+	}
+	return out
+}
+
+// shouldFireDiscoveryFor reports whether a fresh discovery call should be
+// kicked off for contextName. Returns false when (a) a discovery is already
+// in flight for that context — deduplication — or (b) discovery has already
+// completed during this session, in which case re-fetching would just hit
+// the cluster API for nothing.
+//
+// This is the gate that makes stale-while-revalidate work: NewModel prefills
+// m.discoveredResources from disk, but the first hover/navigate of a context
+// returns true here so a live refresh kicks off behind the cached view.
+func (m *Model) shouldFireDiscoveryFor(contextName string) bool {
+	if contextName == "" {
+		return false
+	}
+	if m.discoveringContexts[contextName] {
+		return false
+	}
+	if m.discoveryRefreshedContexts[contextName] {
+		return false
+	}
+	return true
+}
+
+// markDiscoveryStarted records that a discovery call is now in flight for
+// contextName so subsequent shouldFireDiscoveryFor calls deduplicate. Safe
+// to call when discoveringContexts is nil — the function is the canonical
+// place to lazily allocate the map.
+func (m *Model) markDiscoveryStarted(contextName string) {
+	if contextName == "" {
+		return
+	}
+	if m.discoveringContexts == nil {
+		m.discoveringContexts = make(map[string]bool)
+	}
+	m.discoveringContexts[contextName] = true
+}
+
+// modelEntriesFromDiscoveryCache is the inverse: turn a cached snapshot back
+// into model types ready to plug into m.discoveredResources.
+func modelEntriesFromDiscoveryCache(entries []DiscoveryCacheEntry) []model.ResourceTypeEntry {
+	out := make([]model.ResourceTypeEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, model.ResourceTypeEntry{
+			DisplayName:    e.DisplayName,
+			Kind:           e.Kind,
+			APIGroup:       e.APIGroup,
+			APIVersion:     e.APIVersion,
+			Resource:       e.Resource,
+			Namespaced:     e.Namespaced,
+			RequiresCRD:    e.RequiresCRD,
+			Deprecated:     e.Deprecated,
+			DeprecationMsg: e.DeprecationMsg,
+			Verbs:          append([]string(nil), e.Verbs...),
+			PrinterColumns: modelColsFromDiscoveryCache(e.PrinterColumns),
+			Icon: model.Icon{
+				Unicode:  e.Icon.Unicode,
+				Simple:   e.Icon.Simple,
+				Emoji:    e.Icon.Emoji,
+				NerdFont: e.Icon.NerdFont,
+			},
+		})
+	}
+	return out
+}
+
+func modelColsFromDiscoveryCache(cols []DiscoveryCacheCol) []model.PrinterColumn {
+	if len(cols) == 0 {
+		return nil
+	}
+	out := make([]model.PrinterColumn, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, model.PrinterColumn{Name: c.Name, Type: c.Type, JSONPath: c.JSONPath})
+	}
+	return out
+}

--- a/internal/app/discovery_cache.go
+++ b/internal/app/discovery_cache.go
@@ -1,21 +1,35 @@
 package app
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
 // discoveryCacheSchemaVersion bumps whenever the on-disk shape changes.
-// loadDiscoveryCache rejects unknown versions so older binaries don't trip
-// on a forward-incompat write from a newer one — the worst case is one
+// loadDiscoveryCacheForHost rejects unknown versions so older binaries don't
+// trip on a forward-incompat write from a newer one — the worst case is one
 // extra discovery roundtrip on first launch after upgrade.
-const discoveryCacheSchemaVersion = 1
+//
+// v2: per-host file layout (one yaml per ~/.kube/cache/discovery/<host>/)
+// replacing the v1 single-file XDG-state design — shares lifecycle with
+// kubectl/k9s so `kubectl api-resources --invalidate-cache` wipes lfk's
+// cache too. v1 files in the old XDG location are abandoned (the previous
+// build was unreleased).
+const discoveryCacheSchemaVersion = 2
+
+// discoveryCacheFilename is the basename of lfk's enriched cache inside each
+// per-host kubectl-cache dir. Distinct from kubectl's per-group/version JSON
+// files so the two formats can coexist in the same directory.
+const discoveryCacheFilename = "lfk-enriched.yaml"
 
 // DiscoveryCacheEntry is the serialized form of a single ResourceTypeEntry.
 // It mirrors model.ResourceTypeEntry but carries explicit JSON tags so the
@@ -50,74 +64,77 @@ type DiscoveryCacheIcon struct {
 	NerdFont string `json:"nerd_font,omitempty"`
 }
 
-// DiscoveryCacheContext is the per-context block — a snapshot of the API
-// resources the cluster reported, plus the wall-clock time of capture.
-type DiscoveryCacheContext struct {
-	UpdatedAt time.Time             `json:"updated_at"`
-	Entries   []DiscoveryCacheEntry `json:"entries"`
+// DiscoveryCacheHostState is the on-disk shape: one file per cluster API
+// host. Multiple kubeconfig contexts pointing at the same host share one
+// file because cluster-level discovery output is host-keyed, not
+// context-keyed.
+type DiscoveryCacheHostState struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Host          string                `json:"host"`
+	UpdatedAt     time.Time             `json:"updated_at"`
+	Entries       []DiscoveryCacheEntry `json:"entries"`
 }
 
-// DiscoveryCacheState is the top-level on-disk document.
-type DiscoveryCacheState struct {
-	SchemaVersion int                              `json:"schema_version"`
-	Contexts      map[string]DiscoveryCacheContext `json:"contexts,omitempty"`
-}
-
-// discoveryCacheFilePath returns the path to the discovery cache file.
-// Uses the same XDG state directory as session.yaml so cleanup tools that
-// already understand lfk's state dir cover it without extra config.
-func discoveryCacheFilePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+// discoveryCacheFilePathForHost returns the per-host cache file path:
+// $KUBECACHEDIR/discovery/<host>/lfk-enriched.yaml (with $KUBECACHEDIR
+// defaulting to ~/.kube/cache). Returns "" for an empty host or an
+// unresolvable home dir; callers treat that as "skip caching".
+func discoveryCacheFilePathForHost(host string) string {
+	if host == "" {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "discovery-cache.yaml")
+	base := k8s.DiscoveryCacheBaseDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "discovery", k8s.CacheHostDir(host), discoveryCacheFilename)
 }
 
-// loadDiscoveryCache reads the cache file. Returns nil on any failure —
-// missing file, corrupt YAML, unknown schema. Callers fall through to a
-// live discovery, so a nil result is recoverable.
-func loadDiscoveryCache() *DiscoveryCacheState {
-	path := discoveryCacheFilePath()
+// loadDiscoveryCacheForHost reads one host's enriched cache. Returns nil on
+// any failure — missing file, corrupt YAML, schema mismatch — so callers
+// can treat a nil result as "fall through to live discovery".
+func loadDiscoveryCacheForHost(host string) *DiscoveryCacheHostState {
+	path := discoveryCacheFilePathForHost(host)
 	if path == "" {
 		return nil
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			logger.Warn("Discovery cache read failed", "host", host, "error", err)
+		}
 		return nil
 	}
-	var s DiscoveryCacheState
+	var s DiscoveryCacheHostState
 	if err := yaml.Unmarshal(data, &s); err != nil {
-		logger.Warn("Discovery cache is corrupt; ignoring", "error", err, "path", path)
+		logger.Warn("Discovery cache is corrupt; ignoring", "host", host, "error", err)
 		return nil
 	}
 	if s.SchemaVersion != discoveryCacheSchemaVersion {
 		logger.Info("Discovery cache schema version mismatch; ignoring",
-			"got", s.SchemaVersion, "want", discoveryCacheSchemaVersion)
+			"host", host, "got", s.SchemaVersion, "want", discoveryCacheSchemaVersion)
 		return nil
-	}
-	if s.Contexts == nil {
-		s.Contexts = make(map[string]DiscoveryCacheContext)
 	}
 	return &s
 }
 
-// saveDiscoveryCache writes the full cache document atomically (write to a
-// sibling .tmp then rename) so a crash mid-write can't leave a half-written
-// file that loadDiscoveryCache would discard.
-func saveDiscoveryCache(state DiscoveryCacheState) error {
-	path := discoveryCacheFilePath()
+// saveDiscoveryCacheForHost writes one host's enriched cache atomically
+// (sibling .tmp + rename) so a crash mid-write can't leave a half-written
+// file that loadDiscoveryCacheForHost would discard.
+func saveDiscoveryCacheForHost(host string, entries []model.ResourceTypeEntry) error {
+	path := discoveryCacheFilePathForHost(host)
 	if path == "" {
 		return nil
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	state.SchemaVersion = discoveryCacheSchemaVersion
+	state := DiscoveryCacheHostState{
+		SchemaVersion: discoveryCacheSchemaVersion,
+		Host:          host,
+		UpdatedAt:     time.Now().UTC(),
+		Entries:       discoveryCacheEntriesFromModel(entries),
+	}
 	data, err := yaml.Marshal(state)
 	if err != nil {
 		return err
@@ -129,30 +146,53 @@ func saveDiscoveryCache(state DiscoveryCacheState) error {
 	return os.Rename(tmp, path)
 }
 
-// updateDiscoveryCacheContext is the single mutator: it loads the current
-// state (or starts an empty one), replaces a context's entry list with
-// `entries`, and writes the result back to disk. Other contexts in the file
-// are preserved untouched so cluster-level updates don't trash unrelated
-// snapshots.
-func updateDiscoveryCacheContext(contextName string, entries []model.ResourceTypeEntry) error {
-	if contextName == "" {
+// loadAllDiscoveryCaches enumerates every kubeconfig context known to client,
+// resolves each to a host, reads each unique host's cache file once, and
+// returns a map from context display name to cached resource entries ready
+// to plug into m.discoveredResources. Contexts with unresolvable hosts or
+// missing cache files are silently skipped — they fall through to live
+// discovery on first interaction.
+func loadAllDiscoveryCaches(client *k8s.Client) map[string][]model.ResourceTypeEntry {
+	if client == nil {
 		return nil
 	}
-	state := loadDiscoveryCache()
-	if state == nil {
-		state = &DiscoveryCacheState{
-			SchemaVersion: discoveryCacheSchemaVersion,
-			Contexts:      make(map[string]DiscoveryCacheContext),
+	contexts, err := client.GetContexts()
+	if err != nil {
+		return nil
+	}
+	out := make(map[string][]model.ResourceTypeEntry)
+	hostCache := make(map[string]*DiscoveryCacheHostState)
+	for _, ctx := range contexts {
+		host := client.HostForContext(ctx.Name)
+		if host == "" {
+			continue
 		}
+		snap, ok := hostCache[host]
+		if !ok {
+			snap = loadDiscoveryCacheForHost(host)
+			hostCache[host] = snap
+		}
+		if snap == nil {
+			continue
+		}
+		out[ctx.Name] = modelEntriesFromDiscoveryCache(snap.Entries)
 	}
-	if state.Contexts == nil {
-		state.Contexts = make(map[string]DiscoveryCacheContext)
+	return out
+}
+
+// updateDiscoveryCacheForContext is the single mutator used by the discovery
+// success path: resolve the context to its host, write the host's enriched
+// snapshot. No-op when the host can't be resolved — the live data is still
+// authoritative for this session.
+func updateDiscoveryCacheForContext(client *k8s.Client, contextName string, entries []model.ResourceTypeEntry) error {
+	if client == nil || contextName == "" {
+		return nil
 	}
-	state.Contexts[contextName] = DiscoveryCacheContext{
-		UpdatedAt: time.Now().UTC(),
-		Entries:   discoveryCacheEntriesFromModel(entries),
+	host := client.HostForContext(contextName)
+	if host == "" {
+		return nil
 	}
-	return saveDiscoveryCache(*state)
+	return saveDiscoveryCacheForHost(host, entries)
 }
 
 // discoveryCacheEntriesFromModel converts the model's domain types to the
@@ -197,42 +237,6 @@ func discoveryCacheColsFromModel(cols []model.PrinterColumn) []DiscoveryCacheCol
 	return out
 }
 
-// shouldFireDiscoveryFor reports whether a fresh discovery call should be
-// kicked off for contextName. Returns false when (a) a discovery is already
-// in flight for that context — deduplication — or (b) discovery has already
-// completed during this session, in which case re-fetching would just hit
-// the cluster API for nothing.
-//
-// This is the gate that makes stale-while-revalidate work: NewModel prefills
-// m.discoveredResources from disk, but the first hover/navigate of a context
-// returns true here so a live refresh kicks off behind the cached view.
-func (m *Model) shouldFireDiscoveryFor(contextName string) bool {
-	if contextName == "" {
-		return false
-	}
-	if m.discoveringContexts[contextName] {
-		return false
-	}
-	if m.discoveryRefreshedContexts[contextName] {
-		return false
-	}
-	return true
-}
-
-// markDiscoveryStarted records that a discovery call is now in flight for
-// contextName so subsequent shouldFireDiscoveryFor calls deduplicate. Safe
-// to call when discoveringContexts is nil — the function is the canonical
-// place to lazily allocate the map.
-func (m *Model) markDiscoveryStarted(contextName string) {
-	if contextName == "" {
-		return
-	}
-	if m.discoveringContexts == nil {
-		m.discoveringContexts = make(map[string]bool)
-	}
-	m.discoveringContexts[contextName] = true
-}
-
 // modelEntriesFromDiscoveryCache is the inverse: turn a cached snapshot back
 // into model types ready to plug into m.discoveredResources.
 func modelEntriesFromDiscoveryCache(entries []DiscoveryCacheEntry) []model.ResourceTypeEntry {
@@ -270,4 +274,40 @@ func modelColsFromDiscoveryCache(cols []DiscoveryCacheCol) []model.PrinterColumn
 		out = append(out, model.PrinterColumn{Name: c.Name, Type: c.Type, JSONPath: c.JSONPath})
 	}
 	return out
+}
+
+// shouldFireDiscoveryFor reports whether a fresh discovery call should be
+// kicked off for contextName. Returns false when (a) a discovery is already
+// in flight for that context — deduplication — or (b) discovery has already
+// completed during this session, in which case re-fetching would just hit
+// the cluster API for nothing.
+//
+// This is the gate that makes stale-while-revalidate work: NewModel prefills
+// m.discoveredResources from disk, but the first hover/navigate of a context
+// returns true here so a live refresh kicks off behind the cached view.
+func (m *Model) shouldFireDiscoveryFor(contextName string) bool {
+	if contextName == "" {
+		return false
+	}
+	if m.discoveringContexts[contextName] {
+		return false
+	}
+	if m.discoveryRefreshedContexts[contextName] {
+		return false
+	}
+	return true
+}
+
+// markDiscoveryStarted records that a discovery call is now in flight for
+// contextName so subsequent shouldFireDiscoveryFor calls deduplicate. Safe
+// to call when discoveringContexts is nil — the function is the canonical
+// place to lazily allocate the map.
+func (m *Model) markDiscoveryStarted(contextName string) {
+	if contextName == "" {
+		return
+	}
+	if m.discoveringContexts == nil {
+		m.discoveringContexts = make(map[string]bool)
+	}
+	m.discoveringContexts[contextName] = true
 }

--- a/internal/app/discovery_cache_test.go
+++ b/internal/app/discovery_cache_test.go
@@ -8,12 +8,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
-func TestDiscoveryCacheRoundTrip(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
+// withKubeCacheDir points KUBECACHEDIR at a fresh temp dir so each test
+// gets an isolated discovery cache without touching the user's home
+// directory or the kubectl-shared layout. Returns the dir for assertions.
+func withKubeCacheDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("KUBECACHEDIR", dir)
+	return dir
+}
 
+func TestDiscoveryCacheRoundTripPerHost(t *testing.T) {
+	withKubeCacheDir(t)
+
+	host := "https://dev.example.com:6443"
 	entries := []model.ResourceTypeEntry{
 		{
 			DisplayName: "Pods",
@@ -32,141 +44,182 @@ func TestDiscoveryCacheRoundTrip(t *testing.T) {
 			APIVersion:  "v1alpha1",
 			Resource:    "applications",
 			Namespaced:  true,
-			Verbs:       []string{"get", "list", "watch"},
 			PrinterColumns: []model.PrinterColumn{
 				{Name: "Sync Status", Type: "string", JSONPath: ".status.sync.status"},
 			},
 		},
-		{
-			DisplayName:    "ReplicationControllers",
-			Kind:           "ReplicationController",
-			APIGroup:       "",
-			APIVersion:     "v1",
-			Resource:       "replicationcontrollers",
-			Namespaced:     true,
-			Deprecated:     true,
-			DeprecationMsg: "use Deployments",
-		},
 	}
 
-	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", entries))
-	require.NoError(t, updateDiscoveryCacheContext("prod-cluster", entries[:1]))
+	require.NoError(t, saveDiscoveryCacheForHost(host, entries))
 
-	loaded := loadDiscoveryCache()
+	loaded := loadDiscoveryCacheForHost(host)
 	require.NotNil(t, loaded)
-	require.Contains(t, loaded.Contexts, "dev-cluster")
-	require.Contains(t, loaded.Contexts, "prod-cluster")
-
-	dev := loaded.Contexts["dev-cluster"]
-	require.Len(t, dev.Entries, 3)
-	assert.Equal(t, "Pod", dev.Entries[0].Kind)
-	assert.Equal(t, "v1", dev.Entries[0].APIVersion)
-	assert.True(t, dev.Entries[0].Namespaced)
-	assert.Equal(t, []string{"get", "list", "watch"}, dev.Entries[0].Verbs)
-	assert.Equal(t, "□", dev.Entries[0].Icon.Unicode)
-
-	assert.Equal(t, "argoproj.io", dev.Entries[1].APIGroup)
-	require.Len(t, dev.Entries[1].PrinterColumns, 1)
-	assert.Equal(t, "Sync Status", dev.Entries[1].PrinterColumns[0].Name)
-	assert.Equal(t, ".status.sync.status", dev.Entries[1].PrinterColumns[0].JSONPath)
-
-	assert.True(t, dev.Entries[2].Deprecated)
-	assert.Equal(t, "use Deployments", dev.Entries[2].DeprecationMsg)
-
-	assert.Len(t, loaded.Contexts["prod-cluster"].Entries, 1)
+	assert.Equal(t, host, loaded.Host)
+	require.Len(t, loaded.Entries, 2)
+	assert.Equal(t, "Pod", loaded.Entries[0].Kind)
+	assert.Equal(t, "□", loaded.Entries[0].Icon.Unicode)
+	assert.Equal(t, "argoproj.io", loaded.Entries[1].APIGroup)
+	require.Len(t, loaded.Entries[1].PrinterColumns, 1)
+	assert.Equal(t, ".status.sync.status", loaded.Entries[1].PrinterColumns[0].JSONPath)
 }
 
-func TestDiscoveryCacheUpdatePreservesOtherContexts(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
+func TestDiscoveryCacheLivesUnderKubeCacheDir(t *testing.T) {
+	dir := withKubeCacheDir(t)
 
-	require.NoError(t, updateDiscoveryCacheContext("a", []model.ResourceTypeEntry{
+	host := "https://prod.example.com:6443"
+	require.NoError(t, saveDiscoveryCacheForHost(host, []model.ResourceTypeEntry{
 		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
 	}))
-	require.NoError(t, updateDiscoveryCacheContext("b", []model.ResourceTypeEntry{
+
+	// Layout must match kubectl/k9s so `kubectl api-resources --invalidate-cache`
+	// wipes lfk's snapshot too. Path: <KUBECACHEDIR>/discovery/<hostHash>/lfk-enriched.yaml
+	expected := filepath.Join(dir, "discovery", k8s.CacheHostDir(host), "lfk-enriched.yaml")
+	_, err := os.Stat(expected)
+	assert.NoError(t, err, "cache file must live under <KUBECACHEDIR>/discovery/<host>/, got path: %s", expected)
+}
+
+func TestDiscoveryCacheMultipleHostsAreIndependent(t *testing.T) {
+	withKubeCacheDir(t)
+
+	require.NoError(t, saveDiscoveryCacheForHost("https://a.example:6443", []model.ResourceTypeEntry{
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
+	}))
+	require.NoError(t, saveDiscoveryCacheForHost("https://b.example:6443", []model.ResourceTypeEntry{
 		{Kind: "Service", APIGroup: "", APIVersion: "v1", Resource: "services"},
-	}))
-
-	// Updating "a" must not erase "b".
-	require.NoError(t, updateDiscoveryCacheContext("a", []model.ResourceTypeEntry{
-		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
 		{Kind: "ConfigMap", APIGroup: "", APIVersion: "v1", Resource: "configmaps"},
 	}))
 
-	loaded := loadDiscoveryCache()
-	require.NotNil(t, loaded)
-	assert.Len(t, loaded.Contexts["a"].Entries, 2, "context a was updated")
-	assert.Len(t, loaded.Contexts["b"].Entries, 1, "context b must survive untouched")
-	assert.Equal(t, "Service", loaded.Contexts["b"].Entries[0].Kind)
+	a := loadDiscoveryCacheForHost("https://a.example:6443")
+	require.NotNil(t, a)
+	require.Len(t, a.Entries, 1)
+	assert.Equal(t, "Pod", a.Entries[0].Kind)
+
+	b := loadDiscoveryCacheForHost("https://b.example:6443")
+	require.NotNil(t, b)
+	require.Len(t, b.Entries, 2)
+	assert.Equal(t, "Service", b.Entries[0].Kind)
 }
 
 func TestLoadDiscoveryCacheMissingFile(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-
-	loaded := loadDiscoveryCache()
-	assert.Nil(t, loaded, "missing file should return nil, not error")
+	withKubeCacheDir(t)
+	assert.Nil(t, loadDiscoveryCacheForHost("https://nope.example:6443"),
+		"missing file should return nil, not error")
 }
 
 func TestLoadDiscoveryCacheCorruptFile(t *testing.T) {
-	stateDir := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateDir)
+	withKubeCacheDir(t)
 
-	path := discoveryCacheFilePath()
+	host := "https://corrupt.example:6443"
+	path := discoveryCacheFilePathForHost(host)
+	require.NotEmpty(t, path)
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.WriteFile(path, []byte("not: [valid: yaml"), 0o644))
 
-	loaded := loadDiscoveryCache()
-	assert.Nil(t, loaded, "corrupt file should return nil so the app starts fresh")
+	assert.Nil(t, loadDiscoveryCacheForHost(host),
+		"corrupt file should return nil so the app starts fresh")
 }
 
-func TestNavigateClusterFiresDiscoveryWhenCachePrefillIsStale(t *testing.T) {
-	// Stale-while-revalidate: cache prefills discoveredResources, but the
-	// first navigation/hover within the session must still kick off a live
-	// discovery so the user sees fresh data after the brief stale window.
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", []model.ResourceTypeEntry{
+func TestLoadDiscoveryCacheRejectsFutureSchemaVersion(t *testing.T) {
+	withKubeCacheDir(t)
+
+	host := "https://future.example:6443"
+	path := discoveryCacheFilePathForHost(host)
+	require.NotEmpty(t, path)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	// schema_version 99 is from the future — must be ignored gracefully.
+	require.NoError(t, os.WriteFile(path, []byte("schema_version: 99\nhost: x\nentries: []\n"), 0o644))
+
+	assert.Nil(t, loadDiscoveryCacheForHost(host),
+		"unknown schema version must be ignored, not crash")
+}
+
+func TestLoadAllDiscoveryCachesMapsContextsToHostFiles(t *testing.T) {
+	withKubeCacheDir(t)
+
+	hostA := "https://a.example:6443"
+	hostB := "https://b.example:6443"
+
+	// Two contexts share host A — both must populate from the single file.
+	// One context points at host B — gets its own file.
+	require.NoError(t, saveDiscoveryCacheForHost(hostA, []model.ResourceTypeEntry{
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
+	}))
+	require.NoError(t, saveDiscoveryCacheForHost(hostB, []model.ResourceTypeEntry{
+		{Kind: "Service", APIGroup: "", APIVersion: "v1", Resource: "services"},
+	}))
+
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContext("alpha", hostA)
+	client.AddTestContext("beta", hostA) // same host as alpha
+	client.AddTestContext("gamma", hostB)
+
+	loaded := loadAllDiscoveryCaches(client)
+	require.Len(t, loaded["alpha"], 1)
+	require.Len(t, loaded["beta"], 1)
+	require.Len(t, loaded["gamma"], 1)
+	assert.Equal(t, "Pod", loaded["alpha"][0].Kind)
+	assert.Equal(t, "Pod", loaded["beta"][0].Kind, "two contexts on same host share the file")
+	assert.Equal(t, "Service", loaded["gamma"][0].Kind)
+}
+
+func TestLoadAllDiscoveryCachesSkipsContextsWithUnresolvableHost(t *testing.T) {
+	withKubeCacheDir(t)
+
+	// orphan-ctx exists but has no host registered — must not crash and
+	// must not appear in the result map.
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContext("alpha", "https://a.example:6443")
+	require.NoError(t, saveDiscoveryCacheForHost("https://a.example:6443", []model.ResourceTypeEntry{
 		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
 	}))
 
+	loaded := loadAllDiscoveryCaches(client)
+	require.NotNil(t, loaded["alpha"])
+	assert.NotContains(t, loaded, "test-ctx",
+		"the default test-ctx had no cached host file — must not show up here")
+}
+
+func TestNewModelPrefillsDiscoveredResourcesFromCache(t *testing.T) {
+	withKubeCacheDir(t)
+
+	host := "https://dev.example:6443"
+	require.NoError(t, saveDiscoveryCacheForHost(host, []model.ResourceTypeEntry{
+		{Kind: "Application", APIGroup: "argoproj.io", APIVersion: "v1alpha1", Resource: "applications", Namespaced: true},
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}))
+
 	client := newTestClientForOptions(t)
+	client.AddTestContext("dev-cluster", host)
+
 	m := NewModel(client, StartupOptions{})
 
-	require.NotEmpty(t, m.discoveredResources["dev-cluster"], "cache prefill missing")
-	require.False(t, m.discoveryRefreshedContexts["dev-cluster"], "cache prefill must not pose as fresh")
-	require.False(t, m.discoveringContexts["dev-cluster"], "no discovery should be in flight yet")
+	entries, ok := m.discoveredResources["dev-cluster"]
+	require.True(t, ok, "cached context must populate discoveredResources at NewModel time")
+	require.GreaterOrEqual(t, len(entries), 2)
 
-	assert.True(t, m.shouldFireDiscoveryFor("dev-cluster"),
-		"a context that exists only in the disk cache must still trigger live discovery")
-}
+	kinds := make(map[string]bool)
+	for _, e := range entries {
+		kinds[e.Kind] = true
+	}
+	assert.True(t, kinds["Application"], "ArgoCD Application from cache must be present")
+	assert.True(t, kinds["Pod"], "Pod from cache must be present")
 
-func TestNavigateClusterSkipsDiscoveryAfterRefresh(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-
-	m := NewModel(newTestClientForOptions(t), StartupOptions{})
-	m.discoveryRefreshedContexts["dev-cluster"] = true
-
-	assert.False(t, m.shouldFireDiscoveryFor("dev-cluster"),
-		"a context refreshed earlier this session must not re-fire on subsequent hovers")
-}
-
-func TestNavigateClusterSkipsDiscoveryWhileInFlight(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-
-	m := NewModel(newTestClientForOptions(t), StartupOptions{})
-	m.discoveringContexts["dev-cluster"] = true
-
-	assert.False(t, m.shouldFireDiscoveryFor("dev-cluster"),
-		"deduplication must keep an in-flight discovery from being kicked off twice")
+	assert.False(t, m.discoveryRefreshedContexts["dev-cluster"],
+		"cached prefill must not be marked as refreshed — live discovery still has to run")
 }
 
 func TestUpdateAPIResourceDiscoveryWritesCache(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	withKubeCacheDir(t)
+
+	host := "https://dev.example:6443"
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContext("dev-cluster", host)
 
 	m := Model{
+		client:                     client,
 		discoveredResources:        make(map[string][]model.ResourceTypeEntry),
 		discoveringContexts:        map[string]bool{"dev-cluster": true},
 		discoveryRefreshedContexts: make(map[string]bool),
-		// nav.Context = "" so this test exercises the write path even when
-		// the user isn't currently looking at the cluster.
 	}
 
 	entries := []model.ResourceTypeEntry{
@@ -179,32 +232,33 @@ func TestUpdateAPIResourceDiscoveryWritesCache(t *testing.T) {
 	assert.True(t, updated.discoveryRefreshedContexts["dev-cluster"],
 		"successful discovery must mark context as freshly refreshed this session")
 
-	cache := loadDiscoveryCache()
-	require.NotNil(t, cache, "discovery success must write a cache file")
-	require.Contains(t, cache.Contexts, "dev-cluster")
-
-	cached := cache.Contexts["dev-cluster"]
-	require.Len(t, cached.Entries, 2)
-	// Pseudo-resources (helm-releases, port-forwards) must NOT bleed into
-	// the persisted snapshot — those are prepended at runtime.
-	for _, e := range cached.Entries {
+	cache := loadDiscoveryCacheForHost(host)
+	require.NotNil(t, cache, "discovery success must write a cache file at the host's path")
+	assert.Equal(t, host, cache.Host)
+	require.Len(t, cache.Entries, 2)
+	for _, e := range cache.Entries {
 		assert.NotEqual(t, "_helm", e.APIGroup, "pseudo-resource leaked into cache")
 		assert.NotEqual(t, "_portforward", e.APIGroup, "pseudo-resource leaked into cache")
 	}
 }
 
 func TestUpdateAPIResourceDiscoveryFailureDoesNotWriteCache(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	withKubeCacheDir(t)
 
-	// Pre-populate a cache so we can verify the failed call leaves it alone.
-	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", []model.ResourceTypeEntry{
+	host := "https://dev.example:6443"
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContext("dev-cluster", host)
+
+	// Pre-populate so we can verify the failed call leaves it alone.
+	require.NoError(t, saveDiscoveryCacheForHost(host, []model.ResourceTypeEntry{
 		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
 	}))
-	before := loadDiscoveryCache()
+	before := loadDiscoveryCacheForHost(host)
 	require.NotNil(t, before)
-	beforeUpdated := before.Contexts["dev-cluster"].UpdatedAt
+	beforeUpdated := before.UpdatedAt
 
 	m := Model{
+		client:                     client,
 		discoveredResources:        make(map[string][]model.ResourceTypeEntry),
 		discoveringContexts:        map[string]bool{"dev-cluster": true},
 		discoveryRefreshedContexts: make(map[string]bool),
@@ -219,9 +273,9 @@ func TestUpdateAPIResourceDiscoveryFailureDoesNotWriteCache(t *testing.T) {
 	assert.False(t, updated.discoveryRefreshedContexts["dev-cluster"],
 		"failed discovery must NOT mark the context as refreshed")
 
-	after := loadDiscoveryCache()
+	after := loadDiscoveryCacheForHost(host)
 	require.NotNil(t, after)
-	assert.Equal(t, beforeUpdated, after.Contexts["dev-cluster"].UpdatedAt,
+	assert.Equal(t, beforeUpdated, after.UpdatedAt,
 		"failed discovery must not overwrite the previous good snapshot")
 }
 
@@ -229,51 +283,3 @@ func TestUpdateAPIResourceDiscoveryFailureDoesNotWriteCache(t *testing.T) {
 type assertSimpleError string
 
 func (e assertSimpleError) Error() string { return string(e) }
-
-func TestNewModelPrefillsDiscoveredResourcesFromCache(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-
-	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", []model.ResourceTypeEntry{
-		{Kind: "Application", APIGroup: "argoproj.io", APIVersion: "v1alpha1", Resource: "applications", Namespaced: true},
-		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true},
-	}))
-
-	client := newTestClientForOptions(t)
-	m := NewModel(client, StartupOptions{})
-
-	// Sidebar must paint immediately from the cache rather than wait for a
-	// fresh discovery round-trip — that's the entire point of stale-while-
-	// revalidate.
-	entries, ok := m.discoveredResources["dev-cluster"]
-	require.True(t, ok, "cached context must populate discoveredResources at NewModel time")
-
-	// Pseudo-resources (helm releases, port forwards) are prepended at
-	// runtime; the cache stores the cluster-reported set verbatim, so the
-	// loaded length is pseudo + cached.
-	require.GreaterOrEqual(t, len(entries), 2)
-
-	kinds := make(map[string]bool)
-	for _, e := range entries {
-		kinds[e.Kind] = true
-	}
-	assert.True(t, kinds["Application"], "ArgoCD Application from cache must be present")
-	assert.True(t, kinds["Pod"], "Pod from cache must be present")
-
-	// discoveryRefreshedContexts stays empty: the data is from disk, not
-	// from a live API call this session.
-	assert.False(t, m.discoveryRefreshedContexts["dev-cluster"],
-		"cached prefill must not be marked as refreshed — live discovery still has to run")
-}
-
-func TestLoadDiscoveryCacheRejectsFutureSchemaVersion(t *testing.T) {
-	stateDir := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateDir)
-
-	path := discoveryCacheFilePath()
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	// schema_version 99 is from the future — must be ignored gracefully.
-	require.NoError(t, os.WriteFile(path, []byte("schema_version: 99\ncontexts: {}\n"), 0o644))
-
-	loaded := loadDiscoveryCache()
-	assert.Nil(t, loaded, "unknown schema version must be ignored, not crash")
-}

--- a/internal/app/discovery_cache_test.go
+++ b/internal/app/discovery_cache_test.go
@@ -1,0 +1,279 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestDiscoveryCacheRoundTrip(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	entries := []model.ResourceTypeEntry{
+		{
+			DisplayName: "Pods",
+			Kind:        "Pod",
+			APIGroup:    "",
+			APIVersion:  "v1",
+			Resource:    "pods",
+			Namespaced:  true,
+			Verbs:       []string{"get", "list", "watch"},
+			Icon:        model.Icon{Unicode: "□", Simple: "[Po]"},
+		},
+		{
+			DisplayName: "ArgoCD Applications",
+			Kind:        "Application",
+			APIGroup:    "argoproj.io",
+			APIVersion:  "v1alpha1",
+			Resource:    "applications",
+			Namespaced:  true,
+			Verbs:       []string{"get", "list", "watch"},
+			PrinterColumns: []model.PrinterColumn{
+				{Name: "Sync Status", Type: "string", JSONPath: ".status.sync.status"},
+			},
+		},
+		{
+			DisplayName:    "ReplicationControllers",
+			Kind:           "ReplicationController",
+			APIGroup:       "",
+			APIVersion:     "v1",
+			Resource:       "replicationcontrollers",
+			Namespaced:     true,
+			Deprecated:     true,
+			DeprecationMsg: "use Deployments",
+		},
+	}
+
+	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", entries))
+	require.NoError(t, updateDiscoveryCacheContext("prod-cluster", entries[:1]))
+
+	loaded := loadDiscoveryCache()
+	require.NotNil(t, loaded)
+	require.Contains(t, loaded.Contexts, "dev-cluster")
+	require.Contains(t, loaded.Contexts, "prod-cluster")
+
+	dev := loaded.Contexts["dev-cluster"]
+	require.Len(t, dev.Entries, 3)
+	assert.Equal(t, "Pod", dev.Entries[0].Kind)
+	assert.Equal(t, "v1", dev.Entries[0].APIVersion)
+	assert.True(t, dev.Entries[0].Namespaced)
+	assert.Equal(t, []string{"get", "list", "watch"}, dev.Entries[0].Verbs)
+	assert.Equal(t, "□", dev.Entries[0].Icon.Unicode)
+
+	assert.Equal(t, "argoproj.io", dev.Entries[1].APIGroup)
+	require.Len(t, dev.Entries[1].PrinterColumns, 1)
+	assert.Equal(t, "Sync Status", dev.Entries[1].PrinterColumns[0].Name)
+	assert.Equal(t, ".status.sync.status", dev.Entries[1].PrinterColumns[0].JSONPath)
+
+	assert.True(t, dev.Entries[2].Deprecated)
+	assert.Equal(t, "use Deployments", dev.Entries[2].DeprecationMsg)
+
+	assert.Len(t, loaded.Contexts["prod-cluster"].Entries, 1)
+}
+
+func TestDiscoveryCacheUpdatePreservesOtherContexts(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	require.NoError(t, updateDiscoveryCacheContext("a", []model.ResourceTypeEntry{
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
+	}))
+	require.NoError(t, updateDiscoveryCacheContext("b", []model.ResourceTypeEntry{
+		{Kind: "Service", APIGroup: "", APIVersion: "v1", Resource: "services"},
+	}))
+
+	// Updating "a" must not erase "b".
+	require.NoError(t, updateDiscoveryCacheContext("a", []model.ResourceTypeEntry{
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
+		{Kind: "ConfigMap", APIGroup: "", APIVersion: "v1", Resource: "configmaps"},
+	}))
+
+	loaded := loadDiscoveryCache()
+	require.NotNil(t, loaded)
+	assert.Len(t, loaded.Contexts["a"].Entries, 2, "context a was updated")
+	assert.Len(t, loaded.Contexts["b"].Entries, 1, "context b must survive untouched")
+	assert.Equal(t, "Service", loaded.Contexts["b"].Entries[0].Kind)
+}
+
+func TestLoadDiscoveryCacheMissingFile(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	loaded := loadDiscoveryCache()
+	assert.Nil(t, loaded, "missing file should return nil, not error")
+}
+
+func TestLoadDiscoveryCacheCorruptFile(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	path := discoveryCacheFilePath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("not: [valid: yaml"), 0o644))
+
+	loaded := loadDiscoveryCache()
+	assert.Nil(t, loaded, "corrupt file should return nil so the app starts fresh")
+}
+
+func TestNavigateClusterFiresDiscoveryWhenCachePrefillIsStale(t *testing.T) {
+	// Stale-while-revalidate: cache prefills discoveredResources, but the
+	// first navigation/hover within the session must still kick off a live
+	// discovery so the user sees fresh data after the brief stale window.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", []model.ResourceTypeEntry{
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
+	}))
+
+	client := newTestClientForOptions(t)
+	m := NewModel(client, StartupOptions{})
+
+	require.NotEmpty(t, m.discoveredResources["dev-cluster"], "cache prefill missing")
+	require.False(t, m.discoveryRefreshedContexts["dev-cluster"], "cache prefill must not pose as fresh")
+	require.False(t, m.discoveringContexts["dev-cluster"], "no discovery should be in flight yet")
+
+	assert.True(t, m.shouldFireDiscoveryFor("dev-cluster"),
+		"a context that exists only in the disk cache must still trigger live discovery")
+}
+
+func TestNavigateClusterSkipsDiscoveryAfterRefresh(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	m := NewModel(newTestClientForOptions(t), StartupOptions{})
+	m.discoveryRefreshedContexts["dev-cluster"] = true
+
+	assert.False(t, m.shouldFireDiscoveryFor("dev-cluster"),
+		"a context refreshed earlier this session must not re-fire on subsequent hovers")
+}
+
+func TestNavigateClusterSkipsDiscoveryWhileInFlight(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	m := NewModel(newTestClientForOptions(t), StartupOptions{})
+	m.discoveringContexts["dev-cluster"] = true
+
+	assert.False(t, m.shouldFireDiscoveryFor("dev-cluster"),
+		"deduplication must keep an in-flight discovery from being kicked off twice")
+}
+
+func TestUpdateAPIResourceDiscoveryWritesCache(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	m := Model{
+		discoveredResources:        make(map[string][]model.ResourceTypeEntry),
+		discoveringContexts:        map[string]bool{"dev-cluster": true},
+		discoveryRefreshedContexts: make(map[string]bool),
+		// nav.Context = "" so this test exercises the write path even when
+		// the user isn't currently looking at the cluster.
+	}
+
+	entries := []model.ResourceTypeEntry{
+		{Kind: "Application", APIGroup: "argoproj.io", APIVersion: "v1alpha1", Resource: "applications", Namespaced: true},
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}
+	msg := apiResourceDiscoveryMsg{context: "dev-cluster", entries: entries}
+	updated, _ := m.updateAPIResourceDiscovery(msg)
+
+	assert.True(t, updated.discoveryRefreshedContexts["dev-cluster"],
+		"successful discovery must mark context as freshly refreshed this session")
+
+	cache := loadDiscoveryCache()
+	require.NotNil(t, cache, "discovery success must write a cache file")
+	require.Contains(t, cache.Contexts, "dev-cluster")
+
+	cached := cache.Contexts["dev-cluster"]
+	require.Len(t, cached.Entries, 2)
+	// Pseudo-resources (helm-releases, port-forwards) must NOT bleed into
+	// the persisted snapshot — those are prepended at runtime.
+	for _, e := range cached.Entries {
+		assert.NotEqual(t, "_helm", e.APIGroup, "pseudo-resource leaked into cache")
+		assert.NotEqual(t, "_portforward", e.APIGroup, "pseudo-resource leaked into cache")
+	}
+}
+
+func TestUpdateAPIResourceDiscoveryFailureDoesNotWriteCache(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	// Pre-populate a cache so we can verify the failed call leaves it alone.
+	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", []model.ResourceTypeEntry{
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
+	}))
+	before := loadDiscoveryCache()
+	require.NotNil(t, before)
+	beforeUpdated := before.Contexts["dev-cluster"].UpdatedAt
+
+	m := Model{
+		discoveredResources:        make(map[string][]model.ResourceTypeEntry),
+		discoveringContexts:        map[string]bool{"dev-cluster": true},
+		discoveryRefreshedContexts: make(map[string]bool),
+	}
+
+	msg := apiResourceDiscoveryMsg{
+		context: "dev-cluster",
+		err:     assertSimpleError("discovery failed: forbidden"),
+	}
+	updated, _ := m.updateAPIResourceDiscovery(msg)
+
+	assert.False(t, updated.discoveryRefreshedContexts["dev-cluster"],
+		"failed discovery must NOT mark the context as refreshed")
+
+	after := loadDiscoveryCache()
+	require.NotNil(t, after)
+	assert.Equal(t, beforeUpdated, after.Contexts["dev-cluster"].UpdatedAt,
+		"failed discovery must not overwrite the previous good snapshot")
+}
+
+// assertSimpleError returns a basic error value for tests.
+type assertSimpleError string
+
+func (e assertSimpleError) Error() string { return string(e) }
+
+func TestNewModelPrefillsDiscoveredResourcesFromCache(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	require.NoError(t, updateDiscoveryCacheContext("dev-cluster", []model.ResourceTypeEntry{
+		{Kind: "Application", APIGroup: "argoproj.io", APIVersion: "v1alpha1", Resource: "applications", Namespaced: true},
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}))
+
+	client := newTestClientForOptions(t)
+	m := NewModel(client, StartupOptions{})
+
+	// Sidebar must paint immediately from the cache rather than wait for a
+	// fresh discovery round-trip — that's the entire point of stale-while-
+	// revalidate.
+	entries, ok := m.discoveredResources["dev-cluster"]
+	require.True(t, ok, "cached context must populate discoveredResources at NewModel time")
+
+	// Pseudo-resources (helm releases, port forwards) are prepended at
+	// runtime; the cache stores the cluster-reported set verbatim, so the
+	// loaded length is pseudo + cached.
+	require.GreaterOrEqual(t, len(entries), 2)
+
+	kinds := make(map[string]bool)
+	for _, e := range entries {
+		kinds[e.Kind] = true
+	}
+	assert.True(t, kinds["Application"], "ArgoCD Application from cache must be present")
+	assert.True(t, kinds["Pod"], "Pod from cache must be present")
+
+	// discoveryRefreshedContexts stays empty: the data is from disk, not
+	// from a live API call this session.
+	assert.False(t, m.discoveryRefreshedContexts["dev-cluster"],
+		"cached prefill must not be marked as refreshed — live discovery still has to run")
+}
+
+func TestLoadDiscoveryCacheRejectsFutureSchemaVersion(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	path := discoveryCacheFilePath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	// schema_version 99 is from the future — must be ignored gracefully.
+	require.NoError(t, os.WriteFile(path, []byte("schema_version: 99\ncontexts: {}\n"), 0o644))
+
+	loaded := loadDiscoveryCache()
+	assert.Nil(t, loaded, "unknown schema version must be ignored, not crash")
+}

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -163,17 +163,18 @@ func baseModelBoost2() Model {
 // baseModelCov returns a minimal Model for coverage tests.
 func baseModelCov() Model {
 	return Model{
-		nav:                 model.NavigationState{Level: model.LevelResources},
-		tabs:                []TabState{{}},
-		selectedItems:       make(map[string]bool),
-		cursorMemory:        make(map[string]int),
-		itemCache:           make(map[string][]model.Item),
-		cacheFingerprints:   make(map[string]string),
-		discoveredResources: make(map[string][]model.ResourceTypeEntry),
-		discoveringContexts: make(map[string]bool),
-		width:               80,
-		height:              40,
-		execMu:              &sync.Mutex{},
+		nav:                        model.NavigationState{Level: model.LevelResources},
+		tabs:                       []TabState{{}},
+		selectedItems:              make(map[string]bool),
+		cursorMemory:               make(map[string]int),
+		itemCache:                  make(map[string][]model.Item),
+		cacheFingerprints:          make(map[string]string),
+		discoveredResources:        make(map[string][]model.ResourceTypeEntry),
+		discoveringContexts:        make(map[string]bool),
+		discoveryRefreshedContexts: make(map[string]bool),
+		width:                      80,
+		height:                     40,
+		execMu:                     &sync.Mutex{},
 	}
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -520,6 +520,17 @@ func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) (Model, t
 	// with real discovered resources.
 	entries := append(model.PseudoResources(), msg.entries...)
 	m.discoveredResources[msg.context] = entries
+	if m.discoveryRefreshedContexts == nil {
+		m.discoveryRefreshedContexts = make(map[string]bool)
+	}
+	m.discoveryRefreshedContexts[msg.context] = true
+	// Persist the cluster-reported entries (without pseudo-resources, which
+	// are runtime-only) so the next launch can prefill discoveredResources
+	// from disk. Best-effort: a write failure leaves the in-memory state
+	// authoritative for this session.
+	if err := updateDiscoveryCacheContext(msg.context, msg.entries); err != nil {
+		logger.Warn("Could not persist discovery cache", "context", msg.context, "error", err)
+	}
 	merged := model.BuildSidebarItems(entries)
 	// If the user is at LevelClusters and hovering this context, refresh
 	// the right-pane preview so the discovered list replaces the seed

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -525,10 +525,12 @@ func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) (Model, t
 	}
 	m.discoveryRefreshedContexts[msg.context] = true
 	// Persist the cluster-reported entries (without pseudo-resources, which
-	// are runtime-only) so the next launch can prefill discoveredResources
-	// from disk. Best-effort: a write failure leaves the in-memory state
-	// authoritative for this session.
-	if err := updateDiscoveryCacheContext(msg.context, msg.entries); err != nil {
+	// are runtime-only) into the per-host file under ~/.kube/cache/discovery
+	// so the next launch can prefill discoveredResources from disk and so
+	// `kubectl api-resources --invalidate-cache` wipes lfk's snapshot too.
+	// Best-effort: a write failure leaves the in-memory state authoritative
+	// for this session.
+	if err := updateDiscoveryCacheForContext(m.client, msg.context, msg.entries); err != nil {
 		logger.Warn("Could not persist discovery cache", "context", msg.context, "error", err)
 	}
 	merged := model.BuildSidebarItems(entries)

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -456,11 +456,8 @@ func (m Model) navigateToBookmark(bm model.Bookmark) (tea.Model, tea.Cmd) {
 			m.bookmarkAwaitingDiscovery = &bmCopy
 			m.setStatusMessage("Discovering resources...", false)
 			cmds := []tea.Cmd{scheduleStatusClear()}
-			if !m.discoveringContexts[effectiveContext] {
-				if m.discoveringContexts == nil {
-					m.discoveringContexts = make(map[string]bool)
-				}
-				m.discoveringContexts[effectiveContext] = true
+			if m.shouldFireDiscoveryFor(effectiveContext) {
+				m.markDiscoveryStarted(effectiveContext)
 				cmds = append(cmds, m.discoverAPIResources(effectiveContext))
 			}
 			return m, tea.Batch(cmds...)
@@ -633,9 +630,14 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	applySessionNamespaces(&m, sess.AllNamespaces, sess.Namespace, sess.SelectedNamespaces)
 
 	var cmds []tea.Cmd
-	needsDiscovery := false
-	if _, ok := m.discoveredResources[sess.Context]; !ok {
-		needsDiscovery = true
+	// "Needs discovery" means: the saved type ref might not resolve from
+	// the data we have on hand and a live discovery is going to land soon
+	// (or already in flight). Both the cache-prefill case and the
+	// no-data-at-all case set this — the difference is whether the user
+	// sees stale-but-correct data immediately versus a loader.
+	needsDiscovery := m.shouldFireDiscoveryFor(sess.Context)
+	if needsDiscovery {
+		m.markDiscoveryStarted(sess.Context)
 		cmds = append(cmds, m.discoverAPIResources(sess.Context))
 	}
 	if cmd := m.ensureNamespaceCacheFresh(); cmd != nil {

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -301,13 +301,14 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	m.setStatusMessage(fmt.Sprintf("Context: %s", sel.Name), false)
 	m.saveCurrentSession()
 	cmds := []tea.Cmd{m.loadPreview(), scheduleStatusClear()}
-	// Fire discovery only if neither the result nor an in-flight call for
-	// this context already exists — hovering the context in the cluster
-	// list typically already kicked one off via loadPreviewClusters.
-	if _, ok := m.discoveredResources[sel.Name]; !ok && !m.discoveringContexts[sel.Name] {
-		if m.discoveringContexts != nil {
-			m.discoveringContexts[sel.Name] = true
-		}
+	// Fire discovery once per session per context. The disk cache may have
+	// prefilled m.discoveredResources, but stale-while-revalidate still
+	// wants a live refresh on the user's first interaction with the
+	// context. shouldFireDiscoveryFor handles both the prefilled-but-stale
+	// case and the in-flight dedup. loadPreviewClusters typically already
+	// fires this on hover, so navigation usually no-ops here.
+	if m.shouldFireDiscoveryFor(sel.Name) {
+		m.markDiscoveryStarted(sel.Name)
 		cmds = append(cmds, m.discoverAPIResources(sel.Name))
 	}
 	if cmd := m.ensureNamespaceCacheFresh(); cmd != nil {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -75,6 +75,13 @@ type Client struct {
 	testDynClient  any // dynamic.Interface
 	testMetaClient any // metadata.Interface
 
+	// testHostByDisplay, when set, lets tests bypass kubeconfig host
+	// resolution in HostForContext. Most fake test clients are constructed
+	// without Cluster definitions (no server URL), so a real
+	// restConfigForContext call would fail; this map provides synthetic
+	// answers keyed by display name.
+	testHostByDisplay map[string]string
+
 	// secretLazyLoading, when true, routes Secret listing through the
 	// metadata-only API so decoded values are lazy-fetched on hover instead
 	// of being pulled up-front. Configured via the secret_lazy_loading
@@ -353,6 +360,28 @@ func (c *Client) OriginalContextName(displayName string) string {
 		return info.original
 	}
 	return displayName
+}
+
+// HostForContext returns the API server URL recorded in the kubeconfig for
+// the given lfk display name, or "" when the rest config can't be built (no
+// matching cluster, malformed kubeconfig, etc.). Used to key per-host disk
+// caches under ~/.kube/cache/discovery so they share the same lifecycle as
+// kubectl/k9s — `kubectl api-resources --invalidate-cache` wipes both.
+//
+// Tests can pre-seed c.testHostByDisplay to bypass kubeconfig resolution
+// entirely (most fake clients have no Cluster definition with a server URL).
+func (c *Client) HostForContext(displayName string) string {
+	if c == nil {
+		return ""
+	}
+	if h, ok := c.testHostByDisplay[displayName]; ok {
+		return h
+	}
+	cfg, err := c.restConfigForContext(displayName)
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.Host
 }
 
 // buildKubeconfigPaths assembles the list of kubeconfig file paths to load.

--- a/internal/k8s/discovery_cache.go
+++ b/internal/k8s/discovery_cache.go
@@ -22,10 +22,35 @@ const discoveryCacheTTL = 5 * time.Minute
 // them through is harmless.
 var toCacheHostDir = regexp.MustCompile(`[^(\w/.)]`)
 
+// CacheHostDir returns the directory name kubectl/k9s/lfk all use to namespace
+// per-host cache data under ~/.kube/cache/discovery/<dir>/. Exposed so other
+// packages (e.g. lfk's enriched discovery cache) can write into the same
+// per-host layout and inherit the same `kubectl api-resources --invalidate-cache`
+// lifecycle.
+func CacheHostDir(host string) string {
+	return cacheHostDir(host)
+}
+
 func cacheHostDir(host string) string {
 	h := strings.Replace(host, "https://", "", 1)
 	h = strings.Replace(h, "http://", "", 1)
 	return toCacheHostDir.ReplaceAllString(h, "_")
+}
+
+// DiscoveryCacheBaseDir returns the on-disk base for per-host discovery
+// caches: $KUBECACHEDIR or ~/.kube/cache. Returns "" if the home directory
+// can't be resolved (extremely rare; the same fallback the standard
+// disk-cached discovery client uses internally). lfk's enriched cache layers
+// on top of this same root.
+func DiscoveryCacheBaseDir() string {
+	if base := os.Getenv("KUBECACHEDIR"); base != "" {
+		return base
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".kube", "cache")
 }
 
 // discoveryForContext returns a per-context disk-cached discovery client,

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -22,7 +22,40 @@ func NewTestClient(cs, dyn any) *Client {
 		loadingRules: &clientcmd.ClientConfigLoadingRules{
 			Precedence: []string{"/dev/null"},
 		},
-		testClientset: cs,
-		testDynClient: dyn,
+		testClientset:     cs,
+		testDynClient:     dyn,
+		testHostByDisplay: map[string]string{"test-ctx": "https://test-cluster.example.local:6443"},
 	}
+}
+
+// SetTestHostForContext registers a synthetic host URL for a context so
+// HostForContext returns a deterministic value without going through
+// kubeconfig resolution. Intended for tests; production code uses real
+// kubeconfig data.
+func (c *Client) SetTestHostForContext(displayName, host string) {
+	if c == nil {
+		return
+	}
+	if c.testHostByDisplay == nil {
+		c.testHostByDisplay = make(map[string]string)
+	}
+	c.testHostByDisplay[displayName] = host
+}
+
+// AddTestContext registers a synthetic context with its host URL so tests
+// can simulate multi-cluster setups. The context becomes visible to
+// GetContexts and HostForContext returns the supplied host.
+func (c *Client) AddTestContext(displayName, host string) {
+	if c == nil {
+		return
+	}
+	if c.rawConfig.Contexts == nil {
+		c.rawConfig.Contexts = make(map[string]*api.Context)
+	}
+	c.rawConfig.Contexts[displayName] = &api.Context{
+		Namespace: "default",
+		Cluster:   displayName + "-cluster",
+		AuthInfo:  displayName + "-user",
+	}
+	c.SetTestHostForContext(displayName, host)
 }


### PR DESCRIPTION
## Summary

Persist each cluster's full `DiscoverAPIResources` output (resource types + CRD printer columns + deprecation flags + verbs) to a per-host file under `$KUBECACHEDIR/discovery/<host>/lfk-enriched.yaml` so the sidebar paints from disk on first frame instead of waiting for a live discovery roundtrip. Live refresh still fires once per context per session in the background — gated by a new `m.discoveryRefreshedContexts` flag — so cached data is replaced as soon as the live result lands.

The kubectl-style `~/.kube/cache/discovery/<host>/<group>/<version>.json` files have already been used since `884a93b` for the basic `ServerPreferredResources` half (5 min TTL), but the CRD printer-column fetch goes through a dynamic-client `List` on `apiextensions.k8s.io/v1.customresourcedefinitions` which bypassed any caching. This PR closes that gap with an enriched snapshot at the same on-disk root, so `kubectl api-resources --invalidate-cache` wipes both caches in one go and lfk inherits kubectl/k9s's lifecycle conventions.

## Design

**Per-host, not per-context.** Multiple kubeconfig contexts pointing at the same cluster API observe identical discovery output, so they share one file. `NewModel` walks all known contexts via `client.GetContexts()`, resolves each to a host via the new `client.HostForContext()`, reads each unique host file once, and populates `m.discoveredResources` keyed by display name.

**Schema-versioned and decoupled.** `DiscoveryCacheEntry` and friends carry explicit JSON tags so renames in `model.ResourceTypeEntry` don't break the disk format. v1 (XDG-state, single file) was unreleased and is abandoned; v2 (per-host) is what ships.

**Pseudo-resources stay runtime-only.** Helm releases and port-forwards are prepended at runtime by `updateAPIResourceDiscovery`, never persisted, so a future change to that synthetic list doesn't require a cache bump.

**`shouldFireDiscoveryFor` / `markDiscoveryStarted` helpers** replace ad-hoc `discoveringContexts` dedup at the four lazy-trigger sites (`commands_load_preview.go`, `update_navigation.go`, `update_bookmarks.go ×2`). `updateAPIResourceDiscovery` flips `discoveryRefreshedContexts[ctx]` only on success — failure paths leave the previous good snapshot intact.

## What's NOT merged

This PR does not consume kubectl's per-group/version JSON files directly — `lfk-enriched.yaml` is an independent, self-contained snapshot of the merged `[]ResourceTypeEntry`. Reasons covered in the commit body of `9f9316d`:
* CRD printer columns aren't part of the discovery contract, so kubectl's files can't carry them.
* kubectl's on-disk format is an internal detail of `disk.CachedDiscoveryClient`, not a stable API.
* The duplication is small (10–30 KB per cluster) and the simpler single-file design avoids partial-cache reasoning.

The `disk.CachedDiscoveryClient` still serves the live `ServerPreferredResources` half during a session — that part is unchanged.

## New k8s.Client surface

* `HostForContext(displayName) string` — kubeconfig-aware host resolution with a `testHostByDisplay` override hook for fakes that lack `Cluster` URLs.
* `CacheHostDir(host)` / `DiscoveryCacheBaseDir()` — exported so the app package can target the same per-host layout.
* `AddTestContext(name, host)` / `SetTestHostForContext` — test helpers for multi-cluster fakes without a real kubeconfig.

## Test plan

- [x] `go test -race ./...` passes (full suite green)
- [x] `golangci-lint run -D gocyclo ./...` clean
- [x] Cache round-trip per host
- [x] Independent host files (writes to A don't affect B)
- [x] Layout matches `<KUBECACHEDIR>/discovery/<host>/lfk-enriched.yaml` (verified via stat in test)
- [x] Missing / corrupt / future-schema files all gracefully degrade to nil (no crash)
- [x] `loadAllDiscoveryCaches` maps multiple contexts on the same host to the same file
- [x] `loadAllDiscoveryCaches` skips contexts whose host can't be resolved
- [x] NewModel prefills `m.discoveredResources` from the host file
- [x] Successful discovery writes the host file and flips `discoveryRefreshedContexts[ctx]`
- [x] Failed discovery does NOT write and does NOT flip the refreshed flag (preserves previous good snapshot)
- [x] Lazy-trigger gating: fires-when-stale, skips-after-refresh, skips-when-in-flight
- [x] Existing `TestLoadPreviewClusters_Cached*` updated to reflect the revalidate-on-first-hover contract
- [x] Manual smoke: open lfk on a cluster with many CRDs, observe fast first paint; subsequent navigation triggers exactly one background refresh
- [x] Manual smoke: `kubectl api-resources --invalidate-cache` then re-launch lfk — verify both halves re-fetch