### PR TITLE
ci(release-please): treat feat: as patch bump pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "extra-files": [


### PR DESCRIPTION
## Summary

Flips `bump-patch-for-minor-pre-major: false → true` in `release-please-config.json`. While `baseVersion` stays below `1.0.0`, this changes how the bot interprets conventional commit types:

| Commit | Before this PR | After this PR |
|---|---|---|
| `fix:` | `0.9.32` → `0.9.33` | `0.9.32` → `0.9.33` |
| `feat:` | `0.9.32` → **`0.10.0`** | `0.9.32` → **`0.9.33`** |
| `feat!:` / `BREAKING CHANGE:` | `0.9.32` → `0.10.0` | `0.9.32` → `0.10.0` |

Rationale: while lfk is still pre-1.0, individual `feat:` adds aren't worth a minor bump each — we'd burn through `0.10` / `0.11` / `0.12` very quickly. Patch-by-default keeps version churn low and reserves minor bumps for breaking changes, which is the signal downstream consumers actually care about pre-1.0.

The flag is inert post-1.0 (`bump-patch-for-minor-pre-major` only applies while `< 1.0.0`), so `feat:` will resume bumping minor as SemVer prescribes once we ship `1.0.0`. To cross 1.0 deliberately, drop a `Release-As: 1.0.0` trailer on any commit.

## Test plan

- [x] Verify the JSON validates against the release-please schema (`$schema` URL is in the file).
- [x] After merge, the next `feat:` commit on `main` should produce a Release PR titled "release 0.9.33", not "release 0.10.0".
- [x] Confirm `feat!:` / `BREAKING CHANGE:` still bumps minor (`0.10.0`) — the pre-1.0 ceiling is preserved by `bump-minor-pre-major: true`.