### PR TITLE
feat(ui): add y to copy cursor row from rollback / history overlays

### DIFF
--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -71,11 +71,13 @@ func (m Model) overlayHintBarDialog() string {
 		return m.renderHints([]ui.HintEntry{
 			{Key: "jk", Desc: "nav"},
 			{Key: "Enter", Desc: "rollback"},
+			{Key: "y", Desc: "copy"},
 			{Key: "esc", Desc: "cancel"},
 		})
 	case overlayHelmHistory:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "jk", Desc: "nav"},
+			{Key: "y", Desc: "copy"},
 			{Key: "esc", Desc: "close"},
 		})
 	}

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -407,10 +407,39 @@ func (m Model) handleRollbackOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.rollbackDeployment(rev.Revision)
 		}
 		return m, nil
+	case "y":
+		return m.handleRollbackOverlayCopy()
 	case "ctrl+c":
 		return m.closeTabOrQuit()
 	}
 	return m, nil
+}
+
+// handleRollbackOverlayCopy yanks the cursor revision row to the clipboard
+// as tab-separated columns matching the on-screen header. Mirrors the
+// vim-style `y` behaviour added to the read-only viewers and uses the same
+// relative-age format the renderer paints, so what the user copies is
+// exactly what they see.
+func (m Model) handleRollbackOverlayCopy() (tea.Model, tea.Cmd) {
+	if m.rollbackCursor < 0 || m.rollbackCursor >= len(m.rollbackRevisions) {
+		return m, nil
+	}
+	rev := m.rollbackRevisions[m.rollbackCursor]
+	row := joinTSV(
+		fmt.Sprintf("%d", rev.Revision),
+		rev.Name,
+		fmt.Sprintf("%d", rev.Replicas),
+		strings.Join(rev.Images, ","),
+		ui.FormatAge(rev.CreatedAt),
+	)
+	m.setStatusMessage(fmt.Sprintf("Copied revision %d", rev.Revision), false)
+	return m, tea.Batch(copyToSystemClipboard(row), scheduleStatusClear())
+}
+
+// joinTSV joins string columns with a tab separator. Empty values are
+// preserved so column positions stay aligned when pasted into a sheet.
+func joinTSV(cols ...string) string {
+	return strings.Join(cols, "\t")
 }
 
 // handleHelmRollbackOverlayKey handles keyboard input for the Helm rollback overlay.
@@ -463,10 +492,31 @@ func (m Model) handleHelmRollbackOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 			return m, m.rollbackHelmRelease(rev.Revision)
 		}
 		return m, nil
+	case "y":
+		return m.handleHelmRollbackOverlayCopy()
 	case "ctrl+c":
 		return m.closeTabOrQuit()
 	}
 	return m, nil
+}
+
+// handleHelmRollbackOverlayCopy yanks the cursor revision row to the
+// clipboard as tab-separated columns matching the on-screen header.
+func (m Model) handleHelmRollbackOverlayCopy() (tea.Model, tea.Cmd) {
+	if m.helmRollbackCursor < 0 || m.helmRollbackCursor >= len(m.helmRollbackRevisions) {
+		return m, nil
+	}
+	rev := m.helmRollbackRevisions[m.helmRollbackCursor]
+	row := joinTSV(
+		fmt.Sprintf("%d", rev.Revision),
+		rev.Status,
+		rev.Chart,
+		rev.AppVersion,
+		rev.Description,
+		rev.Updated,
+	)
+	m.setStatusMessage(fmt.Sprintf("Copied revision %d", rev.Revision), false)
+	return m, tea.Batch(copyToSystemClipboard(row), scheduleStatusClear())
 }
 
 // handleHelmHistoryOverlayKey handles keyboard input for the read-only Helm
@@ -514,10 +564,33 @@ func (m Model) handleHelmHistoryOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.pendingG = false
 		m.helmHistoryCursor = 0
 		return m, nil
+	case "y":
+		return m.handleHelmHistoryOverlayCopy()
 	case "ctrl+c":
 		return m.closeTabOrQuit()
 	}
 	return m, nil
+}
+
+// handleHelmHistoryOverlayCopy yanks the cursor revision row to the
+// clipboard as tab-separated columns matching the on-screen header.
+// Identical shape to the helm rollback variant — the two overlays share
+// the same row schema, only Enter behaviour differs.
+func (m Model) handleHelmHistoryOverlayCopy() (tea.Model, tea.Cmd) {
+	if m.helmHistoryCursor < 0 || m.helmHistoryCursor >= len(m.helmHistoryRevisions) {
+		return m, nil
+	}
+	rev := m.helmHistoryRevisions[m.helmHistoryCursor]
+	row := joinTSV(
+		fmt.Sprintf("%d", rev.Revision),
+		rev.Status,
+		rev.Chart,
+		rev.AppVersion,
+		rev.Description,
+		rev.Updated,
+	)
+	m.setStatusMessage(fmt.Sprintf("Copied revision %d", rev.Revision), false)
+	return m, tea.Batch(copyToSystemClipboard(row), scheduleStatusClear())
 }
 
 // handleColorschemeOverlayKey handles keyboard input for the color scheme selector overlay.

--- a/internal/app/update_overlays_selectors_extra_test.go
+++ b/internal/app/update_overlays_selectors_extra_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
@@ -974,6 +975,130 @@ func TestColorschemeFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
 	assert.Equal(t, overlayNone, result.overlay, "overlay must close")
 	assert.Empty(t, result.schemeFilter.Value, "filter must be cleared after commit")
 	assert.NotNil(t, cmd, "scheduleStatusClear command must be returned")
+}
+
+// --- y to copy cursor row from rollback overlays ---
+
+// The user is sizing up a rollback (deciding which revision to roll back to)
+// and wants to paste the row into a ticket / Slack. y must yank the cursor
+// row as a tab-separated line and keep the overlay open — pressing Enter
+// would actually trigger the rollback, which is destructive.
+func TestRollbackOverlayYCopiesCursorRow(t *testing.T) {
+	created := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	revisions := []k8s.DeploymentRevision{
+		{Revision: 1, Name: "rs-1", Replicas: 3, Images: []string{"nginx:1"}, CreatedAt: created},
+		{Revision: 2, Name: "rs-2", Replicas: 5, Images: []string{"nginx:2"}, CreatedAt: created},
+	}
+	m := Model{
+		overlay:           overlayRollback,
+		rollbackRevisions: revisions,
+		rollbackCursor:    1,
+		tabs:              []TabState{{}},
+		width:             80,
+		height:            40,
+	}
+	ret, cmd := m.handleRollbackOverlayKey(runeKey('y'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayRollback, result.overlay, "overlay must stay open after copy")
+	assert.True(t, result.hasStatusMessage())
+	assert.Contains(t, result.statusMessage, "Copied revision 2")
+	assert.NotNil(t, cmd, "tea.Batch(copy, scheduleStatusClear) must be returned")
+}
+
+func TestRollbackOverlayYNoOpWhenEmpty(t *testing.T) {
+	m := Model{
+		overlay:           overlayRollback,
+		rollbackRevisions: nil,
+		tabs:              []TabState{{}},
+		width:             80,
+		height:            40,
+	}
+	ret, _ := m.handleRollbackOverlayKey(runeKey('y'))
+	result := ret.(Model)
+	assert.False(t, result.hasStatusMessage(), "no message when there is no row to copy")
+}
+
+func TestHelmRollbackOverlayYCopiesCursorRow(t *testing.T) {
+	revisions := []ui.HelmRevision{
+		{Revision: 1, Status: "deployed", Chart: "argo-cd-5.0.0", AppVersion: "2.4.0", Description: "Install complete", Updated: "2026-04-27"},
+		{Revision: 2, Status: "superseded", Chart: "argo-cd-5.1.0", AppVersion: "2.5.0", Description: "Upgrade complete", Updated: "2026-04-28"},
+	}
+	m := Model{
+		overlay:               overlayHelmRollback,
+		helmRollbackRevisions: revisions,
+		helmRollbackCursor:    1,
+		tabs:                  []TabState{{}},
+		width:                 80,
+		height:                40,
+	}
+	ret, cmd := m.handleHelmRollbackOverlayKey(runeKey('y'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayHelmRollback, result.overlay, "overlay must stay open after copy")
+	assert.True(t, result.hasStatusMessage())
+	assert.Contains(t, result.statusMessage, "Copied revision 2")
+	assert.NotNil(t, cmd)
+}
+
+func TestHelmRollbackOverlayYNoOpWhenEmpty(t *testing.T) {
+	m := Model{
+		overlay:               overlayHelmRollback,
+		helmRollbackRevisions: nil,
+		tabs:                  []TabState{{}},
+		width:                 80,
+		height:                40,
+	}
+	ret, _ := m.handleHelmRollbackOverlayKey(runeKey('y'))
+	result := ret.(Model)
+	assert.False(t, result.hasStatusMessage())
+}
+
+// Helm Release History overlay shares the row schema with Helm Rollback
+// but is read-only (no Enter binding). y must still copy the cursor row
+// so users can paste a revision into a ticket without first arming the
+// destructive overlay.
+func TestHelmHistoryOverlayYCopiesCursorRow(t *testing.T) {
+	revisions := []ui.HelmRevision{
+		{Revision: 1, Status: "deployed", Chart: "argo-cd-5.0.0", AppVersion: "2.4.0", Description: "Install complete", Updated: "2026-04-27"},
+		{Revision: 2, Status: "superseded", Chart: "argo-cd-5.1.0", AppVersion: "2.5.0", Description: "Upgrade complete", Updated: "2026-04-28"},
+	}
+	m := Model{
+		overlay:              overlayHelmHistory,
+		helmHistoryRevisions: revisions,
+		helmHistoryCursor:    1,
+		tabs:                 []TabState{{}},
+		width:                80,
+		height:               40,
+	}
+	ret, cmd := m.handleHelmHistoryOverlayKey(runeKey('y'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayHelmHistory, result.overlay, "overlay must stay open after copy")
+	assert.True(t, result.hasStatusMessage())
+	assert.Contains(t, result.statusMessage, "Copied revision 2")
+	assert.NotNil(t, cmd)
+}
+
+func TestHelmHistoryOverlayYNoOpWhenEmpty(t *testing.T) {
+	m := Model{
+		overlay:              overlayHelmHistory,
+		helmHistoryRevisions: nil,
+		tabs:                 []TabState{{}},
+		width:                80,
+		height:               40,
+	}
+	ret, _ := m.handleHelmHistoryOverlayKey(runeKey('y'))
+	result := ret.(Model)
+	assert.False(t, result.hasStatusMessage())
+}
+
+// joinTSV is the contract the copy handlers depend on for paste-into-spreadsheet
+// behaviour. Empty values must be preserved (so column positions stay aligned)
+// and the separator must be a literal tab.
+func TestJoinTSVPreservesEmptyColumns(t *testing.T) {
+	got := joinTSV("a", "", "c")
+	assert.Equal(t, "a\t\tc", got)
 }
 
 // Two filtered results: Enter must keep the legacy behavior — exit filter

--- a/internal/ui/rollbackview.go
+++ b/internal/ui/rollbackview.go
@@ -126,20 +126,13 @@ func RenderHelmRollbackOverlay(revisions []HelmRevision, cursor int, screenWidth
 		Render(body)
 }
 
-// FormatAge returns a human-readable age string.
+// FormatAge returns a human-readable age string for a timestamp. Zero time
+// renders as "-"; otherwise delegates to k8s.FormatAge so deployment-rollback
+// rows match the format used everywhere else in the app (including the year
+// suffix once a revision is older than ~12 months).
 func FormatAge(t time.Time) string {
 	if t.IsZero() {
 		return "-"
 	}
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	case d < time.Hour:
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh", int(d.Hours()))
-	default:
-		return fmt.Sprintf("%dd", int(d.Hours()/24))
-	}
+	return k8s.FormatAge(time.Since(t))
 }

--- a/internal/ui/rollbackview.go
+++ b/internal/ui/rollbackview.go
@@ -42,7 +42,7 @@ func RenderRollbackOverlay(revisions []k8s.DeploymentRevision, cursor int, scree
 				img += fmt.Sprintf(" +%d", len(rev.Images)-1)
 			}
 		}
-		age := formatAge(rev.CreatedAt)
+		age := FormatAge(rev.CreatedAt)
 		line := fmt.Sprintf("  %-8d  %-30s  %-8d  %-30s  %s",
 			rev.Revision, Truncate(rev.Name, 30), rev.Replicas, Truncate(img, 30), age)
 
@@ -126,8 +126,8 @@ func RenderHelmRollbackOverlay(revisions []HelmRevision, cursor int, screenWidth
 		Render(body)
 }
 
-// formatAge returns a human-readable age string.
-func formatAge(t time.Time) string {
+// FormatAge returns a human-readable age string.
+func FormatAge(t time.Time) string {
 	if t.IsZero() {
 		return "-"
 	}

--- a/internal/ui/rollbackview_test.go
+++ b/internal/ui/rollbackview_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// --- formatAge ---
+// --- FormatAge ---
 
 func TestFormatAge(t *testing.T) {
 	tests := []struct {
@@ -29,12 +29,12 @@ func TestFormatAge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := formatAge(time.Now().Add(-tt.offset))
+			result := FormatAge(time.Now().Add(-tt.offset))
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 
 	t.Run("zero time returns dash", func(t *testing.T) {
-		assert.Equal(t, "-", formatAge(time.Time{}))
+		assert.Equal(t, "-", FormatAge(time.Time{}))
 	})
 }


### PR DESCRIPTION
## Summary

The Deployment Rollback, Helm Rollback, and Helm Release History overlays already track a cursor and let the user pick a revision via `Enter` (read-only in History). Users routinely want to paste that revision into a ticket or Slack — chart version, image, ReplicaSet name, description — but had to retype it by hand. None of the three overlays handled `y`. Now `y` yanks the cursor row as a tab-separated line that mirrors the on-screen header.

## Type of change

- [x] feat: new user-facing feature

## Related issue

<!-- none -->

## Changes

- Added `y` handler in Deployment Rollback, Helm Rollback, and Helm Release History overlays to copy the cursor row as TSV (`REV\tREPLICASET\tPODS\tIMAGE\tAGE` for Deployments; `REV\tSTATUS\tCHART\tAPP_VER\tDESCRIPTION\tUPDATED` for both Helm overlays)
- Status message `Copied revision N` reuses the existing copy-feedback path so the bottom hint bar confirms the yank
- Hint bars updated to advertise the new `y copy` binding for all three overlays
- Exported `ui.FormatAge` (was unexported `formatAge`) so the deployment-row copy can reuse the renderer's relative-age format (`5m`/`2h`/`3d`) — what's copied matches what's painted
- Added `joinTSV` helper that preserves empty columns so paste positions stay aligned

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified: `y` in all three overlays copies the cursor row, status flashes `Copied revision N`, paste matches the on-screen line; empty list / loading state is a no-op; existing Enter, j/k, esc behaviour unchanged

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- none -->