### PR TITLE
feat(ui): add key hints to quit confirmation overlay

### DIFF
--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -369,12 +369,12 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 		w := min(70, m.width-10)
 		return ui.RenderActionOverlay(m.overlayItems, m.overlayCursor, w), w, min(15, m.height-6), true
 	case overlayQuitConfirm:
-		// Box outer 32x7. Inside (after 2 border + 4/2 padding):
+		// Box outer 32x9. Inside (after 2 border + 4/2 padding):
 		//   inner width  = 32 - 2 - 4 = 26
-		//   inner height =  7 - 2 - 2 =  3
-		// The renderer centers the line both axes within that inner area.
+		//   inner height =  9 - 2 - 2 =  5
+		// The renderer centers question + hint both axes within that inner area.
 		qw := min(32, m.width-10)
-		qh := min(7, m.height-6)
+		qh := min(9, m.height-6)
 		return ui.RenderQuitConfirmOverlay(qw-6, qh-4), qw, qh, true
 	case overlayConfirm:
 		return ui.RenderConfirmOverlay(m.confirmAction), min(50, m.width-10), min(8, m.height-6), true

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -270,16 +270,24 @@ func RenderConfirmOverlay(action string) string {
 // RenderQuitConfirmOverlay renders the quit confirmation overlay content
 // centered both horizontally and vertically within (innerWidth, innerHeight),
 // using the title color for emphasis. The dimensions should be the overlay
-// box's content area (overlayW/H minus border + padding). Single line —
-// a separate "Quit" title used to read as a second option in a two-line
-// layout, so it was dropped.
+// box's content area (overlayW/H minus border + padding).
 func RenderQuitConfirmOverlay(innerWidth, innerHeight int) string {
-	return OverlayTitleStyle.
+	question := OverlayTitleStyle.
 		Padding(0).
+		Width(innerWidth).
+		Align(lipgloss.Center).
+		Render("Quit lfk?")
+	hint := OverlayDimStyle.
+		Width(innerWidth).
+		Align(lipgloss.Center).
+		Render("[y] yes  [n] no")
+	content := question + "\n\n" + hint
+
+	return lipgloss.NewStyle().
 		Width(innerWidth).
 		Height(innerHeight).
 		Align(lipgloss.Center, lipgloss.Center).
-		Render("Quit lfk?")
+		Render(content)
 }
 
 // RenderPasteConfirmOverlay renders the multiline paste confirmation overlay.

--- a/internal/ui/overlay_extra_test.go
+++ b/internal/ui/overlay_extra_test.go
@@ -10,33 +10,25 @@ import (
 // --- RenderQuitConfirmOverlay ---
 
 func TestRenderQuitConfirmOverlay(t *testing.T) {
-	// Single question, centered both horizontally and vertically within
-	// (innerWidth, innerHeight). The previous two-line layout (title +
-	// question) was being misread as a menu, so it was dropped.
-	result := RenderQuitConfirmOverlay(26, 3)
+	// Question + key hint, centered both horizontally and vertically within
+	// (innerWidth, innerHeight).
+	result := RenderQuitConfirmOverlay(26, 5)
 	assert.Contains(t, result, "Quit lfk?", "should show the question")
+	assert.Contains(t, result, "[y] yes", "should show yes hint")
+	assert.Contains(t, result, "[n] no", "should show no hint")
 
-	// Vertical centering: 3 rows total, 1 row of question → 1 blank row
-	// above and below.
+	// Should fill innerHeight rows.
 	lines := strings.Split(result, "\n")
-	assert.Equal(t, 3, len(lines), "should fill innerHeight rows")
+	assert.Equal(t, 5, len(lines), "should fill innerHeight rows")
+
+	// Question should appear in the output.
 	questionRow := -1
 	for i, line := range lines {
 		if strings.Contains(stripANSI(line), "Quit lfk?") {
 			questionRow = i
 		}
 	}
-	assert.Equal(t, 1, questionRow, "question must sit on the middle row")
-
-	// Horizontal centering: roughly equal leading/trailing whitespace.
-	plain := stripANSI(lines[questionRow])
-	leading := len(plain) - len(strings.TrimLeft(plain, " "))
-	trailing := len(plain) - len(strings.TrimRight(plain, " "))
-	diff := leading - trailing
-	if diff < 0 {
-		diff = -diff
-	}
-	assert.LessOrEqual(t, diff, 1, "text should be horizontally centered (leading=%d trailing=%d)", leading, trailing)
+	assert.GreaterOrEqual(t, questionRow, 0, "question must be present")
 }
 
 // --- RenderConfirmTypeOverlay ---


### PR DESCRIPTION
## Summary

- Add `[y] yes  [n] no` key hint text to the quit confirmation dialog so users know which keys to press
- Increase overlay height from 7 to 9 to accommodate the hint line
- Follows the same pattern used by the paste confirmation overlay
<img width="534" height="350" alt="Screenshot 2026-04-28 at 12 07 56 PM" src="https://github.com/user-attachments/assets/08ab8ff9-1f41-4648-9562-b13160499b43" />



## Test plan

- [x] Unit tests updated and passing
- [x] Verify visually that the overlay renders the hint text below "Quit lfk?"
- [x] Confirm `y`/`n`/`Enter`/`Esc` still work as expected