### PR TITLE
fix(ui): hide no-op sort and actions at picker levels

### DIFF
--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -189,15 +189,7 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 		return m.executeSetCommand(arg)
 
 	case "sort":
-		if arg == "" {
-			m.setStatusMessage("Usage: :sort <column>", true)
-			return m, scheduleStatusClear()
-		}
-		m.sortColumnName = arg
-		m.sortMiddleItems()
-		m.clampCursor()
-		m.setStatusMessage(fmt.Sprintf("Sort by %s", arg), false)
-		return m, scheduleStatusClear()
+		return m.executeSortCommand(arg)
 
 	case "export":
 		lower := strings.ToLower(arg)
@@ -270,6 +262,27 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 		m.setStatusMessage(fmt.Sprintf("Unknown command: %s", canonical), true)
 		return m, scheduleStatusClear()
 	}
+}
+
+// executeSortCommand handles the :sort builtin command. At LevelClusters
+// and LevelResourceTypes the sort engine early-returns, so accepting :sort
+// silently would mutate sortColumnName and emit a misleading "Sort by ..."
+// status while items stayed put. Surface that as an explicit error so the
+// user understands why the typed command had no effect.
+func (m Model) executeSortCommand(arg string) (tea.Model, tea.Cmd) {
+	if arg == "" {
+		m.setStatusMessage("Usage: :sort <column>", true)
+		return m, scheduleStatusClear()
+	}
+	if !m.sortApplies() {
+		m.setStatusMessage("Sort is not available at this level", true)
+		return m, scheduleStatusClear()
+	}
+	m.sortColumnName = arg
+	m.sortMiddleItems()
+	m.clampCursor()
+	m.setStatusMessage(fmt.Sprintf("Sort by %s", arg), false)
+	return m, scheduleStatusClear()
 }
 
 // executeSetCommand handles the :set builtin command.

--- a/internal/app/commandbar_execute_test.go
+++ b/internal/app/commandbar_execute_test.go
@@ -334,6 +334,36 @@ func TestExecuteBuiltinCommand(t *testing.T) {
 		assert.Equal(t, "Name", rm.sortColumnName)
 	})
 
+	// :sort at picker levels (LevelClusters, LevelResourceTypes) is a no-op
+	// because sortMiddleItems() early-returns there. The command must not
+	// mutate sort state silently — it must signal the user with an error
+	// status so they understand why typing :sort had no visible effect.
+	t.Run("sort_no_op_at_clusters_level", func(t *testing.T) {
+		m := baseModelCov()
+		m.nav.Level = model.LevelClusters
+		m.sortColumnName = "Name"
+		m.sortAscending = true
+
+		result, _ := m.executeBuiltinCommand("sort Age")
+		rm := result.(Model)
+
+		assert.Equal(t, "Name", rm.sortColumnName, "sort column must not change at LevelClusters")
+		assert.True(t, rm.sortAscending, "sortAscending must not change at LevelClusters")
+		assert.True(t, rm.statusMessageErr, "must signal error to user who explicitly invoked :sort")
+	})
+
+	t.Run("sort_no_op_at_resource_types_level", func(t *testing.T) {
+		m := baseModelCov()
+		m.nav.Level = model.LevelResourceTypes
+		m.sortColumnName = "Name"
+
+		result, _ := m.executeBuiltinCommand("sort Age")
+		rm := result.(Model)
+
+		assert.Equal(t, "Name", rm.sortColumnName, "sort column must not change at LevelResourceTypes")
+		assert.True(t, rm.statusMessageErr, "must signal error to user who explicitly invoked :sort")
+	})
+
 	t.Run("unknown_builtin_returns_error", func(t *testing.T) {
 		m := baseModelCov()
 		result, _ := m.executeBuiltinCommand("notabuiltin")

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -109,10 +109,20 @@ func (m *Model) fetchFingerprint() string {
 	return b.String()
 }
 
+// sortApplies reports whether sort keybindings (>, <, =, -) have any
+// effect at the current navigation level. False at the cluster picker
+// and resource type browser, where items keep their original ordering.
+// Callers in the key-handler layer must short-circuit before mutating
+// sort state so the bar doesn't lie that sort changed when items stay
+// put.
+func (m *Model) sortApplies() bool {
+	return m.nav.Level != model.LevelClusters && m.nav.Level != model.LevelResourceTypes
+}
+
 // sortMiddleItems sorts middleItems based on the current sort column and direction.
 // At LevelResourceTypes and LevelClusters, items keep their original ordering.
 func (m *Model) sortMiddleItems() {
-	if m.nav.Level == model.LevelResourceTypes || m.nav.Level == model.LevelClusters {
+	if !m.sortApplies() {
 		return
 	}
 

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -417,6 +417,9 @@ func (m Model) handleExplorerActionKeyJumpOwner() (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) handleExplorerActionKeySortNext() (tea.Model, tea.Cmd, bool) {
+	if !m.sortApplies() {
+		return m, nil, true
+	}
 	colCount := ui.ActiveSortableColumnCount
 	if colCount > 0 {
 		idx := sortColumnIndex(m.sortColumnName)
@@ -430,6 +433,9 @@ func (m Model) handleExplorerActionKeySortNext() (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) handleExplorerActionKeySortPrev() (tea.Model, tea.Cmd, bool) {
+	if !m.sortApplies() {
+		return m, nil, true
+	}
 	colCount := ui.ActiveSortableColumnCount
 	if colCount > 0 {
 		idx := sortColumnIndex(m.sortColumnName)
@@ -443,6 +449,9 @@ func (m Model) handleExplorerActionKeySortPrev() (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) handleExplorerActionKeySortFlip() (tea.Model, tea.Cmd, bool) {
+	if !m.sortApplies() {
+		return m, nil, true
+	}
 	m.sortAscending = !m.sortAscending
 	m.sortMiddleItems()
 	m.clampCursor()
@@ -451,6 +460,9 @@ func (m Model) handleExplorerActionKeySortFlip() (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) handleExplorerActionKeySortReset() (tea.Model, tea.Cmd, bool) {
+	if !m.sortApplies() {
+		return m, nil, true
+	}
 	m.sortColumnName = sortColDefault
 	m.sortAscending = true
 	m.sortMiddleItems()

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -205,6 +205,73 @@ func TestActionKeyLessCyclesSortPrev(t *testing.T) {
 	assert.Equal(t, "Status", result.sortColumnName)
 }
 
+// --- handleExplorerActionKey: sort keys are no-ops at picker levels ---
+//
+// At LevelClusters and LevelResourceTypes, sortMiddleItems() early-returns,
+// so >, <, =, - mutating sort state and emitting "Sort: ..." status messages
+// is misleading: the bar lies that sort changed when items are unmoved.
+// These keys must short-circuit silently at those levels.
+
+func TestActionKeySortNextNoOpAtResourceTypes(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResourceTypes
+	m.sortColumnName = "Name"
+	m.sortAscending = true
+	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
+	ui.ActiveSortableColumnCount = 3
+
+	ret, cmd, handled := m.handleExplorerActionKey(runeKey('>'))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.Equal(t, "Name", result.sortColumnName, "sort column must not change at LevelResourceTypes")
+	assert.True(t, result.sortAscending)
+	assert.Empty(t, result.statusMessage, "no misleading status message")
+	assert.Nil(t, cmd)
+}
+
+func TestActionKeySortPrevNoOpAtResourceTypes(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResourceTypes
+	m.sortColumnName = "Name"
+	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
+	ui.ActiveSortableColumnCount = 3
+
+	ret, cmd, handled := m.handleExplorerActionKey(runeKey('<'))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.Equal(t, "Name", result.sortColumnName)
+	assert.Empty(t, result.statusMessage)
+	assert.Nil(t, cmd)
+}
+
+func TestActionKeySortFlipNoOpAtClusters(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelClusters
+	m.sortAscending = true
+
+	ret, cmd, handled := m.handleExplorerActionKey(runeKey('='))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.True(t, result.sortAscending, "sortAscending must not toggle at LevelClusters")
+	assert.Empty(t, result.statusMessage)
+	assert.Nil(t, cmd)
+}
+
+func TestActionKeySortResetNoOpAtResourceTypes(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResourceTypes
+	m.sortColumnName = "Status"
+	m.sortAscending = false
+
+	ret, cmd, handled := m.handleExplorerActionKey(runeKey('-'))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.Equal(t, "Status", result.sortColumnName, "reset must not clobber column at LevelResourceTypes")
+	assert.False(t, result.sortAscending, "reset must not flip ascending at LevelResourceTypes")
+	assert.Empty(t, result.statusMessage)
+	assert.Nil(t, cmd)
+}
+
 // --- handleExplorerActionKey: y copies resource name ---
 
 func TestActionKeyYCopiesResourceName(t *testing.T) {

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -217,6 +217,12 @@ func TestActionKeySortNextNoOpAtResourceTypes(t *testing.T) {
 	m.nav.Level = model.LevelResourceTypes
 	m.sortColumnName = "Name"
 	m.sortAscending = true
+	oldCols := ui.ActiveSortableColumns
+	oldCount := ui.ActiveSortableColumnCount
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = oldCols
+		ui.ActiveSortableColumnCount = oldCount
+	})
 	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
 	ui.ActiveSortableColumnCount = 3
 
@@ -233,6 +239,12 @@ func TestActionKeySortPrevNoOpAtResourceTypes(t *testing.T) {
 	m := baseExplorerModel()
 	m.nav.Level = model.LevelResourceTypes
 	m.sortColumnName = "Name"
+	oldCols := ui.ActiveSortableColumns
+	oldCount := ui.ActiveSortableColumnCount
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = oldCols
+		ui.ActiveSortableColumnCount = oldCount
+	})
 	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
 	ui.ActiveSortableColumnCount = 3
 

--- a/internal/app/update_mouse.go
+++ b/internal/app/update_mouse.go
@@ -153,6 +153,9 @@ func findSortableCol(name string) int {
 // from click X to column key always matches the actual rendered order, even when
 // the user has reordered columns via the column-toggle overlay.
 func (m Model) handleHeaderClick(relX int) (tea.Model, tea.Cmd) {
+	if !m.sortApplies() {
+		return m, nil
+	}
 	items := m.visibleMiddleItems()
 	if len(items) == 0 || len(ui.ActiveSortableColumns) == 0 || len(ui.ActiveMiddleColumnLayout) == 0 {
 		return m, nil

--- a/internal/app/update_mouse_test.go
+++ b/internal/app/update_mouse_test.go
@@ -186,6 +186,72 @@ func TestHandleHeaderClickNameColumn(t *testing.T) {
 	assert.Equal(t, "Name", result.sortColumnName) // clicks Name column
 }
 
+// At LevelClusters and LevelResourceTypes, sortMiddleItems() early-returns,
+// so a column-header click that mutates sort state and emits "Sort: ..."
+// would mislead the user about the row ordering. The handler must short-
+// circuit silently before touching state.
+func TestHandleHeaderClickNoOpAtClustersLevel(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelClusters
+	m.sortColumnName = "Age"
+	m.sortAscending = true
+	m.middleItems = []model.Item{{Name: "ctx-a"}}
+
+	oldCols := ui.ActiveSortableColumns
+	oldCount := ui.ActiveSortableColumnCount
+	oldLayout := ui.ActiveMiddleColumnLayout
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = oldCols
+		ui.ActiveSortableColumnCount = oldCount
+		ui.ActiveMiddleColumnLayout = oldLayout
+	})
+	ui.ActiveSortableColumns = []string{"Name", "Age"}
+	ui.ActiveSortableColumnCount = 2
+	ui.ActiveMiddleColumnLayout = []ui.MiddleColumnRegion{
+		{Key: "Name", StartX: 0, EndX: 10},
+		{Key: "Age", StartX: 10, EndX: 20},
+	}
+
+	ret, cmd := m.handleHeaderClick(5)
+	result := ret.(Model)
+
+	assert.Equal(t, "Age", result.sortColumnName, "sort column must not change at LevelClusters")
+	assert.True(t, result.sortAscending, "sortAscending must not toggle at LevelClusters")
+	assert.Empty(t, result.statusMessage, "no misleading status message")
+	assert.Nil(t, cmd)
+}
+
+func TestHandleHeaderClickNoOpAtResourceTypesLevel(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResourceTypes
+	m.sortColumnName = "Age"
+	m.sortAscending = true
+	m.middleItems = []model.Item{{Name: "Pod"}}
+
+	oldCols := ui.ActiveSortableColumns
+	oldCount := ui.ActiveSortableColumnCount
+	oldLayout := ui.ActiveMiddleColumnLayout
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = oldCols
+		ui.ActiveSortableColumnCount = oldCount
+		ui.ActiveMiddleColumnLayout = oldLayout
+	})
+	ui.ActiveSortableColumns = []string{"Name", "Age"}
+	ui.ActiveSortableColumnCount = 2
+	ui.ActiveMiddleColumnLayout = []ui.MiddleColumnRegion{
+		{Key: "Name", StartX: 0, EndX: 10},
+		{Key: "Age", StartX: 10, EndX: 20},
+	}
+
+	ret, cmd := m.handleHeaderClick(5)
+	result := ret.(Model)
+
+	assert.Equal(t, "Age", result.sortColumnName)
+	assert.True(t, result.sortAscending)
+	assert.Empty(t, result.statusMessage)
+	assert.Nil(t, cmd)
+}
+
 func TestP4MouseClickLeftColumn(t *testing.T) {
 	m := bp4()
 	m.mode = modeExplorer

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -240,8 +240,12 @@ func (m Model) statusBar() string {
 		parts = append(parts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d]", cur, total)))
 	}
 
-	// Sort mode indicator.
-	parts = append(parts, ui.BarDimStyle.Render("sort:"+m.sortModeName()))
+	// Sort mode indicator. Hidden at picker levels where sortMiddleItems
+	// early-returns — claiming a sort there would mislead the user about
+	// the row ordering.
+	if m.sortApplies() {
+		parts = append(parts, ui.BarDimStyle.Render("sort:"+m.sortModeName()))
+	}
 
 	// Styled key hints -- show a reduced set for dashboard views.
 	kb := ui.ActiveKeybindings
@@ -266,14 +270,20 @@ func (m Model) statusBar() string {
 			{Key: kb.NamespaceSelector, Desc: "namespace"},
 			{Key: kb.AllNamespaces, Desc: "all-ns"},
 		}
-		// The action menu has no entries at the kubeconfig list level, so
-		// hide the hint there to avoid advertising a no-op key.
-		if m.nav.Level != model.LevelClusters {
+		// At the cluster picker and resource-type browser, both the action
+		// menu and column sort are no-ops: selectedResourceKind() returns
+		// "" so openActionMenu() bails out, and sortMiddleItems() early-
+		// returns so </> doesn't reorder anything. Hide both hints there
+		// to avoid advertising dead keys.
+		hasResourceContext := m.nav.Level != model.LevelClusters && m.nav.Level != model.LevelResourceTypes
+		if hasResourceContext {
 			hintEntries = append(hintEntries, ui.HintEntry{Key: kb.ActionMenu, Desc: "actions"})
 		}
+		hintEntries = append(hintEntries, ui.HintEntry{Key: kb.CreateTemplate, Desc: "create"})
+		if hasResourceContext {
+			hintEntries = append(hintEntries, ui.HintEntry{Key: kb.SortNext + "/" + kb.SortPrev, Desc: "sort"})
+		}
 		hintEntries = append(hintEntries,
-			ui.HintEntry{Key: kb.CreateTemplate, Desc: "create"},
-			ui.HintEntry{Key: kb.SortNext + "/" + kb.SortPrev, Desc: "sort"},
 			ui.HintEntry{Key: kb.Filter, Desc: "filter"},
 			ui.HintEntry{Key: kb.SetMark + "/" + kb.OpenMarks, Desc: "marks"},
 			ui.HintEntry{Key: kb.Help, Desc: "help"},

--- a/internal/app/view_status_extra_test.go
+++ b/internal/app/view_status_extra_test.go
@@ -233,6 +233,52 @@ func TestStatusBarResourceListShowsActionsHint(t *testing.T) {
 	}
 	stripped := stripANSI(m.statusBar())
 	assert.Contains(t, stripped, "actions")
+	assert.Contains(t, stripped, ">/<: sort")
+	assert.Contains(t, stripped, "sort:", "sort indicator must show where sort applies")
+}
+
+// --- statusBar: resource-type picker hints omit "actions" and "sort" ---
+//
+// At LevelResourceTypes (the RESOURCE TYPE column listing Pod, Deployment,
+// etc.) selectedResourceKind() returns "" so openActionMenu() is a no-op,
+// and sortMiddleItems() early-returns so </> doesn't reorder anything.
+// Both the hint and the "sort:<col>" indicator must stay hidden so the
+// bar doesn't advertise dead keys or claim a sort that isn't enforced.
+func TestStatusBarResourceTypePickerOmitsActionsAndSort(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelResourceTypes},
+		middleItems:   []model.Item{{Name: "Pod", Extra: "/v1/pods"}},
+		width:         200,
+		height:        40,
+		tabs:          []TabState{{}},
+		selectedItems: make(map[string]bool),
+	}
+	stripped := stripANSI(m.statusBar())
+	assert.NotContains(t, stripped, "actions")
+	assert.NotContains(t, stripped, ">/<: sort")
+	assert.NotContains(t, stripped, "sort:", "sort indicator must hide where sort is a no-op")
+	assert.Contains(t, stripped, "create")
+	assert.Contains(t, stripped, "filter")
+	assert.Contains(t, stripped, "marks")
+}
+
+// --- statusBar: cluster-list hints also omit "sort" ---
+//
+// sortMiddleItems() early-returns at LevelClusters too, so the </> hint
+// and the "sort:<col>" indicator are just as misleading there as they
+// are at LevelResourceTypes.
+func TestStatusBarClusterListOmitsSortHint(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelClusters},
+		middleItems:   []model.Item{{Name: "ctx-a"}},
+		width:         200,
+		height:        40,
+		tabs:          []TabState{{}},
+		selectedItems: make(map[string]bool),
+	}
+	stripped := stripANSI(m.statusBar())
+	assert.NotContains(t, stripped, ">/<: sort")
+	assert.NotContains(t, stripped, "sort:")
 }
 
 // --- statusBar: small width ---


### PR DESCRIPTION
## Summary

At the kubeconfig picker (`LevelClusters`) and resource type browser (`LevelResourceTypes`), the bottom status bar advertised an `x actions` hint, a `>/<: sort` hint, and a `sort:<col>` indicator — but the action menu opens nothing (`selectedResourceKind()` is `""`) and `sortMiddleItems()` early-returns at those levels. Pressing `>`, `<`, `=`, `-` mutated sort state and flashed a `Sort: ...` status message even though items never reordered. This PR hides those surfaces and silences the keys.

## Type of change

- [x] fix: bug fix

## Related issue

n/a

## Changes

- Hide `x actions` and `>/<: sort` hint entries at `LevelClusters` and `LevelResourceTypes`.
- Hide `sort:<col>` indicator at the same levels.
- Add `sortApplies()` helper; gate the four sort handlers (`>`, `<`, `=`, `-`) on it so they no-op silently — no state mutation, no status flash, no preview reload.
- Reuse `sortApplies()` inside `sortMiddleItems()` to keep the rule in one place.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (4 new sort-handler tests, 2 new + 1 strengthened status-bar tests)
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style
- [ ] README / `docs/` updated when user-visible behavior or config changed (no doc changes — keybindings unchanged, only level-conditional hint visibility)
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (no key changes)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork

## Screenshots / recordings

n/a — bottom status bar text only.