### PR TITLE
ci: install Go before codeql-action/init

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,18 +34,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
-
-      - name: Set up Go
-        if: matrix.language == 'go'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: go.mod
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3


### PR DESCRIPTION
## Summary
- Reorder the CodeQL workflow so `Set up Go` runs **before** `Initialize CodeQL`.
- Resolves the workflow warning: *"Go was installed after the codeql-action/init Action was run"*.
- Preserves the `if: matrix.language == 'go'` guard so the `actions` matrix entry remains a no-op.

## Why
CodeQL records compiler invocations during init; installing the toolchain afterwards can interfere with autobuild and miss code paths from the database.

## Test plan
- [x] CodeQL workflow runs green on the PR
- [x] No "Go was installed after..." warning in the workflow run
- [x] Both matrix legs (`go`, `actions`) succeed