### PR TITLE
feat(app): apply y/Y to multi-selection

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -96,9 +96,11 @@ Resource-specific actions (exec, scale, restart, secret editor, etc.) are availa
 
 | Key | Action |
 |---|---|
-| `y` | Copy resource name to clipboard |
-| `Y` | Copy resource YAML to clipboard |
+| `y` | Copy resource name to clipboard (with multi-selection: newline-joined names of all selected items) |
+| `Y` | Copy resource YAML to clipboard (with multi-selection: multi-doc YAML, items joined with `---`) |
 | `Ctrl+P` | Apply resource from clipboard (`kubectl apply`) |
+
+When items are multi-selected (`Space` / `Ctrl+Space` / `Ctrl+A`), `y` and `Y` operate on the selection rather than the cursor row — mirroring the precedence used by `D` (delete) and other bulk actions. `Y` is capped at 50 manifests per copy (client-go's default rate limiter serializes the per-item fetches).
 
 ## Multi-Selection
 

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -195,7 +195,11 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 	case "export":
 		lower := strings.ToLower(arg)
 		if lower == "yaml" || lower == "json" || lower == "" {
-			return m, m.copyYAMLToClipboard()
+			// Share the bulk-or-cursor dispatcher with the `Y` keybinding
+			// so multi-selection (cap, "Fetching N..." status, level gating)
+			// behaves the same whether the user types `:export yaml` or
+			// hits `Y`.
+			return m.dispatchYAMLClipboardCopy()
 		}
 		m.setStatusMessage(fmt.Sprintf("Unknown export format: %s", arg), true)
 		return m, scheduleStatusClear()

--- a/internal/app/commandbar_execute_test.go
+++ b/internal/app/commandbar_execute_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 
@@ -368,6 +369,107 @@ func TestExecuteBuiltinCommand(t *testing.T) {
 		m := baseModelCov()
 		result, _ := m.executeBuiltinCommand("notabuiltin")
 		rm := result.(Model)
+		assert.True(t, rm.statusMessageErr)
+	})
+
+	// `:export yaml` shares the multi-selection bulk path with the `Y` key.
+	// Without this hookup the command-bar route silently dispatches a bulk
+	// fetch (which can hit dozens of items at QPS=5) with no progress
+	// indicator and no over-cap protection, so the user is left staring at
+	// a blank toast for ~10s.
+	t.Run("export_yaml_with_selection_shows_fetching_status", func(t *testing.T) {
+		m := basePush80Model()
+		m.toggleSelection(m.middleItems[0])
+		m.toggleSelection(m.middleItems[1])
+
+		result, cmd := m.executeBuiltinCommand("export yaml")
+		rm := result.(Model)
+
+		assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage,
+			":export must mirror Y's bulk dispatcher status")
+		assert.NotNil(t, cmd)
+	})
+
+	// Cap protection: `:export yaml` past maxBulkYAMLCopy must reject with
+	// the same error toast the Y key path uses, not silently kick off a
+	// 100-item sequential fetch behind the rate limiter.
+	t.Run("export_yaml_over_cap_rejects", func(t *testing.T) {
+		m := basePush80Model()
+		m.middleItems = make([]model.Item, maxBulkYAMLCopy+1)
+		for i := range m.middleItems {
+			m.middleItems[i] = model.Item{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: "default",
+				Kind:      "Pod",
+			}
+			m.toggleSelection(m.middleItems[i])
+		}
+
+		result, cmd := m.executeBuiltinCommand("export yaml")
+		rm := result.(Model)
+
+		assert.Equal(t, fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), rm.statusMessage)
+		assert.True(t, rm.statusMessageErr, "must surface as error toast")
+		assert.NotNil(t, cmd, "auto-clear timer is still dispatched")
+	})
+
+	// No selection: `:export yaml` falls through to the cursor-row single-
+	// item fetch — no "Fetching N..." status (that's reserved for the bulk
+	// path). The cmd is still non-nil so the YAML still goes to clipboard.
+	t.Run("export_yaml_no_selection_uses_cursor", func(t *testing.T) {
+		m := basePush80Model()
+		m.setCursor(0)
+
+		result, cmd := m.executeBuiltinCommand("export yaml")
+		rm := result.(Model)
+
+		assert.Empty(t, rm.statusMessage,
+			"single-item path dispatches silently; status is set only when the fetch resolves")
+		assert.NotNil(t, cmd)
+	})
+
+	// `:export json` is treated as an alias for yaml in the existing impl
+	// (the format toggle is a no-op today). Pin the alias to keep the bulk
+	// hookup symmetric.
+	t.Run("export_json_with_selection_shows_fetching_status", func(t *testing.T) {
+		m := basePush80Model()
+		m.toggleSelection(m.middleItems[0])
+		m.toggleSelection(m.middleItems[1])
+
+		result, cmd := m.executeBuiltinCommand("export json")
+		rm := result.(Model)
+
+		assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage)
+		assert.NotNil(t, cmd)
+	})
+
+	// LevelContainers must NOT show "Fetching N...": copyYAMLToClipboard
+	// fetches the parent Pod by OwnedName regardless of selection (containers
+	// don't have separate YAML), so the bulk indicator would be a lie.
+	t.Run("export_yaml_at_level_containers_falls_back_silently", func(t *testing.T) {
+		m := basePush80Model()
+		m.nav.Level = model.LevelContainers
+		m.nav.OwnedName = "pod-1"
+		m.middleItems = []model.Item{
+			{Name: "container-1", Kind: "Container", Namespace: "default"},
+			{Name: "container-2", Kind: "Container", Namespace: "default"},
+		}
+		m.toggleSelection(m.middleItems[0])
+		m.toggleSelection(m.middleItems[1])
+
+		result, cmd := m.executeBuiltinCommand("export yaml")
+		rm := result.(Model)
+
+		assert.Empty(t, rm.statusMessage,
+			"LevelContainers cmd ignores selection; dispatcher must skip the bulk indicator")
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("export_unknown_format_returns_error", func(t *testing.T) {
+		m := basePush80Model()
+		result, _ := m.executeBuiltinCommand("export csv")
+		rm := result.(Model)
+		assert.Contains(t, rm.statusMessage, "Unknown export format")
 		assert.True(t, rm.statusMessageErr)
 	})
 }

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -745,6 +745,58 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 			return yamlClipboardMsg{content: content, count: 1, err: err}
 		}
 	case model.LevelOwned:
+		// Bulk path mirrors LevelResources: gate on visible selection so a
+		// selection that's been filtered out of view falls through to the
+		// cursor branch instead of dispatching an empty fetch. Per-item Kind
+		// dispatch (Pod -> GetPodYAML; others -> resolveOwnedResourceType +
+		// GetResourceYAML) is resolved before the closure runs to keep the
+		// goroutine off the model.
+		if items := m.selectedItemsList(); len(items) > 0 {
+			type fetchTarget struct {
+				ns, name string
+				isPod    bool
+				rt       model.ResourceTypeEntry
+				resolved bool
+				kind     string
+			}
+			targets := make([]fetchTarget, len(items))
+			for i, it := range items {
+				itemNs := ns
+				if it.Namespace != "" {
+					itemNs = it.Namespace
+				}
+				t := fetchTarget{ns: itemNs, name: it.Name, kind: it.Kind, isPod: it.Kind == "Pod"}
+				if !t.isPod {
+					t.rt, t.resolved = m.resolveOwnedResourceType(&items[i])
+				}
+				targets[i] = t
+			}
+			return func() tea.Msg {
+				docs := make([]string, 0, len(targets))
+				for _, t := range targets {
+					var (
+						content string
+						err     error
+					)
+					switch {
+					case t.isPod:
+						content, err = m.client.GetPodYAML(context.Background(), kctx, t.ns, t.name)
+					case t.resolved:
+						content, err = m.client.GetResourceYAML(context.Background(), kctx, t.ns, t.rt, t.name)
+					default:
+						err = fmt.Errorf("unknown resource type: %s", t.kind)
+					}
+					if err != nil {
+						return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+					}
+					docs = append(docs, strings.TrimRight(content, "\n"))
+				}
+				return yamlClipboardMsg{
+					content: strings.Join(docs, "\n---\n") + "\n",
+					count:   len(docs),
+				}
+			}
+		}
 		sel := m.selectedMiddleItem()
 		if sel == nil {
 			return nil

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -700,11 +700,41 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 
 	switch m.nav.Level {
 	case model.LevelResources:
+		rt := m.nav.ResourceType
+		// Gate on visible selection, not raw hasSelection() — selected rows
+		// can be filtered out of view, in which case we want the single-item
+		// (cursor) path, not an empty multi-doc fetch.
+		if items := m.selectedItemsList(); len(items) > 0 {
+			type fetchTarget struct {
+				ns, name string
+			}
+			targets := make([]fetchTarget, len(items))
+			for i, it := range items {
+				itemNs := ns
+				if it.Namespace != "" {
+					itemNs = it.Namespace
+				}
+				targets[i] = fetchTarget{ns: itemNs, name: it.Name}
+			}
+			return func() tea.Msg {
+				docs := make([]string, 0, len(targets))
+				for _, t := range targets {
+					content, err := m.client.GetResourceYAML(context.Background(), kctx, t.ns, rt, t.name)
+					if err != nil {
+						return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+					}
+					docs = append(docs, strings.TrimRight(content, "\n"))
+				}
+				return yamlClipboardMsg{
+					content: strings.Join(docs, "\n---\n") + "\n",
+					count:   len(docs),
+				}
+			}
+		}
 		sel := m.selectedMiddleItem()
 		if sel == nil {
 			return nil
 		}
-		rt := m.nav.ResourceType
 		name := sel.Name
 		itemNs := ns
 		if sel.Namespace != "" {
@@ -712,7 +742,7 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 		}
 		return func() tea.Msg {
 			content, err := m.client.GetResourceYAML(context.Background(), kctx, itemNs, rt, name)
-			return yamlClipboardMsg{content: content, err: err}
+			return yamlClipboardMsg{content: content, count: 1, err: err}
 		}
 	case model.LevelOwned:
 		sel := m.selectedMiddleItem()
@@ -727,7 +757,7 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 		if sel.Kind == "Pod" {
 			return func() tea.Msg {
 				content, err := m.client.GetPodYAML(context.Background(), kctx, itemNs, name)
-				return yamlClipboardMsg{content: content, err: err}
+				return yamlClipboardMsg{content: content, count: 1, err: err}
 			}
 		}
 		rt, ok := m.resolveOwnedResourceType(sel)
@@ -738,13 +768,13 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 		}
 		return func() tea.Msg {
 			content, err := m.client.GetResourceYAML(context.Background(), kctx, itemNs, rt, name)
-			return yamlClipboardMsg{content: content, err: err}
+			return yamlClipboardMsg{content: content, count: 1, err: err}
 		}
 	case model.LevelContainers:
 		podName := m.nav.OwnedName
 		return func() tea.Msg {
 			content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
-			return yamlClipboardMsg{content: content, err: err}
+			return yamlClipboardMsg{content: content, count: 1, err: err}
 		}
 	}
 	return nil

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -1772,6 +1772,9 @@ func TestCov80CopyYAMLLevelOwnedPod(t *testing.T) {
 	m.setCursor(0)
 	cmd := m.copyYAMLToClipboard()
 	require.NotNil(t, cmd)
+	ymsg, ok := cmd().(yamlClipboardMsg)
+	require.True(t, ok)
+	assert.Equal(t, 1, ymsg.count, "single-item path must tag count=1")
 }
 
 func TestCov80CopyYAMLLevelOwnedKnownKind(t *testing.T) {
@@ -1804,6 +1807,9 @@ func TestCov80CopyYAMLLevelContainers(t *testing.T) {
 	m.setCursor(0)
 	cmd := m.copyYAMLToClipboard()
 	require.NotNil(t, cmd)
+	ymsg, ok := cmd().(yamlClipboardMsg)
+	require.True(t, ok)
+	assert.Equal(t, 1, ymsg.count, "single-item path must tag count=1")
 }
 
 func TestCov80LoadYAMLLevelResources(t *testing.T) {

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -154,8 +154,10 @@ type monitoringDashboardMsg struct {
 }
 
 // yamlClipboardMsg carries YAML content to be copied to clipboard.
+// count is the number of manifests joined into content (1 for single).
 type yamlClipboardMsg struct {
 	content string
+	count   int
 	err     error
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1497,7 +1497,11 @@ func (m Model) updateYamlClipboard(msg yamlClipboardMsg) (tea.Model, tea.Cmd) {
 		m.setErrorFromErr("Error: ", msg.err)
 		return m, scheduleStatusClear()
 	}
-	m.setStatusMessage("YAML copied to clipboard", false)
+	if msg.count > 1 {
+		m.setStatusMessage(fmt.Sprintf("Copied %d manifests to clipboard", msg.count), false)
+	} else {
+		m.setStatusMessage("YAML copied to clipboard", false)
+	}
 	return m, tea.Batch(copyToSystemClipboard(msg.content), scheduleStatusClear())
 }
 

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -517,9 +517,20 @@ func (m Model) handleExplorerActionKeyCopyName() (tea.Model, tea.Cmd, bool) {
 // (QPS=5/Burst=10) serializes per-item Gets regardless of goroutine count.
 const maxBulkYAMLCopy = 50
 
+// supportsBulkYAMLCopy reports whether copyYAMLToClipboard implements a
+// per-selection bulk fetch at the current navigation level. LevelContainers
+// is single-Pod-by-OwnedName (containers don't have separate YAML), so its
+// dispatcher must fall through to the cursor branch even with a selection
+// — otherwise the user sees a "Fetching N..." toast but the clipboard ends
+// up with one Pod's YAML. Keep this in sync with the bulk branches in
+// copyYAMLToClipboard.
+func (m Model) supportsBulkYAMLCopy() bool {
+	return m.nav.Level == model.LevelResources || m.nav.Level == model.LevelOwned
+}
+
 func (m Model) handleExplorerActionKeyCopyYAML() (tea.Model, tea.Cmd, bool) {
 	// See handleExplorerActionKeyCopyName for the n==0 rationale.
-	if m.hasSelection() {
+	if m.hasSelection() && m.supportsBulkYAMLCopy() {
 		n := len(m.selectedItemsList())
 		if n > maxBulkYAMLCopy {
 			m.setStatusMessage(fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), true)

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -528,23 +528,35 @@ func (m Model) supportsBulkYAMLCopy() bool {
 	return m.nav.Level == model.LevelResources || m.nav.Level == model.LevelOwned
 }
 
-func (m Model) handleExplorerActionKeyCopyYAML() (tea.Model, tea.Cmd, bool) {
-	// See handleExplorerActionKeyCopyName for the n==0 rationale.
+// dispatchYAMLClipboardCopy routes Y / `:export yaml` to either the
+// multi-selection bulk path (with cap + "Fetching N..." status) or the
+// cursor-row single-item path. Shared so the command-bar entry behaves
+// identically to the explorer keybinding — without it, `:export` would
+// silently kick off uncapped sequential fetches behind the rate limiter
+// with no progress indicator.
+//
+// See handleExplorerActionKeyCopyName for the n==0 rationale.
+func (m Model) dispatchYAMLClipboardCopy() (tea.Model, tea.Cmd) {
 	if m.hasSelection() && m.supportsBulkYAMLCopy() {
 		n := len(m.selectedItemsList())
 		if n > maxBulkYAMLCopy {
 			m.setStatusMessage(fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), true)
-			return m, scheduleStatusClear(), true
+			return m, scheduleStatusClear()
 		}
 		if n > 0 {
 			m.setStatusMessage(fmt.Sprintf("Fetching %d manifests...", n), false)
-			return m, m.copyYAMLToClipboard(), true
+			return m, m.copyYAMLToClipboard()
 		}
 	}
 	if m.selectedMiddleItem() == nil {
-		return m, nil, true
+		return m, nil
 	}
-	return m, m.copyYAMLToClipboard(), true
+	return m, m.copyYAMLToClipboard()
+}
+
+func (m Model) handleExplorerActionKeyCopyYAML() (tea.Model, tea.Cmd, bool) {
+	ret, cmd := m.dispatchYAMLClipboardCopy()
+	return ret, cmd, true
 }
 
 func (m Model) handleExplorerActionKeyNewTab() (tea.Model, tea.Cmd, bool) {

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -491,6 +491,20 @@ func (m Model) handleExplorerActionKeyOpenBrowser() (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) handleExplorerActionKeyCopyName() (tea.Model, tea.Cmd, bool) {
+	// hasSelection looks at the raw map, but selectedItemsList only returns
+	// visible items — they diverge when the user filters away every selected
+	// row. Fall through to cursor in that case rather than copying nothing.
+	if m.hasSelection() {
+		if items := m.selectedItemsList(); len(items) > 0 {
+			names := make([]string, len(items))
+			for i, it := range items {
+				names[i] = it.Name
+			}
+			joined := strings.Join(names, "\n")
+			m.setStatusMessage(fmt.Sprintf("Copied %d names", len(names)), false)
+			return m, tea.Batch(copyToSystemClipboard(joined), scheduleStatusClear()), true
+		}
+	}
 	sel := m.selectedMiddleItem()
 	if sel != nil {
 		m.setStatusMessage("Copied: "+sel.Name, false)
@@ -499,12 +513,27 @@ func (m Model) handleExplorerActionKeyCopyName() (tea.Model, tea.Cmd, bool) {
 	return m, nil, true
 }
 
+// maxBulkYAMLCopy caps `Y` bulk copy: client-go's default rate limiter
+// (QPS=5/Burst=10) serializes per-item Gets regardless of goroutine count.
+const maxBulkYAMLCopy = 50
+
 func (m Model) handleExplorerActionKeyCopyYAML() (tea.Model, tea.Cmd, bool) {
-	sel := m.selectedMiddleItem()
-	if sel != nil {
-		return m, m.copyYAMLToClipboard(), true
+	// See handleExplorerActionKeyCopyName for the n==0 rationale.
+	if m.hasSelection() {
+		n := len(m.selectedItemsList())
+		if n > maxBulkYAMLCopy {
+			m.setStatusMessage(fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), true)
+			return m, scheduleStatusClear(), true
+		}
+		if n > 0 {
+			m.setStatusMessage(fmt.Sprintf("Fetching %d manifests...", n), false)
+			return m, m.copyYAMLToClipboard(), true
+		}
 	}
-	return m, nil, true
+	if m.selectedMiddleItem() == nil {
+		return m, nil, true
+	}
+	return m, m.copyYAMLToClipboard(), true
 }
 
 func (m Model) handleExplorerActionKeyNewTab() (tea.Model, tea.Cmd, bool) {

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -734,4 +735,189 @@ func TestActionKeyToggleRareAtLevelResourcesUpdatesCursorMemory(t *testing.T) {
 	require.GreaterOrEqual(t, podIdx, 0, "Pod must be present in rebuilt leftItems")
 	assert.Equal(t, podIdx, rm.cursorMemory["test"],
 		"cursorMemory[context] must point at the current resource type after rebuild")
+}
+
+// --- y / Y bulk copy: selection wins over cursor (mirrors directActionDelete) ---
+
+// TestCopyNameBulkUsesSelectionOverCursor verifies pressing `y` with N items
+// multi-selected joins their names, copies them, and reports the count —
+// rather than copying just the cursor row. Mirrors the precedence used by
+// directActionDelete.
+func TestCopyNameBulkUsesSelectionOverCursor(t *testing.T) {
+	m := basePush80Model()
+	m.toggleSelection(m.middleItems[0]) // pod-1
+	m.toggleSelection(m.middleItems[2]) // pod-3
+	m.setCursor(1)                      // cursor on pod-2 — must be ignored
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyName()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Equal(t, "Copied 2 names", rm.statusMessage)
+	assert.NotNil(t, cmd, "must dispatch a clipboard cmd")
+}
+
+// TestCopyNameNoSelectionFallsBackToCursor guards the single-item fallback —
+// without a selection, `y` still copies just the cursor row.
+func TestCopyNameNoSelectionFallsBackToCursor(t *testing.T) {
+	m := basePush80Model()
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyName()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Equal(t, "Copied: pod-1", rm.statusMessage)
+	assert.NotNil(t, cmd)
+}
+
+// TestCopyNameSelectionFilteredOutFallsBack guards the n==0 edge case: a
+// selection survives in the raw map but every selected row is currently
+// filtered out of view, so selectedItemsList returns empty. `y` must fall
+// through to copy the cursor row rather than emit an empty clipboard write.
+func TestCopyNameSelectionFilteredOutFallsBack(t *testing.T) {
+	m := basePush80Model()
+	// Forge a "ghost" selection — a key not present in middleItems, so
+	// hasSelection() == true but selectedItemsList() == [].
+	m.selectedItems["ghost-ns/ghost-pod"] = true
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyName()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Equal(t, "Copied: pod-1", rm.statusMessage,
+		"must fall through to cursor when selection has no visible items")
+	assert.NotNil(t, cmd)
+}
+
+// TestCopyYAMLSelectionFilteredOutFallsBack mirrors the above for `Y`.
+// The single-item cursor path dispatches silently — no bulk "Fetching..."
+// or cap "Max ..." status is set before the fetch resolves. Asserting
+// statusMessage is empty pins down the "took the cursor branch silently"
+// intent rather than just "didn't take the bulk branch."
+func TestCopyYAMLSelectionFilteredOutFallsBack(t *testing.T) {
+	m := basePush80Model()
+	m.selectedItems["ghost-ns/ghost-pod"] = true
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Empty(t, rm.statusMessage,
+		"cursor path dispatches silently; status only updates once the fetch resolves")
+	assert.NotNil(t, cmd, "must still dispatch single-item fetch from cursor")
+}
+
+// TestCopyYAMLBulkErrorWrapsNamespaceName checks that the bulk fetch path
+// surfaces fetch errors tagged with the offending ns/name — the marker that
+// proves the bulk branch ran (vs the single-item path, which would emit an
+// unwrapped error). The successful join + count is exercised by
+// TestUpdateYamlClipboardCountAwareStatus/bulk against the receiver directly.
+func TestCopyYAMLBulkErrorWrapsNamespaceName(t *testing.T) {
+	m := basePush80Model()
+	m.toggleSelection(m.middleItems[0]) // default/pod-1
+	m.toggleSelection(m.middleItems[1]) // ns-2/pod-2
+
+	cmd := m.copyYAMLToClipboard()
+	require.NotNil(t, cmd)
+
+	ymsg, ok := cmd().(yamlClipboardMsg)
+	require.True(t, ok)
+	require.Error(t, ymsg.err, "fake client has no pods seeded; first fetch must fail")
+	assert.Contains(t, ymsg.err.Error(), "default/pod-1",
+		"bulk path must wrap errors with ns/name")
+	assert.Equal(t, 0, ymsg.count, "early-return on error keeps count at zero")
+}
+
+// TestCopyYAMLBulkSetsFetchingStatus checks the wrapper surfaces a
+// "Fetching N manifests..." hint before dispatching, so the user has
+// feedback during the sequential fetch (client-go's default rate limiter
+// serializes the per-item Gets — see maxBulkYAMLCopy comment).
+func TestCopyYAMLBulkSetsFetchingStatus(t *testing.T) {
+	m := basePush80Model()
+	m.toggleSelection(m.middleItems[0])
+	m.toggleSelection(m.middleItems[1])
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage)
+	assert.NotNil(t, cmd)
+}
+
+// TestCopyYAMLBulkRejectsOverCap verifies selections larger than
+// maxBulkYAMLCopy bail out with an error toast and no fetch is dispatched
+// — protects the UI from multi-second stalls behind the rate limiter.
+func TestCopyYAMLBulkRejectsOverCap(t *testing.T) {
+	m := basePush80Model()
+	m.middleItems = make([]model.Item, maxBulkYAMLCopy+1)
+	for i := range m.middleItems {
+		m.middleItems[i] = model.Item{
+			Name:      fmt.Sprintf("pod-%d", i),
+			Namespace: "default",
+			Kind:      "Pod",
+		}
+		m.toggleSelection(m.middleItems[i])
+	}
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Equal(t, fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), rm.statusMessage)
+	assert.True(t, rm.statusMessageErr, "must surface as error toast")
+	// Cmd is the auto-clear timer, not a fetch.
+	assert.NotNil(t, cmd)
+}
+
+// TestCopyYAMLBulkAtCapDispatches confirms the boundary case (exactly N=cap)
+// is allowed through.
+func TestCopyYAMLBulkAtCapDispatches(t *testing.T) {
+	m := basePush80Model()
+	m.middleItems = make([]model.Item, maxBulkYAMLCopy)
+	for i := range m.middleItems {
+		m.middleItems[i] = model.Item{
+			Name:      fmt.Sprintf("pod-%d", i),
+			Namespace: "default",
+			Kind:      "Pod",
+		}
+		m.toggleSelection(m.middleItems[i])
+	}
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Contains(t, rm.statusMessage, "Fetching")
+	assert.False(t, rm.statusMessageErr)
+	assert.NotNil(t, cmd)
+}
+
+// TestUpdateYamlClipboardCountAwareStatus verifies the receiver picks the
+// "Copied N manifests" message when count > 1, and the legacy single-item
+// message otherwise.
+func TestUpdateYamlClipboardCountAwareStatus(t *testing.T) {
+	t.Run("bulk", func(t *testing.T) {
+		m := basePush80Model()
+		ret, cmd := m.updateYamlClipboard(yamlClipboardMsg{
+			content: "a\n---\nb\n",
+			count:   3,
+		})
+		rm := ret.(Model)
+		assert.Equal(t, "Copied 3 manifests to clipboard", rm.statusMessage)
+		assert.NotNil(t, cmd)
+	})
+	t.Run("single", func(t *testing.T) {
+		m := basePush80Model()
+		ret, cmd := m.updateYamlClipboard(yamlClipboardMsg{
+			content: "a\n",
+			count:   1,
+		})
+		rm := ret.(Model)
+		assert.Equal(t, "YAML copied to clipboard", rm.statusMessage)
+		assert.NotNil(t, cmd)
+	})
 }

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -921,3 +921,77 @@ func TestUpdateYamlClipboardCountAwareStatus(t *testing.T) {
 		assert.NotNil(t, cmd)
 	})
 }
+
+// TestCopyYAMLBulkLevelOwnedWrapsErrorWithNamespaceName guards bulk Y at
+// LevelOwned. Multi-select is allowed at LevelOwned (>= LevelResources) and
+// bulk delete works there, so bulk YAML must too — otherwise the dispatcher
+// shows "Fetching N manifests..." but the cmd silently returns just the
+// cursor row's YAML (count=1) and the user gets one manifest when the toast
+// promised N. The bulk branch wraps fetch errors with ns/name and tags
+// count=0 on early-return; the single-item path does neither, so this
+// assertion pins down which branch ran.
+func TestCopyYAMLBulkLevelOwnedWrapsErrorWithNamespaceName(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelOwned
+	m.toggleSelection(m.middleItems[0]) // default/pod-1
+	m.toggleSelection(m.middleItems[1]) // ns-2/pod-2
+
+	cmd := m.copyYAMLToClipboard()
+	require.NotNil(t, cmd)
+
+	ymsg, ok := cmd().(yamlClipboardMsg)
+	require.True(t, ok)
+	require.Error(t, ymsg.err, "fake client has no pods seeded; first fetch must fail")
+	assert.Contains(t, ymsg.err.Error(), "default/pod-1",
+		"bulk path must wrap errors with ns/name (single-item path does not)")
+	assert.Equal(t, 0, ymsg.count, "early-return on error keeps count at zero")
+}
+
+// TestCopyYAMLBulkLevelOwnedDispatcherShowsFetchingStatus confirms the
+// dispatcher's "Fetching N manifests..." pre-fetch status applies at
+// LevelOwned the same as LevelResources.
+func TestCopyYAMLBulkLevelOwnedDispatcherShowsFetchingStatus(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelOwned
+	m.toggleSelection(m.middleItems[0])
+	m.toggleSelection(m.middleItems[1])
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage)
+	assert.NotNil(t, cmd)
+}
+
+// TestCopyYAMLLevelContainersIgnoresSelection guards LevelContainers, where
+// the cmd unconditionally fetches the parent Pod's YAML — bulk doesn't
+// apply (containers don't have separate YAML). With selection, the
+// dispatcher must skip the misleading "Fetching N manifests..." status and
+// fall through to the single-pod path silently. Without this gate, a user
+// who multi-selects two containers and presses `Y` sees a "Fetching 2..."
+// toast but the clipboard ends up with the parent Pod's YAML once and the
+// final status flips to "YAML copied" — promising N, delivering 1.
+func TestCopyYAMLLevelContainersIgnoresSelection(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelContainers
+	m.nav.OwnedName = "pod-1"
+	m.middleItems = []model.Item{
+		{Name: "container-1", Kind: "Container", Namespace: "default"},
+		{Name: "container-2", Kind: "Container", Namespace: "default"},
+	}
+	m.toggleSelection(m.middleItems[0])
+	m.toggleSelection(m.middleItems[1])
+
+	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	require.True(t, handled)
+	rm := ret.(Model)
+
+	assert.Empty(t, rm.statusMessage,
+		"LevelContainers does not support bulk; dispatcher must take the cursor branch silently")
+	require.NotNil(t, cmd, "must still dispatch a single-pod fetch")
+
+	ymsg, ok := cmd().(yamlClipboardMsg)
+	require.True(t, ok)
+	assert.Equal(t, 1, ymsg.count, "single-pod fetch must be tagged count=1")
+}


### PR DESCRIPTION
## Summary

`y` and `Y` now operate on multi-selection (newline-joined names / multi-doc YAML), mirroring the precedence pattern used by `D`. Bulk `Y` is capped at 50 manifests to keep the per-item fetch loop under client-go's default rate limiter (QPS=5/Burst=10) within a reasonable wait.

## Type of change

- [x] feat: new user-facing feature

## Related issue

<!-- none -->

## Changes

- `y` with N selected → copies `name1\nname2\n...`, status `Copied N names`.
- `Y` with N selected → multi-doc YAML joined with `---`, status `Copied N manifests to clipboard`.
- Bulk `Y` cap of 50 with `Max 50 exceeded for bulk YAML copy` toast above; `Fetching N manifests...` hint below.
- `n==0` fallthrough in both wrappers and the inner `copyYAMLToClipboard` (selection survives in the raw map but every selected row is filtered out → fall through to cursor).
- `yamlClipboardMsg` gains `count` so the receiver picks the count-aware status; existing single-item paths tagged `count: 1`.
- Docs (`docs/keybindings.md`) updated.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (via pre-commit hook)
- [ ] Manually verified against a real cluster

## Checklist

- [x] Commits follow conventional commit style (`feat:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- N/A -->