### PR TITLE
fix(app): require typed confirmation for action-menu Force Delete

### DIFF
--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -882,19 +882,18 @@ func (m Model) executeActionSimpleLoading(verb string, cmdFn func() tea.Cmd) (te
 	return m, cmdFn()
 }
 
-// executeActionForceDelete handles the "Force Delete" action.
-func (m Model) executeActionForceDelete() (tea.Model, tea.Cmd) {
-	ns := m.actionCtx.namespace
-	name := m.actionCtx.name
-	ctx := m.actionCtx.context
-	rt := m.actionCtx.resourceType
-	nsArg := ""
-	if rt.Namespaced {
-		nsArg = " -n " + ns
-	}
-	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl delete %s %s --grace-period=0 --force%s --context %s", rt.Resource, name, nsArg, ctx))
-	m.loading = true
-	return m, m.forceDeleteResource()
+// executeActionForceDelete handles the "Force Delete" action from the action
+// menu. Mirrors directActionForceDelete and the bulk Force Delete path: opens
+// a typed-confirmation overlay (user must type DELETE + Enter) so a stray
+// x->X cannot nuke a pod without explicit acknowledgement (#89).
+func (m Model) executeActionForceDelete() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
+	m.confirmAction = m.actionCtx.name + " (FORCE)"
+	m.confirmTitle = "Confirm Force Delete"
+	m.confirmQuestion = fmt.Sprintf("Force delete %s? (--force --grace-period=0)", m.actionCtx.name)
+	m.confirmTypeInput.Clear()
+	m.overlay = overlayConfirmType
+	m.pendingAction = "Force Delete"
+	return m, nil
 }
 
 // executeActionForceFinalize handles the "Force Finalize" action.

--- a/internal/app/update_actions_test.go
+++ b/internal/app/update_actions_test.go
@@ -823,11 +823,18 @@ func TestCovExecuteActionDebugMount(t *testing.T) {
 }
 
 func TestCovExecuteActionForceDelete(t *testing.T) {
+	// Regression for #89: action-menu Force Delete must request typed
+	// confirmation, mirroring directActionForceDelete and the bulk path,
+	// so an accidental x->X (or wrong list cursor) cannot nuke a pod.
 	m := testModelExec()
 	result, cmd := m.executeAction("Force Delete")
 	rm := result.(Model)
-	assert.NotNil(t, cmd)
-	assert.True(t, rm.loading)
+	assert.Nil(t, cmd)
+	assert.False(t, rm.loading)
+	assert.Equal(t, overlayConfirmType, rm.overlay)
+	assert.Equal(t, "Force Delete", rm.pendingAction)
+	assert.Contains(t, rm.confirmTitle, "Force Delete")
+	assert.Contains(t, rm.confirmQuestion, "--force --grace-period=0")
 }
 
 func TestCovExecuteActionForceFinalize(t *testing.T) {
@@ -1698,11 +1705,15 @@ func TestFinalExecuteActionConfigMapEditor(t *testing.T) {
 }
 
 func TestFinalExecuteActionForceDelete(t *testing.T) {
+	// Regression for #89: action-menu Force Delete must request typed
+	// confirmation, not fire kubectl delete --force directly.
 	m := baseFinalModel()
 	result, cmd := m.executeAction("Force Delete")
-	require.NotNil(t, cmd)
+	assert.Nil(t, cmd)
 	rm := result.(Model)
-	assert.True(t, rm.loading)
+	assert.False(t, rm.loading)
+	assert.Equal(t, overlayConfirmType, rm.overlay)
+	assert.Equal(t, "Force Delete", rm.pendingAction)
 }
 
 func TestFinalExecuteActionForceFinalize(t *testing.T) {


### PR DESCRIPTION
## Summary

- Closes #89: action-menu Force Delete (`x` → `X` on Pods/Jobs) ran `kubectl delete --force --grace-period=0` immediately, while direct Shift+X and bulk Force Delete both required typing `DELETE` in an `overlayConfirmType` overlay.
- `docs/views-and-overlays.md` already documented `overlayConfirmType` for force delete / force finalize — the implementation was the odd one out.
- Mirror `executeActionForceFinalize`: open `overlayConfirmType` with title "Confirm Force Delete" and a kubectl-flavored question, set `pendingAction = "Force Delete"`, and let the existing `handleConfirmTypeOverlayKey` switch route the confirmed action to `forceDeleteResource()`.

## Behaviour

- `x` → action menu → `X` (Force Delete) → typed-confirmation overlay (must type `DELETE` + Enter) → `kubectl delete --force --grace-period=0`.
- Identical behaviour to direct Shift+X and bulk Force Delete (parity with `executeActionForceFinalize`).
- No keybinding, hint bar, help text, or doc changes required — all already aligned with the typed-confirmation contract.

## Test plan

- [x] `TestCovExecuteActionForceDelete` and `TestFinalExecuteActionForceDelete` rewritten as #89 regression tests (asserted overlayConfirmType / pendingAction / no fired cmd / not loading); RED before the fix, GREEN after.
- [x] `go test -race ./...` (all packages green).
- [x] `make lint` (golangci-lint, 0 issues).
- [x] Manual review against direct path (`directActionForceDelete`) and bulk path (`executeBulkAction("Force Delete")`) — same overlay, same `pendingAction`.