### PR TITLE
fix(app): unify Force Delete help text across menus, dialogs, and docs

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -183,7 +183,7 @@ All keybindings can be overridden. Only specify the keys you want to change -- d
 | `exec` | `s` | Exec into container (action menu only) |
 | `describe` | `v` | Describe selected resource |
 | `delete` | `D` | Delete resource (force delete Pod/Job if already deleting) |
-| `force_delete` | `X` | Force delete with --grace-period=0 (Pod/Job only) |
+| `force_delete` | `X` | Force delete (Pod/Job only) |
 | `scale` | `S` | Scale resource (deployments, statefulsets, daemonsets) |
 | `edit` | `E` | Edit selected resource in $EDITOR |
 | `label_editor` | `i` | Edit labels/annotations |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -81,7 +81,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `R` | Refresh current view | `refresh` |
 | `v` | Describe selected resource | `describe` |
 | `D` | Delete resource (force delete Pod/Job if already deleting, force finalize others) | `delete` |
-| `X` | Force delete with grace-period=0 (Pod/Job only) | `force_delete` |
+| `X` | Force delete (Pod/Job only) | `force_delete` |
 | `S` | Scale / Export resource YAML to file | `scale` / `save_resource` |
 | `Ctrl+O` | Open ingress host in browser | `open_browser` |
 | `i` | Edit labels/annotations | `label_editor` |

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -114,7 +114,7 @@ func (m Model) openActionMenu() Model {
 			if item.Name == "Delete" {
 				if model.IsForceDeleteableKind(kind) {
 					items[i].Name = "Force Delete"
-					items[i].Extra = "Force delete (--force --grace-period=0)"
+					items[i].Extra = "Force delete this " + strings.ToLower(kind)
 				} else {
 					items[i].Name = "Force Finalize"
 					items[i].Extra = "Remove finalizers to force finalize"
@@ -238,10 +238,10 @@ func (m Model) directActionDelete() (tea.Model, tea.Cmd) {
 		m.confirmTypeInput.Clear()
 		m.overlay = overlayConfirmType
 		if model.IsForceDeleteableKind(kind) {
-			// Pod/Job: offer force delete (--force --grace-period=0).
+			// Pod/Job: offer force delete.
 			m.confirmAction = sel.Name + " (FORCE)"
 			m.confirmTitle = "Confirm Force Delete"
-			m.confirmQuestion = fmt.Sprintf("Force delete %s? (--force --grace-period=0)", sel.Name)
+			m.confirmQuestion = fmt.Sprintf("Force delete %s?", sel.Name)
 			m.pendingAction = "Force Delete"
 		} else {
 			// Other kinds: offer force finalize (remove finalizers).
@@ -889,7 +889,7 @@ func (m Model) executeActionSimpleLoading(verb string, cmdFn func() tea.Cmd) (te
 func (m Model) executeActionForceDelete() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
 	m.confirmAction = m.actionCtx.name + " (FORCE)"
 	m.confirmTitle = "Confirm Force Delete"
-	m.confirmQuestion = fmt.Sprintf("Force delete %s? (--force --grace-period=0)", m.actionCtx.name)
+	m.confirmQuestion = fmt.Sprintf("Force delete %s?", m.actionCtx.name)
 	m.confirmTypeInput.Clear()
 	m.overlay = overlayConfirmType
 	m.pendingAction = "Force Delete"

--- a/internal/app/update_actions_test.go
+++ b/internal/app/update_actions_test.go
@@ -29,7 +29,7 @@ func TestDirectActionDelete_DeletingPod_ForceDeletes(t *testing.T) {
 	assert.Equal(t, overlayConfirmType, result.overlay)
 	assert.Equal(t, "Force Delete", result.pendingAction)
 	assert.Contains(t, result.confirmTitle, "Force Delete")
-	assert.Contains(t, result.confirmQuestion, "--force --grace-period=0")
+	assert.Contains(t, result.confirmQuestion, "Force delete stuck-pod")
 }
 
 func TestDirectActionDelete_DeletingDeployment_ForceFinalize(t *testing.T) {
@@ -108,7 +108,7 @@ func TestOpenActionMenu_DeletingPod_ShowsForceDelete(t *testing.T) {
 	for _, item := range result.overlayItems {
 		if item.Name == "Force Delete" {
 			found = true
-			assert.Contains(t, item.Extra, "--force --grace-period=0")
+			assert.Contains(t, item.Extra, "Force delete this pod")
 			break
 		}
 	}
@@ -834,7 +834,7 @@ func TestCovExecuteActionForceDelete(t *testing.T) {
 	assert.Equal(t, overlayConfirmType, rm.overlay)
 	assert.Equal(t, "Force Delete", rm.pendingAction)
 	assert.Contains(t, rm.confirmTitle, "Force Delete")
-	assert.Contains(t, rm.confirmQuestion, "--force --grace-period=0")
+	assert.Contains(t, rm.confirmQuestion, "Force delete")
 }
 
 func TestCovExecuteActionForceFinalize(t *testing.T) {

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -75,7 +75,7 @@ func actionsForCoreKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this pod", Key: "D"},
-			{Label: "Force Delete", Description: "Force delete this pod (grace-period=0)", Key: "X"},
+			{Label: "Force Delete", Description: "Force delete this pod", Key: "X"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true
 	case "Node":
@@ -236,7 +236,7 @@ func actionsForWorkloadKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this job", Key: "D"},
-			{Label: "Force Delete", Description: "Force delete this job (grace-period=0)", Key: "X"},
+			{Label: "Force Delete", Description: "Force delete this job", Key: "X"},
 			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in namespace", Key: "b"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true

--- a/internal/model/actions_force_delete_test.go
+++ b/internal/model/actions_force_delete_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForceDeleteHotkeyConsistency verifies that every "Force Delete" entry
+// across the action-menu variants uses the same hotkey ("X") and a
+// description that follows the same "Force delete..." prefix convention as
+// the regular "Delete" entries. The point of this test is to prevent the
+// re-introduction of inconsistent help texts (#issue: "Force delete hotkeys
+// are showing different help texts").
+func TestForceDeleteHotkeyConsistency(t *testing.T) {
+	tests := []struct {
+		name        string
+		items       []ActionMenuItem
+		wantPrefix  string
+		wantNoFlags bool // descriptions must not leak kubectl flags
+	}{
+		{name: "Pod", items: ActionsForKind("Pod"), wantPrefix: "Force delete this pod"},
+		{name: "Job", items: ActionsForKind("Job"), wantPrefix: "Force delete this job"},
+		{name: "Bulk", items: ActionsForBulk(""), wantPrefix: "Force delete selected resources"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			item, ok := findAction(tc.items, "Force Delete")
+			require.True(t, ok, "%s actions must include Force Delete", tc.name)
+			assert.Equal(t, "X", item.Key, "Force Delete must be on key X")
+			assert.True(t,
+				strings.HasPrefix(item.Description, tc.wantPrefix),
+				"%s Force Delete description must start with %q, got %q",
+				tc.name, tc.wantPrefix, item.Description)
+			assert.NotContains(t, item.Description, "--force",
+				"description must not leak kubectl flags")
+			assert.NotContains(t, item.Description, "grace-period",
+				"description must not leak kubectl flags")
+		})
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -106,7 +106,7 @@ func helpSections() []helpSection {
 				{kb.Refresh, "Refresh current view"},
 				{kb.Describe, "Describe selected resource"},
 				{kb.Delete, "Delete (force delete Pod/Job if already deleting, force finalize others)"},
-				{kb.ForceDelete, "Force delete (grace-period=0, Pod/Job only)"},
+				{kb.ForceDelete, "Force delete (Pod/Job only)"},
 				{helpKeyDisplay(kb.FinalizerSearch), "Finalizer search and remove (scan, select, remove finalizers)"},
 				{kb.JumpOwner, "Jump to owner/controller of selected resource"},
 				{kb.CopyName, "Copy resource name to clipboard"},


### PR DESCRIPTION
## Summary

The `Force Delete` (X) action surfaced **six different descriptions** across the per-kind menus, bulk menu, escalated Delete-on-Deleting menu, top-level help screen, and docs — variations like ` (grace-period=0)`, ` (--force --grace-period=0)`, ` with grace-period=0 (Pod/Job only)`, or no qualifier at all. Confirm dialogs were similarly inconsistent (some included the kubectl flags, others didn't).

This PR drops the kubectl flags from user-facing strings (they remain on the actual kubectl invocations) and standardizes on:

| Surface | Text |
|---|---|
| Per-kind menu (Pod / Job) | `Force delete this pod` / `Force delete this job` |
| Bulk action menu | `Force delete selected resources` |
| Escalated Delete-on-Deleting menu | `Force delete this <kind>` (lower-cased) |
| Top-level help (`?`) | `Force delete (Pod/Job only)` |
| `docs/keybindings.md` / `docs/config-reference.md` | `Force delete (Pod/Job only)` |
| All confirm dialogs (single + bulk) | `Force delete <name>?` / `Force delete N resources?` |

## Test plan

- [x] `go test -race ./internal/model/ ./internal/ui/ ./internal/app/` passes
- [x] New regression `internal/model/actions_force_delete_test.go` pins the canonical prefix and forbids `--force` / `grace-period` from leaking back into descriptions
- [x] Updated three existing tests in `update_actions_test.go` that pinned the old flag-bearing text
- [x] Manual: open action menu on a Pod, on a Job, in bulk-mode, and on a Pod that's already terminating — confirm all four show consistent `Force delete ...` extras
- [x] Manual: press `X` on a Pod and confirm dialog reads `Force delete <name>?`
- [x] Manual: open `?` help and confirm `X` row reads `Force delete (Pod/Job only)`