### PR TITLE
fix(ui): widen Quick Filters overlay and clean up selected row

### DIFF
--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -480,7 +480,10 @@ func (m Model) renderOverlayFilterPreset() (string, int, int) {
 	for i, p := range m.filterPresets {
 		entries[i] = ui.FilterPresetEntry{Name: p.Name, Description: p.Description, Key: p.Key}
 	}
-	return ui.RenderFilterPresetOverlay(entries, m.overlayCursor, activePresetName), min(55, m.width-10), min(15, m.height-6)
+	overlayW := min(72, m.width-10)
+	// OverlayStyle reserves 4 cells horizontally for Padding(1, 2).
+	contentW := max(overlayW-4, 0)
+	return ui.RenderFilterPresetOverlay(entries, m.overlayCursor, activePresetName, contentW), overlayW, min(15, m.height-6)
 }
 
 func (m Model) renderOverlayRBAC() (string, int, int) {

--- a/internal/ui/overlay_monitoring.go
+++ b/internal/ui/overlay_monitoring.go
@@ -315,7 +315,9 @@ func RenderColorschemeOverlay(entries []SchemeEntry, filter string, cursor int, 
 
 // RenderFilterPresetOverlay renders the quick filter preset selection overlay content.
 // activePresetName is the name of the currently active preset (empty if none).
-func RenderFilterPresetOverlay(presets []FilterPresetEntry, cursor int, activePresetName string) string {
+// width is the inner content width used to pad the cursor row so the
+// selection background spans the entire line.
+func RenderFilterPresetOverlay(presets []FilterPresetEntry, cursor int, activePresetName string, width int) string {
 	var b strings.Builder
 	b.WriteString(OverlayTitleStyle.Render("Quick Filters"))
 	b.WriteString("\n\n")
@@ -326,15 +328,24 @@ func RenderFilterPresetOverlay(presets []FilterPresetEntry, cursor int, activePr
 	}
 
 	for i, preset := range presets {
-		keyHint := OverlayFilterStyle.Render("[" + preset.Key + "]")
-		activeMarker := "  "
-		if preset.Name == activePresetName {
-			activeMarker = OverlayFilterStyle.Render("\u2713 ")
-		}
-		line := fmt.Sprintf("  %s%s %s  %s", activeMarker, keyHint, preset.Name, OverlayDimStyle.Render(preset.Description))
 		if i == cursor {
-			b.WriteString(OverlaySelectedStyle.Render(line))
+			// Selected row: render as plain text with a single uniform
+			// style so the highlight background covers the whole line
+			// (embedded styles would otherwise punch holes in the
+			// selection background).
+			activeMarker := "  "
+			if preset.Name == activePresetName {
+				activeMarker = "\u2713 "
+			}
+			line := fmt.Sprintf("  %s[%s] %s  %s", activeMarker, preset.Key, preset.Name, preset.Description)
+			b.WriteString(OverlaySelectedStyle.Width(width).Render(line))
 		} else {
+			keyHint := OverlayFilterStyle.Render("[" + preset.Key + "]")
+			activeMarker := "  "
+			if preset.Name == activePresetName {
+				activeMarker = OverlayFilterStyle.Render("\u2713 ")
+			}
+			line := fmt.Sprintf("  %s%s %s  %s", activeMarker, keyHint, preset.Name, OverlayDimStyle.Render(preset.Description))
 			b.WriteString(OverlayNormalStyle.Render(line))
 		}
 		if i < len(presets)-1 {

--- a/internal/ui/overlay_monitoring_extra_test.go
+++ b/internal/ui/overlay_monitoring_extra_test.go
@@ -1,17 +1,21 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 )
 
 // --- RenderFilterPresetOverlay ---
 
 func TestRenderFilterPresetOverlay(t *testing.T) {
+	const w = 60
+
 	t.Run("empty presets shows message", func(t *testing.T) {
-		result := RenderFilterPresetOverlay(nil, 0, "")
+		result := RenderFilterPresetOverlay(nil, 0, "", w)
 		assert.Contains(t, result, "Quick Filters")
 		assert.Contains(t, result, "No filter presets available")
 	})
@@ -21,7 +25,7 @@ func TestRenderFilterPresetOverlay(t *testing.T) {
 			{Name: "Running", Description: "Show running pods", Key: "r"},
 			{Name: "Failed", Description: "Show failed pods", Key: "f"},
 		}
-		result := RenderFilterPresetOverlay(presets, 0, "")
+		result := RenderFilterPresetOverlay(presets, 0, "", w)
 		assert.Contains(t, result, "Quick Filters")
 		assert.Contains(t, result, "Running")
 		assert.Contains(t, result, "Show running pods")
@@ -35,7 +39,7 @@ func TestRenderFilterPresetOverlay(t *testing.T) {
 			{Name: "A", Description: "desc a", Key: "a"},
 			{Name: "B", Description: "desc b", Key: "b"},
 		}
-		result := RenderFilterPresetOverlay(presets, 1, "")
+		result := RenderFilterPresetOverlay(presets, 1, "", w)
 		assert.Contains(t, result, "B")
 	})
 
@@ -43,7 +47,7 @@ func TestRenderFilterPresetOverlay(t *testing.T) {
 		presets := []FilterPresetEntry{
 			{Name: "Running", Description: "desc", Key: "r"},
 		}
-		result := RenderFilterPresetOverlay(presets, 0, "Running")
+		result := RenderFilterPresetOverlay(presets, 0, "Running", w)
 		assert.Contains(t, result, "\u2713")
 	})
 
@@ -51,7 +55,7 @@ func TestRenderFilterPresetOverlay(t *testing.T) {
 		presets := []FilterPresetEntry{
 			{Name: "Running", Description: "desc", Key: "r"},
 		}
-		result := RenderFilterPresetOverlay(presets, 0, "Other")
+		result := RenderFilterPresetOverlay(presets, 0, "Other", w)
 		// The check mark should not appear for the Running preset.
 		assert.NotContains(t, result, "\u2713 ")
 	})
@@ -59,9 +63,50 @@ func TestRenderFilterPresetOverlay(t *testing.T) {
 	t.Run("footer hints removed from overlay body", func(t *testing.T) {
 		// Hints now live in the main status bar, not inline.
 		presets := []FilterPresetEntry{{Name: "P", Description: "d", Key: "p"}}
-		result := RenderFilterPresetOverlay(presets, 0, "")
+		result := RenderFilterPresetOverlay(presets, 0, "", w)
 		assert.NotContains(t, result, "enter: apply")
 		assert.NotContains(t, result, "esc: close")
+	})
+
+	t.Run("selected row visible width matches inner width", func(t *testing.T) {
+		// Cursor row should be padded to the full content width so the
+		// selected background extends across the entire row, not just
+		// the text segments.
+		presets := []FilterPresetEntry{
+			{Name: "Short", Description: "x", Key: "s"},
+		}
+		result := RenderFilterPresetOverlay(presets, 0, "", w)
+		var line string
+		for l := range strings.SplitSeq(result, "\n") {
+			if strings.Contains(l, "Short") {
+				line = l
+				break
+			}
+		}
+		assert.NotEmpty(t, line, "expected to find selected line")
+		assert.Equal(t, w, lipgloss.Width(line),
+			"selected row should be padded to full content width")
+	})
+
+	t.Run("non-selected row keeps short visible width", func(t *testing.T) {
+		// Non-selected rows are not padded, so embedded styling
+		// (filter color on key, dim color on description) is preserved
+		// without forcing a full-width background.
+		presets := []FilterPresetEntry{
+			{Name: "Short", Description: "x", Key: "s"},
+			{Name: "Other", Description: "y", Key: "o"},
+		}
+		result := RenderFilterPresetOverlay(presets, 0, "", w)
+		var nonSelected string
+		for l := range strings.SplitSeq(result, "\n") {
+			if strings.Contains(l, "Other") {
+				nonSelected = l
+				break
+			}
+		}
+		assert.NotEmpty(t, nonSelected)
+		assert.Less(t, lipgloss.Width(nonSelected), w,
+			"non-selected row should not be padded to full width")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Bumps the Quick Filters overlay outer width cap from 55 → 72 so descriptions like `CrashLoop / Error / ImagePull / OOMKilled` no longer wrap.
- Renders the cursor row as plain text inside a single `OverlaySelectedStyle.Width(width)` so the selection background covers the whole row instead of being broken up by embedded filter/dim ANSI escapes.
- Non-cursor rows still keep the colored `[k]` key hint and dim description for visual hierarchy.

## What changed

- `internal/app/view_status.go` — widen `overlayW` to `min(72, m.width-10)`, compute inner `contentW = overlayW - 4` (for `OverlayStyle.Padding(1, 2)`), and pass it to the renderer.
- `internal/ui/overlay_monitoring.go` — `RenderFilterPresetOverlay` now takes a `width int`; selected row is built as plain text and styled with `OverlaySelectedStyle.Width(width)` for a uniform highlight.
- `internal/ui/overlay_monitoring_extra_test.go` — updated existing tests to the new signature; added two assertions verifying the selected row is padded to the inner width while non-selected rows are not.

## Test plan

- [x] `go test ./internal/ui/... ./internal/app/... -race -count=1`
- [x] `go build ./...`
- [x] golangci-lint pre-commit hook passes
- [x] **Manual TUI verification**: open the Quick Filters overlay (default \`Ctrl-F\` / preset hotkey) and confirm:
  - [x] No description text wraps to a second line.
  - [x] Cursor selection background extends uniformly across the entire row, no "holes" around \`[k]\` or the description.
  - [x] Active preset still shows the ✓ marker on both selected and non-selected rows.

## Screenshots

_Reporter description of the bug:_
\`\`\`
Quick Filters
    [f] Failing  CrashLoop / Error / ImagePull / OO
MKilled
    [p] Pending  Pending / ContainerCreating / Term
inating
\`\`\`