### PR TITLE
feat(k8s): cache resource lists via shared informer (closes #86)

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -350,3 +350,15 @@ confirm_on_exit: true
 # Override with the --watch-interval CLI flag.
 # Default: 2s
 # watch_interval: 2s
+
+# ─── Informer Cache ───────────────────────────────────────────────────────────
+# How resource list calls are routed:
+#   "off"     - round-trip every list to the API server (matches kubectl).
+#   "auto"    - default; per resource type, start in direct-list mode and
+#               promote to a shared informer once a list returns >= 1000
+#               items. Demote back to direct lists when the cached size
+#               stays below 500 for three consecutive calls. Recommended.
+#   "always"  - open a watch eagerly on first use of each resource type.
+# Legacy bool form: true → "always", false → "off".
+# Default: auto
+# informer_cache: auto

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -31,6 +31,7 @@ The configuration file is located at `~/.config/lfk/config.yaml`. All fields are
 | `read_only` | bool | `false` | Disable all mutating actions (delete, edit, scale, restart, exec, port-forward, drain, cordon, etc.) globally. Per-context overrides under `clusters.<name>.read_only` and the `--read-only` CLI flag take precedence. See [Read-Only Mode](usage.md#read-only-mode). |
 | `clusters.<name>.read_only` | bool | _(unset)_ | Per-context read-only override. Wins over the global `read_only` so you can mark specific clusters (e.g. `prod`) read-only while leaving others mutable. |
 | `secret_lazy_loading` | bool | `false` | When `true`, Secret listing fetches metadata only and decoded values load on hover. Much faster in clusters with many Helm release secrets (each release is a multi-hundred-KB Secret) or large TLS payloads, at the cost of an extra GET per hovered Secret. When `false` (default), Secrets list like every other resource type — full objects are pulled and `data` is eagerly decoded, so the Type column and decoded values are visible immediately. See [Secret lazy loading](#secret-lazy-loading) for trade-offs. |
+| `informer_cache` | bool or string | `auto` | Selects the list strategy. Accepts `off` (round-trip every list — matches kubectl), `auto` (default; promote a resource type to a shared informer once a list crosses 1000 items, demote when sustained below 500), and `always` (open a watch eagerly on first use). Legacy bool form is still accepted: `true` → `always`, `false` → `off`. See [Informer cache](#informer-cache) for trade-offs. |
 | `min_contrast_ratio` | float | `0.0` | Normalized readability knob in `[0.0, 1.0]`. When above zero, foreground colors are nudged in HSL lightness space to meet a minimum WCAG contrast ratio against their paired background. See [Minimum Contrast Ratio](#minimum-contrast-ratio). |
 
 ### Auto dark/light mode
@@ -427,6 +428,63 @@ this option is designed to fix.
 
 ```yaml
 secret_lazy_loading: true
+```
+
+## Informer cache
+
+Without the cache, every navigation event in the resource list — drill-in,
+namespace switch, watch tick, `shift+r` refresh — issues a fresh `LIST`
+against the API server. On large clusters this becomes visible: a 7k-pod
+list takes 1–2 seconds to round-trip, and switching the namespace filter
+re-pays that cost every time even though filtering is conceptually a
+client-side operation against an already-known list (issue #86).
+
+The `informer_cache` knob has three modes:
+
+- **`off`** — every list round-trips to the API server, matching kubectl
+  semantics. Pick this when the apiserver is sensitive to extra watch
+  connections or when you are debugging server-side behaviour.
+- **`auto`** (default) — start in `off` mode per `(context, resource type)`,
+  but the moment a list returns ≥ 1000 items, promote that resource type
+  to a [shared informer](https://pkg.go.dev/k8s.io/client-go/dynamic/dynamicinformer).
+  Subsequent lists for that resource type — including namespace switches —
+  are served from the in-memory index. Once cached size has stayed below
+  500 for three consecutive cached calls, the watch is closed and the
+  resource type goes back to direct lists. Hysteresis between the promote
+  (1000) and demote (500) thresholds prevents flapping when a list size
+  hovers near the edge.
+- **`always`** — every resource type starts a watch on first use,
+  regardless of size. Use when you know the cluster is large and want to
+  skip the one-time direct list before promotion.
+
+Promoted resource types serve namespace switches as in-memory walks; the
+watch keeps the cache fresh so deleted pods drop out and `Age` advances on
+the next render even though we never re-issue a `LIST`.
+
+### Trade-offs
+
+| | `off` | `auto` (default) | `always` |
+|---|---|---|---|
+| Namespace switch on 7k-pod list | 1–2 s API round trip | In-process walk (after first list) | In-process walk (after first list) |
+| API server load (small clusters) | One LIST per nav | One LIST per nav (never promoted) | One LIST + one watch per opened type |
+| API server load (large clusters) | One LIST per nav | One initial LIST then one watch per promoted type | Same as `auto` |
+| Memory in lfk | View only | Cached objects for promoted types | Cached objects for every opened type |
+| One-off large list strands a watch | n/a | No (auto-demote closes it) | Yes (until shutdown) |
+
+The legacy bool form is still accepted for backward compatibility:
+
+- `informer_cache: true` is treated as `always`.
+- `informer_cache: false` is treated as `off`.
+
+```yaml
+# Default — adapts per resource type without configuration:
+informer_cache: auto
+
+# Force everything through informers:
+# informer_cache: always
+
+# Disable entirely (kubectl-equivalent semantics):
+# informer_cache: off
 ```
 
 ## Minimum Contrast Ratio

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -92,12 +92,62 @@ type Client struct {
 	// across different contexts.
 	discoveryMu      sync.Mutex
 	discoveryClients map[string]*disk.CachedDiscoveryClient
+
+	// informerMode selects the routing strategy for GetResources. See
+	// InformerCacheMode for the three values; default (zero value "") is
+	// treated as InformerCacheAuto so users get the issue #86 win without
+	// any config change.
+	informerMode InformerCacheMode
+	// informers is built lazily the first time the mode resolves to
+	// anything other than InformerCacheOff. Stays nil for tests that do not
+	// touch the cache, keeping the existing fake-client surface unchanged.
+	informers *informerCache
 }
 
 // SetSecretLazyLoading toggles the metadata-only list path for Secrets.
 // Typically called once at startup after loading the config file.
 func (c *Client) SetSecretLazyLoading(enabled bool) {
 	c.secretLazyLoading = enabled
+}
+
+// SetInformerCacheMode selects how GetResources routes its list requests.
+// See InformerCacheMode for the three values: off, auto, and always. Unknown
+// values fall back to auto — that's the safest default because auto-mode
+// stays out of the way until a list is actually large.
+//
+// The mode argument is normalized (trimmed + lower-cased) before matching,
+// so callers passing "Always" or "  off " resolve to the same modes the
+// YAML unmarshaler accepts. Without that, programmatic callers would get
+// silently dropped to the auto fallback on a casing mismatch.
+//
+// Issue #86: on a 7k-pod cluster the cached path turns each namespace switch
+// from a 1–2s round trip into an in-process slice walk. Auto-mode promotes
+// to the cache automatically once a list crosses 1000 items, and demotes
+// back to a direct list (closing the watch) after three consecutive cached
+// lists fall below 500. The hysteresis prevents flapping when a list size
+// hovers near the threshold.
+//
+// Typically called once at startup after loading the config file.
+func (c *Client) SetInformerCacheMode(mode InformerCacheMode) {
+	normalized := InformerCacheMode(strings.ToLower(strings.TrimSpace(string(mode))))
+	switch normalized {
+	case InformerCacheOff, InformerCacheAuto, InformerCacheAlways:
+		c.informerMode = normalized
+	default:
+		c.informerMode = InformerCacheAuto
+	}
+	if c.informerMode != InformerCacheOff && c.informers == nil {
+		c.informers = newInformerCache(c.dynamicForContext)
+	}
+}
+
+// Shutdown closes any background watches the client started (informer cache,
+// future stream subscribers). Idempotent and safe to call from a defer in
+// main.go even when no informers were ever started.
+func (c *Client) Shutdown() {
+	if c.informers != nil {
+		c.informers.Stop()
+	}
 }
 
 // RBACCheck represents a single permission check result.
@@ -582,15 +632,40 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 		return c.listSecretsMetadata(ctx, contextName, namespace, rt)
 	}
 
-	dynClient, err := c.dynamicForContext(contextName)
-	if err != nil {
-		return nil, err
-	}
-
 	gvr := schema.GroupVersionResource{
 		Group:    rt.APIGroup,
 		Version:  rt.APIVersion,
 		Resource: rt.Resource,
+	}
+
+	// Issue #86: route through the informer cache when it makes sense.
+	// "always" forces every list through the cache; "auto" promotes a
+	// (context, GVR) on the first large list and demotes it back to direct
+	// once cached size has stayed below the demote threshold for several
+	// calls. Cache miss (sync timeout) falls through to the direct path so
+	// the UI always gets a result.
+	//
+	// listItems memoizes per-item by namespace/name + the object's own
+	// resourceVersion: items unchanged since the last call are reused
+	// without re-running buildResourceItem or copying anything. On a
+	// busy cluster only the few churning pods rebuild; the rest hit the
+	// memo. That's what removes the residual ~300ms per-call cost on a
+	// 6k-pod list when the cluster has background churn.
+	if c.cacheEnabled() && c.shouldUseCache(contextName, gvr) {
+		build := func(obj *unstructured.Unstructured) model.Item {
+			return c.buildResourceItem(obj, &rt)
+		}
+		items, _, cerr := c.informers.listItems(ctx, contextName, gvr, namespace, build)
+		if cerr == nil {
+			items = sortResourceItems(items, rt.Kind)
+			c.informers.observeCachedListSize(contextName, gvr, len(items))
+			return items, nil
+		}
+	}
+
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return nil, err
 	}
 
 	var lister dynamic.ResourceInterface
@@ -606,21 +681,53 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	}
 
 	items := make([]model.Item, 0, len(list.Items))
-	for _, item := range list.Items {
-		ti := c.buildResourceItem(&item, &rt)
+	for i := range list.Items {
+		ti := c.buildResourceItem(&list.Items[i], &rt)
 		items = append(items, ti)
 	}
-	// Sort events by most recent observation first (LastSeen, not CreatedAt).
-	// CreatedAt holds the firstTimestamp — sorting on it would push recurring
-	// incidents to the bottom even when their latest report is the freshest
-	// thing in the list. Users expect "what happened most recently" at the top.
-	// All other resources sort alphabetically by name.
-	if rt.Kind == "Event" {
+
+	// Auto-mode promotion fires after the direct list, when we know the
+	// observed result size. Crossing the threshold flips the (context, GVR)
+	// to cache-backed for the *next* GetResources call, which is what makes
+	// subsequent namespace switches on a 7k-pod list feel instant.
+	if c.informerMode == InformerCacheAuto && c.informers != nil {
+		c.informers.observeDirectListSize(contextName, gvr, len(items))
+	}
+	return sortResourceItems(items, rt.Kind), nil
+}
+
+// cacheEnabled reports whether the informer cache is wired up at all. False
+// in InformerCacheOff or when SetInformerCacheMode has not been called.
+func (c *Client) cacheEnabled() bool {
+	return c.informers != nil && c.informerMode != InformerCacheOff
+}
+
+// shouldUseCache decides — for the current call — whether to take the
+// informer-backed path or fall through to a direct list. Always-mode
+// short-circuits to true; auto-mode consults the per-(context, GVR) state
+// machine maintained by observeDirectListSize / observeCachedListSize.
+func (c *Client) shouldUseCache(contextName string, gvr schema.GroupVersionResource) bool {
+	if c.informerMode == InformerCacheAlways {
+		return true
+	}
+	if c.informerMode == InformerCacheAuto {
+		return c.informers.isPromoted(contextName, gvr)
+	}
+	return false
+}
+
+// sortResourceItems applies the canonical row order GetResources uses
+// regardless of whether the items came from a fresh apiserver LIST or from
+// the informer cache. Events sort by most recent observation (LastSeen, not
+// CreatedAt) so a recurring incident's latest report stays on top; everything
+// else sorts alphabetically by Name.
+func sortResourceItems(items []model.Item, kind string) []model.Item {
+	if kind == "Event" {
 		sort.Slice(items, func(i, j int) bool { return items[i].LastSeen.After(items[j].LastSeen) })
 	} else {
 		sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
 	}
-	return items, nil
+	return items
 }
 
 // listSecretsMetadata fetches the Secret list using the metadata-only API,

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -93,15 +93,31 @@ type Client struct {
 	discoveryMu      sync.Mutex
 	discoveryClients map[string]*disk.CachedDiscoveryClient
 
+	// informerMu guards informerMode + informers. Writes happen at most
+	// once (SetInformerCacheMode at startup); reads happen on every
+	// GetResources. RWMutex is overkill for the call rate but documents
+	// the intent — and a future runtime config-reload path can flip the
+	// mode safely without retrofitting synchronization across callers.
+	informerMu sync.RWMutex
 	// informerMode selects the routing strategy for GetResources. See
 	// InformerCacheMode for the three values; default (zero value "") is
 	// treated as InformerCacheAuto so users get the issue #86 win without
-	// any config change.
+	// any config change. Read via informerSnapshot.
 	informerMode InformerCacheMode
 	// informers is built lazily the first time the mode resolves to
 	// anything other than InformerCacheOff. Stays nil for tests that do not
 	// touch the cache, keeping the existing fake-client surface unchanged.
+	// Read via informerSnapshot.
 	informers *informerCache
+}
+
+// informerSnapshot returns the current routing config as a single
+// consistent pair so callers don't observe a half-updated state if a
+// future SetInformerCacheMode lands between reads.
+func (c *Client) informerSnapshot() (InformerCacheMode, *informerCache) {
+	c.informerMu.RLock()
+	defer c.informerMu.RUnlock()
+	return c.informerMode, c.informers
 }
 
 // SetSecretLazyLoading toggles the metadata-only list path for Secrets.
@@ -127,9 +143,12 @@ func (c *Client) SetSecretLazyLoading(enabled bool) {
 // lists fall below 500. The hysteresis prevents flapping when a list size
 // hovers near the threshold.
 //
-// Typically called once at startup after loading the config file.
+// Typically called once at startup after loading the config file. Safe
+// to call concurrently with GetResources thanks to informerMu.
 func (c *Client) SetInformerCacheMode(mode InformerCacheMode) {
 	normalized := InformerCacheMode(strings.ToLower(strings.TrimSpace(string(mode))))
+	c.informerMu.Lock()
+	defer c.informerMu.Unlock()
 	switch normalized {
 	case InformerCacheOff, InformerCacheAuto, InformerCacheAlways:
 		c.informerMode = normalized
@@ -145,8 +164,9 @@ func (c *Client) SetInformerCacheMode(mode InformerCacheMode) {
 // future stream subscribers). Idempotent and safe to call from a defer in
 // main.go even when no informers were ever started.
 func (c *Client) Shutdown() {
-	if c.informers != nil {
-		c.informers.Stop()
+	_, infs := c.informerSnapshot()
+	if infs != nil {
+		infs.Stop()
 	}
 }
 
@@ -651,14 +671,15 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	// busy cluster only the few churning pods rebuild; the rest hit the
 	// memo. That's what removes the residual ~300ms per-call cost on a
 	// 6k-pod list when the cluster has background churn.
-	if c.cacheEnabled() && c.shouldUseCache(contextName, gvr) {
+	mode, infs := c.informerSnapshot()
+	if cacheEnabled(mode, infs) && shouldUseCache(mode, infs, contextName, gvr) {
 		build := func(obj *unstructured.Unstructured) model.Item {
 			return c.buildResourceItem(obj, &rt)
 		}
-		items, _, cerr := c.informers.listItems(ctx, contextName, gvr, namespace, build)
+		items, _, cerr := infs.listItems(ctx, contextName, gvr, namespace, build)
 		if cerr == nil {
 			items = sortResourceItems(items, rt.Kind)
-			c.informers.observeCachedListSize(contextName, gvr, len(items))
+			infs.observeCachedListSize(contextName, gvr, len(items))
 			return items, nil
 		}
 	}
@@ -690,28 +711,30 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	// observed result size. Crossing the threshold flips the (context, GVR)
 	// to cache-backed for the *next* GetResources call, which is what makes
 	// subsequent namespace switches on a 7k-pod list feel instant.
-	if c.informerMode == InformerCacheAuto && c.informers != nil {
-		c.informers.observeDirectListSize(contextName, gvr, len(items))
+	if mode == InformerCacheAuto && infs != nil {
+		infs.observeDirectListSize(contextName, gvr, len(items))
 	}
 	return sortResourceItems(items, rt.Kind), nil
 }
 
 // cacheEnabled reports whether the informer cache is wired up at all. False
 // in InformerCacheOff or when SetInformerCacheMode has not been called.
-func (c *Client) cacheEnabled() bool {
-	return c.informers != nil && c.informerMode != InformerCacheOff
+// Pure helper on a snapshot — callers must already have taken
+// informerSnapshot so the mode + pointer are consistent.
+func cacheEnabled(mode InformerCacheMode, infs *informerCache) bool {
+	return infs != nil && mode != InformerCacheOff
 }
 
 // shouldUseCache decides — for the current call — whether to take the
 // informer-backed path or fall through to a direct list. Always-mode
 // short-circuits to true; auto-mode consults the per-(context, GVR) state
 // machine maintained by observeDirectListSize / observeCachedListSize.
-func (c *Client) shouldUseCache(contextName string, gvr schema.GroupVersionResource) bool {
-	if c.informerMode == InformerCacheAlways {
+func shouldUseCache(mode InformerCacheMode, infs *informerCache, contextName string, gvr schema.GroupVersionResource) bool {
+	if mode == InformerCacheAlways {
 		return true
 	}
-	if c.informerMode == InformerCacheAuto {
-		return c.informers.isPromoted(contextName, gvr)
+	if mode == InformerCacheAuto {
+		return infs.isPromoted(contextName, gvr)
 	}
 	return false
 }

--- a/internal/k8s/informer_cache.go
+++ b/internal/k8s/informer_cache.go
@@ -25,12 +25,14 @@ import (
 // new information beyond what the watch already delivers.
 const informerResyncPeriod = time.Duration(0)
 
-// initialSyncTimeout caps how long the first GetResources call after enabling
-// the cache will block waiting for the informer's initial LIST to complete.
-// On a sluggish API server this prevents the UI from hanging indefinitely on
-// the first namespace switch — instead we fall back to a direct list and try
-// the cache again on the next request, by which time it has typically synced.
-const initialSyncTimeout = 30 * time.Second
+// defaultInitialSyncTimeout caps how long the first GetResources call after
+// enabling the cache will block waiting for the informer's initial LIST to
+// complete. On a sluggish API server this prevents the UI from hanging
+// indefinitely on the first namespace switch — instead we fall back to a
+// direct list and try the cache again on the next request, by which time it
+// has typically synced. Stored on informerCache so tests can dial it down
+// without hard-coding a long sleep into the suite.
+const defaultInitialSyncTimeout = 30 * time.Second
 
 // InformerCacheMode controls how GetResources is routed: never use the cache,
 // always use it, or auto-promote to it on large lists and auto-demote back
@@ -134,6 +136,12 @@ type informerCache struct {
 	demoteBelow  int
 	demoteAfterN int
 
+	// initialSyncTimeout is the wall-clock cap waitForSync enforces on the
+	// first list per (context, GVR). Tests dial it down to milliseconds so
+	// the timeout-fallback path is exercisable without parking the suite
+	// for the production 30s.
+	initialSyncTimeout time.Duration
+
 	// wg counts the inf.Run + cache-sync goroutines launched in
 	// getOrStart. Stop blocks on it so the docstring's "blocks until all
 	// informer goroutines have exited" promise is real, not aspirational.
@@ -147,13 +155,14 @@ type informerCache struct {
 // tests inject a fake dynamic client without going through kubeconfig.
 func newInformerCache(clientFactory func(string) (dynamic.Interface, error)) *informerCache {
 	return &informerCache{
-		clientFactory: clientFactory,
-		clients:       make(map[string]dynamic.Interface),
-		entries:       make(map[string]map[schema.GroupVersionResource]*informerEntry),
-		auto:          make(map[string]map[schema.GroupVersionResource]*gvrAutoState),
-		promoteAt:     autoPromoteAt,
-		demoteBelow:   autoDemoteBelow,
-		demoteAfterN:  autoDemoteAfterN,
+		clientFactory:      clientFactory,
+		clients:            make(map[string]dynamic.Interface),
+		entries:            make(map[string]map[schema.GroupVersionResource]*informerEntry),
+		auto:               make(map[string]map[schema.GroupVersionResource]*gvrAutoState),
+		promoteAt:          autoPromoteAt,
+		demoteBelow:        autoDemoteBelow,
+		demoteAfterN:       autoDemoteAfterN,
+		initialSyncTimeout: defaultInitialSyncTimeout,
 	}
 }
 
@@ -292,7 +301,7 @@ func (ic *informerCache) listItems(ctx context.Context, contextName string, gvr 
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := waitForSync(ctx, entry); err != nil {
+	if err := waitForSync(ctx, entry, ic.initialSyncTimeout); err != nil {
 		return nil, 0, err
 	}
 
@@ -465,22 +474,22 @@ func (ic *informerCache) getOrStart(contextName string, gvr schema.GroupVersionR
 
 // waitForSync blocks until the informer's initial LIST has completed, the
 // informer is stopped (Stop or auto-demote), the caller's context is
-// cancelled, or initialSyncTimeout elapses. The timeout is a safety valve
-// for slow API servers: rather than freezing the UI on the first namespace
-// switch, we surface an error and the caller falls back to a direct list,
-// by which time the watch has usually caught up in the background.
+// cancelled, or timeout elapses. The timeout is a safety valve for slow
+// API servers: rather than freezing the UI on the first namespace switch,
+// we surface an error and the caller falls back to a direct list, by
+// which time the watch has usually caught up in the background.
 //
 // The stopCh case keeps Shutdown responsive — without it a list() blocked
 // here would have to ride out the full timeout before returning, which
 // would also stall ic.wg.Wait inside Stop.
-func waitForSync(ctx context.Context, entry *informerEntry) error {
+func waitForSync(ctx context.Context, entry *informerEntry, timeout time.Duration) error {
 	select {
 	case <-entry.synced:
 		return nil
 	default:
 	}
 
-	timer := time.NewTimer(initialSyncTimeout)
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
 	select {
@@ -491,7 +500,7 @@ func waitForSync(ctx context.Context, entry *informerEntry) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-timer.C:
-		return fmt.Errorf("informer cache: initial sync timed out after %s", initialSyncTimeout)
+		return fmt.Errorf("informer cache: initial sync timed out after %s", timeout)
 	}
 }
 

--- a/internal/k8s/informer_cache.go
+++ b/internal/k8s/informer_cache.go
@@ -1,0 +1,526 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Default resync period for informers: zero means "never resync from a full
+// list" — we still see live updates via the watch channel. Setting a non-zero
+// resync period would replay every cached object through the event handlers
+// on a timer, which costs CPU on a 7k-pod cluster without giving the UI any
+// new information beyond what the watch already delivers.
+const informerResyncPeriod = time.Duration(0)
+
+// initialSyncTimeout caps how long the first GetResources call after enabling
+// the cache will block waiting for the informer's initial LIST to complete.
+// On a sluggish API server this prevents the UI from hanging indefinitely on
+// the first namespace switch — instead we fall back to a direct list and try
+// the cache again on the next request, by which time it has typically synced.
+const initialSyncTimeout = 30 * time.Second
+
+// InformerCacheMode controls how GetResources is routed: never use the cache,
+// always use it, or auto-promote to it on large lists and auto-demote back
+// to direct lists when a resource type shrinks below the demote threshold.
+type InformerCacheMode string
+
+// Recognised modes for the informer_cache config option. The string values
+// are also what the config file accepts.
+const (
+	// InformerCacheOff routes every list directly to the apiserver. Matches
+	// kubectl semantics; recommended when the apiserver dislikes extra
+	// watch traffic.
+	InformerCacheOff InformerCacheMode = "off"
+	// InformerCacheAuto starts in direct-list mode per (context, GVR) and
+	// promotes to a shared informer once a list returns more items than
+	// autoPromoteAt. The watch is closed (demoted) again after
+	// autoDemoteAfterN consecutive cached lists fall below autoDemoteBelow,
+	// so a one-off large list does not strand a permanent watch.
+	InformerCacheAuto InformerCacheMode = "auto"
+	// InformerCacheAlways routes every list through the informer cache,
+	// starting watches eagerly on first use. Matches the always-on behaviour
+	// from issue #86's first cut; use when you know the cluster is large.
+	InformerCacheAlways InformerCacheMode = "always"
+)
+
+// Auto-mode thresholds. Tuned for the issue #86 reporter's 7k-pod cluster:
+// promotion fires at 1000 items (well above the noise floor of typical
+// namespaced views), demotion happens once cached size has been below 500
+// for autoDemoteAfterN consecutive calls. The hysteresis between
+// autoPromoteAt and autoDemoteBelow stops the cache flapping when a list
+// hovers around the threshold.
+const (
+	autoPromoteAt    = 1000
+	autoDemoteBelow  = 500
+	autoDemoteAfterN = 3
+)
+
+// gvrAutoState tracks the auto-mode position for one (context, GVR) so a
+// resource type can move between direct-list and informer-backed without
+// losing its history of recent list sizes.
+type gvrAutoState struct {
+	mu               sync.Mutex
+	promoted         bool // true => current path is the informer cache
+	consecutiveSmall int  // count of cached lists below autoDemoteBelow
+}
+
+// itemMemoEntry caches one converted model.Item alongside the
+// resourceVersion of the unstructured object it was built from. Per-item
+// keying (rather than per-list) is what makes the cache useful on a
+// busy cluster: pod-A churn doesn't invalidate pod-B's cached row, so
+// "the list as a whole" almost always sees a high hit rate even when
+// the informer's LastSyncResourceVersion changes between every call.
+//
+// The cached model.Item is shared by-value with every consumer. Slice
+// fields (Columns, Conditions, GroupedRefs) point to the same backing
+// arrays across reuses — the read paths in this codebase either
+// reassign whole slices (carryOverMetricsColumns) or clone first
+// (cloneEventItem), so this aliasing is safe. New mutators must follow
+// the same convention or call DeepCopy themselves.
+type itemMemoEntry struct {
+	rv   string
+	item model.Item
+}
+
+// informerEntry tracks a single (context, GVR) informer lifecycle.
+type informerEntry struct {
+	informer cache.SharedIndexInformer
+	stopCh   chan struct{}
+	synced   chan struct{} // closed when the informer's first LIST has completed
+
+	// memoMu guards memo. Keys are "<namespace>/<name>" (or "/<name>"
+	// for cluster-scoped resources). Entries grow over the cache's
+	// lifetime; entries for deleted pods linger until Stop. At typical
+	// scales (a few thousand items, hours-long sessions) this is a
+	// negligible memory footprint relative to the indexer itself.
+	memoMu sync.Mutex
+	memo   map[string]itemMemoEntry
+}
+
+// informerCache holds per-context dynamic informer factories, lazily
+// instantiating one informer per resource type on first use. The cache is
+// goroutine-safe: tea.Cmd workers may call into it concurrently from different
+// contexts and resource types.
+//
+// Lifecycle: factories and informers persist for the lifetime of the parent
+// Client. Stop() closes every watch and blocks until all informer goroutines
+// have exited; it is called from Client.Shutdown().
+type informerCache struct {
+	clientFactory func(contextName string) (dynamic.Interface, error)
+
+	mu      sync.Mutex
+	clients map[string]dynamic.Interface
+	entries map[string]map[schema.GroupVersionResource]*informerEntry
+	auto    map[string]map[schema.GroupVersionResource]*gvrAutoState
+
+	// promoteAt / demoteBelow / demoteAfterN are package-default constants
+	// at runtime, but stored on the struct so unit tests can dial them down
+	// without needing to fabricate 1000-item fixtures. Test helpers set
+	// these directly on a cache instance.
+	promoteAt    int
+	demoteBelow  int
+	demoteAfterN int
+
+	// wg counts the inf.Run + cache-sync goroutines launched in
+	// getOrStart. Stop blocks on it so the docstring's "blocks until all
+	// informer goroutines have exited" promise is real, not aspirational.
+	wg sync.WaitGroup
+
+	stopped bool
+}
+
+// newInformerCache builds an informerCache that resolves dynamic clients via
+// the supplied factory. Decoupling client construction from the cache lets
+// tests inject a fake dynamic client without going through kubeconfig.
+func newInformerCache(clientFactory func(string) (dynamic.Interface, error)) *informerCache {
+	return &informerCache{
+		clientFactory: clientFactory,
+		clients:       make(map[string]dynamic.Interface),
+		entries:       make(map[string]map[schema.GroupVersionResource]*informerEntry),
+		auto:          make(map[string]map[schema.GroupVersionResource]*gvrAutoState),
+		promoteAt:     autoPromoteAt,
+		demoteBelow:   autoDemoteBelow,
+		demoteAfterN:  autoDemoteAfterN,
+	}
+}
+
+// getAutoState returns the auto-mode bookkeeping for a (context, GVR),
+// allocating it on first access. Safe to call from any goroutine.
+func (ic *informerCache) getAutoState(contextName string, gvr schema.GroupVersionResource) *gvrAutoState {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+
+	perCtx := ic.auto[contextName]
+	if perCtx == nil {
+		perCtx = make(map[schema.GroupVersionResource]*gvrAutoState)
+		ic.auto[contextName] = perCtx
+	}
+	state, ok := perCtx[gvr]
+	if !ok {
+		state = &gvrAutoState{}
+		perCtx[gvr] = state
+	}
+	return state
+}
+
+// observeDirectListSize is called from GetResources after a direct (non-cache)
+// LIST against the apiserver. When the result crosses promoteAt items, the
+// (context, GVR) is flipped to informer-backed for subsequent calls — that's
+// what makes namespace switching on a 7k-pod cluster feel instant from the
+// second list onward.
+func (ic *informerCache) observeDirectListSize(contextName string, gvr schema.GroupVersionResource, n int) {
+	if n < ic.promoteAt {
+		return
+	}
+	state := ic.getAutoState(contextName, gvr)
+	state.mu.Lock()
+	state.promoted = true
+	state.consecutiveSmall = 0
+	state.mu.Unlock()
+}
+
+// observeCachedListSize is called from GetResources after a cache-served list.
+// It returns true when the (context, GVR) just transitioned back to the
+// direct-list path (auto-demote): the underlying watch is torn down so we
+// stop paying for a connection that no longer pays for itself. Hysteresis
+// between promoteAt and demoteBelow plus a consecutive-call counter prevents
+// flapping when a list size hovers near the threshold.
+func (ic *informerCache) observeCachedListSize(contextName string, gvr schema.GroupVersionResource, n int) bool {
+	state := ic.getAutoState(contextName, gvr)
+	state.mu.Lock()
+	if n < ic.demoteBelow {
+		state.consecutiveSmall++
+	} else {
+		state.consecutiveSmall = 0
+	}
+	shouldDemote := state.promoted && state.consecutiveSmall >= ic.demoteAfterN
+	if shouldDemote {
+		state.promoted = false
+		state.consecutiveSmall = 0
+	}
+	state.mu.Unlock()
+
+	if shouldDemote {
+		ic.stopOne(contextName, gvr)
+	}
+	return shouldDemote
+}
+
+// isPromoted reports whether the auto-mode router should send the next list
+// for (contextName, gvr) through the informer cache. False means take the
+// direct path; observeDirectListSize will decide whether to flip later.
+func (ic *informerCache) isPromoted(contextName string, gvr schema.GroupVersionResource) bool {
+	state := ic.getAutoState(contextName, gvr)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.promoted
+}
+
+// stopOne tears down the watch for a single (contextName, gvr). Used by
+// auto-demote: a resource type that shrunk no longer justifies a persistent
+// connection. Safe to call when no informer was ever started — that's the
+// no-op fast path.
+//
+// The ic.stopped early-out is what prevents the double-close race with
+// Stop(): once Stop has flipped the flag, every later stopOne is a no-op
+// and Stop owns the channel close. The check sits inside the same lock
+// region Stop uses to snapshot entries, so the two cannot interleave.
+func (ic *informerCache) stopOne(contextName string, gvr schema.GroupVersionResource) {
+	ic.mu.Lock()
+	if ic.stopped {
+		ic.mu.Unlock()
+		return
+	}
+	perCtx, ok := ic.entries[contextName]
+	if !ok {
+		ic.mu.Unlock()
+		return
+	}
+	entry, ok := perCtx[gvr]
+	if !ok {
+		ic.mu.Unlock()
+		return
+	}
+	delete(perCtx, gvr)
+	if len(perCtx) == 0 {
+		delete(ic.entries, contextName)
+	}
+	ic.mu.Unlock()
+
+	close(entry.stopCh)
+}
+
+// listItems walks the cached objects for (context, GVR) filtered by
+// namespace and returns them as []model.Item. Each object is keyed in
+// the per-item memo by namespace/name plus its own
+// metadata.resourceVersion; items whose RV matches the cached entry
+// are reused as-is, only items whose RV differs (or whose key was
+// never seen) run through build.
+//
+// On a busy cluster where most pods are byte-identical between calls
+// but a few churn, this delivers a high cache hit rate where per-list
+// memoization gets none — the informer's LastSyncResourceVersion
+// changes whenever any object changes, but most objects' own RV stays
+// stable across calls.
+//
+// build is the per-item conversion callback (in production:
+// c.buildResourceItem). Tests can swap it for a deterministic stub.
+// The returned builds count is the number of times build was actually
+// invoked, so callers can log hit ratios.
+//
+// Skipping the DeepCopy is correct here because the indexer replaces
+// cache entries by-pointer when watch events arrive: an event landing
+// during the loop swaps the indexer's pointer for a fresh
+// *unstructured, leaving any captured pointer's Object map untouched.
+// That pointer-stability invariant is what makes this faster than the
+// previous DeepCopy-every-item path.
+func (ic *informerCache) listItems(ctx context.Context, contextName string, gvr schema.GroupVersionResource, namespace string, build func(*unstructured.Unstructured) model.Item) ([]model.Item, int, error) {
+	entry, err := ic.getOrStart(contextName, gvr)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := waitForSync(ctx, entry); err != nil {
+		return nil, 0, err
+	}
+
+	indexer := entry.informer.GetIndexer()
+	var raw []*unstructured.Unstructured
+	collect := func(obj any) {
+		if u, ok := obj.(*unstructured.Unstructured); ok {
+			raw = append(raw, u)
+		}
+	}
+	if namespace == "" {
+		err = cache.ListAll(indexer, labels.Everything(), collect)
+	} else {
+		err = cache.ListAllByNamespace(indexer, namespace, labels.Everything(), collect)
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing cached %s: %w", gvr.Resource, err)
+	}
+
+	items, builds := entry.applyMemo(namespace, raw, build)
+	return items, builds, nil
+}
+
+// applyMemo walks objs and returns one model.Item per object, reusing the
+// cached row when (key, RV) matches and invoking build only when it
+// doesn't. New rows are added to the memo so subsequent calls hit.
+//
+// listNamespace is the scope of the current list call: "" for all
+// namespaces, or a specific namespace name. After the cache lookup we
+// prune memo entries that fall within this scope but were not in the
+// supplied objs slice — i.e. resources that have been deleted or moved
+// out of namespace since the previous call. This keeps memo growth
+// bounded by the live cluster size rather than by all-time churn,
+// without losing entries from namespaces the current call doesn't
+// know about (a per-ns list is not authoritative outside its own ns).
+func (e *informerEntry) applyMemo(listNamespace string, objs []*unstructured.Unstructured, build func(*unstructured.Unstructured) model.Item) ([]model.Item, int) {
+	e.memoMu.Lock()
+	defer e.memoMu.Unlock()
+	if e.memo == nil {
+		e.memo = make(map[string]itemMemoEntry)
+	}
+
+	out := make([]model.Item, 0, len(objs))
+	seen := make(map[string]struct{}, len(objs))
+	builds := 0
+	for _, obj := range objs {
+		key := memoKey(obj)
+		seen[key] = struct{}{}
+		rv := obj.GetResourceVersion()
+		if cached, ok := e.memo[key]; ok && cached.rv == rv {
+			out = append(out, cached.item)
+			continue
+		}
+		item := build(obj)
+		e.memo[key] = itemMemoEntry{rv: rv, item: item}
+		out = append(out, item)
+		builds++
+	}
+
+	// Prune memo entries within the current list's scope that did not
+	// appear in objs. An all-namespaces list ("") is authoritative for
+	// every key; a namespaced list is only authoritative for keys with
+	// that namespace prefix, so we leave other namespaces' entries
+	// untouched. Without this, deleted pods accumulate in the memo for
+	// the lifetime of the informer.
+	scopePrefix := ""
+	if listNamespace != "" {
+		scopePrefix = listNamespace + "/"
+	}
+	for key := range e.memo {
+		if _, kept := seen[key]; kept {
+			continue
+		}
+		if scopePrefix != "" && !strings.HasPrefix(key, scopePrefix) {
+			continue
+		}
+		delete(e.memo, key)
+	}
+	return out, builds
+}
+
+// memoKey produces a stable identifier for an unstructured resource.
+// The leading slash on cluster-scoped objects (empty namespace) keeps
+// the format unambiguous: "/foo" cannot collide with "ns/foo" because
+// any namespaced resource has a non-empty namespace prefix.
+func memoKey(obj *unstructured.Unstructured) string {
+	return obj.GetNamespace() + "/" + obj.GetName()
+}
+
+// getOrStart returns the informer entry for (contextName, gvr), creating and
+// starting it if necessary. It does not block on cache sync — that is the
+// caller's responsibility via waitForSync, so the lock is released before any
+// network IO begins.
+//
+// We bypass dynamicinformer.DynamicSharedInformerFactory because that factory
+// caches informers per-GVR forever and refuses to restart one whose stop
+// channel has been closed — fatal for auto-mode, where a demote followed by
+// a re-promote needs a fresh informer. NewFilteredDynamicInformer hands us a
+// standalone informer per (context, GVR) lifecycle that we own end-to-end.
+func (ic *informerCache) getOrStart(contextName string, gvr schema.GroupVersionResource) (*informerEntry, error) {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+
+	if ic.stopped {
+		return nil, fmt.Errorf("informer cache is shutting down")
+	}
+
+	if perCtx, ok := ic.entries[contextName]; ok {
+		if entry, ok := perCtx[gvr]; ok {
+			return entry, nil
+		}
+	}
+
+	dc, ok := ic.clients[contextName]
+	if !ok {
+		built, err := ic.clientFactory(contextName)
+		if err != nil {
+			return nil, fmt.Errorf("dynamic client for context %q: %w", contextName, err)
+		}
+		dc = built
+		ic.clients[contextName] = dc
+	}
+
+	// All namespaces — namespace filtering happens client-side from the
+	// cache. That is the entire point of issue #86: one watch streams every
+	// pod, and namespace selector switching becomes an in-memory walk.
+	generic := dynamicinformer.NewFilteredDynamicInformer(
+		dc, gvr, metav1.NamespaceAll, informerResyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		nil,
+	)
+	informer := generic.Informer()
+	entry := &informerEntry{
+		informer: informer,
+		stopCh:   make(chan struct{}),
+		synced:   make(chan struct{}),
+	}
+
+	// Two goroutines per (context, GVR): one runs the informer, one watches
+	// for the initial sync to complete. Both are tracked on ic.wg so Stop
+	// can join them — that is what makes the "blocks until all informer
+	// goroutines have exited" docstring true. Add() before the goroutines
+	// start so a concurrent Stop+Wait can never see a zero counter that
+	// races the goroutine launch.
+	ic.wg.Add(2)
+	go func(inf cache.SharedIndexInformer, stopCh chan struct{}) {
+		defer ic.wg.Done()
+		inf.Run(stopCh)
+	}(informer, entry.stopCh)
+	go func(inf cache.SharedIndexInformer, stopCh, synced chan struct{}) {
+		defer ic.wg.Done()
+		// HasSynced flips true after the initial LIST completes; we close
+		// `synced` so the first list() call can return promptly without
+		// burning CPU in cache.WaitForCacheSync's polling loop. When
+		// stopCh closes before sync (Stop or auto-demote during warmup),
+		// WaitForCacheSync returns false and we leave `synced` open — any
+		// list() caller still inside waitForSync will pick up the stopCh
+		// signal instead.
+		if cache.WaitForCacheSync(stopCh, inf.HasSynced) {
+			close(synced)
+		}
+	}(informer, entry.stopCh, entry.synced)
+
+	if ic.entries[contextName] == nil {
+		ic.entries[contextName] = make(map[schema.GroupVersionResource]*informerEntry)
+	}
+	ic.entries[contextName][gvr] = entry
+	return entry, nil
+}
+
+// waitForSync blocks until the informer's initial LIST has completed, the
+// informer is stopped (Stop or auto-demote), the caller's context is
+// cancelled, or initialSyncTimeout elapses. The timeout is a safety valve
+// for slow API servers: rather than freezing the UI on the first namespace
+// switch, we surface an error and the caller falls back to a direct list,
+// by which time the watch has usually caught up in the background.
+//
+// The stopCh case keeps Shutdown responsive — without it a list() blocked
+// here would have to ride out the full timeout before returning, which
+// would also stall ic.wg.Wait inside Stop.
+func waitForSync(ctx context.Context, entry *informerEntry) error {
+	select {
+	case <-entry.synced:
+		return nil
+	default:
+	}
+
+	timer := time.NewTimer(initialSyncTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-entry.synced:
+		return nil
+	case <-entry.stopCh:
+		return fmt.Errorf("informer cache: stopped before initial sync")
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return fmt.Errorf("informer cache: initial sync timed out after %s", initialSyncTimeout)
+	}
+}
+
+// Stop closes every watch and blocks until all informer goroutines have
+// exited. Idempotent — safe to call from a defer in main.go even if the
+// cache was never used; concurrent Stop calls all wait on the same
+// WaitGroup. After Stop, getOrStart returns an error rather than silently
+// spinning up a new informer that would leak.
+func (ic *informerCache) Stop() {
+	ic.mu.Lock()
+	if ic.stopped {
+		ic.mu.Unlock()
+		// A second caller still wants the same guarantee the first one
+		// got: by the time Stop returns, no informer goroutine is
+		// running. Wait on the same counter the first caller is draining.
+		ic.wg.Wait()
+		return
+	}
+	ic.stopped = true
+	allEntries := make([]*informerEntry, 0)
+	for _, perCtx := range ic.entries {
+		for _, entry := range perCtx {
+			allEntries = append(allEntries, entry)
+		}
+	}
+	ic.mu.Unlock()
+
+	for _, entry := range allEntries {
+		close(entry.stopCh)
+	}
+	ic.wg.Wait()
+}

--- a/internal/k8s/informer_cache_test.go
+++ b/internal/k8s/informer_cache_test.go
@@ -207,34 +207,79 @@ func TestInformerCache_StopIsIdempotent(t *testing.T) {
 // the second one panics with "close of closed channel". The
 // ic.stopped early-out in stopOne is what prevents that, and this test
 // is the regression guard — run with -race for full effect.
+//
+// The barrier + iteration loop give the runtime plenty of opportunities
+// to schedule the two goroutines in interleaved orders. A single shot
+// would still trip -race if the close-vs-close path were broken, but
+// repeated runs make a CI flake far less likely to silently hide a
+// regression where the race detector never observed both orderings.
 func TestInformerCache_ConcurrentStopAndDemoteNoPanic(t *testing.T) {
-	// One pod per call so cached lists trivially fall under any
-	// reasonable demote threshold.
+	for iter := range 20 {
+		dc := newFakeDynClient(pod("a", "ns"))
+		c := NewTestClient(nil, dc)
+		c.SetInformerCacheMode(InformerCacheAuto)
+		withTunedThresholds(c, 1, 5, 1)
+
+		// Warm up: promotes on first list (1 item >= promoteAt=1).
+		_, err := c.GetResources(context.Background(), "", "", podRT)
+		require.NoError(t, err, "iter %d", iter)
+		require.True(t, c.informers.isPromoted("", podGVR()), "iter %d", iter)
+
+		// Race: one goroutine triggers a cached list (which auto-demotes,
+		// trying to stopOne), another calls Shutdown (which Stop()s every
+		// remaining entry). Both want to close the same stopCh — the
+		// barrier ensures both arrive simultaneously rather than the
+		// second one finding ic.stopped already set on the cheap path.
+		barrier := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-barrier
+			_, _ = c.GetResources(context.Background(), "", "", podRT)
+		}()
+		go func() {
+			defer wg.Done()
+			<-barrier
+			c.Shutdown()
+		}()
+		close(barrier)
+		wg.Wait()
+		// Reaching this line without a panic is the assertion.
+	}
+}
+
+// TestInformerCache_WaitForSyncTimeoutFallsBack exercises the safety
+// valve when the informer's initial LIST never completes (slow / hung
+// apiserver). The waitForSync timeout must surface an error to listItems
+// rather than freeze the UI on the first namespace switch — and
+// GetResources must then fall through to a direct list so the user
+// always gets data. Without an injectable timeout this path was
+// untestable at production-realistic timescales.
+func TestInformerCache_WaitForSyncTimeoutFallsBack(t *testing.T) {
 	dc := newFakeDynClient(pod("a", "ns"))
 	c := NewTestClient(nil, dc)
-	c.SetInformerCacheMode(InformerCacheAuto)
-	withTunedThresholds(c, 1, 5, 1)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
 
-	// Warm up: promotes on first list (1 item >= promoteAt=1).
-	_, err := c.GetResources(context.Background(), "", "", podRT)
+	entry, err := c.informers.getOrStart("", podGVR())
 	require.NoError(t, err)
-	require.True(t, c.informers.isPromoted("", podGVR()))
+	// Synthetic stuck-sync: drop the synced channel without ever closing
+	// it, simulating an apiserver that never returns the initial LIST.
+	// The real informer goroutine is still running but its sync watcher
+	// goroutine will never fire close(synced), so waitForSync must rely
+	// on the timeout path.
+	entry.synced = make(chan struct{})
 
-	// Race: one goroutine triggers a cached list (which auto-demotes,
-	// trying to stopOne), another calls Shutdown (which Stop()s every
-	// remaining entry). Both want to close the same stopCh.
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		_, _ = c.GetResources(context.Background(), "", "", podRT)
-	}()
-	go func() {
-		defer wg.Done()
-		c.Shutdown()
-	}()
-	wg.Wait()
-	// Reaching this line without a panic is the assertion.
+	start := time.Now()
+	err = waitForSync(context.Background(), entry, 10*time.Millisecond)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "expected timeout error when sync never completes")
+	assert.Contains(t, err.Error(), "timed out",
+		"timeout error must mention what happened so logs are debuggable")
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"the timeout must actually fire — a 10ms cap should not park the test for half a second")
 }
 
 // TestInformerCache_StopWaitsForGoroutines verifies the docstring promise

--- a/internal/k8s/informer_cache_test.go
+++ b/internal/k8s/informer_cache_test.go
@@ -1,0 +1,660 @@
+package k8s
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// podRT is the ResourceTypeEntry used by every informer-cache test in this file.
+// Pods are the resource that motivated issue #86 (~7k of them on the bug
+// reporter's cluster) and exercise the namespaced + dynamic-client path
+// GetResources cares about.
+var podRT = model.ResourceTypeEntry{
+	APIGroup:   "",
+	APIVersion: "v1",
+	Resource:   "pods",
+	Kind:       "Pod",
+	Namespaced: true,
+}
+
+// pod builds a minimal *unstructured.Unstructured for a pod with name+namespace.
+func pod(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":              name,
+				"namespace":         namespace,
+				"creationTimestamp": "2026-04-01T00:00:00Z",
+			},
+		},
+	}
+}
+
+// listActionCount returns how many list-pods actions the fake dynamic client
+// has observed. The informer issues exactly one initial list per (context,
+// GVR); every subsequent GetResources call after the cache is warm should
+// leave this number unchanged.
+func listActionCount(actions []clienttesting.Action) int {
+	n := 0
+	for _, a := range actions {
+		if a.GetVerb() == "list" && a.GetResource().Resource == "pods" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestGetResources_InformerCache_NamespaceSwitchHitsCache is the regression
+// guard for issue #86. Switching the namespace filter must NOT issue a fresh
+// LIST against the apiserver once the informer has synced — that was the
+// 7k-pod lag the user was seeing.
+func TestGetResources_InformerCache_NamespaceSwitchHitsCache(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+		pod("worker-1", "team-b"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	// First list — primes the informer (the underlying watch fires one LIST).
+	itemsAll, err := c.GetResources(context.Background(), "", "", podRT)
+	require.NoError(t, err)
+	require.Len(t, itemsAll, 3)
+
+	listsAfterWarmup := listActionCount(dc.Actions())
+	require.GreaterOrEqual(t, listsAfterWarmup, 1, "informer should have issued at least one LIST to populate the cache")
+
+	// Switch to team-a, then team-b, then back to all-namespaces. Each call
+	// is the moment the user pressed the namespace selector — under the
+	// pre-#86 code these would have round-tripped to the apiserver.
+	itemsA, err := c.GetResources(context.Background(), "", "team-a", podRT)
+	require.NoError(t, err)
+	itemsB, err := c.GetResources(context.Background(), "", "team-b", podRT)
+	require.NoError(t, err)
+	itemsAll2, err := c.GetResources(context.Background(), "", "", podRT)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"api-1", "api-2"}, []string{itemsA[0].Name, itemsA[1].Name})
+	assert.Equal(t, []string{"worker-1"}, []string{itemsB[0].Name})
+	assert.Len(t, itemsAll2, 3)
+
+	listsAfterSwitches := listActionCount(dc.Actions())
+	assert.Equal(t, listsAfterWarmup, listsAfterSwitches,
+		"namespace switching must not issue extra LIST calls — that is the whole point of issue #86")
+}
+
+// TestGetResources_InformerCache_OffModeHitsApiserverEveryTime verifies
+// that explicit "off" mode always round-trips to the apiserver — useful
+// when the operator has chosen to keep kubectl-equivalent semantics.
+func TestGetResources_InformerCache_OffModeHitsApiserverEveryTime(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheOff)
+
+	for range 3 {
+		_, err := c.GetResources(context.Background(), "", "team-a", podRT)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 3, listActionCount(dc.Actions()),
+		"with informer_cache=off, each GetResources call should LIST the apiserver as before")
+}
+
+// TestGetResources_InformerCache_PicksUpDeletes verifies that the cache
+// stays fresh under the watch — a deletion observed by the informer must
+// drop out of subsequent list results without forcing a refresh round trip.
+// This is the property that lets us serve cached results without falling
+// back to "stale data" semantics: deleted pods don't linger.
+func TestGetResources_InformerCache_PicksUpDeletes(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	// Warm the cache.
+	items, err := c.GetResources(context.Background(), "", "team-a", podRT)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	// Delete api-2 via the dynamic client. The informer's watch sees this
+	// asynchronously, so we poll the cached list until it converges instead
+	// of asserting on the very next call.
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(context.Background(), "api-2", metav1.DeleteOptions{}))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		items, err = c.GetResources(context.Background(), "", "team-a", podRT)
+		require.NoError(t, err)
+		if len(items) == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	require.Len(t, items, 1, "watch should have removed api-2 from the cache")
+	assert.Equal(t, "api-1", items[0].Name)
+}
+
+// TestSetInformerCacheMode_NormalizesInput guards the API contract that
+// callers passing mode strings with stray casing or whitespace resolve
+// to the right mode rather than silently falling back to auto. Without
+// this, a programmatic caller like an integration test or a third-party
+// embedder would get the auto fallback on a typo or trim mismatch.
+func TestSetInformerCacheMode_NormalizesInput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   InformerCacheMode
+		want InformerCacheMode
+	}{
+		{"lowercase off matches", "off", InformerCacheOff},
+		{"uppercase ALWAYS lowered", "ALWAYS", InformerCacheAlways},
+		{"mixed case Auto lowered", "Auto", InformerCacheAuto},
+		{"leading whitespace trimmed", "  always", InformerCacheAlways},
+		{"trailing whitespace trimmed", "off  ", InformerCacheOff},
+		{"unknown value falls back to auto", "maybe", InformerCacheAuto},
+		{"empty string falls back to auto", "", InformerCacheAuto},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewTestClient(nil, nil)
+			c.SetInformerCacheMode(tc.in)
+			assert.Equal(t, tc.want, c.informerMode)
+			c.Shutdown()
+		})
+	}
+}
+
+// TestInformerCache_StopIsIdempotent guards against a regression where
+// Shutdown() panics if called twice (e.g. once from a deferred client.Shutdown
+// and once explicitly in a test cleanup). Cheap to enforce, easy to break.
+func TestInformerCache_StopIsIdempotent(t *testing.T) {
+	dc := newFakeDynClient()
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+
+	c.Shutdown()
+	c.Shutdown() // must not panic
+}
+
+// TestInformerCache_ConcurrentStopAndDemoteNoPanic exercises the race
+// between Stop (called from main.go's defer client.Shutdown()) and
+// stopOne (called when auto-demote fires inside a still-in-flight
+// GetResources). Both paths close the same stopCh; without coordination
+// the second one panics with "close of closed channel". The
+// ic.stopped early-out in stopOne is what prevents that, and this test
+// is the regression guard — run with -race for full effect.
+func TestInformerCache_ConcurrentStopAndDemoteNoPanic(t *testing.T) {
+	// One pod per call so cached lists trivially fall under any
+	// reasonable demote threshold.
+	dc := newFakeDynClient(pod("a", "ns"))
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAuto)
+	withTunedThresholds(c, 1, 5, 1)
+
+	// Warm up: promotes on first list (1 item >= promoteAt=1).
+	_, err := c.GetResources(context.Background(), "", "", podRT)
+	require.NoError(t, err)
+	require.True(t, c.informers.isPromoted("", podGVR()))
+
+	// Race: one goroutine triggers a cached list (which auto-demotes,
+	// trying to stopOne), another calls Shutdown (which Stop()s every
+	// remaining entry). Both want to close the same stopCh.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = c.GetResources(context.Background(), "", "", podRT)
+	}()
+	go func() {
+		defer wg.Done()
+		c.Shutdown()
+	}()
+	wg.Wait()
+	// Reaching this line without a panic is the assertion.
+}
+
+// TestInformerCache_StopWaitsForGoroutines verifies the docstring promise
+// that Stop blocks until informer goroutines have exited. We can't observe
+// goroutine ids directly, but we can sample runtime.NumGoroutine before and
+// after to confirm the count returned to baseline rather than leaking the
+// inf.Run / WaitForCacheSync goroutines past Shutdown.
+func TestInformerCache_StopWaitsForGoroutines(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	dc := newFakeDynClient(pod("a", "ns"))
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+
+	// Force the informer to start by issuing a list.
+	_, err := c.GetResources(context.Background(), "", "", podRT)
+	require.NoError(t, err)
+	require.Greater(t, runtime.NumGoroutine(), baseline,
+		"expected new goroutines for inf.Run + sync watcher")
+
+	c.Shutdown()
+
+	// Goroutines exit asynchronously even after their stop channel
+	// closes; give the scheduler a brief window to run their defers.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+1 { // +1 tolerance for runtime jitter
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Shutdown did not drain informer goroutines: baseline=%d, after=%d",
+		baseline, runtime.NumGoroutine())
+}
+
+// withTunedThresholds dials the auto promote/demote thresholds down so a
+// test can drive transitions with handful-sized fixtures rather than 1000+
+// pods. Using small numbers keeps fixtures readable and the test fast,
+// while still exercising the same state-machine paths the production
+// thresholds drive.
+func withTunedThresholds(c *Client, promoteAt, demoteBelow, demoteAfterN int) {
+	c.informers.promoteAt = promoteAt
+	c.informers.demoteBelow = demoteBelow
+	c.informers.demoteAfterN = demoteAfterN
+}
+
+// TestGetResources_InformerCache_AutoPromote drives the auto-promote arc
+// of the state machine: a direct list returning ≥ promoteAt items must
+// flip the (context, GVR) into informer mode, so the next call goes to
+// the cache instead of the apiserver. This is the path that gives big
+// clusters the issue #86 win without forcing users to find a config knob.
+func TestGetResources_InformerCache_AutoPromote(t *testing.T) {
+	pods := []*unstructured.Unstructured{
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+		pod("api-3", "team-a"),
+		pod("worker-1", "team-b"),
+	}
+	dc := newFakeDynClient(toRuntimeObjects(pods)...)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAuto)
+	t.Cleanup(c.Shutdown)
+	// Promote at 4 items so the fixture above triggers it; demote thresholds
+	// don't matter for this test but must satisfy demoteBelow < promoteAt.
+	withTunedThresholds(c, 4, 2, 3)
+
+	// First call: direct LIST against the apiserver (cache not yet warm).
+	// Result has 4 items, which crosses promoteAt.
+	_, err := c.GetResources(context.Background(), "", "", podRT)
+	require.NoError(t, err)
+	listsAfterFirst := listActionCount(dc.Actions())
+	require.Equal(t, 1, listsAfterFirst, "first auto-mode call should LIST the apiserver directly")
+	require.True(t, c.informers.isPromoted("", podGVR()),
+		"4 items >= promoteAt=4 must flip the GVR to informer mode")
+
+	// Second call: routed through the informer. The informer's own initial
+	// LIST counts as one apiserver call; subsequent namespace switches do
+	// not. Wait briefly for the watch to populate before asserting items.
+	_, err = c.GetResources(context.Background(), "", "team-a", podRT)
+	require.NoError(t, err)
+
+	// Third call (different namespace) — must not add another apiserver list.
+	listsBefore := listActionCount(dc.Actions())
+	_, err = c.GetResources(context.Background(), "", "team-b", podRT)
+	require.NoError(t, err)
+	assert.Equal(t, listsBefore, listActionCount(dc.Actions()),
+		"after promotion, namespace switching should be served from the cache")
+}
+
+// TestGetResources_InformerCache_AutoDemote drives the auto-demote arc:
+// once a (context, GVR) has been promoted, sustained cached lists below
+// the demote threshold must close the watch and return to direct lists,
+// so a one-off large list does not leave a permanent watch behind.
+func TestGetResources_InformerCache_AutoDemote(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAuto)
+	t.Cleanup(c.Shutdown)
+	withTunedThresholds(c, 1, 5, 3)
+	// promoteAt=1 means even tiny lists promote; demoteBelow=5 means cached
+	// lists in this fixture (2 items) always count as "small"; demoteAfterN=3
+	// is the minimum to exercise the consecutive-call counter.
+
+	// Warm up: first list promotes the GVR (2 items >= promoteAt=1).
+	_, err := c.GetResources(context.Background(), "", "", podRT)
+	require.NoError(t, err)
+	require.True(t, c.informers.isPromoted("", podGVR()), "expected promotion after first list")
+
+	// Three more cached lists, each below demoteBelow. The third must trip
+	// the demote: state flips back to direct and the watch is torn down.
+	for i := range 3 {
+		_, err := c.GetResources(context.Background(), "", "", podRT)
+		require.NoError(t, err, "cached list iteration %d", i)
+	}
+	assert.False(t, c.informers.isPromoted("", podGVR()),
+		"3 consecutive cached lists below demoteBelow should auto-demote back to direct")
+
+	// Verify the watch was actually closed by re-promoting and observing
+	// that a fresh informer was started — i.e. demote is not a no-op.
+	listsBefore := listActionCount(dc.Actions())
+	_, err = c.GetResources(context.Background(), "", "", podRT)
+	require.NoError(t, err)
+	listsAfter := listActionCount(dc.Actions())
+	assert.Greater(t, listsAfter, listsBefore,
+		"after demote, the next call should issue a fresh apiserver LIST")
+}
+
+// podGVR is the GroupVersionResource for core/v1 pods, used by the auto
+// tests when poking at internal cache state. Defined as a function (not a
+// var) so the value is unambiguous at the call site without an init order
+// dance.
+func podGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+}
+
+// TestListItems_MemoizesPerItem is the regression guard for the
+// per-call DeepCopy + buildResourceItem cost on a 6k-pod list. After
+// the warmup, a follow-up listItems call against an unchanged indexer
+// must reuse every cached row — build is invoked zero times.
+func TestListItems_MemoizesPerItem(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	gvr := podGVR()
+	buildCalls := 0
+	build := func(obj *unstructured.Unstructured) model.Item {
+		buildCalls++
+		return model.Item{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	}
+
+	// Warmup: starts the informer, walks indexer, runs build per item,
+	// stores memo. GetResources is deliberately not used here so we
+	// don't pre-populate the memo with the production build.
+	first, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, 2, builds, "warmup builds every item once")
+	assert.Equal(t, 2, buildCalls)
+
+	second, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	require.Len(t, second, 2)
+	assert.Equal(t, 0, builds,
+		"unchanged indexer must reuse every cached row — that's the optimization")
+	assert.Equal(t, 2, buildCalls, "build must not run again when nothing changed")
+}
+
+// TestListItems_RebuildsOnlyChangedItems is the per-item invalidation
+// guard. When the informer observes a watch event for one pod, only
+// that pod's row should rebuild — the rest stay cached. This is the
+// property that makes the memo useful on a busy cluster: pod-A churn
+// doesn't force pod-B through buildResourceItem.
+func TestListItems_RebuildsOnlyChangedItems(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+		pod("api-3", "team-a"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	gvr := podGVR()
+	build := func(obj *unstructured.Unstructured) model.Item {
+		return model.Item{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	}
+
+	// Warmup: builds all 3.
+	_, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	require.Equal(t, 3, builds)
+
+	// Mutate exactly one pod: the watch bumps its individual RV; the
+	// other two pods' resourceVersion stays unchanged.
+	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(context.Background(), "api-2", metav1.DeleteOptions{}))
+
+	// Poll until the indexer reflects the delete (watch is async).
+	// Once it has, the next listItems should return 2 items and have
+	// rebuilt zero of them — both api-1 and api-3 still match their
+	// memo entries.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		items, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+		require.NoError(t, err)
+		if len(items) == 2 {
+			assert.Equal(t, 0, builds,
+				"only api-2 changed (deleted) — api-1 and api-3 should reuse their memo entries")
+			names := []string{items[0].Name, items[1].Name}
+			assert.Contains(t, names, "api-1")
+			assert.Contains(t, names, "api-3")
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("indexer never converged on the post-delete state")
+}
+
+// TestListItems_RebuildsUpdatedItem verifies the targeted-rebuild path
+// when an item's resourceVersion changes (a Modified watch event):
+// only that one item should run through build, neighbours stay cached.
+func TestListItems_RebuildsUpdatedItem(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	gvr := podGVR()
+	buildNames := []string{}
+	build := func(obj *unstructured.Unstructured) model.Item {
+		buildNames = append(buildNames, obj.GetName())
+		return model.Item{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	}
+
+	_, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"api-1", "api-2"}, buildNames)
+	buildNames = buildNames[:0]
+
+	// Update api-2 with an explicit resourceVersion bump. The dynamic
+	// fake doesn't auto-stamp resourceVersion on Update, so we have to
+	// supply one ourselves — the watch event then carries the new RV
+	// to the informer, which in turn invalidates the memo entry.
+	updated := pod("api-2", "team-a")
+	meta := updated.Object["metadata"].(map[string]any)
+	meta["labels"] = map[string]any{"updated": "true"}
+	meta["resourceVersion"] = "2"
+	_, err = dc.Resource(gvr).Namespace("team-a").Update(context.Background(), updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		buildNames = buildNames[:0]
+		_, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+		require.NoError(t, err)
+		if builds == 1 && len(buildNames) == 1 && buildNames[0] == "api-2" {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("update never triggered exactly one rebuild for api-2: last buildNames=%v", buildNames)
+}
+
+// toRuntimeObjects converts a slice of *unstructured to []runtime.Object so
+// it can be passed to newFakeDynClient's variadic parameter. Saves a
+// for-loop in every fixture-heavy test below.
+func toRuntimeObjects(in []*unstructured.Unstructured) []apiruntime.Object {
+	out := make([]apiruntime.Object, 0, len(in))
+	for _, u := range in {
+		out = append(out, u)
+	}
+	return out
+}
+
+// namespaceObj builds an unstructured Namespace resource. Used by the
+// cluster-scoped tests below — namespaces are themselves cluster-scoped
+// (Namespaced: false), so they exercise the memoKey "/<name>" branch
+// that doesn't fire for namespaced resources like pods.
+func namespaceObj(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name":              name,
+				"creationTimestamp": "2026-04-01T00:00:00Z",
+			},
+		},
+	}
+}
+
+// TestListItems_ClusterScopedResource verifies the cluster-scoped path
+// through applyMemo. memoKey produces "/<name>" for objects with no
+// namespace; the test confirms two calls (a) return correct items and
+// (b) hit the memo on the second call, just like namespaced resources.
+// Without this we'd be silently regressing on Namespaces, Nodes, CRDs,
+// etc., which all flow through the same listItems API.
+func TestListItems_ClusterScopedResource(t *testing.T) {
+	dc := newFakeDynClient(
+		namespaceObj("default"),
+		namespaceObj("kube-system"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	build := func(obj *unstructured.Unstructured) model.Item {
+		return model.Item{Name: obj.GetName(), Kind: "Namespace"}
+	}
+
+	first, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, 2, builds, "warmup builds every cluster-scoped item once")
+
+	second, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	require.Len(t, second, 2)
+	assert.Equal(t, 0, builds,
+		"cluster-scoped items must memoize the same way namespaced ones do")
+
+	// Sanity check: the cache key for a cluster-scoped object starts with
+	// "/" — that's what keeps "/foo" from colliding with "ns/foo".
+	entry, ok := c.informers.entries[""][gvr]
+	require.True(t, ok, "informer entry must exist after listItems")
+	require.Contains(t, entry.memo, "/default")
+	require.Contains(t, entry.memo, "/kube-system")
+}
+
+// TestApplyMemo_PrunesDeletedKeysOnAllNamespacesList verifies the memo's
+// growth-bounding sweep. After a pod has been removed from the indexer,
+// the next all-namespaces list must drop its memo entry — otherwise
+// long sessions on busy clusters leak entries linearly with churn.
+func TestApplyMemo_PrunesDeletedKeysOnAllNamespacesList(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	gvr := podGVR()
+	build := func(obj *unstructured.Unstructured) model.Item {
+		return model.Item{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	}
+
+	// Warmup: memo gets both keys.
+	_, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	entry := c.informers.entries[""][gvr]
+	require.Contains(t, entry.memo, "team-a/api-1")
+	require.Contains(t, entry.memo, "team-a/api-2")
+
+	// Delete api-2 and wait for the watch to apply.
+	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(context.Background(), "api-2", metav1.DeleteOptions{}))
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		items, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+		require.NoError(t, err)
+		if len(items) == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The next listItems must have pruned api-2's memo entry. Without
+	// the prune, this assertion fails — the entry would linger forever.
+	assert.NotContains(t, entry.memo, "team-a/api-2",
+		"deleted pod's memo entry must be pruned by the all-ns sweep")
+	assert.Contains(t, entry.memo, "team-a/api-1",
+		"surviving pod's memo entry must remain")
+}
+
+// TestApplyMemo_PerNamespaceListDoesNotPruneOtherNamespaces guards the
+// scope of the prune sweep. A namespaced list is only authoritative for
+// its own namespace — pruning entries from other namespaces would erase
+// useful memo state for any prior all-namespaces or other-namespace
+// list, defeating the purpose of caching across views.
+func TestApplyMemo_PerNamespaceListDoesNotPruneOtherNamespaces(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("api-2", "team-a"),
+		pod("worker-1", "team-b"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	gvr := podGVR()
+	build := func(obj *unstructured.Unstructured) model.Item {
+		return model.Item{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	}
+
+	// Warmup: all-namespaces list seeds memo with all three pods.
+	_, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	require.NoError(t, err)
+	entry := c.informers.entries[""][gvr]
+	require.Contains(t, entry.memo, "team-a/api-1")
+	require.Contains(t, entry.memo, "team-a/api-2")
+	require.Contains(t, entry.memo, "team-b/worker-1")
+
+	// Now list only team-a. Even though team-b/worker-1 is not in the
+	// returned objs, the prune logic must leave its memo entry alone —
+	// the team-a list isn't authoritative for team-b.
+	_, _, err = c.informers.listItems(context.Background(), "", gvr, "team-a", build)
+	require.NoError(t, err)
+	assert.Contains(t, entry.memo, "team-a/api-1")
+	assert.Contains(t, entry.memo, "team-a/api-2")
+	assert.Contains(t, entry.memo, "team-b/worker-1",
+		"per-namespace list must not prune entries from other namespaces")
+}

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -19,16 +19,44 @@ import (
 // accepts both the legacy bool form (true → "always", false → "off") and
 // the named-mode form ("off" / "auto" / "always"). Resolved during
 // LoadConfig and stored in ConfigInformerCacheMode.
+//
+// UnmarshalJSON is deliberately tolerant: a typo or unsupported shape is
+// captured in raw + invalid rather than aborting the whole config load.
+// applyConfigOptions then surfaces a single logger.Warn and falls back to
+// the default — same pattern terminal/scrollback_lines use, so a bad
+// informer_cache value never silently nukes unrelated keys like
+// keybindings or colorscheme.
 type informerCacheSetting struct {
-	mode string
+	mode    string
+	raw     string
+	invalid bool
 }
 
-// UnmarshalJSON accepts either a bool or one of the recognised mode strings.
-// LoadConfig goes through sigs.k8s.io/yaml, which converts YAML to JSON
-// before unmarshalling — so the unmarshaler hooks here are also what handle
-// YAML config files. Unknown strings fail loudly so a typo in the config
-// surfaces at startup instead of silently falling back to a default the
-// user did not pick.
+// applyInformerCacheSetting writes the resolved mode into
+// ConfigInformerCacheMode, or warns and falls back to the default if the
+// user supplied an unrecognised shape. Extracted from applyConfigOptions
+// to keep that function under the project's cyclomatic-complexity cap.
+func applyInformerCacheSetting(s *informerCacheSetting) {
+	if s == nil {
+		return
+	}
+	if s.invalid {
+		logger.Warn("unrecognised informer_cache value in config; falling back to default",
+			"value", s.raw,
+			"valid", []string{InformerCacheOff, InformerCacheAuto, InformerCacheAlways},
+			"default", ConfigInformerCacheMode)
+		return
+	}
+	if s.mode != "" {
+		ConfigInformerCacheMode = s.mode
+	}
+}
+
+// UnmarshalJSON parses the bool / string union forms into mode. Anything
+// else (unknown string, number, object) is recorded on raw + invalid so
+// applyConfigOptions can warn-and-fallback. LoadConfig goes through
+// sigs.k8s.io/yaml, which converts YAML to JSON before unmarshalling — so
+// the unmarshaler hook here is also what handles YAML config files.
 func (s *informerCacheSetting) UnmarshalJSON(data []byte) error {
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
@@ -41,14 +69,27 @@ func (s *informerCacheSetting) UnmarshalJSON(data []byte) error {
 	}
 	var raw string
 	if err := json.Unmarshal(data, &raw); err == nil {
-		switch strings.ToLower(strings.TrimSpace(raw)) {
-		case InformerCacheOff, InformerCacheAuto, InformerCacheAlways:
-			s.mode = strings.ToLower(strings.TrimSpace(raw))
+		trimmed := strings.ToLower(strings.TrimSpace(raw))
+		// An explicit empty value is treated as "key absent", not a typo —
+		// users sometimes leave keys present-but-empty when scaffolding a
+		// config file from a template.
+		if trimmed == "" {
 			return nil
 		}
-		return fmt.Errorf("informer_cache: unknown mode %q (want off, auto, or always)", raw)
+		switch trimmed {
+		case InformerCacheOff, InformerCacheAuto, InformerCacheAlways:
+			s.mode = trimmed
+			return nil
+		}
+		s.raw = raw
+		s.invalid = true
+		return nil
 	}
-	return fmt.Errorf("informer_cache: must be a bool or one of off/auto/always")
+	// Truly unparseable shape (number, object, array). Keep the raw bytes
+	// so the warning log shows the user what they actually wrote.
+	s.raw = strings.TrimSpace(string(data))
+	s.invalid = true
+	return nil
 }
 
 // Watch interval bounds.
@@ -750,6 +791,13 @@ func loadConfigFile(configOverride string) (configFile, bool) {
 
 	var cfg configFile
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		// Surface YAML parse errors directly to stderr: LoadConfig runs
+		// before logger.Init in main.go, so logger.Warn here would go to
+		// io.Discard. Dropping the entire config silently was the previous
+		// behaviour and made typos very hard to debug.
+		fmt.Fprintf(os.Stderr,
+			"lfk: could not parse config %s: %v\nfalling back to built-in defaults\n",
+			configPath, err)
 		return configFile{}, false
 	}
 	return cfg, true
@@ -916,13 +964,7 @@ func applyConfigOptions(cfg configFile) {
 	if cfg.SecretLazyLoading != nil {
 		ConfigSecretLazyLoading = *cfg.SecretLazyLoading
 	}
-	if cfg.InformerCache != nil {
-		// UnmarshalJSON guarantees mode is one of off/auto/always when it
-		// returned nil; an unknown value would have aborted LoadConfig
-		// before we reached applyConfigOptions, so a single-leg check is
-		// enough — no need for a redundant empty-string guard.
-		ConfigInformerCacheMode = cfg.InformerCache.mode
-	}
+	applyInformerCacheSetting(cfg.InformerCache)
 	if cfg.MinContrastRatio != nil {
 		ConfigMinContrastRatio = clamp01(*cfg.MinContrastRatio)
 	}

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,6 +14,42 @@ import (
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 )
+
+// informerCacheSetting holds the parsed informer_cache config value. It
+// accepts both the legacy bool form (true → "always", false → "off") and
+// the named-mode form ("off" / "auto" / "always"). Resolved during
+// LoadConfig and stored in ConfigInformerCacheMode.
+type informerCacheSetting struct {
+	mode string
+}
+
+// UnmarshalJSON accepts either a bool or one of the recognised mode strings.
+// LoadConfig goes through sigs.k8s.io/yaml, which converts YAML to JSON
+// before unmarshalling — so the unmarshaler hooks here are also what handle
+// YAML config files. Unknown strings fail loudly so a typo in the config
+// surfaces at startup instead of silently falling back to a default the
+// user did not pick.
+func (s *informerCacheSetting) UnmarshalJSON(data []byte) error {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		if b {
+			s.mode = InformerCacheAlways
+		} else {
+			s.mode = InformerCacheOff
+		}
+		return nil
+	}
+	var raw string
+	if err := json.Unmarshal(data, &raw); err == nil {
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case InformerCacheOff, InformerCacheAuto, InformerCacheAlways:
+			s.mode = strings.ToLower(strings.TrimSpace(raw))
+			return nil
+		}
+		return fmt.Errorf("informer_cache: unknown mode %q (want off, auto, or always)", raw)
+	}
+	return fmt.Errorf("informer_cache: must be a bool or one of off/auto/always")
+}
 
 // Watch interval bounds.
 const (
@@ -315,6 +353,22 @@ var ConfigDashboard = true
 // between hover and fetch completion.
 var ConfigSecretLazyLoading bool
 
+// Recognised string values for the informer_cache config knob. The Go
+// constants are duplicated from internal/k8s.InformerCacheMode to keep the
+// ui package free of a k8s dependency — main.go does the conversion.
+const (
+	InformerCacheOff    = "off"
+	InformerCacheAuto   = "auto"
+	InformerCacheAlways = "always"
+)
+
+// ConfigInformerCacheMode resolves to one of "off"/"auto"/"always" after
+// LoadConfig. Default "auto" so users on large clusters (issue #86) get the
+// namespace-switch perf win for free; small clusters pay nothing because
+// auto-mode only promotes a (context, GVR) to the cache once a list crosses
+// 1000 items, and demotes it again when the list shrinks.
+var ConfigInformerCacheMode = InformerCacheAuto
+
 // ConfigMinContrastRatio is the normalized readability knob in [0.0, 1.0].
 // When greater than zero, ApplyTheme nudges foreground colors in HSL lightness
 // space so each fg/bg pair meets a minimum WCAG contrast ratio. The mapping is:
@@ -569,6 +623,16 @@ type configFile struct {
 	// the trade-off is a per-hover GET and a brief blank-data frame until the
 	// fetch resolves.
 	SecretLazyLoading *bool `json:"secret_lazy_loading" yaml:"secret_lazy_loading"`
+	// InformerCache controls how lists are routed: "off" round-trips every
+	// time (matches kubectl), "auto" (default) starts in direct mode per
+	// (context, GVR) and promotes to a shared informer once a list crosses
+	// 1000 items — demoting again when the list shrinks below 500 for three
+	// consecutive cached calls — and "always" eagerly opens a watch on the
+	// first list. Accepts the legacy bool form for compatibility: `true`
+	// maps to "always", `false` maps to "off". Issue #86 was the original
+	// motivation: on a 7k-pod cluster a namespace switch goes from a 1–2s
+	// round trip to an in-process slice walk under "auto"/"always".
+	InformerCache *informerCacheSetting `json:"informer_cache" yaml:"informer_cache"`
 	// MinContrastRatio is a normalized readability knob in [0.0, 1.0]. When set
 	// above zero, ApplyTheme nudges each foreground color's HSL lightness until
 	// the fg/bg pair meets the derived WCAG contrast ratio:
@@ -851,6 +915,13 @@ func applyConfigOptions(cfg configFile) {
 	}
 	if cfg.SecretLazyLoading != nil {
 		ConfigSecretLazyLoading = *cfg.SecretLazyLoading
+	}
+	if cfg.InformerCache != nil {
+		// UnmarshalJSON guarantees mode is one of off/auto/always when it
+		// returned nil; an unknown value would have aborted LoadConfig
+		// before we reached applyConfigOptions, so a single-leg check is
+		// enough — no need for a redundant empty-string guard.
+		ConfigInformerCacheMode = cfg.InformerCache.mode
 	}
 	if cfg.MinContrastRatio != nil {
 		ConfigMinContrastRatio = clamp01(*cfg.MinContrastRatio)

--- a/internal/ui/config_informer_cache_consts_test.go
+++ b/internal/ui/config_informer_cache_consts_test.go
@@ -1,0 +1,40 @@
+package ui_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// TestInformerCacheConstants_MatchK8sPackage guards against silent drift
+// between ui.InformerCache* and k8s.InformerCache*. The duplication is
+// intentional (the comment in config.go explains: keep ui free of a k8s
+// dependency in the production graph), but if anyone changes one set of
+// strings without the other, main.go's k8s.InformerCacheMode(ui.Config…)
+// cast would silently land on the auto-fallback in SetInformerCacheMode
+// instead of the mode the user picked. This test fails loudly the moment
+// the two sets drift.
+//
+// Living in package ui_test keeps the import direction clean — no
+// production code in internal/ui imports internal/k8s for these strings.
+func TestInformerCacheConstants_MatchK8sPackage(t *testing.T) {
+	cases := []struct {
+		name string
+		ui   string
+		k8s  k8s.InformerCacheMode
+	}{
+		{"off", ui.InformerCacheOff, k8s.InformerCacheOff},
+		{"auto", ui.InformerCacheAuto, k8s.InformerCacheAuto},
+		{"always", ui.InformerCacheAlways, k8s.InformerCacheAlways},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.ui, string(tc.k8s),
+				"ui and k8s package constants for %q must match — main.go casts string→k8s.InformerCacheMode and a mismatch silently lands on the auto fallback",
+				tc.name)
+		})
+	}
+}

--- a/internal/ui/config_informer_cache_test.go
+++ b/internal/ui/config_informer_cache_test.go
@@ -13,6 +13,11 @@ import (
 // users who flipped the original boolean knob keep working; the string
 // form ("off"/"auto"/"always") is the new way to spell each mode and must
 // be honoured case-insensitively. Default — no key set — is "auto".
+//
+// Bad values must NOT silently mutate the active mode and must NOT poison
+// the rest of the config — earlier behaviour discarded every key on a
+// parse error, masking unrelated keybinding/colorscheme settings. The
+// "typo doesn't nuke unrelated keys" subtest is the regression guard.
 func TestLoadConfig_InformerCache(t *testing.T) {
 	orig := ConfigInformerCacheMode
 	t.Cleanup(func() { ConfigInformerCacheMode = orig })
@@ -27,17 +32,28 @@ func TestLoadConfig_InformerCache(t *testing.T) {
 		{"legacy true maps to always", "informer_cache: true\n", InformerCacheAuto, InformerCacheAlways},
 		{"legacy false maps to off", "informer_cache: false\n", InformerCacheAuto, InformerCacheOff},
 		// String form, all three modes.
-		{"explicit off", "informer_cache: off\n", InformerCacheAuto, InformerCacheOff},
+		{"explicit off", "informer_cache: \"off\"\n", InformerCacheAuto, InformerCacheOff},
 		{"explicit auto", "informer_cache: auto\n", InformerCacheOff, InformerCacheAuto},
 		{"explicit always", "informer_cache: always\n", InformerCacheOff, InformerCacheAlways},
 		// Case-insensitivity is a small but real ergonomic win — config
 		// files mixed with comments tend to drift in casing.
 		{"uppercase Always normalised to lowercase", "informer_cache: ALWAYS\n", InformerCacheOff, InformerCacheAlways},
-		// Unknown values must not silently change the active mode; a typo
-		// in the config file should leave the start value untouched and
-		// surface in the load-error path (which LoadConfig handles by
-		// returning early on Unmarshal failure).
+		// Whitespace tolerance: copy-paste mistakes shouldn't silently
+		// fall through to "auto" on a trim mismatch.
+		{"surrounding whitespace trimmed", "informer_cache: \"  always  \"\n", InformerCacheOff, InformerCacheAlways},
+		// Unknown / unparseable values: warn-and-fallback. The active
+		// mode stays at its start value; logger.Warn is fired (silent at
+		// LoadConfig time but present for future Init reordering).
 		{"unknown mode falls back to start value", "informer_cache: maybe\n", InformerCacheAuto, InformerCacheAuto},
+		{"empty quoted string treated as unset", "informer_cache: \"\"\n", InformerCacheOff, InformerCacheOff},
+		{"numeric value falls back to start", "informer_cache: 42\n", InformerCacheAuto, InformerCacheAuto},
+		// YAML 1.1 boolean coercion: bare `off` / `on` / `yes` / `no`
+		// resolve as bools, NOT as strings. Documented quirk; passing
+		// quoted "off" goes through the string branch instead. The
+		// matrix here pins the actual behaviour so a future YAML lib
+		// upgrade that changes coercion rules trips this test.
+		{"yaml 1.1 bare off coerces to bool false", "informer_cache: off\n", InformerCacheAuto, InformerCacheOff},
+		{"yaml 1.1 bare on coerces to bool true", "informer_cache: on\n", InformerCacheOff, InformerCacheAlways},
 		// Unrelated config keys should not touch the mode.
 		{"unset leaves default auto", "colorscheme: dracula\n", InformerCacheAuto, InformerCacheAuto},
 	}
@@ -54,4 +70,35 @@ func TestLoadConfig_InformerCache(t *testing.T) {
 			assert.Equal(t, tc.want, ConfigInformerCacheMode)
 		})
 	}
+}
+
+// TestLoadConfig_InformerCacheTypoDoesNotPoisonRestOfFile is the
+// regression guard for the silent-discard behaviour: a typo'd
+// informer_cache value used to abort yaml.Unmarshal and drop the entire
+// config, which masked unrelated colorscheme / keybinding / etc. keys.
+// After the warn-and-fallback fix, only informer_cache resets while
+// every other key in the file lands as written.
+func TestLoadConfig_InformerCacheTypoDoesNotPoisonRestOfFile(t *testing.T) {
+	origMode := ConfigInformerCacheMode
+	origScheme := ConfigDarkColorscheme
+	t.Cleanup(func() {
+		ConfigInformerCacheMode = origMode
+		ConfigDarkColorscheme = origScheme
+	})
+
+	ConfigInformerCacheMode = InformerCacheAuto
+	ConfigDarkColorscheme = ""
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yaml := "informer_cache: maybe\ncolorscheme: \"dark:dracula\"\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	LoadConfig(path)
+
+	assert.Equal(t, InformerCacheAuto, ConfigInformerCacheMode,
+		"typo'd informer_cache must fall back to default")
+	assert.Equal(t, "dracula", ConfigDarkColorscheme,
+		"unrelated colorscheme key must still apply — earlier behaviour silently dropped it")
 }

--- a/internal/ui/config_informer_cache_test.go
+++ b/internal/ui/config_informer_cache_test.go
@@ -1,0 +1,57 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLoadConfig_InformerCache verifies the bool-or-string union for the
+// informer_cache key. The legacy `true`/`false` form must still parse so
+// users who flipped the original boolean knob keep working; the string
+// form ("off"/"auto"/"always") is the new way to spell each mode and must
+// be honoured case-insensitively. Default — no key set — is "auto".
+func TestLoadConfig_InformerCache(t *testing.T) {
+	orig := ConfigInformerCacheMode
+	t.Cleanup(func() { ConfigInformerCacheMode = orig })
+
+	tests := []struct {
+		name       string
+		yaml       string
+		startValue string
+		want       string
+	}{
+		// Legacy bool form.
+		{"legacy true maps to always", "informer_cache: true\n", InformerCacheAuto, InformerCacheAlways},
+		{"legacy false maps to off", "informer_cache: false\n", InformerCacheAuto, InformerCacheOff},
+		// String form, all three modes.
+		{"explicit off", "informer_cache: off\n", InformerCacheAuto, InformerCacheOff},
+		{"explicit auto", "informer_cache: auto\n", InformerCacheOff, InformerCacheAuto},
+		{"explicit always", "informer_cache: always\n", InformerCacheOff, InformerCacheAlways},
+		// Case-insensitivity is a small but real ergonomic win — config
+		// files mixed with comments tend to drift in casing.
+		{"uppercase Always normalised to lowercase", "informer_cache: ALWAYS\n", InformerCacheOff, InformerCacheAlways},
+		// Unknown values must not silently change the active mode; a typo
+		// in the config file should leave the start value untouched and
+		// surface in the load-error path (which LoadConfig handles by
+		// returning early on Unmarshal failure).
+		{"unknown mode falls back to start value", "informer_cache: maybe\n", InformerCacheAuto, InformerCacheAuto},
+		// Unrelated config keys should not touch the mode.
+		{"unset leaves default auto", "colorscheme: dracula\n", InformerCacheAuto, InformerCacheAuto},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ConfigInformerCacheMode = tc.startValue
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			LoadConfig(path)
+			assert.Equal(t, tc.want, ConfigInformerCacheMode)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -106,6 +106,8 @@ func runTUI(opts app.StartupOptions) error {
 	}
 	model.PinnedGroups = ui.ConfigPinnedGroups
 	client.SetSecretLazyLoading(ui.ConfigSecretLazyLoading)
+	client.SetInformerCacheMode(k8s.InformerCacheMode(ui.ConfigInformerCacheMode))
+	defer client.Shutdown()
 
 	if err := logger.Init(ui.ConfigLogPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not initialize logger: %v\n", err)
@@ -114,7 +116,11 @@ func runTUI(opts app.StartupOptions) error {
 
 	// Now that the logger is initialized, redirect klog output to our application log.
 	klog.SetOutput(logger.KlogWriter())
-	logger.Info("Application started")
+	logger.Info("Application started",
+		"informer_cache", ui.ConfigInformerCacheMode,
+		"secret_lazy_loading", ui.ConfigSecretLazyLoading,
+		"config_path", opts.Config,
+	)
 
 	// Redirect os.Stderr to capture output from exec credential plugins (e.g., AWS SSO
 	// errors from `aws eks get-token`). Without this, subprocess stderr output goes


### PR DESCRIPTION
## Summary

Issue #86 reports a 1–2 s lag every time the namespace filter is switched on a 7k-pod cluster, because every nav event re-issues a fresh `LIST` against the apiserver. This routes `GetResources` through a per-`(context, GVR)` shared informer when it makes sense, so namespace switching becomes a client-side walk against an in-memory index. The watch keeps the cache fresh — deleted pods drop out and `Age` advances without a manual refresh.

## Type of change

- [x] perf: performance improvement

## Related issue

Closes #86

## Changes

- New `informer_cache` config knob with three modes:
  - `off` — every list round-trips to the apiserver (matches kubectl).
  - `auto` (default) — promote a resource type to the cache once a list crosses 1000 items, demote after three consecutive cached lists below 500. Hysteresis prevents flapping.
  - `always` — open a watch eagerly on first use of each resource type.
  - Legacy bool form still accepted: `true` → `always`, `false` → `off`.
- Per-item memoization keyed on `namespace/name + metadata.resourceVersion`. Items unchanged since the last call are reused without re-running `buildResourceItem` or copying anything; only the few churning items rebuild.
- Memo eviction sweep at the end of every list keeps memo growth bounded by live cluster size, not by all-time churn — scoped so a per-namespace list never prunes other namespaces.
- `Client.Shutdown()` blocks on a `WaitGroup` until all informer goroutines have exited; double-close race between `Stop` and the auto-demote `stopOne` is guarded by an `ic.stopped` early-out.
- 17 unit tests covering cache hit/miss, off/auto/always modes, watch-event invalidation, per-item rebuild, cluster-scoped resources, memo eviction (with scope), concurrent stop+demote, and config-input normalization.
- Docs: `informer_cache` knob + trade-off table in `docs/config-reference.md` and `docs/config-example.yaml`.

## Testing

Verified against a 6,300-pod EKS cluster on `informer_cache: always`:

| Phase | Duration before | Duration after |
|---|---|---|
| First all-namespaces list (cold cache) | 5–10 s | 5–10 s (one-time, includes informer's initial LIST) |
| Subsequent all-namespaces lists, per-list memo only | n/a | 240–800 ms |
| Subsequent all-namespaces lists, **per-item memo (this PR)** | 240–800 ms | **5–15 ms** |
| Switching to a small namespace (~14 items) | < 50 ms | < 50 ms |

The per-item memo achieves a 98–99 % reuse ratio on a churning cluster (e.g. `n=5800, builds=92, reused=5708`), so the headline namespace-switch lag drops by **20–50×** in the warm-cache case while leaving small-cluster behaviour unchanged.

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (6,300 pods, EKS v1.32)
- [x] Race-clean: `go test ./internal/k8s/ -race` (10× repetitions of the new tests)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (no keybinding changes)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

Not applicable — no UI changes; the win is purely latency.