### PR TITLE
perf(app): seed namespace selector overlay from existing cache

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1131,7 +1131,14 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 // namespaceCacheEntry holds the result of a namespace fetch plus the
 // time it completed. The fetchedAt timestamp lets the command bar
 // refresh stale entries without refetching on every open.
+//
+// items is the full model.Item slice (Name + Status), so the namespace
+// selector overlay can reuse the cache without losing the Active /
+// Terminating status colour. names is a parallel slice kept for the
+// command-bar autocompleter, which only needs the strings — the small
+// duplication is cheaper than re-extracting names on every keystroke.
 type namespaceCacheEntry struct {
+	items     []model.Item
 	names     []string
 	fetchedAt time.Time
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -990,7 +990,6 @@ func (m Model) updateNamespacesLoaded(msg namespacesLoadedMsg) (tea.Model, tea.C
 		return m, scheduleStatusClear()
 	}
 	m.err = nil
-	m.overlayItems = buildNamespaceOverlayItems(msg.items)
 	// Cache namespace items + names for command-bar autocompletion and
 	// for synchronous overlay seeding on subsequent opens. Keyed by the
 	// context the fetch was issued for so tabs / `:ctx` switching the
@@ -1009,6 +1008,16 @@ func (m Model) updateNamespacesLoaded(msg namespacesLoadedMsg) (tea.Model, tea.C
 		names:     names,
 		fetchedAt: time.Now(),
 	}
+	// Silent loads are background cache refreshes (stale-while-revalidate
+	// after an overlay open, session restore, `:ctx` switch). They must
+	// not mutate overlayItems / overlayCursor: the user may be navigating
+	// the open namespace overlay right now, and overwriting the items
+	// would yank the cursor off whatever they're hovering. The next open
+	// will pick up the freshly cached entry.
+	if msg.silent {
+		return m, nil
+	}
+	m.overlayItems = buildNamespaceOverlayItems(msg.items)
 	m.overlayCursor = namespaceOverlayCursor(m.overlayItems, m.namespace, m.allNamespaces)
 	return m, nil
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -990,13 +990,13 @@ func (m Model) updateNamespacesLoaded(msg namespacesLoadedMsg) (tea.Model, tea.C
 		return m, scheduleStatusClear()
 	}
 	m.err = nil
-	allNsItem := model.Item{Name: "All Namespaces", Status: "all"}
-	m.overlayItems = append([]model.Item{allNsItem}, msg.items...)
-	// Cache namespace names for command bar autocompletion, keyed by the
-	// context the fetch was issued for. Keying avoids stale results when
-	// tabs / `:ctx` change nav.Context between the request and reply.
-	// Stamp fetchedAt so the next command bar open can decide whether
-	// the entry is still fresh or should trigger a background refresh.
+	m.overlayItems = buildNamespaceOverlayItems(msg.items)
+	// Cache namespace items + names for command-bar autocompletion and
+	// for synchronous overlay seeding on subsequent opens. Keyed by the
+	// context the fetch was issued for so tabs / `:ctx` switching the
+	// nav.Context between request and reply doesn't leak stale results.
+	// fetchedAt stamps the entry so callers can decide whether to use
+	// it as-is or trigger a background refresh.
 	if m.cachedNamespaces == nil {
 		m.cachedNamespaces = make(map[string]namespaceCacheEntry)
 	}
@@ -1005,20 +1005,40 @@ func (m Model) updateNamespacesLoaded(msg namespacesLoadedMsg) (tea.Model, tea.C
 		names = append(names, item.Name)
 	}
 	m.cachedNamespaces[msg.context] = namespaceCacheEntry{
+		items:     msg.items,
 		names:     names,
 		fetchedAt: time.Now(),
 	}
-	if m.allNamespaces {
-		m.overlayCursor = 0
-	} else {
-		for i, item := range m.overlayItems {
-			if item.Name == m.namespace {
-				m.overlayCursor = i
-				break
-			}
+	m.overlayCursor = namespaceOverlayCursor(m.overlayItems, m.namespace, m.allNamespaces)
+	return m, nil
+}
+
+// buildNamespaceOverlayItems prepends the synthetic "All Namespaces" header
+// to a fetched namespace list so the same shape is produced whether items
+// come from a fresh API call or from cachedNamespaces.
+func buildNamespaceOverlayItems(items []model.Item) []model.Item {
+	allNsItem := model.Item{Name: "All Namespaces", Status: "all"}
+	out := make([]model.Item, 0, len(items)+1)
+	out = append(out, allNsItem)
+	out = append(out, items...)
+	return out
+}
+
+// namespaceOverlayCursor returns the row index the overlay cursor should
+// land on when first opened: the "All Namespaces" header when the user is
+// in all-ns mode, otherwise the row matching the active namespace name.
+// Falls back to 0 when no match is found, which keeps the cursor on the
+// "All Namespaces" header instead of leaving it at -1.
+func namespaceOverlayCursor(items []model.Item, currentNs string, allNamespaces bool) int {
+	if allNamespaces {
+		return 0
+	}
+	for i, item := range items {
+		if item.Name == currentNs {
+			return i
 		}
 	}
-	return m, nil
+	return 0
 }
 
 func (m Model) updateYamlLoaded(msg yamlLoadedMsg) (tea.Model, tea.Cmd) {

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -655,10 +655,31 @@ func (m Model) handleKeyNamespaceSelector() (tea.Model, tea.Cmd) {
 	m.overlay = overlayNamespace
 	m.overlayFilter.Clear()
 	m.overlayCursor = 0
-	m.overlayItems = nil // will be populated when namespacesLoadedMsg arrives
 	ui.ResetOverlayNsScroll()
-	m.loading = true
 	m.nsSelectionModified = false
+
+	// Reuse the existing per-context namespace cache (also used by the
+	// command-bar autocompleter). When a cached entry exists we seed the
+	// overlay synchronously so it opens instantly — even when the entry
+	// is stale we show its rows immediately and rely on the
+	// stale-while-revalidate refresh to swap in fresh data shortly after.
+	// Only the empty/missing-cache case still pays the loading-spinner +
+	// API round-trip path the original implementation always took.
+	entry, ok := m.cachedNamespaces[m.activeContext()]
+	if ok && len(entry.items) > 0 {
+		m.overlayItems = buildNamespaceOverlayItems(entry.items)
+		m.overlayCursor = namespaceOverlayCursor(m.overlayItems, m.namespace, m.allNamespaces)
+		m.loading = false
+		// ensureNamespaceCacheFresh returns nil when the entry is fresh
+		// (cache hit, no work) and a silent loader when it has aged past
+		// namespaceCacheTTL — the silent flag keeps the spinner off so
+		// the already-shown overlay is not blanked while the refresh is
+		// in flight.
+		return m, m.ensureNamespaceCacheFresh()
+	}
+
+	m.overlayItems = nil // populated when namespacesLoadedMsg arrives
+	m.loading = true
 	return m, m.loadNamespaces()
 }
 

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -654,7 +654,6 @@ func (m Model) handleKeyPrevMatch() (tea.Model, tea.Cmd) {
 func (m Model) handleKeyNamespaceSelector() (tea.Model, tea.Cmd) {
 	m.overlay = overlayNamespace
 	m.overlayFilter.Clear()
-	m.overlayCursor = 0
 	ui.ResetOverlayNsScroll()
 	m.nsSelectionModified = false
 
@@ -672,13 +671,14 @@ func (m Model) handleKeyNamespaceSelector() (tea.Model, tea.Cmd) {
 		m.loading = false
 		// ensureNamespaceCacheFresh returns nil when the entry is fresh
 		// (cache hit, no work) and a silent loader when it has aged past
-		// namespaceCacheTTL — the silent flag keeps the spinner off so
-		// the already-shown overlay is not blanked while the refresh is
-		// in flight.
+		// namespaceCacheTTL — the silent flag keeps the spinner off and
+		// makes updateNamespacesLoaded skip the overlay-state rewrite, so
+		// the user's cursor and item list survive the background refresh.
 		return m, m.ensureNamespaceCacheFresh()
 	}
 
 	m.overlayItems = nil // populated when namespacesLoadedMsg arrives
+	m.overlayCursor = 0
 	m.loading = true
 	return m, m.loadNamespaces()
 }

--- a/internal/app/update_keys_namespace_selector_test.go
+++ b/internal/app/update_keys_namespace_selector_test.go
@@ -97,36 +97,28 @@ func TestHandleKeyNamespaceSelector_AllNamespacesParksCursorOnHeader(t *testing.
 	assert.Equal(t, "All Namespaces", result.overlayItems[0].Name)
 }
 
-// TestHandleKeyNamespaceSelector_StaleCacheStillSeedsAndRefreshes is
-// the stale-while-revalidate path: an aged entry must still populate
-// the overlay immediately so the open feels instant, while a silent
-// refresh fires in the background to swap in fresh data. The user
-// never sees a spinner here either — the silent flag keeps loading
-// off so the overlay isn't blanked under them.
-func TestHandleKeyNamespaceSelector_StaleCacheStillSeedsAndRefreshes(t *testing.T) {
+// TestHandleKeyNamespaceSelector_StaleCacheStillSeedsOverlay covers the
+// synchronous half of the stale-while-revalidate path: an aged entry
+// must still populate the overlay immediately so the open feels
+// instant, with no spinner. The cmd-side wiring (silent refresh
+// scheduled) is asserted separately in
+// TestHandleKeyNamespaceSelector_StaleCacheSchedulesBackgroundRefresh,
+// which uses a real fake client.
+func TestHandleKeyNamespaceSelector_StaleCacheStillSeedsOverlay(t *testing.T) {
 	m := nsSelectorModel()
-	m.client = nil // ensureNamespaceCacheFresh's silent loader returns nil if client is nil
-	// Use a fake client placeholder via the loader path: leave client nil
-	// is fine because the test only asserts on the synchronous result.
 	m.cachedNamespaces[m.activeContext()] = namespaceCacheEntry{
 		items:     []model.Item{{Name: "default"}, {Name: "kube-system"}},
 		names:     []string{"default", "kube-system"},
 		fetchedAt: time.Now().Add(-2 * namespaceCacheTTL),
 	}
 
-	ret, cmd := m.handleKeyNamespaceSelector()
+	ret, _ := m.handleKeyNamespaceSelector()
 	result := ret.(Model)
 
 	assert.Equal(t, overlayNamespace, result.overlay)
 	assert.False(t, result.loading, "stale cache hit must not blank the already-shown overlay")
 	require.Len(t, result.overlayItems, 3,
 		"stale entry should still seed the overlay synchronously")
-	// loadNamespacesSilent returns nil when m.client is nil, so the cmd
-	// returned here is nil — but that's fine: the assertion above
-	// (overlay seeded synchronously) is the behavioural change we care
-	// about, and the refresh wiring is exercised separately by tests
-	// covering ensureNamespaceCacheFresh.
-	_ = cmd
 }
 
 // TestHandleKeyNamespaceSelector_EmptyCacheFallsBackToLoadingSpinner
@@ -150,4 +142,105 @@ func TestHandleKeyNamespaceSelector_EmptyCacheFallsBackToLoadingSpinner(t *testi
 	if m.client != nil {
 		assert.NotNil(t, cmd, "empty cache must schedule a load command")
 	}
+}
+
+// TestHandleKeyNamespaceSelector_StaleCacheSchedulesBackgroundRefresh is
+// the integration counterpart to the stale-cache seed test: with a real
+// client wired in, the stale cache hit must seed the overlay AND return
+// a non-nil refresh cmd (the silent loader). Without this assertion the
+// stale-while-revalidate wiring could regress without any test failure
+// — the cache would be stuck on stale data forever.
+func TestHandleKeyNamespaceSelector_StaleCacheSchedulesBackgroundRefresh(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.cachedNamespaces = map[string]namespaceCacheEntry{
+		m.activeContext(): {
+			items:     []model.Item{{Name: "default"}, {Name: "kube-system"}},
+			names:     []string{"default", "kube-system"},
+			fetchedAt: time.Now().Add(-2 * namespaceCacheTTL),
+		},
+	}
+
+	ret, cmd := m.handleKeyNamespaceSelector()
+	result := ret.(Model)
+
+	require.Len(t, result.overlayItems, 3, "stale cache must still seed the overlay")
+	assert.False(t, result.loading, "stale cache hit must not blank the overlay")
+	assert.NotNil(t, cmd, "stale cache must schedule a silent refresh command")
+}
+
+// TestUpdateNamespacesLoaded_SilentPreservesOverlayCursor guards the
+// race between the user navigating an open overlay and the silent
+// stale-while-revalidate refresh landing. Without this guard, the
+// cursor jumps back to the active namespace under the user's hand
+// every time the silent refresh lands during an overlay session.
+func TestUpdateNamespacesLoaded_SilentPreservesOverlayCursor(t *testing.T) {
+	m := nsSelectorModel()
+	m.namespace = "default"
+	m.allNamespaces = false
+	m.overlay = overlayNamespace
+	m.overlayItems = []model.Item{
+		{Name: "All Namespaces", Status: "all"},
+		{Name: "default"},
+		{Name: "kube-system"},
+		{Name: "production"},
+	}
+	// User has navigated to "production" (index 3); a non-silent load
+	// would snap the cursor back to row 1 ("default").
+	m.overlayCursor = 3
+
+	ret, _ := m.Update(namespacesLoadedMsg{
+		context: m.activeContext(),
+		items: []model.Item{
+			{Name: "default"},
+			{Name: "kube-system"},
+			{Name: "production"},
+		},
+		silent: true,
+	})
+	result := ret.(Model)
+
+	assert.Equal(t, 3, result.overlayCursor,
+		"silent refresh must not yank the cursor away from the user")
+}
+
+// TestUpdateNamespacesLoaded_SilentLeavesOverlayItemsAlone is the
+// companion to the cursor test: a silent refresh that lands while a
+// non-namespace overlay is open (or while the user is mid-interaction
+// in the namespace overlay) must not rewrite m.overlayItems either.
+// The cache is updated for the next open; the currently-displayed
+// overlay is left untouched.
+func TestUpdateNamespacesLoaded_SilentLeavesOverlayItemsAlone(t *testing.T) {
+	m := nsSelectorModel()
+	original := []model.Item{
+		{Name: "All Namespaces", Status: "all"},
+		{Name: "default", Status: "Active"},
+		{Name: "kube-system", Status: "Active"},
+	}
+	m.overlay = overlayNamespace
+	m.overlayItems = original
+	m.overlayCursor = 2
+
+	ret, _ := m.Update(namespacesLoadedMsg{
+		context: m.activeContext(),
+		// Refreshed list: a brand-new namespace appeared and "default"
+		// is now Terminating. Silent path must not splice this in
+		// under the user's open overlay.
+		items: []model.Item{
+			{Name: "default", Status: "Terminating"},
+			{Name: "kube-system", Status: "Active"},
+			{Name: "newly-created", Status: "Active"},
+		},
+		silent: true,
+	})
+	result := ret.(Model)
+
+	assert.Equal(t, original, result.overlayItems,
+		"silent refresh must leave the visible overlay items alone")
+	// The cache must still be updated so the next overlay open sees
+	// the fresh data — that's the whole point of the background refresh.
+	entry, ok := result.cachedNamespaces[m.activeContext()]
+	require.True(t, ok)
+	require.Len(t, entry.items, 3)
+	assert.Equal(t, "newly-created", entry.items[2].Name,
+		"silent refresh must still update the per-context cache")
 }

--- a/internal/app/update_keys_namespace_selector_test.go
+++ b/internal/app/update_keys_namespace_selector_test.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// nsSelectorModel returns a baseExplorerModel wired up so the namespace
+// selector code path can run end-to-end: the active context resolves, the
+// cachedNamespaces map exists, and the overlay subsystem is at its
+// initial state.
+func nsSelectorModel() Model {
+	m := baseExplorerModel()
+	m.cachedNamespaces = make(map[string]namespaceCacheEntry)
+	return m
+}
+
+// TestHandleKeyNamespaceSelector_SeedsFromFreshCache is the regression
+// guard for the lag a user reported when opening the namespace overlay
+// on a slow API server. With a fresh cache entry, the overlay must
+// populate synchronously: overlayItems is non-nil before any tea.Cmd
+// runs, m.loading stays false, and ensureNamespaceCacheFresh returns nil
+// so no API call is scheduled.
+func TestHandleKeyNamespaceSelector_SeedsFromFreshCache(t *testing.T) {
+	m := nsSelectorModel()
+	m.cachedNamespaces[m.activeContext()] = namespaceCacheEntry{
+		items: []model.Item{
+			{Name: "default", Status: "Active"},
+			{Name: "kube-system", Status: "Active"},
+		},
+		names:     []string{"default", "kube-system"},
+		fetchedAt: time.Now(),
+	}
+
+	ret, cmd := m.handleKeyNamespaceSelector()
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay)
+	assert.False(t, result.loading, "cached open must not show the loading spinner")
+	require.Len(t, result.overlayItems, 3, "expected All Namespaces header + 2 cached items")
+	assert.Equal(t, "All Namespaces", result.overlayItems[0].Name)
+	assert.Equal(t, "default", result.overlayItems[1].Name)
+	assert.Equal(t, "Active", result.overlayItems[1].Status,
+		"status must round-trip through the cache so Terminating namespaces still render correctly")
+	assert.Nil(t, cmd, "fresh cache hit must not schedule an API refresh")
+}
+
+// TestHandleKeyNamespaceSelector_CursorPositionsOnCurrentNamespace
+// verifies the overlay opens with the cursor on the user's active
+// namespace, mirroring the post-fetch behaviour. Without this the
+// synchronously-seeded overlay would stick the cursor on row 0
+// regardless of the current selection.
+func TestHandleKeyNamespaceSelector_CursorPositionsOnCurrentNamespace(t *testing.T) {
+	m := nsSelectorModel()
+	m.namespace = "kube-system"
+	m.allNamespaces = false
+	m.cachedNamespaces[m.activeContext()] = namespaceCacheEntry{
+		items: []model.Item{
+			{Name: "default"},
+			{Name: "kube-system"},
+			{Name: "monitoring"},
+		},
+		names:     []string{"default", "kube-system", "monitoring"},
+		fetchedAt: time.Now(),
+	}
+
+	ret, _ := m.handleKeyNamespaceSelector()
+	result := ret.(Model)
+
+	// items: [All Namespaces, default, kube-system, monitoring] → cursor 2.
+	assert.Equal(t, 2, result.overlayCursor)
+}
+
+// TestHandleKeyNamespaceSelector_AllNamespacesParksCursorOnHeader
+// verifies that when the user is in all-ns mode, the cursor lands on
+// the "All Namespaces" header row (index 0) rather than on whatever
+// namespace happened to match m.namespace.
+func TestHandleKeyNamespaceSelector_AllNamespacesParksCursorOnHeader(t *testing.T) {
+	m := nsSelectorModel()
+	m.namespace = "default"
+	m.allNamespaces = true
+	m.cachedNamespaces[m.activeContext()] = namespaceCacheEntry{
+		items:     []model.Item{{Name: "default"}, {Name: "kube-system"}},
+		names:     []string{"default", "kube-system"},
+		fetchedAt: time.Now(),
+	}
+
+	ret, _ := m.handleKeyNamespaceSelector()
+	result := ret.(Model)
+
+	assert.Equal(t, 0, result.overlayCursor)
+	assert.Equal(t, "All Namespaces", result.overlayItems[0].Name)
+}
+
+// TestHandleKeyNamespaceSelector_StaleCacheStillSeedsAndRefreshes is
+// the stale-while-revalidate path: an aged entry must still populate
+// the overlay immediately so the open feels instant, while a silent
+// refresh fires in the background to swap in fresh data. The user
+// never sees a spinner here either — the silent flag keeps loading
+// off so the overlay isn't blanked under them.
+func TestHandleKeyNamespaceSelector_StaleCacheStillSeedsAndRefreshes(t *testing.T) {
+	m := nsSelectorModel()
+	m.client = nil // ensureNamespaceCacheFresh's silent loader returns nil if client is nil
+	// Use a fake client placeholder via the loader path: leave client nil
+	// is fine because the test only asserts on the synchronous result.
+	m.cachedNamespaces[m.activeContext()] = namespaceCacheEntry{
+		items:     []model.Item{{Name: "default"}, {Name: "kube-system"}},
+		names:     []string{"default", "kube-system"},
+		fetchedAt: time.Now().Add(-2 * namespaceCacheTTL),
+	}
+
+	ret, cmd := m.handleKeyNamespaceSelector()
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay)
+	assert.False(t, result.loading, "stale cache hit must not blank the already-shown overlay")
+	require.Len(t, result.overlayItems, 3,
+		"stale entry should still seed the overlay synchronously")
+	// loadNamespacesSilent returns nil when m.client is nil, so the cmd
+	// returned here is nil — but that's fine: the assertion above
+	// (overlay seeded synchronously) is the behavioural change we care
+	// about, and the refresh wiring is exercised separately by tests
+	// covering ensureNamespaceCacheFresh.
+	_ = cmd
+}
+
+// TestHandleKeyNamespaceSelector_EmptyCacheFallsBackToLoadingSpinner
+// preserves the original first-open behaviour: with no cached entry,
+// the overlay shows the loading spinner and schedules a synchronous
+// (non-silent) load command. Without this the user would see an
+// "empty namespace list" flash before the load lands.
+func TestHandleKeyNamespaceSelector_EmptyCacheFallsBackToLoadingSpinner(t *testing.T) {
+	m := nsSelectorModel()
+	// cachedNamespaces map exists but is empty.
+
+	ret, cmd := m.handleKeyNamespaceSelector()
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay)
+	assert.True(t, result.loading, "empty cache must show the loading spinner")
+	assert.Nil(t, result.overlayItems, "empty cache must not populate items synchronously")
+	// loadNamespaces -> loadNamespacesSilent(false): returns a tea.Cmd
+	// even when client is nil (the cmd would surface a nil-client error
+	// at execute time). Either way, it's not nil here.
+	if m.client != nil {
+		assert.NotNil(t, cmd, "empty cache must schedule a load command")
+	}
+}


### PR DESCRIPTION
## Summary

Pressing the namespace-selector key always issued a fresh `List` against the apiserver before the picker could render, even though lfk already maintains a per-context namespace cache (60 s TTL) for the command-bar autocompleter. On a slow apiserver this shows up as a perceptible lag every time the user opens the picker. This PR seeds the overlay synchronously from the existing cache and only falls back to the loading-spinner path when no cached entry exists.

## Type of change

- [x] perf: performance improvement

## Related issue

Found while investigating #86.

## Changes

- `handleKeyNamespaceSelector` consults `cachedNamespaces` first. When a fresh entry exists the overlay opens with rows already populated; when stale, rows still show immediately and a silent refresh fires via `ensureNamespaceCacheFresh` (stale-while-revalidate). Empty cache keeps the original spinner behaviour so the user never sees an empty overlay flash on first open.
- `namespaceCacheEntry` gains an `items []model.Item` field alongside the existing `names []string` so reused rows preserve `Active` / `Terminating` status colour. The two slices share the same source; the small duplication is cheaper than re-extracting names on every command-bar keystroke.
- Helpers `buildNamespaceOverlayItems` and `namespaceOverlayCursor` extracted so the synchronous-seed path and the post-fetch handler produce identical overlay shape and cursor placement.
- 5 tests covering: fresh cache seeds synchronously, cursor positions on the active namespace, all-ns mode parks on the header, stale cache still seeds + refreshes, empty cache falls back to spinner.

## Testing

Verified by opening the namespace selector repeatedly in a session against a real cluster:

| Action | Before | After |
|---|---|---|
| First open after entering a context | API round-trip + spinner | API round-trip + spinner (unchanged — populates cache) |
| Subsequent opens within 60 s | API round-trip + spinner | **Instant — synchronous from cache** |
| Subsequent opens after 60 s | API round-trip + spinner | **Instant — stale rows shown, silent refresh in background** |

Cache invalidation already works for free — `commandbar_execute.go` calls `invalidateNamespaceCache` on `:k create ns` / `:k delete ns` / template applies, so the overlay shares the same freshness guarantees as the autocompleter.

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [ ] README / `docs/` updated when user-visible behavior or config changed (no user-visible config change)
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (no keybinding changes)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

Not applicable — purely a latency improvement on an existing UI flow.