### PR TITLE
Feature/add quit keymaps hint to window

### DIFF
--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -270,16 +270,19 @@ func RenderConfirmOverlay(action string) string {
 // RenderQuitConfirmOverlay renders the quit confirmation overlay content
 // centered both horizontally and vertically within (innerWidth, innerHeight),
 // using the title color for emphasis. The dimensions should be the overlay
-// box's content area (overlayW/H minus border + padding). Single line —
-// a separate "Quit" title used to read as a second option in a two-line
-// layout, so it was dropped.
+// box's content area (overlayW/H minus border + padding).
 func RenderQuitConfirmOverlay(innerWidth, innerHeight int) string {
-	return OverlayTitleStyle.
-		Padding(0).
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(OverlayTitleStyle.Render("Quit lfk?"))
+	b.WriteString("\n")
+	b.WriteString(OverlayDimStyle.Render("[y] yes  [n] no"))
+
+	return lipgloss.NewStyle().
 		Width(innerWidth).
 		Height(innerHeight).
 		Align(lipgloss.Center, lipgloss.Center).
-		Render("Quit lfk?")
+		Render(b.String())
 }
 
 // RenderPasteConfirmOverlay renders the multiline paste confirmation overlay.

--- a/internal/ui/overlay_extra_test.go
+++ b/internal/ui/overlay_extra_test.go
@@ -10,25 +10,34 @@ import (
 // --- RenderQuitConfirmOverlay ---
 
 func TestRenderQuitConfirmOverlay(t *testing.T) {
-	// Single question, centered both horizontally and vertically within
-	// (innerWidth, innerHeight). The previous two-line layout (title +
-	// question) was being misread as a menu, so it was dropped.
-	result := RenderQuitConfirmOverlay(26, 3)
+	// Two-line layout: question + key hint, separated by a blank
+	// spacer row, centered both horizontally and vertically within
+	// (innerWidth, innerHeight).
+	result := RenderQuitConfirmOverlay(26, 5)
 	assert.Contains(t, result, "Quit lfk?", "should show the question")
+	assert.Contains(t, result, "[y] yes", "should show the yes hint")
+	assert.Contains(t, result, "[n] no", "should show the no hint")
 
-	// Vertical centering: 3 rows total, 1 row of question → 1 blank row
-	// above and below.
+	// Vertical centering: 5 rows total. Content is 3 rows (question,
+	// blank spacer, hint), leaving 1 blank row above and 1 below.
 	lines := strings.Split(result, "\n")
-	assert.Equal(t, 3, len(lines), "should fill innerHeight rows")
-	questionRow := -1
+	assert.Equal(t, 5, len(lines), "should fill innerHeight rows")
+
+	questionRow, hintRow := -1, -1
 	for i, line := range lines {
-		if strings.Contains(stripANSI(line), "Quit lfk?") {
+		plain := stripANSI(line)
+		if strings.Contains(plain, "Quit lfk?") {
 			questionRow = i
 		}
+		if strings.Contains(plain, "[y] yes") {
+			hintRow = i
+		}
 	}
-	assert.Equal(t, 1, questionRow, "question must sit on the middle row")
+	assert.Equal(t, 1, questionRow, "question must sit on the second row")
+	assert.Equal(t, 3, hintRow, "hint must sit two rows below the question")
 
-	// Horizontal centering: roughly equal leading/trailing whitespace.
+	// Horizontal centering of the question line: roughly equal
+	// leading/trailing whitespace.
 	plain := stripANSI(lines[questionRow])
 	leading := len(plain) - len(strings.TrimLeft(plain, " "))
 	trailing := len(plain) - len(strings.TrimRight(plain, " "))


### PR DESCRIPTION
## Summary

Add `[y] yes [n] no` hint to "Quit lfk?" window.

The window wasn't intuitive to me at first, there was a blank space on the lower half, it almost felt like there was a hint supposed to be there, so I added it. Without it one would the typicals like `q`/`y` but may not see (like I did) that there was a dark hint on the bottom bar saying to press `Enter`.

## Type of change

- [x] feat: new user-facing feature
- [ ] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [x] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

<!-- e.g. Closes #123 -->

## Changes

- Add hint under Quit window title
- Modify test accordingly

## Testing

<!-- How did you verify this works? Include the cluster / terminal you tested against when relevant. -->

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->
