### PR TITLE
fix(app): make node shell work on SELinux-enforcing immutable distros

### DIFF
--- a/internal/app/commands_exec.go
+++ b/internal/app/commands_exec.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand/v2"
 	"os"
@@ -995,7 +996,68 @@ func (m Model) triggerCronJob() tea.Cmd {
 	})
 }
 
-// execKubectlNodeShell opens a debug shell on a node using kubectl debug.
+// nodeShellOverrides builds the JSON pod-spec override that kubectl run
+// applies to the auto-generated pod. The pod is privileged with hostPID,
+// hostIPC, and hostNetwork enabled, pinned to the target node, and runs
+// nsenter into PID 1's namespaces.
+//
+// Why we don't use `kubectl debug node/<name>`: that path's profiles all
+// mount `hostPath: /` at `/host` so callers can `chroot /host`. On
+// SELinux-enforcing distros (openSUSE MicroOS, Talos, Bottlerocket) the
+// host-root mount keeps the container labelled `container_t`, where
+// `nsenter` cannot read `/proc/1/ns/*` (EPERM). A clean privileged pod
+// without that mount gets labelled `spc_t` (super privileged container)
+// where namespace entry succeeds. This is the same shape k9s and Lens
+// produce for their node shell feature.
+func nodeShellOverrides(podName, nodeName string) (string, error) {
+	spec := map[string]any{
+		"apiVersion": "v1",
+		"spec": map[string]any{
+			"hostPID":     true,
+			"hostIPC":     true,
+			"hostNetwork": true,
+			"nodeName":    nodeName,
+			"tolerations": []map[string]any{{"operator": "Exists"}},
+			"containers": []map[string]any{{
+				"name":  podName,
+				"image": "busybox",
+				"stdin": true,
+				"tty":   true,
+				"securityContext": map[string]any{
+					"privileged": true,
+				},
+				"command": []string{
+					"nsenter",
+					"--target", "1",
+					"--mount", "--uts", "--ipc", "--net", "--pid",
+					"--", "/bin/sh",
+				},
+			}},
+		},
+	}
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal node shell pod spec: %w", err)
+	}
+	return string(b), nil
+}
+
+// nodeShellArgs builds the kubectl-run arguments that, combined with the
+// override JSON, launch a privileged debug pod on the target node and
+// attach to it. See nodeShellOverrides for why we avoid `kubectl debug`.
+func nodeShellArgs(podName, kctx, overrides string) []string {
+	return []string{
+		"run", podName,
+		"-n", "default",
+		"--rm", "-it", "--restart=Never",
+		"--image=busybox",
+		"--context", kctx,
+		"--overrides=" + overrides,
+	}
+}
+
+// execKubectlNodeShell launches a privileged debug pod on the target node
+// and attaches the user's terminal to a shell entered via nsenter.
 func (m Model) execKubectlNodeShell() tea.Cmd {
 	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil {
@@ -1006,14 +1068,16 @@ func (m Model) execKubectlNodeShell() tea.Cmd {
 
 	nodeName := m.actionCtx.name
 	ctx := m.actionCtx.context
+	podName := "lfk-node-shell-" + randomSuffix(5)
 
-	args := []string{
-		"debug", "node/" + nodeName, "-it",
-		"--image=busybox",
-		"--context", m.kubectlContext(ctx),
-		"--", "chroot", "/host", "/bin/sh",
+	overrides, err := nodeShellOverrides(podName, nodeName)
+	if err != nil {
+		return func() tea.Msg {
+			return actionResultMsg{err: err}
+		}
 	}
 
+	args := nodeShellArgs(podName, m.kubectlContext(ctx), overrides)
 	cmd := exec.Command(kubectlPath, args...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 	logExecCmd("Running kubectl command", cmd)
@@ -1032,10 +1096,7 @@ func (m Model) execKubectlNodeShell() tea.Cmd {
 	}
 
 	title := fmt.Sprintf("Node Shell: %s", nodeName)
-	// `kubectl debug node/...` already takes the terminal cleanly via
-	// chroot — clearBeforeExec is unnecessary and would race with the
-	// debug pod's own startup output.
-	return runInteractiveShellExec(cmd, title, "Node shell", false)
+	return runInteractiveShellExec(cmd, title, "Node shell", true)
 }
 
 // --- Explain commands ---

--- a/internal/app/commands_exec_test.go
+++ b/internal/app/commands_exec_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"os/exec"
 	"strings"
 	"testing"
@@ -119,6 +120,93 @@ func TestPush3ExecKubectlNodeShellNoKubectl(t *testing.T) {
 	cmd := m.execKubectlNodeShell()
 	require.NotNil(t, cmd)
 	// This returns a tea.ExecProcess or error cmd.
+}
+
+// Node shell must launch via `kubectl run --overrides` with a clean pod spec
+// — same pattern k9s and Lens use. Going through `kubectl debug node` adds a
+// hostPath /host volume that on SELinux-enforcing distros (openSUSE MicroOS,
+// Talos, Bottlerocket) leaves the container in `container_t` and blocks
+// nsenter's access to `/proc/1/ns/*`. The standalone privileged pod gets
+// labelled `spc_t`, where nsenter into PID 1 succeeds.
+func TestNodeShellArgsUseRunWithCleanOverrides(t *testing.T) {
+	podName := "lfk-node-shell-abc12"
+	overrides, err := nodeShellOverrides(podName, "node-1")
+	require.NoError(t, err)
+
+	args := nodeShellArgs(podName, "test-ctx", overrides)
+
+	require.Equal(t, "run", args[0], "must use `kubectl run`, not `kubectl debug`")
+	require.Equal(t, podName, args[1])
+	assert.Contains(t, args, "--rm")
+	assert.Contains(t, args, "-it")
+	assert.Contains(t, args, "--restart=Never")
+	assert.Contains(t, args, "--image=busybox")
+	assert.Contains(t, args, "--context")
+	assert.Contains(t, args, "test-ctx")
+
+	for _, a := range args {
+		assert.NotEqual(t, "debug", a, "kubectl debug pulls in /host mount which breaks SELinux")
+		assert.NotContains(t, a, "chroot", "chroot leaves shell in container's MAC domain")
+		assert.NotContains(t, a, "/host", "host-root mount must not appear")
+	}
+
+	var overridesArg string
+	for _, a := range args {
+		if rest, ok := strings.CutPrefix(a, "--overrides="); ok {
+			overridesArg = rest
+			break
+		}
+	}
+	require.NotEmpty(t, overridesArg, "args must contain --overrides=<json>")
+
+	var spec struct {
+		Spec struct {
+			HostPID     bool   `json:"hostPID"`
+			HostIPC     bool   `json:"hostIPC"`
+			HostNetwork bool   `json:"hostNetwork"`
+			NodeName    string `json:"nodeName"`
+			Tolerations []struct {
+				Operator string `json:"operator"`
+			} `json:"tolerations"`
+			Containers []struct {
+				Name            string   `json:"name"`
+				Image           string   `json:"image"`
+				Stdin           bool     `json:"stdin"`
+				TTY             bool     `json:"tty"`
+				Command         []string `json:"command"`
+				SecurityContext struct {
+					Privileged bool `json:"privileged"`
+				} `json:"securityContext"`
+			} `json:"containers"`
+		} `json:"spec"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(overridesArg), &spec))
+
+	assert.True(t, spec.Spec.HostPID, "hostPID required so nsenter sees host's PID 1")
+	assert.True(t, spec.Spec.HostIPC, "hostIPC required for nsenter --ipc")
+	assert.True(t, spec.Spec.HostNetwork)
+	assert.Equal(t, "node-1", spec.Spec.NodeName, "pod must pin to the target node")
+	require.Len(t, spec.Spec.Tolerations, 1, "must tolerate all taints to land on control-plane nodes")
+	assert.Equal(t, "Exists", spec.Spec.Tolerations[0].Operator)
+
+	require.Len(t, spec.Spec.Containers, 1)
+	c := spec.Spec.Containers[0]
+	assert.Equal(t, podName, c.Name, "container name must match pod name so kubectl can attach")
+	assert.Equal(t, "busybox", c.Image)
+	assert.True(t, c.Stdin)
+	assert.True(t, c.TTY)
+	assert.True(t, c.SecurityContext.Privileged, "privileged required for nsenter")
+
+	require.NotEmpty(t, c.Command)
+	assert.Equal(t, "nsenter", c.Command[0])
+	assert.Contains(t, c.Command, "--target")
+	assert.Contains(t, c.Command, "1")
+	for _, flag := range []string{"--mount", "--uts", "--ipc", "--net", "--pid"} {
+		assert.Contains(t, c.Command, flag, "missing namespace flag %s", flag)
+	}
+	for _, short := range []string{"-t", "-m", "-u", "-i", "-n", "-p"} {
+		assert.NotContains(t, c.Command, short, "expected long flag instead of %s", short)
+	}
 }
 
 func TestPush3ExecKubectlDescribeNoKubectl(t *testing.T) {

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -991,7 +991,7 @@ func (m Model) executeActionTrigger() (tea.Model, tea.Cmd) {
 func (m Model) executeActionShell() (tea.Model, tea.Cmd) {
 	name := m.actionCtx.name
 	ctx := m.actionCtx.context
-	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl debug node/%s -it --image=busybox --context %s -- chroot /host /bin/sh", name, ctx))
+	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl run lfk-node-shell-<rand> -n default --rm -it --restart=Never --image=busybox --context %s --overrides='<spec pinned to %s with hostPID/IPC/Net + privileged + nsenter>'", ctx, name))
 	return m, m.execKubectlNodeShell()
 }
 


### PR DESCRIPTION
## Summary

- Make node shell work on SELinux-enforcing immutable distros (openSUSE MicroOS, Talos, Bottlerocket, Flatcar) by replacing `kubectl debug node/<n> -- chroot /host /bin/sh` with a hand-built privileged pod launched via `kubectl run --overrides`, mirroring the pattern used by k9s and Lens.
- nsenter into PID 1's namespaces (long flags: `--target / --mount / --uts / --ipc / --net / --pid`) gives the user the host's mount table, real `/proc/1`, host SELinux context, and a working `systemctl` / `journalctl` / `transactional-update` / `rebootmgrctl`.
- Adds `nodeShellOverrides()` + `nodeShellArgs()` helpers and a comprehensive table-style assertion that decodes the override JSON and checks every safety-critical field.

## Why this changes more than the launch command

Two layered failures had to be unwound:

1. `chroot /host /bin/sh` only swaps the root directory; it leaves the shell in the *container's* mount/PID/IPC/UTS/network and SELinux MAC domain. Host pidfiles like `/run/auditd.pid` come back as `?????????` (MAC denial, not Unix permission), and `systemctl` / `journalctl` don't see host services.

2. Switching the entrypoint to `nsenter --target 1 ...` then failed on MicroOS with:

    ```
    nsenter: can't open '/proc/1/ns/ipc': Permission denied
    ```

    Root cause: every `kubectl debug node` profile mounts `hostPath: /` at `/host` (that's what `chroot /host` is *for*). On MicroOS the runtime keeps that pod labelled `container_t`, which SELinux denies `process2:ptrace` against `init_t`. A clean privileged pod *without* the host-root mount gets labelled `spc_t` (super privileged container), where ptrace_read against PID 1 is allowed.

    Confirmed empirically: `cat /proc/self/attr/current` in a working k9s node-shell pod returns `spc_t`; the same in a `kubectl debug node` pod stays `container_t`.

## What we now send

```sh
kubectl run lfk-node-shell-<rand> -n default --rm -it --restart=Never \
  --image=busybox --context <ctx> \
  --overrides=<JSON: hostPID/IPC/Net + privileged + tolerations + nsenter --target 1 --mount --uts --ipc --net --pid -- /bin/sh>
```

Same shape as k9s `shellPod` and Lens node-shell.

## Test plan

- [x] `go test -race ./...` — all packages green
- [x] `gofumpt`, `go vet`, `golangci-lint run ./...` — 0 issues
- [x] New `TestNodeShellArgsUseRunWithCleanOverrides` decodes the override JSON and asserts host namespaces, privileged, nsenter long flags, container name == pod name, absence of `chroot` / `/host` / `kubectl debug`
- [x] Verified manually on a Hetzner Cloud node running openSUSE MicroOS:
    - Old `chroot` path: shell came up but couldn't touch host services / pidfiles (MAC denial)
    - Intermediate `kubectl debug node + nsenter` path: failed with EPERM on `/proc/1/ns/ipc`
    - This PR's path: `cat /proc/self/attr/current` → `spc_t`, full host shell, `transactional-update status` and `rebootmgrctl status` work
