### PR TITLE
feat(ui): center quit overlay + advertise y/n on confirm dialogs

### DIFF
--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -27,18 +27,18 @@ func (m Model) overlayHintBarDialog() string {
 	switch m.overlay {
 	case overlayConfirm:
 		return m.renderHints([]ui.HintEntry{
-			{Key: "Enter", Desc: "confirm"},
-			{Key: "Esc", Desc: "cancel"},
+			{Key: "Enter/y", Desc: "confirm"},
+			{Key: "Esc/n", Desc: "cancel"},
 		})
 	case overlayQuitConfirm:
 		return m.renderHints([]ui.HintEntry{
-			{Key: "Enter", Desc: "quit"},
-			{Key: "Esc", Desc: "cancel"},
+			{Key: "Enter/y", Desc: "quit"},
+			{Key: "Esc/n", Desc: "cancel"},
 		})
 	case overlayPasteConfirm:
 		return m.renderHints([]ui.HintEntry{
-			{Key: "Enter", Desc: "paste"},
-			{Key: "Esc", Desc: "cancel"},
+			{Key: "Enter/y", Desc: "paste"},
+			{Key: "Esc/n", Desc: "cancel"},
 		})
 	case overlayConfirmType:
 		return m.renderHints([]ui.HintEntry{
@@ -228,13 +228,13 @@ func (m Model) overlayHintBarBookmarks() string {
 		})
 	case bookmarkModeConfirmDelete:
 		return m.renderHints([]ui.HintEntry{
-			{Key: "Enter", Desc: "delete"},
-			{Key: "Esc", Desc: "cancel"},
+			{Key: "Enter/y", Desc: "delete"},
+			{Key: "Esc/n", Desc: "cancel"},
 		})
 	case bookmarkModeConfirmDeleteAll:
 		return m.renderHints([]ui.HintEntry{
-			{Key: "Enter", Desc: "delete all"},
-			{Key: "Esc", Desc: "cancel"},
+			{Key: "Enter/y", Desc: "delete all"},
+			{Key: "Esc/n", Desc: "cancel"},
 		})
 	default:
 		// tab desc flips with state: "load ns" when the user can arm

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -35,6 +35,11 @@ func (m Model) overlayHintBarDialog() string {
 			{Key: "Enter", Desc: "quit"},
 			{Key: "Esc", Desc: "cancel"},
 		})
+	case overlayPasteConfirm:
+		return m.renderHints([]ui.HintEntry{
+			{Key: "Enter", Desc: "paste"},
+			{Key: "Esc", Desc: "cancel"},
+		})
 	case overlayConfirmType:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "type DELETE", Desc: "confirm"},

--- a/internal/app/overlay_hintbar_test.go
+++ b/internal/app/overlay_hintbar_test.go
@@ -29,6 +29,7 @@ func TestOverlayHintBar_ReturnsNonEmpty(t *testing.T) {
 		{"Action", overlayAction, nil, "enter"},
 		{"Confirm", overlayConfirm, nil, "Enter"},
 		{"QuitConfirm", overlayQuitConfirm, nil, "Enter"},
+		{"PasteConfirm", overlayPasteConfirm, nil, "paste"},
 		{"ConfirmType", overlayConfirmType, nil, "DELETE"},
 		{"ScaleInput", overlayScaleInput, nil, "Enter"},
 		{"PortForward", overlayPortForward, nil, "enter"},

--- a/internal/app/overlay_hintbar_test.go
+++ b/internal/app/overlay_hintbar_test.go
@@ -81,6 +81,52 @@ func TestOverlayHintBar_ReturnsNonEmpty(t *testing.T) {
 	}
 }
 
+// Confirm-style dialogs advertise both halves of the key pair the
+// handlers accept — Enter/y for confirm and Esc/n for cancel. Users
+// who reach for y or n shouldn't have to read source to find them.
+// PRs #80 and #97 surfaced this gap by trying to add inline `[y] yes
+// [n] no` text inside the overlay; the hint bar is now the place
+// these letters live.
+func TestOverlayHintBar_ConfirmDialogsAdvertiseYAndN(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func() Model
+	}{
+		{"Confirm", func() Model {
+			return Model{overlay: overlayConfirm, width: 120}
+		}},
+		{"QuitConfirm", func() Model {
+			return Model{overlay: overlayQuitConfirm, width: 120}
+		}},
+		{"PasteConfirm", func() Model {
+			return Model{overlay: overlayPasteConfirm, width: 120}
+		}},
+		{"BookmarkConfirmDelete", func() Model {
+			return Model{overlay: overlayBookmarks, bookmarkSearchMode: bookmarkModeConfirmDelete, width: 120}
+		}},
+		{"BookmarkConfirmDeleteAll", func() Model {
+			return Model{overlay: overlayBookmarks, bookmarkSearchMode: bookmarkModeConfirmDeleteAll, width: 120}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.setup().overlayHintBar()
+			if got == "" {
+				t.Fatalf("overlayHintBar() returned empty for %s", tc.name)
+			}
+			// Both halves of the pair must appear. We check substring
+			// presence rather than exact form so that future renaming
+			// (e.g. "Enter/y" → "y/Enter") still keeps the contract.
+			for _, want := range []string{"Enter", "y", "Esc", "n"} {
+				if !strings.Contains(got, want) {
+					t.Errorf("overlayHintBar() for %s missing %q in %q", tc.name, want, got)
+				}
+			}
+		})
+	}
+}
+
 // TestStatusBar_ShowsOverlayHints verifies the status bar uses overlay hints when an overlay is active.
 func TestStatusBar_ShowsOverlayHints(t *testing.T) {
 	m := Model{

--- a/internal/app/overlay_hintbar_test.go
+++ b/internal/app/overlay_hintbar_test.go
@@ -115,13 +115,17 @@ func TestOverlayHintBar_ConfirmDialogsAdvertiseYAndN(t *testing.T) {
 			if got == "" {
 				t.Fatalf("overlayHintBar() returned empty for %s", tc.name)
 			}
-			// Both halves of the pair must appear. We check substring
-			// presence rather than exact form so that future renaming
-			// (e.g. "Enter/y" → "y/Enter") still keeps the contract.
-			for _, want := range []string{"Enter", "y", "Esc", "n"} {
-				if !strings.Contains(got, want) {
-					t.Errorf("overlayHintBar() for %s missing %q in %q", tc.name, want, got)
-				}
+			// Both halves of the pair must appear, slash-grouped. Plain
+			// "n" / "y" substring matches would be satisfied by "Enter"
+			// or "cancel" alone, so we lock in the slash form (or its
+			// reverse) instead.
+			confirm := strings.Contains(got, "Enter/y") || strings.Contains(got, "y/Enter")
+			cancel := strings.Contains(got, "Esc/n") || strings.Contains(got, "n/Esc")
+			if !confirm {
+				t.Errorf("overlayHintBar() for %s missing Enter/y pair in %q", tc.name, got)
+			}
+			if !cancel {
+				t.Errorf("overlayHintBar() for %s missing Esc/n pair in %q", tc.name, got)
 			}
 		})
 	}

--- a/internal/app/quit_render_inspect_test.go
+++ b/internal/app/quit_render_inspect_test.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The Quit overlay must render as a 5-row box with "Quit lfk?" on the
+// middle row. lipgloss `Height(N)` counts inner+padding (not border), so the
+// arithmetic in renderOverlayContent has to compensate (qh=3 produces a
+// 5-row outer box). PRs #80, #97 highlighted that contributors notice when
+// "Quit lfk?" floats above empty space — keep this test green to catch the
+// regression directly instead of waiting for the next PR.
+func TestQuitOverlayCentersTextOnMiddleRow(t *testing.T) {
+	m := Model{
+		overlay: overlayQuitConfirm,
+		width:   80,
+		height:  24,
+	}
+	bg := strings.Repeat("background row\n", 24)
+	out := m.renderOverlay(bg)
+	lines := strings.Split(out, "\n")
+
+	var topBorder, bottomBorder, textRow int
+	topBorder = -1
+	bottomBorder = -1
+	textRow = -1
+	for i, line := range lines {
+		stripped := ansi.Strip(line)
+		switch {
+		case strings.Contains(stripped, "╭"):
+			topBorder = i
+		case strings.Contains(stripped, "╰"):
+			bottomBorder = i
+		case strings.Contains(stripped, "Quit lfk?"):
+			textRow = i
+		}
+	}
+
+	require.NotEqual(t, -1, topBorder, "top border row not found")
+	require.NotEqual(t, -1, bottomBorder, "bottom border row not found")
+	require.NotEqual(t, -1, textRow, "text row not found")
+
+	dialogHeight := bottomBorder - topBorder + 1
+	assert.Equal(t, 5, dialogHeight, "dialog should be exactly 5 rows tall (border / padding / text / padding / border)")
+
+	// Middle row of 5 is offset 2 from the top border (0-indexed).
+	expectedTextRow := topBorder + 2
+	assert.Equal(t, expectedTextRow, textRow,
+		"text must sit on the middle row (border@%d, text@%d, expected@%d)", topBorder, textRow, expectedTextRow)
+}

--- a/internal/app/quit_render_inspect_test.go
+++ b/internal/app/quit_render_inspect_test.go
@@ -25,10 +25,7 @@ func TestQuitOverlayCentersTextOnMiddleRow(t *testing.T) {
 	out := m.renderOverlay(bg)
 	lines := strings.Split(out, "\n")
 
-	var topBorder, bottomBorder, textRow int
-	topBorder = -1
-	bottomBorder = -1
-	textRow = -1
+	topBorder, bottomBorder, textRow := -1, -1, -1
 	for i, line := range lines {
 		stripped := ansi.Strip(line)
 		switch {

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -396,13 +396,20 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 		w := min(70, m.width-10)
 		return ui.RenderActionOverlay(m.overlayItems, m.overlayCursor, w), w, min(15, m.height-6), true
 	case overlayQuitConfirm:
-		// Box outer 32x7. Inside (after 2 border + 4/2 padding):
-		//   inner width  = 32 - 2 - 4 = 26
-		//   inner height =  7 - 2 - 2 =  3
-		// The renderer centers the line both axes within that inner area.
+		// Width: outer 32, inner = 32 − 2(border) − 4(left+right padding) = 26.
+		//
+		// Height is trickier than the comment used to claim. OverlayStyle
+		// renders with Height(qh) and a Border, but `Height` in lipgloss
+		// counts the inner area + padding (NOT the border) — so the visible
+		// outer height is qh+2. To land "Quit lfk?" on the visual middle
+		// row we ship a content slice that exactly fills the inner area
+		// (qh − 2 rows after the 1+1 padding), letting the renderer's own
+		// `Align(Center, Center)` do the vertical centering. Setting qh=3
+		// gives a 5-row outer box: border / padding / Quit lfk? / padding
+		// / border, with the text on the middle row.
 		qw := min(32, m.width-10)
-		qh := min(7, m.height-6)
-		return ui.RenderQuitConfirmOverlay(qw-6, qh-4), qw, qh, true
+		qh := min(3, m.height-6)
+		return ui.RenderQuitConfirmOverlay(qw-6, qh-2), qw, qh, true
 	case overlayConfirm:
 		return ui.RenderConfirmOverlay(m.confirmAction), min(50, m.width-10), min(8, m.height-6), true
 	case overlayConfirmType:

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -260,8 +260,9 @@ func RenderActionOverlay(items []model.Item, cursor int, width int) string {
 // for standard destructive actions (delete, drain).
 //
 // Keymap hints live in overlayHintBarDialog (Enter/Esc); do not add inline
-// `[y] yes [n] no` text here. The hint bar is the single source of truth for
-// confirm dialogs — see CONTRIBUTING.md "UI conventions" and PRs #80, #97.
+// `[y] yes [n] no` text here. The hint bar is the single source of truth
+// for confirm dialogs — PRs #80, #97 proposed inline hints and were closed
+// as inconsistent.
 func RenderConfirmOverlay(action string) string {
 	var b strings.Builder
 	b.WriteString(OverlayTitleStyle.Render("Confirm Delete"))
@@ -279,8 +280,9 @@ func RenderConfirmOverlay(action string) string {
 // layout, so it was dropped.
 //
 // Keymap hints live in overlayHintBarDialog (Enter/Esc); do not add inline
-// `[y] yes [n] no` text here. The hint bar is the single source of truth for
-// confirm dialogs — see CONTRIBUTING.md "UI conventions" and PRs #80, #97.
+// `[y] yes [n] no` text here. The hint bar is the single source of truth
+// for confirm dialogs — PRs #80, #97 proposed inline hints and were closed
+// as inconsistent.
 func RenderQuitConfirmOverlay(innerWidth, innerHeight int) string {
 	return OverlayTitleStyle.
 		Padding(0).
@@ -294,8 +296,9 @@ func RenderQuitConfirmOverlay(innerWidth, innerHeight int) string {
 // lineCount is the number of lines in the pasted text.
 //
 // Keymap hints live in overlayHintBarDialog (Enter/Esc); do not add inline
-// `[y] yes [n] no` text here. The hint bar is the single source of truth for
-// confirm dialogs — see CONTRIBUTING.md "UI conventions" and PRs #80, #97.
+// `[y] yes [n] no` text here. The hint bar is the single source of truth
+// for confirm dialogs — PRs #80, #97 proposed inline hints and were closed
+// as inconsistent.
 func RenderPasteConfirmOverlay(lineCount int) string {
 	var b strings.Builder
 	b.WriteString(OverlayTitleStyle.Render("Paste"))

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -258,6 +258,10 @@ func RenderActionOverlay(items []model.Item, cursor int, width int) string {
 
 // RenderConfirmOverlay renders the y/n confirmation overlay content
 // for standard destructive actions (delete, drain).
+//
+// Keymap hints live in overlayHintBarDialog (Enter/Esc); do not add inline
+// `[y] yes [n] no` text here. The hint bar is the single source of truth for
+// confirm dialogs — see CONTRIBUTING.md "UI conventions" and PRs #80, #97.
 func RenderConfirmOverlay(action string) string {
 	var b strings.Builder
 	b.WriteString(OverlayTitleStyle.Render("Confirm Delete"))
@@ -273,6 +277,10 @@ func RenderConfirmOverlay(action string) string {
 // box's content area (overlayW/H minus border + padding). Single line —
 // a separate "Quit" title used to read as a second option in a two-line
 // layout, so it was dropped.
+//
+// Keymap hints live in overlayHintBarDialog (Enter/Esc); do not add inline
+// `[y] yes [n] no` text here. The hint bar is the single source of truth for
+// confirm dialogs — see CONTRIBUTING.md "UI conventions" and PRs #80, #97.
 func RenderQuitConfirmOverlay(innerWidth, innerHeight int) string {
 	return OverlayTitleStyle.
 		Padding(0).
@@ -284,15 +292,17 @@ func RenderQuitConfirmOverlay(innerWidth, innerHeight int) string {
 
 // RenderPasteConfirmOverlay renders the multiline paste confirmation overlay.
 // lineCount is the number of lines in the pasted text.
+//
+// Keymap hints live in overlayHintBarDialog (Enter/Esc); do not add inline
+// `[y] yes [n] no` text here. The hint bar is the single source of truth for
+// confirm dialogs — see CONTRIBUTING.md "UI conventions" and PRs #80, #97.
 func RenderPasteConfirmOverlay(lineCount int) string {
 	var b strings.Builder
 	b.WriteString(OverlayTitleStyle.Render("Paste"))
 	b.WriteString("\n\n")
 	b.WriteString(OverlayNormalStyle.Render(fmt.Sprintf("Paste contains %d lines.", lineCount)))
 	b.WriteString("\n")
-	b.WriteString(OverlayNormalStyle.Render("Flatten to single line and insert?"))
-	b.WriteString("\n\n")
-	b.WriteString(OverlayDimStyle.Render("[y] yes  [n] no"))
+	b.WriteString(OverlayNormalStyle.Render("Flatten and paste?"))
 	return b.String()
 }
 

--- a/internal/ui/overlay_extra_test.go
+++ b/internal/ui/overlay_extra_test.go
@@ -11,9 +11,8 @@ import (
 
 // Paste confirm overlay must NOT include inline `[y] yes [n] no` text.
 // Keymap hints belong in the bottom hint bar (overlayHintBarDialog) so all
-// confirm overlays share one convention. See CONTRIBUTING.md "UI conventions"
-// and PRs #80, #97 — both proposed the same inline-hint addition and were
-// closed as inconsistent with the design.
+// confirm overlays share one convention. PRs #80 and #97 both proposed the
+// same inline-hint addition and were closed as inconsistent with the design.
 func TestRenderPasteConfirmOverlayHasNoInlineKeyHints(t *testing.T) {
 	result := stripANSI(RenderPasteConfirmOverlay(7))
 	assert.Contains(t, result, "Paste", "should show the title")

--- a/internal/ui/overlay_extra_test.go
+++ b/internal/ui/overlay_extra_test.go
@@ -7,36 +7,68 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// --- RenderPasteConfirmOverlay ---
+
+// Paste confirm overlay must NOT include inline `[y] yes [n] no` text.
+// Keymap hints belong in the bottom hint bar (overlayHintBarDialog) so all
+// confirm overlays share one convention. See CONTRIBUTING.md "UI conventions"
+// and PRs #80, #97 — both proposed the same inline-hint addition and were
+// closed as inconsistent with the design.
+func TestRenderPasteConfirmOverlayHasNoInlineKeyHints(t *testing.T) {
+	result := stripANSI(RenderPasteConfirmOverlay(7))
+	assert.Contains(t, result, "Paste", "should show the title")
+	assert.Contains(t, result, "Paste contains 7 lines.")
+	assert.Contains(t, result, "Flatten and paste?")
+	assert.NotContains(t, result, "[y]", "inline y/n hints belong in the hint bar")
+	assert.NotContains(t, result, "[n]")
+	assert.NotContains(t, result, "yes")
+	assert.NotContains(t, result, "no")
+}
+
 // --- RenderQuitConfirmOverlay ---
 
 func TestRenderQuitConfirmOverlay(t *testing.T) {
 	// Single question, centered both horizontally and vertically within
 	// (innerWidth, innerHeight). The previous two-line layout (title +
 	// question) was being misread as a menu, so it was dropped.
-	result := RenderQuitConfirmOverlay(26, 3)
-	assert.Contains(t, result, "Quit lfk?", "should show the question")
 
-	// Vertical centering: 3 rows total, 1 row of question → 1 blank row
-	// above and below.
-	lines := strings.Split(result, "\n")
-	assert.Equal(t, 3, len(lines), "should fill innerHeight rows")
-	questionRow := -1
-	for i, line := range lines {
-		if strings.Contains(stripANSI(line), "Quit lfk?") {
-			questionRow = i
+	t.Run("multi-row inner centers on middle row", func(t *testing.T) {
+		result := RenderQuitConfirmOverlay(26, 3)
+		assert.Contains(t, result, "Quit lfk?", "should show the question")
+
+		// Vertical centering: 3 rows total, 1 row of question → 1 blank row
+		// above and below.
+		lines := strings.Split(result, "\n")
+		assert.Equal(t, 3, len(lines), "should fill innerHeight rows")
+		questionRow := -1
+		for i, line := range lines {
+			if strings.Contains(stripANSI(line), "Quit lfk?") {
+				questionRow = i
+			}
 		}
-	}
-	assert.Equal(t, 1, questionRow, "question must sit on the middle row")
+		assert.Equal(t, 1, questionRow, "question must sit on the middle row")
 
-	// Horizontal centering: roughly equal leading/trailing whitespace.
-	plain := stripANSI(lines[questionRow])
-	leading := len(plain) - len(strings.TrimLeft(plain, " "))
-	trailing := len(plain) - len(strings.TrimRight(plain, " "))
-	diff := leading - trailing
-	if diff < 0 {
-		diff = -diff
-	}
-	assert.LessOrEqual(t, diff, 1, "text should be horizontally centered (leading=%d trailing=%d)", leading, trailing)
+		// Horizontal centering: roughly equal leading/trailing whitespace.
+		plain := stripANSI(lines[questionRow])
+		leading := len(plain) - len(strings.TrimLeft(plain, " "))
+		trailing := len(plain) - len(strings.TrimRight(plain, " "))
+		diff := leading - trailing
+		if diff < 0 {
+			diff = -diff
+		}
+		assert.LessOrEqual(t, diff, 1, "text should be horizontally centered (leading=%d trailing=%d)", leading, trailing)
+	})
+
+	// Production sizing — view_status.go passes (overlayW-6, overlayH-4)
+	// with overlayW=32 and overlayH=5, giving 26x1. Pin this so a future
+	// "let's add more padding" change doesn't silently revive the
+	// floating-text-in-empty-box look that triggered PRs #80 and #97.
+	t.Run("production 26x1 inner produces single centered row", func(t *testing.T) {
+		result := RenderQuitConfirmOverlay(26, 1)
+		lines := strings.Split(result, "\n")
+		assert.Equal(t, 1, len(lines), "single inner row")
+		assert.Contains(t, stripANSI(lines[0]), "Quit lfk?")
+	})
 }
 
 // --- RenderConfirmTypeOverlay ---


### PR DESCRIPTION
## Summary
- Quit overlay shrinks to a 5-row box (border / pad / "Quit lfk?" / pad / border) with the question on the middle row. lipgloss `Height(N)` counts inner+padding (not border), so the arithmetic in `renderOverlayContent` is `qh=3` → outer 5.
- Closes the floating-text-above-empty-space look that prompted PRs #80 and #97.
- Inline `[y] yes [n] no` text removed from the paste confirm overlay; paste case added to `overlayHintBarDialog` so every confirm keeps its keymap in the bottom hint bar — the single source of truth #80 / #97 were trying to bypass.
- `Enter/y` / `Esc/n` now appear together on the bottom hint bar for `overlayConfirm`, `overlayQuitConfirm`, `overlayPasteConfirm`, and the bookmark delete confirms. Slash-grouped pairs match the existing `q/Esc`, `j/k` style. `q` is the only confirm/cancel alias still left unadvertised.
- `CONTRIBUTING.md` gains a UI Conventions section spelling out the hint-bar-as-source-of-truth rule.

## Test plan
- [x] `go test -race ./...` is clean
- [x] Open Quit overlay (`ctrl+c` on last tab) — text sits on the middle row of a 5-row box, no floating space above
- [x] Open delete confirm on a resource, paste-confirm with multi-line clipboard — both show `Enter/y: <action> | Esc/n: cancel` in the bottom bar
- [x] Press `y` and `n` on each confirm — handlers still accept them
- [x] Bookmark single-delete (`ctrl+x`) and delete-all (`alt+x`) — Enter/y / Esc/n hints visible
- [x] No inline `[y] yes [n] no` text in any overlay body