### PR TITLE
feat(ui): pin info chips far-right + entry-aware keymap fit

### DIFF
--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -1,0 +1,490 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// --- Overlay rendering ---
+//
+// All overlay rendering helpers live in this file. They were extracted
+// from view_status.go to keep that file focused on the status-bar /
+// breadcrumb / column-header concerns and to bring it back under the
+// 800-line guideline. The dispatch entry point is renderOverlay, which
+// either delegates to a fullscreen-overlay renderer or composes a
+// centered overlay box via renderOverlayContent.
+
+func (m Model) renderOverlay(background string) string {
+	// Fullscreen overlays bypass the standard overlay rendering.
+	switch m.overlay {
+	case overlaySecretEditor, overlayConfigMapEditor, overlayRollback, overlayHelmRollback, overlayHelmHistory, overlayLabelEditor, overlayAutoSync:
+		return m.renderOverlayFullscreen(background)
+	case overlayCanI:
+		return m.renderCanIOverlay(background)
+	case overlayCanISubject:
+		return m.renderOverlayCanISubject(background)
+	case overlayNetworkPolicy:
+		if result := m.renderOverlayNetworkPolicy(background); result != "" {
+			return result
+		}
+	}
+
+	content, overlayW, overlayH, ok := m.renderOverlayContent()
+	if !ok {
+		return background
+	}
+
+	if overlayW < 10 {
+		overlayW = 10
+	}
+	if overlayH < 3 {
+		overlayH = 3
+	}
+
+	content = ui.FillLinesBg(content, overlayW-4, ui.SurfaceBg)
+	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(content)
+	bg := ui.PadToHeight(background, m.height)
+	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
+}
+
+// renderOverlayContent returns the overlay content and dimensions for standard (non-fullscreen) overlays.
+func (m Model) renderOverlayContent() (string, int, int, bool) {
+	switch m.overlay {
+	case overlayNamespace:
+		content := ui.RenderNamespaceOverlay(m.filteredOverlayItems(), m.overlayFilter.Value, m.overlayCursor, m.namespace, m.allNamespaces, m.selectedNamespaces, m.nsFilterMode)
+		return content, min(60, m.width-10), min(20, m.height-6), true
+	case overlayAction:
+		w := min(70, m.width-10)
+		return ui.RenderActionOverlay(m.overlayItems, m.overlayCursor, w), w, min(15, m.height-6), true
+	case overlayQuitConfirm:
+		// Box outer 32x7. Inside (after 2 border + 4/2 padding):
+		//   inner width  = 32 - 2 - 4 = 26
+		//   inner height =  7 - 2 - 2 =  3
+		// The renderer centers the line both axes within that inner area.
+		qw := min(32, m.width-10)
+		qh := min(7, m.height-6)
+		return ui.RenderQuitConfirmOverlay(qw-6, qh-4), qw, qh, true
+	case overlayConfirm:
+		return ui.RenderConfirmOverlay(m.confirmAction), min(50, m.width-10), min(8, m.height-6), true
+	case overlayConfirmType:
+		return ui.RenderConfirmTypeOverlay(m.confirmTitle, m.confirmQuestion, m.confirmTypeInput.Value), min(55, m.width-10), min(10, m.height-6), true
+	case overlayScaleInput:
+		return ui.RenderScaleOverlay(m.scaleInput.Value), min(45, m.width-10), min(8, m.height-6), true
+	case overlayPVCResize:
+		return ui.RenderPVCResizeOverlay(m.scaleInput.Value, m.pvcCurrentSize), min(45, m.width-10), min(10, m.height-6), true
+	case overlayPortForward:
+		content := ui.RenderPortForwardOverlay(m.portForwardInput.Value, m.pfAvailablePorts, m.pfPortCursor, m.actionCtx.name)
+		return content, min(55, m.width-10), min(5+len(m.pfAvailablePorts)+4, m.height-6), true
+	case overlayContainerSelect:
+		return ui.RenderContainerSelectOverlay(m.overlayItems, m.overlayCursor), min(50, m.width-10), min(15, m.height-6), true
+	case overlayPodSelect, overlayLogPodSelect:
+		content := ui.RenderPodSelectOverlay(m.filteredLogPodItems(), m.overlayCursor, m.logPodFilterText, m.logPodFilterActive)
+		return content, min(60, m.width-10), min(20, m.height-6), true
+	case overlayLogContainerSelect:
+		content := ui.RenderLogContainerSelectOverlay(m.filteredLogContainerItems(), m.overlayCursor, m.logSelectedContainers, m.logContainerFilterText, m.logContainerFilterActive, m.logParentKind != "")
+		return content, min(60, m.width-10), min(len(m.filteredLogContainerItems())+9, m.height-6), true
+	case overlayBookmarks:
+		w, h := min(90, m.width-10), min(25, m.height-6)
+		return ui.RenderBookmarkOverlay(m.bookmarks, m.bookmarkFilter.Value, m.overlayCursor, int(m.bookmarkSearchMode), m.bookmarkLoadNamespace), w, h, true
+	case overlayTemplates:
+		w, h := min(60, m.width-10), min(25, m.height-6)
+		return ui.RenderTemplateOverlay(m.filteredTemplates(), m.templateFilter.Value, m.templateCursor, m.templateSearchMode, h), w, h, true
+	case overlayColorscheme:
+		content := ui.RenderColorschemeOverlay(m.schemeEntries, m.schemeFilter.Value, m.schemeCursor, m.schemeFilterMode)
+		return content, min(50, m.width-10), min(22, m.height-6), true
+	case overlayFilterPreset:
+		c, w, h := m.renderOverlayFilterPreset()
+		return c, w, h, true
+	case overlayRBAC:
+		c, w, h := m.renderOverlayRBAC()
+		return c, w, h, true
+	case overlayBatchLabel:
+		content := ui.RenderBatchLabelOverlay(m.batchLabelMode, m.batchLabelInput.Value, m.batchLabelRemove)
+		return content, min(50, m.width-10), min(12, m.height-6), true
+	case overlayPodStartup:
+		c, w, h := m.renderOverlayPodStartup()
+		return c, w, h, true
+	case overlayQuotaDashboard:
+		c, w, h := m.renderOverlayQuotaDashboard()
+		return c, w, h, true
+	case overlayEventTimeline:
+		c, w, h := m.renderOverlayEventTimeline()
+		return c, w, h, true
+	case overlayAlerts:
+		c, w, h := m.renderOverlayAlerts()
+		return c, w, h, true
+	case overlayBackgroundTasks:
+		c, w, h := m.renderOverlayBackgroundTasks()
+		return c, w, h, true
+	case overlayExplainSearch:
+		c, w, h := m.renderOverlayExplainSearch()
+		return c, w, h, true
+	case overlayColumnToggle:
+		c, w, h := m.renderOverlayColumnToggle()
+		return c, w, h, true
+	case overlayFinalizerSearch:
+		c, w, h := m.renderOverlayFinalizerSearch()
+		return c, w, h, true
+	case overlayPasteConfirm:
+		lineCount := strings.Count(strings.TrimRight(m.pendingPaste, "\n"), "\n") + 1
+		return ui.RenderPasteConfirmOverlay(lineCount), min(45, m.width-10), min(8, m.height-6), true
+	}
+	return "", 0, 0, false
+}
+
+func (m Model) renderOverlayFilterPreset() (string, int, int) {
+	var activePresetName string
+	if m.activeFilterPreset != nil {
+		activePresetName = m.activeFilterPreset.Name
+	}
+	entries := make([]ui.FilterPresetEntry, len(m.filterPresets))
+	for i, p := range m.filterPresets {
+		entries[i] = ui.FilterPresetEntry{Name: p.Name, Description: p.Description, Key: p.Key}
+	}
+	overlayW := min(72, m.width-10)
+	// OverlayStyle reserves 4 cells horizontally for Padding(1, 2).
+	contentW := max(overlayW-4, 0)
+	return ui.RenderFilterPresetOverlay(entries, m.overlayCursor, activePresetName, contentW), overlayW, min(15, m.height-6)
+}
+
+func (m Model) renderOverlayRBAC() (string, int, int) {
+	entries := make([]ui.RBACCheckEntry, len(m.rbacResults))
+	for i, r := range m.rbacResults {
+		entries[i] = ui.RBACCheckEntry{Verb: r.Verb, Allowed: r.Allowed}
+	}
+	return ui.RenderRBACOverlay(entries, m.rbacKind), min(45, m.width-10), min(15, m.height-6)
+}
+
+func (m Model) renderOverlayPodStartup() (string, int, int) {
+	w, h := min(70, m.width-10), min(25, m.height-6)
+	if m.podStartupData == nil {
+		return "", w, h
+	}
+	entry := ui.PodStartupEntry{
+		PodName: m.podStartupData.PodName, Namespace: m.podStartupData.Namespace, TotalTime: m.podStartupData.TotalTime,
+	}
+	for _, p := range m.podStartupData.Phases {
+		entry.Phases = append(entry.Phases, ui.StartupPhaseEntry{Name: p.Name, Duration: p.Duration, Status: p.Status})
+	}
+	return ui.RenderPodStartupOverlay(entry), w, h
+}
+
+func (m Model) renderOverlayQuotaDashboard() (string, int, int) {
+	entries := make([]ui.QuotaEntry, len(m.quotaData))
+	for i, q := range m.quotaData {
+		resources := make([]ui.QuotaResourceEntry, len(q.Resources))
+		for j, r := range q.Resources {
+			resources[j] = ui.QuotaResourceEntry{Name: r.Name, Hard: r.Hard, Used: r.Used, Percent: r.Percent}
+		}
+		entries[i] = ui.QuotaEntry{Name: q.Name, Namespace: q.Namespace, Resources: resources}
+	}
+	w, h := min(80, m.width-10), min(30, m.height-6)
+	return ui.RenderQuotaDashboardOverlay(entries, w, h), w, h
+}
+
+func (m Model) renderOverlayEventTimeline() (string, int, int) {
+	w, h := min(100, m.width-6), min(30, m.height-4)
+	params := ui.EventViewerParams{
+		Lines: m.eventTimelineLines, ResourceName: m.actionCtx.name,
+		Scroll: m.eventTimelineScroll, Cursor: m.eventTimelineCursor, CursorCol: m.eventTimelineCursorCol,
+		Width: w, Height: h, Wrap: m.eventTimelineWrap, Fullscreen: false,
+		VisualMode: m.eventTimelineVisualMode, VisualStart: m.eventTimelineVisualStart, VisualCol: m.eventTimelineVisualCol,
+		SearchQuery: m.eventTimelineSearchQuery, SearchActive: m.eventTimelineSearchActive, SearchInput: m.eventTimelineSearchInput.Value,
+	}
+	return ui.RenderEventViewer(params), w, h
+}
+
+func (m Model) renderOverlayAlerts() (string, int, int) {
+	entries := make([]ui.AlertEntry, len(m.alertsData))
+	for i, a := range m.alertsData {
+		entries[i] = ui.AlertEntry{
+			Name: a.Name, State: a.State, Severity: a.Severity, Summary: a.Summary,
+			Description: a.Description, Since: a.Since, GrafanaURL: a.GrafanaURL,
+		}
+	}
+	w, h := min(80, m.width-10), min(25, m.height-6)
+	return ui.RenderAlertsOverlay(entries, m.alertsScroll, w, h), w, h
+}
+
+func (m Model) renderOverlayBackgroundTasks() (string, int, int) {
+	var rows []ui.BackgroundTaskRow
+	mode := ui.ModeRunning
+	if m.tasksOverlayShowCompleted {
+		mode = ui.ModeCompleted
+		// Collapse identical (Kind, Name, Target) entries into a single
+		// row with "×N" appended to Name. Without this, a watch-mode
+		// session fills the 50-entry history with twelve consecutive
+		// "List Pods / dev-envs" refreshes and evicts genuinely
+		// interesting one-off tasks.
+		rows = groupCompletedTasks(m.bgtasks.SnapshotCompleted())
+	} else {
+		snap := m.bgtasks.Snapshot()
+		rows = make([]ui.BackgroundTaskRow, len(snap))
+		for i, t := range snap {
+			rows[i] = ui.BackgroundTaskRow{
+				Kind:      t.Kind.String(),
+				Name:      t.Name,
+				Target:    t.Target,
+				StartedAt: t.StartedAt,
+			}
+		}
+	}
+	w, h := min(120, m.width-10), min(20, m.height-6)
+	return ui.RenderBackgroundTasksOverlay(rows, mode, m.tasksOverlayScroll, w, h), w, h
+}
+
+func (m Model) renderOverlayCanISubject(background string) string {
+	canIBg := m.renderCanIOverlay(background)
+	w, h := min(80, m.width-10), min(20, m.height-6)
+	content := ui.RenderCanISubjectOverlay(m.filteredOverlayItems(), m.overlayFilter.Value, m.overlayCursor, m.canISubjectFilterMode)
+	content = ui.FillLinesBg(content, w-4, ui.SurfaceBg)
+	overlay := ui.OverlayStyle.Width(w).Height(h).Render(content)
+	return ui.PlaceOverlay(m.width, m.height, overlay, canIBg)
+}
+
+func (m Model) renderOverlayExplainSearch() (string, int, int) {
+	w := min(m.width-6, m.width*70/100)
+	h := min(m.height-4, m.height*70/100)
+	maxVisible := max(h-6, 1)
+	filtered := m.filteredExplainRecursiveResults()
+	return ui.RenderExplainSearchOverlay(filtered, m.explainRecursiveCursor, m.explainRecursiveScroll, maxVisible, m.explainRecursiveFilter.Value, m.explainRecursiveFilterActive), w, h
+}
+
+func (m Model) renderOverlayNetworkPolicy(background string) string {
+	if m.netpolData == nil {
+		return ""
+	}
+	entry := ui.NetworkPolicyEntry{
+		Name: m.netpolData.Name, Namespace: m.netpolData.Namespace,
+		PodSelector: m.netpolData.PodSelector, PolicyTypes: m.netpolData.PolicyTypes,
+		AffectedPods: m.netpolData.AffectedPods,
+	}
+	for _, r := range m.netpolData.IngressRules {
+		entry.IngressRules = append(entry.IngressRules, convertNetpolRule(r))
+	}
+	for _, r := range m.netpolData.EgressRules {
+		entry.EgressRules = append(entry.EgressRules, convertNetpolRule(r))
+	}
+	w, h := min(100, m.width-6), min(35, m.height-4)
+	innerW, innerH := w-4, h-2
+	netpolContent := ui.RenderNetworkPolicyOverlay(entry, m.netpolScroll, innerW, innerH)
+	netpolContent = ui.FillLinesBg(netpolContent, innerW, ui.SurfaceBg)
+	overlay := ui.OverlayStyle.Width(w).Render(netpolContent)
+	bg := ui.PadToHeight(background, m.height)
+	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
+}
+
+func (m Model) renderOverlayFullscreen(background string) string {
+	var overlay string
+	switch m.overlay {
+	case overlaySecretEditor:
+		overlay = ui.RenderSecretEditorOverlay(
+			m.secretData, m.secretCursor, m.secretRevealed, m.secretAllRevealed,
+			m.secretEditing, m.secretEditKey.Value, m.secretEditValue.Value, m.secretEditColumn,
+			m.width, m.height,
+		)
+	case overlayConfigMapEditor:
+		overlay = ui.RenderConfigMapEditorOverlay(
+			m.configMapData, m.configMapCursor,
+			m.configMapEditing, m.configMapEditKey.Value, m.configMapEditValue.Value, m.configMapEditColumn,
+			m.width, m.height,
+		)
+	case overlayRollback:
+		overlay = ui.RenderRollbackOverlay(m.rollbackRevisions, m.rollbackCursor, m.width, m.height)
+	case overlayHelmRollback:
+		overlay = ui.RenderHelmRollbackOverlay(m.helmRollbackRevisions, m.helmRollbackCursor, m.width, m.height, m.helmRevisionsLoading)
+	case overlayHelmHistory:
+		overlay = ui.RenderHelmHistoryOverlay(m.helmHistoryRevisions, m.helmHistoryCursor, m.width, m.height, m.helmRevisionsLoading)
+	case overlayLabelEditor:
+		overlay = ui.RenderLabelEditorOverlay(
+			m.labelData, m.labelCursor, m.labelTab,
+			m.labelEditing, m.labelEditKey.Value, m.labelEditValue.Value, m.labelEditColumn,
+			m.width, m.height,
+		)
+	case overlayAutoSync:
+		overlay = ui.RenderAutoSyncOverlay(
+			m.autoSyncEnabled, m.autoSyncSelfHeal, m.autoSyncPrune,
+			m.autoSyncCursor, m.width, m.height,
+		)
+	default:
+		return background
+	}
+	bg := ui.PadToHeight(background, m.height)
+	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
+}
+
+func (m Model) renderOverlayColumnToggle() (string, int, int) {
+	filtered := m.filteredColumnToggleItems()
+	entries := make([]ui.ColumnToggleEntry, len(filtered))
+	for i, e := range filtered {
+		entries[i] = ui.ColumnToggleEntry{Key: e.key, Visible: e.visible}
+	}
+	// Pass the overlay box dimensions (not the full screen) so the
+	// renderer's maxVisible cap matches what fits inside the box.
+	// Otherwise on a tall terminal the renderer emits ~34 lines into a
+	// 20-tall box; the box visibly grew on overflow and "shrank" back
+	// as the filter narrowed results — looked like the window was
+	// resizing.
+	overlayW := min(50, m.width-10)
+	overlayH := min(20, m.height-6)
+	return ui.RenderColumnToggleOverlay(entries, m.columnToggleCursor, m.columnToggleFilter, m.columnToggleFilterActive, overlayW, overlayH),
+		overlayW, overlayH
+}
+
+func (m Model) renderOverlayFinalizerSearch() (string, int, int) {
+	filtered := m.filteredFinalizerResults()
+	entries := make([]ui.FinalizerMatchEntry, len(filtered))
+	for i, r := range filtered {
+		entries[i] = ui.FinalizerMatchEntry{
+			Name: r.Name, Namespace: r.Namespace, Kind: r.Kind, Matched: r.Matched, Age: r.Age,
+		}
+	}
+	w := min(m.width-6, m.width*80/100)
+	if w < 60 {
+		w = min(60, m.width-4)
+	}
+	h := min(m.height-4, m.height*70/100)
+	return ui.RenderFinalizerSearchOverlay(
+		entries, m.finalizerSearchCursor, m.finalizerSearchSelected,
+		m.finalizerSearchPattern, m.finalizerSearchFilter, m.finalizerSearchFilterActive,
+		m.finalizerSearchLoading, w, h,
+	), w, h
+}
+
+// convertNetpolRule converts a k8s.NetpolRule to a ui.NetpolRuleEntry.
+func convertNetpolRule(r k8s.NetpolRule) ui.NetpolRuleEntry {
+	re := ui.NetpolRuleEntry{}
+	for _, p := range r.Ports {
+		re.Ports = append(re.Ports, ui.NetpolPortEntry{Protocol: p.Protocol, Port: p.Port})
+	}
+	for _, p := range r.Peers {
+		re.Peers = append(re.Peers, ui.NetpolPeerEntry{
+			Type: p.Type, Selector: p.Selector,
+			CIDR: p.CIDR, Except: p.Except, Namespace: p.Namespace,
+		})
+	}
+	return re
+}
+
+// renderCanIOverlay renders the Can-I browser overlay on top of the given background.
+func (m Model) renderCanIOverlay(background string) string {
+	visibleGroupIdxs := m.canIVisibleGroups()
+	groupNames := make([]string, len(visibleGroupIdxs))
+	for i, idx := range visibleGroupIdxs {
+		name := m.canIGroups[idx].Name
+		if name == "" {
+			name = "core"
+		}
+		count := len(m.canIGroups[idx].Resources)
+		if m.canIAllowedOnly {
+			count = countAllowedResources(m.canIGroups[idx].Resources)
+		}
+		groupNames[i] = fmt.Sprintf("%s (%d)", name, count)
+	}
+	var resources []model.CanIResource
+	if m.canIGroupCursor >= 0 && m.canIGroupCursor < len(visibleGroupIdxs) {
+		resources = m.canIGroups[visibleGroupIdxs[m.canIGroupCursor]].Resources
+		if m.canIAllowedOnly {
+			resources = filterAllowedResources(resources)
+		}
+	}
+	subjectName := m.canISubjectName
+	if subjectName == "" {
+		subjectName = "Current User"
+	}
+	overlayW := min(m.width-4, m.width*90/100)
+	overlayH := min(m.height-4, m.height*80/100)
+	innerW := overlayW - 4
+	innerH := overlayH - 2
+
+	// Search bar shown inside the overlay; normal hints moved to the main status bar.
+	var hintBar string
+	if m.canISearchActive {
+		searchBar := ui.HelpKeyStyle.Render("/") + ui.BarNormalStyle.Render(m.canISearchInput.CursorLeft()) + ui.BarDimStyle.Render("█") + ui.BarNormalStyle.Render(m.canISearchInput.CursorRight())
+		hintBar = ui.StatusBarBgStyle.Width(innerW).Render(searchBar)
+	} else if m.canISearchQuery != "" {
+		searchBar := ui.HelpKeyStyle.Render("/") + ui.BarNormalStyle.Render(m.canISearchQuery)
+		hintBar = ui.StatusBarBgStyle.Width(innerW).Render(searchBar)
+	}
+
+	canIContent := ui.RenderCanIView(
+		groupNames, resources,
+		m.canIGroupCursor, m.canIGroupScroll,
+		subjectName, m.canINamespaces,
+		innerW, innerH,
+		hintBar,
+		m.canIResourceScroll,
+	)
+	canIContent = ui.FillLinesBg(canIContent, overlayW-4, ui.SurfaceBg)
+	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(canIContent)
+	bg := ui.PadToHeight(background, m.height)
+	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
+}
+
+// renderErrorLogOverlay renders the error log overlay on top of the given background.
+// In fullscreen mode it replaces the background entirely; in overlay mode it centers on top.
+func (m Model) renderErrorLogOverlay(background string) string {
+	vp := ui.ErrorLogVisualParams{
+		VisualMode:     m.errorLogVisualMode,
+		VisualStart:    m.errorLogVisualStart,
+		VisualStartCol: m.errorLogVisualStartCol,
+		CursorLine:     m.errorLogCursorLine,
+		CursorCol:      m.errorLogCursorCol,
+	}
+
+	if m.errorLogFullscreen {
+		// Fullscreen rendering is handled by viewExplorer via the
+		// viewErrorLogFullscreen helper (same pattern as the dashboard
+		// fullscreen). The background passed in here is already that
+		// composed view, so just return it unchanged.
+		return background
+	}
+
+	overlayW := min(140, m.width-4)
+	overlayH := min(30, m.height-4)
+	if overlayW < 10 {
+		overlayW = 10
+	}
+	if overlayH < 3 {
+		overlayH = 3
+	}
+
+	// OverlayStyle adds 2 border + 2*2 horizontal padding + 2*1 vertical padding,
+	// so the inner content area is overlayW-6 wide and overlayH-4 tall. Render
+	// only that many lines so lipgloss does not expand the overlay to fit
+	// overflowing content.
+	innerW := overlayW - 6
+	innerH := overlayH - 4
+	if innerW < 1 {
+		innerW = 1
+	}
+	if innerH < 1 {
+		innerH = 1
+	}
+	content := ui.RenderErrorLogOverlay(m.errorLog, m.errorLogScroll, innerH, m.showDebugLogs, vp)
+	content = clampErrorLogLines(content, innerW, innerH)
+	content = ui.FillLinesBg(content, innerW, ui.SurfaceBg)
+	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(content)
+	bg := ui.PadToHeight(background, m.height)
+	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
+}
+
+// clampErrorLogLines truncates each line of content to maxW visual columns
+// and caps the total line count at maxH. Lines that exceed maxW are cut with
+// a trailing "~" marker via ui.Truncate; extra lines beyond maxH are dropped.
+// This prevents long error messages from wrapping and pushing the overlay
+// past its allocated height.
+func clampErrorLogLines(content string, maxW, maxH int) string {
+	lines := strings.Split(content, "\n")
+	if len(lines) > maxH {
+		lines = lines[:maxH]
+	}
+	for i, line := range lines {
+		lines[i] = ui.Truncate(line, maxW)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -234,14 +233,37 @@ func (m Model) statusBar() string {
 	// the right side as priority — on overflow the keymap is the part
 	// that yields. Overlay hint bars use a separate code path above and
 	// are unaffected by this layout.
+	right := m.explorerStatusChips()
+
+	// Pre-fit the keymap to the left budget so JoinStatusBar never has to
+	// hard-cut a hint mid-description. FormatHintPartsFit drops any entry
+	// that wouldn't fit whole and continues scanning later entries — so the
+	// reader sees only complete `key: desc` units, and the gap between the
+	// keymap and the chip group is whitespace, never a stray `~`. Reserve
+	// 2 columns so the gap between keymap and chips reads as a clear gutter
+	// (the elastic-spacer minimum is 1, but a 2-col gutter is more comfortable).
+	leftBudget := max(innerWidth-lipgloss.Width(right)-2, 0)
+	left := ui.FormatHintPartsFit(m.explorerHintEntries(), leftBudget)
+
+	content := ui.JoinStatusBar(left, right, innerWidth)
+	return ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(content)
+}
+
+// explorerStatusChips composes the right-anchored chip group for the
+// explorer status bar: sort indicator, cursor counter or selection
+// badge, active filter preset, and NYAN flag. Reading order is
+// left-to-right; the chip group as a whole is right-aligned by
+// JoinStatusBar in statusBar(). Returns the joined string ready to
+// pass as the `right` argument to JoinStatusBar.
+func (m Model) explorerStatusChips() string {
 	visible := m.visibleMiddleItems()
 	total := len(m.middleItems)
 	cur := m.cursor() + 1
 
-	var rightParts []string
+	var parts []string
 
 	if m.sortApplies() {
-		rightParts = append(rightParts, ui.BarDimStyle.Render("sort:"+m.sortModeName()))
+		parts = append(parts, ui.BarDimStyle.Render("sort:"+m.sortModeName()))
 	}
 	// Counter ↔ selection swap. By default we surface the cursor position
 	// inside the visible item list ("[1/47]"); the moment the user marks
@@ -252,36 +274,24 @@ func (m Model) statusBar() string {
 	// pushed the keymap into truncation territory and was perceived as
 	// "the hint bar gets trimmed when I select items".
 	if m.hasSelection() {
-		rightParts = append(rightParts, ui.SelectionCountStyle.Render(fmt.Sprintf(" %d selected ", len(m.selectedItems))))
+		parts = append(parts, ui.SelectionCountStyle.Render(fmt.Sprintf(" %d selected ", len(m.selectedItems))))
 	} else if m.filterText != "" {
-		rightParts = append(rightParts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d filtered: %d/%d]", cur, len(visible), len(visible), total)))
+		parts = append(parts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d filtered: %d/%d]", cur, len(visible), len(visible), total)))
 	} else {
-		rightParts = append(rightParts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d]", cur, total)))
+		parts = append(parts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d]", cur, total)))
 	}
 
 	// Filter preset and NYAN are decorations rather than primary signals,
 	// so they sit at the far-right tail — first to be visually pushed
 	// against the right edge, last in the chip group's reading order.
 	if m.activeFilterPreset != nil {
-		rightParts = append(rightParts, ui.HelpKeyStyle.Render("[filter: "+m.activeFilterPreset.Name+"]"))
+		parts = append(parts, ui.HelpKeyStyle.Render("[filter: "+m.activeFilterPreset.Name+"]"))
 	}
 	if m.nyanMode {
-		rightParts = append(rightParts, ui.HelpKeyStyle.Render("[NYAN]"))
+		parts = append(parts, ui.HelpKeyStyle.Render("[NYAN]"))
 	}
 
-	right := strings.Join(rightParts, "  ")
-
-	// Pre-fit the keymap to the left budget so JoinStatusBar never has to
-	// hard-cut a hint mid-description. FormatHintPartsFit drops any entry
-	// that wouldn't fit whole and continues scanning later entries — so the
-	// reader sees only complete `key: desc` units, and the gap between the
-	// keymap and the chip group is whitespace, never a stray `~`. Reserve
-	// 2 columns of separator (matches the elastic-spacer minimum).
-	leftBudget := max(innerWidth-lipgloss.Width(right)-2, 0)
-	left := ui.FormatHintPartsFit(m.explorerHintEntries(), leftBudget)
-
-	content := ui.JoinStatusBar(left, right, innerWidth)
-	return ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(content)
+	return strings.Join(parts, "  ")
 }
 
 // explorerHintEntries builds the bottom hint bar for explorer views (cluster
@@ -380,479 +390,6 @@ func (m Model) appendEventsHintEntries(entries []ui.HintEntry) []ui.HintEntry {
 	out = append(out, extras...)
 	out = append(out, entries[len(entries)-1])
 	return out
-}
-
-// --- Overlay rendering ---
-
-func (m Model) renderOverlay(background string) string {
-	// Fullscreen overlays bypass the standard overlay rendering.
-	switch m.overlay {
-	case overlaySecretEditor, overlayConfigMapEditor, overlayRollback, overlayHelmRollback, overlayHelmHistory, overlayLabelEditor, overlayAutoSync:
-		return m.renderOverlayFullscreen(background)
-	case overlayCanI:
-		return m.renderCanIOverlay(background)
-	case overlayCanISubject:
-		return m.renderOverlayCanISubject(background)
-	case overlayNetworkPolicy:
-		if result := m.renderOverlayNetworkPolicy(background); result != "" {
-			return result
-		}
-	}
-
-	content, overlayW, overlayH, ok := m.renderOverlayContent()
-	if !ok {
-		return background
-	}
-
-	if overlayW < 10 {
-		overlayW = 10
-	}
-	if overlayH < 3 {
-		overlayH = 3
-	}
-
-	content = ui.FillLinesBg(content, overlayW-4, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(content)
-	bg := ui.PadToHeight(background, m.height)
-	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
-}
-
-// renderOverlayContent returns the overlay content and dimensions for standard (non-fullscreen) overlays.
-func (m Model) renderOverlayContent() (string, int, int, bool) {
-	switch m.overlay {
-	case overlayNamespace:
-		content := ui.RenderNamespaceOverlay(m.filteredOverlayItems(), m.overlayFilter.Value, m.overlayCursor, m.namespace, m.allNamespaces, m.selectedNamespaces, m.nsFilterMode)
-		return content, min(60, m.width-10), min(20, m.height-6), true
-	case overlayAction:
-		w := min(70, m.width-10)
-		return ui.RenderActionOverlay(m.overlayItems, m.overlayCursor, w), w, min(15, m.height-6), true
-	case overlayQuitConfirm:
-		// Box outer 32x7. Inside (after 2 border + 4/2 padding):
-		//   inner width  = 32 - 2 - 4 = 26
-		//   inner height =  7 - 2 - 2 =  3
-		// The renderer centers the line both axes within that inner area.
-		qw := min(32, m.width-10)
-		qh := min(7, m.height-6)
-		return ui.RenderQuitConfirmOverlay(qw-6, qh-4), qw, qh, true
-	case overlayConfirm:
-		return ui.RenderConfirmOverlay(m.confirmAction), min(50, m.width-10), min(8, m.height-6), true
-	case overlayConfirmType:
-		return ui.RenderConfirmTypeOverlay(m.confirmTitle, m.confirmQuestion, m.confirmTypeInput.Value), min(55, m.width-10), min(10, m.height-6), true
-	case overlayScaleInput:
-		return ui.RenderScaleOverlay(m.scaleInput.Value), min(45, m.width-10), min(8, m.height-6), true
-	case overlayPVCResize:
-		return ui.RenderPVCResizeOverlay(m.scaleInput.Value, m.pvcCurrentSize), min(45, m.width-10), min(10, m.height-6), true
-	case overlayPortForward:
-		content := ui.RenderPortForwardOverlay(m.portForwardInput.Value, m.pfAvailablePorts, m.pfPortCursor, m.actionCtx.name)
-		return content, min(55, m.width-10), min(5+len(m.pfAvailablePorts)+4, m.height-6), true
-	case overlayContainerSelect:
-		return ui.RenderContainerSelectOverlay(m.overlayItems, m.overlayCursor), min(50, m.width-10), min(15, m.height-6), true
-	case overlayPodSelect, overlayLogPodSelect:
-		content := ui.RenderPodSelectOverlay(m.filteredLogPodItems(), m.overlayCursor, m.logPodFilterText, m.logPodFilterActive)
-		return content, min(60, m.width-10), min(20, m.height-6), true
-	case overlayLogContainerSelect:
-		content := ui.RenderLogContainerSelectOverlay(m.filteredLogContainerItems(), m.overlayCursor, m.logSelectedContainers, m.logContainerFilterText, m.logContainerFilterActive, m.logParentKind != "")
-		return content, min(60, m.width-10), min(len(m.filteredLogContainerItems())+9, m.height-6), true
-	case overlayBookmarks:
-		w, h := min(90, m.width-10), min(25, m.height-6)
-		return ui.RenderBookmarkOverlay(m.bookmarks, m.bookmarkFilter.Value, m.overlayCursor, int(m.bookmarkSearchMode), m.bookmarkLoadNamespace), w, h, true
-	case overlayTemplates:
-		w, h := min(60, m.width-10), min(25, m.height-6)
-		return ui.RenderTemplateOverlay(m.filteredTemplates(), m.templateFilter.Value, m.templateCursor, m.templateSearchMode, h), w, h, true
-	case overlayColorscheme:
-		content := ui.RenderColorschemeOverlay(m.schemeEntries, m.schemeFilter.Value, m.schemeCursor, m.schemeFilterMode)
-		return content, min(50, m.width-10), min(22, m.height-6), true
-	case overlayFilterPreset:
-		c, w, h := m.renderOverlayFilterPreset()
-		return c, w, h, true
-	case overlayRBAC:
-		c, w, h := m.renderOverlayRBAC()
-		return c, w, h, true
-	case overlayBatchLabel:
-		content := ui.RenderBatchLabelOverlay(m.batchLabelMode, m.batchLabelInput.Value, m.batchLabelRemove)
-		return content, min(50, m.width-10), min(12, m.height-6), true
-	case overlayPodStartup:
-		c, w, h := m.renderOverlayPodStartup()
-		return c, w, h, true
-	case overlayQuotaDashboard:
-		c, w, h := m.renderOverlayQuotaDashboard()
-		return c, w, h, true
-	case overlayEventTimeline:
-		c, w, h := m.renderOverlayEventTimeline()
-		return c, w, h, true
-	case overlayAlerts:
-		c, w, h := m.renderOverlayAlerts()
-		return c, w, h, true
-	case overlayBackgroundTasks:
-		c, w, h := m.renderOverlayBackgroundTasks()
-		return c, w, h, true
-	case overlayExplainSearch:
-		c, w, h := m.renderOverlayExplainSearch()
-		return c, w, h, true
-	case overlayColumnToggle:
-		c, w, h := m.renderOverlayColumnToggle()
-		return c, w, h, true
-	case overlayFinalizerSearch:
-		c, w, h := m.renderOverlayFinalizerSearch()
-		return c, w, h, true
-	case overlayPasteConfirm:
-		lineCount := strings.Count(strings.TrimRight(m.pendingPaste, "\n"), "\n") + 1
-		return ui.RenderPasteConfirmOverlay(lineCount), min(45, m.width-10), min(8, m.height-6), true
-	}
-	return "", 0, 0, false
-}
-
-func (m Model) renderOverlayFilterPreset() (string, int, int) {
-	var activePresetName string
-	if m.activeFilterPreset != nil {
-		activePresetName = m.activeFilterPreset.Name
-	}
-	entries := make([]ui.FilterPresetEntry, len(m.filterPresets))
-	for i, p := range m.filterPresets {
-		entries[i] = ui.FilterPresetEntry{Name: p.Name, Description: p.Description, Key: p.Key}
-	}
-	overlayW := min(72, m.width-10)
-	// OverlayStyle reserves 4 cells horizontally for Padding(1, 2).
-	contentW := max(overlayW-4, 0)
-	return ui.RenderFilterPresetOverlay(entries, m.overlayCursor, activePresetName, contentW), overlayW, min(15, m.height-6)
-}
-
-func (m Model) renderOverlayRBAC() (string, int, int) {
-	entries := make([]ui.RBACCheckEntry, len(m.rbacResults))
-	for i, r := range m.rbacResults {
-		entries[i] = ui.RBACCheckEntry{Verb: r.Verb, Allowed: r.Allowed}
-	}
-	return ui.RenderRBACOverlay(entries, m.rbacKind), min(45, m.width-10), min(15, m.height-6)
-}
-
-func (m Model) renderOverlayPodStartup() (string, int, int) {
-	w, h := min(70, m.width-10), min(25, m.height-6)
-	if m.podStartupData == nil {
-		return "", w, h
-	}
-	entry := ui.PodStartupEntry{
-		PodName: m.podStartupData.PodName, Namespace: m.podStartupData.Namespace, TotalTime: m.podStartupData.TotalTime,
-	}
-	for _, p := range m.podStartupData.Phases {
-		entry.Phases = append(entry.Phases, ui.StartupPhaseEntry{Name: p.Name, Duration: p.Duration, Status: p.Status})
-	}
-	return ui.RenderPodStartupOverlay(entry), w, h
-}
-
-func (m Model) renderOverlayQuotaDashboard() (string, int, int) {
-	entries := make([]ui.QuotaEntry, len(m.quotaData))
-	for i, q := range m.quotaData {
-		resources := make([]ui.QuotaResourceEntry, len(q.Resources))
-		for j, r := range q.Resources {
-			resources[j] = ui.QuotaResourceEntry{Name: r.Name, Hard: r.Hard, Used: r.Used, Percent: r.Percent}
-		}
-		entries[i] = ui.QuotaEntry{Name: q.Name, Namespace: q.Namespace, Resources: resources}
-	}
-	w, h := min(80, m.width-10), min(30, m.height-6)
-	return ui.RenderQuotaDashboardOverlay(entries, w, h), w, h
-}
-
-func (m Model) renderOverlayEventTimeline() (string, int, int) {
-	w, h := min(100, m.width-6), min(30, m.height-4)
-	params := ui.EventViewerParams{
-		Lines: m.eventTimelineLines, ResourceName: m.actionCtx.name,
-		Scroll: m.eventTimelineScroll, Cursor: m.eventTimelineCursor, CursorCol: m.eventTimelineCursorCol,
-		Width: w, Height: h, Wrap: m.eventTimelineWrap, Fullscreen: false,
-		VisualMode: m.eventTimelineVisualMode, VisualStart: m.eventTimelineVisualStart, VisualCol: m.eventTimelineVisualCol,
-		SearchQuery: m.eventTimelineSearchQuery, SearchActive: m.eventTimelineSearchActive, SearchInput: m.eventTimelineSearchInput.Value,
-	}
-	return ui.RenderEventViewer(params), w, h
-}
-
-func (m Model) renderOverlayAlerts() (string, int, int) {
-	entries := make([]ui.AlertEntry, len(m.alertsData))
-	for i, a := range m.alertsData {
-		entries[i] = ui.AlertEntry{
-			Name: a.Name, State: a.State, Severity: a.Severity, Summary: a.Summary,
-			Description: a.Description, Since: a.Since, GrafanaURL: a.GrafanaURL,
-		}
-	}
-	w, h := min(80, m.width-10), min(25, m.height-6)
-	return ui.RenderAlertsOverlay(entries, m.alertsScroll, w, h), w, h
-}
-
-func (m Model) renderOverlayBackgroundTasks() (string, int, int) {
-	var rows []ui.BackgroundTaskRow
-	mode := ui.ModeRunning
-	if m.tasksOverlayShowCompleted {
-		mode = ui.ModeCompleted
-		// Collapse identical (Kind, Name, Target) entries into a single
-		// row with "×N" appended to Name. Without this, a watch-mode
-		// session fills the 50-entry history with twelve consecutive
-		// "List Pods / dev-envs" refreshes and evicts genuinely
-		// interesting one-off tasks.
-		rows = groupCompletedTasks(m.bgtasks.SnapshotCompleted())
-	} else {
-		snap := m.bgtasks.Snapshot()
-		rows = make([]ui.BackgroundTaskRow, len(snap))
-		for i, t := range snap {
-			rows[i] = ui.BackgroundTaskRow{
-				Kind:      t.Kind.String(),
-				Name:      t.Name,
-				Target:    t.Target,
-				StartedAt: t.StartedAt,
-			}
-		}
-	}
-	w, h := min(120, m.width-10), min(20, m.height-6)
-	return ui.RenderBackgroundTasksOverlay(rows, mode, m.tasksOverlayScroll, w, h), w, h
-}
-
-func (m Model) renderOverlayCanISubject(background string) string {
-	canIBg := m.renderCanIOverlay(background)
-	w, h := min(80, m.width-10), min(20, m.height-6)
-	content := ui.RenderCanISubjectOverlay(m.filteredOverlayItems(), m.overlayFilter.Value, m.overlayCursor, m.canISubjectFilterMode)
-	content = ui.FillLinesBg(content, w-4, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(w).Height(h).Render(content)
-	return ui.PlaceOverlay(m.width, m.height, overlay, canIBg)
-}
-
-func (m Model) renderOverlayExplainSearch() (string, int, int) {
-	w := min(m.width-6, m.width*70/100)
-	h := min(m.height-4, m.height*70/100)
-	maxVisible := max(h-6, 1)
-	filtered := m.filteredExplainRecursiveResults()
-	return ui.RenderExplainSearchOverlay(filtered, m.explainRecursiveCursor, m.explainRecursiveScroll, maxVisible, m.explainRecursiveFilter.Value, m.explainRecursiveFilterActive), w, h
-}
-
-func (m Model) renderOverlayNetworkPolicy(background string) string {
-	if m.netpolData == nil {
-		return ""
-	}
-	entry := ui.NetworkPolicyEntry{
-		Name: m.netpolData.Name, Namespace: m.netpolData.Namespace,
-		PodSelector: m.netpolData.PodSelector, PolicyTypes: m.netpolData.PolicyTypes,
-		AffectedPods: m.netpolData.AffectedPods,
-	}
-	for _, r := range m.netpolData.IngressRules {
-		entry.IngressRules = append(entry.IngressRules, convertNetpolRule(r))
-	}
-	for _, r := range m.netpolData.EgressRules {
-		entry.EgressRules = append(entry.EgressRules, convertNetpolRule(r))
-	}
-	w, h := min(100, m.width-6), min(35, m.height-4)
-	innerW, innerH := w-4, h-2
-	netpolContent := ui.RenderNetworkPolicyOverlay(entry, m.netpolScroll, innerW, innerH)
-	netpolContent = ui.FillLinesBg(netpolContent, innerW, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(w).Render(netpolContent)
-	bg := ui.PadToHeight(background, m.height)
-	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
-}
-
-func (m Model) renderOverlayFullscreen(background string) string {
-	var overlay string
-	switch m.overlay {
-	case overlaySecretEditor:
-		overlay = ui.RenderSecretEditorOverlay(
-			m.secretData, m.secretCursor, m.secretRevealed, m.secretAllRevealed,
-			m.secretEditing, m.secretEditKey.Value, m.secretEditValue.Value, m.secretEditColumn,
-			m.width, m.height,
-		)
-	case overlayConfigMapEditor:
-		overlay = ui.RenderConfigMapEditorOverlay(
-			m.configMapData, m.configMapCursor,
-			m.configMapEditing, m.configMapEditKey.Value, m.configMapEditValue.Value, m.configMapEditColumn,
-			m.width, m.height,
-		)
-	case overlayRollback:
-		overlay = ui.RenderRollbackOverlay(m.rollbackRevisions, m.rollbackCursor, m.width, m.height)
-	case overlayHelmRollback:
-		overlay = ui.RenderHelmRollbackOverlay(m.helmRollbackRevisions, m.helmRollbackCursor, m.width, m.height, m.helmRevisionsLoading)
-	case overlayHelmHistory:
-		overlay = ui.RenderHelmHistoryOverlay(m.helmHistoryRevisions, m.helmHistoryCursor, m.width, m.height, m.helmRevisionsLoading)
-	case overlayLabelEditor:
-		overlay = ui.RenderLabelEditorOverlay(
-			m.labelData, m.labelCursor, m.labelTab,
-			m.labelEditing, m.labelEditKey.Value, m.labelEditValue.Value, m.labelEditColumn,
-			m.width, m.height,
-		)
-	case overlayAutoSync:
-		overlay = ui.RenderAutoSyncOverlay(
-			m.autoSyncEnabled, m.autoSyncSelfHeal, m.autoSyncPrune,
-			m.autoSyncCursor, m.width, m.height,
-		)
-	default:
-		return background
-	}
-	bg := ui.PadToHeight(background, m.height)
-	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
-}
-
-func (m Model) renderOverlayColumnToggle() (string, int, int) {
-	filtered := m.filteredColumnToggleItems()
-	entries := make([]ui.ColumnToggleEntry, len(filtered))
-	for i, e := range filtered {
-		entries[i] = ui.ColumnToggleEntry{Key: e.key, Visible: e.visible}
-	}
-	// Pass the overlay box dimensions (not the full screen) so the
-	// renderer's maxVisible cap matches what fits inside the box.
-	// Otherwise on a tall terminal the renderer emits ~34 lines into a
-	// 20-tall box; the box visibly grew on overflow and "shrank" back
-	// as the filter narrowed results — looked like the window was
-	// resizing.
-	overlayW := min(50, m.width-10)
-	overlayH := min(20, m.height-6)
-	return ui.RenderColumnToggleOverlay(entries, m.columnToggleCursor, m.columnToggleFilter, m.columnToggleFilterActive, overlayW, overlayH),
-		overlayW, overlayH
-}
-
-func (m Model) renderOverlayFinalizerSearch() (string, int, int) {
-	filtered := m.filteredFinalizerResults()
-	entries := make([]ui.FinalizerMatchEntry, len(filtered))
-	for i, r := range filtered {
-		entries[i] = ui.FinalizerMatchEntry{
-			Name: r.Name, Namespace: r.Namespace, Kind: r.Kind, Matched: r.Matched, Age: r.Age,
-		}
-	}
-	w := min(m.width-6, m.width*80/100)
-	if w < 60 {
-		w = min(60, m.width-4)
-	}
-	h := min(m.height-4, m.height*70/100)
-	return ui.RenderFinalizerSearchOverlay(
-		entries, m.finalizerSearchCursor, m.finalizerSearchSelected,
-		m.finalizerSearchPattern, m.finalizerSearchFilter, m.finalizerSearchFilterActive,
-		m.finalizerSearchLoading, w, h,
-	), w, h
-}
-
-// convertNetpolRule converts a k8s.NetpolRule to a ui.NetpolRuleEntry.
-func convertNetpolRule(r k8s.NetpolRule) ui.NetpolRuleEntry {
-	re := ui.NetpolRuleEntry{}
-	for _, p := range r.Ports {
-		re.Ports = append(re.Ports, ui.NetpolPortEntry{Protocol: p.Protocol, Port: p.Port})
-	}
-	for _, p := range r.Peers {
-		re.Peers = append(re.Peers, ui.NetpolPeerEntry{
-			Type: p.Type, Selector: p.Selector,
-			CIDR: p.CIDR, Except: p.Except, Namespace: p.Namespace,
-		})
-	}
-	return re
-}
-
-// renderCanIOverlay renders the Can-I browser overlay on top of the given background.
-func (m Model) renderCanIOverlay(background string) string {
-	visibleGroupIdxs := m.canIVisibleGroups()
-	groupNames := make([]string, len(visibleGroupIdxs))
-	for i, idx := range visibleGroupIdxs {
-		name := m.canIGroups[idx].Name
-		if name == "" {
-			name = "core"
-		}
-		count := len(m.canIGroups[idx].Resources)
-		if m.canIAllowedOnly {
-			count = countAllowedResources(m.canIGroups[idx].Resources)
-		}
-		groupNames[i] = fmt.Sprintf("%s (%d)", name, count)
-	}
-	var resources []model.CanIResource
-	if m.canIGroupCursor >= 0 && m.canIGroupCursor < len(visibleGroupIdxs) {
-		resources = m.canIGroups[visibleGroupIdxs[m.canIGroupCursor]].Resources
-		if m.canIAllowedOnly {
-			resources = filterAllowedResources(resources)
-		}
-	}
-	subjectName := m.canISubjectName
-	if subjectName == "" {
-		subjectName = "Current User"
-	}
-	overlayW := min(m.width-4, m.width*90/100)
-	overlayH := min(m.height-4, m.height*80/100)
-	innerW := overlayW - 4
-	innerH := overlayH - 2
-
-	// Search bar shown inside the overlay; normal hints moved to the main status bar.
-	var hintBar string
-	if m.canISearchActive {
-		searchBar := ui.HelpKeyStyle.Render("/") + ui.BarNormalStyle.Render(m.canISearchInput.CursorLeft()) + ui.BarDimStyle.Render("\u2588") + ui.BarNormalStyle.Render(m.canISearchInput.CursorRight())
-		hintBar = ui.StatusBarBgStyle.Width(innerW).Render(searchBar)
-	} else if m.canISearchQuery != "" {
-		searchBar := ui.HelpKeyStyle.Render("/") + ui.BarNormalStyle.Render(m.canISearchQuery)
-		hintBar = ui.StatusBarBgStyle.Width(innerW).Render(searchBar)
-	}
-
-	canIContent := ui.RenderCanIView(
-		groupNames, resources,
-		m.canIGroupCursor, m.canIGroupScroll,
-		subjectName, m.canINamespaces,
-		innerW, innerH,
-		hintBar,
-		m.canIResourceScroll,
-	)
-	canIContent = ui.FillLinesBg(canIContent, overlayW-4, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(canIContent)
-	bg := ui.PadToHeight(background, m.height)
-	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
-}
-
-// renderErrorLogOverlay renders the error log overlay on top of the given background.
-// In fullscreen mode it replaces the background entirely; in overlay mode it centers on top.
-func (m Model) renderErrorLogOverlay(background string) string {
-	vp := ui.ErrorLogVisualParams{
-		VisualMode:     m.errorLogVisualMode,
-		VisualStart:    m.errorLogVisualStart,
-		VisualStartCol: m.errorLogVisualStartCol,
-		CursorLine:     m.errorLogCursorLine,
-		CursorCol:      m.errorLogCursorCol,
-	}
-
-	if m.errorLogFullscreen {
-		// Fullscreen rendering is handled by viewExplorer via the
-		// viewErrorLogFullscreen helper (same pattern as the dashboard
-		// fullscreen). The background passed in here is already that
-		// composed view, so just return it unchanged.
-		return background
-	}
-
-	overlayW := min(140, m.width-4)
-	overlayH := min(30, m.height-4)
-	if overlayW < 10 {
-		overlayW = 10
-	}
-	if overlayH < 3 {
-		overlayH = 3
-	}
-
-	// OverlayStyle adds 2 border + 2*2 horizontal padding + 2*1 vertical padding,
-	// so the inner content area is overlayW-6 wide and overlayH-4 tall. Render
-	// only that many lines so lipgloss does not expand the overlay to fit
-	// overflowing content.
-	innerW := overlayW - 6
-	innerH := overlayH - 4
-	if innerW < 1 {
-		innerW = 1
-	}
-	if innerH < 1 {
-		innerH = 1
-	}
-	content := ui.RenderErrorLogOverlay(m.errorLog, m.errorLogScroll, innerH, m.showDebugLogs, vp)
-	content = clampErrorLogLines(content, innerW, innerH)
-	content = ui.FillLinesBg(content, innerW, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(content)
-	bg := ui.PadToHeight(background, m.height)
-	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
-}
-
-// clampErrorLogLines truncates each line of content to maxW visual columns
-// and caps the total line count at maxH. Lines that exceed maxW are cut with
-// a trailing "~" marker via ui.Truncate; extra lines beyond maxH are dropped.
-// This prevents long error messages from wrapping and pushing the overlay
-// past its allocated height.
-func clampErrorLogLines(content string, maxW, maxH int) string {
-	lines := strings.Split(content, "\n")
-	if len(lines) > maxH {
-		lines = lines[:maxH]
-	}
-	for i, line := range lines {
-		lines[i] = ui.Truncate(line, maxW)
-	}
-	return strings.Join(lines, "\n")
 }
 
 // renderInputWithCursor renders a text input value with a reverse-video

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -226,14 +228,12 @@ func (m Model) statusBar() string {
 		return ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(hint)
 	}
 
-	// Layout: keymap hints anchor the LEFT edge; the informational chip
-	// group (sort, counter / selected count, filter preset, NYAN) anchors
-	// the FAR RIGHT. JoinStatusBar treats the right side as priority — on
-	// overflow the keymap is the part that truncates, so the at-a-glance
-	// state indicators always remain visible. Overlay hint bars use a
-	// separate code path above and are unaffected.
-	left := ui.FormatHintParts(m.explorerHintEntries())
-
+	// Layout: the informational chip group (sort, counter / selected
+	// count, filter preset, NYAN) anchors the FAR RIGHT; the keymap
+	// hints fill the remaining space on the left. JoinStatusBar treats
+	// the right side as priority — on overflow the keymap is the part
+	// that yields. Overlay hint bars use a separate code path above and
+	// are unaffected by this layout.
 	visible := m.visibleMiddleItems()
 	total := len(m.middleItems)
 	cur := m.cursor() + 1
@@ -270,6 +270,16 @@ func (m Model) statusBar() string {
 	}
 
 	right := strings.Join(rightParts, "  ")
+
+	// Pre-fit the keymap to the left budget so JoinStatusBar never has to
+	// hard-cut a hint mid-description. FormatHintPartsFit drops any entry
+	// that wouldn't fit whole and continues scanning later entries — so the
+	// reader sees only complete `key: desc` units, and the gap between the
+	// keymap and the chip group is whitespace, never a stray `~`. Reserve
+	// 2 columns of separator (matches the elastic-spacer minimum).
+	leftBudget := max(innerWidth-lipgloss.Width(right)-2, 0)
+	left := ui.FormatHintPartsFit(m.explorerHintEntries(), leftBudget)
+
 	content := ui.JoinStatusBar(left, right, innerWidth)
 	return ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(content)
 }

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -162,9 +162,22 @@ func (m Model) statusBar() string {
 		return m.renderStatusHint()
 	}
 
-	// When an overlay is active, show overlay-specific hints instead of explorer hints.
+	// When an overlay is active, show overlay-specific hints instead of
+	// explorer hints. During a bulk action — the overlay was opened with
+	// multiple items selected, e.g. bulk delete/drain confirms, the
+	// confirm-type force-delete prompt, batch label editor — also pin
+	// the selection-count badge to the right edge so the user keeps
+	// "how many am I about to affect?" in view while reading the
+	// confirm. Other overlays (theme picker, namespace selector, etc.)
+	// do not carry that context, so the badge stays scoped to bulkMode.
 	if hint := m.overlayHintBar(); hint != "" {
-		content := ui.Truncate(hint, innerWidth)
+		var content string
+		if m.bulkMode && len(m.bulkItems) > 0 {
+			right := ui.SelectionCountStyle.Render(fmt.Sprintf(" %d selected ", len(m.bulkItems)))
+			content = ui.JoinStatusBar(hint, right, innerWidth)
+		} else {
+			content = ui.Truncate(hint, innerWidth)
+		}
 		return ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(content)
 	}
 

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -213,43 +213,51 @@ func (m Model) statusBar() string {
 		return ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(hint)
 	}
 
-	var parts []string
-
-	// Show selection count when items are selected.
-	if m.hasSelection() {
-		parts = append(parts, ui.SelectionCountStyle.Render(fmt.Sprintf(" %d selected ", len(m.selectedItems))))
-	}
-
-	// Show active filter preset indicator.
-	if m.activeFilterPreset != nil {
-		parts = append(parts, ui.HelpKeyStyle.Render("[filter: "+m.activeFilterPreset.Name+"]"))
-	}
-
-	// Show nyan mode indicator.
-	if m.nyanMode {
-		parts = append(parts, ui.HelpKeyStyle.Render("[NYAN]"))
-	}
+	// Layout: keymap hints anchor the LEFT edge; the informational chip
+	// group (sort, counter / selected count, filter preset, NYAN) anchors
+	// the FAR RIGHT. JoinStatusBar treats the right side as priority — on
+	// overflow the keymap is the part that truncates, so the at-a-glance
+	// state indicators always remain visible. Overlay hint bars use a
+	// separate code path above and are unaffected.
+	left := ui.FormatHintParts(m.explorerHintEntries())
 
 	visible := m.visibleMiddleItems()
 	total := len(m.middleItems)
 	cur := m.cursor() + 1
 
-	if m.filterText != "" {
-		parts = append(parts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d filtered: %d/%d]", cur, len(visible), len(visible), total)))
-	} else {
-		parts = append(parts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d]", cur, total)))
-	}
+	var rightParts []string
 
-	// Sort mode indicator. Hidden at picker levels where sortMiddleItems
-	// early-returns — claiming a sort there would mislead the user about
-	// the row ordering.
 	if m.sortApplies() {
-		parts = append(parts, ui.BarDimStyle.Render("sort:"+m.sortModeName()))
+		rightParts = append(rightParts, ui.BarDimStyle.Render("sort:"+m.sortModeName()))
+	}
+	// Counter ↔ selection swap. By default we surface the cursor position
+	// inside the visible item list ("[1/47]"); the moment the user marks
+	// at least one item we replace that chip with the selection-count
+	// badge ("3 selected"). Showing both was redundant — the user knows
+	// they're in bulk mode the second they kick off a selection — and the
+	// stacked chips made the bar grow noticeably wider, which in turn
+	// pushed the keymap into truncation territory and was perceived as
+	// "the hint bar gets trimmed when I select items".
+	if m.hasSelection() {
+		rightParts = append(rightParts, ui.SelectionCountStyle.Render(fmt.Sprintf(" %d selected ", len(m.selectedItems))))
+	} else if m.filterText != "" {
+		rightParts = append(rightParts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d filtered: %d/%d]", cur, len(visible), len(visible), total)))
+	} else {
+		rightParts = append(rightParts, ui.BarDimStyle.Render(fmt.Sprintf("[%d/%d]", cur, total)))
 	}
 
-	parts = append(parts, ui.FormatHintParts(m.explorerHintEntries()))
+	// Filter preset and NYAN are decorations rather than primary signals,
+	// so they sit at the far-right tail — first to be visually pushed
+	// against the right edge, last in the chip group's reading order.
+	if m.activeFilterPreset != nil {
+		rightParts = append(rightParts, ui.HelpKeyStyle.Render("[filter: "+m.activeFilterPreset.Name+"]"))
+	}
+	if m.nyanMode {
+		rightParts = append(rightParts, ui.HelpKeyStyle.Render("[NYAN]"))
+	}
 
-	content := strings.Join(parts, "  ")
+	right := strings.Join(rightParts, "  ")
+	content := ui.JoinStatusBar(left, right, innerWidth)
 	return ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(content)
 }
 

--- a/internal/app/view_status_test.go
+++ b/internal/app/view_status_test.go
@@ -342,13 +342,21 @@ func TestStatusBarChipsSurviveLargeSelection(t *testing.T) {
 	assert.Contains(t, baseline, "[1/20]", "counter must remain visible when no selection")
 
 	// Selecting items swaps the counter for the selection badge AND
-	// keeps it intact — that's the contract this test pins. The
-	// keymap (left side) was the long string; with right-priority
-	// truncation it carries the `~` marker, not the chips.
+	// keeps it intact — that's the contract this test pins.
 	assert.Contains(t, loaded, "20 selected",
 		"selection badge must remain visible at the right edge regardless of keymap pressure")
 	assert.NotContains(t, loaded, "[1/20]",
 		"the counter chip swaps out for the selection badge; both must not appear together")
+
+	// The keymap is fitted entry-by-entry to its budget, so the gap
+	// between the truncated keymap and the chip group on the right is
+	// pure whitespace. A stray `~` between the two would mean the bar
+	// hard-cut a hint mid-description, which is the regression this
+	// pair of assertions guards against.
+	assert.NotContains(t, baseline, "~",
+		"baseline bar must use a clean separator, not a truncate marker")
+	assert.NotContains(t, loaded, "~",
+		"selected bar must use a clean separator, not a truncate marker")
 }
 
 // While a bulk-action confirm overlay is open the user must keep their

--- a/internal/app/view_status_test.go
+++ b/internal/app/view_status_test.go
@@ -351,6 +351,55 @@ func TestStatusBarChipsSurviveLargeSelection(t *testing.T) {
 		"the counter chip swaps out for the selection badge; both must not appear together")
 }
 
+// While a bulk-action confirm overlay is open the user must keep their
+// "how many am I about to affect?" indicator. The overlay branch of
+// statusBar() normally suppresses chips and shows just the overlay's
+// keymap, but when bulkMode is set (i.e. the overlay was triggered with
+// multiple items selected) the selection badge is pinned to the right
+// edge alongside the overlay keymap.
+func TestStatusBarBulkActionOverlayKeepsSelectionBadge(t *testing.T) {
+	items := []model.Item{{Name: "pod-1"}, {Name: "pod-2"}, {Name: "pod-3"}}
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelResources},
+		middleItems:   items,
+		overlay:       overlayConfirm,
+		confirmAction: "3 resources",
+		bulkMode:      true,
+		bulkItems:     items,
+		selectedItems: map[string]bool{"pod-1": true, "pod-2": true, "pod-3": true},
+		width:         120,
+		height:        40,
+		tabs:          []TabState{{}},
+	}
+	stripped := stripANSI(m.statusBar())
+
+	assert.Contains(t, stripped, "Enter", "overlay keymap must still be present")
+	assert.Contains(t, stripped, "3 selected",
+		"bulk action overlays must keep the selection-count badge visible on the right")
+}
+
+// Non-bulk overlays (theme picker, namespace selector, paste confirm,
+// etc.) do not carry "how many am I about to affect?" context. The
+// selection badge is scoped to bulkMode so it does not bleed into
+// unrelated overlays — even when the user happens to have a stale
+// selection from before opening the overlay.
+func TestStatusBarNonBulkOverlayHidesSelectionBadge(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelResources},
+		middleItems:   []model.Item{{Name: "pod-1"}, {Name: "pod-2"}},
+		overlay:       overlayColorscheme, // not a bulk action
+		bulkMode:      false,
+		selectedItems: map[string]bool{"pod-1": true, "pod-2": true},
+		width:         120,
+		height:        40,
+		tabs:          []TabState{{}},
+	}
+	stripped := stripANSI(m.statusBar())
+
+	assert.NotContains(t, stripped, "selected",
+		"non-bulk overlays must not show the selection badge — the chip is scoped to bulkMode")
+}
+
 // --- View ---
 
 func TestViewLoadingScreen(t *testing.T) {

--- a/internal/app/view_status_test.go
+++ b/internal/app/view_status_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -255,6 +256,12 @@ func TestStatusBarShowsSortMode(t *testing.T) {
 	assert.Contains(t, stripped, "sort:Age")
 }
 
+// The cursor-position counter and the selection-count badge share a
+// single chip slot — by default the bar surfaces "[cur/total]"; the
+// moment the user marks even one item the chip swaps to "N selected"
+// and the counter is hidden. Showing both at once was redundant
+// (the user just made the selection) and the stacked chips were one
+// of the things that made the keymap feel cramped.
 func TestStatusBarShowsSelectionCount(t *testing.T) {
 	m := Model{
 		nav:         model.NavigationState{Level: model.LevelResources},
@@ -269,7 +276,9 @@ func TestStatusBarShowsSelectionCount(t *testing.T) {
 	}
 	bar := m.statusBar()
 	stripped := stripANSI(bar)
-	assert.Contains(t, stripped, "2 selected")
+	assert.Contains(t, stripped, "2 selected", "selection badge takes the chip slot when items are marked")
+	assert.NotContains(t, stripped, "[1/2]",
+		"counter must be replaced (not stacked) by the selection badge — both at once was the old, cluttered layout")
 }
 
 func TestStatusBarKeyHints(t *testing.T) {
@@ -285,6 +294,61 @@ func TestStatusBarKeyHints(t *testing.T) {
 	stripped := stripANSI(bar)
 	assert.Contains(t, stripped, "help")
 	assert.Contains(t, stripped, "quit")
+}
+
+// User-reported bug: "When I select multiple items, the hint bar is
+// trimmed." The fix has two parts working together. (1) The chip group
+// (sort, counter / selected count, filter preset, NYAN) moves to the
+// FAR RIGHT and JoinStatusBar pins it intact on overflow — the keymap
+// is the part that truncates, never the chips. (2) The cursor-position
+// counter is replaced by the selection badge instead of stacking, so
+// the chip group's width barely grows when the user enters bulk mode.
+//
+// We render at width 120 (where the explorer keymap alone exceeds the
+// bar, exercising the truncation path) and assert the chips are intact
+// across two snapshots: no selection (counter visible) and 20 items
+// selected (selection badge visible, counter hidden, full keymap
+// truncated with the `~` marker).
+func TestStatusBarChipsSurviveLargeSelection(t *testing.T) {
+	items := make([]model.Item, 20)
+	selected := make(map[string]bool, len(items))
+	for i := range items {
+		name := fmt.Sprintf("pod-with-a-fairly-long-name-%02d", i)
+		items[i] = model.Item{Name: name}
+		selected[name] = true
+	}
+
+	noSel := Model{
+		nav:           model.NavigationState{Level: model.LevelResources},
+		middleItems:   items,
+		width:         120,
+		height:        40,
+		tabs:          []TabState{{}},
+		selectedItems: make(map[string]bool),
+	}
+	withSel := Model{
+		nav:           model.NavigationState{Level: model.LevelResources},
+		middleItems:   items,
+		width:         120,
+		height:        40,
+		tabs:          []TabState{{}},
+		selectedItems: selected,
+	}
+
+	baseline := stripANSI(noSel.statusBar())
+	loaded := stripANSI(withSel.statusBar())
+
+	// Counter is the right-anchored chip when nothing is selected.
+	assert.Contains(t, baseline, "[1/20]", "counter must remain visible when no selection")
+
+	// Selecting items swaps the counter for the selection badge AND
+	// keeps it intact — that's the contract this test pins. The
+	// keymap (left side) was the long string; with right-priority
+	// truncation it carries the `~` marker, not the chips.
+	assert.Contains(t, loaded, "20 selected",
+		"selection badge must remain visible at the right edge regardless of keymap pressure")
+	assert.NotContains(t, loaded, "[1/20]",
+		"the counter chip swaps out for the selection badge; both must not appear together")
 }
 
 // --- View ---

--- a/internal/ui/hintbar.go
+++ b/internal/ui/hintbar.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // HintEntry represents a single key-description pair for a hint bar.
@@ -27,6 +28,45 @@ func FormatHintParts(hints []HintEntry) string {
 	return strings.Join(parts, BarDimStyle.Render(" | "))
 }
 
+// FormatHintPartsFit builds the same styled content as FormatHintParts but
+// constrained to maxWidth visual columns. Each hint entry is included as a
+// whole unit — keys and descriptions are never split mid-character, so the
+// reader never sees a half-cut "naviga…" or "ctrl+r: toggle R~". Entries
+// that don't fit are skipped; subsequent shorter entries can still be
+// appended. The list's left-to-right reading order is preserved.
+//
+// Returns "" when no entry fits in maxWidth, or when hints is empty / the
+// width is non-positive.
+func FormatHintPartsFit(hints []HintEntry, maxWidth int) string {
+	if len(hints) == 0 || maxWidth <= 0 {
+		return ""
+	}
+	sep := BarDimStyle.Render(" | ")
+	sepW := lipgloss.Width(sep)
+
+	var b strings.Builder
+	used := 0
+	first := true
+	for _, h := range hints {
+		entry := HelpKeyStyle.Render(h.Key) + BarDimStyle.Render(": "+h.Desc)
+		entryW := lipgloss.Width(entry)
+		add := entryW
+		if !first {
+			add += sepW
+		}
+		if used+add > maxWidth {
+			continue // skip this entry; a shorter later one might still fit
+		}
+		if !first {
+			b.WriteString(sep)
+		}
+		b.WriteString(entry)
+		used += add
+		first = false
+	}
+	return b.String()
+}
+
 // RenderHintBar builds a full-width status bar from hint entries using the
 // standard HelpKeyStyle + BarDimStyle pattern. This is the single source of
 // truth for hint bar styling -- if the style needs to change, only this
@@ -40,17 +80,15 @@ func RenderHintBar(hints []HintEntry, width int) string {
 // edge and `right` content anchored to the right edge, separated by an elastic
 // run of spaces so the bar exactly fills `width` visual columns.
 //
-// When the combined width exceeds `width`, the RIGHT side gets priority — the
-// left chunk is truncated (with `~`) to make room for the right intact. This
-// matches the explorer's bottom bar contract: the right-anchored info chips
-// (sort, counter / selected count, filter preset, NYAN) are stable, compact
-// state indicators that the user expects to see at a glance, while the
-// keymap hints on the left are a long, mostly-static list that degrades
-// gracefully when truncated. Overlay hint bars do not use this helper —
-// they render hints alone via a separate code path — so the right-priority
-// rule is scoped to the chip-bearing explorer bar.
+// When the combined width exceeds `width`, the RIGHT side gets priority and
+// the left chunk is hard-cut (no truncate marker) to make room for the right
+// intact. The cut is unmarked deliberately: the separator between the two
+// halves is whitespace only, never a stray `~`, so the eye cleanly reads the
+// info chips on the right. Callers passing hint-entry content as `left`
+// should pre-fit it with FormatHintPartsFit so the cut here is only ever
+// a safety fallback for non-entry content.
 //
-// If the right alone exceeds `width`, the right is truncated and the left
+// If the right alone exceeds `width`, the right is hard-cut and the left
 // is dropped entirely. width <= 0 returns "".
 func JoinStatusBar(left, right string, width int) string {
 	if width <= 0 {
@@ -69,9 +107,9 @@ func JoinStatusBar(left, right string, width int) string {
 		return left + strings.Repeat(" ", spacer) + right
 	}
 
-	// Right alone exceeds available width — truncate right, drop left.
+	// Right alone exceeds available width — hard-cut right, drop left.
 	if rightW >= width {
-		return Truncate(right, width)
+		return ansi.Truncate(right, width, "")
 	}
 
 	// Left needs trimming to fit alongside the right with one separating space.
@@ -80,7 +118,7 @@ func JoinStatusBar(left, right string, width int) string {
 		// No room for any left content; pad to right edge.
 		return strings.Repeat(" ", width-rightW) + right
 	}
-	truncatedLeft := Truncate(left, leftMax)
+	truncatedLeft := ansi.Truncate(left, leftMax, "")
 	spacer := max(width-lipgloss.Width(truncatedLeft)-rightW, 1)
 	return truncatedLeft + strings.Repeat(" ", spacer) + right
 }

--- a/internal/ui/hintbar.go
+++ b/internal/ui/hintbar.go
@@ -1,6 +1,10 @@
 package ui
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // HintEntry represents a single key-description pair for a hint bar.
 type HintEntry struct {
@@ -30,4 +34,53 @@ func FormatHintParts(hints []HintEntry) string {
 func RenderHintBar(hints []HintEntry, width int) string {
 	content := FormatHintParts(hints)
 	return StatusBarBgStyle.Width(width).MaxWidth(width).MaxHeight(1).Render(content)
+}
+
+// JoinStatusBar composes a status bar with `left` content anchored to the left
+// edge and `right` content anchored to the right edge, separated by an elastic
+// run of spaces so the bar exactly fills `width` visual columns.
+//
+// When the combined width exceeds `width`, the RIGHT side gets priority — the
+// left chunk is truncated (with `~`) to make room for the right intact. This
+// matches the explorer's bottom bar contract: the right-anchored info chips
+// (sort, counter / selected count, filter preset, NYAN) are stable, compact
+// state indicators that the user expects to see at a glance, while the
+// keymap hints on the left are a long, mostly-static list that degrades
+// gracefully when truncated. Overlay hint bars do not use this helper —
+// they render hints alone via a separate code path — so the right-priority
+// rule is scoped to the chip-bearing explorer bar.
+//
+// If the right alone exceeds `width`, the right is truncated and the left
+// is dropped entirely. width <= 0 returns "".
+func JoinStatusBar(left, right string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	leftW := lipgloss.Width(left)
+	rightW := lipgloss.Width(right)
+
+	if leftW == 0 && rightW == 0 {
+		return ""
+	}
+
+	// Both fit with at least one column of separator.
+	if leftW+rightW < width {
+		spacer := width - leftW - rightW
+		return left + strings.Repeat(" ", spacer) + right
+	}
+
+	// Right alone exceeds available width — truncate right, drop left.
+	if rightW >= width {
+		return Truncate(right, width)
+	}
+
+	// Left needs trimming to fit alongside the right with one separating space.
+	leftMax := width - rightW - 1
+	if leftMax <= 0 {
+		// No room for any left content; pad to right edge.
+		return strings.Repeat(" ", width-rightW) + right
+	}
+	truncatedLeft := Truncate(left, leftMax)
+	spacer := max(width-lipgloss.Width(truncatedLeft)-rightW, 1)
+	return truncatedLeft + strings.Repeat(" ", spacer) + right
 }

--- a/internal/ui/hintbar.go
+++ b/internal/ui/hintbar.go
@@ -80,6 +80,10 @@ func RenderHintBar(hints []HintEntry, width int) string {
 // edge and `right` content anchored to the right edge, separated by an elastic
 // run of spaces so the bar exactly fills `width` visual columns.
 //
+// A single-column gutter between the two halves is always preserved: when
+// `leftW + rightW == width` (a perfect fit with no gap), the left side is
+// trimmed by 1 column rather than rendering the two halves butted together.
+//
 // When the combined width exceeds `width`, the RIGHT side gets priority and
 // the left chunk is hard-cut (no truncate marker) to make room for the right
 // intact. The cut is unmarked deliberately: the separator between the two

--- a/internal/ui/hintbar_test.go
+++ b/internal/ui/hintbar_test.go
@@ -3,6 +3,9 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRenderHintBar_SingleHint(t *testing.T) {
@@ -105,4 +108,72 @@ func TestFormatHintParts_Empty(t *testing.T) {
 	if got != "" {
 		t.Errorf("expected empty string for nil hints, got: %q", got)
 	}
+}
+
+func TestJoinStatusBar(t *testing.T) {
+	t.Run("returns empty for non-positive width", func(t *testing.T) {
+		assert.Equal(t, "", JoinStatusBar("left", "right", 0))
+		assert.Equal(t, "", JoinStatusBar("left", "right", -5))
+	})
+
+	t.Run("returns empty when both sides empty", func(t *testing.T) {
+		assert.Equal(t, "", JoinStatusBar("", "", 80))
+	})
+
+	t.Run("right-aligns hints with elastic spacer when both fit", func(t *testing.T) {
+		out := JoinStatusBar("LEFT", "RIGHT", 20)
+		assert.Equal(t, 20, lipgloss.Width(out), "must fill exactly width columns")
+		assert.True(t, strings.HasPrefix(out, "LEFT"), "left content sits at the left edge")
+		assert.True(t, strings.HasSuffix(out, "RIGHT"), "right content sits at the right edge")
+		// Middle is whitespace-only.
+		middle := out[len("LEFT") : len(out)-len("RIGHT")]
+		assert.Equal(t, strings.Repeat(" ", len(middle)), middle, "spacer must be pure whitespace")
+	})
+
+	t.Run("only-left content padded to fill width", func(t *testing.T) {
+		out := JoinStatusBar("LEFT", "", 10)
+		assert.Equal(t, 10, lipgloss.Width(out))
+		assert.True(t, strings.HasPrefix(out, "LEFT"))
+		assert.Equal(t, "      ", out[len("LEFT"):], "trailing spaces fill the bar")
+	})
+
+	t.Run("only-right content padded to fill width with leading spaces", func(t *testing.T) {
+		out := JoinStatusBar("", "HINTS", 10)
+		assert.Equal(t, 10, lipgloss.Width(out))
+		assert.True(t, strings.HasSuffix(out, "HINTS"))
+		assert.Equal(t, "     ", out[:len(out)-len("HINTS")], "leading spaces right-align the hints")
+	})
+
+	t.Run("left truncated with marker when combined exceeds width", func(t *testing.T) {
+		// Left is 30 cols, right is 15 cols, width is 30. Right must stay
+		// intact; left must shrink (and pick up the truncate marker).
+		left := strings.Repeat("L", 30)
+		right := strings.Repeat("R", 15)
+		out := JoinStatusBar(left, right, 30)
+		assert.Equal(t, 30, lipgloss.Width(out), "must fill exactly width columns")
+		assert.True(t, strings.HasSuffix(out, right), "info chips (right) must survive intact")
+		assert.Contains(t, out, "~", "truncated left should pick up the truncate marker")
+	})
+
+	t.Run("right truncated when alone wider than width", func(t *testing.T) {
+		left := "DROPPED"
+		right := strings.Repeat("R", 30)
+		out := JoinStatusBar(left, right, 10)
+		assert.Equal(t, 10, lipgloss.Width(out), "must not exceed width")
+		assert.NotContains(t, out, "DROPPED", "left chunk dropped when right alone overflows")
+	})
+
+	t.Run("info chips survive a long keymap — explorer bar contract", func(t *testing.T) {
+		// The explorer's full keymap is ~165 cols on its own. JoinStatusBar
+		// pins the right-anchored info chips (sort, counter / selected, etc.)
+		// to the right edge and truncates the keymap on overflow so the
+		// user keeps the at-a-glance state indicators intact even on a
+		// terminal narrow enough to clip the hint list.
+		bigLeft := strings.Repeat("hint | ", 25) // ~175 cols
+		chips := "sort:name  [42/100]"
+		out := JoinStatusBar(bigLeft, chips, 60)
+		assert.Equal(t, 60, lipgloss.Width(out))
+		assert.True(t, strings.HasSuffix(out, chips),
+			"chips must remain at the right edge in full; got %q", out)
+	})
 }

--- a/internal/ui/hintbar_test.go
+++ b/internal/ui/hintbar_test.go
@@ -110,6 +110,64 @@ func TestFormatHintParts_Empty(t *testing.T) {
 	}
 }
 
+func TestFormatHintPartsFit(t *testing.T) {
+	hints := []HintEntry{
+		{Key: "j/k", Desc: "move"},
+		{Key: "enter", Desc: "view"},
+		{Key: "ctrl+r", Desc: "toggle RO"},
+		{Key: "a", Desc: "create"},
+		{Key: "?", Desc: "help"},
+	}
+
+	t.Run("empty hints returns empty", func(t *testing.T) {
+		assert.Equal(t, "", FormatHintPartsFit(nil, 80))
+	})
+
+	t.Run("non-positive width returns empty", func(t *testing.T) {
+		assert.Equal(t, "", FormatHintPartsFit(hints, 0))
+		assert.Equal(t, "", FormatHintPartsFit(hints, -1))
+	})
+
+	t.Run("all entries fit returns full join", func(t *testing.T) {
+		got := FormatHintPartsFit(hints, 200)
+		full := FormatHintParts(hints)
+		assert.Equal(t, full, got, "with ample width all entries appear in full")
+	})
+
+	t.Run("first entry doesn't fit returns empty", func(t *testing.T) {
+		assert.Equal(t, "", FormatHintPartsFit(hints, 5))
+	})
+
+	t.Run("greedy fit lands exactly on entry boundary", func(t *testing.T) {
+		two := FormatHintParts(hints[:2])
+		got := FormatHintPartsFit(hints, lipgloss.Width(two))
+		assert.Equal(t, two, got, "must fit exactly the first two entries")
+	})
+
+	t.Run("never cuts mid-description", func(t *testing.T) {
+		two := FormatHintParts(hints[:2])
+		budget := lipgloss.Width(two) + 5 // mid-third entry territory
+		got := FormatHintPartsFit(hints, budget)
+		stripped := stripANSI(got)
+		assert.NotContains(t, stripped, "ctrl+r:", "third entry must not appear partially")
+		assert.NotContains(t, stripped, "toggle", "no fragment of the third entry's desc")
+		assert.Contains(t, stripped, "j/k: move")
+		assert.Contains(t, stripped, "enter: view")
+	})
+
+	t.Run("skips a too-large entry but keeps later shorter ones", func(t *testing.T) {
+		// Width 35 fits j/k + enter + (skip ctrl+r, too wide) + a.
+		got := FormatHintPartsFit(hints, 35)
+		stripped := stripANSI(got)
+		assert.Contains(t, stripped, "j/k: move")
+		assert.Contains(t, stripped, "enter: view")
+		assert.NotContains(t, stripped, "ctrl+r: toggle RO",
+			"the wide entry that doesn't fit must be skipped")
+		assert.Contains(t, stripped, "a: create",
+			"a shorter later entry must be picked up after a skip")
+	})
+}
+
 func TestJoinStatusBar(t *testing.T) {
 	t.Run("returns empty for non-positive width", func(t *testing.T) {
 		assert.Equal(t, "", JoinStatusBar("left", "right", 0))
@@ -144,15 +202,18 @@ func TestJoinStatusBar(t *testing.T) {
 		assert.Equal(t, "     ", out[:len(out)-len("HINTS")], "leading spaces right-align the hints")
 	})
 
-	t.Run("left truncated with marker when combined exceeds width", func(t *testing.T) {
+	t.Run("left hard-cut without marker when combined exceeds width", func(t *testing.T) {
 		// Left is 30 cols, right is 15 cols, width is 30. Right must stay
-		// intact; left must shrink (and pick up the truncate marker).
+		// intact; left must shrink. The cut is unmarked — the gap between
+		// the truncated left and the right is whitespace-only, never a `~`,
+		// because the explorer status bar relies on a clean visual gutter
+		// between the keymap and the chip group.
 		left := strings.Repeat("L", 30)
 		right := strings.Repeat("R", 15)
 		out := JoinStatusBar(left, right, 30)
 		assert.Equal(t, 30, lipgloss.Width(out), "must fill exactly width columns")
 		assert.True(t, strings.HasSuffix(out, right), "info chips (right) must survive intact")
-		assert.Contains(t, out, "~", "truncated left should pick up the truncate marker")
+		assert.NotContains(t, out, "~", "no truncate marker may bleed into the separator")
 	})
 
 	t.Run("right truncated when alone wider than width", func(t *testing.T) {


### PR DESCRIPTION
## Summary
**Bug fixed**: "When I select multiple items, the hint bar is trimmed." The old layout joined the selection chip on the left with the keymap on the right and let lipgloss MaxWidth chop overflow from the right edge — every additional selection ate into the keymap.

**Layout**: keymap hints are pinned to the LEFT edge; the informational chip group (sort, counter / selected count, filter preset, NYAN) anchors the FAR RIGHT, separated by an elastic run of spaces. Adding or removing chips no longer shifts the keymap.

**Right-priority overflow** via new `ui.JoinStatusBar(left, right, width)` helper — the right side stays intact, the keymap yields. Overlay hint bars render via a separate path (no chip group) so the right-priority rule is scoped to the chip-bearing explorer bar.

**Counter ↔ selection swap**: `[cur/total]` and `N selected` share a single chip slot. The slot defaults to the counter; selecting any item flips it to the selection badge (counter hidden). Eliminates the stacked-chip widening that was the user-visible source of the trim.

**Bulk-action overlays keep the badge**: when `m.bulkMode` is set the selection-count badge stays visible alongside the overlay's keymap, so the user retains "how many am I about to affect?" context while reading the confirm.

**Entry-aware keymap fit**: new `ui.FormatHintPartsFit(hints, maxWidth)` builds the styled keymap by greedy entry-by-entry inclusion. Whole `key: desc` units only — never half-rendered descriptions. Entries that don't fit are skipped, but subsequent shorter ones still get appended.

**Clean separator**: `JoinStatusBar`'s safety-fallback truncation switches from `ui.Truncate` (which appends `~`) to `ansi.Truncate` with empty marker. The gutter between keymap and chips is whitespace only, never a stray `~`.

## Test plan
- [x] `go test -race ./...` is clean
- [x] Resource list: keymap on the left, chips (`sort:Name ↑  [1/47]`) flush right
- [x] Select multiple items (`v`) — counter `[1/47]` flips to ` 5 selected `; keymap doesn't shift
- [x] Press `d` to delete with multiple items selected — confirm overlay opens, ` 5 selected ` badge stays visible on the right
- [x] Press `Esc` — back to explorer, full chip group restored
- [x] Resize terminal narrow (~120 cols) — keymap truncates entry-by-entry (no half-rendered hint, no `~` between keymap and chips), chips remain intact
- [x] Theme picker (`overlayColorscheme`) — no chip group (overlay path is unaffected by this layout)
- [x] Long preset name in `[filter: <name>]` chip — fits on right; if it pushes things, falls off the right end