### PR TITLE
fix(ui): apply theme to middle column without delay

### DIFF
--- a/internal/ui/explorer_table_renderer.go
+++ b/internal/ui/explorer_table_renderer.go
@@ -57,7 +57,7 @@ func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor in
 		itemsLen:     len(items),
 		middleRev:    middleRev,
 		selRev:       selRev,
-		themeRev:     ThemeRev,
+		themeRev:     ThemeRev.Load(),
 		ageBucket:    time.Now().Unix() / ageBucketSeconds,
 		width:        width,
 		height:       height,

--- a/internal/ui/explorer_table_renderer.go
+++ b/internal/ui/explorer_table_renderer.go
@@ -34,6 +34,7 @@ type tableFingerprint struct {
 	itemsLen     int
 	middleRev    uint64
 	selRev       uint64
+	themeRev     uint64
 	ageBucket    int64
 	width        int
 	height       int
@@ -56,6 +57,7 @@ func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor in
 		itemsLen:     len(items),
 		middleRev:    middleRev,
 		selRev:       selRev,
+		themeRev:     ThemeRev,
 		ageBucket:    time.Now().Unix() / ageBucketSeconds,
 		width:        width,
 		height:       height,

--- a/internal/ui/explorer_table_renderer_test.go
+++ b/internal/ui/explorer_table_renderer_test.go
@@ -113,6 +113,46 @@ func TestTableRendererInvalidatesOnIconModeChange(t *testing.T) {
 	assert.Equal(t, "none", r.fp.iconMode)
 }
 
+// Reproduces the "middle column applies the new theme with a slight
+// delay" report. The colourscheme picker calls ApplyTheme on every
+// cursor move, but the table-renderer fingerprint did not include any
+// theme identity — so the cache held row strings with the *old* theme's
+// ANSI sequences baked in until something else (data tick, age bucket
+// roll, resize, no-color toggle) changed.
+//
+// We plant a sentinel that can only survive if Render decides r.fp is
+// unchanged and reuses r.rows. After ApplyTheme to a visibly different
+// palette, the next Render must invalidate the cache and clear the
+// sentinel.
+func TestTableRendererInvalidatesOnApplyTheme(t *testing.T) {
+	prevTheme := ActiveTheme
+	t.Cleanup(func() { ApplyTheme(prevTheme) })
+
+	ApplyTheme(DefaultTheme())
+
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	require.NotEmpty(t, r.rows, "first render must populate the cache")
+
+	const sentinelKey = -1
+	r.rows[sentinelKey] = "sentinel"
+
+	other := DefaultTheme()
+	other.Text = "#ff00ff" // visibly different so style globals diverge
+	other.Primary = "#00ff00"
+	other.Dimmed = "#ffaa00"
+	ApplyTheme(other)
+
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+
+	_, present := r.rows[sentinelKey]
+	assert.False(t, present,
+		"ApplyTheme between renders must invalidate the row cache; sentinel survived, "+
+			"so the middle column would keep painting the previous theme until something else "+
+			"in the fingerprint changed")
+}
+
 func TestTableRendererRestoresGlobalsAfterRender(t *testing.T) {
 	sentinelCache := map[int]string{99: "sentinel"}
 	sentinelLayout := &TableLayoutCache{Computed: true}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"sync/atomic"
+
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -12,10 +14,12 @@ var ActiveTheme = DefaultTheme()
 // styled strings (e.g. TableRenderer's row cache for the middle column)
 // must include this in their fingerprint so a theme switch invalidates
 // them on the very next frame instead of waiting for an unrelated field
-// (data tick, age bucket roll, resize) to change. Treated as a UI-thread
-// scalar — same race posture as the other Active* / Config* globals
-// touched by Update and read by View.
-var ThemeRev uint64
+// (data tick, age bucket roll, resize) to change. Atomic because the
+// other Active* / Config* globals are bound by an undocumented
+// "UI-thread only" contract; making this one self-enforcing eliminates
+// a torn-read class of bug if a future caller invokes ApplyTheme from
+// an informer callback or other background goroutine.
+var ThemeRev atomic.Uint64
 
 // Theme defines the color palette for the application.
 type Theme struct {
@@ -93,7 +97,7 @@ func ApplyTheme(t Theme) {
 		t.SelectedFg = EnforceMinContrast(t.SelectedFg, t.SelectedBg, ConfigMinContrastRatio)
 	}
 	ActiveTheme = t
-	ThemeRev++
+	ThemeRev.Add(1)
 	if ConfigNoColor {
 		applyNoColorTheme()
 		return

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -8,6 +8,15 @@ import (
 // reads this when rebuilding style globals after toggling color mode.
 var ActiveTheme = DefaultTheme()
 
+// ThemeRev is bumped on every ApplyTheme call. Render caches that bake
+// styled strings (e.g. TableRenderer's row cache for the middle column)
+// must include this in their fingerprint so a theme switch invalidates
+// them on the very next frame instead of waiting for an unrelated field
+// (data tick, age bucket roll, resize) to change. Treated as a UI-thread
+// scalar — same race posture as the other Active* / Config* globals
+// touched by Update and read by View.
+var ThemeRev uint64
+
 // Theme defines the color palette for the application.
 type Theme struct {
 	Primary    string `json:"primary"`
@@ -84,6 +93,7 @@ func ApplyTheme(t Theme) {
 		t.SelectedFg = EnforceMinContrast(t.SelectedFg, t.SelectedBg, ConfigMinContrastRatio)
 	}
 	ActiveTheme = t
+	ThemeRev++
 	if ConfigNoColor {
 		applyNoColorTheme()
 		return

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -290,20 +290,18 @@ func TestTransparentBgConfig(t *testing.T) {
 
 // ApplyTheme must bump ThemeRev so cache fingerprints (notably the
 // middle-column row cache in TableRenderer) invalidate immediately
-// instead of waiting for an unrelated field to change.
+// instead of waiting for an unrelated field to change. The contract is
+// monotonic growth, not absolute values, so we only restore ActiveTheme
+// — letting ApplyTheme own the counter via its sole sanctioned writer.
 func TestApplyThemeBumpsThemeRev(t *testing.T) {
 	prevTheme := ActiveTheme
-	prevRev := ThemeRev
-	t.Cleanup(func() {
-		ApplyTheme(prevTheme)
-		ThemeRev = prevRev
-	})
+	t.Cleanup(func() { ApplyTheme(prevTheme) })
 
 	ApplyTheme(DefaultTheme())
-	first := ThemeRev
+	first := ThemeRev.Load()
 
 	ApplyTheme(DefaultTheme())
-	assert.Greater(t, ThemeRev, first,
+	assert.Greater(t, ThemeRev.Load(), first,
 		"ApplyTheme must bump ThemeRev on every call so style-keyed caches invalidate; "+
 			"this is the contract that fixes the middle-column theme-apply delay")
 }

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -287,3 +287,23 @@ func TestTransparentBgConfig(t *testing.T) {
 		assert.False(t, isNoColor, "SelectedStyle should keep background in transparent mode")
 	})
 }
+
+// ApplyTheme must bump ThemeRev so cache fingerprints (notably the
+// middle-column row cache in TableRenderer) invalidate immediately
+// instead of waiting for an unrelated field to change.
+func TestApplyThemeBumpsThemeRev(t *testing.T) {
+	prevTheme := ActiveTheme
+	prevRev := ThemeRev
+	t.Cleanup(func() {
+		ApplyTheme(prevTheme)
+		ThemeRev = prevRev
+	})
+
+	ApplyTheme(DefaultTheme())
+	first := ThemeRev
+
+	ApplyTheme(DefaultTheme())
+	assert.Greater(t, ThemeRev, first,
+		"ApplyTheme must bump ThemeRev on every call so style-keyed caches invalidate; "+
+			"this is the contract that fixes the middle-column theme-apply delay")
+}


### PR DESCRIPTION
## Summary
- Bug: previewing themes via the colourscheme picker, the middle column (resource list) kept painting the previous palette for a beat before catching up. Other parts of the screen flipped instantly.
- Root cause: `TableRenderer` (`internal/ui/explorer_table_renderer.go`) caches non-cursor row strings with their ANSI sequences baked in, keyed on `tableFingerprint`. The fingerprint covered data identity, layout, age bucket, highlight, hidden columns, icon mode, and `ConfigNoColor` — but had no theme identity. `ApplyTheme` rebuilt every style global synchronously, but from `Render`'s perspective nothing in the fingerprint had changed, so `r.rows` was reused unchanged. The "delay" was the user waiting for some unrelated field to roll (data tick → `middleRev`, 30s age bucket, resize) and incidentally trigger a cache rebuild.
- Fix: a `ThemeRev uint64` counter in `internal/ui/theme.go` is bumped on every `ApplyTheme` call and included in `tableFingerprint` as `themeRev`. Theme switch → rev bump → fingerprint differs → cache cleared → next frame paints with the new palette.
- Counter beats keying on the scheme name because the picker's `t` shortcut re-applies the SAME named scheme to flip `ConfigTransparentBg` — that toggle would still hit the delay if we keyed on name. Counter captures every "style globals were just rebuilt" event.

## Test plan
- [x] `go test -race ./...` is clean
- [x] Open colourscheme picker (`overlayColorscheme`), navigate with `j/k` — resource list (middle column) updates instantly with each preview
- [x] Same picker, press `t` to toggle transparent background — middle column reflects the change immediately
- [x] Quick smoke at higher item counts (>50 rows) to confirm no flicker / leftover ANSI from old palette