### PR TITLE
ci(release): add SLSA build provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,9 @@ jobs:
       contents: write
       # id-token is required for keyless cosign signing via Sigstore OIDC.
       id-token: write
+      # attestations is required for actions/attest-build-provenance to publish
+      # SLSA provenance attestations on the release artifacts.
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -194,3 +197,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           NIGHTLY_DATE: ${{ needs.detect.outputs.nightly_date }}
+
+      # Generates SLSA build provenance attestations for every release artifact.
+      # GitHub publishes the attestations alongside the release so downstream
+      # tools (e.g. OpenSSF Scorecard, `gh attestation verify`) can prove the
+      # artifacts were built from this repo at this commit.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+            dist/*.rpm
+            dist/*.sbom.json
+            dist/checksums.txt


### PR DESCRIPTION
## Summary
- Adds `actions/attest-build-provenance` to the release workflow, generating SLSA build provenance for every artifact GoReleaser produces (archives, deb/rpm, SBOM, checksums).
- Grants the release job `attestations: write` so the action can publish the bundles to the release.

## Why
OpenSSF Scorecard's `SignedReleases` check has been emitting:

```
Warn: release artifact v0.9.35 does not have provenance: ...
Warn: release artifact v0.9.34 does not have provenance: ...
Warn: release artifact v0.9.33 does not have provenance: ...
Warn: release artifact v0.9.32 does not have provenance: ...
```

Today only `checksums.txt` carries a cosign detached signature; the archives, packages, and SBOM are unsigned per-asset, so Scorecard rates the release as not provenant. SLSA build provenance via the GitHub-native attest action is the modern, Scorecard-recognised fix and also enables `gh attestation verify` for downstream consumers.

## Test plan
- [ ] Cut a nightly tag (e.g. `v0.9.37-nightly.20260501`) and confirm the release page shows attestations.
- [ ] Run `gh attestation verify dist/lfk_<ver>_linux_amd64.tar.gz --owner janosmiko` against an artifact from that release.
- [ ] After 5 new releases, confirm the Scorecard `SignedReleases` warnings drop off.

## Notes
- Existing `v0.9.32-v0.9.35` warnings won't disappear retroactively — Scorecard inspects the most recent 5 releases, so they age out as new releases ship.
- Docker image provenance is unchanged (still `docker_signs` via cosign keyless).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release process to include automated generation and publication of build provenance attestations, improving the security and verifiability of release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->