### PR TITLE
fix(ui): keep "/" search highlight from corrupting SGR codes

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -432,8 +432,20 @@ func helpSections() []helpSection {
 // current view (empty = explorer). Exported so the app layer can run
 // the same line-building pipeline to compute search match indices for
 // n/N navigation.
+//
+// Returns plain (un-styled) text in the same row order RenderHelpScreen
+// will display. Plain text is what app-layer search routines need:
+// running MatchLine / strings.Contains over a styled line lets a
+// digit query match bytes that live inside an SGR escape (e.g. the
+// "1" in "\x1b[33;1m"), inflating match counts and pointing n/N at
+// rows with no visible match.
 func BuildHelpLines(filter, contextMode string) []string {
-	return buildHelpLines(filter, contextMode)
+	specs := buildHelpSpecs(filter, contextMode)
+	out := make([]string, len(specs))
+	for i, s := range specs {
+		out[i] = helpSpecPlain(s)
+	}
+	return out
 }
 
 // HelpVisibleLines returns the number of help-content rows that fit
@@ -448,12 +460,46 @@ func HelpVisibleLines(screenHeight int) int {
 	return visibleLines
 }
 
-// buildHelpLines is the internal implementation kept unexported to
-// avoid forcing callers to import context-specific styling state.
-func buildHelpLines(filter, contextMode string) []string {
+// helpLineKind labels each logical row in the help screen so the
+// renderer can pick the correct outer style for that row's plain text.
+type helpLineKind int
+
+const (
+	helpLineBlank helpLineKind = iota
+	helpLineSectionHeader
+	helpLineEntry
+	helpLineMessage
+)
+
+// helpLineSpec is the structural form of a help row, kept un-styled
+// so the renderer can splice the search highlight into plain text
+// before applying the outer styles. The pre-style highlight path
+// avoids the bug where a "/" search query containing digits matched
+// bytes inside an SGR escape sequence on the already-styled line —
+// terminals rendered the leftover sequence fragments as literal
+// "[33;" / ";1m" text on screen.
+type helpLineSpec struct {
+	kind helpLineKind
+	// text is the plain content for header and message rows.
+	text string
+	// key is the padded plain key column for entry rows.
+	key string
+	// desc is the plain description column for entry rows.
+	desc string
+}
+
+// helpKeyColumnWidth is the fixed-width key column so descriptions
+// align vertically across every entry row.
+const helpKeyColumnWidth = 14
+
+// buildHelpSpecs walks the help sections and produces structural
+// specs (un-styled) in the exact display order. Used by both
+// BuildHelpLines and RenderHelpScreen so the plain match indices
+// computed by the app layer line up 1:1 with the styled rows on
+// screen.
+func buildHelpSpecs(filter, contextMode string) []helpLineSpec {
 	sections := helpSections()
-	lines := make([]string, 0, 64)
-	keyW := 14
+	specs := make([]helpLineSpec, 0, 64)
 	for si, section := range sections {
 		// Context filtering: when a context is active, show only sections
 		// that match that context. When no context (explorer), show only
@@ -468,39 +514,91 @@ func buildHelpLines(filter, contextMode string) []string {
 			}
 		}
 
-		var sectionLines []string
+		var entries []helpLineSpec
 		for _, b := range section.bindings {
 			if filter != "" {
 				if !MatchLine(b.key, filter) && !MatchLine(b.desc, filter) {
 					continue
 				}
 			}
-			keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Bold(true).Background(SurfaceBg)
-			keyPart := keyStyle.Render(fmt.Sprintf("%-*s", keyW, b.key))
-			descPart := OverlayDimStyle.Render(b.desc)
-			sectionLines = append(sectionLines, "    "+keyPart+"  "+descPart)
+			entries = append(entries, helpLineSpec{
+				kind: helpLineEntry,
+				key:  fmt.Sprintf("%-*s", helpKeyColumnWidth, b.key),
+				desc: b.desc,
+			})
 		}
 
 		// Only include sections that have matching bindings.
-		if len(sectionLines) == 0 {
+		if len(entries) == 0 {
 			continue
 		}
 
-		if len(lines) > 0 || si > 0 {
-			if len(lines) > 0 {
-				lines = append(lines, "")
+		if len(specs) > 0 || si > 0 {
+			if len(specs) > 0 {
+				specs = append(specs, helpLineSpec{kind: helpLineBlank})
 			}
 		}
-		header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorPrimary)).Underline(true).Background(SurfaceBg).Render(section.title)
-		lines = append(lines, "  "+header)
-		lines = append(lines, sectionLines...)
+		specs = append(specs, helpLineSpec{kind: helpLineSectionHeader, text: section.title})
+		specs = append(specs, entries...)
 	}
 
-	if filter != "" && len(lines) == 0 {
-		lines = append(lines, OverlayDimStyle.Render("  No matching keybindings"))
+	if filter != "" && len(specs) == 0 {
+		specs = append(specs, helpLineSpec{kind: helpLineMessage, text: "No matching keybindings"})
 	}
 
-	return lines
+	return specs
+}
+
+// helpSpecPlain returns the un-styled visible form of a help-line
+// spec. The plain form is what the app-layer match counter sees, so
+// substring/regex/fuzzy queries match the same characters the user
+// reads on screen — never bytes hidden inside an ANSI SGR sequence.
+func helpSpecPlain(s helpLineSpec) string {
+	switch s.kind {
+	case helpLineBlank:
+		return ""
+	case helpLineSectionHeader:
+		return "  " + s.text
+	case helpLineEntry:
+		return "    " + s.key + "  " + s.desc
+	case helpLineMessage:
+		return "  " + s.text
+	}
+	return ""
+}
+
+// helpSpecStyled renders a help-line spec to its final styled form.
+// When search is non-empty the inline highlight is applied to plain
+// key/desc/text first via HighlightMatchStyledOver, then wrapped with
+// the segment's outer style via RenderOverPrestyled. Highlighting on
+// plain segments keeps the match-finder away from any ANSI bytes —
+// fixing the "/ search of a digit prints raw [33;1m" report.
+//
+// isCurrent flips the row's highlight to SelectedSearchHighlightStyle
+// so n/N navigation can mark the active match distinctly.
+func helpSpecStyled(s helpLineSpec, search string, isCurrent bool) string {
+	hl := SearchHighlightStyle
+	if isCurrent {
+		hl = SelectedSearchHighlightStyle
+	}
+	switch s.kind {
+	case helpLineBlank:
+		return ""
+	case helpLineSectionHeader:
+		headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorPrimary)).Underline(true).Background(SurfaceBg)
+		inner := HighlightMatchStyledOver(s.text, search, hl, headerStyle)
+		return "  " + RenderOverPrestyled(inner, headerStyle)
+	case helpLineEntry:
+		keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Bold(true).Background(SurfaceBg)
+		descStyle := OverlayDimStyle
+		keyInner := HighlightMatchStyledOver(s.key, search, hl, keyStyle)
+		descInner := HighlightMatchStyledOver(s.desc, search, hl, descStyle)
+		return "    " + RenderOverPrestyled(keyInner, keyStyle) + "  " + RenderOverPrestyled(descInner, descStyle)
+	case helpLineMessage:
+		inner := HighlightMatchStyledOver(s.text, search, hl, OverlayDimStyle)
+		return "  " + RenderOverPrestyled(inner, OverlayDimStyle)
+	}
+	return ""
 }
 
 // RenderHelpScreen renders a full help overlay with all keybindings.
@@ -523,7 +621,14 @@ func RenderHelpScreen(screenWidth, screenHeight, scroll int, filter, search, con
 
 	title := OverlayTitleStyle.Render("Keybindings")
 
-	lines := buildHelpLines(filter, contextMode)
+	// Build structural specs once, then render each row with the
+	// search highlight pre-spliced into the plain segments before the
+	// outer style is applied. Highlighting on plain text keeps the
+	// match-finder away from ANSI escape bytes — the previous
+	// "highlight on already-styled, already-truncated line" path could
+	// match a digit query inside an SGR like \x1b[33;1m, which broke
+	// the sequence and printed "[33;" / ";1m" as visible text.
+	specs := buildHelpSpecs(filter, contextMode)
 	// Truncate each line to the inner-panel content width so one entry
 	// in `lines` always renders as exactly one row. Lipgloss's
 	// auto-wrap behavior would otherwise silently expand long
@@ -531,19 +636,9 @@ func RenderHelpScreen(screenWidth, screenHeight, scroll int, filter, search, con
 	// from len(lines), and the outer box height would drift — making
 	// a filter that narrows results visibly shrink the window.
 	innerW := max(contentW-2, 10)
-	for i, line := range lines {
-		lines[i] = Truncate(line, innerW)
-	}
-	if search != "" {
-		for i, line := range lines {
-			style := SearchHighlightStyle
-			if i == currentMatchLine {
-				// Distinct "selected match" style so the user can see
-				// which match the next n/N press will move from.
-				style = SelectedSearchHighlightStyle
-			}
-			lines[i] = HighlightMatchStyled(line, search, style)
-		}
+	lines := make([]string, len(specs))
+	for i, s := range specs {
+		lines[i] = Truncate(helpSpecStyled(s, search, i == currentMatchLine), innerW)
 	}
 	totalLines := len(lines)
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -500,7 +500,7 @@ const helpKeyColumnWidth = 14
 func buildHelpSpecs(filter, contextMode string) []helpLineSpec {
 	sections := helpSections()
 	specs := make([]helpLineSpec, 0, 64)
-	for si, section := range sections {
+	for _, section := range sections {
 		// Context filtering: when a context is active, show only sections
 		// that match that context. When no context (explorer), show only
 		// sections with empty context (explorer sections).
@@ -533,10 +533,8 @@ func buildHelpSpecs(filter, contextMode string) []helpLineSpec {
 			continue
 		}
 
-		if len(specs) > 0 || si > 0 {
-			if len(specs) > 0 {
-				specs = append(specs, helpLineSpec{kind: helpLineBlank})
-			}
+		if len(specs) > 0 {
+			specs = append(specs, helpLineSpec{kind: helpLineBlank})
 		}
 		specs = append(specs, helpLineSpec{kind: helpLineSectionHeader, text: section.title})
 		specs = append(specs, entries...)

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
@@ -105,4 +106,64 @@ func TestRenderHelpScreen_CurrentMatchStyledDifferently(t *testing.T) {
 		}
 	}
 	t.Fatalf("no line index produced a different render — current-match style is not applied")
+}
+
+// Searching for a digit must not corrupt the rendered output.
+//
+// The previous "/" search path ran HighlightMatchStyled on the
+// already-styled, already-truncated help lines. SGR sequences carry
+// digits as parameters (e.g. \x1b[33;1m for bold + yellow fg), so a
+// byte-indexed search for "1" matched bytes inside the escape
+// sequences and the highlight wrapper split them into fragments
+// terminals rendered as literal "[33;" / ";1m" text on screen.
+//
+// Asserts: stripping ANSI from the rendered output produces the same
+// visible characters whether the user typed a digit query or no
+// query at all. Search adds highlight color but never visible chars.
+func TestRenderHelpScreen_DigitSearchDoesNotLeakEscapeFragments(t *testing.T) {
+	original := lipgloss.DefaultRenderer().ColorProfile()
+	originalNoColor := ConfigNoColor
+	t.Cleanup(func() {
+		lipgloss.DefaultRenderer().SetColorProfile(original)
+		ConfigNoColor = originalNoColor
+		ApplyTheme(DefaultTheme())
+	})
+	ConfigNoColor = false
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	ApplyTheme(DefaultTheme())
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+
+	plain := RenderHelpScreen(120, 200, 0, "", "", "", -1)
+
+	// Each digit query exercises a different byte that the old code
+	// could match inside SGR parameters. "1" was the most visible in
+	// the user report; the others guard against regressions in the
+	// other common SGR digits.
+	for _, q := range []string{"1", "0", "5", "33"} {
+		t.Run("query="+q, func(t *testing.T) {
+			searched := RenderHelpScreen(120, 200, 0, "", q, "", -1)
+
+			assert.Equal(t, ansi.Strip(plain), ansi.Strip(searched),
+				"digit search must not change the visible characters in the help screen — only the highlight color")
+
+			assert.NotContains(t, searched, "\x1b\x1b",
+				"rendered output must not contain doubled-ESC bytes (smoking gun for fragmented SGR sequences)")
+		})
+	}
+}
+
+// helpRecomputeMatches in the app layer iterates over BuildHelpLines
+// and counts hits via MatchLine. When BuildHelpLines returned styled
+// strings, a "1" query would substring-match bytes inside SGR codes
+// (e.g. the "1" in \x1b[33;1m) and inflate the match count to roughly
+// every styled row, pointing n/N at rows with no visible "1".
+//
+// Asserts: the plain lines BuildHelpLines now returns contain no ESC
+// bytes, so MatchLine sees only the visible characters.
+func TestBuildHelpLines_ReturnsPlainText(t *testing.T) {
+	lines := BuildHelpLines("", "")
+	for i, line := range lines {
+		assert.NotContains(t, line, "\x1b",
+			"BuildHelpLines must return plain text (no ANSI escapes) — line %d: %q", i, line)
+	}
 }

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -131,6 +131,12 @@ func TestRenderHelpScreen_DigitSearchDoesNotLeakEscapeFragments(t *testing.T) {
 	ConfigNoColor = false
 	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
 	ApplyTheme(DefaultTheme())
+	// ApplyTheme can re-detect/restore the color profile from
+	// originalColorProfile (theme.go:109-110), so re-force TrueColor
+	// here. Without this, the test runs under the harness's default
+	// stripped profile, lipgloss emits no SGR digits, and the
+	// regression we're guarding against — digit-query corruption
+	// inside SGR sequences — could not occur in the first place.
 	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
 
 	plain := RenderHelpScreen(120, 200, 0, "", "", "", -1)
@@ -160,7 +166,25 @@ func TestRenderHelpScreen_DigitSearchDoesNotLeakEscapeFragments(t *testing.T) {
 //
 // Asserts: the plain lines BuildHelpLines now returns contain no ESC
 // bytes, so MatchLine sees only the visible characters.
+//
+// Forces a TrueColor profile so lipgloss actually emits SGR escapes
+// for any styling it would apply — without this, the test harness's
+// default stripped profile makes lipgloss render plain text anyway
+// and the assertion would pass vacuously even if BuildHelpLines went
+// back to returning styled output.
 func TestBuildHelpLines_ReturnsPlainText(t *testing.T) {
+	original := lipgloss.DefaultRenderer().ColorProfile()
+	originalNoColor := ConfigNoColor
+	t.Cleanup(func() {
+		lipgloss.DefaultRenderer().SetColorProfile(original)
+		ConfigNoColor = originalNoColor
+		ApplyTheme(DefaultTheme())
+	})
+	ConfigNoColor = false
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	ApplyTheme(DefaultTheme())
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+
 	lines := BuildHelpLines("", "")
 	for i, line := range lines {
 		assert.NotContains(t, line, "\x1b",

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -316,7 +316,7 @@ func HighlightMatchInline(line, rawQuery string, hlStyle lipgloss.Style) string 
 // spans inside a (possibly already-styled) line. Spans are positions
 // in ansi.Strip(line); they're mapped to visual columns and spliced
 // back into the styled line via ansi.Cut / ansi.TruncateLeft so the
-// surrounding ANSI is preserved between matches.
+// surrounding ANSI between matches is preserved.
 //
 // The previous helpers sliced the styled line by raw byte offsets, so
 // a query that happened to match bytes inside an SGR escape (e.g. the
@@ -324,6 +324,17 @@ func HighlightMatchInline(line, rawQuery string, hlStyle lipgloss.Style) string 
 // terminal printed the orphan parameters as visible "[33;" text.
 // Operating on plain text first eliminates that class of bug for
 // every caller.
+//
+// Restriction: the matched span itself is rendered from plain text
+// (style.Render(plain[s:e])), so any per-character inner styling
+// inside the span is dropped — only the outer style around the span
+// survives via the ansi.Cut bridges. Today's callers all pass either
+// plain text (help.go path) or text whose inner styling is uniform
+// (search-bar paths), so this is a non-issue in practice. A future
+// caller passing a syntax-highlighted line (e.g. log content with
+// per-token colors) would lose styling on matched characters; in
+// that case use HighlightMatchInline (search.go) which tracks
+// activeOpen across the highlighted segment.
 //
 // restoreCodes is emitted after each highlight reset so an outer
 // style wrapping the result keeps its background through the

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -6,6 +6,7 @@ import (
 	"unicode"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // SearchMode represents the type of search being performed.
@@ -311,77 +312,123 @@ func HighlightMatchInline(line, rawQuery string, hlStyle lipgloss.Style) string 
 	return b.String()
 }
 
-// highlightSubstring highlights all occurrences of query in line
-// (case-insensitive). When restoreCodes is non-empty it's emitted
-// after each inner highlight reset so a wrapping outer style's
-// background stays visible for the post-match segment.
-func highlightSubstring(line, query string, style lipgloss.Style, restoreCodes string) string {
-	queryLower := strings.ToLower(query)
-	lineLower := strings.ToLower(line)
-	if !strings.Contains(lineLower, queryLower) {
+// highlightSpans applies style to a list of [start, end) plain-byte
+// spans inside a (possibly already-styled) line. Spans are positions
+// in ansi.Strip(line); they're mapped to visual columns and spliced
+// back into the styled line via ansi.Cut / ansi.TruncateLeft so the
+// surrounding ANSI is preserved between matches.
+//
+// The previous helpers sliced the styled line by raw byte offsets, so
+// a query that happened to match bytes inside an SGR escape (e.g. the
+// "1" in "\x1b[33;1m") would split the escape sequence and the
+// terminal printed the orphan parameters as visible "[33;" text.
+// Operating on plain text first eliminates that class of bug for
+// every caller.
+//
+// restoreCodes is emitted after each highlight reset so an outer
+// style wrapping the result keeps its background through the
+// post-match segment.
+func highlightSpans(line, plain string, spans [][2]int, style lipgloss.Style, restoreCodes string) string {
+	if len(spans) == 0 {
 		return line
 	}
 	var b strings.Builder
-	pos := 0
-	for pos < len(line) {
-		idx := strings.Index(strings.ToLower(line[pos:]), queryLower)
-		if idx < 0 {
-			b.WriteString(line[pos:])
-			break
+	pos := 0 // plain byte offset
+	for _, sp := range spans {
+		s, e := sp[0], sp[1]
+		if s > pos {
+			posCol := ansi.StringWidth(plain[:pos])
+			startCol := ansi.StringWidth(plain[:s])
+			b.WriteString(ansi.Cut(line, posCol, startCol))
 		}
-		b.WriteString(line[pos : pos+idx])
-		b.WriteString(style.Render(line[pos+idx : pos+idx+len(query)]))
+		b.WriteString(style.Render(plain[s:e]))
 		b.WriteString(restoreCodes)
-		pos = pos + idx + len(query)
+		pos = e
+	}
+	if pos < len(plain) {
+		posCol := ansi.StringWidth(plain[:pos])
+		b.WriteString(ansi.TruncateLeft(line, posCol, ""))
 	}
 	return b.String()
 }
 
+// highlightSubstring highlights all occurrences of query in line
+// (case-insensitive). When restoreCodes is non-empty it's emitted
+// after each inner highlight reset so a wrapping outer style's
+// background stays visible for the post-match segment.
+//
+// Match-finding runs against the ANSI-stripped plain form of line,
+// so a digit query never matches bytes inside an SGR escape.
+func highlightSubstring(line, query string, style lipgloss.Style, restoreCodes string) string {
+	if query == "" {
+		return line
+	}
+	plain := ansi.Strip(line)
+	plainLower := strings.ToLower(plain)
+	queryLower := strings.ToLower(query)
+	if !strings.Contains(plainLower, queryLower) {
+		return line
+	}
+	var spans [][2]int
+	pos := 0
+	for {
+		idx := strings.Index(plainLower[pos:], queryLower)
+		if idx < 0 {
+			break
+		}
+		s := pos + idx
+		e := s + len(queryLower)
+		spans = append(spans, [2]int{s, e})
+		pos = e
+	}
+	return highlightSpans(line, plain, spans, style, restoreCodes)
+}
+
 // highlightRegex highlights all regex matches in the line. See
-// highlightSubstring for the restoreCodes contract.
+// highlightSubstring for the restoreCodes contract. Match-finding
+// runs against the plain form so the regex sees the same characters
+// the user sees on screen, never ANSI bytes.
 func highlightRegex(line, query string, style lipgloss.Style, restoreCodes string) string {
 	re, err := regexp.Compile("(?i)" + query)
 	if err != nil {
 		return highlightSubstring(line, query, style, restoreCodes) // fallback
 	}
-	matches := re.FindAllStringIndex(line, -1)
+	plain := ansi.Strip(line)
+	matches := re.FindAllStringIndex(plain, -1)
 	if len(matches) == 0 {
 		return line
 	}
-	var b strings.Builder
-	pos := 0
-	for _, m := range matches {
-		if m[0] > pos {
-			b.WriteString(line[pos:m[0]])
-		}
-		b.WriteString(style.Render(line[m[0]:m[1]]))
-		b.WriteString(restoreCodes)
-		pos = m[1]
+	spans := make([][2]int, len(matches))
+	for i, m := range matches {
+		spans[i] = [2]int{m[0], m[1]}
 	}
-	if pos < len(line) {
-		b.WriteString(line[pos:])
-	}
-	return b.String()
+	return highlightSpans(line, plain, spans, style, restoreCodes)
 }
 
 // highlightFuzzy highlights the matched characters in a fuzzy match.
-// See highlightSubstring for the restoreCodes contract.
+// See highlightSubstring for the restoreCodes contract. Walks the
+// plain (ANSI-stripped) runes so query characters can't accidentally
+// match bytes inside an SGR escape sequence.
 func highlightFuzzy(line, query string, style lipgloss.Style, restoreCodes string) string {
-	lineLower := strings.ToLower(line)
+	if query == "" {
+		return line
+	}
+	plain := ansi.Strip(line)
+	plainLower := strings.ToLower(plain)
 	queryLower := strings.ToLower(query)
-	lineRunes := []rune(line)
-	lineLowerRunes := []rune(lineLower)
+	plainRunes := []rune(plain)
+	plainLowerRunes := []rune(plainLower)
 	queryRunes := []rune(queryLower)
 
 	if len(queryRunes) == 0 {
 		return line
 	}
 
-	// Find matching positions.
-	matchPositions := make([]bool, len(lineRunes))
+	// Find matching rune indices in the plain form.
+	matchPositions := make([]bool, len(plainRunes))
 	qi := 0
-	for li := 0; li < len(lineLowerRunes) && qi < len(queryRunes); li++ {
-		if lineLowerRunes[li] == queryRunes[qi] {
+	for li := 0; li < len(plainLowerRunes) && qi < len(queryRunes); li++ {
+		if plainLowerRunes[li] == queryRunes[qi] {
 			matchPositions[li] = true
 			qi++
 		}
@@ -390,30 +437,36 @@ func highlightFuzzy(line, query string, style lipgloss.Style, restoreCodes strin
 		return line // No full match.
 	}
 
-	// Build highlighted string, grouping consecutive matched characters.
-	var b strings.Builder
-	inHighlight := false
-	highlightStart := 0
-	for i, r := range lineRunes {
+	// Convert rune indices to plain byte offsets so highlightSpans can
+	// map them to visual columns. range over plain yields the byte
+	// offset of each rune; the trailing len(plain) closes the last
+	// run.
+	runeByteOff := make([]int, 0, len(plainRunes)+1)
+	for byteOff := range plain {
+		runeByteOff = append(runeByteOff, byteOff)
+	}
+	runeByteOff = append(runeByteOff, len(plain))
+
+	// Group consecutive matched runes into spans.
+	var spans [][2]int
+	inSpan := false
+	spanStart := 0
+	for i := range plainRunes {
 		if matchPositions[i] {
-			if !inHighlight {
-				inHighlight = true
-				highlightStart = i
+			if !inSpan {
+				inSpan = true
+				spanStart = i
 			}
-		} else {
-			if inHighlight {
-				b.WriteString(style.Render(string(lineRunes[highlightStart:i])))
-				b.WriteString(restoreCodes)
-				inHighlight = false
-			}
-			b.WriteRune(r)
+		} else if inSpan {
+			spans = append(spans, [2]int{runeByteOff[spanStart], runeByteOff[i]})
+			inSpan = false
 		}
 	}
-	if inHighlight {
-		b.WriteString(style.Render(string(lineRunes[highlightStart:])))
-		b.WriteString(restoreCodes)
+	if inSpan {
+		spans = append(spans, [2]int{runeByteOff[spanStart], runeByteOff[len(plainRunes)]})
 	}
-	return b.String()
+
+	return highlightSpans(line, plain, spans, style, restoreCodes)
 }
 
 // SearchModeIndicator returns a short string to show in the search bar

--- a/internal/ui/search_test.go
+++ b/internal/ui/search_test.go
@@ -3,6 +3,11 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetectSearchMode(t *testing.T) {
@@ -236,6 +241,73 @@ func TestHighlightFuzzy(t *testing.T) {
 	result = highlightFuzzy("deployment", "dplmnt", LogSearchHighlightStyle, "")
 	if !strings.Contains(result, "e") {
 		t.Error("fuzzy highlight should preserve non-matched characters")
+	}
+}
+
+// Each highlight helper used to slice its `line` argument by raw byte
+// offsets, so a query that happened to match a byte inside an SGR
+// escape (e.g. the "1" in "\x1b[33;1m") split the escape sequence and
+// the terminal printed "[33;" / ";1m" as visible text. The helpers
+// now find matches on the ANSI-stripped form and splice highlights at
+// visual columns, so any styled input is safe.
+//
+// These tests pass styled input directly so the regression is caught
+// in isolation, even if the help-overlay caller ever stops feeding
+// them plain text again.
+func TestHighlightHelpers_StyledInputDoesNotLeakSGRFragments(t *testing.T) {
+	originalProfile := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(originalProfile) })
+
+	// Force a real color profile so styled output actually contains
+	// SGR escape sequences with digit parameters — the surface that
+	// the old highlighters' byte-indexed slicing corrupted. Without
+	// this, lipgloss runs in the test harness's stripped profile and
+	// renders plain text, so the test would pass vacuously.
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+
+	// Use Reverse() for the highlight so the output contains visible
+	// SGR codes regardless of color profile decisions.
+	hl := lipgloss.NewStyle().Reverse(true).Bold(true)
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true)
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+
+	// Compose a styled line: "<key>L</key>  <desc>Toggle help screen</desc>".
+	styled := keyStyle.Render("L") + "  " + descStyle.Render("Toggle help screen")
+
+	// The plain form is what the user sees on screen.
+	plain := ansi.Strip(styled)
+
+	helpers := []struct {
+		name string
+		fn   func(line, query string) string
+	}{
+		{"highlightSubstring", func(line, q string) string { return highlightSubstring(line, q, hl, "") }},
+		{"highlightRegex", func(line, q string) string { return highlightRegex(line, q, hl, "") }},
+		{"highlightFuzzy", func(line, q string) string { return highlightFuzzy(line, q, hl, "") }},
+	}
+
+	// Digit queries that previously matched bytes inside SGR
+	// parameters. "1" was the user-reported case; the others guard
+	// against SGR codes containing those digits in different palettes.
+	queries := []string{"1", "0", "8"}
+
+	for _, h := range helpers {
+		for _, q := range queries {
+			t.Run(h.name+"_query="+q, func(t *testing.T) {
+				out := h.fn(styled, q)
+
+				// Visible characters must be unchanged — the helpers add
+				// highlight color, never visible text.
+				assert.Equal(t, plain, ansi.Strip(out),
+					"%s with query %q corrupted visible text", h.name, q)
+
+				// Doubled-ESC is the smoking gun for fragmented SGR
+				// sequences (the highlight wrapper landed inside an
+				// escape and lipgloss double-introducer'd the result).
+				assert.NotContains(t, out, "\x1b\x1b",
+					"%s with query %q produced doubled-ESC bytes — SGR fragmentation: %q", h.name, q, out)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION

<img width="635" height="288" alt="image" src="https://github.com/user-attachments/assets/30ace984-409d-4fb2-99f1-38fce168afd2" />


## Summary

Help-overlay `/` search rendered raw SGR fragments (`[33;`, `;1m`) on screen when the query was a digit (e.g. /1). The byte-indexed substring search was matching bytes inside ANSI escape sequences on the already-styled help lines.

Fix moves the highlight into the producer (per maintainer review-bar pattern: don't post-render-surgery already-styled output) and as a defense-in-depth makes the generic highlight helpers ANSI-aware so any future caller that passes styled input is safe.

## Type of change

- [x] fix: bug fix

## Related issue

N/A

## Changes

- `internal/ui/help.go`: split `buildHelpLines` into structural specs (`buildHelpSpecs` / `helpSpecPlain` / `helpSpecStyled`); inline highlight is applied to plain key/desc, then wrapped with the segment style via `RenderOverPrestyled`. Exported `BuildHelpLines` now returns plain text so the app-side `helpRecomputeMatches` counts hits against visible characters, not SGR bytes.
- `internal/ui/search.go`: `highlightSubstring` / `highlightRegex` / `highlightFuzzy` find matches on `ansi.Strip(line)` and splice highlights at visual columns via a shared `highlightSpans` helper (uses `ansi.Cut` / `ansi.TruncateLeft`).
- Regression tests: digit-query rendering on the help screen, and styled-input fragmentation guards on each highlight helper (forced ANSI256 profile so the test actually exercises SGR-bearing input).

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

N/A