### PR TITLE
ci: pin golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: latest
+          version: v2.11.4
 
   govulncheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Pin the golangci-lint binary version in CI so lint results are reproducible across runs.

## Type of change

- [x] ci: CI/CD configuration

## Related issue

<!-- none -->

## Changes

- `.github/workflows/ci.yml`: change `version: latest` → `version: v2.11.4` for the `golangci/golangci-lint-action` step.

The action wrapper was already pinned by SHA, but the `version: latest` input meant the linter binary itself floated. v2.12.0 (released after main last went green on v2.11.4) introduced new govet/modernize rules and started failing PRs whose code hadn't actually changed. Pinning to v2.11.4 — the version main was last green on — restores reproducibility. A future PR can bump the pin together with whatever cleanup the new rules require.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (locally on v2.11.4)
- [ ] Manually verified against a real cluster (when behavior changed)

N/A — workflow-only change.

## Checklist

- [x] Commits follow conventional commit style
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to pin linter version for consistent code validation across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->