### PR TITLE
feat(ui): support count-prefixed motion (Nj/Nk) in read-only viewers

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -173,6 +173,7 @@ my namespace" mode.
 | Key | Action |
 |---|---|
 | `j` / `k` | Scroll up/down |
+| `123j` / `123k` | Move cursor down/up N visible lines (count-prefixed motion; folds skipped) |
 | `h` / `l` | Move cursor column left/right |
 | `0` / `$` | Move cursor to line start/end |
 | `^` | Move cursor to first non-whitespace character |
@@ -204,6 +205,7 @@ my namespace" mode.
 | Key | Action |
 |---|---|
 | `j` / `k` | Move cursor up/down |
+| `123j` / `123k` | Move cursor down/up N lines (count-prefixed motion) |
 | `h` / `l` | Move cursor column left/right |
 | `0` / `$` / `^` | Move cursor to line start / end / first non-whitespace |
 | `w` / `b` / `e` / `W` / `B` / `E` | Word / WORD motions |
@@ -226,6 +228,7 @@ my namespace" mode.
 | Key | Action |
 |---|---|
 | `j` / `k` | Move cursor up/down |
+| `123j` / `123k` | Move cursor down/up N lines (count-prefixed motion) |
 | `h` / `l` / `Left` / `Right` | Move cursor column left/right |
 | `0` / `$` | Move cursor to line start/end |
 | `^` | Move cursor to first non-whitespace character |
@@ -312,6 +315,7 @@ from `terminal:` in the config.
 | Key | Action |
 |---|---|
 | `j` / `k` | Move cursor up/down |
+| `123j` / `123k` | Move cursor down/up N lines (count-prefixed motion) |
 | `h` / `l` | Move cursor column left/right |
 | `0` / `$` | Move cursor to line start/end |
 | `^` | Move cursor to first non-whitespace |

--- a/internal/app/count_motion_test.go
+++ b/internal/app/count_motion_test.go
@@ -1,0 +1,271 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// `123j` / `123k` reuse the same digit accumulator that powers `123y` and
+// `123G`. The buffer must be consumed by the motion (so digits don't leak
+// into the next command), the cursor must move by the requested count, and
+// the count must clamp to the available range rather than walking off the
+// end.
+
+func TestYAMLNormalCountPrefixJumpsDown(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeYAML,
+		yamlContent:   "a: 1\nb: 2\nc: 3\nd: 4\ne: 5\nf: 6",
+		yamlCollapsed: map[string]bool{},
+		yamlCursor:    0,
+		yamlLineInput: "3",
+		tabs:          []TabState{{}},
+	}
+	ret, _ := m.handleYAMLKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 3, rm.yamlCursor)
+	assert.Empty(t, rm.yamlLineInput, "digit buffer must be consumed by the motion")
+}
+
+func TestYAMLNormalCountPrefixJumpsUp(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeYAML,
+		yamlContent:   "a: 1\nb: 2\nc: 3\nd: 4\ne: 5\nf: 6",
+		yamlCollapsed: map[string]bool{},
+		yamlCursor:    5,
+		yamlLineInput: "3",
+		tabs:          []TabState{{}},
+	}
+	ret, _ := m.handleYAMLKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 2, rm.yamlCursor)
+	assert.Empty(t, rm.yamlLineInput)
+}
+
+func TestYAMLNormalCountClampsAtBottom(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeYAML,
+		yamlContent:   "a: 1\nb: 2\nc: 3",
+		yamlCollapsed: map[string]bool{},
+		yamlCursor:    1,
+		yamlLineInput: "100",
+		tabs:          []TabState{{}},
+	}
+	ret, _ := m.handleYAMLKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 2, rm.yamlCursor, "count must clamp to last visible line")
+}
+
+func TestYAMLNormalCountClampsAtTop(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeYAML,
+		yamlContent:   "a: 1\nb: 2\nc: 3",
+		yamlCollapsed: map[string]bool{},
+		yamlCursor:    1,
+		yamlLineInput: "100",
+		tabs:          []TabState{{}},
+	}
+	ret, _ := m.handleYAMLKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 0, rm.yamlCursor)
+}
+
+func TestDescribeNormalCountPrefixJumpsDown(t *testing.T) {
+	m := baseModelDescribe()
+	m.describeCursor = 0
+	m.describeLineInput = "4"
+	ret, _ := m.handleDescribeKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 4, rm.describeCursor)
+	assert.Empty(t, rm.describeLineInput)
+}
+
+func TestDescribeNormalCountPrefixJumpsUp(t *testing.T) {
+	m := baseModelDescribe()
+	m.describeCursor = 8
+	m.describeLineInput = "5"
+	ret, _ := m.handleDescribeKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 3, rm.describeCursor)
+	assert.Empty(t, rm.describeLineInput)
+}
+
+func TestDescribeNormalCountClampsAtBottom(t *testing.T) {
+	m := baseModelDescribe()
+	m.describeCursor = 8
+	m.describeLineInput = "100"
+	ret, _ := m.handleDescribeKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 9, rm.describeCursor, "10-line fixture clamps to index 9")
+}
+
+func TestDiffNormalCountPrefixJumpsDown(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeDiff,
+		diffLeft: "a\nb\nc\nd\ne\nf", diffRight: "a\nb\nc\nd\ne\nf",
+		diffLeftName: "before", diffRightName: "after",
+		diffCursor:    0,
+		diffLineInput: "3",
+		tabs:          []TabState{{}},
+	}
+	ret, _ := m.handleDiffKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 3, rm.diffCursor)
+	assert.Empty(t, rm.diffLineInput)
+}
+
+func TestDiffNormalCountPrefixJumpsUp(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeDiff,
+		diffLeft: "a\nb\nc\nd\ne\nf", diffRight: "a\nb\nc\nd\ne\nf",
+		diffLeftName: "before", diffRightName: "after",
+		diffCursor:    5,
+		diffLineInput: "4",
+		tabs:          []TabState{{}},
+	}
+	ret, _ := m.handleDiffKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 1, rm.diffCursor)
+	assert.Empty(t, rm.diffLineInput)
+}
+
+func TestDiffNormalCountClampsAtTop(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeDiff,
+		diffLeft: "a\nb\nc", diffRight: "a\nb\nc",
+		diffLeftName: "before", diffRightName: "after",
+		diffCursor:    1,
+		diffLineInput: "100",
+		tabs:          []TabState{{}},
+	}
+	ret, _ := m.handleDiffKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 0, rm.diffCursor)
+}
+
+func TestLogsNormalCountPrefixJumpsDown(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeLogs,
+		logLines:     []string{"a", "b", "c", "d", "e", "f"},
+		logCursor:    0,
+		logLineInput: "3",
+		tabs:         []TabState{{}},
+	}
+	ret, _ := m.handleLogKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 3, rm.logCursor)
+	assert.Empty(t, rm.logLineInput)
+	assert.False(t, rm.logFollow, "any j press disables follow mode")
+}
+
+func TestLogsNormalCountPrefixJumpsUp(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeLogs,
+		logLines:     []string{"a", "b", "c", "d", "e", "f"},
+		logCursor:    5,
+		logLineInput: "4",
+		tabs:         []TabState{{}},
+	}
+	ret, _ := m.handleLogKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 1, rm.logCursor)
+	assert.Empty(t, rm.logLineInput)
+}
+
+func TestLogsNormalCountClampsAtTop(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeLogs,
+		logLines:     []string{"a", "b", "c"},
+		logCursor:    1,
+		logLineInput: "100",
+		tabs:         []TabState{{}},
+	}
+	ret, _ := m.handleLogKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 0, rm.logCursor)
+}
+
+func TestLogsNormalCountClampsAtBottom(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeLogs,
+		logLines:     []string{"a", "b", "c"},
+		logCursor:    1,
+		logLineInput: "100",
+		tabs:         []TabState{{}},
+	}
+	ret, _ := m.handleLogKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 2, rm.logCursor)
+}
+
+// Empty log buffer must not let the cursor go negative when a count motion
+// fires before any lines arrive — the `max(len-1, 0)` guard in handleLogKeyJ
+// keeps cursor pinned at 0.
+func TestLogsNormalCountOnEmptyBufferStaysAtZero(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeLogs,
+		logLines:     nil,
+		logCursor:    0,
+		logLineInput: "5",
+		tabs:         []TabState{{}},
+	}
+	ret, _ := m.handleLogKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 0, rm.logCursor)
+	assert.Empty(t, rm.logLineInput)
+}
+
+func TestEventTimelineCountPrefixJumpsDown(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeEventViewer,
+		eventTimelineLines:     []string{"e0", "e1", "e2", "e3", "e4"},
+		eventTimelineCursor:    0,
+		eventTimelineLineInput: "3",
+		tabs:                   []TabState{{}},
+	}
+	ret, _ := m.handleEventTimelineOverlayKey(keyMsg("j"))
+	rm := ret.(Model)
+	assert.Equal(t, 3, rm.eventTimelineCursor)
+	assert.Empty(t, rm.eventTimelineLineInput)
+}
+
+func TestEventTimelineCountPrefixJumpsUp(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeEventViewer,
+		eventTimelineLines:     []string{"e0", "e1", "e2", "e3", "e4"},
+		eventTimelineCursor:    4,
+		eventTimelineLineInput: "3",
+		tabs:                   []TabState{{}},
+	}
+	ret, _ := m.handleEventTimelineOverlayKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 1, rm.eventTimelineCursor)
+	assert.Empty(t, rm.eventTimelineLineInput)
+}
+
+func TestEventTimelineCountClampsAtTop(t *testing.T) {
+	m := Model{
+		width: 80, height: 30, mode: modeEventViewer,
+		eventTimelineLines:     []string{"e0", "e1", "e2"},
+		eventTimelineCursor:    1,
+		eventTimelineLineInput: "100",
+		tabs:                   []TabState{{}},
+	}
+	ret, _ := m.handleEventTimelineOverlayKey(keyMsg("k"))
+	rm := ret.(Model)
+	assert.Equal(t, 0, rm.eventTimelineCursor)
+}
+
+// Plain `j` / `k` (no digits) must keep their single-step behaviour so users
+// who never type counts notice no change.
+func TestPlainJKStillMovesByOne(t *testing.T) {
+	m := baseModelDescribe()
+	m.describeCursor = 4
+	ret, _ := m.handleDescribeKey(keyMsg("j"))
+	assert.Equal(t, 5, ret.(Model).describeCursor)
+
+	m = baseModelDescribe()
+	m.describeCursor = 4
+	ret, _ = m.handleDescribeKey(keyMsg("k"))
+	assert.Equal(t, 3, ret.(Model).describeCursor)
+}

--- a/internal/app/count_motion_test.go
+++ b/internal/app/count_motion_test.go
@@ -148,6 +148,7 @@ func TestLogsNormalCountPrefixJumpsDown(t *testing.T) {
 		width: 80, height: 30, mode: modeLogs,
 		logLines:     []string{"a", "b", "c", "d", "e", "f"},
 		logCursor:    0,
+		logFollow:    true,
 		logLineInput: "3",
 		tabs:         []TabState{{}},
 	}

--- a/internal/app/count_prefix.go
+++ b/internal/app/count_prefix.go
@@ -2,10 +2,19 @@ package app
 
 import "strconv"
 
+// maxCountPrefix caps the parsed count to keep `cursor + n` arithmetic in the
+// call sites from overflowing on a pathologically large prefix. One million
+// lines is comfortably larger than any real viewer fixture (log buffers cap
+// well below this) so the cap is invisible to actual users; what it prevents
+// is a 19-digit count silently wrapping into a negative cursor and panicking
+// on slice indexing downstream.
+const maxCountPrefix = 1_000_000
+
 // parseCountPrefix parses the digit-prefix buffer that powers count-prefixed
 // commands (e.g. `123y`, `123G`, `123j`, `123k`) and returns the count to
 // apply. An empty or invalid buffer falls back to 1 so plain `j`/`k`/`y` keep
-// their single-step behaviour.
+// their single-step behaviour. Counts above maxCountPrefix saturate at the
+// cap.
 func parseCountPrefix(buf string) int {
 	if buf == "" {
 		return 1
@@ -14,7 +23,7 @@ func parseCountPrefix(buf string) int {
 	if err != nil || n < 1 {
 		return 1
 	}
-	return n
+	return min(n, maxCountPrefix)
 }
 
 // consumeCountPrefix parses the digit-prefix buffer and clears it in one step.

--- a/internal/app/count_prefix.go
+++ b/internal/app/count_prefix.go
@@ -1,0 +1,28 @@
+package app
+
+import "strconv"
+
+// parseCountPrefix parses the digit-prefix buffer that powers count-prefixed
+// commands (e.g. `123y`, `123G`, `123j`, `123k`) and returns the count to
+// apply. An empty or invalid buffer falls back to 1 so plain `j`/`k`/`y` keep
+// their single-step behaviour.
+func parseCountPrefix(buf string) int {
+	if buf == "" {
+		return 1
+	}
+	n, err := strconv.Atoi(buf)
+	if err != nil || n < 1 {
+		return 1
+	}
+	return n
+}
+
+// consumeCountPrefix parses the digit-prefix buffer and clears it in one step.
+// Every count-prefixed handler must consume the buffer (so the digits don't
+// leak into the next command), so doing parse + clear together keeps the call
+// sites symmetric and prevents anyone forgetting the second half.
+func consumeCountPrefix(buf *string) int {
+	n := parseCountPrefix(*buf)
+	*buf = ""
+	return n
+}

--- a/internal/app/count_prefix_test.go
+++ b/internal/app/count_prefix_test.go
@@ -18,6 +18,8 @@ func TestParseCountPrefix(t *testing.T) {
 		{"non-numeric falls back to 1", "abc", 1},
 		{"zero falls back to 1", "0", 1},
 		{"negative-looking string falls back to 1", "-3", 1},
+		{"value at cap is preserved", "1000000", maxCountPrefix},
+		{"value above cap saturates", "9999999999", maxCountPrefix},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/app/count_prefix_test.go
+++ b/internal/app/count_prefix_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCountPrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  string
+		want int
+	}{
+		{"empty buffer falls back to 1", "", 1},
+		{"single digit", "5", 5},
+		{"multi digit", "42", 42},
+		{"non-numeric falls back to 1", "abc", 1},
+		{"zero falls back to 1", "0", 1},
+		{"negative-looking string falls back to 1", "-3", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseCountPrefix(tc.buf))
+		})
+	}
+}
+
+// consumeCountPrefix must both parse the buffer and clear it in one step —
+// every caller relies on the buffer being empty after the command so the
+// digits don't leak into the next one.
+func TestConsumeCountPrefix(t *testing.T) {
+	cases := []struct {
+		name      string
+		buf       string
+		wantCount int
+	}{
+		{"empty buffer falls back to 1", "", 1},
+		{"valid count is parsed", "5", 5},
+		{"multi digit", "42", 42},
+		{"non-numeric falls back to 1", "abc", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := tc.buf
+			n := consumeCountPrefix(&buf)
+			assert.Equal(t, tc.wantCount, n)
+			assert.Empty(t, buf, "buffer must be cleared after consume")
+		})
+	}
+}

--- a/internal/app/update_describe.go
+++ b/internal/app/update_describe.go
@@ -48,17 +48,13 @@ func (m Model) handleDescribeNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		return m.handleDescribeQuit()
 	case "j", "down":
-		m.describeLineInput = ""
-		if m.describeCursor < maxIdx {
-			m.describeCursor++
-		}
+		n := consumeCountPrefix(&m.describeLineInput)
+		m.describeCursor = min(m.describeCursor+n, maxIdx)
 		m.ensureDescribeCursorVisible()
 		return m, nil
 	case "k", "up":
-		m.describeLineInput = ""
-		if m.describeCursor > 0 {
-			m.describeCursor--
-		}
+		n := consumeCountPrefix(&m.describeLineInput)
+		m.describeCursor = max(m.describeCursor-n, 0)
 		m.ensureDescribeCursorVisible()
 		return m, nil
 	case "h", "left":
@@ -121,7 +117,7 @@ func (m Model) handleDescribeNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+v":
 		return m.describeEnterVisual('B')
 	case "y":
-		n := consumeYankCount(&m.describeLineInput)
+		n := consumeCountPrefix(&m.describeLineInput)
 		if m.describeCursor < 0 || m.describeCursor >= len(lines) {
 			return m, nil
 		}
@@ -642,17 +638,13 @@ func (m Model) handleDiffNormalKey(msg tea.KeyMsg, foldRegions []ui.DiffFoldRegi
 	case "q", "esc":
 		return m.handleDiffQuit()
 	case "j", "down":
-		m.diffLineInput = ""
-		if m.diffCursor < maxCursor {
-			m.diffCursor++
-		}
+		n := consumeCountPrefix(&m.diffLineInput)
+		m.diffCursor = min(m.diffCursor+n, maxCursor)
 		m.ensureDiffCursorVisible(visibleLines, maxScroll)
 		return m, nil
 	case "k", "up":
-		m.diffLineInput = ""
-		if m.diffCursor > 0 {
-			m.diffCursor--
-		}
+		n := consumeCountPrefix(&m.diffLineInput)
+		m.diffCursor = max(m.diffCursor-n, 0)
 		m.ensureDiffCursorVisible(visibleLines, maxScroll)
 		return m, nil
 	case "h", "left":
@@ -973,7 +965,7 @@ func (m Model) diffVisualToggle(mode rune) (tea.Model, tea.Cmd) {
 // many lines; an empty buffer falls back to a single line. Empty-side lines
 // are skipped so a count that straddles them still copies real content.
 func (m Model) handleDiffNormalCopy(foldRegions []ui.DiffFoldRegion, totalLines int) (tea.Model, tea.Cmd) {
-	n := consumeYankCount(&m.diffLineInput)
+	n := consumeCountPrefix(&m.diffLineInput)
 	end := min(m.diffCursor+n, totalLines)
 	parts := make([]string, 0, end-m.diffCursor)
 	for i := m.diffCursor; i < end; i++ {

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -482,20 +482,16 @@ func (m Model) handleLogKeyQ() Model {
 
 func (m Model) handleLogKeyJ() Model {
 	m.logFollow = false
-	m.logLineInput = ""
-	if m.logCursor < len(m.logLines)-1 {
-		m.logCursor++
-	}
+	n := consumeCountPrefix(&m.logLineInput)
+	m.logCursor = min(m.logCursor+n, max(len(m.logLines)-1, 0))
 	m.ensureLogCursorVisible()
 	return m
 }
 
 func (m Model) handleLogKeyK() (tea.Model, tea.Cmd) {
 	m.logFollow = false
-	m.logLineInput = ""
-	if m.logCursor > 0 {
-		m.logCursor--
-	}
+	n := consumeCountPrefix(&m.logLineInput)
+	m.logCursor = max(m.logCursor-n, 0)
 	m.ensureLogCursorVisible()
 	cmd := m.maybeLoadMoreHistory()
 	return m, cmd
@@ -1011,7 +1007,7 @@ func (m Model) handleLogVisualKeyY() (tea.Model, tea.Cmd) {
 // clipboard. A digit prefix (e.g. `123y`) yanks that many lines; an empty
 // buffer falls back to a single line.
 func (m Model) handleLogNormalCopy() (tea.Model, tea.Cmd) {
-	n := consumeYankCount(&m.logLineInput)
+	n := consumeCountPrefix(&m.logLineInput)
 	if m.logCursor < 0 || m.logCursor >= len(m.logLines) {
 		return m, nil
 	}

--- a/internal/app/update_overlays_events.go
+++ b/internal/app/update_overlays_events.go
@@ -194,10 +194,8 @@ func (m Model) handleEventTimelineMovementKey(msg tea.KeyMsg) (Model, bool) {
 	maxIdx := max(len(m.eventTimelineLines)-1, 0)
 	switch key {
 	case "j", "down":
-		m.eventTimelineLineInput = ""
-		if m.eventTimelineCursor < maxIdx {
-			m.eventTimelineCursor++
-		}
+		n := consumeCountPrefix(&m.eventTimelineLineInput)
+		m.eventTimelineCursor = min(m.eventTimelineCursor+n, maxIdx)
 		m.ensureEventCursorVisible()
 		return m, true
 	case "k", "up":
@@ -535,10 +533,8 @@ func (m Model) handleEventTimelineOverlayKeyQ() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleEventTimelineOverlayKeyK() Model {
-	m.eventTimelineLineInput = ""
-	if m.eventTimelineCursor > 0 {
-		m.eventTimelineCursor--
-	}
+	n := consumeCountPrefix(&m.eventTimelineLineInput)
+	m.eventTimelineCursor = max(m.eventTimelineCursor-n, 0)
 	m.ensureEventCursorVisible()
 	return m
 }
@@ -690,7 +686,7 @@ func (m Model) handleEventTimelineOverlayKeyCtrlV() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleEventTimelineOverlayKeyY() (tea.Model, tea.Cmd) {
-	n := consumeYankCount(&m.eventTimelineLineInput)
+	n := consumeCountPrefix(&m.eventTimelineLineInput)
 	if m.eventTimelineCursor < 0 || m.eventTimelineCursor >= len(m.eventTimelineLines) {
 		return m, nil
 	}

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -214,7 +214,7 @@ func (m Model) handleYAMLVisualG(totalVisible, maxScroll int) (tea.Model, tea.Cm
 // not in scope — a count that reaches a folded section jumps over its hidden
 // children and continues with the lines that follow.
 func (m Model) handleYAMLNormalCopy() (tea.Model, tea.Cmd) {
-	n := consumeYankCount(&m.yamlLineInput)
+	n := consumeCountPrefix(&m.yamlLineInput)
 	_, mapping := buildVisibleLines(m.yamlContent, m.yamlSections, m.yamlCollapsed)
 	if m.yamlCursor < 0 || m.yamlCursor >= len(mapping) {
 		return m, nil
@@ -457,10 +457,8 @@ func (m Model) handleYAMLNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "$", "w", "b", "e", "E", "B", "W", "^":
 		return m.handleYAMLVisualWordMotion(msg.String())
 	case "j", "down":
-		m.yamlLineInput = ""
-		if m.yamlCursor < totalVisible-1 {
-			m.yamlCursor++
-		}
+		n := consumeCountPrefix(&m.yamlLineInput)
+		m.yamlCursor = min(m.yamlCursor+n, max(totalVisible-1, 0))
 		m.ensureYAMLCursorVisible()
 		return m, nil
 	case "k", "up":
@@ -883,10 +881,8 @@ func (m Model) handleYAMLKeyZero() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleYAMLKeyK() (tea.Model, tea.Cmd) {
-	m.yamlLineInput = ""
-	if m.yamlCursor > 0 {
-		m.yamlCursor--
-	}
+	n := consumeCountPrefix(&m.yamlLineInput)
+	m.yamlCursor = max(m.yamlCursor-n, 0)
 	m.ensureYAMLCursorVisible()
 	return m, nil
 }

--- a/internal/app/yank.go
+++ b/internal/app/yank.go
@@ -1,33 +1,6 @@
 package app
 
-import (
-	"fmt"
-	"strconv"
-)
-
-// parseYankCount parses the digit-prefix buffer that powers count-prefixed
-// motions (e.g. `123y`, `123G`) and returns the count to apply. An empty or
-// invalid buffer falls back to 1 so plain `y` keeps yanking a single line.
-func parseYankCount(buf string) int {
-	if buf == "" {
-		return 1
-	}
-	n, err := strconv.Atoi(buf)
-	if err != nil || n < 1 {
-		return 1
-	}
-	return n
-}
-
-// consumeYankCount parses the digit-prefix buffer and clears it in one step.
-// Every count-prefixed yank handler must consume the buffer (so the digits
-// don't leak into the next command), so doing parse + clear together keeps
-// the call sites symmetric and prevents anyone forgetting the second half.
-func consumeYankCount(buf *string) int {
-	n := parseYankCount(*buf)
-	*buf = ""
-	return n
-}
+import "fmt"
 
 // formatCopiedLines returns the status message for an N-line yank.
 // Singular for n=1, plural otherwise — preserves the existing

--- a/internal/app/yank_test.go
+++ b/internal/app/yank_test.go
@@ -6,52 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseYankCount(t *testing.T) {
-	cases := []struct {
-		name string
-		buf  string
-		want int
-	}{
-		{"empty buffer falls back to 1", "", 1},
-		{"single digit", "5", 5},
-		{"multi digit", "42", 42},
-		{"non-numeric falls back to 1", "abc", 1},
-		{"zero falls back to 1", "0", 1},
-		{"negative-looking string falls back to 1", "-3", 1},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, parseYankCount(tc.buf))
-		})
-	}
-}
-
 func TestFormatCopiedLines(t *testing.T) {
 	assert.Equal(t, "Copied 1 line", formatCopiedLines(1))
 	assert.Equal(t, "Copied 2 lines", formatCopiedLines(2))
 	assert.Equal(t, "Copied 100 lines", formatCopiedLines(100))
-}
-
-// consumeYankCount must both parse the buffer and clear it in one step —
-// every caller relies on the buffer being empty after the yank so the
-// digits don't leak into the next command.
-func TestConsumeYankCount(t *testing.T) {
-	cases := []struct {
-		name      string
-		buf       string
-		wantCount int
-	}{
-		{"empty buffer falls back to 1", "", 1},
-		{"valid count is parsed", "5", 5},
-		{"multi digit", "42", 42},
-		{"non-numeric falls back to 1", "abc", 1},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			buf := tc.buf
-			n := consumeYankCount(&buf)
-			assert.Equal(t, tc.wantCount, n)
-			assert.Empty(t, buf, "buffer must be cleared after consume")
-		})
-	}
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -188,6 +188,7 @@ func helpSections() []helpSection {
 			title: "YAML View", context: "YAML View",
 			bindings: []helpEntry{
 				{"j/k", "Scroll up/down"},
+				{"123j/123k", "Move cursor down/up N visible lines (count-prefixed; folds skipped)"},
 				{"h/l", "Move cursor column left/right"},
 				{"0/$", "Move cursor to line start/end"},
 				{"^", "Move cursor to first non-whitespace"},
@@ -219,6 +220,7 @@ func helpSections() []helpSection {
 			title: "Describe View", context: "Describe View",
 			bindings: []helpEntry{
 				{"j/k", "Move cursor up/down"},
+				{"123j/123k", "Move cursor down/up N lines (count-prefixed)"},
 				{"h/l", "Move cursor column left/right"},
 				{"0/$", "Move cursor to line start/end"},
 				{"^", "Move cursor to first non-whitespace"},
@@ -245,6 +247,7 @@ func helpSections() []helpSection {
 			title: "Diff View", context: "Diff View",
 			bindings: []helpEntry{
 				{"j/k", "Move cursor up/down"},
+				{"123j/123k", "Move cursor down/up N lines (count-prefixed)"},
 				{"h/l", "Move cursor column left/right"},
 				{"0/$", "Move cursor to line start/end"},
 				{"^", "Move cursor to first non-whitespace"},
@@ -331,6 +334,7 @@ func helpSections() []helpSection {
 			title: "Log Viewer", context: "Log Viewer",
 			bindings: []helpEntry{
 				{"j/k", "Move cursor up/down"},
+				{"123j/123k", "Move cursor down/up N lines (count-prefixed)"},
 				{"h/l/left/right", "Move cursor column left/right"},
 				{"0/$", "Move cursor to line start/end"},
 				{"^", "Move cursor to first non-whitespace"},


### PR DESCRIPTION
## Summary

The digit accumulator that already powers `Ny` and `123G` jump-to-line now also feeds the `j`/`k` cursor handlers in the YAML, describe, diff, log, and event-timeline viewers — `5j` jumps down five lines, `12k` jumps up twelve, plain `j`/`k` is unchanged.

## Type of change

- [x] feat: new user-facing feature

## Related issue

N/A

## Changes

- `Nj` / `Nk` count-prefixed motion in YAML, describe, diff, log, and event-timeline viewers; counts clamp at top/bottom and the digit buffer is consumed by the motion (no leak into the next command).
- Split `parseCountPrefix` / `consumeCountPrefix` out of `yank.go` into a new `count_prefix.go` since they're now shared with motions; `formatCopiedLines` stays in `yank.go`. Renamed from `parseYankCount` / `consumeYankCount` and updated all callers.
- Tests: clamp at top + bottom in each viewer, empty-buffer guard for log viewer, plain-`j`/`k` regression guard.
- Docs: `123j` / `123k` row added to YAML / Describe / Diff / Log sections in `docs/keybindings.md` and `internal/ui/help.go`.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (pre-commit hook)
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Count-prefixed vertical navigation in YAML, Describe, Diff, Log, and Event Timeline views (e.g., `123j` / `123k`) to move by N lines with clamping.
  * Count-prefixed yank/copy now uses the same numeric-prefix semantics for consistent multi-line copies.

* **Documentation**
  * Keybindings docs and help overlay updated to show the new count-prefixed cursor motion entries.

* **Tests**
  * Added coverage validating count-prefix navigation, yanks, clamping, empty-buffer behavior, and plain single-step motions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->