### PR TITLE
feat(logs): persistent search history with Up/Down recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ All search and filter inputs support three modes, auto-detected from the query s
 
 **Clipboard paste**: All search, filter, and command bar inputs accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). Multiline paste shows a confirmation dialog.
 
-**Recall previous queries**: While the `f` filter or `/` search input is open, press `Up` / `Down` to cycle through previous queries. `/` and `f` share one history (the matcher and matched fields are identical between them), kept separate from the `:` command bar. Both persist across sessions under `$XDG_STATE_HOME/lfk/` (default `~/.local/state/lfk/`) — `query-history` for `/` and `f`, `history` for the command bar.
+**Recall previous queries**: While the `f` filter or `/` search input is open, press `Up` / `Down` to cycle through previous queries. `/` and `f` share one history (the matcher and matched fields are identical between them), kept separate from the `:` command bar. The log viewer's `/` search has its own history because it matches raw log lines (substring/regex over arbitrary text) rather than resource names — pooling it would surface irrelevant entries. All three persist across sessions under `$XDG_STATE_HOME/lfk/` (default `~/.local/state/lfk/`) — `query-history` for explorer `/` and `f`, `log-search-history` for the log viewer's `/`, and `history` for the command bar.
 
 ## Contributing
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -249,6 +249,7 @@ my namespace" mode.
 | `J` / `K` | Scroll the preview side panel down / up (one row, no-op when panel is hidden) |
 | `c` | Toggle previous container logs |
 | `/` | Search in logs |
+| `Up` / `Down` | Inside `/`: cycle through previous log search queries (persistent history). |
 | `n` / `N` | Next / previous search match |
 | `123G` | Jump to specific line number |
 | `S` | Save loaded logs to file (path copied to clipboard) |
@@ -261,6 +262,8 @@ my namespace" mode.
 | `123y` | Copy number of lines from cursor (count-prefixed yank) |
 | `\` | Switch pod / filter containers (space: select, enter: apply, / to filter) |
 | `q` / `Esc` | Close log viewer |
+
+The log viewer's `/` keeps its own persistent history at `$XDG_STATE_HOME/lfk/log-search-history` (default `~/.local/state/lfk/log-search-history`), separate from the explorer's `query-history`. Log search matches raw log lines (substring/regex over arbitrary text) rather than resource names, so pooling the two would surface irrelevant entries on Up/Down in either context.
 
 > **Tail-first loading**: Full Logs (`L` key or action menu `L`) load the last 1000 lines initially (configurable via `log_tail_lines`). Tail Logs (action menu `l`) load only the last 10 lines (configurable via `log_tail_lines_short`) — useful for a quick peek without the full history hit. Scrolling to the top automatically loads older log history in both modes.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -507,9 +507,10 @@ type Model struct {
 	logLineInput string
 
 	// Log viewer: search state.
-	logSearchActive bool
-	logSearchInput  TextInput
-	logSearchQuery  string // applied search
+	logSearchActive  bool
+	logSearchInput   TextInput
+	logSearchQuery   string // applied search
+	logSearchHistory *commandHistory
 
 	// Describe viewer state.
 	describeContent      string
@@ -1029,6 +1030,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		pendingPortForwards:        loadPortForwardState(),
 		commandHistory:             loadCommandHistory(),
 		queryHistory:               loadInputHistory(historyFileQuery),
+		logSearchHistory:           loadInputHistory(historyFileLogSearch),
 		pinnedState:                pinnedSt,
 		namespace:                  defaultNS,
 		spinner:                    s,

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -27,8 +27,8 @@ const (
 )
 
 // commandHistory manages a persistent ring of recent text-input entries.
-// Used by the command bar and (per filename) the explorer search and
-// filter inputs.
+// Used by the command bar, the explorer search and filter inputs, and
+// the log viewer's `/` search (per filename).
 type commandHistory struct {
 	entries  []string
 	cursor   int    // -1 means "not browsing history" (typing new command)

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -15,10 +15,15 @@ const maxHistoryEntries = 500
 // fields are identical between the two, only the action on a match differs
 // (jump vs. narrow), so users want to recall the same query regardless of
 // which mode they re-enter. The `:` command bar stays separate because its
-// inputs are kubectl-shaped commands, not resource-name queries.
+// inputs are kubectl-shaped commands, not resource-name queries. The log
+// viewer's `/` search is also kept separate: it matches against raw log
+// lines (substring/regex over arbitrary text), not resource names, so
+// pooling it with the explorer query history would surface irrelevant
+// entries on Up/Down in either context.
 const (
-	historyFileCommand = "history"
-	historyFileQuery   = "query-history"
+	historyFileCommand   = "history"
+	historyFileQuery     = "query-history"
+	historyFileLogSearch = "log-search-history"
 )
 
 // commandHistory manages a persistent ring of recent text-input entries.

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -122,12 +122,16 @@ func (h *commandHistory) save() {
 	if path == "" {
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// 0700/0600: history files persist raw search/filter/log-search
+	// queries that may contain sensitive fragments (tokens, emails),
+	// so restrict them to the owning user — same convention as
+	// ~/.bash_history etc.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		logger.Warn("Failed to create history directory", "error", err, "path", path)
 		return
 	}
 	content := strings.Join(h.entries, "\n") + "\n"
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		logger.Warn("Failed to write history file", "error", err, "path", path)
 	}
 }

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -178,3 +178,16 @@ func (h *commandHistory) reset() {
 	h.cursor = -1
 	h.draft = ""
 }
+
+// leaveBrowse exits history browsing while preserving the pre-recall
+// draft. Use this when the user edits a recalled entry (typing,
+// backspace, ctrl+w, ctrl+u): the edited text becomes the new content,
+// but a subsequent Down past the newest entry should restore the
+// original draft the user had before pressing Up — not "" (which is
+// what reset() would leave behind). Nil receiver no-op.
+func (h *commandHistory) leaveBrowse() {
+	if h == nil {
+		return
+	}
+	h.cursor = -1
+}

--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -125,6 +125,27 @@ func TestCommandHistoryReset(t *testing.T) {
 	assert.Empty(t, h.draft)
 }
 
+// --- commandHistory.leaveBrowse ---
+
+// leaveBrowse exits browse mode but preserves draft so a subsequent
+// Down past newest restores the user's original pre-recall input.
+func TestCommandHistoryLeaveBrowse(t *testing.T) {
+	h := &commandHistory{
+		entries: []string{"a", "b"},
+		cursor:  1,
+		draft:   "pre-recall",
+	}
+
+	h.leaveBrowse()
+	assert.Equal(t, -1, h.cursor)
+	assert.Equal(t, "pre-recall", h.draft, "draft must be preserved")
+}
+
+func TestCommandHistoryLeaveBrowseNilReceiver(t *testing.T) {
+	var h *commandHistory
+	assert.NotPanics(t, func() { h.leaveBrowse() })
+}
+
 // --- commandHistory.save / loadCommandHistory ---
 
 func TestCommandHistorySaveAndLoad(t *testing.T) {

--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -280,6 +280,30 @@ func TestLoadInputHistoryIsolatesQueryFromCommand(t *testing.T) {
 	assert.Equal(t, []string{":get pods"}, gotCmd.entries)
 }
 
+// TestLoadInputHistoryIsolatesLogSearchFromQuery pins the second
+// separation that matters: the log viewer's `/` matches raw log lines
+// (substring/regex over arbitrary text), not resource names. Pooling
+// it with the explorer query history would surface kubernetes resource
+// patterns when recalling in the log viewer, and log fragments when
+// recalling in the explorer — both irrelevant to the user.
+func TestLoadInputHistoryIsolatesLogSearchFromQuery(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	qh := loadInputHistory(historyFileQuery)
+	qh.add("nginx")
+	qh.save()
+
+	lh := loadInputHistory(historyFileLogSearch)
+	lh.add("ERROR connection refused")
+	lh.save()
+
+	gotQuery := loadInputHistory(historyFileQuery)
+	gotLog := loadInputHistory(historyFileLogSearch)
+
+	assert.Equal(t, []string{"nginx"}, gotQuery.entries)
+	assert.Equal(t, []string{"ERROR connection refused"}, gotLog.entries)
+}
+
 // TestSavePreservesFilenameAcrossSaves verifies a loaded instance keeps
 // writing back to the same file, rather than silently defaulting to
 // "history" after the first save.

--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -170,6 +170,27 @@ func TestCommandHistorySaveAndLoad(t *testing.T) {
 	assert.Equal(t, -1, loaded.cursor)
 }
 
+// History files persist raw search queries that may contain sensitive
+// fragments (tokens, emails). On shared hosts, default 0644/0755 modes
+// would leak these to other local users. Save() must use 0600 for the
+// file and 0700 for the parent directory.
+func TestCommandHistorySaveUsesRestrictivePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
+	h := &commandHistory{cursor: -1}
+	h.add("secret query")
+	h.save()
+
+	dirInfo, err := os.Stat(filepath.Join(tmpDir, "lfk"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm(), "lfk dir must be user-only")
+
+	fileInfo, err := os.Stat(filepath.Join(tmpDir, "lfk", "history"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm(), "history file must be user-only")
+}
+
 func TestLoadCommandHistoryNoFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmpDir)

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -271,16 +271,16 @@ func (m Model) handleLogSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(m.logSearchInput.Value) > 0 {
 			m.logSearchInput.Backspace()
 			m.logSearchQuery = m.logSearchInput.Value
-			// Editing a recalled entry leaves history navigation: the
-			// edited text becomes the new draft, so a later Down past
-			// newest restores the edits, not the original pre-recall
-			// draft.
-			m.logSearchHistory.reset()
+			// Editing a recalled entry leaves history navigation but
+			// keeps the pre-recall draft intact, so a later Down past
+			// newest restores the original draft the user had before
+			// pressing Up — not the recalled-then-edited text.
+			m.logSearchHistory.leaveBrowse()
 		}
 	case "ctrl+w":
 		m.logSearchInput.DeleteWord()
 		m.logSearchQuery = m.logSearchInput.Value
-		m.logSearchHistory.reset()
+		m.logSearchHistory.leaveBrowse()
 	case "ctrl+a":
 		m.logSearchInput.Home()
 	case "ctrl+e":
@@ -300,7 +300,7 @@ func (m Model) handleLogSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// findNextLogMatch; before that the user only saw the input
 			// echo with no feedback on whether the query matches anything.
 			m.logSearchQuery = m.logSearchInput.Value
-			m.logSearchHistory.reset()
+			m.logSearchHistory.leaveBrowse()
 		}
 	}
 	return m, nil

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -254,19 +254,32 @@ func (m Model) handleLogSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		m.logSearchActive = false
 		m.logSearchQuery = m.logSearchInput.Value
+		m.logSearchHistory.add(m.logSearchInput.Value)
+		m.logSearchHistory.save()
 		m.findNextLogMatch(true)
 	case "esc":
 		m.logSearchActive = false
 		m.logSearchInput.Clear()
 		m.logSearchQuery = ""
+	case "up":
+		m.logSearchInput.Set(m.logSearchHistory.up(m.logSearchInput.Value))
+		m.logSearchQuery = m.logSearchInput.Value
+	case "down":
+		m.logSearchInput.Set(m.logSearchHistory.down())
+		m.logSearchQuery = m.logSearchInput.Value
 	case "backspace":
 		if len(m.logSearchInput.Value) > 0 {
 			m.logSearchInput.Backspace()
 		}
 		m.logSearchQuery = m.logSearchInput.Value
+		// Editing a recalled entry leaves history navigation: the edited
+		// text becomes the new draft, so a later Down past newest restores
+		// the edits, not the original pre-recall draft.
+		m.logSearchHistory.reset()
 	case "ctrl+w":
 		m.logSearchInput.DeleteWord()
 		m.logSearchQuery = m.logSearchInput.Value
+		m.logSearchHistory.reset()
 	case "ctrl+a":
 		m.logSearchInput.Home()
 	case "ctrl+e":
@@ -286,6 +299,7 @@ func (m Model) handleLogSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// findNextLogMatch; before that the user only saw the input
 			// echo with no feedback on whether the query matches anything.
 			m.logSearchQuery = m.logSearchInput.Value
+			m.logSearchHistory.reset()
 		}
 	}
 	return m, nil
@@ -786,6 +800,7 @@ func (m Model) handleLogKeySlash() Model {
 	m.logLineInput = ""
 	m.logSearchActive = true
 	m.logSearchInput.Clear()
+	m.logSearchHistory.reset()
 	return m
 }
 

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -270,12 +270,13 @@ func (m Model) handleLogSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "backspace":
 		if len(m.logSearchInput.Value) > 0 {
 			m.logSearchInput.Backspace()
+			m.logSearchQuery = m.logSearchInput.Value
+			// Editing a recalled entry leaves history navigation: the
+			// edited text becomes the new draft, so a later Down past
+			// newest restores the edits, not the original pre-recall
+			// draft.
+			m.logSearchHistory.reset()
 		}
-		m.logSearchQuery = m.logSearchInput.Value
-		// Editing a recalled entry leaves history navigation: the edited
-		// text becomes the new draft, so a later Down past newest restores
-		// the edits, not the original pre-recall draft.
-		m.logSearchHistory.reset()
 	case "ctrl+w":
 		m.logSearchInput.DeleteWord()
 		m.logSearchQuery = m.logSearchInput.Value

--- a/internal/app/update_logs_test.go
+++ b/internal/app/update_logs_test.go
@@ -535,6 +535,165 @@ func TestLogSearchTypingUpdatesQueryLive(t *testing.T) {
 		"backspace must keep logSearchQuery in sync, not leave the highlight stale")
 }
 
+// --- log search history (Up/Down recall, persisted to log-search-history) ---
+
+// Enter commits the query into the per-viewer log search history so
+// later sessions can recall it via Up. Mirrors the explorer's `/`
+// behaviour (queryHistory.add+save in handleSearchKey) but writes to a
+// separate file because log search runs on raw log bytes, not resource
+// names.
+func TestLogSearchHistoryEnterAdds(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{cursor: -1}
+	m.logSearchActive = true
+	m.logSearchInput.Insert("error")
+	m.logLines = []string{"error line"}
+
+	result, _ := m.handleLogKey(keyMsg("enter"))
+	rm := result.(Model)
+	assert.Equal(t, []string{"error"}, rm.logSearchHistory.entries)
+}
+
+// Esc cancels without committing — the input is wiped and the history
+// stays untouched. Otherwise an aborted exploratory query would clutter
+// recall.
+func TestLogSearchHistoryEscDoesNotAdd(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{cursor: -1}
+	m.logSearchActive = true
+	m.logSearchInput.Insert("typo")
+
+	result, _ := m.handleLogKey(keyMsg("esc"))
+	rm := result.(Model)
+	assert.Empty(t, rm.logSearchHistory.entries)
+}
+
+// Up replays the most recent entry into the input and mirrors it into
+// logSearchQuery so the live highlight repaints (same contract as
+// typing). Down past the newest entry restores the draft the user was
+// composing before they started recalling.
+func TestLogSearchHistoryUpDownRecall(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{
+		cursor:  -1,
+		entries: []string{"first", "second"},
+	}
+	m.logSearchActive = true
+	m.logSearchInput.Insert("draft")
+	m.logSearchQuery = "draft"
+
+	// Up -> newest entry, draft saved.
+	result, _ := m.handleLogKey(keyMsg("up"))
+	rm := result.(Model)
+	assert.Equal(t, "second", rm.logSearchInput.Value)
+	assert.Equal(t, "second", rm.logSearchQuery)
+
+	// Up again -> older entry.
+	result, _ = rm.handleLogKey(keyMsg("up"))
+	rm = result.(Model)
+	assert.Equal(t, "first", rm.logSearchInput.Value)
+
+	// Down -> back toward newer.
+	result, _ = rm.handleLogKey(keyMsg("down"))
+	rm = result.(Model)
+	assert.Equal(t, "second", rm.logSearchInput.Value)
+
+	// Down past newest -> restores the original draft.
+	result, _ = rm.handleLogKey(keyMsg("down"))
+	rm = result.(Model)
+	assert.Equal(t, "draft", rm.logSearchInput.Value)
+	assert.Equal(t, "draft", rm.logSearchQuery)
+}
+
+// Editing a recalled entry must drop the user out of history-browsing
+// mode (cursor -> -1, draft cleared). Otherwise a subsequent Down would
+// snap back to the original pre-recall draft and silently discard the
+// edits the user just typed.
+func TestLogSearchHistoryEditAfterRecallResets(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{
+		cursor:  -1,
+		entries: []string{"old"},
+	}
+	m.logSearchActive = true
+
+	// Recall the entry.
+	result, _ := m.handleLogKey(keyMsg("up"))
+	rm := result.(Model)
+	assert.Equal(t, "old", rm.logSearchInput.Value)
+	assert.NotEqual(t, -1, rm.logSearchHistory.cursor)
+
+	// Type a char -> resets cursor to -1.
+	result, _ = rm.handleLogKey(keyMsg("x"))
+	rm = result.(Model)
+	assert.Equal(t, -1, rm.logSearchHistory.cursor)
+	assert.Equal(t, "oldx", rm.logSearchInput.Value)
+}
+
+// Ctrl+W (delete-word) after recall must also drop out of history
+// browsing, for the same reason as backspace and typing — a follow-up
+// Down past newest should restore the post-edit text, not the
+// pre-recall draft.
+func TestLogSearchHistoryCtrlWAfterRecallResets(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{
+		cursor:  -1,
+		entries: []string{"hello world"},
+	}
+	m.logSearchActive = true
+
+	result, _ := m.handleLogKey(keyMsg("up"))
+	rm := result.(Model)
+	assert.NotEqual(t, -1, rm.logSearchHistory.cursor)
+
+	result, _ = rm.handleLogKey(keyMsg("ctrl+w"))
+	rm = result.(Model)
+	assert.Equal(t, -1, rm.logSearchHistory.cursor)
+}
+
+// Backspace after recall also resets the history cursor for the same
+// reason as the typing case above.
+func TestLogSearchHistoryBackspaceAfterRecallResets(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{
+		cursor:  -1,
+		entries: []string{"old"},
+	}
+	m.logSearchActive = true
+
+	result, _ := m.handleLogKey(keyMsg("up"))
+	rm := result.(Model)
+	assert.NotEqual(t, -1, rm.logSearchHistory.cursor)
+
+	result, _ = rm.handleLogKey(keyMsg("backspace"))
+	rm = result.(Model)
+	assert.Equal(t, -1, rm.logSearchHistory.cursor)
+}
+
+// Opening search via `/` resets any leftover cursor from a prior
+// recall so the next Up starts at the newest entry, not partway through
+// the previous browse.
+func TestLogSearchHistorySlashResetsCursor(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{
+		cursor:  0, // simulating a prior in-progress recall
+		entries: []string{"a", "b"},
+		draft:   "stale",
+	}
+
+	result, _ := m.handleLogKey(keyMsg("/"))
+	rm := result.(Model)
+	assert.Equal(t, -1, rm.logSearchHistory.cursor)
+	assert.Equal(t, "", rm.logSearchHistory.draft)
+}
+
 func TestCovLogVisualKeyEsc(t *testing.T) {
 	m := baseModelNav()
 	m.mode = modeLogs

--- a/internal/app/update_logs_test.go
+++ b/internal/app/update_logs_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- findNextLogMatch ---
@@ -674,6 +675,36 @@ func TestLogSearchHistoryBackspaceAfterRecallResets(t *testing.T) {
 	result, _ = rm.handleLogKey(keyMsg("backspace"))
 	rm = result.(Model)
 	assert.Equal(t, -1, rm.logSearchHistory.cursor)
+}
+
+// TestLogSearchHistoryEditThenDownRestoresPreRecallDraft pins the fix
+// from issue #115 for the log viewer's / search: after Up→edit, Down
+// past newest must restore the original pre-recall draft, not "".
+func TestLogSearchHistoryEditThenDownRestoresPreRecallDraft(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchHistory = &commandHistory{
+		cursor:  -1,
+		entries: []string{"err"},
+	}
+	m.logSearchActive = true
+	m.logSearchInput.Set("ngi")
+
+	// Up: recall "err", draft "ngi" saved.
+	result, _ := m.handleLogKey(keyMsg("up"))
+	rm := result.(Model)
+	require.Equal(t, "err", rm.logSearchInput.Value)
+
+	// Edit: type a char. Must leave browse but preserve draft.
+	result, _ = rm.handleLogKey(keyMsg("x"))
+	rm = result.(Model)
+	require.Equal(t, "errx", rm.logSearchInput.Value)
+	require.Equal(t, -1, rm.logSearchHistory.cursor)
+
+	// Down past newest: pre-recall draft "ngi" must come back.
+	result, _ = rm.handleLogKey(keyMsg("down"))
+	rm = result.(Model)
+	assert.Equal(t, "ngi", rm.logSearchInput.Value, "Down past newest must restore pre-recall draft")
 }
 
 // Opening search via `/` resets any leftover cursor from a prior

--- a/internal/app/update_search.go
+++ b/internal/app/update_search.go
@@ -294,6 +294,9 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = m.filterInput.Value
 			m.setCursor(0)
 			m.clampCursor()
+			// Paste counts as an edit: leave history-browse so a
+			// follow-up Down doesn't keep navigating history.
+			m.queryHistory.leaveBrowse()
 		}
 		return m, nil
 	}
@@ -412,6 +415,9 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if text != "" {
 			m.searchInput.Insert(text)
 			m.jumpToSearchMatch(0)
+			// Paste counts as an edit: leave history-browse so a
+			// follow-up Down doesn't keep navigating history.
+			m.queryHistory.leaveBrowse()
 		}
 		return m, nil
 	}

--- a/internal/app/update_search.go
+++ b/internal/app/update_search.go
@@ -353,11 +353,11 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = m.filterInput.Value
 			m.setCursor(0)
 			m.clampCursor()
-			// Editing a recalled entry leaves history navigation: the
-			// edited text becomes the new draft, so a later Down past
-			// newest restores the edits, not the original pre-recall
-			// draft.
-			m.queryHistory.reset()
+			// Editing a recalled entry leaves history navigation but
+			// keeps the pre-recall draft intact, so a later Down past
+			// newest restores the original draft the user had before
+			// pressing Up — not the recalled-then-edited text.
+			m.queryHistory.leaveBrowse()
 		}
 		return m, nil
 	case "ctrl+w":
@@ -365,14 +365,14 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filterText = m.filterInput.Value
 		m.setCursor(0)
 		m.clampCursor()
-		m.queryHistory.reset()
+		m.queryHistory.leaveBrowse()
 		return m, nil
 	case "ctrl+u":
 		m.filterInput.DeleteLine()
 		m.filterText = m.filterInput.Value
 		m.setCursor(0)
 		m.clampCursor()
-		m.queryHistory.reset()
+		m.queryHistory.leaveBrowse()
 		return m, nil
 	case "ctrl+a":
 		m.filterInput.Home()
@@ -395,7 +395,7 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = m.filterInput.Value
 			m.setCursor(0)
 			m.clampCursor()
-			m.queryHistory.reset()
+			m.queryHistory.leaveBrowse()
 		}
 		return m, nil
 	}
@@ -461,18 +461,18 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.jumpToSearchMatch(0)
 			// Editing a recalled entry leaves history navigation; see
 			// the analogous comment in handleFilterKey for rationale.
-			m.queryHistory.reset()
+			m.queryHistory.leaveBrowse()
 		}
 		return m, nil
 	case "ctrl+w":
 		m.searchInput.DeleteWord()
 		m.jumpToSearchMatch(0)
-		m.queryHistory.reset()
+		m.queryHistory.leaveBrowse()
 		return m, nil
 	case "ctrl+u":
 		m.searchInput.DeleteLine()
 		m.jumpToSearchMatch(0)
-		m.queryHistory.reset()
+		m.queryHistory.leaveBrowse()
 		return m, nil
 	case "ctrl+a":
 		m.searchInput.Home()
@@ -499,7 +499,7 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(key) == 1 && key[0] >= 32 && key[0] < 127 {
 			m.searchInput.Insert(key)
 			m.jumpToSearchMatch(0)
-			m.queryHistory.reset()
+			m.queryHistory.leaveBrowse()
 		}
 		return m, nil
 	}

--- a/internal/app/update_search_test.go
+++ b/internal/app/update_search_test.go
@@ -797,6 +797,36 @@ func TestHandleFilterKeyEditAfterRecallPreservesEdits(t *testing.T) {
 	assert.Equal(t, "defaultx", m.filterInput.Value)
 }
 
+// TestHandleFilterKeyEditThenDownRestoresPreRecallDraft pins the fix
+// from issue #115: after Up→edit, Down past newest must restore the
+// user's original pre-recall draft rather than an empty string. This
+// is what differentiates leaveBrowse() from reset(): cursor goes back
+// to -1, but draft is preserved.
+func TestHandleFilterKeyEditThenDownRestoresPreRecallDraft(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("default")
+	m.filterActive = true
+	m.filterInput.Set("ngi")
+
+	// Up: recall "default", original draft "ngi" saved.
+	result, _ := m.handleFilterKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "default", m.filterInput.Value)
+
+	// Edit: type one char. Must leave browse but keep draft="ngi".
+	result, _ = m.handleFilterKey(keyMsg("x"))
+	m = result.(Model)
+	require.Equal(t, "defaultx", m.filterInput.Value)
+	require.Equal(t, -1, m.queryHistory.cursor)
+
+	// Down past newest: should restore "ngi" (the pre-recall draft),
+	// not "" (which is what the buggy reset()-based code returns).
+	result, _ = m.handleFilterKey(keyMsg("down"))
+	m = result.(Model)
+	assert.Equal(t, "ngi", m.filterInput.Value, "Down past newest must restore pre-recall draft")
+}
+
 // TestHandleFilterKeyBackspaceAfterRecallResetsHistory: backspace is
 // also an edit and must reset the history cursor. Same rationale as
 // TestHandleFilterKeyEditAfterRecallPreservesEdits.
@@ -842,6 +872,30 @@ func TestHandleSearchKeyEditAfterRecallPreservesEdits(t *testing.T) {
 	result, _ = m.handleSearchKey(keyMsg("down"))
 	m = result.(Model)
 	assert.Equal(t, "redisx", m.searchInput.Value)
+}
+
+// TestHandleSearchKeyEditThenDownRestoresPreRecallDraft pins the fix
+// from issue #115 for the / search handler — see the filter
+// counterpart for full rationale.
+func TestHandleSearchKeyEditThenDownRestoresPreRecallDraft(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("redis")
+	m.searchActive = true
+	m.searchInput.Set("ngi")
+
+	result, _ := m.handleSearchKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "redis", m.searchInput.Value)
+
+	result, _ = m.handleSearchKey(keyMsg("x"))
+	m = result.(Model)
+	require.Equal(t, "redisx", m.searchInput.Value)
+	require.Equal(t, -1, m.queryHistory.cursor)
+
+	result, _ = m.handleSearchKey(keyMsg("down"))
+	m = result.(Model)
+	assert.Equal(t, "ngi", m.searchInput.Value, "Down past newest must restore pre-recall draft")
 }
 
 // TestHandleSearchKeyBackspaceAfterRecallResetsHistory: backspace must

--- a/internal/app/update_search_test.go
+++ b/internal/app/update_search_test.go
@@ -847,6 +847,53 @@ func TestHandleFilterKeyBackspaceAfterRecallResetsHistory(t *testing.T) {
 	assert.Equal(t, -1, m.queryHistory.cursor, "backspace must reset history cursor")
 }
 
+// TestHandleFilterKeyPasteAfterRecallLeavesBrowse pins that paste is
+// also an edit: pasting into a recalled entry must leave history-browse
+// mode so a follow-up Down doesn't navigate further into history.
+func TestHandleFilterKeyPasteAfterRecallLeavesBrowse(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("older")
+	m.queryHistory.add("default")
+	m.filterActive = true
+	m.filterInput.Set("ngi")
+
+	// Up: recall newest "default", draft "ngi" saved.
+	result, _ := m.handleFilterKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "default", m.filterInput.Value)
+	require.NotEqual(t, -1, m.queryHistory.cursor)
+
+	// Paste: must mutate the input and exit history-browse.
+	pasteMsg := tea.KeyMsg{Runes: []rune("XYZ"), Paste: true}
+	result, _ = m.handleFilterKey(pasteMsg)
+	m = result.(Model)
+	require.Equal(t, "defaultXYZ", m.filterInput.Value)
+	assert.Equal(t, -1, m.queryHistory.cursor, "paste must leave history-browse")
+}
+
+// TestHandleSearchKeyPasteAfterRecallLeavesBrowse: / search counterpart
+// to the filter paste test above.
+func TestHandleSearchKeyPasteAfterRecallLeavesBrowse(t *testing.T) {
+	m := basePush4Model()
+	m.queryHistory = &commandHistory{cursor: -1}
+	m.queryHistory.add("older")
+	m.queryHistory.add("redis")
+	m.searchActive = true
+	m.searchInput.Set("ngi")
+
+	result, _ := m.handleSearchKey(keyMsg("up"))
+	m = result.(Model)
+	require.Equal(t, "redis", m.searchInput.Value)
+	require.NotEqual(t, -1, m.queryHistory.cursor)
+
+	pasteMsg := tea.KeyMsg{Runes: []rune("XYZ"), Paste: true}
+	result, _ = m.handleSearchKey(pasteMsg)
+	m = result.(Model)
+	require.Equal(t, "redisXYZ", m.searchInput.Value)
+	assert.Equal(t, -1, m.queryHistory.cursor, "paste must leave history-browse")
+}
+
 // TestHandleSearchKeyEditAfterRecallPreservesEdits is the / search
 // counterpart to the filter test.
 func TestHandleSearchKeyEditAfterRecallPreservesEdits(t *testing.T) {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -354,6 +354,7 @@ func helpSections() []helpSection {
 				{"J/K", "Scroll preview side panel down/up (when visible)"},
 				{"c", "Toggle previous container logs"},
 				{"/", "Search in logs"},
+				{"", "Up/Down inside log search recalls previous queries (persistent across sessions)."},
 				{"n", "Next search match"},
 				{"N", "Previous search match"},
 				{"123G", "Jump to line number"},


### PR DESCRIPTION
## Summary

Add Up/Down recall to the log viewer's `/` search, mirroring the explorer's search/filter pattern. Persisted to a separate `$XDG_STATE_HOME/lfk/log-search-history` file because log search matches raw log lines (substring/regex over arbitrary text), not resource names — pooling it with the explorer's `query-history` would surface irrelevant entries on Up/Down in either context.

## Type of change

- [x] feat: new user-facing feature

## Related issue

<!-- n/a -->

## Changes

- New `historyFileLogSearch` constant; new `Model.logSearchHistory *commandHistory` field, initialized via `loadInputHistory`
- `handleLogSearchKey`: save on Enter, Up/Down recall, reset on edit (typing/backspace/Ctrl+W)
- `handleLogKeySlash`: reset history cursor when reopening search so the next Up starts from newest
- README, in-app help (`internal/ui/help.go`) and `docs/keybindings.md` updated
- 7 new tests covering enter-adds, esc-doesn't-add, Up/Down recall + draft restore, edit-after-recall resets (typing / backspace / Ctrl+W), `/` resets cursor on open, and cross-history isolation between log-search and explorer query-history

## Testing

- [x] \`go build ./...\` succeeds
- [x] \`go test ./...\` passes
- [x] \`golangci-lint run\` passes
- [ ] Manually verified against a real cluster

## Checklist

- [x] Commits follow conventional commit style
- [x] README / \`docs/\` updated when user-visible behavior or config changed
- [x] \`docs/keybindings.md\` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's \`main\`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log viewer `/` search has its own persistent history. Up/Down recall previous log searches; Enter commits and jumps to next match; Esc cancels and clears active search. Starting `/` clears input.

* **Bug Fixes**
  * Editing a recalled entry exits history-browse so subsequent Down restores the original pre-recall draft.

* **Documentation**
  * Help and docs clarify log-search history behavior, keybindings, and history separation.

* **Tests**
  * Added/expanded tests for history persistence, navigation, commit, cancel, and edit behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->