### PR TITLE
fix(logs): handle Ctrl+U (delete-line) in log viewer search input

### DIFF
--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -267,6 +267,9 @@ func (m Model) handleLogSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+w":
 		m.logSearchInput.DeleteWord()
 		m.logSearchQuery = m.logSearchInput.Value
+	case "ctrl+u":
+		m.logSearchInput.DeleteLine()
+		m.logSearchQuery = m.logSearchInput.Value
 	case "ctrl+a":
 		m.logSearchInput.Home()
 	case "ctrl+e":

--- a/internal/app/update_logs_test.go
+++ b/internal/app/update_logs_test.go
@@ -499,6 +499,28 @@ func TestCovLogSearchKeyBackspace(t *testing.T) {
 	assert.Equal(t, "a", rm.logSearchInput.Value)
 }
 
+// Ctrl+U is the standard readline "delete-to-line-start" shortcut and
+// is supported by the explorer's `/` and `f` inputs (via DeleteLine).
+// The log viewer's `/` input previously dropped Ctrl+U on the floor —
+// it fell through to the printable-char branch in `default`, which
+// rejected it. Verify both that the input is cleared and that
+// logSearchQuery is kept in sync so the live highlight overlay stops
+// painting matches for the now-empty query.
+func TestCovLogSearchKeyCtrlU(t *testing.T) {
+	m := baseModelNav()
+	m.mode = modeLogs
+	m.logSearchActive = true
+	m.logSearchInput.Insert("error")
+	m.logSearchQuery = "error"
+	m.logLines = []string{"error line"}
+
+	result, _ := m.handleLogKey(keyMsg("ctrl+u"))
+	rm := result.(Model)
+	assert.Equal(t, "", rm.logSearchInput.Value)
+	assert.Equal(t, "", rm.logSearchQuery,
+		"Ctrl+U must clear logSearchQuery so the highlight overlay stops painting")
+}
+
 func TestCovLogSearchKeyTyping(t *testing.T) {
 	m := baseModelNav()
 	m.mode = modeLogs


### PR DESCRIPTION
## Summary

`Ctrl+U` is the standard readline shortcut for "delete to line start" and is supported by the explorer's `/` and `f` inputs (via `TextInput.DeleteLine`). The log viewer's `/` search input dropped `Ctrl+U` on the floor — it fell through to the printable-char branch in `default`, which rejected it — so users had no single-keystroke way to clear the search input.

This PR mirrors the explorer pattern: call `DeleteLine()` and keep `logSearchQuery` in sync so the live highlight overlay stops painting matches for the now-empty query.

Pre-existing gap; not a regression. Found while reviewing the log search history feature in #113.

## Type of change

- [x] fix: bug fix

## Related issue

<!-- n/a; spotted during review of #113 -->

## Changes

- `handleLogSearchKey`: add `case "ctrl+u"` calling `DeleteLine()` + sync `logSearchQuery`
- New test `TestCovLogSearchKeyCtrlU` covering the cleared input and synced query state

## Testing

- [x] \`go build ./...\` succeeds
- [x] \`go test ./...\` passes
- [x] \`golangci-lint run\` passes
- [ ] Manually verified against a real cluster

## Checklist

- [x] Commits follow conventional commit style
- [ ] README / \`docs/\` updated when user-visible behavior or config changed (not needed — \`Ctrl+U\` is a standard readline binding, not in the keybindings reference for any other input either)
- [ ] \`docs/keybindings.md\` and the in-app help screen updated when keybindings changed (same reason)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's \`main\`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+U keyboard shortcut to clear log search input

* **Tests**
  * Added test case for log search keyboard shortcut functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->