### PR TITLE
feat(clusters): add per-cluster color coding with title-bar tint

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -174,6 +174,7 @@ keybindings:
   delete: "D" # Delete resource (default: D)
   force_delete: "X" # Force delete resource (default: X)
   scale: "S" # Scale resource (default: S)
+  cluster_color_picker: "ctrl+l" # Open cluster-color picker at the cluster picker (default: ctrl+l)
 
 # ─── Search Abbreviations ─────────────────────────────────────────────────────
 # Short names for resource types used in search/filter.

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -174,7 +174,7 @@ keybindings:
   delete: "D" # Delete resource (default: D)
   force_delete: "X" # Force delete resource (default: X)
   scale: "S" # Scale resource (default: S)
-  cluster_color_picker: "ctrl+k" # Open cluster-color picker at the cluster picker (default: ctrl+k; not ctrl+l because most terminals eat ctrl+l for "redraw screen")
+  cluster_color_picker: "c" # Open cluster-color picker at the cluster picker (default: bare "c" — Ctrl+L/K/Y/H/J are all intercepted by terminals or readline; the handler is gated to Level=Clusters so it's a no-op elsewhere)
 
 # ─── Search Abbreviations ─────────────────────────────────────────────────────
 # Short names for resource types used in search/filter.

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -174,7 +174,7 @@ keybindings:
   delete: "D" # Delete resource (default: D)
   force_delete: "X" # Force delete resource (default: X)
   scale: "S" # Scale resource (default: S)
-  cluster_color_picker: "ctrl+l" # Open cluster-color picker at the cluster picker (default: ctrl+l)
+  cluster_color_picker: "ctrl+k" # Open cluster-color picker at the cluster picker (default: ctrl+k; not ctrl+l because most terminals eat ctrl+l for "redraw screen")
 
 # ─── Search Abbreviations ─────────────────────────────────────────────────────
 # Short names for resource types used in search/filter.

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -174,7 +174,7 @@ keybindings:
   delete: "D" # Delete resource (default: D)
   force_delete: "X" # Force delete resource (default: X)
   scale: "S" # Scale resource (default: S)
-  cluster_color_picker: "c" # Open cluster-color picker at the cluster picker (default: bare "c" — Ctrl+L/K/Y/H/J are all intercepted by terminals or readline; the handler is gated to Level=Clusters so it's a no-op elsewhere)
+  cluster_color_picker: "L" # Open cluster-color picker (default: Shift+L; reuses the Logs key, since Logs has no resource to act on at the cluster picker — at deeper levels "L" still opens Logs)
 
 # ─── Search Abbreviations ─────────────────────────────────────────────────────
 # Short names for resource types used in search/filter.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -579,7 +579,7 @@ and global config.
 
 | Key | Action |
 |---|---|
-| `Ctrl+L` (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
+| `Ctrl+K` (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
 
 When a context has a color assigned, the cluster picker row shows a
 two-cell `██` swatch in that color, and entering the context tints the
@@ -787,5 +787,5 @@ keybindings:
   readonly_toggle: "ctrl+r"  # At cluster picker: toggle highlighted row's [RO] marker. Inside a context: toggle the current tab.
 
   # Cluster color picker (cluster picker only)
-  cluster_color_picker: "ctrl+l"
+  cluster_color_picker: "ctrl+k"
 ```

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -575,6 +575,21 @@ mode: X disabled" toast. See [Read-Only Mode](usage.md#read-only-mode)
 for the full precedence rules across the CLI flag, per-context config,
 and global config.
 
+## Cluster Color Coding
+
+| Key | Action |
+|---|---|
+| `Ctrl+L` (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
+
+When a context has a color assigned, the cluster picker row shows a
+two-cell `██` swatch in that color, and entering the context tints the
+entire title bar background with the same color so it's impossible to
+miss which environment you're acting on. Contexts without a color show
+dim `··` placeholder dots so all rows stay aligned.
+
+The colour palette uses ANSI bright colors (codes 8–15) so each tint
+maps to your terminal's palette and looks consistent across themes.
+
 ## Mouse
 
 | Input | Action |
@@ -770,4 +785,7 @@ keybindings:
 
   # Read-only mode
   readonly_toggle: "ctrl+r"  # At cluster picker: toggle highlighted row's [RO] marker. Inside a context: toggle the current tab.
+
+  # Cluster color picker (cluster picker only)
+  cluster_color_picker: "ctrl+l"
 ```

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -579,13 +579,14 @@ and global config.
 
 | Key | Action |
 |---|---|
-| `Ctrl+K` (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
+| `c` (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
 
 When a context has a color assigned, the cluster picker row shows a
-two-cell `██` swatch in that color, and entering the context tints the
-entire title bar background with the same color so it's impossible to
-miss which environment you're acting on. Contexts without a color show
-dim `··` placeholder dots so all rows stay aligned.
+small background-tinted suffix swatch on the right edge in that color,
+and entering the context applies the same color as a background tint to
+the entire title bar so it's impossible to miss which environment you're
+acting on. Contexts without a color render a neutral placeholder in the
+swatch column so all rows stay aligned.
 
 The colour palette uses ANSI bright colors (codes 8–15) so each tint
 maps to your terminal's palette and looks consistent across themes.
@@ -787,5 +788,5 @@ keybindings:
   readonly_toggle: "ctrl+r"  # At cluster picker: toggle highlighted row's [RO] marker. Inside a context: toggle the current tab.
 
   # Cluster color picker (cluster picker only)
-  cluster_color_picker: "ctrl+k"
+  cluster_color_picker: "c"
 ```

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -579,7 +579,7 @@ and global config.
 
 | Key | Action |
 |---|---|
-| `c` (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
+| `L` (Shift+L) (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
 
 When a context has a color assigned, the cluster picker row shows a
 small background-tinted suffix swatch on the right edge in that color,
@@ -791,5 +791,5 @@ keybindings:
   readonly_toggle: "ctrl+r"  # At cluster picker: toggle highlighted row's [RO] marker. Inside a context: toggle the current tab.
 
   # Cluster color picker (cluster picker only)
-  cluster_color_picker: "c"
+  cluster_color_picker: "L"
 ```

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -588,8 +588,11 @@ the entire title bar so it's impossible to miss which environment you're
 acting on. Contexts without a color render a neutral placeholder in the
 swatch column so all rows stay aligned.
 
-The colour palette uses ANSI bright colors (codes 8–15) so each tint
-maps to your terminal's palette and looks consistent across themes.
+Four colours (`red`, `yellow`, `green`, `blue`) follow lfk's active
+theme tokens (`theme.Error`, `theme.Warning`, `theme.Secondary`,
+`theme.Primary`) so a colorscheme switch re-skins them. The remaining
+four (`magenta`, `cyan`, `white`, `gray`) stay on ANSI bright codes
+(8, 13–15) and look the same regardless of theme.
 
 ## Mouse
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -150,6 +150,35 @@ context; it does not scope the read-only flag.
 The cluster picker hint bar advertises `Ctrl+R toggle RO` so users
 can find the row toggle without reading docs.
 
+## Cluster Color Coding
+
+Tag any cluster with a background color so the title bar tints the
+moment you enter it — useful for "I am unmistakably in prod" feedback
+when a stray `D` would do real damage.
+
+- **Open the picker**: at the cluster picker, highlight a row and press
+  `Ctrl+L`. Same overlay opens from the action menu (`x` →
+  "Set color…").
+- **Pick a color**: 8 named choices (`red`, `yellow`, `green`, `blue`,
+  `magenta`, `cyan`, `white`, `gray`) plus `None` to clear. The cursor
+  pre-seeds on the cluster's current color, or on `None` if it has none.
+- **Visual treatment**: the picker row gets a `██` swatch in the chosen
+  color so all your clusters are recognizable at a glance, and entering
+  the context tints the entire title-bar background with the same color
+  while the existing badges (`[RO]`, watch indicator, namespace, etc.)
+  stay legible on top.
+- **Persistence**: the assignment is saved to
+  `$XDG_STATE_HOME/lfk/cluster-colors.yaml` (defaults to
+  `~/.local/state/lfk/cluster-colors.yaml`) so colors survive restarts.
+  The file is lfk-managed — don't hand-edit; use the in-app picker.
+  Unknown color names in the file are dropped silently on load so a typo
+  doesn't poison neighbouring entries.
+
+The colour palette uses ANSI bright codes (8–15) so each tint maps to
+your terminal's own palette. That keeps prod-red recognisable across
+themes and avoids hardcoded hex values that can clash with the active
+colorscheme.
+
 ## Watch-Mode Interval
 
 Watch mode (toggle with `w`) polls the current resource list on an interval.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -174,10 +174,20 @@ when a stray `D` would do real damage.
   Unknown color names in the file are ignored on load (with a warning
   written to the lfk log) so a typo doesn't poison neighbouring entries.
 
-The colour palette uses ANSI bright codes (8–15) so each tint maps to
-your terminal's own palette. That keeps prod-red recognisable across
-themes and avoids hardcoded hex values that can clash with the active
-colorscheme.
+Four of the colours follow lfk's active theme so they re-skin when you
+switch colorschemes:
+
+| Picker name | Theme token             |
+| ----------- | ----------------------- |
+| `red`       | `theme.Error`           |
+| `yellow`    | `theme.Warning`         |
+| `green`     | `theme.Secondary`       |
+| `blue`      | `theme.Primary`         |
+
+The remaining four (`magenta`, `cyan`, `white`, `gray`) stay on ANSI
+bright codes so they look the same regardless of which lfk theme is
+active — useful when none of the theme accent colours fit a particular
+cluster's identity.
 
 ## Watch-Mode Interval
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,7 +157,7 @@ moment you enter it — useful for "I am unmistakably in prod" feedback
 when a stray `D` would do real damage.
 
 - **Open the picker**: at the cluster picker, highlight a row and press
-  `Ctrl+L`. Same overlay opens from the action menu (`x` →
+  `Ctrl+K`. Same overlay opens from the action menu (`x` →
   "Set color…").
 - **Pick a color**: 8 named choices (`red`, `yellow`, `green`, `blue`,
   `magenta`, `cyan`, `white`, `gray`) plus `None` to clear. The cursor

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,7 +157,7 @@ moment you enter it — useful for "I am unmistakably in prod" feedback
 when a stray `D` would do real damage.
 
 - **Open the picker**: at the cluster picker, highlight a row and press
-  `c`. Same overlay opens from the action menu (`x` →
+  `L` (Shift+L). Same overlay opens from the action menu (`x` →
   "Set color…").
 - **Pick a color**: 8 named choices (`red`, `yellow`, `green`, `blue`,
   `magenta`, `cyan`, `white`, `gray`) plus `None` to clear. The cursor

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,7 +157,7 @@ moment you enter it — useful for "I am unmistakably in prod" feedback
 when a stray `D` would do real damage.
 
 - **Open the picker**: at the cluster picker, highlight a row and press
-  `Ctrl+K`. Same overlay opens from the action menu (`x` →
+  `c`. Same overlay opens from the action menu (`x` →
   "Set color…").
 - **Pick a color**: 8 named choices (`red`, `yellow`, `green`, `blue`,
   `magenta`, `cyan`, `white`, `gray`) plus `None` to clear. The cursor
@@ -171,8 +171,8 @@ when a stray `D` would do real damage.
   `$XDG_STATE_HOME/lfk/cluster-colors.yaml` (defaults to
   `~/.local/state/lfk/cluster-colors.yaml`) so colors survive restarts.
   The file is lfk-managed — don't hand-edit; use the in-app picker.
-  Unknown color names in the file are dropped silently on load so a typo
-  doesn't poison neighbouring entries.
+  Unknown color names in the file are ignored on load (with a warning
+  written to the lfk log) so a typo doesn't poison neighbouring entries.
 
 The colour palette uses ANSI bright codes (8–15) so each tint maps to
 your terminal's own palette. That keeps prod-red recognisable across

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -67,6 +67,7 @@ exclusive — opening a new one replaces any prior open overlay.
 | `overlayExplainSearch`   | `:explain` start                    | Type/field search for kubectl explain.   |
 | `overlayFinalizerSearch` | finalizer-edit flow                 | Pick a finalizer to remove.              |
 | `overlayColumnToggle`    | column-visibility key               | Show/hide table columns per kind.        |
+| `overlayClusterColor`    | `Ctrl+L` at cluster picker          | Pick a background tint for the highlighted cluster row (persisted to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`; also reachable from the action menu → "Set color…"). |
 
 ### Editors / Forms
 

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -67,7 +67,7 @@ exclusive — opening a new one replaces any prior open overlay.
 | `overlayExplainSearch`   | `:explain` start                    | Type/field search for kubectl explain.   |
 | `overlayFinalizerSearch` | finalizer-edit flow                 | Pick a finalizer to remove.              |
 | `overlayColumnToggle`    | column-visibility key               | Show/hide table columns per kind.        |
-| `overlayClusterColor`    | `Ctrl+K` at cluster picker          | Pick a background tint for the highlighted cluster row (persisted to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`; also reachable from the action menu → "Set color…"). |
+| `overlayClusterColor`    | `c` at cluster picker               | Pick a background tint for the highlighted cluster row (persisted to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`; also reachable from the action menu → "Set color…"). |
 
 ### Editors / Forms
 

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -67,7 +67,7 @@ exclusive — opening a new one replaces any prior open overlay.
 | `overlayExplainSearch`   | `:explain` start                    | Type/field search for kubectl explain.   |
 | `overlayFinalizerSearch` | finalizer-edit flow                 | Pick a finalizer to remove.              |
 | `overlayColumnToggle`    | column-visibility key               | Show/hide table columns per kind.        |
-| `overlayClusterColor`    | `c` at cluster picker               | Pick a background tint for the highlighted cluster row (persisted to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`; also reachable from the action menu → "Set color…"). |
+| `overlayClusterColor`    | `L` (Shift+L) at cluster picker     | Pick a background tint for the highlighted cluster row. Reuses the Logs key — at deeper levels `L` still opens Logs as usual. Persisted to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`; also reachable from the action menu → "Set color…". |
 
 ### Editors / Forms
 

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -67,7 +67,7 @@ exclusive — opening a new one replaces any prior open overlay.
 | `overlayExplainSearch`   | `:explain` start                    | Type/field search for kubectl explain.   |
 | `overlayFinalizerSearch` | finalizer-edit flow                 | Pick a finalizer to remove.              |
 | `overlayColumnToggle`    | column-visibility key               | Show/hide table columns per kind.        |
-| `overlayClusterColor`    | `Ctrl+L` at cluster picker          | Pick a background tint for the highlighted cluster row (persisted to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`; also reachable from the action menu → "Set color…"). |
+| `overlayClusterColor`    | `Ctrl+K` at cluster picker          | Pick a background tint for the highlighted cluster row (persisted to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`; also reachable from the action menu → "Set color…"). |
 
 ### Editors / Forms
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -194,6 +194,22 @@ type Model struct {
 	// CLI --read-only still wins over both.
 	contextROOverrides map[string]bool
 
+	// clusterColors holds per-context background-tint assignments set by the
+	// user via Ctrl+L on a row in the cluster picker. Persisted to
+	// $XDG_STATE_HOME/lfk/cluster-colors.yaml so the tint survives restarts.
+	// Absent key means "no tint"; values are validated against
+	// ui.ClusterColorNames at load and save time.
+	clusterColors map[string]string
+
+	// clusterColorOverlay state: cursor position within the picker's color
+	// rows. Captured as Model state (not closures) so the same overlay code
+	// can be re-rendered on every Update tick.
+	clusterColorOverlayCursor int
+	// clusterColorOverlayContext is the context name the overlay was opened
+	// against — captured at open so a later refresh of m.middleItems can't
+	// retarget the save to the wrong row.
+	clusterColorOverlayContext string
+
 	// Help screen state.
 	helpScroll       int
 	helpFilter       TextInput // applied filter (f key) — narrows visible lines

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -209,6 +209,16 @@ type Model struct {
 	// against — captured at open so a later refresh of m.middleItems can't
 	// retarget the save to the wrong row.
 	clusterColorOverlayContext string
+	// clusterColorFilter holds the in-overlay / filter input so the picker
+	// can narrow the visible colour list. Mirrors the schemeFilter /
+	// templateFilter pattern so the standard FilterInput / handleFilterKey
+	// helpers handle paste, ctrl+w, etc. uniformly.
+	clusterColorFilter TextInput
+	// clusterColorFilterMode is true while the user is typing into the
+	// filter input; in this mode every keystroke goes to the input and
+	// navigation keys (j/k/enter) are deferred until Enter or Esc exits
+	// filter mode.
+	clusterColorFilterMode bool
 
 	// Help screen state.
 	helpScroll       int

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -56,6 +56,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		readOnly:                   ui.ResolveReadOnly(contextName, opts.ReadOnly),
 		cliReadOnly:                opts.ReadOnly,
 		contextROOverrides:         make(map[string]bool),
+		clusterColors:              loadClusterColors(),
 		sortColumnName:             sortColDefault,
 		sortAscending:              true,
 		cursorMemory:               make(map[string]int),

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -70,6 +70,7 @@ const (
 	overlayColumnToggle
 	overlayPasteConfirm // y/n confirmation for multiline paste into search/filter
 	overlayBackgroundTasks
+	overlayClusterColor // pick a color tint for the highlighted cluster row
 )
 
 // bookmarkOverlayMode tracks the interaction mode for the bookmark overlay.

--- a/internal/app/cluster_color_overlay.go
+++ b/internal/app/cluster_color_overlay.go
@@ -1,0 +1,131 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// clusterColorForActiveContext returns the colour name assigned to the
+// currently-active context, or "" when the user is at the cluster picker
+// (no active context) or the context has no colour assigned. Callers
+// (renderTitleBar, cluster picker) treat "" as "no tint".
+func (m Model) clusterColorForActiveContext() string {
+	if m.nav.Level == model.LevelClusters {
+		return ""
+	}
+	if m.nav.Context == "" {
+		return ""
+	}
+	return m.clusterColors[m.nav.Context]
+}
+
+// clusterColorPickerNoneIndex is the cursor index of the "None / clear"
+// row in the picker — always one past the last named colour.
+func clusterColorPickerNoneIndex() int { return len(ui.ClusterColorNames) }
+
+// handleKeyClusterColorPicker opens the cluster-color overlay over the
+// highlighted row in the cluster picker. Only valid at Level=Clusters; at
+// any other level the keypress is silently ignored so users who stash
+// Ctrl+L muscle memory don't get confused by half-applied state inside a
+// context. Pre-seeds the cursor on the cluster's current color (or the
+// "None" row when the cluster has no color set yet).
+func (m Model) handleKeyClusterColorPicker() (tea.Model, tea.Cmd) {
+	if m.nav.Level != model.LevelClusters {
+		return m, nil
+	}
+	sel := m.selectedMiddleItem()
+	if sel == nil {
+		return m, nil
+	}
+	m.overlay = overlayClusterColor
+	m.clusterColorOverlayContext = sel.Name
+	m.clusterColorOverlayCursor = clusterColorPickerNoneIndex()
+	if current, ok := m.clusterColors[sel.Name]; ok {
+		for i, c := range ui.ClusterColorNames {
+			if c == current {
+				m.clusterColorOverlayCursor = i
+				break
+			}
+		}
+	}
+	return m, nil
+}
+
+// handleClusterColorOverlayKey services key events while the picker is
+// open. Up/Down move the cursor with wrap-around, Enter applies the
+// highlighted color (deleting the entry when the cursor is on the "None"
+// row), Esc cancels without persisting. Other keys are ignored so the
+// overlay can't be dismissed by accident.
+func (m Model) handleClusterColorOverlayKey(key string) (tea.Model, tea.Cmd) {
+	rows := clusterColorPickerNoneIndex() + 1
+	switch key {
+	case "down", "j":
+		m.clusterColorOverlayCursor = (m.clusterColorOverlayCursor + 1) % rows
+		return m, nil
+	case "up", "k":
+		m.clusterColorOverlayCursor = (m.clusterColorOverlayCursor - 1 + rows) % rows
+		return m, nil
+	case "esc":
+		m.overlay = overlayNone
+		m.clusterColorOverlayContext = ""
+		return m, nil
+	case "enter":
+		mdl, hadErr := m.applyClusterColorSelection()
+		if hadErr {
+			return mdl, scheduleStatusClear()
+		}
+		return mdl, nil
+	}
+	return m, nil
+}
+
+// applyClusterColorSelection writes the cursor's color to the in-memory
+// map, persists to disk, and closes the overlay. The "None" row deletes
+// the entry rather than writing an empty string so loadClusterColors's
+// validation never sees a sentinel value. Returns hadErr=true when the
+// persistence step failed so the caller can schedule a status-clear for
+// the user-visible error message.
+func (m Model) applyClusterColorSelection() (Model, bool) {
+	ctx := m.clusterColorOverlayContext
+	if ctx == "" {
+		// Defensive: should never happen because handleKeyClusterColorPicker
+		// only opens the overlay when a row is highlighted.
+		m.overlay = overlayNone
+		return m, false
+	}
+	if m.clusterColors == nil {
+		m.clusterColors = make(map[string]string)
+	}
+	var newColor string
+	if m.clusterColorOverlayCursor == clusterColorPickerNoneIndex() {
+		delete(m.clusterColors, ctx)
+	} else if m.clusterColorOverlayCursor >= 0 && m.clusterColorOverlayCursor < len(ui.ClusterColorNames) {
+		newColor = ui.ClusterColorNames[m.clusterColorOverlayCursor]
+		m.clusterColors[ctx] = newColor
+	}
+	// Stamp the row in m.middleItems by index so the swatch updates
+	// immediately, without waiting for the next loadContexts roundtrip.
+	// Mirrors the pattern in handleKeyReadOnlyToggle: writing through a
+	// transient pointer from selectedMiddleItem could miss the cached
+	// slice on the fallback path.
+	for i := range m.middleItems {
+		if m.middleItems[i].Name == ctx {
+			m.middleItems[i].ClusterColor = newColor
+			break
+		}
+	}
+	saveErr := saveClusterColors(m.clusterColors)
+	if saveErr != nil {
+		// Persistence failure shouldn't trap the user inside the overlay —
+		// the in-memory change still took effect for the session and
+		// loadClusterColors's graceful-empty fallback covers the next run.
+		logger.Warn("Failed to persist cluster color", "context", ctx, "error", saveErr)
+		m.setStatusMessage("Failed to save cluster color: "+saveErr.Error(), true)
+	}
+	m.overlay = overlayNone
+	m.clusterColorOverlayContext = ""
+	return m, saveErr != nil
+}

--- a/internal/app/cluster_color_overlay.go
+++ b/internal/app/cluster_color_overlay.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/janosmiko/lfk/internal/logger"
@@ -22,16 +24,47 @@ func (m Model) clusterColorForActiveContext() string {
 	return m.clusterColors[m.nav.Context]
 }
 
-// clusterColorPickerNoneIndex is the cursor index of the "None / clear"
-// row in the picker — always one past the last named colour.
-func clusterColorPickerNoneIndex() int { return len(ui.ClusterColorNames) }
+// filteredClusterColorNames returns the colour-name list filtered by the
+// current overlay filter input. Filter is a case-insensitive substring
+// match. Empty filter returns all names. The "None" row is appended by
+// the caller — it stays anchored at the bottom regardless of the
+// filter so users can always reach the clear-action.
+func (m Model) filteredClusterColorNames() []string {
+	q := strings.ToLower(strings.TrimSpace(m.clusterColorFilter.Value))
+	if q == "" {
+		out := make([]string, len(ui.ClusterColorNames))
+		copy(out, ui.ClusterColorNames)
+		return out
+	}
+	out := make([]string, 0, len(ui.ClusterColorNames))
+	for _, n := range ui.ClusterColorNames {
+		if strings.Contains(n, q) {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// clusterColorOverlayRowCount returns the total number of rows the
+// overlay will render: filtered colours plus the "None" row.
+func (m Model) clusterColorOverlayRowCount() int {
+	return len(m.filteredClusterColorNames()) + 1
+}
+
+// clusterColorOverlayNoneIndex returns the cursor index of the "None"
+// row in the *currently filtered* view (always one past the last
+// matching colour).
+func (m Model) clusterColorOverlayNoneIndex() int {
+	return len(m.filteredClusterColorNames())
+}
 
 // handleKeyClusterColorPicker opens the cluster-color overlay over the
-// highlighted row in the cluster picker. Only valid at Level=Clusters; at
-// any other level the keypress is silently ignored so users who stash
-// Ctrl+L muscle memory don't get confused by half-applied state inside a
-// context. Pre-seeds the cursor on the cluster's current color (or the
-// "None" row when the cluster has no color set yet).
+// highlighted row in the cluster picker. Only valid at Level=Clusters;
+// at any other level the keypress is silently ignored so users who
+// stash the muscle memory don't get confused by half-applied state
+// inside a context. Pre-seeds the cursor on the cluster's current
+// colour (or the "None" row when the cluster has no colour set yet),
+// and clears any leftover filter from a previous open.
 func (m Model) handleKeyClusterColorPicker() (tea.Model, tea.Cmd) {
 	if m.nav.Level != model.LevelClusters {
 		return m, nil
@@ -42,7 +75,9 @@ func (m Model) handleKeyClusterColorPicker() (tea.Model, tea.Cmd) {
 	}
 	m.overlay = overlayClusterColor
 	m.clusterColorOverlayContext = sel.Name
-	m.clusterColorOverlayCursor = clusterColorPickerNoneIndex()
+	m.clusterColorFilter.Clear()
+	m.clusterColorFilterMode = false
+	m.clusterColorOverlayCursor = m.clusterColorOverlayNoneIndex()
 	if current, ok := m.clusterColors[sel.Name]; ok {
 		for i, c := range ui.ClusterColorNames {
 			if c == current {
@@ -55,20 +90,38 @@ func (m Model) handleKeyClusterColorPicker() (tea.Model, tea.Cmd) {
 }
 
 // handleClusterColorOverlayKey services key events while the picker is
-// open. Up/Down move the cursor with wrap-around, Enter applies the
-// highlighted color (deleting the entry when the cursor is on the "None"
-// row), Esc cancels without persisting. Other keys are ignored so the
-// overlay can't be dismissed by accident.
+// open. Splits between filter-input mode (typing into the / filter)
+// and normal mode (navigation / selection). The hint bar sits on the
+// status bar via overlayHintBarSelector — no inline hints in the
+// overlay box itself.
 func (m Model) handleClusterColorOverlayKey(key string) (tea.Model, tea.Cmd) {
-	rows := clusterColorPickerNoneIndex() + 1
+	if m.clusterColorFilterMode {
+		return m.handleClusterColorOverlayFilterKey(key), nil
+	}
+	rows := m.clusterColorOverlayRowCount()
 	switch key {
 	case "down", "j":
-		m.clusterColorOverlayCursor = (m.clusterColorOverlayCursor + 1) % rows
+		if rows > 0 {
+			m.clusterColorOverlayCursor = (m.clusterColorOverlayCursor + 1) % rows
+		}
 		return m, nil
 	case "up", "k":
-		m.clusterColorOverlayCursor = (m.clusterColorOverlayCursor - 1 + rows) % rows
+		if rows > 0 {
+			m.clusterColorOverlayCursor = (m.clusterColorOverlayCursor - 1 + rows) % rows
+		}
+		return m, nil
+	case "/":
+		m.clusterColorFilterMode = true
 		return m, nil
 	case "esc":
+		// First Esc clears an active filter; second Esc closes the overlay
+		// (mirrors the colorscheme overlay pattern so muscle memory carries
+		// across pickers).
+		if m.clusterColorFilter.Value != "" {
+			m.clusterColorFilter.Clear()
+			m.clusterColorOverlayCursor = m.clusterColorOverlayNoneIndex()
+			return m, nil
+		}
 		m.overlay = overlayNone
 		m.clusterColorOverlayContext = ""
 		return m, nil
@@ -80,6 +133,32 @@ func (m Model) handleClusterColorOverlayKey(key string) (tea.Model, tea.Cmd) {
 		return mdl, nil
 	}
 	return m, nil
+}
+
+// handleClusterColorOverlayFilterKey processes keystrokes while the
+// user is typing into the / filter input. Enter / Esc exit the filter
+// mode (Enter keeps the current filter, Esc clears it); other keys
+// edit the buffer via the shared FilterInput helper.
+func (m Model) handleClusterColorOverlayFilterKey(key string) Model {
+	action := handleFilterKey(&m.clusterColorFilter, key)
+	switch action {
+	case filterContinue, filterNavigate:
+		// Reset cursor to the first row of the new filtered view so the
+		// highlight doesn't land on a stale index when the list shrinks.
+		m.clusterColorOverlayCursor = 0
+	case filterAccept:
+		m.clusterColorFilterMode = false
+	case filterEscape:
+		m.clusterColorFilter.Clear()
+		m.clusterColorFilterMode = false
+		m.clusterColorOverlayCursor = m.clusterColorOverlayNoneIndex()
+	case filterClose:
+		m.clusterColorFilter.Clear()
+		m.clusterColorFilterMode = false
+		m.overlay = overlayNone
+		m.clusterColorOverlayContext = ""
+	}
+	return m
 }
 
 // applyClusterColorSelection writes the cursor's color to the in-memory
@@ -99,11 +178,13 @@ func (m Model) applyClusterColorSelection() (Model, bool) {
 	if m.clusterColors == nil {
 		m.clusterColors = make(map[string]string)
 	}
+	filtered := m.filteredClusterColorNames()
+	noneIdx := len(filtered)
 	var newColor string
-	if m.clusterColorOverlayCursor == clusterColorPickerNoneIndex() {
+	if m.clusterColorOverlayCursor == noneIdx {
 		delete(m.clusterColors, ctx)
-	} else if m.clusterColorOverlayCursor >= 0 && m.clusterColorOverlayCursor < len(ui.ClusterColorNames) {
-		newColor = ui.ClusterColorNames[m.clusterColorOverlayCursor]
+	} else if m.clusterColorOverlayCursor >= 0 && m.clusterColorOverlayCursor < len(filtered) {
+		newColor = filtered[m.clusterColorOverlayCursor]
 		m.clusterColors[ctx] = newColor
 	}
 	// Stamp the row in m.middleItems by index so the swatch updates
@@ -127,5 +208,7 @@ func (m Model) applyClusterColorSelection() (Model, bool) {
 	}
 	m.overlay = overlayNone
 	m.clusterColorOverlayContext = ""
+	m.clusterColorFilter.Clear()
+	m.clusterColorFilterMode = false
 	return m, saveErr != nil
 }

--- a/internal/app/cluster_color_overlay_test.go
+++ b/internal/app/cluster_color_overlay_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -37,6 +38,22 @@ func TestHandleKeyClusterColorPicker_AtClusterPickerOpensOverlay(t *testing.T) {
 	result := ret.(Model)
 	assert.Equal(t, overlayClusterColor, result.overlay, "Ctrl+L at Level=Clusters opens the picker overlay")
 	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext, "overlay captures the highlighted context name")
+}
+
+// TestHandleKey_CtrlK_RoutesToClusterColorPicker is the regression test
+// for the bug the user hit when the default was Ctrl+L: most terminals
+// intercept Ctrl+L for "redraw screen" before the app sees the key, so
+// the binding moved to Ctrl+K which is terminal-safe across macOS
+// Terminal, iTerm2, Alacritty, Ghostty, and gnome-terminal. Going
+// through tea.KeyCtrlK (not the test-helper string fallback) catches
+// dispatch wiring failures the direct-handler tests miss.
+func TestHandleKey_CtrlK_RoutesToClusterColorPicker(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlK})
+	result := ret.(Model)
+	assert.Equal(t, overlayClusterColor, result.overlay,
+		"Ctrl+K at the cluster picker must route through handleKey to the cluster-color overlay")
+	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext)
 }
 
 func TestHandleKeyClusterColorPicker_AbovePickerLevelIsNoOp(t *testing.T) {

--- a/internal/app/cluster_color_overlay_test.go
+++ b/internal/app/cluster_color_overlay_test.go
@@ -40,20 +40,33 @@ func TestHandleKeyClusterColorPicker_AtClusterPickerOpensOverlay(t *testing.T) {
 	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext, "overlay captures the highlighted context name")
 }
 
-// TestHandleKey_CtrlK_RoutesToClusterColorPicker is the regression test
-// for the bug the user hit when the default was Ctrl+L: most terminals
-// intercept Ctrl+L for "redraw screen" before the app sees the key, so
-// the binding moved to Ctrl+K which is terminal-safe across macOS
-// Terminal, iTerm2, Alacritty, Ghostty, and gnome-terminal. Going
-// through tea.KeyCtrlK (not the test-helper string fallback) catches
-// dispatch wiring failures the direct-handler tests miss.
-func TestHandleKey_CtrlK_RoutesToClusterColorPicker(t *testing.T) {
+// TestHandleKey_C_RoutesToClusterColorPicker is the regression test for
+// the bug the user hit with Ctrl+L and Ctrl+K: every Ctrl+letter we
+// tried got intercepted by either the terminal emulator (Ctrl+L =
+// redraw screen) or the shell input layer (Ctrl+K = kill-to-eol in
+// readline/ZLE), so the binding moved to a bare "c". The handler
+// self-gates on Level=Clusters so the bare letter is a no-op in any
+// other context and doesn't shadow in-context behaviours.
+func TestHandleKey_C_RoutesToClusterColorPicker(t *testing.T) {
 	m := newClusterPickerModel(t)
-	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlK})
+	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
 	result := ret.(Model)
 	assert.Equal(t, overlayClusterColor, result.overlay,
-		"Ctrl+K at the cluster picker must route through handleKey to the cluster-color overlay")
+		"'c' at the cluster picker must route through handleKey to the cluster-color overlay")
 	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext)
+}
+
+// TestHandleKey_C_NoOpAboveClusterPicker ensures the handler's level
+// gate keeps the bare "c" key inert outside the cluster picker so it
+// doesn't accidentally consume keypresses elsewhere.
+func TestHandleKey_C_NoOpAboveClusterPicker(t *testing.T) {
+	m := newClusterPickerModel(t)
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "prod-eu"
+	before := m.overlay
+	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	result := ret.(Model)
+	assert.Equal(t, before, result.overlay, "above the cluster picker, 'c' must not open the colour overlay")
 }
 
 func TestHandleKeyClusterColorPicker_AbovePickerLevelIsNoOp(t *testing.T) {

--- a/internal/app/cluster_color_overlay_test.go
+++ b/internal/app/cluster_color_overlay_test.go
@@ -40,33 +40,36 @@ func TestHandleKeyClusterColorPicker_AtClusterPickerOpensOverlay(t *testing.T) {
 	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext, "overlay captures the highlighted context name")
 }
 
-// TestHandleKey_C_RoutesToClusterColorPicker is the regression test for
-// the bug the user hit with Ctrl+L and Ctrl+K: every Ctrl+letter we
-// tried got intercepted by either the terminal emulator (Ctrl+L =
+// TestHandleKey_ShiftL_RoutesToClusterColorPicker is the regression
+// test for the bug the user hit with Ctrl+L / Ctrl+K: every Ctrl+letter
+// we tried got intercepted by either the terminal emulator (Ctrl+L =
 // redraw screen) or the shell input layer (Ctrl+K = kill-to-eol in
-// readline/ZLE), so the binding moved to a bare "c". The handler
-// self-gates on Level=Clusters so the bare letter is a no-op in any
-// other context and doesn't shadow in-context behaviours.
-func TestHandleKey_C_RoutesToClusterColorPicker(t *testing.T) {
+// readline/ZLE). Capital "L" works because the picker only exists at
+// Level=Clusters where Logs has no resource to act on — the dispatch
+// case is gated on Level=Clusters and breaks out at deeper levels so
+// "L" continues to open Logs everywhere else.
+func TestHandleKey_ShiftL_RoutesToClusterColorPicker(t *testing.T) {
 	m := newClusterPickerModel(t)
-	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
 	result := ret.(Model)
 	assert.Equal(t, overlayClusterColor, result.overlay,
-		"'c' at the cluster picker must route through handleKey to the cluster-color overlay")
+		"Shift+L at the cluster picker must route through handleKey to the cluster-color overlay")
 	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext)
 }
 
-// TestHandleKey_C_NoOpAboveClusterPicker ensures the handler's level
-// gate keeps the bare "c" key inert outside the cluster picker so it
-// doesn't accidentally consume keypresses elsewhere.
-func TestHandleKey_C_NoOpAboveClusterPicker(t *testing.T) {
+// TestHandleKey_ShiftL_FallsThroughAboveClusterPicker ensures the
+// dispatch's level gate lets "L" keep its Logs binding at deeper
+// levels — pressing "L" on a Pod must reach the Logs handler instead
+// of being eaten by the (gated) cluster-colour case.
+func TestHandleKey_ShiftL_FallsThroughAboveClusterPicker(t *testing.T) {
 	m := newClusterPickerModel(t)
 	m.nav.Level = model.LevelResources
 	m.nav.Context = "prod-eu"
 	before := m.overlay
-	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	ret, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
 	result := ret.(Model)
-	assert.Equal(t, before, result.overlay, "above the cluster picker, 'c' must not open the colour overlay")
+	assert.Equal(t, before, result.overlay,
+		"above the cluster picker, Shift+L must fall through the cluster-colour case so the existing Logs handler still fires")
 }
 
 func TestHandleKeyClusterColorPicker_AbovePickerLevelIsNoOp(t *testing.T) {

--- a/internal/app/cluster_color_overlay_test.go
+++ b/internal/app/cluster_color_overlay_test.go
@@ -174,6 +174,110 @@ func TestClusterColorOverlay_NoneRowClearsAndPersists(t *testing.T) {
 	assert.False(t, persistedPresent, "deletion is persisted to the state file")
 }
 
+func TestClusterColorOverlay_SlashEntersFilterMode(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	require.False(t, m.clusterColorFilterMode, "filter mode is off by default when the overlay opens")
+
+	ret, _ = m.handleClusterColorOverlayKey("/")
+	result := ret.(Model)
+	assert.True(t, result.clusterColorFilterMode,
+		"`/` flips into filter-input mode so the next keystrokes go into the filter buffer")
+}
+
+func TestClusterColorOverlay_FilterNarrowsList(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+
+	// Type "/", then two keys spelling "ll" — substring match against
+	// the names list narrows down to "yellow" only. Single letters
+	// match too liberally for an assertable test ("y" matches yellow,
+	// cyan, gray) so use a longer disambiguating substring.
+	ret, _ = m.handleClusterColorOverlayKey("/")
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("l")
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("l")
+	result := ret.(Model)
+
+	filtered := result.filteredClusterColorNames()
+	assert.Equal(t, []string{"yellow"}, filtered,
+		"substring filter must narrow the visible colour list to matches against the colour names")
+	assert.Equal(t, 0, result.clusterColorOverlayCursor,
+		"cursor resets to the first row when the filter changes so the highlight doesn't land on a stale index")
+}
+
+func TestClusterColorOverlay_FilterModeEscClearsFilter(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("/")
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("y")
+	m = ret.(Model)
+
+	ret, _ = m.handleClusterColorOverlayKey("esc")
+	result := ret.(Model)
+	assert.False(t, result.clusterColorFilterMode, "Esc in filter mode exits filter mode")
+	assert.Empty(t, result.clusterColorFilter.Value, "Esc in filter mode clears the buffer")
+	assert.Equal(t, overlayClusterColor, result.overlay,
+		"Esc in filter mode does NOT close the overlay — only clears the filter")
+}
+
+func TestClusterColorOverlay_NormalModeEscClearsFilterFirstThenCloses(t *testing.T) {
+	// Mirrors the colorscheme overlay's two-stage Esc: with a filter
+	// active, first Esc clears the filter; second Esc closes.
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("/")
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("y")
+	m = ret.(Model)
+	// Exit filter mode with Enter so we're back in normal mode but with
+	// the filter buffer still set.
+	ret, _ = m.handleClusterColorOverlayKey("enter")
+	m = ret.(Model)
+	require.NotEmpty(t, m.clusterColorFilter.Value, "filter buffer survives an Enter from filter mode")
+
+	// First Esc in normal mode: clears the filter, leaves overlay open.
+	ret, _ = m.handleClusterColorOverlayKey("esc")
+	m = ret.(Model)
+	assert.Empty(t, m.clusterColorFilter.Value)
+	assert.Equal(t, overlayClusterColor, m.overlay)
+
+	// Second Esc: closes.
+	ret, _ = m.handleClusterColorOverlayKey("esc")
+	result := ret.(Model)
+	assert.Equal(t, overlayNone, result.overlay)
+}
+
+func TestClusterColorOverlay_FilterAffectsApply(t *testing.T) {
+	// With the filter narrowed to "yellow", cursor=0 must apply
+	// "yellow", not "red" (which would be index 0 in the unfiltered
+	// list). Catches the off-by-everything bug where Apply would read
+	// from the unfiltered slice.
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("/")
+	m = ret.(Model)
+	ret, _ = m.handleClusterColorOverlayKey("y")
+	m = ret.(Model)
+	// Exit filter mode but keep the filter active.
+	ret, _ = m.handleClusterColorOverlayKey("enter")
+	m = ret.(Model)
+	// Cursor is at 0 = first filtered match = "yellow".
+	require.Equal(t, 0, m.clusterColorOverlayCursor)
+
+	ret, _ = m.handleClusterColorOverlayKey("enter")
+	result := ret.(Model)
+	assert.Equal(t, "yellow", result.clusterColors["prod-eu"],
+		"Apply with a filter active must read from the filtered list, not from ClusterColorNames directly")
+}
+
 func TestClusterColorOverlay_EscDoesNotMutate(t *testing.T) {
 	m := newClusterPickerModel(t)
 	m.clusterColors = map[string]string{"prod-eu": "yellow"}

--- a/internal/app/cluster_color_overlay_test.go
+++ b/internal/app/cluster_color_overlay_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// newClusterPickerModel returns a Model parked at the cluster picker with
+// two contexts and a temp XDG state dir so save() doesn't clobber the
+// developer's real cluster-colors file.
+func newClusterPickerModel(t *testing.T) Model {
+	t.Helper()
+	withClusterColorsStateDir(t)
+	return Model{
+		nav: model.NavigationState{Level: model.LevelClusters},
+		middleItems: []model.Item{
+			{Name: "prod-eu"},
+			{Name: "dev-local"},
+		},
+		cursors:           [5]int{0, 0, 0, 0, 0},
+		tabs:              []TabState{{}},
+		itemCache:         map[string][]model.Item{},
+		cacheFingerprints: map[string]string{},
+		clusterColors:     map[string]string{},
+		width:             80, height: 40,
+	}
+}
+
+func TestHandleKeyClusterColorPicker_AtClusterPickerOpensOverlay(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	result := ret.(Model)
+	assert.Equal(t, overlayClusterColor, result.overlay, "Ctrl+L at Level=Clusters opens the picker overlay")
+	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext, "overlay captures the highlighted context name")
+}
+
+func TestHandleKeyClusterColorPicker_AbovePickerLevelIsNoOp(t *testing.T) {
+	m := newClusterPickerModel(t)
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "prod-eu"
+	ret, _ := m.handleKeyClusterColorPicker()
+	result := ret.(Model)
+	assert.Equal(t, overlayNone, result.overlay, "outside the cluster picker the hotkey is a no-op")
+}
+
+func TestHandleKeyClusterColorPicker_NoSelectionIsNoOp(t *testing.T) {
+	m := newClusterPickerModel(t)
+	m.middleItems = nil
+	ret, _ := m.handleKeyClusterColorPicker()
+	result := ret.(Model)
+	assert.Equal(t, overlayNone, result.overlay, "with no row to target, the overlay must not open")
+}
+
+func TestHandleKeyClusterColorPicker_PreseedsCursorToCurrentColor(t *testing.T) {
+	m := newClusterPickerModel(t)
+	// "yellow" is index 1 in ui.ClusterColorNames.
+	m.clusterColors = map[string]string{"prod-eu": "yellow"}
+	ret, _ := m.handleKeyClusterColorPicker()
+	result := ret.(Model)
+	wantIdx := -1
+	for i, c := range ui.ClusterColorNames {
+		if c == "yellow" {
+			wantIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, wantIdx, 0)
+	assert.Equal(t, wantIdx, result.clusterColorOverlayCursor,
+		"opening on a coloured cluster pre-seeds the picker cursor to its current color")
+}
+
+func TestHandleKeyClusterColorPicker_PreseedsCursorToNoneWhenUnset(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	result := ret.(Model)
+	// "None / clear" lives at the end of the picker, after every named color.
+	assert.Equal(t, len(ui.ClusterColorNames), result.clusterColorOverlayCursor,
+		"opening on a non-coloured cluster pre-seeds cursor on the None / clear row")
+}
+
+func TestClusterColorOverlay_DownArrowMovesCursor(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	start := m.clusterColorOverlayCursor
+
+	ret, _ = m.handleClusterColorOverlayKey("down")
+	result := ret.(Model)
+	expected := (start + 1) % (len(ui.ClusterColorNames) + 1)
+	assert.Equal(t, expected, result.clusterColorOverlayCursor, "down arrow advances the cursor (wraps at end)")
+}
+
+func TestClusterColorOverlay_UpArrowMovesCursor(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	m.clusterColorOverlayCursor = 0
+
+	ret, _ = m.handleClusterColorOverlayKey("up")
+	result := ret.(Model)
+	assert.Equal(t, len(ui.ClusterColorNames), result.clusterColorOverlayCursor,
+		"up arrow at top wraps to the bottom (None row)")
+}
+
+func TestClusterColorOverlay_EnterAppliesColorAndCloses(t *testing.T) {
+	m := newClusterPickerModel(t)
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	m.clusterColorOverlayCursor = 0 // first color = "red"
+
+	ret, _ = m.handleClusterColorOverlayKey("enter")
+	result := ret.(Model)
+	assert.Equal(t, "red", result.clusterColors["prod-eu"], "Enter writes the selected color to the in-memory map")
+	assert.Equal(t, overlayNone, result.overlay, "Enter closes the overlay")
+
+	// Disk too — the file lookup hits the temp XDG dir set in
+	// newClusterPickerModel via withClusterColorsStateDir.
+	persisted := loadClusterColors()
+	assert.Equal(t, "red", persisted["prod-eu"], "Enter persists the selection so it survives restart")
+}
+
+func TestClusterColorOverlay_NoneRowClearsAndPersists(t *testing.T) {
+	m := newClusterPickerModel(t)
+	m.clusterColors = map[string]string{"prod-eu": "yellow"}
+	require.NoError(t, saveClusterColors(m.clusterColors))
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	m.clusterColorOverlayCursor = len(ui.ClusterColorNames) // "None" row
+
+	ret, _ = m.handleClusterColorOverlayKey("enter")
+	result := ret.(Model)
+	_, present := result.clusterColors["prod-eu"]
+	assert.False(t, present, "selecting None deletes the entry rather than storing an empty string")
+
+	persisted := loadClusterColors()
+	_, persistedPresent := persisted["prod-eu"]
+	assert.False(t, persistedPresent, "deletion is persisted to the state file")
+}
+
+func TestClusterColorOverlay_EscDoesNotMutate(t *testing.T) {
+	m := newClusterPickerModel(t)
+	m.clusterColors = map[string]string{"prod-eu": "yellow"}
+	require.NoError(t, saveClusterColors(m.clusterColors))
+	ret, _ := m.handleKeyClusterColorPicker()
+	m = ret.(Model)
+	m.clusterColorOverlayCursor = 0 // would have applied "red"
+
+	ret, _ = m.handleClusterColorOverlayKey("esc")
+	result := ret.(Model)
+	assert.Equal(t, "yellow", result.clusterColors["prod-eu"], "Esc must leave the in-memory state untouched")
+	assert.Equal(t, overlayNone, result.overlay, "Esc closes the overlay")
+
+	persisted := loadClusterColors()
+	assert.Equal(t, "yellow", persisted["prod-eu"], "Esc must not persist the would-be-applied color")
+}

--- a/internal/app/cluster_color_picker_swatch_test.go
+++ b/internal/app/cluster_color_picker_swatch_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestUpdateContextsLoaded_AnnotatesPerContextColor(t *testing.T) {
+	// updateContextsLoaded must walk the freshly loaded context list and
+	// stamp each Item.ClusterColor from m.clusterColors so the cluster-
+	// picker renderer can paint per-row swatches without taking the colors
+	// map as a render argument.
+	withClusterColorsStateDir(t)
+	m := Model{
+		nav:               model.NavigationState{Level: model.LevelClusters},
+		tabs:              []TabState{{}},
+		itemCache:         map[string][]model.Item{},
+		cacheFingerprints: map[string]string{},
+		clusterColors: map[string]string{
+			"prod-eu":   "red",
+			"dev-local": "green",
+		},
+		width: 80, height: 40,
+	}
+	msg := contextsLoadedMsg{
+		items: []model.Item{
+			{Name: "prod-eu"},
+			{Name: "dev-local"},
+			{Name: "scratch"},
+		},
+	}
+	ret, _ := m.updateContextsLoaded(msg)
+	result := ret.(Model)
+
+	assert.Equal(t, "red", result.middleItems[0].ClusterColor, "prod-eu must inherit its red assignment")
+	assert.Equal(t, "green", result.middleItems[1].ClusterColor, "dev-local must inherit its green assignment")
+	assert.Equal(t, "", result.middleItems[2].ClusterColor, "scratch (no entry in clusterColors) must have empty ClusterColor")
+}
+
+func TestOpenActionMenu_AtClusterPickerListsSetColor(t *testing.T) {
+	m := newClusterPickerModel(t)
+	result := m.openActionMenu()
+	assert.Equal(t, overlayAction, result.overlay, "x at Level=Clusters opens the action menu")
+	require.Len(t, result.overlayItems, 1, "today only one entry — Set color…")
+	assert.Equal(t, "Set color…", result.overlayItems[0].Name)
+}
+
+func TestExecuteAction_SetColorAtClusterPickerOpensColorOverlay(t *testing.T) {
+	m := newClusterPickerModel(t)
+	m.overlay = overlayAction
+	ret, _ := m.executeAction("Set color…")
+	result := ret.(Model)
+	assert.Equal(t, overlayClusterColor, result.overlay,
+		"selecting Set color… from the action menu hands off to the color picker overlay")
+	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext)
+}
+
+func TestApplyClusterColorSelection_RefreshesMiddleItemsRow(t *testing.T) {
+	// Saving a color from the overlay must immediately stamp the row in
+	// m.middleItems so the next render shows the swatch — without waiting
+	// for the next loadContexts roundtrip. Mirrors the index-based update
+	// in handleKeyReadOnlyToggle so a transient filtered-slice pointer
+	// can't leave the row stale.
+	withClusterColorsStateDir(t)
+	m := Model{
+		nav: model.NavigationState{Level: model.LevelClusters},
+		middleItems: []model.Item{
+			{Name: "prod-eu"},
+			{Name: "dev-local"},
+		},
+		cursors:                    [5]int{0, 0, 0, 0, 0},
+		tabs:                       []TabState{{}},
+		itemCache:                  map[string][]model.Item{},
+		cacheFingerprints:          map[string]string{},
+		clusterColors:              map[string]string{},
+		clusterColorOverlayContext: "prod-eu",
+		clusterColorOverlayCursor:  0, // "red"
+		overlay:                    overlayClusterColor,
+	}
+	result, _ := m.applyClusterColorSelection()
+
+	assert.Equal(t, "red", result.middleItems[0].ClusterColor, "row in m.middleItems must reflect the new color immediately")
+	assert.Equal(t, "", result.middleItems[1].ClusterColor, "non-targeted rows must be left untouched")
+}

--- a/internal/app/cluster_color_picker_swatch_test.go
+++ b/internal/app/cluster_color_picker_swatch_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 func TestUpdateContextsLoaded_AnnotatesPerContextColor(t *testing.T) {
@@ -45,17 +46,19 @@ func TestOpenActionMenu_AtClusterPickerListsSetColor(t *testing.T) {
 	m := newClusterPickerModel(t)
 	result := m.openActionMenu()
 	assert.Equal(t, overlayAction, result.overlay, "x at Level=Clusters opens the action menu")
-	require.Len(t, result.overlayItems, 1, "today only one entry — Set color…")
-	assert.Equal(t, "Set color…", result.overlayItems[0].Name)
+	require.Len(t, result.overlayItems, 1, "today only one entry — Set color")
+	assert.Equal(t, "Set color", result.overlayItems[0].Name)
+	assert.Equal(t, ui.ActiveKeybindings.ClusterColorPicker, result.overlayItems[0].Status,
+		"Status carries the keybinding so the action menu renders [L] Set color and the in-menu shortcut matches the global one")
 }
 
 func TestExecuteAction_SetColorAtClusterPickerOpensColorOverlay(t *testing.T) {
 	m := newClusterPickerModel(t)
 	m.overlay = overlayAction
-	ret, _ := m.executeAction("Set color…")
+	ret, _ := m.executeAction("Set color")
 	result := ret.(Model)
 	assert.Equal(t, overlayClusterColor, result.overlay,
-		"selecting Set color… from the action menu hands off to the color picker overlay")
+		"selecting Set color from the action menu hands off to the color picker overlay")
 	assert.Equal(t, "prod-eu", result.clusterColorOverlayContext)
 }
 

--- a/internal/app/cluster_color_render_test.go
+++ b/internal/app/cluster_color_render_test.go
@@ -4,10 +4,25 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
+
+// forceANSIRendering switches lipgloss to the ANSI colour profile so
+// styled strings actually emit colour SGR codes during the test —
+// otherwise lipgloss strips colour when stdout isn't a TTY (the
+// `go test` default), which makes it impossible to distinguish a
+// tinted from an untinted render by string comparison.
+func forceANSIRendering(t *testing.T) {
+	t.Helper()
+	r := lipgloss.DefaultRenderer()
+	prev := r.ColorProfile()
+	r.SetColorProfile(termenv.ANSI)
+	t.Cleanup(func() { r.SetColorProfile(prev) })
+}
 
 func TestClusterColorForActiveContext_ReturnsAssignedColor(t *testing.T) {
 	m := Model{
@@ -37,23 +52,30 @@ func TestClusterColorForActiveContext_EmptyForUnknownContext(t *testing.T) {
 }
 
 func TestRenderTitleBar_TintedWhenContextHasColor(t *testing.T) {
-	m := minimalRenderableModel()
-	m.nav = model.NavigationState{Level: model.LevelResources, Context: "prod-eu"}
-	m.clusterColors = map[string]string{"prod-eu": "red"}
-	out := m.renderTitleBar()
+	// lipgloss strips colour when not on a TTY, so without forcing the
+	// ANSI profile here the tinted and untinted renders would produce
+	// identical plain-text strings and the NotEqual would be a
+	// tautology even with the test fix CodeRabbit suggested.
+	forceANSIRendering(t)
 
-	// The tinted title bar must include the breadcrumb and namespace badge
-	// — i.e. the existing structure must keep working — and additionally
-	// the bar background must be the tinted style. We probe the latter by
-	// confirming the rendered output is *different* between the tinted and
-	// untinted variants.
-	mUnt := minimalRenderableModel()
-	mUnt.nav = model.NavigationState{Level: model.LevelResources, Context: "scratch"}
-	untinted := mUnt.renderTitleBar()
+	// Both variants use the SAME context so any difference in output is
+	// attributable to the cluster-color tint rather than incidental
+	// breadcrumb / context text differences. CodeRabbit caught the prior
+	// version using different contexts which made NotEqual a tautology.
+	mTinted := minimalRenderableModel()
+	mTinted.nav = model.NavigationState{Level: model.LevelResources, Context: "prod-eu"}
+	mTinted.clusterColors = map[string]string{"prod-eu": "red"}
+	tinted := mTinted.renderTitleBar()
 
-	assert.NotEqual(t, untinted, out, "tinted title bar must differ visually from the untinted variant")
-	assert.True(t, strings.Contains(out, "scratch") || strings.Contains(out, "prod-eu") || true,
-		"sanity: the breadcrumb section must still render (placeholder check)")
+	mPlain := minimalRenderableModel()
+	mPlain.nav = model.NavigationState{Level: model.LevelResources, Context: "prod-eu"}
+	mPlain.clusterColors = nil // same context, no color: only the tint can differ
+	plain := mPlain.renderTitleBar()
+
+	assert.NotEqual(t, plain, tinted,
+		"tinted title bar must differ visually from the untinted variant when only the colour assignment changes")
+	assert.True(t, strings.Contains(tinted, "prod-eu"),
+		"sanity: the breadcrumb section must still render the context name in the tinted variant")
 }
 
 func TestRenderTitleBar_NotTintedAtClusterPicker(t *testing.T) {

--- a/internal/app/cluster_color_render_test.go
+++ b/internal/app/cluster_color_render_test.go
@@ -1,0 +1,82 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestClusterColorForActiveContext_ReturnsAssignedColor(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelResources, Context: "prod-eu"},
+		clusterColors: map[string]string{"prod-eu": "red"},
+	}
+	assert.Equal(t, "red", m.clusterColorForActiveContext(),
+		"inside a context with a stored color, the color must surface to the title bar")
+}
+
+func TestClusterColorForActiveContext_EmptyAtClusterPicker(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelClusters},
+		clusterColors: map[string]string{"prod-eu": "red"},
+	}
+	assert.Equal(t, "", m.clusterColorForActiveContext(),
+		"at the cluster picker there is no active context — return no color so the bar stays neutral")
+}
+
+func TestClusterColorForActiveContext_EmptyForUnknownContext(t *testing.T) {
+	m := Model{
+		nav:           model.NavigationState{Level: model.LevelResources, Context: "scratch"},
+		clusterColors: map[string]string{"prod-eu": "red"},
+	}
+	assert.Equal(t, "", m.clusterColorForActiveContext(),
+		"context with no color stored must produce no tint")
+}
+
+func TestRenderTitleBar_TintedWhenContextHasColor(t *testing.T) {
+	m := minimalRenderableModel()
+	m.nav = model.NavigationState{Level: model.LevelResources, Context: "prod-eu"}
+	m.clusterColors = map[string]string{"prod-eu": "red"}
+	out := m.renderTitleBar()
+
+	// The tinted title bar must include the breadcrumb and namespace badge
+	// — i.e. the existing structure must keep working — and additionally
+	// the bar background must be the tinted style. We probe the latter by
+	// confirming the rendered output is *different* between the tinted and
+	// untinted variants.
+	mUnt := minimalRenderableModel()
+	mUnt.nav = model.NavigationState{Level: model.LevelResources, Context: "scratch"}
+	untinted := mUnt.renderTitleBar()
+
+	assert.NotEqual(t, untinted, out, "tinted title bar must differ visually from the untinted variant")
+	assert.True(t, strings.Contains(out, "scratch") || strings.Contains(out, "prod-eu") || true,
+		"sanity: the breadcrumb section must still render (placeholder check)")
+}
+
+func TestRenderTitleBar_NotTintedAtClusterPicker(t *testing.T) {
+	m := minimalRenderableModel()
+	m.nav = model.NavigationState{Level: model.LevelClusters}
+	m.clusterColors = map[string]string{"prod-eu": "red"}
+
+	mPlain := minimalRenderableModel()
+	mPlain.nav = model.NavigationState{Level: model.LevelClusters}
+	mPlain.clusterColors = nil
+
+	assert.Equal(t, mPlain.renderTitleBar(), m.renderTitleBar(),
+		"at the cluster picker the bar must be identical regardless of stored colors")
+}
+
+// minimalRenderableModel returns a Model with the bare minimum state for
+// renderTitleBar to run without panicking. Width/height are wide enough that
+// the breadcrumb truncation logic doesn't trigger and complicate diffs.
+func minimalRenderableModel() Model {
+	return Model{
+		width:  120,
+		height: 40,
+		nav:    model.NavigationState{Level: model.LevelClusters},
+		tabs:   []TabState{{}},
+	}
+}

--- a/internal/app/cluster_colors.go
+++ b/internal/app/cluster_colors.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// clusterColorsSchemaVersion bumps whenever the on-disk shape changes.
+// loadClusterColors rejects unknown versions so older binaries don't trip on
+// a forward-incompat write from a newer one — the worst case is the user
+// loses their colour assignments until they re-set them.
+const clusterColorsSchemaVersion = 1
+
+// clusterColorsState is the on-disk shape: schema-versioned map of context
+// name → colour name. The colour name must be one of ui.ClusterColorNames.
+type clusterColorsState struct {
+	SchemaVersion int               `json:"schema_version"`
+	Contexts      map[string]string `json:"contexts"`
+}
+
+// clusterColorsFilePath returns the path to the cluster-colors state file.
+// Uses $XDG_STATE_HOME/lfk/ (defaults to ~/.local/state/lfk/) per XDG spec —
+// same convention as bookmarks.yaml and the input histories.
+func clusterColorsFilePath() string {
+	stateDir := os.Getenv("XDG_STATE_HOME")
+	if stateDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		stateDir = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateDir, "lfk", "cluster-colors.yaml")
+}
+
+// loadClusterColors reads the cluster-colours map from disk. Returns an
+// empty (non-nil) map on any failure — missing file, corrupt YAML, schema
+// mismatch — so callers can treat it as "no colours assigned yet". Unknown
+// colour names are dropped silently; a typo on one entry must not poison
+// the rest of the file.
+func loadClusterColors() map[string]string {
+	out := make(map[string]string)
+	path := clusterColorsFilePath()
+	if path == "" {
+		return out
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Warn("Cluster colors read failed", "path", path, "error", err)
+		}
+		return out
+	}
+	var s clusterColorsState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		logger.Warn("Cluster colors file is corrupt; ignoring", "path", path, "error", err)
+		return out
+	}
+	if s.SchemaVersion != clusterColorsSchemaVersion {
+		logger.Info("Cluster colors schema version mismatch; ignoring",
+			"path", path, "got", s.SchemaVersion, "want", clusterColorsSchemaVersion)
+		return out
+	}
+	for ctx, color := range s.Contexts {
+		if !ui.IsValidClusterColor(color) {
+			logger.Warn("Cluster colors: dropping unknown color", "context", ctx, "color", color)
+			continue
+		}
+		out[ctx] = color
+	}
+	return out
+}
+
+// saveClusterColors writes the cluster-colours map to disk atomically
+// (sibling .tmp + rename) so a crash mid-write can't leave a half-written
+// file that loadClusterColors would discard. Rejects unknown colour names
+// at the boundary so the on-disk file is always valid.
+func saveClusterColors(colors map[string]string) error {
+	for ctx, color := range colors {
+		if !ui.IsValidClusterColor(color) {
+			return fmt.Errorf("cluster colors: unknown color %q for context %q", color, ctx)
+		}
+	}
+	path := clusterColorsFilePath()
+	if path == "" {
+		return errors.New("cluster colors: cannot resolve state file path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	state := clusterColorsState{
+		SchemaVersion: clusterColorsSchemaVersion,
+		Contexts:      colors,
+	}
+	data, err := yaml.Marshal(state)
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/app/cluster_colors.go
+++ b/internal/app/cluster_colors.go
@@ -103,9 +103,36 @@ func saveClusterColors(colors map[string]string) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	// Use os.CreateTemp with a unique suffix instead of a fixed ".tmp"
+	// sibling so two concurrent saves can't collide on the temp filename
+	// — a fixed suffix would race in the (admittedly unusual) case of
+	// two lfk instances saving to the same XDG state dir at the same
+	// moment, leaving one with a half-written file or a botched rename.
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp.*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmpPath := tmpFile.Name()
+	// Best-effort cleanup if anything below fails: the temp file is
+	// orphaned and will not be retried on next save.
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
 }

--- a/internal/app/cluster_colors_test.go
+++ b/internal/app/cluster_colors_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withClusterColorsStateDir points XDG_STATE_HOME at a fresh temp dir so each
+// test gets an isolated cluster-colors file without touching the user's real
+// state dir. Returns the dir for path assertions.
+func withClusterColorsStateDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	return dir
+}
+
+func TestClusterColors_RoundTrip(t *testing.T) {
+	withClusterColorsStateDir(t)
+
+	in := map[string]string{
+		"prod-eu":    "red",
+		"staging-eu": "yellow",
+		"dev-local":  "green",
+	}
+	require.NoError(t, saveClusterColors(in))
+
+	loaded := loadClusterColors()
+	assert.Equal(t, in, loaded)
+}
+
+func TestClusterColors_LivesUnderXDGStateHome(t *testing.T) {
+	dir := withClusterColorsStateDir(t)
+
+	require.NoError(t, saveClusterColors(map[string]string{"prod": "red"}))
+
+	expected := filepath.Join(dir, "lfk", "cluster-colors.yaml")
+	_, err := os.Stat(expected)
+	assert.NoError(t, err, "state file must live at <XDG_STATE_HOME>/lfk/cluster-colors.yaml, got: %s", expected)
+}
+
+func TestLoadClusterColors_MissingFileReturnsEmpty(t *testing.T) {
+	withClusterColorsStateDir(t)
+	got := loadClusterColors()
+	assert.Empty(t, got, "missing file should yield an empty map (graceful fallback)")
+}
+
+func TestLoadClusterColors_CorruptFileReturnsEmpty(t *testing.T) {
+	dir := withClusterColorsStateDir(t)
+	path := filepath.Join(dir, "lfk", "cluster-colors.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("this: is: not: yaml: ::"), 0o644))
+
+	got := loadClusterColors()
+	assert.Empty(t, got, "corrupt YAML must not panic and must fall back to empty map")
+}
+
+func TestLoadClusterColors_FutureSchemaReturnsEmpty(t *testing.T) {
+	dir := withClusterColorsStateDir(t)
+	path := filepath.Join(dir, "lfk", "cluster-colors.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`schema_version: 999
+contexts:
+  prod: red
+`), 0o644))
+
+	got := loadClusterColors()
+	assert.Empty(t, got, "unknown schema version must be ignored so older binaries don't trip on a forward-incompat write")
+}
+
+func TestLoadClusterColors_DropsUnknownColors(t *testing.T) {
+	dir := withClusterColorsStateDir(t)
+	path := filepath.Join(dir, "lfk", "cluster-colors.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`schema_version: 1
+contexts:
+  prod-eu: red
+  weird: chartreuse
+  dev: green
+`), 0o644))
+
+	got := loadClusterColors()
+	assert.Equal(t, map[string]string{
+		"prod-eu": "red",
+		"dev":     "green",
+	}, got, "unknown color names must be dropped silently so a typo doesn't poison every other entry")
+}
+
+func TestSaveClusterColors_Atomic(t *testing.T) {
+	dir := withClusterColorsStateDir(t)
+	require.NoError(t, saveClusterColors(map[string]string{"prod": "red"}))
+
+	// No leftover .tmp file after a successful write.
+	tmpPath := filepath.Join(dir, "lfk", "cluster-colors.yaml.tmp")
+	_, err := os.Stat(tmpPath)
+	assert.True(t, os.IsNotExist(err), ".tmp sibling must be renamed away on successful save")
+}
+
+func TestSaveClusterColors_EmptyMapClearsFile(t *testing.T) {
+	withClusterColorsStateDir(t)
+	require.NoError(t, saveClusterColors(map[string]string{"prod": "red"}))
+	require.NoError(t, saveClusterColors(map[string]string{}))
+
+	got := loadClusterColors()
+	assert.Empty(t, got, "saving an empty map should leave nothing for a subsequent load")
+}
+
+func TestSaveClusterColors_RejectsUnknownColor(t *testing.T) {
+	withClusterColorsStateDir(t)
+	err := saveClusterColors(map[string]string{"prod": "chartreuse"})
+	assert.Error(t, err, "unknown colors must be rejected at save time so callers can surface a UI error")
+}

--- a/internal/app/cluster_colors_test.go
+++ b/internal/app/cluster_colors_test.go
@@ -46,6 +46,10 @@ func TestClusterColors_LivesUnderXDGStateHome(t *testing.T) {
 func TestLoadClusterColors_MissingFileReturnsEmpty(t *testing.T) {
 	withClusterColorsStateDir(t)
 	got := loadClusterColors()
+	// NotNil + Empty: callers always range over the returned map, so it
+	// must be a real (empty) map and not nil — defends the contract
+	// loadClusterColors documents.
+	assert.NotNil(t, got, "missing file must yield a real map, not nil")
 	assert.Empty(t, got, "missing file should yield an empty map (graceful fallback)")
 }
 
@@ -56,6 +60,7 @@ func TestLoadClusterColors_CorruptFileReturnsEmpty(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("this: is: not: yaml: ::"), 0o644))
 
 	got := loadClusterColors()
+	assert.NotNil(t, got, "corrupt file must yield a real map, not nil")
 	assert.Empty(t, got, "corrupt YAML must not panic and must fall back to empty map")
 }
 
@@ -69,6 +74,7 @@ contexts:
 `), 0o644))
 
 	got := loadClusterColors()
+	assert.NotNil(t, got, "future schema must yield a real map, not nil")
 	assert.Empty(t, got, "unknown schema version must be ignored so older binaries don't trip on a forward-incompat write")
 }
 

--- a/internal/app/filter_input.go
+++ b/internal/app/filter_input.go
@@ -118,6 +118,7 @@ const (
 	pasteTargetBookmarkFilter
 	pasteTargetLogPodFilter
 	pasteTargetLogContainerFilter
+	pasteTargetClusterColorFilter
 )
 
 // triggerPasteConfirm sets up the paste confirmation overlay for multiline input.
@@ -142,6 +143,8 @@ func (m *Model) resolvePasteTarget(id pasteTarget) FilterInput {
 		return &m.templateFilter
 	case pasteTargetSchemeFilter:
 		return &m.schemeFilter
+	case pasteTargetClusterColorFilter:
+		return &m.clusterColorFilter
 	case pasteTargetBookmarkFilter:
 		return &m.bookmarkFilter
 	case pasteTargetLogPodFilter:

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -159,6 +159,19 @@ func (m Model) overlayHintBarSelector() string {
 			{Key: "/", Desc: "filter"},
 			{Key: "esc", Desc: "close"},
 		})
+	case overlayClusterColor:
+		if m.clusterColorFilterMode {
+			return m.renderHints([]ui.HintEntry{
+				{Key: "enter", Desc: "accept filter"},
+				{Key: "esc", Desc: "clear filter"},
+			})
+		}
+		return m.renderHints([]ui.HintEntry{
+			{Key: "j/k", Desc: "navigate"},
+			{Key: "/", Desc: "filter"},
+			{Key: "enter", Desc: "apply"},
+			{Key: "esc", Desc: "close"},
+		})
 	}
 	return ""
 }

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -60,6 +60,29 @@ func (m Model) openActionMenu() Model {
 		return m
 	}
 
+	// At the cluster picker, the action menu is a tiny per-cluster
+	// metadata menu. Today only "Set color…" lives there; Ctrl+R remains
+	// the hotkey for read-only. The dedicated branch keeps the kind-based
+	// `selectedResourceKind` machinery below from firing on a level that
+	// has no resource type.
+	if m.nav.Level == model.LevelClusters {
+		sel := m.selectedMiddleItem()
+		if sel == nil {
+			return m
+		}
+		m.bulkMode = false
+		m.overlay = overlayAction
+		m.overlayItems = []model.Item{
+			{
+				Name:   "Set color…",
+				Extra:  "Assign a background tint to this cluster",
+				Status: "color",
+			},
+		}
+		m.overlayCursor = 0
+		return m
+	}
+
 	kind := m.selectedResourceKind()
 	if kind == "" {
 		return m
@@ -300,6 +323,14 @@ func (m Model) directActionScale() (tea.Model, tea.Cmd) {
 
 func (m Model) executeAction(actionLabel string) (tea.Model, tea.Cmd) {
 	m.overlay = overlayNone
+
+	// Cluster-picker actions live outside the kind-based machinery: they
+	// don't have an actionCtx and there is no resource type at this level.
+	// Dispatch them by label and short-circuit before the read-only check
+	// fires on a label that has no kind to consult.
+	if m.nav.Level == model.LevelClusters && actionLabel == "Set color…" {
+		return m.handleKeyClusterColorPicker()
+	}
 
 	// Handle bulk actions.
 	if m.bulkMode && len(m.bulkItems) > 0 {

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -74,9 +74,15 @@ func (m Model) openActionMenu() Model {
 		m.overlay = overlayAction
 		m.overlayItems = []model.Item{
 			{
-				Name:   "Set color…",
-				Extra:  "Assign a background tint to this cluster",
-				Status: "color",
+				Name: "Set color",
+				// "Status" doubles as the in-menu hotkey hint
+				// rendered as "[L] Set color - …" by RenderActionOverlay.
+				// Using the same key the global handler uses
+				// (kb.ClusterColorPicker) keeps the menu and the bare
+				// keypress in sync, so users who learn one path
+				// automatically know the other.
+				Status: ui.ActiveKeybindings.ClusterColorPicker,
+				Extra:  "Assign a background tint to this context",
 			},
 		}
 		m.overlayCursor = 0
@@ -328,7 +334,7 @@ func (m Model) executeAction(actionLabel string) (tea.Model, tea.Cmd) {
 	// don't have an actionCtx and there is no resource type at this level.
 	// Dispatch them by label and short-circuit before the read-only check
 	// fires on a label that has no kind to consult.
-	if m.nav.Level == model.LevelClusters && actionLabel == "Set color…" {
+	if m.nav.Level == model.LevelClusters && actionLabel == "Set color" {
 		return m.handleKeyClusterColorPicker()
 	}
 

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -124,6 +124,12 @@ func (m Model) handleExplorerNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		mdl, cmd := m.handleKeyReadOnlyToggle()
 		return mdl, cmd, true
 	case kb.ClusterColorPicker:
+		// Gate on Level=Clusters so the bare-letter default "c" doesn't
+		// silently shadow other handlers at deeper levels — the handler
+		// also self-gates as a defensive belt-and-braces measure.
+		if m.nav.Level != model.LevelClusters {
+			break
+		}
 		mdl, cmd := m.handleKeyClusterColorPicker()
 		return mdl, cmd, true
 	case kb.Right, "right":

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -123,6 +123,9 @@ func (m Model) handleExplorerNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	case kb.ReadOnlyToggle:
 		mdl, cmd := m.handleKeyReadOnlyToggle()
 		return mdl, cmd, true
+	case kb.ClusterColorPicker:
+		mdl, cmd := m.handleKeyClusterColorPicker()
+		return mdl, cmd, true
 	case kb.Right, "right":
 		mdl, cmd := m.navigateChild()
 		return mdl, cmd, true

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -164,6 +164,9 @@ func (m Model) handleOverlayKeySecondary(msg tea.KeyMsg) (tea.Model, tea.Cmd, bo
 	case overlayPasteConfirm:
 		mdl, cmd := m.handlePasteConfirmKey(msg)
 		return mdl, cmd, true
+	case overlayClusterColor:
+		mdl, cmd := m.handleClusterColorOverlayKey(msg.String())
+		return mdl, cmd, true
 	}
 	return m, nil, false
 }

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -42,6 +42,8 @@ func (m Model) isOverlayToggleKey(key string) bool {
 		return key == kb.ColumnToggle
 	case overlayQuotaDashboard:
 		return key == kb.QuotaDashboard
+	case overlayClusterColor:
+		return key == kb.ClusterColorPicker
 	}
 	return false
 }

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -25,6 +25,7 @@ func (m Model) updateContextsLoaded(msg contextsLoadedMsg) (tea.Model, tea.Cmd) 
 	// ensures Ctrl+R toggles survive a context list refresh.
 	for i := range msg.items {
 		msg.items[i].ReadOnly = m.effectiveContextReadOnly(msg.items[i].Name)
+		msg.items[i].ClusterColor = m.clusterColors[msg.items[i].Name]
 	}
 	m.setMiddleItems(msg.items)
 	m.itemCache[m.navKey()] = m.middleItems

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -435,9 +435,23 @@ func (m Model) renderTitleBar() string {
 	}
 	nsLabel := ui.NamespaceBadgeStyle.Render(" ns: " + nsText + " ")
 
+	// Resolve cluster-tint up front so the breadcrumb / gap / version
+	// segments below can use the tint as their *own* background instead
+	// of leaning on the outer wrapping style. Wrapping a string of
+	// pre-styled segments in an outer Background only fills cells that
+	// don't already have a background — and every segment here has one
+	// (barBg or a badge bg). Without per-segment overrides, only the
+	// wrapper's Padding cells would show the tint.
+	tint := m.clusterColorForActiveContext()
+	tintStyle := ui.ClusterColorTitleBarStyle(tint)
+
 	var versionLabel string
 	if m.version != "" {
-		versionLabel = ui.BarDimStyle.Render(" " + m.version)
+		if tint != "" {
+			versionLabel = tintStyle.Render(" " + m.version)
+		} else {
+			versionLabel = ui.BarDimStyle.Render(" " + m.version)
+		}
 	}
 
 	// Calculate available width for breadcrumb.
@@ -453,19 +467,32 @@ func (m Model) renderTitleBar() string {
 			bcText = string(runes[:maxBcWidth-2]) + "~ "
 		}
 	}
-	bc := ui.TitleBreadcrumbStyle.Render(bcText)
+	var bc string
+	if tint != "" {
+		// Bold black-on-bright matches ClusterColorTitleBarStyle and keeps
+		// the breadcrumb path legible against every named tint.
+		bc = tintStyle.Render(bcText)
+	} else {
+		bc = ui.TitleBreadcrumbStyle.Render(bcText)
+	}
 
 	contentWidth := lipgloss.Width(bc) + lipgloss.Width(watchIndicator) + lipgloss.Width(readOnlyIndicator) + lipgloss.Width(mutationProgress) + lipgloss.Width(tasksIndicator) + lipgloss.Width(nsLabel) + lipgloss.Width(versionLabel)
 	gap := max(innerWidth-contentWidth, 0)
 
-	barContent := bc + watchIndicator + readOnlyIndicator + ui.BarDimStyle.Render(strings.Repeat(" ", gap)) + mutationProgress + tasksIndicator + nsLabel + versionLabel
-	if tint := m.clusterColorForActiveContext(); tint != "" {
-		// Inside a context with a stored colour: tint the whole title bar
-		// background so the operator cannot miss which environment they
-		// are about to act on. Renders the bar background directly with
-		// the cluster-color style and lets the existing badges keep their
-		// own foregrounds — the bold-on-bright contrast keeps them legible.
-		return ui.ClusterColorTitleBarStyle(tint).
+	var gapContent string
+	if tint != "" {
+		gapContent = tintStyle.Render(strings.Repeat(" ", gap))
+	} else {
+		gapContent = ui.BarDimStyle.Render(strings.Repeat(" ", gap))
+	}
+
+	barContent := bc + watchIndicator + readOnlyIndicator + gapContent + mutationProgress + tasksIndicator + nsLabel + versionLabel
+	if tint != "" {
+		// Outer wrap also uses the tint so the Padding(0, 1) cells share
+		// the bar background — the inner segments each carry the tint
+		// explicitly so it spans every column even with the [RO] / ns /
+		// watch badges layered on top with their own backgrounds.
+		return tintStyle.
 			Width(m.width).MaxWidth(m.width).MaxHeight(1).
 			Padding(0, 1).
 			Render(barContent)

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -392,9 +392,22 @@ func (m Model) renderTitleBar() string {
 	// The inner content area is m.width - 2.
 	innerWidth := max(m.width-2, 10)
 
+	// Resolve cluster-tint up front: when set, every segment that
+	// normally carries barBg needs to swap to the tint colour as its
+	// background instead \u2014 otherwise the tint only fills cells without
+	// an explicit bg (the wrapper's Padding cells), leaving badges /
+	// breadcrumb / gap looking untinted.
+	tint := m.clusterColorForActiveContext()
+	tintStyle := ui.ClusterColorTitleBarStyle(tint)
+	tintBg := tintStyle.GetBackground()
+
 	var watchIndicator string
 	if m.watchMode {
-		watchIndicator = ui.HelpKeyStyle.Render(" \u27f3 ")
+		st := ui.HelpKeyStyle
+		if tint != "" {
+			st = st.Background(tintBg)
+		}
+		watchIndicator = st.Render(" \u27f3 ")
 	}
 
 	var readOnlyIndicator string
@@ -409,8 +422,13 @@ func (m Model) renderTitleBar() string {
 	var mutationProgress, tasksIndicator string
 	if m.bgtasks != nil && m.bgtasks.Len() > 0 {
 		snap := m.bgtasks.Snapshot()
-		mutationProgress = renderMutationProgress(m.spinner.View(), snap)
-		tasksIndicator = renderTasksIndicator(m.spinner.View(), snap)
+		if tint != "" {
+			mutationProgress = renderMutationProgressOverrideBg(m.spinner.View(), snap, tintBg)
+			tasksIndicator = renderTasksIndicatorOverrideBg(m.spinner.View(), snap, tintBg)
+		} else {
+			mutationProgress = renderMutationProgress(m.spinner.View(), snap)
+			tasksIndicator = renderTasksIndicator(m.spinner.View(), snap)
+		}
 	}
 
 	nsText := m.namespace
@@ -434,16 +452,6 @@ func (m Model) renderTitleBar() string {
 		}
 	}
 	nsLabel := ui.NamespaceBadgeStyle.Render(" ns: " + nsText + " ")
-
-	// Resolve cluster-tint up front so the breadcrumb / gap / version
-	// segments below can use the tint as their *own* background instead
-	// of leaning on the outer wrapping style. Wrapping a string of
-	// pre-styled segments in an outer Background only fills cells that
-	// don't already have a background — and every segment here has one
-	// (barBg or a badge bg). Without per-segment overrides, only the
-	// wrapper's Padding cells would show the tint.
-	tint := m.clusterColorForActiveContext()
-	tintStyle := ui.ClusterColorTitleBarStyle(tint)
 
 	var versionLabel string
 	if m.version != "" {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -459,6 +459,17 @@ func (m Model) renderTitleBar() string {
 	gap := max(innerWidth-contentWidth, 0)
 
 	barContent := bc + watchIndicator + readOnlyIndicator + ui.BarDimStyle.Render(strings.Repeat(" ", gap)) + mutationProgress + tasksIndicator + nsLabel + versionLabel
+	if tint := m.clusterColorForActiveContext(); tint != "" {
+		// Inside a context with a stored colour: tint the whole title bar
+		// background so the operator cannot miss which environment they
+		// are about to act on. Renders the bar background directly with
+		// the cluster-color style and lets the existing badges keep their
+		// own foregrounds — the bold-on-bright contrast keeps them legible.
+		return ui.ClusterColorTitleBarStyle(tint).
+			Width(m.width).MaxWidth(m.width).MaxHeight(1).
+			Padding(0, 1).
+			Render(barContent)
+	}
 	return ui.TitleBarStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(barContent)
 }
 

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -139,6 +139,9 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 	case overlayPasteConfirm:
 		lineCount := strings.Count(strings.TrimRight(m.pendingPaste, "\n"), "\n") + 1
 		return ui.RenderPasteConfirmOverlay(lineCount), min(45, m.width-10), min(8, m.height-6), true
+	case overlayClusterColor:
+		content := ui.RenderClusterColorOverlay(m.clusterColorOverlayContext, m.clusterColorOverlayCursor)
+		return content, min(40, m.width-10), min(13, m.height-6), true
 	}
 	return "", 0, 0, false
 }

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -140,8 +140,14 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 		lineCount := strings.Count(strings.TrimRight(m.pendingPaste, "\n"), "\n") + 1
 		return ui.RenderPasteConfirmOverlay(lineCount), min(45, m.width-10), min(8, m.height-6), true
 	case overlayClusterColor:
-		content := ui.RenderClusterColorOverlay(m.clusterColorOverlayContext, m.clusterColorOverlayCursor)
-		return content, min(40, m.width-10), min(13, m.height-6), true
+		content := ui.RenderClusterColorOverlay(
+			m.clusterColorOverlayContext,
+			m.filteredClusterColorNames(),
+			m.clusterColorOverlayCursor,
+			m.clusterColorFilter.Value,
+			m.clusterColorFilterMode,
+		)
+		return content, min(40, m.width-10), min(15, m.height-6), true
 	}
 	return "", 0, 0, false
 }

--- a/internal/app/view_titlebar_tasks.go
+++ b/internal/app/view_titlebar_tasks.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/janosmiko/lfk/internal/app/bgtasks"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -49,6 +51,39 @@ func renderMutationProgress(spinnerFrame string, snapshot []bgtasks.Task) string
 		label := shortMutationLabel(t.Name)
 		text := fmt.Sprintf(" %s %d/%d %s ", label, t.Current, t.Total, spinnerFrame)
 		return ui.StatusMessageOkStyle.Render(text)
+	}
+	return ""
+}
+
+// renderTasksIndicatorOverrideBg is renderTasksIndicator with the
+// background colour swapped to bg. Used by the title-bar render path
+// when a cluster colour tint is active, so the background of the
+// indicator matches the rest of the bar instead of leaking the default
+// barBg through.
+func renderTasksIndicatorOverrideBg(spinnerFrame string, snapshot []bgtasks.Task, bg lipgloss.TerminalColor) string {
+	n := 0
+	for _, t := range snapshot {
+		if t.Kind == bgtasks.KindMutation && t.Total > 0 {
+			continue
+		}
+		n++
+	}
+	if n == 0 {
+		return ""
+	}
+	return ui.BarDimStyle.Background(bg).Render(" " + spinnerFrame + " ")
+}
+
+// renderMutationProgressOverrideBg is renderMutationProgress with the
+// background colour swapped to bg. See renderTasksIndicatorOverrideBg.
+func renderMutationProgressOverrideBg(spinnerFrame string, snapshot []bgtasks.Task, bg lipgloss.TerminalColor) string {
+	for _, t := range snapshot {
+		if t.Kind != bgtasks.KindMutation || t.Total == 0 {
+			continue
+		}
+		label := shortMutationLabel(t.Name)
+		text := fmt.Sprintf(" %s %d/%d %s ", label, t.Current, t.Total, spinnerFrame)
+		return ui.StatusMessageOkStyle.Background(bg).Render(text)
 	}
 	return ""
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -129,6 +129,7 @@ type Item struct {
 	Deprecated    bool             // Whether this resource uses a deprecated API version
 	Deleting      bool             // Whether this resource has a deletionTimestamp set
 	ReadOnly      bool             // Whether this item represents a context locked in read-only mode (renders as a [RO] suffix in the picker)
+	ClusterColor  string           // Optional named color (one of ui.ClusterColorNames) for context rows; empty = no swatch.
 	GroupedRefs   []GroupedRef     // For grouped rows (Events): all underlying resource identifiers
 }
 

--- a/internal/ui/cluster_color.go
+++ b/internal/ui/cluster_color.go
@@ -45,21 +45,27 @@ func IsValidClusterColor(name string) bool {
 }
 
 // clusterColorBg resolves the named colour to a lipgloss background.
-// Theme-mapped names (red/yellow/green/blue) resolve to the current
-// theme tokens so they propagate when the user switches colorschemes;
-// the rest map to ANSI bright codes that follow the terminal palette.
+// Theme-mapped names (red/yellow/green/blue) read directly from
+// ActiveTheme so a colorscheme switch propagates on the next render —
+// the package-level Color* slots are stuck on Tokyo Night defaults
+// (they only branch between "default" and "no-color blanked" inside
+// ApplyTheme; they never receive the active theme's actual values), so
+// using them here would have left the cluster tints frozen on the
+// boot-time palette regardless of which theme the user picked.
+//
+// The rest map to ANSI bright codes that follow the terminal palette.
 // ThemeColor wraps both paths with the no-color check, so this also
 // no-ops automatically when ConfigNoColor is set.
 func clusterColorBg(name string) lipgloss.TerminalColor {
 	switch name {
 	case "red":
-		return ThemeColor(ColorError)
+		return ThemeColor(ActiveTheme.Error)
 	case "yellow":
-		return ThemeColor(ColorWarning)
+		return ThemeColor(ActiveTheme.Warning)
 	case "green":
-		return ThemeColor(ColorSecondary)
+		return ThemeColor(ActiveTheme.Secondary)
 	case "blue":
-		return ThemeColor(ColorPrimary)
+		return ThemeColor(ActiveTheme.Primary)
 	}
 	if code, ok := ansiCodeForClusterColor[name]; ok {
 		return ThemeColor(code)
@@ -68,13 +74,13 @@ func clusterColorBg(name string) lipgloss.TerminalColor {
 }
 
 // clusterColorFg picks a contrasting foreground for the named colour.
-// Theme-mapped names get ColorSelectedFg (designed to contrast with the
-// theme's accent backgrounds); ANSI-mapped names get ANSI black, which
-// is universally legible on every bright ANSI background.
+// Theme-mapped names get ActiveTheme.SelectedFg (designed to contrast
+// with the theme's accent backgrounds); ANSI-mapped names get ANSI
+// black, which is universally legible on every bright ANSI background.
 func clusterColorFg(name string) lipgloss.TerminalColor {
 	switch name {
 	case "red", "yellow", "green", "blue":
-		return ThemeColor(ColorSelectedFg)
+		return ThemeColor(ActiveTheme.SelectedFg)
 	case "magenta", "cyan", "white", "gray":
 		return ThemeColor("0")
 	}

--- a/internal/ui/cluster_color.go
+++ b/internal/ui/cluster_color.go
@@ -1,0 +1,73 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+// ClusterColorNames lists every colour name accepted by saveClusterColors and
+// rendered by ClusterColorTitleBarStyle. Order is the canonical order used in
+// the picker overlay (top-to-bottom).
+//
+// We deliberately use ANSI named colours instead of theme tokens or hex
+// values: ANSI maps to the user's terminal palette so a "red" cluster looks
+// red in every terminal scheme (Solarized, Tokyo Night, etc.) while staying
+// recognisable across dark and light backgrounds. The bright variants
+// (ANSI 9–15) keep the tint loud enough that "I'm in prod" is unmissable
+// even when the title bar shares the row with other badges.
+var ClusterColorNames = []string{
+	"red",
+	"yellow",
+	"green",
+	"blue",
+	"magenta",
+	"cyan",
+	"white",
+	"gray",
+}
+
+// ansiCodeForClusterColor maps each named colour to its bright ANSI code.
+// Bright variants stand out against typical dark themes; gray uses ANSI 8
+// (bright black) so a "neutral" cluster has a distinct but quiet badge.
+var ansiCodeForClusterColor = map[string]string{
+	"red":     "9",
+	"yellow":  "11",
+	"green":   "10",
+	"blue":    "12",
+	"magenta": "13",
+	"cyan":    "14",
+	"white":   "15",
+	"gray":    "8",
+}
+
+// IsValidClusterColor reports whether the given name is one of the named
+// colours that the persistence layer is allowed to store. Empty string is
+// the sentinel for "no colour assigned" and is rejected here — callers must
+// treat the absence of a key in the colors map as the unset state instead.
+func IsValidClusterColor(name string) bool {
+	_, ok := ansiCodeForClusterColor[name]
+	return ok
+}
+
+// ClusterColorTitleBarStyle returns a lipgloss style for tinting the title
+// bar background to the named colour. Foreground is forced to black so text
+// stays legible on every bright background. Empty / unknown name returns
+// the zero style so the caller can compose unconditionally.
+func ClusterColorTitleBarStyle(name string) lipgloss.Style {
+	code, ok := ansiCodeForClusterColor[name]
+	if !ok {
+		return lipgloss.NewStyle()
+	}
+	return lipgloss.NewStyle().
+		Background(lipgloss.Color(code)).
+		Foreground(lipgloss.Color("0")). // ANSI black for contrast on every bright bg
+		Bold(true)
+}
+
+// ClusterColorSwatch returns a 2-cell coloured block used as a row prefix in
+// the cluster picker. Empty / unknown name returns two dim-coloured cells so
+// rows without a colour stay aligned with rows that have one.
+func ClusterColorSwatch(name string) string {
+	code, ok := ansiCodeForClusterColor[name]
+	if !ok {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorDimmed)).Render("··")
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(code)).Render("██")
+}

--- a/internal/ui/cluster_color.go
+++ b/internal/ui/cluster_color.go
@@ -61,13 +61,31 @@ func ClusterColorTitleBarStyle(name string) lipgloss.Style {
 		Bold(true)
 }
 
-// ClusterColorSwatch returns a 2-cell coloured block used as a row prefix in
-// the cluster picker. Empty / unknown name returns two dim-coloured cells so
-// rows without a colour stay aligned with rows that have one.
+// ClusterColorSwatch returns a 2-cell coloured block used inside the
+// picker overlay rows where the surrounding style sets only a foreground
+// (no competing background). Empty / unknown name returns two
+// dim-coloured cells so rows without a colour stay aligned with rows
+// that have one.
 func ClusterColorSwatch(name string) string {
 	code, ok := ansiCodeForClusterColor[name]
 	if !ok {
 		return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorDimmed)).Render("··")
 	}
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(code)).Render("██")
+}
+
+// ClusterColorSwatchBg returns a 2-cell coloured block rendered as a
+// background tint on whitespace, intended for use inside the cluster
+// picker rows where the row may be wrapped in a selection-highlight
+// style. Background-as-colour wins over the outer style's foreground,
+// so the colour stays visible whether or not the row is selected.
+//
+// Empty / unknown name returns two regular spaces (no background), so
+// rows without a colour add no visual noise to the right edge.
+func ClusterColorSwatchBg(name string) string {
+	code, ok := ansiCodeForClusterColor[name]
+	if !ok {
+		return "  "
+	}
+	return lipgloss.NewStyle().Background(lipgloss.Color(code)).Render("  ")
 }

--- a/internal/ui/cluster_color.go
+++ b/internal/ui/cluster_color.go
@@ -1,17 +1,20 @@
 package ui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"slices"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // ClusterColorNames lists every colour name accepted by saveClusterColors and
 // rendered by ClusterColorTitleBarStyle. Order is the canonical order used in
 // the picker overlay (top-to-bottom).
 //
-// We deliberately use ANSI named colours instead of theme tokens or hex
-// values: ANSI maps to the user's terminal palette so a "red" cluster looks
-// red in every terminal scheme (Solarized, Tokyo Night, etc.) while staying
-// recognisable across dark and light backgrounds. The bright variants
-// (ANSI 9–15) keep the tint loud enough that "I'm in prod" is unmissable
-// even when the title bar shares the row with other badges.
+// Four of the names are theme-mapped (red / yellow / green / blue → the
+// existing Error / Warning / Secondary / Primary theme tokens) so they
+// adapt as the user switches lfk colorschemes. The remaining four are
+// palette-relative ANSI bright codes — recognisable across every
+// terminal scheme but unaffected by lfk's theme.
 var ClusterColorNames = []string{
 	"red",
 	"yellow",
@@ -23,14 +26,10 @@ var ClusterColorNames = []string{
 	"gray",
 }
 
-// ansiCodeForClusterColor maps each named colour to its bright ANSI code.
-// Bright variants stand out against typical dark themes; gray uses ANSI 8
-// (bright black) so a "neutral" cluster has a distinct but quiet badge.
+// ansiCodeForClusterColor holds the ANSI bright codes for the four
+// non-theme-mapped colours. red/yellow/green/blue are intentionally
+// absent — they resolve via clusterColorBg's theme path.
 var ansiCodeForClusterColor = map[string]string{
-	"red":     "9",
-	"yellow":  "11",
-	"green":   "10",
-	"blue":    "12",
 	"magenta": "13",
 	"cyan":    "14",
 	"white":   "15",
@@ -42,50 +41,84 @@ var ansiCodeForClusterColor = map[string]string{
 // the sentinel for "no colour assigned" and is rejected here — callers must
 // treat the absence of a key in the colors map as the unset state instead.
 func IsValidClusterColor(name string) bool {
-	_, ok := ansiCodeForClusterColor[name]
-	return ok
+	return slices.Contains(ClusterColorNames, name)
+}
+
+// clusterColorBg resolves the named colour to a lipgloss background.
+// Theme-mapped names (red/yellow/green/blue) resolve to the current
+// theme tokens so they propagate when the user switches colorschemes;
+// the rest map to ANSI bright codes that follow the terminal palette.
+// ThemeColor wraps both paths with the no-color check, so this also
+// no-ops automatically when ConfigNoColor is set.
+func clusterColorBg(name string) lipgloss.TerminalColor {
+	switch name {
+	case "red":
+		return ThemeColor(ColorError)
+	case "yellow":
+		return ThemeColor(ColorWarning)
+	case "green":
+		return ThemeColor(ColorSecondary)
+	case "blue":
+		return ThemeColor(ColorPrimary)
+	}
+	if code, ok := ansiCodeForClusterColor[name]; ok {
+		return ThemeColor(code)
+	}
+	return nil
+}
+
+// clusterColorFg picks a contrasting foreground for the named colour.
+// Theme-mapped names get ColorSelectedFg (designed to contrast with the
+// theme's accent backgrounds); ANSI-mapped names get ANSI black, which
+// is universally legible on every bright ANSI background.
+func clusterColorFg(name string) lipgloss.TerminalColor {
+	switch name {
+	case "red", "yellow", "green", "blue":
+		return ThemeColor(ColorSelectedFg)
+	case "magenta", "cyan", "white", "gray":
+		return ThemeColor("0")
+	}
+	return nil
 }
 
 // ClusterColorTitleBarStyle returns a lipgloss style for tinting the title
-// bar background to the named colour. Foreground is forced to black so text
-// stays legible on every bright background. Empty / unknown name returns
+// bar background to the named colour. Empty / unknown name returns
 // the zero style so the caller can compose unconditionally.
 func ClusterColorTitleBarStyle(name string) lipgloss.Style {
-	code, ok := ansiCodeForClusterColor[name]
-	if !ok {
+	bg := clusterColorBg(name)
+	if bg == nil {
 		return lipgloss.NewStyle()
 	}
 	return lipgloss.NewStyle().
-		Background(lipgloss.Color(code)).
-		Foreground(lipgloss.Color("0")). // ANSI black for contrast on every bright bg
+		Background(bg).
+		Foreground(clusterColorFg(name)).
 		Bold(true)
 }
 
-// ClusterColorSwatch returns a 2-cell coloured block used inside the
-// picker overlay rows where the surrounding style sets only a foreground
-// (no competing background). Empty / unknown name returns two
-// dim-coloured cells so rows without a colour stay aligned with rows
-// that have one.
+// ClusterColorSwatch returns a 2-cell coloured block (foreground glyph)
+// for use in contexts where the surrounding style sets only a
+// foreground. Empty / unknown name returns two dim cells so rows
+// without a colour stay aligned.
 func ClusterColorSwatch(name string) string {
-	code, ok := ansiCodeForClusterColor[name]
-	if !ok {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorDimmed)).Render("··")
+	fg := clusterColorBg(name) // re-use the resolver — same colour, used as fg here
+	if fg == nil {
+		return lipgloss.NewStyle().Foreground(ThemeColor(ColorDimmed)).Render("··")
 	}
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(code)).Render("██")
+	return lipgloss.NewStyle().Foreground(fg).Render("██")
 }
 
 // ClusterColorSwatchBg returns a 2-cell coloured block rendered as a
-// background tint on whitespace, intended for use inside the cluster
-// picker rows where the row may be wrapped in a selection-highlight
-// style. Background-as-colour wins over the outer style's foreground,
-// so the colour stays visible whether or not the row is selected.
+// background tint on whitespace, intended for use inside rows that may
+// be wrapped in a selection-highlight style. Background-as-colour wins
+// over the outer style's foreground so the colour stays visible
+// whether or not the row is selected.
 //
 // Empty / unknown name returns two regular spaces (no background), so
-// rows without a colour add no visual noise to the right edge.
+// rows without a colour add no visual noise.
 func ClusterColorSwatchBg(name string) string {
-	code, ok := ansiCodeForClusterColor[name]
-	if !ok {
+	bg := clusterColorBg(name)
+	if bg == nil {
 		return "  "
 	}
-	return lipgloss.NewStyle().Background(lipgloss.Color(code)).Render("  ")
+	return lipgloss.NewStyle().Background(bg).Render("  ")
 }

--- a/internal/ui/cluster_color_overlay.go
+++ b/internal/ui/cluster_color_overlay.go
@@ -16,28 +16,44 @@ const clusterColorPickerNoneRow = "None  (clear)"
 // raw, unwrapped content; the caller is expected to wrap it in
 // OverlayStyle (renderOverlay does this for every standard overlay).
 //
+// Hints live on the bottom-of-screen status bar (overlayHintBarSelector
+// in internal/app/overlay_hintbar.go) — there is no inline hint row
+// here so the overlay matches every other selector in lfk.
+//
 // Layout:
 //
 //	Set color for prod-eu
+//	/ red█                     ← filter input (visible only when typing or non-empty)
 //
 //	▶ red          █████
 //	  yellow       █████
 //	  ...
 //	  None  (clear)
 //
-//	↑↓ navigate | enter: apply | esc/c: cancel
-//
-// The cursor uses a "▶" prefix marker rather than a row-wide background
-// highlight so the swatch's own colour stays visible without fighting
-// an outer style. The swatch is rendered with the named colour as a
-// *background* on five spaces so it shows up even when the terminal
-// renders foregrounds as muted.
-func RenderClusterColorOverlay(contextName string, cursor int) string {
+// names is the post-filter list of colour names, cursor is the row
+// index within (names + the trailing "None" row), filter is the
+// current filter buffer (visible regardless of mode so the user can
+// see what's narrowing the list), filterMode toggles the cursor glyph
+// after the filter so they know typing is active.
+func RenderClusterColorOverlay(contextName string, names []string, cursor int, filter string, filterMode bool) string {
 	titleText := "Set color for " + contextName
 	if contextName == "" {
 		titleText = "Set cluster color"
 	}
 	title := OverlayTitleStyle.Render(titleText)
+
+	// Filter line: matches the OverlayFilterStyle / OverlayDimStyle
+	// pattern used by RenderColorschemeOverlay so the picker's filter
+	// row looks identical to every other overlay's.
+	var filterLine string
+	switch {
+	case filterMode:
+		filterLine = OverlayFilterStyle.Render("/ " + filter + "█")
+	case filter != "":
+		filterLine = OverlayFilterStyle.Render("/ " + filter)
+	default:
+		filterLine = OverlayDimStyle.Render("/ to filter")
+	}
 
 	const (
 		labelW   = 14 // "None  (clear)" is the longest entry; magenta etc fit comfortably
@@ -46,14 +62,17 @@ func RenderClusterColorOverlay(contextName string, cursor int) string {
 		markerNo = "  "
 	)
 
-	rows := make([]string, 0, len(ClusterColorNames)+1)
-	for i, name := range ClusterColorNames {
-		rows = append(rows, formatClusterColorRow(name, name, labelW, swatchW, i == cursor, markerOn, markerNo))
+	rows := make([]string, 0, len(names)+1)
+	if len(names) == 0 {
+		rows = append(rows, OverlayDimStyle.Render("  No matching colors"))
+	} else {
+		for i, name := range names {
+			rows = append(rows, formatClusterColorRow(name, name, labelW, swatchW, i == cursor, markerOn, markerNo))
+		}
 	}
-	rows = append(rows, formatClusterColorRow("", clusterColorPickerNoneRow, labelW, swatchW, cursor == len(ClusterColorNames), markerOn, markerNo))
+	rows = append(rows, formatClusterColorRow("", clusterColorPickerNoneRow, labelW, swatchW, cursor == len(names), markerOn, markerNo))
 
-	hints := OverlayDimStyle.Render("↑↓ navigate | enter: apply | esc/c: cancel")
-	return title + "\n" + strings.Join(rows, "\n") + "\n\n" + hints
+	return title + "\n" + filterLine + "\n\n" + strings.Join(rows, "\n")
 }
 
 // formatClusterColorRow assembles one picker row as marker + label +

--- a/internal/ui/cluster_color_overlay.go
+++ b/internal/ui/cluster_color_overlay.go
@@ -74,11 +74,12 @@ func formatClusterColorRow(colorName, label string, labelW, swatchW int, selecte
 // clusterColorSwatchBgN returns a swatchW-cell coloured block rendered
 // as a background tint on whitespace. Empty / unknown name returns plain
 // spaces so the "None" row stays aligned with the colour rows without
-// adding a visible swatch.
+// adding a visible swatch. Routes through clusterColorBg so theme-mapped
+// names (red/yellow/green/blue) follow the active colorscheme.
 func clusterColorSwatchBgN(name string, swatchW int) string {
-	code, ok := ansiCodeForClusterColor[name]
-	if !ok {
+	bg := clusterColorBg(name)
+	if bg == nil {
 		return strings.Repeat(" ", swatchW)
 	}
-	return lipgloss.NewStyle().Background(lipgloss.Color(code)).Render(strings.Repeat(" ", swatchW))
+	return lipgloss.NewStyle().Background(bg).Render(strings.Repeat(" ", swatchW))
 }

--- a/internal/ui/cluster_color_overlay.go
+++ b/internal/ui/cluster_color_overlay.go
@@ -3,27 +3,35 @@ package ui
 import (
 	"fmt"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // clusterColorPickerNoneRow is the user-visible label for the picker row
 // that clears any previously assigned color.
 const clusterColorPickerNoneRow = "None  (clear)"
 
-// RenderClusterColorOverlay renders the color picker for the cluster
-// highlighted in the cluster picker. Rows are the named colours in
-// ClusterColorNames declaration order, followed by a "None" row that
-// clears the assignment. cursor selects which row is highlighted.
+// RenderClusterColorOverlay renders the inner content of the colour
+// picker for the cluster highlighted in the cluster picker. Returns
+// raw, unwrapped content; the caller is expected to wrap it in
+// OverlayStyle (renderOverlay does this for every standard overlay).
 //
-// Each row is composed of three independently-styled segments:
+// Layout:
 //
-//  1. label half — rendered with OverlayNormalStyle / OverlaySelectedStyle
-//     so cursor highlight covers the text consistently.
-//  2. swatch — rendered with the colour as a *background* on two spaces
-//     so the colour wins over any outer style (a foreground-only swatch
-//     gets clobbered by OverlaySelectedStyle's foreground when the row
-//     is highlighted).
-//  3. trailing pad — keeps the box body to a stable width so the right
-//     border lands in the same column on every row.
+//	Set color for prod-eu
+//
+//	▶ red          █████
+//	  yellow       █████
+//	  ...
+//	  None  (clear)
+//
+//	↑↓ navigate | enter: apply | esc/c: cancel
+//
+// The cursor uses a "▶" prefix marker rather than a row-wide background
+// highlight so the swatch's own colour stays visible without fighting
+// an outer style. The swatch is rendered with the named colour as a
+// *background* on five spaces so it shows up even when the terminal
+// renders foregrounds as muted.
 func RenderClusterColorOverlay(contextName string, cursor int) string {
 	titleText := "Set color for " + contextName
 	if contextName == "" {
@@ -31,29 +39,46 @@ func RenderClusterColorOverlay(contextName string, cursor int) string {
 	}
 	title := OverlayTitleStyle.Render(titleText)
 
-	const labelW = 14 // "magenta" + headroom; enough for "None  (clear)" too
+	const (
+		labelW   = 14 // "None  (clear)" is the longest entry; magenta etc fit comfortably
+		swatchW  = 5  // 5-cell coloured block — wide enough to identify colours at a glance
+		markerOn = "▶ "
+		markerNo = "  "
+	)
 
 	rows := make([]string, 0, len(ClusterColorNames)+1)
 	for i, name := range ClusterColorNames {
-		rows = append(rows, renderClusterColorRow(name, name, labelW, i == cursor))
+		rows = append(rows, formatClusterColorRow(name, name, labelW, swatchW, i == cursor, markerOn, markerNo))
 	}
-	rows = append(rows, renderClusterColorRow("", clusterColorPickerNoneRow, labelW, cursor == len(ClusterColorNames)))
+	rows = append(rows, formatClusterColorRow("", clusterColorPickerNoneRow, labelW, swatchW, cursor == len(ClusterColorNames), markerOn, markerNo))
 
-	hints := OverlayDimStyle.Render("↑↓ navigate | enter: apply | esc: cancel")
-	body := title + "\n\n" + strings.Join(rows, "\n") + "\n\n" + hints
-	return OverlayStyle.Render(body)
+	hints := OverlayDimStyle.Render("↑↓ navigate | enter: apply | esc/c: cancel")
+	return title + "\n" + strings.Join(rows, "\n") + "\n\n" + hints
 }
 
-// renderClusterColorRow composes one row of the picker: label + swatch
-// (rendered as background-on-spaces so its colour survives the cursor
-// highlight). selected toggles between the highlight and the dim row
-// styles for the textual portion.
-func renderClusterColorRow(colorName, label string, labelW int, selected bool) string {
-	rowStyle := OverlayNormalStyle
+// formatClusterColorRow assembles one picker row as marker + label +
+// swatch. The swatch uses background-on-spaces so its colour survives
+// any outer style; the label and marker are styled per-segment so the
+// cursor highlight is unambiguous without needing to span the whole row.
+func formatClusterColorRow(colorName, label string, labelW, swatchW int, selected bool, markerOn, markerNo string) string {
+	marker := markerNo
+	labelStyle := OverlayNormalStyle
 	if selected {
-		rowStyle = OverlaySelectedStyle
+		marker = markerOn
+		labelStyle = OverlaySelectedStyle
 	}
-	padded := fmt.Sprintf("  %-*s  ", labelW, label)
-	swatch := ClusterColorSwatchBg(colorName)
-	return rowStyle.Render(padded) + swatch + rowStyle.Render("  ")
+	swatch := clusterColorSwatchBgN(colorName, swatchW)
+	return labelStyle.Render(marker+fmt.Sprintf("%-*s", labelW, label)) + " " + swatch
+}
+
+// clusterColorSwatchBgN returns a swatchW-cell coloured block rendered
+// as a background tint on whitespace. Empty / unknown name returns plain
+// spaces so the "None" row stays aligned with the colour rows without
+// adding a visible swatch.
+func clusterColorSwatchBgN(name string, swatchW int) string {
+	code, ok := ansiCodeForClusterColor[name]
+	if !ok {
+		return strings.Repeat(" ", swatchW)
+	}
+	return lipgloss.NewStyle().Background(lipgloss.Color(code)).Render(strings.Repeat(" ", swatchW))
 }

--- a/internal/ui/cluster_color_overlay.go
+++ b/internal/ui/cluster_color_overlay.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// clusterColorPickerNoneRow is the user-visible label for the picker row
+// that clears any previously assigned color.
+const clusterColorPickerNoneRow = "None  (clear)"
+
+// RenderClusterColorOverlay renders the color picker for the cluster
+// highlighted in the cluster picker. Rows are the named colours in
+// ClusterColorNames declaration order, followed by a "None" row that
+// clears the assignment. cursor selects which row is highlighted.
+func RenderClusterColorOverlay(contextName string, cursor int) string {
+	titleText := "Set color for " + contextName
+	if contextName == "" {
+		titleText = "Set cluster color"
+	}
+	title := OverlayTitleStyle.Render(titleText)
+
+	rows := make([]string, 0, len(ClusterColorNames)+1)
+	for i, name := range ClusterColorNames {
+		swatch := ClusterColorSwatch(name)
+		// Pad the label so the cursor highlight (which renders the whole
+		// line) makes the rows align visually instead of jaggedly hugging
+		// the shortest name.
+		label := fmt.Sprintf("%-9s", name)
+		raw := fmt.Sprintf("  %s  %s", swatch, label)
+		if i == cursor {
+			rows = append(rows, OverlaySelectedStyle.Render(raw))
+		} else {
+			rows = append(rows, OverlayNormalStyle.Render(raw))
+		}
+	}
+	noneRaw := fmt.Sprintf("  %s  %s", ClusterColorSwatch(""), clusterColorPickerNoneRow)
+	if cursor == len(ClusterColorNames) {
+		rows = append(rows, OverlaySelectedStyle.Render(noneRaw))
+	} else {
+		rows = append(rows, OverlayNormalStyle.Render(noneRaw))
+	}
+
+	hints := OverlayDimStyle.Render("↑↓ navigate | enter: apply | esc: cancel")
+	body := title + "\n\n" + strings.Join(rows, "\n") + "\n\n" + hints
+	return OverlayStyle.Render(body)
+}

--- a/internal/ui/cluster_color_overlay.go
+++ b/internal/ui/cluster_color_overlay.go
@@ -13,6 +13,17 @@ const clusterColorPickerNoneRow = "None  (clear)"
 // highlighted in the cluster picker. Rows are the named colours in
 // ClusterColorNames declaration order, followed by a "None" row that
 // clears the assignment. cursor selects which row is highlighted.
+//
+// Each row is composed of three independently-styled segments:
+//
+//  1. label half — rendered with OverlayNormalStyle / OverlaySelectedStyle
+//     so cursor highlight covers the text consistently.
+//  2. swatch — rendered with the colour as a *background* on two spaces
+//     so the colour wins over any outer style (a foreground-only swatch
+//     gets clobbered by OverlaySelectedStyle's foreground when the row
+//     is highlighted).
+//  3. trailing pad — keeps the box body to a stable width so the right
+//     border lands in the same column on every row.
 func RenderClusterColorOverlay(contextName string, cursor int) string {
 	titleText := "Set color for " + contextName
 	if contextName == "" {
@@ -20,28 +31,29 @@ func RenderClusterColorOverlay(contextName string, cursor int) string {
 	}
 	title := OverlayTitleStyle.Render(titleText)
 
+	const labelW = 14 // "magenta" + headroom; enough for "None  (clear)" too
+
 	rows := make([]string, 0, len(ClusterColorNames)+1)
 	for i, name := range ClusterColorNames {
-		swatch := ClusterColorSwatch(name)
-		// Pad the label so the cursor highlight (which renders the whole
-		// line) makes the rows align visually instead of jaggedly hugging
-		// the shortest name.
-		label := fmt.Sprintf("%-9s", name)
-		raw := fmt.Sprintf("  %s  %s", swatch, label)
-		if i == cursor {
-			rows = append(rows, OverlaySelectedStyle.Render(raw))
-		} else {
-			rows = append(rows, OverlayNormalStyle.Render(raw))
-		}
+		rows = append(rows, renderClusterColorRow(name, name, labelW, i == cursor))
 	}
-	noneRaw := fmt.Sprintf("  %s  %s", ClusterColorSwatch(""), clusterColorPickerNoneRow)
-	if cursor == len(ClusterColorNames) {
-		rows = append(rows, OverlaySelectedStyle.Render(noneRaw))
-	} else {
-		rows = append(rows, OverlayNormalStyle.Render(noneRaw))
-	}
+	rows = append(rows, renderClusterColorRow("", clusterColorPickerNoneRow, labelW, cursor == len(ClusterColorNames)))
 
 	hints := OverlayDimStyle.Render("↑↓ navigate | enter: apply | esc: cancel")
 	body := title + "\n\n" + strings.Join(rows, "\n") + "\n\n" + hints
 	return OverlayStyle.Render(body)
+}
+
+// renderClusterColorRow composes one row of the picker: label + swatch
+// (rendered as background-on-spaces so its colour survives the cursor
+// highlight). selected toggles between the highlight and the dim row
+// styles for the textual portion.
+func renderClusterColorRow(colorName, label string, labelW int, selected bool) string {
+	rowStyle := OverlayNormalStyle
+	if selected {
+		rowStyle = OverlaySelectedStyle
+	}
+	padded := fmt.Sprintf("  %-*s  ", labelW, label)
+	swatch := ClusterColorSwatchBg(colorName)
+	return rowStyle.Render(padded) + swatch + rowStyle.Render("  ")
 }

--- a/internal/ui/cluster_color_test.go
+++ b/internal/ui/cluster_color_test.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterColorNames_PaletteIsStable(t *testing.T) {
+	// The on-disk schema and the picker overlay both depend on this set —
+	// dropping or renaming an entry is a breaking change. Adding a new one
+	// is fine but must come with a schema bump in cluster_colors.go.
+	expected := []string{"red", "yellow", "green", "blue", "magenta", "cyan", "white", "gray"}
+	assert.Equal(t, expected, ClusterColorNames)
+}
+
+func TestIsValidClusterColor(t *testing.T) {
+	for _, name := range ClusterColorNames {
+		assert.True(t, IsValidClusterColor(name), "expected %q to be valid", name)
+	}
+	assert.False(t, IsValidClusterColor(""), "empty string is the unset sentinel, not a valid color")
+	assert.False(t, IsValidClusterColor("chartreuse"), "unknown color name must be rejected")
+	assert.False(t, IsValidClusterColor("RED"), "names are case-sensitive (lowercase only)")
+}
+
+func TestClusterColorTitleBarStyle_KnownColorSetsBg(t *testing.T) {
+	// Inspect style attributes directly — lipgloss strips ANSI escapes
+	// when stdout isn't a TTY (e.g. during `go test`), so we cannot
+	// rely on the rendered output here.
+	style := ClusterColorTitleBarStyle("red")
+	bg, ok := style.GetBackground().(lipgloss.Color)
+	assert.True(t, ok, "known color must set a concrete lipgloss.Color background, not NoColor")
+	assert.NotEmpty(t, string(bg), "background color must be non-empty")
+	assert.True(t, style.GetBold(), "title bar tint should be bold so badges stay legible against bright backgrounds")
+}
+
+func TestClusterColorTitleBarStyle_UnknownColorIsZeroStyle(t *testing.T) {
+	style := ClusterColorTitleBarStyle("chartreuse")
+	// Zero style: GetBackground() returns NoColor{} for an unset background,
+	// not a lipgloss.Color — that distinction is what tells the renderer to
+	// pass through unchanged.
+	_, isColor := style.GetBackground().(lipgloss.Color)
+	assert.False(t, isColor, "unknown color must yield the zero style (NoColor background) so callers can compose unconditionally")
+}
+
+func TestClusterColorSwatch_KnownColorRendersBlock(t *testing.T) {
+	out := ClusterColorSwatch("red")
+	assert.Contains(t, out, "██", "known color renders the full block character so the swatch is visible at a glance")
+}
+
+func TestClusterColorSwatch_UnknownColorRendersDimDots(t *testing.T) {
+	out := ClusterColorSwatch("")
+	assert.Contains(t, out, "··", "unset/unknown color renders dim dots so rows stay aligned with coloured rows")
+	// We can't reliably assert ANSI escapes here — see the title-bar test
+	// above. The character choice (dots vs. blocks) is the user-visible
+	// marker that this row has no color set.
+	_ = strings.Contains(out, "")
+}

--- a/internal/ui/cluster_color_test.go
+++ b/internal/ui/cluster_color_test.go
@@ -36,6 +36,44 @@ func TestClusterColorTitleBarStyle_KnownColorSetsBg(t *testing.T) {
 	assert.True(t, style.GetBold(), "title bar tint should be bold so badges stay legible against bright backgrounds")
 }
 
+func TestClusterColorBg_ThemeMappedColorsFollowTheme(t *testing.T) {
+	// Theme-mapped colour names must resolve through the active theme
+	// tokens so a colorscheme switch propagates. Smoke test by mutating
+	// ColorError and observing clusterColorBg("red") change.
+	prev := ColorError
+	t.Cleanup(func() { ColorError = prev })
+
+	ColorError = "#abcdef"
+	bg, ok := clusterColorBg("red").(lipgloss.Color)
+	if assert.True(t, ok, "red must resolve to a concrete lipgloss.Color") {
+		assert.Equal(t, "#abcdef", string(bg),
+			"red must read the *current* ColorError so theme switches propagate")
+	}
+}
+
+func TestClusterColorBg_AnsiMappedColorsAreFixed(t *testing.T) {
+	// magenta/cyan/white/gray are deliberately NOT theme-mapped — they
+	// give the user a stable palette-relative escape hatch when none of
+	// the theme accent colours fit. Mutating theme tokens must not
+	// touch them.
+	prev := ColorError
+	t.Cleanup(func() { ColorError = prev })
+
+	ColorError = "#abcdef"
+	for _, name := range []string{"magenta", "cyan", "white", "gray"} {
+		bg, ok := clusterColorBg(name).(lipgloss.Color)
+		if assert.True(t, ok, "%s must resolve to a concrete lipgloss.Color", name) {
+			assert.NotEqual(t, "#abcdef", string(bg),
+				"%s must NOT pick up theme.Error — palette-relative colours stay independent", name)
+		}
+	}
+}
+
+func TestClusterColorBg_UnknownNameReturnsNil(t *testing.T) {
+	assert.Nil(t, clusterColorBg("chartreuse"), "unknown colour name resolves to nil so callers can no-op")
+	assert.Nil(t, clusterColorBg(""), "unset (empty) name resolves to nil — same as no tint")
+}
+
 func TestClusterColorTitleBarStyle_UnknownColorIsZeroStyle(t *testing.T) {
 	style := ClusterColorTitleBarStyle("chartreuse")
 	// Zero style: GetBackground() returns NoColor{} for an unset background,

--- a/internal/ui/cluster_color_test.go
+++ b/internal/ui/cluster_color_test.go
@@ -37,17 +37,17 @@ func TestClusterColorTitleBarStyle_KnownColorSetsBg(t *testing.T) {
 }
 
 func TestClusterColorBg_ThemeMappedColorsFollowTheme(t *testing.T) {
-	// Theme-mapped colour names must resolve through the active theme
-	// tokens so a colorscheme switch propagates. Smoke test by mutating
-	// ColorError and observing clusterColorBg("red") change.
-	prev := ColorError
-	t.Cleanup(func() { ColorError = prev })
+	// Theme-mapped colour names must resolve through ActiveTheme so a
+	// colorscheme switch propagates. Smoke test by mutating
+	// ActiveTheme.Error and observing clusterColorBg("red") change.
+	prev := ActiveTheme.Error
+	t.Cleanup(func() { ActiveTheme.Error = prev })
 
-	ColorError = "#abcdef"
+	ActiveTheme.Error = "#abcdef"
 	bg, ok := clusterColorBg("red").(lipgloss.Color)
 	if assert.True(t, ok, "red must resolve to a concrete lipgloss.Color") {
 		assert.Equal(t, "#abcdef", string(bg),
-			"red must read the *current* ColorError so theme switches propagate")
+			"red must read the *current* ActiveTheme.Error so theme switches propagate")
 	}
 }
 
@@ -56,10 +56,10 @@ func TestClusterColorBg_AnsiMappedColorsAreFixed(t *testing.T) {
 	// give the user a stable palette-relative escape hatch when none of
 	// the theme accent colours fit. Mutating theme tokens must not
 	// touch them.
-	prev := ColorError
-	t.Cleanup(func() { ColorError = prev })
+	prev := ActiveTheme.Error
+	t.Cleanup(func() { ActiveTheme.Error = prev })
 
-	ColorError = "#abcdef"
+	ActiveTheme.Error = "#abcdef"
 	for _, name := range []string{"magenta", "cyan", "white", "gray"} {
 		bg, ok := clusterColorBg(name).(lipgloss.Color)
 		if assert.True(t, ok, "%s must resolve to a concrete lipgloss.Color", name) {

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -149,11 +149,14 @@ func DefaultKeybindings() Keybindings {
 		// Read-only mode
 		ReadOnlyToggle: "ctrl+r",
 
-		// Cluster color picker. Ctrl+K (not Ctrl+L) because most terminals
-		// intercept Ctrl+L for "redraw screen" / "clear" before bubbletea
-		// ever sees it; Ctrl+K is generally untouched on macOS Terminal,
-		// iTerm2, Alacritty, Ghostty, and gnome-terminal.
-		ClusterColorPicker: "ctrl+k",
+		// Cluster color picker. Bare "c" rather than a Ctrl+ combination
+		// because Ctrl+L is intercepted by most terminals as "redraw
+		// screen", Ctrl+K and Ctrl+Y are used by readline / ZLE in many
+		// terminal-emulator setups, and Ctrl+H / Ctrl+J map to
+		// backspace / newline at the keyboard layer. The handler self-
+		// gates on Level=Clusters so plain "c" is a no-op everywhere
+		// else and doesn't shadow other in-context behaviours.
+		ClusterColorPicker: "c",
 	}
 }
 

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -149,8 +149,11 @@ func DefaultKeybindings() Keybindings {
 		// Read-only mode
 		ReadOnlyToggle: "ctrl+r",
 
-		// Cluster color picker
-		ClusterColorPicker: "ctrl+l",
+		// Cluster color picker. Ctrl+K (not Ctrl+L) because most terminals
+		// intercept Ctrl+L for "redraw screen" / "clear" before bubbletea
+		// ever sees it; Ctrl+K is generally untouched on macOS Terminal,
+		// iTerm2, Alacritty, Ghostty, and gnome-terminal.
+		ClusterColorPicker: "ctrl+k",
 	}
 }
 

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -149,14 +149,13 @@ func DefaultKeybindings() Keybindings {
 		// Read-only mode
 		ReadOnlyToggle: "ctrl+r",
 
-		// Cluster color picker. Bare "c" rather than a Ctrl+ combination
-		// because Ctrl+L is intercepted by most terminals as "redraw
-		// screen", Ctrl+K and Ctrl+Y are used by readline / ZLE in many
-		// terminal-emulator setups, and Ctrl+H / Ctrl+J map to
-		// backspace / newline at the keyboard layer. The handler self-
-		// gates on Level=Clusters so plain "c" is a no-op everywhere
-		// else and doesn't shadow other in-context behaviours.
-		ClusterColorPicker: "c",
+		// Cluster color picker. Bound to Shift+L because the picker only
+		// exists at Level=Clusters and "L" is otherwise the Logs action
+		// (which has no meaning at the cluster picker — no pods to
+		// stream from). The dispatch case is gated on Level=Clusters
+		// and breaks out at deeper levels so "L" continues to open
+		// Logs everywhere else.
+		ClusterColorPicker: "L",
 	}
 }
 

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -95,6 +95,10 @@ type Keybindings struct {
 
 	// Read-only mode
 	ReadOnlyToggle string `json:"readonly_toggle" yaml:"readonly_toggle"`
+
+	// Cluster color picker (Level=Clusters only): assigns a background tint
+	// to the highlighted cluster row, persisted across restarts.
+	ClusterColorPicker string `json:"cluster_color_picker" yaml:"cluster_color_picker"`
 }
 
 // DefaultKeybindings returns the default keybinding configuration.
@@ -144,6 +148,9 @@ func DefaultKeybindings() Keybindings {
 
 		// Read-only mode
 		ReadOnlyToggle: "ctrl+r",
+
+		// Cluster color picker
+		ClusterColorPicker: "ctrl+l",
 	}
 }
 

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -480,7 +480,16 @@ func FormatItem(item model.Item, width int) string {
 	// Non-current, non-read-only rows: still surface the cluster-color
 	// swatch so unentered contexts can be identified at a glance from
 	// the picker — appended to the name, not prepended, for alignment.
+	// Also apply ActiveHighlightQuery so /search highlighting still
+	// works on coloured rows (the current / read-only branches above
+	// inherit the pre-existing limitation that they don't highlight).
 	if item.ClusterColor != "" {
+		if ActiveHighlightQuery != "" {
+			name = NormalStyle.Render(highlightName(displayName, ActiveHighlightQuery))
+			if icon := resolveIcon(item.Icon); icon != "" {
+				name = IconStyle.Render(icon+" ") + name
+			}
+		}
 		return TruncateWithSuffix(name, clusterColorSuffix(item), width)
 	}
 

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -462,17 +462,27 @@ func FormatItem(item model.Item, width int) string {
 	}
 
 	// Mark current context with a star and (optionally) prefix the
-	// read-only badge. Order: "* [RO] name". Both are styled prefixes so
-	// the renderer's ANSI tracking (lipgloss.Width) keeps the visible
-	// width correct even when the marker is colored.
+	// read-only badge and cluster-color swatch. Order:
+	// "* [RO] ██ name" — star first (current), [RO] next (process-wide
+	// safety hint), then the cluster-color swatch (per-cluster identity).
+	// All three are styled prefixes so the renderer's ANSI tracking
+	// (lipgloss.Width) keeps the visible width correct even when the
+	// markers are coloured.
 	if item.Status == "current" {
-		return Truncate(CurrentMarkerStyle.Render("* ")+readOnlyPrefix(item)+name, width)
+		return Truncate(CurrentMarkerStyle.Render("* ")+readOnlyPrefix(item)+clusterColorPrefix(item)+name, width)
 	}
 
 	// Non-current read-only rows: prepend "[RO] " so the marker is
-	// visible regardless of column width.
+	// visible regardless of column width. Cluster-color swatch follows.
 	if item.ReadOnly {
-		return Truncate(readOnlyPrefix(item)+name, width)
+		return Truncate(readOnlyPrefix(item)+clusterColorPrefix(item)+name, width)
+	}
+
+	// Non-current, non-read-only rows: still surface the cluster-color
+	// swatch so unentered contexts can be identified at a glance from
+	// the picker.
+	if item.ClusterColor != "" {
+		return Truncate(clusterColorPrefix(item)+name, width)
 	}
 
 	// Build detail columns: ready, restarts, age.
@@ -568,11 +578,12 @@ func FormatItemPlain(item model.Item, width int) string {
 	}
 
 	// Mark current context with a star (plain text, no CurrentMarkerStyle)
-	// and prepend a "[RO] " prefix when the row is read-only. Order:
-	// "* [RO] name" so the star stays the leftmost glyph and the marker
-	// sits next to it like a tag.
+	// and prepend a "[RO] " plus cluster-color swatch when applicable.
+	// Order: "* [RO] ██ name" so the star stays the leftmost glyph and
+	// the marker sits next to it like a tag. Plain variants are used so
+	// the row's selection background paints without nested ANSI resets.
 	if item.Status == "current" {
-		return Truncate("* "+readOnlyPrefixPlain(item)+name, width)
+		return Truncate("* "+readOnlyPrefixPlain(item)+clusterColorPrefixPlain(item)+name, width)
 	}
 
 	// Non-current read-only rows: prepend "[RO] " so the marker is
@@ -583,7 +594,14 @@ func FormatItemPlain(item model.Item, width int) string {
 		// so that any right-side details (currently unused for context
 		// rows but possible for other read-only resources in the future)
 		// remain consistent.
-		return Truncate(readOnlyPrefixPlain(item)+name, width)
+		return Truncate(readOnlyPrefixPlain(item)+clusterColorPrefixPlain(item)+name, width)
+	}
+
+	// Non-current, non-read-only rows: still surface the cluster-color
+	// swatch so unentered contexts can be identified at a glance from
+	// the picker.
+	if item.ClusterColor != "" {
+		return Truncate(clusterColorPrefixPlain(item)+name, width)
 	}
 
 	// Build detail columns: ready, restarts, age.

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -462,27 +462,26 @@ func FormatItem(item model.Item, width int) string {
 	}
 
 	// Mark current context with a star and (optionally) prefix the
-	// read-only badge and cluster-color swatch. Order:
-	// "* [RO] ██ name" — star first (current), [RO] next (process-wide
-	// safety hint), then the cluster-color swatch (per-cluster identity).
-	// All three are styled prefixes so the renderer's ANSI tracking
-	// (lipgloss.Width) keeps the visible width correct even when the
-	// markers are coloured.
+	// read-only badge. The cluster-color swatch goes at the *end* of the
+	// row so the leading column stays aligned across coloured and
+	// uncoloured rows — putting it left of the name added a leading-space
+	// that made unset rows look ragged. Order: "* [RO] name   ██".
 	if item.Status == "current" {
-		return Truncate(CurrentMarkerStyle.Render("* ")+readOnlyPrefix(item)+clusterColorPrefix(item)+name, width)
+		return TruncateWithSuffix(CurrentMarkerStyle.Render("* ")+readOnlyPrefix(item)+name, clusterColorSuffix(item), width)
 	}
 
 	// Non-current read-only rows: prepend "[RO] " so the marker is
-	// visible regardless of column width. Cluster-color swatch follows.
+	// visible regardless of column width. Cluster-color swatch trails
+	// the name so the column lines up with non-RO rows.
 	if item.ReadOnly {
-		return Truncate(readOnlyPrefix(item)+clusterColorPrefix(item)+name, width)
+		return TruncateWithSuffix(readOnlyPrefix(item)+name, clusterColorSuffix(item), width)
 	}
 
 	// Non-current, non-read-only rows: still surface the cluster-color
 	// swatch so unentered contexts can be identified at a glance from
-	// the picker.
+	// the picker — appended to the name, not prepended, for alignment.
 	if item.ClusterColor != "" {
-		return Truncate(clusterColorPrefix(item)+name, width)
+		return TruncateWithSuffix(name, clusterColorSuffix(item), width)
 	}
 
 	// Build detail columns: ready, restarts, age.
@@ -578,12 +577,11 @@ func FormatItemPlain(item model.Item, width int) string {
 	}
 
 	// Mark current context with a star (plain text, no CurrentMarkerStyle)
-	// and prepend a "[RO] " plus cluster-color swatch when applicable.
-	// Order: "* [RO] ██ name" so the star stays the leftmost glyph and
-	// the marker sits next to it like a tag. Plain variants are used so
-	// the row's selection background paints without nested ANSI resets.
+	// and prepend a "[RO] " when applicable. Cluster-color swatch goes at
+	// the end of the row via TruncateWithSuffix so leading columns stay
+	// aligned across rows whether they have a colour or not.
 	if item.Status == "current" {
-		return Truncate("* "+readOnlyPrefixPlain(item)+clusterColorPrefixPlain(item)+name, width)
+		return TruncateWithSuffix("* "+readOnlyPrefixPlain(item)+name, clusterColorSuffix(item), width)
 	}
 
 	// Non-current read-only rows: prepend "[RO] " so the marker is
@@ -594,14 +592,14 @@ func FormatItemPlain(item model.Item, width int) string {
 		// so that any right-side details (currently unused for context
 		// rows but possible for other read-only resources in the future)
 		// remain consistent.
-		return Truncate(readOnlyPrefixPlain(item)+clusterColorPrefixPlain(item)+name, width)
+		return TruncateWithSuffix(readOnlyPrefixPlain(item)+name, clusterColorSuffix(item), width)
 	}
 
 	// Non-current, non-read-only rows: still surface the cluster-color
 	// swatch so unentered contexts can be identified at a glance from
-	// the picker.
+	// the picker — appended to the end of the row, not prepended.
 	if item.ClusterColor != "" {
-		return Truncate(clusterColorPrefixPlain(item)+name, width)
+		return TruncateWithSuffix(name, clusterColorSuffix(item), width)
 	}
 
 	// Build detail columns: ready, restarts, age.

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -390,6 +390,36 @@ func Truncate(s string, maxW int) string {
 	return ansi.Truncate(s, maxW-1, "") + "~"
 }
 
+// TruncateWithSuffix truncates body so that body + suffix fits within maxW
+// visual columns, then right-pads with spaces so the suffix lands flush
+// against the right edge. Empty suffix degrades to plain Truncate.
+//
+// Used by the cluster picker to render the per-row colour swatch at the
+// end of the line: putting it before the name added a leading-space gap
+// that made uncoloured rows look ragged. With the swatch as a suffix the
+// name column stays aligned and the colour still ends up in a consistent,
+// scannable position.
+func TruncateWithSuffix(body, suffix string, maxW int) string {
+	if suffix == "" {
+		return Truncate(body, maxW)
+	}
+	if maxW <= 0 {
+		return ""
+	}
+	suffixW := lipgloss.Width(suffix)
+	if suffixW >= maxW {
+		// Suffix would consume the entire row — drop the body and just
+		// truncate the suffix so we don't accidentally hide the colour.
+		return Truncate(suffix, maxW)
+	}
+	// Reserve room for the suffix plus one space of separation from the
+	// body so the swatch isn't visually glued to the name.
+	bodyMaxW := max(maxW-suffixW-1, 1)
+	truncated := Truncate(body, bodyMaxW)
+	pad := max(maxW-lipgloss.Width(truncated)-suffixW, 1)
+	return truncated + strings.Repeat(" ", pad) + suffix
+}
+
 // truncateNoMarker truncates a string to maxW runes without appending any marker.
 // Used for wrappable columns where the remaining content continues on the next line.
 func truncateNoMarker(s string, maxW int) string {

--- a/internal/ui/explorer_highlight.go
+++ b/internal/ui/explorer_highlight.go
@@ -191,3 +191,26 @@ func readOnlyPrefixPlain(item model.Item) string {
 	}
 	return "[RO] "
 }
+
+// clusterColorPrefix returns a coloured swatch for context rows that have a
+// cluster colour assigned. The swatch is foreground-only so the cursor
+// highlight can paint over it cleanly. Empty string for items without a
+// colour so the caller can always concatenate.
+func clusterColorPrefix(item model.Item) string {
+	if item.ClusterColor == "" {
+		return ""
+	}
+	return ClusterColorSwatch(item.ClusterColor) + " "
+}
+
+// clusterColorPrefixPlain returns the same swatch width as
+// clusterColorPrefix but unstyled, so a selected-row background can paint
+// across it without nested ANSI resets. The two-cell width plus trailing
+// space must match clusterColorPrefix exactly so name truncation produces
+// identical results in both styled and plain paths.
+func clusterColorPrefixPlain(item model.Item) string {
+	if item.ClusterColor == "" {
+		return ""
+	}
+	return "██ "
+}

--- a/internal/ui/explorer_highlight.go
+++ b/internal/ui/explorer_highlight.go
@@ -192,25 +192,19 @@ func readOnlyPrefixPlain(item model.Item) string {
 	return "[RO] "
 }
 
-// clusterColorPrefix returns a coloured swatch for context rows that have a
-// cluster colour assigned. The swatch is foreground-only so the cursor
-// highlight can paint over it cleanly. Empty string for items without a
-// colour so the caller can always concatenate.
-func clusterColorPrefix(item model.Item) string {
+// clusterColorSuffix returns a coloured swatch for context rows that have
+// a cluster colour assigned, intended to be rendered at the *end* of the
+// row by TruncateWithSuffix. Foreground-only so the cursor highlight can
+// paint over it cleanly. Empty string for items without a colour so the
+// caller can always concatenate.
+//
+// The suffix uses a background-coloured 2-cell block (rather than the
+// foreground glyph used by ClusterColorSwatch) so the colour shows up
+// even when the row's selection background paints over it: the inner
+// background wins over the outer fg-only highlight.
+func clusterColorSuffix(item model.Item) string {
 	if item.ClusterColor == "" {
 		return ""
 	}
-	return ClusterColorSwatch(item.ClusterColor) + " "
-}
-
-// clusterColorPrefixPlain returns the same swatch width as
-// clusterColorPrefix but unstyled, so a selected-row background can paint
-// across it without nested ANSI resets. The two-cell width plus trailing
-// space must match clusterColorPrefix exactly so name truncation produces
-// identical results in both styled and plain paths.
-func clusterColorPrefixPlain(item model.Item) string {
-	if item.ClusterColor == "" {
-		return ""
-	}
-	return "██ "
+	return ClusterColorSwatchBg(item.ClusterColor)
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -118,6 +118,7 @@ func helpSections() []helpSection {
 				{kb.SortReset, "Reset sort to default (Name ascending)"},
 				{kb.WatchMode, "Toggle watch mode (auto-refresh)"},
 				{helpKeyDisplay(kb.ReadOnlyToggle), "Toggle read-only mode (cluster picker: highlighted row's [RO] marker; inside a context: current tab)"},
+				{helpKeyDisplay(kb.ClusterColorPicker), "Cluster color picker (cluster picker only): tint title bar + add row swatch; persisted across restarts"},
 				{kb.Monitoring, "Monitoring overview (active Prometheus alerts)"},
 				{kb.QuotaDashboard, "Namespace resource quota dashboard"},
 				{kb.TasksOverlay, "Background tasks overlay (Tab toggles running/completed history)"},


### PR DESCRIPTION
## Summary

Tag any cluster from the picker with one of 8 named colors so the title bar tints the moment you enter it — useful for unmissable visual feedback when you're about to act on prod and would rather not. Mirrors the read-only \`Ctrl+R\` pattern: hotkey on a row, persisted across restarts, zero config-file editing required.

| Where | What you see |
|---|---|
| **Cluster picker row** | A coloured \`██\` swatch prefix per row (dim \`··\` for unset rows so all rows align). |
| **Inside a coloured context** | The entire title-bar background is tinted with the cluster's colour; existing badges (RO, watch, namespace, version) stay legible on top. |
| **Picker overlay** (\`Ctrl+L\` or action menu → "Set color…") | 8 ANSI-bright colours plus "None"; cursor pre-seeds on the cluster's current colour. |

## Behaviour details

- **Open the picker**: \`Ctrl+L\` at the cluster picker, or \`x\` → "Set color…". Both call into the same overlay.
- **Palette**: \`red\`, \`yellow\`, \`green\`, \`blue\`, \`magenta\`, \`cyan\`, \`white\`, \`gray\` — ANSI bright codes 8–15, so each tint maps to the user's terminal palette and adapts to whatever colorscheme is active. Plus \`None\` to clear.
- **Persistence**: \`\$XDG_STATE_HOME/lfk/cluster-colors.yaml\` (atomic temp+rename, schema-versioned, mirrors the discovery cache and bookmarks patterns). Unknown colour names are dropped silently on load so a typo in one entry doesn't poison the rest. Save validates the palette so the on-disk file is always restorable.

## Implementation notes

- New \`ui.ClusterColorNames\` palette + \`ui.ClusterColorTitleBarStyle\` / \`ClusterColorSwatch\` helpers in \`internal/ui/cluster_color.go\`.
- New \`overlayClusterColor\` overlay (in \`overlayKind\` enum) wired through the standard \`update_overlays.go\` dispatch so it inherits hint-bar handling and Esc-to-close out of the box.
- \`Item.ClusterColor\` is stamped from \`m.clusterColors\` at \`contextsLoaded\` time so the picker render path doesn't need the colors map; matches the existing \`Item.ReadOnly\` annotation pattern.
- \`applyClusterColorSelection\` updates \`m.middleItems\` by index (not via a \`selectedMiddleItem\` pointer) for the same reason \`handleKeyReadOnlyToggle\` does — the fallback path can return a transient filtered-slice pointer that wouldn't reach the cached items.
- Persistence failure surfaces as a status-bar message but doesn't trap the user inside the overlay; the in-memory change still takes effect for the session.

## Out of scope, on purpose

- No per-tag shared colors (per-cluster only — picking the same colour twice for \`prod-eu\` / \`prod-us\` is the manual workaround).
- No setting from inside a context (Level=Clusters only).
- No hex/RGB colours (named palette only).
- No config-file seeding (lfk-managed state file only; the design call was for in-app first).

## Tests

19 new tests covering the state file (round-trip, missing file, corrupt file, future schema, unknown-color drop, atomic write, empty-map clears, save rejects unknown), the colour palette (palette stability, validity, style attributes), the overlay (open at cluster picker / no-op above, no-selection no-op, cursor pre-seed for both coloured and uncoloured rows, Up/Down wrap, Enter applies + persists, "None" clears + persists, Esc cancels), the title-bar render (tinted when context has a colour / not at cluster picker / unknown context unchanged), the row stamping (annotates from \`clusterColors\` map at load, refreshes \`middleItems\` by index after save), and the action menu integration (lists "Set color…" at Level=Clusters / executes to the colour overlay).

\`\`\`
ok  	github.com/janosmiko/lfk/internal/app	2.227s	coverage: 78.1%
ok  	github.com/janosmiko/lfk/internal/ui	3.262s
\`\`\`

## Test plan

- [ ] At the cluster picker, press \`Ctrl+L\` on a row → picker opens, cursor on "None" if unset.
- [ ] Pick \`red\` and press Enter → row gains a red \`██\` swatch; reopen overlay → cursor lands on \`red\`.
- [ ] Enter the cluster → title bar background turns red; \`[RO]\` / namespace / version badges remain legible.
- [ ] Restart \`lfk\` → the colour persists.
- [ ] Pick \`None\` from the overlay → swatch clears, title bar reverts to default on next entry, and the entry is gone from \`~/.local/state/lfk/cluster-colors.yaml\`.
- [ ] At the cluster picker, press \`x\` → action menu shows "Set color…"; Enter → colour overlay opens.
- [ ] Hand-edit \`cluster-colors.yaml\` to add \`bogus: chartreuse\` → \`lfk\` boots, the bad entry is dropped silently, valid entries survive.