### PR TITLE
fix(quit): cancel in-flight API requests so quit doesn't hang on dead clusters

### DIFF
--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -90,6 +90,21 @@ func (m *Model) cancelAndReset() {
 	m.reqCtx, m.reqCancel = context.WithCancel(context.Background())
 }
 
+// cancelInFlightRequests cancels every outstanding API request (lists,
+// discovery, YAML fetches, etc.) without creating a fresh context. Used
+// by the quit paths so in-flight goroutines abort with context.Canceled
+// rather than riding out kernel TCP timeouts on an unreachable cluster
+// — which can stretch the apparent "quit" wait to a minute or more
+// while the process waits for those goroutines to release the
+// resources held in main's deferred cleanup (informer wg, stderr-pipe
+// reader, etc.). cancelAndReset would also work here, but allocating a
+// fresh context we never use is wasted motion at shutdown.
+func (m *Model) cancelInFlightRequests() {
+	if m.reqCancel != nil {
+		m.reqCancel()
+	}
+}
+
 // applyPinnedGroups merges config-level pinned groups with per-context pinned groups
 // and sets model.PinnedGroups.
 func (m *Model) applyPinnedGroups() {

--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -105,6 +105,23 @@ func (m *Model) cancelInFlightRequests() {
 	}
 }
 
+// performQuitCleanup runs every shutdown side effect that must happen
+// before tea.Quit is dispatched: stop port-forwards, cancel log
+// streams, cancel in-flight API requests, and persist session state.
+// Centralising this here keeps the three quit entry points
+// (handleQuitConfirmOverlayKey, closeTabOrQuit's last-tab branch, and
+// the :quit command) in lockstep so adding a fourth path — or a new
+// cleanup step — does not require remembering the full sequence at
+// every call site.
+func (m *Model) performQuitCleanup() {
+	if m.portForwardMgr != nil {
+		m.portForwardMgr.StopAll()
+	}
+	m.cancelAllTabLogStreams()
+	m.cancelInFlightRequests()
+	m.saveCurrentSession()
+}
+
 // applyPinnedGroups merges config-level pinned groups with per-context pinned groups
 // and sets model.PinnedGroups.
 func (m *Model) applyPinnedGroups() {

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -146,12 +146,7 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 		// kubectl log streams started from any tab don't outlive the
 		// process. Without this, `:q` / `:q!` / `:quit` leaks the
 		// kubectl subprocess and its reader goroutine — issue #48.
-		if m.portForwardMgr != nil {
-			m.portForwardMgr.StopAll()
-		}
-		m.cancelAllTabLogStreams()
-		m.cancelInFlightRequests()
-		m.saveCurrentSession()
+		m.performQuitCleanup()
 		return m, tea.Quit
 
 	case "namespace":

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -150,6 +150,7 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 			m.portForwardMgr.StopAll()
 		}
 		m.cancelAllTabLogStreams()
+		m.cancelInFlightRequests()
 		m.saveCurrentSession()
 		return m, tea.Quit
 

--- a/internal/app/quit_cancel_inflight_test.go
+++ b/internal/app/quit_cancel_inflight_test.go
@@ -71,6 +71,22 @@ func TestCloseTabOrQuit_LastTab_CancelsInFlightRequests(t *testing.T) {
 		"closeTabOrQuit's last-tab branch must cancel m.reqCtx before tea.Quit")
 }
 
+// Third quit entry point: the :quit command bar (also :q, :q!).
+// Mirrors the overlay-confirm and ctrl+c paths — must cancel reqCtx
+// before tea.Quit so in-flight goroutines abort.
+func TestExecuteBuiltinCommand_Quit_CancelsInFlightRequests(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}}
+	reqCtx := armReqCtx(&m)
+
+	_, cmd := m.executeBuiltinCommand("q")
+	require.NotNil(t, cmd, ":quit must dispatch tea.Quit")
+
+	assert.ErrorIs(t, reqCtx.Err(), context.Canceled,
+		":quit (and :q, :q!) must cancel m.reqCtx before tea.Quit so "+
+			"in-flight API requests abort instead of riding out TCP timeouts")
+}
+
 // Multi-tab close (not a quit) must NOT cancel reqCtx — surviving
 // tabs need the request context to stay live for their loads.
 func TestCloseTabOrQuit_MultiTab_PreservesReqCtx(t *testing.T) {

--- a/internal/app/quit_cancel_inflight_test.go
+++ b/internal/app/quit_cancel_inflight_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// armReqCtx wires a cancelable request context onto the model so the
+// quit handlers' m.cancelInFlightRequests() call can actually do its
+// job. baseModelWithFakeClient leaves reqCancel nil, which would make
+// the cancel a silent no-op and miss the regression.
+func armReqCtx(m *Model) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	m.reqCtx = ctx
+	m.reqCancel = cancel
+	return ctx
+}
+
+// All three quit paths (overlay confirm, ctrl+c last-tab, :quit
+// command) must cancel m.reqCtx before returning tea.Quit so
+// in-flight goroutines (discovery, list, owned, containers) abort
+// with context.Canceled rather than riding out kernel TCP timeouts.
+//
+// Without this, on an unreachable cluster the quit can stretch to
+// minutes while main's deferred cleanups (informer wg.Wait,
+// stderr-pipe reader, etc.) wait for those goroutines to finish
+// their HTTP calls naturally.
+
+func TestHandleQuitConfirmOverlayKey_CancelsInFlightRequests(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}}
+	reqCtx := armReqCtx(&m)
+	require.NoError(t, reqCtx.Err(),
+		"precondition: reqCtx must not be canceled before quit")
+
+	result, cmd := m.handleQuitConfirmOverlayKey(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune{'y'},
+	})
+
+	require.NotNil(t, cmd, "quit handler must dispatch tea.Quit")
+	_ = result.(Model)
+
+	assert.ErrorIs(t, reqCtx.Err(), context.Canceled,
+		"quit confirm must cancel m.reqCtx so in-flight API requests "+
+			"abort instead of riding out TCP timeouts during shutdown")
+}
+
+func TestCloseTabOrQuit_LastTab_CancelsInFlightRequests(t *testing.T) {
+	// Disable the confirm overlay so closeTabOrQuit goes straight to
+	// the quit branch instead of bouncing through handleQuitConfirmOverlayKey.
+	prev := ui.ConfigConfirmOnExit
+	ui.ConfigConfirmOnExit = false
+	defer func() { ui.ConfigConfirmOnExit = prev }()
+
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}} // single tab → quit path
+	reqCtx := armReqCtx(&m)
+
+	result, cmd := m.closeTabOrQuit()
+	require.NotNil(t, cmd, "last-tab close with confirm-off must dispatch tea.Quit")
+	_ = result.(Model)
+
+	assert.ErrorIs(t, reqCtx.Err(), context.Canceled,
+		"closeTabOrQuit's last-tab branch must cancel m.reqCtx before tea.Quit")
+}
+
+// Multi-tab close (not a quit) must NOT cancel reqCtx — surviving
+// tabs need the request context to stay live for their loads.
+func TestCloseTabOrQuit_MultiTab_PreservesReqCtx(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}, {}}
+	m.activeTab = 1
+	reqCtx := armReqCtx(&m)
+
+	result, _ := m.closeTabOrQuit()
+	_ = result.(Model)
+
+	assert.NoError(t, reqCtx.Err(),
+		"closing one tab when others remain must not cancel reqCtx — "+
+			"surviving tabs still need it for their fetches")
+}

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -710,6 +710,7 @@ func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 		m.portForwardMgr.StopAll()
 	}
 	m.cancelAllTabLogStreams()
+	m.cancelInFlightRequests()
 	m.saveCurrentSession()
 	return m, tea.Quit
 }

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -705,13 +705,7 @@ func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 		m.overlay = overlayQuitConfirm
 		return m, nil
 	}
-	// Stop all active port forwards before quitting.
-	if m.portForwardMgr != nil {
-		m.portForwardMgr.StopAll()
-	}
-	m.cancelAllTabLogStreams()
-	m.cancelInFlightRequests()
-	m.saveCurrentSession()
+	m.performQuitCleanup()
 	return m, tea.Quit
 }
 

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -399,12 +399,7 @@ func (m Model) handleQuitConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 	switch msg.String() {
 	case "enter", "y", "Y":
 		m.overlay = overlayNone
-		if m.portForwardMgr != nil {
-			m.portForwardMgr.StopAll()
-		}
-		m.cancelAllTabLogStreams()
-		m.cancelInFlightRequests()
-		m.saveCurrentSession()
+		m.performQuitCleanup()
 		return m, tea.Quit
 	case "n", "N", "esc", "q":
 		m.overlay = overlayNone

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -403,6 +403,7 @@ func (m Model) handleQuitConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 			m.portForwardMgr.StopAll()
 		}
 		m.cancelAllTabLogStreams()
+		m.cancelInFlightRequests()
 		m.saveCurrentSession()
 		return m, tea.Quit
 	case "n", "N", "esc", "q":


### PR DESCRIPTION
## Summary

When the active cluster is unreachable (paused kind container, dead VPN, etc.), pressing q+y can hang the terminal for a minute or more before the prompt returns. In-flight API goroutines (debounced previews, periodic discovery) ride out kernel TCP timeouts (~30s each) while main's deferred cleanups wait for resources they hold.

Fix: cancel `m.reqCtx` in all three quit paths (overlay confirm, ctrl+c last-tab, `:quit` command) so those goroutines abort with `context.Canceled` immediately instead.

## Type of change

- [ ] feat: new user-facing feature
- [x] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

<!-- none -->

## Changes

- Added `Model.cancelInFlightRequests()` helper alongside existing `cancelAndReset()` (cancel without allocating a fresh context we won't use at shutdown)
- Wired it into all three quit paths: `handleQuitConfirmOverlayKey`, `closeTabOrQuit` last-tab branch, `executeBuiltinCommand` `:quit` case
- Regression tests for all three quit entry points + a non-regression test for multi-tab close (must NOT cancel)

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (pre-commit hook)
- [x] Manually verified against a paused kind cluster: pre-fix prompt returns after 1+ minute, post-fix sub-second

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots