### PR TITLE
feat(networking): per-endpoint preview for Endpoints / EndpointSlices

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -225,7 +225,7 @@ win and removes redundant load on the API server.
 The right-pane preview for the **Endpoints** and **EndpointSlices** kinds
 shows every endpoint individually, with target pod, node, and ready state:
 
-```
+```text
 READY      3
 NOT READY  1
 PORTS      http:80/TCP

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -220,6 +220,33 @@ win and removes redundant load on the API server.
 - **TTL:** 5 minutes. Stale entries are refetched automatically on the
   next discovery request.
 
+## Endpoint Visibility
+
+The right-pane preview for the **Endpoints** and **EndpointSlices** kinds
+shows every endpoint individually, with target pod, node, and ready state:
+
+```
+READY      3
+NOT READY  1
+PORTS      http:80/TCP
+
+ENDPOINTS
+  192.168.1.5  → pod/foo-7d9         on node-a
+  192.168.1.6  → pod/foo-7d9-9fr     on node-b
+  192.168.1.7  → pod/foo-7d9-2qx     on node-a
+  192.168.1.8  → pod/foo-7d9-broken  on node-c   (NotReady)
+```
+
+Ready endpoints render with no status suffix; only `(NotReady)` is shown
+inline so the eye is drawn to the broken ones. A row degrades gracefully
+when `targetRef` (no target pod) or `nodeName` (host-network endpoints)
+is absent. Multiple addresses on a single EndpointSlice entry (dual-stack
+IPv4/IPv6 setups) each get their own line.
+
+For a Service's effective endpoints, press `v` (Describe) — `kubectl
+describe service` lists the resolved Endpoints inline as today. A
+dedicated rollup in the Service preview is on the roadmap.
+
 ## Secret Lazy Loading
 
 On clusters with many Helm releases or large TLS secrets, listing the

--- a/internal/k8s/client_populate_endpoints_test.go
+++ b/internal/k8s/client_populate_endpoints_test.go
@@ -167,6 +167,70 @@ func TestPopulateEndpointSlice_EmitsEndpointsMultiLine(t *testing.T) {
 	assert.Contains(t, lines[1], "192.168.1.6 → pod/foo-7d9-broken (NotReady)")
 }
 
+// Regression for the previous inverted default: per
+// discovery.k8s.io/v1, an absent / null conditions.ready means
+// "unknown" and must be interpreted as *ready*. The previous default
+// of false was flagging every endpoint on a slice without an explicit
+// ready field as (NotReady) — including the slices written by older
+// API versions that don't populate the field.
+func TestPopulateEndpointSlice_MissingConditionsTreatedAsReady(t *testing.T) {
+	obj := map[string]any{
+		"addressType": "IPv4",
+		"endpoints": []any{
+			map[string]any{
+				"addresses": []any{"192.168.1.5"},
+				// conditions absent: API spec says treat as ready.
+				"targetRef": map[string]any{"kind": "Pod", "name": "foo"},
+			},
+			map[string]any{
+				"addresses":  []any{"192.168.1.6"},
+				"conditions": map[string]any{},
+				// conditions.ready absent: API spec says treat as ready.
+				"targetRef": map[string]any{"kind": "Pod", "name": "bar"},
+			},
+			map[string]any{
+				"addresses":  []any{"192.168.1.7"},
+				"conditions": map[string]any{"ready": nil},
+				// conditions.ready explicitly null: API spec says treat as ready.
+				"targetRef": map[string]any{"kind": "Pod", "name": "baz"},
+			},
+		},
+	}
+	ti := &model.Item{}
+	populateEndpointSlice(ti, obj)
+
+	value := findColumnValue(ti.Columns, "Endpoints")
+	for i, line := range strings.Split(value, "\n") {
+		assert.NotContains(t, line, "NotReady",
+			"row %d (%q): missing/null conditions.ready must be treated as Ready, not (NotReady)",
+			i, line)
+	}
+	assert.Equal(t, "3", findColumnValue(ti.Columns, "Ready"),
+		"all three endpoints with absent/empty/null conditions count as Ready")
+	assert.Empty(t, findColumnValue(ti.Columns, "Not Ready"),
+		"no Not Ready column when every endpoint is treated as ready")
+}
+
+func TestPopulateEndpointSlice_ExplicitlyFalseConditionsAreNotReady(t *testing.T) {
+	// Symmetric check: when conditions.ready *is* set and is false, the
+	// endpoint must still flag as (NotReady) — the missing-treated-as-
+	// ready fix above must not also swallow explicit false.
+	obj := map[string]any{
+		"addressType": "IPv4",
+		"endpoints": []any{
+			map[string]any{
+				"addresses":  []any{"192.168.1.5"},
+				"conditions": map[string]any{"ready": false},
+				"targetRef":  map[string]any{"kind": "Pod", "name": "broken"},
+			},
+		},
+	}
+	ti := &model.Item{}
+	populateEndpointSlice(ti, obj)
+	assert.Contains(t, findColumnValue(ti.Columns, "Endpoints"), "(NotReady)")
+	assert.Equal(t, "1", findColumnValue(ti.Columns, "Not Ready"))
+}
+
 func TestPopulateEndpointSlice_MultipleAddressesPerEndpointEmitOneLineEach(t *testing.T) {
 	// EndpointSlice entries can carry multiple addresses (rare for IPv4, normal
 	// for IPv4/IPv6 dual-stack). Each address must get its own preview line so

--- a/internal/k8s/client_populate_endpoints_test.go
+++ b/internal/k8s/client_populate_endpoints_test.go
@@ -1,0 +1,189 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// findColumnValue returns the first column matching key, or "" when absent.
+// Helper kept private to this test file to avoid noisy public surface.
+func findColumnValue(cols []model.KeyValue, key string) string {
+	for _, kv := range cols {
+		if kv.Key == key {
+			return kv.Value
+		}
+	}
+	return ""
+}
+
+// --- formatEndpointLine ---
+
+func TestFormatEndpointLine_Ready(t *testing.T) {
+	got := formatEndpointLine("192.168.1.5", "Pod", "foo-7d9", "node-a", true)
+	assert.Equal(t, "192.168.1.5 → pod/foo-7d9 on node-a", got,
+		"ready endpoints render without a state suffix so the user's eye is drawn to broken ones")
+}
+
+func TestFormatEndpointLine_NotReady(t *testing.T) {
+	got := formatEndpointLine("192.168.1.5", "Pod", "foo-7d9", "node-a", false)
+	assert.Equal(t, "192.168.1.5 → pod/foo-7d9 on node-a (NotReady)", got,
+		"not-ready endpoints append a (NotReady) marker")
+}
+
+func TestFormatEndpointLine_NoTargetRef(t *testing.T) {
+	got := formatEndpointLine("10.0.0.1", "", "", "", true)
+	assert.Equal(t, "10.0.0.1", got,
+		"address with no target ref renders bare — common for headless services with manually registered endpoints")
+}
+
+func TestFormatEndpointLine_NoNode(t *testing.T) {
+	got := formatEndpointLine("192.168.1.5", "Pod", "foo-7d9", "", true)
+	assert.Equal(t, "192.168.1.5 → pod/foo-7d9", got,
+		"endpoints without a nodeName drop the 'on <node>' segment cleanly")
+}
+
+func TestFormatEndpointLine_LowercasesKindForKubectlStyle(t *testing.T) {
+	got := formatEndpointLine("1.2.3.4", "Pod", "x", "", true)
+	assert.True(t, strings.Contains(got, "pod/x"),
+		"target kind is lowercased so the output matches kubectl's pod/foo style — output: %q", got)
+}
+
+// --- populateEndpoints (v1 Endpoints) ---
+
+func TestPopulateEndpoints_EmitsEndpointsMultiLine(t *testing.T) {
+	obj := map[string]any{
+		"subsets": []any{
+			map[string]any{
+				"addresses": []any{
+					map[string]any{
+						"ip":       "192.168.1.5",
+						"nodeName": "node-a",
+						"targetRef": map[string]any{
+							"kind": "Pod",
+							"name": "foo-7d9",
+						},
+					},
+					map[string]any{
+						"ip":       "192.168.1.6",
+						"nodeName": "node-b",
+						"targetRef": map[string]any{
+							"kind": "Pod",
+							"name": "foo-7d9-9fr",
+						},
+					},
+				},
+				"notReadyAddresses": []any{
+					map[string]any{
+						"ip": "192.168.1.7",
+						"targetRef": map[string]any{
+							"kind": "Pod",
+							"name": "foo-7d9-broken",
+						},
+					},
+				},
+				"ports": []any{
+					map[string]any{"name": "http", "port": float64(80), "protocol": "TCP"},
+				},
+			},
+		},
+	}
+	ti := &model.Item{}
+	populateEndpoints(ti, obj)
+
+	value := findColumnValue(ti.Columns, "Endpoints")
+	require := assert.New(t)
+	require.NotEmpty(value, "Endpoints multi-line block must be emitted when subsets contain addresses")
+	lines := strings.Split(value, "\n")
+	assert.Len(t, lines, 3, "one line per address (ready + not-ready), so the preview shows every endpoint")
+	assert.Contains(t, lines[0], "192.168.1.5 → pod/foo-7d9 on node-a")
+	assert.NotContains(t, lines[0], "NotReady", "ready endpoints have no NotReady marker")
+	assert.Contains(t, lines[1], "192.168.1.6 → pod/foo-7d9-9fr on node-b")
+	assert.Contains(t, lines[2], "192.168.1.7 → pod/foo-7d9-broken (NotReady)",
+		"not-ready endpoints flagged inline so a degraded service is obvious at a glance")
+}
+
+func TestPopulateEndpoints_PreservesReadyCounts(t *testing.T) {
+	// Existing rollup columns (Ready / Not Ready / Ports) must stay so the
+	// preview keeps its summary stats above the new per-endpoint block.
+	obj := map[string]any{
+		"subsets": []any{
+			map[string]any{
+				"addresses":         []any{map[string]any{"ip": "1.1.1.1"}},
+				"notReadyAddresses": []any{map[string]any{"ip": "2.2.2.2"}},
+				"ports":             []any{map[string]any{"port": float64(80), "protocol": "TCP"}},
+			},
+		},
+	}
+	ti := &model.Item{}
+	populateEndpoints(ti, obj)
+
+	assert.Equal(t, "1", findColumnValue(ti.Columns, "Ready"))
+	assert.Equal(t, "1", findColumnValue(ti.Columns, "Not Ready"))
+	assert.NotEmpty(t, findColumnValue(ti.Columns, "Ports"))
+}
+
+func TestPopulateEndpoints_NoSubsetsFallsBackToNoneNotice(t *testing.T) {
+	ti := &model.Item{}
+	populateEndpoints(ti, map[string]any{})
+	assert.Equal(t, "<none>", findColumnValue(ti.Columns, "Endpoints"),
+		"missing subsets surface as <none> so the user sees that the resource is empty rather than just blank")
+}
+
+// --- populateEndpointSlice (discovery.k8s.io/v1) ---
+
+func TestPopulateEndpointSlice_EmitsEndpointsMultiLine(t *testing.T) {
+	obj := map[string]any{
+		"addressType": "IPv4",
+		"endpoints": []any{
+			map[string]any{
+				"addresses":  []any{"192.168.1.5"},
+				"conditions": map[string]any{"ready": true},
+				"nodeName":   "node-a",
+				"targetRef":  map[string]any{"kind": "Pod", "name": "foo-7d9"},
+			},
+			map[string]any{
+				"addresses":  []any{"192.168.1.6"},
+				"conditions": map[string]any{"ready": false},
+				"targetRef":  map[string]any{"kind": "Pod", "name": "foo-7d9-broken"},
+			},
+		},
+		"ports": []any{
+			map[string]any{"name": "http", "port": float64(80), "protocol": "TCP"},
+		},
+	}
+	ti := &model.Item{}
+	populateEndpointSlice(ti, obj)
+
+	value := findColumnValue(ti.Columns, "Endpoints")
+	assert.NotEmpty(t, value)
+	lines := strings.Split(value, "\n")
+	assert.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "192.168.1.5 → pod/foo-7d9 on node-a")
+	assert.NotContains(t, lines[0], "NotReady")
+	assert.Contains(t, lines[1], "192.168.1.6 → pod/foo-7d9-broken (NotReady)")
+}
+
+func TestPopulateEndpointSlice_MultipleAddressesPerEndpointEmitOneLineEach(t *testing.T) {
+	// EndpointSlice entries can carry multiple addresses (rare for IPv4, normal
+	// for IPv4/IPv6 dual-stack). Each address must get its own preview line so
+	// users can tell which address is up.
+	obj := map[string]any{
+		"addressType": "IPv4",
+		"endpoints": []any{
+			map[string]any{
+				"addresses":  []any{"192.168.1.5", "192.168.1.6"},
+				"conditions": map[string]any{"ready": true},
+				"targetRef":  map[string]any{"kind": "Pod", "name": "foo"},
+			},
+		},
+	}
+	ti := &model.Item{}
+	populateEndpointSlice(ti, obj)
+	value := findColumnValue(ti.Columns, "Endpoints")
+	lines := strings.Split(value, "\n")
+	assert.Len(t, lines, 2, "each address in a multi-address endpoint gets its own preview line")
+}

--- a/internal/k8s/client_populate_misc.go
+++ b/internal/k8s/client_populate_misc.go
@@ -336,36 +336,81 @@ func populateNetworkPolicy(ti *model.Item, spec map[string]any) {
 	}
 }
 
+// endpointEntry is the per-address payload extracted from a v1 Endpoints
+// subset or a discovery.k8s.io/v1 EndpointSlice endpoint. Used to build
+// the multi-line "Endpoints" preview block uniformly across both kinds.
+type endpointEntry struct {
+	addr       string
+	targetKind string
+	targetName string
+	nodeName   string
+	ready      bool
+}
+
+// formatEndpointLine renders a single endpoint as
+// "addr → kind/name on node (NotReady)" for the per-endpoint multi-line
+// "Endpoints" preview field. The (NotReady) suffix is only emitted when
+// the endpoint is *not* ready — ready is the silent default so the eye
+// is drawn to broken endpoints. Missing target ref / node degrade the
+// line gracefully (drop the segment).
+func formatEndpointLine(addr, targetKind, targetName, nodeName string, ready bool) string {
+	parts := []string{addr}
+	if targetKind != "" && targetName != "" {
+		parts = append(parts, "→", strings.ToLower(targetKind)+"/"+targetName)
+	}
+	if nodeName != "" {
+		parts = append(parts, "on", nodeName)
+	}
+	line := strings.Join(parts, " ")
+	if !ready {
+		line += " (NotReady)"
+	}
+	return line
+}
+
+// joinEndpointLines turns a list of endpointEntry values into the
+// newline-separated value of the "Endpoints" KeyValue. The renderer
+// (extended in this PR to split on `\n` for the "Endpoints" key) emits
+// one preview line per entry.
+func joinEndpointLines(entries []endpointEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, formatEndpointLine(e.addr, e.targetKind, e.targetName, e.nodeName, e.ready))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// extractTargetRef pulls (kind, name) from a targetRef map. Returns
+// empty strings when the ref is absent or malformed — formatEndpointLine
+// degrades gracefully on missing values.
+func extractTargetRef(m map[string]any) (kind, name string) {
+	ref, ok := m["targetRef"].(map[string]any)
+	if !ok {
+		return "", ""
+	}
+	kind, _ = ref["kind"].(string)
+	name, _ = ref["name"].(string)
+	return kind, name
+}
+
 func populateEndpoints(ti *model.Item, obj map[string]any) {
 	subsets, ok := obj["subsets"].([]any)
 	if !ok {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Endpoints", Value: "<none>"})
 		return
 	}
-	var addrs, notReady, portStrs []string
+	var entries []endpointEntry
+	var portStrs []string
 	for _, s := range subsets {
 		subset, ok := s.(map[string]any)
 		if !ok {
 			continue
 		}
-		if list, ok := subset["addresses"].([]any); ok {
-			for _, a := range list {
-				if amap, ok := a.(map[string]any); ok {
-					if ip, ok := amap["ip"].(string); ok {
-						addrs = append(addrs, ip)
-					}
-				}
-			}
-		}
-		if list, ok := subset["notReadyAddresses"].([]any); ok {
-			for _, a := range list {
-				if amap, ok := a.(map[string]any); ok {
-					if ip, ok := amap["ip"].(string); ok {
-						notReady = append(notReady, ip)
-					}
-				}
-			}
-		}
+		entries = append(entries, collectV1EndpointAddresses(subset, "addresses", true)...)
+		entries = append(entries, collectV1EndpointAddresses(subset, "notReadyAddresses", false)...)
 		if list, ok := subset["ports"].([]any); ok {
 			for _, p := range list {
 				if pmap, ok := p.(map[string]any); ok {
@@ -374,12 +419,59 @@ func populateEndpoints(ti *model.Item, obj map[string]any) {
 			}
 		}
 	}
-	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Ready", Value: fmt.Sprintf("%d", len(addrs))})
-	if len(notReady) > 0 {
-		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Not Ready", Value: fmt.Sprintf("%d", len(notReady))})
+	emitEndpointPreviewColumns(ti, entries, portStrs)
+}
+
+// collectV1EndpointAddresses pulls one of "addresses" or "notReadyAddresses"
+// from a v1 Endpoints subset and returns endpointEntry values flagged with
+// the supplied ready state.
+func collectV1EndpointAddresses(subset map[string]any, key string, ready bool) []endpointEntry {
+	list, ok := subset[key].([]any)
+	if !ok {
+		return nil
 	}
-	if v := summarizeEndpointAddresses(addrs); v != "" {
-		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Addresses", Value: v})
+	out := make([]endpointEntry, 0, len(list))
+	for _, a := range list {
+		amap, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		ip, _ := amap["ip"].(string)
+		if ip == "" {
+			continue
+		}
+		nodeName, _ := amap["nodeName"].(string)
+		kind, name := extractTargetRef(amap)
+		out = append(out, endpointEntry{
+			addr:       ip,
+			targetKind: kind,
+			targetName: name,
+			nodeName:   nodeName,
+			ready:      ready,
+		})
+	}
+	return out
+}
+
+// emitEndpointPreviewColumns appends the Ready / Not Ready / Endpoints /
+// Ports preview columns from a fully-collected entry slice. Shared by
+// both populateEndpoints and populateEndpointSlice so the two kinds
+// stay visually identical even though they read different API shapes.
+func emitEndpointPreviewColumns(ti *model.Item, entries []endpointEntry, portStrs []string) {
+	var ready, notReady int
+	for _, e := range entries {
+		if e.ready {
+			ready++
+		} else {
+			notReady++
+		}
+	}
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Ready", Value: fmt.Sprintf("%d", ready)})
+	if notReady > 0 {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Not Ready", Value: fmt.Sprintf("%d", notReady)})
+	}
+	if v := joinEndpointLines(entries); v != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Endpoints", Value: v})
 	}
 	if len(portStrs) > 0 {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Ports", Value: strings.Join(portStrs, ", ")})
@@ -391,7 +483,7 @@ func populateEndpointSlice(ti *model.Item, obj map[string]any) {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Type", Value: t})
 	}
 	endpoints, _ := obj["endpoints"].([]any)
-	var ready, notReady, addrs []string
+	var entries []endpointEntry
 	for _, e := range endpoints {
 		ep, ok := e.(map[string]any)
 		if !ok {
@@ -403,37 +495,33 @@ func populateEndpointSlice(ti *model.Item, obj map[string]any) {
 				isReady = true
 			}
 		}
+		nodeName, _ := ep["nodeName"].(string)
+		kind, name := extractTargetRef(ep)
 		if as, ok := ep["addresses"].([]any); ok {
 			for _, a := range as {
-				if s, ok := a.(string); ok {
-					addrs = append(addrs, s)
-					if isReady {
-						ready = append(ready, s)
-					} else {
-						notReady = append(notReady, s)
-					}
+				s, ok := a.(string)
+				if !ok || s == "" {
+					continue
 				}
+				entries = append(entries, endpointEntry{
+					addr:       s,
+					targetKind: kind,
+					targetName: name,
+					nodeName:   nodeName,
+					ready:      isReady,
+				})
 			}
 		}
 	}
-	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Ready", Value: fmt.Sprintf("%d", len(ready))})
-	if len(notReady) > 0 {
-		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Not Ready", Value: fmt.Sprintf("%d", len(notReady))})
-	}
-	if v := summarizeEndpointAddresses(addrs); v != "" {
-		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Addresses", Value: v})
-	}
+	var portStrs []string
 	if ports, ok := obj["ports"].([]any); ok {
-		var portStrs []string
 		for _, p := range ports {
 			if pmap, ok := p.(map[string]any); ok {
 				portStrs = append(portStrs, formatEndpointPort(pmap))
 			}
 		}
-		if len(portStrs) > 0 {
-			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Ports", Value: strings.Join(portStrs, ", ")})
-		}
 	}
+	emitEndpointPreviewColumns(ti, entries, portStrs)
 }
 
 func formatEndpointPort(p map[string]any) string {
@@ -447,16 +535,4 @@ func formatEndpointPort(p map[string]any) string {
 		return fmt.Sprintf("%s:%d/%s", name, int64(port), proto)
 	}
 	return fmt.Sprintf("%d/%s", int64(port), proto)
-}
-
-func summarizeEndpointAddresses(addrs []string) string {
-	const maxShown = 3
-	switch {
-	case len(addrs) == 0:
-		return ""
-	case len(addrs) <= maxShown:
-		return strings.Join(addrs, ", ")
-	default:
-		return strings.Join(addrs[:maxShown], ", ") + fmt.Sprintf(" +%d more", len(addrs)-maxShown)
-	}
 }

--- a/internal/k8s/client_populate_misc.go
+++ b/internal/k8s/client_populate_misc.go
@@ -489,10 +489,18 @@ func populateEndpointSlice(ti *model.Item, obj map[string]any) {
 		if !ok {
 			continue
 		}
-		isReady := false
+		// Per discovery.k8s.io/v1: a missing or null conditions.ready is
+		// "unknown" and consumers should interpret unknown as *ready*
+		// (per the upstream API spec — older API versions didn't
+		// populate the field, so absence means "not enough info to
+		// declare not-ready"). Default to true and only flip to false
+		// when ready is explicitly present and false. The previous
+		// inverted default would have flagged every endpoint on an
+		// older slice as (NotReady).
+		isReady := true
 		if cond, ok := ep["conditions"].(map[string]any); ok {
-			if r, ok := cond["ready"].(bool); ok && r {
-				isReady = true
+			if r, ok := cond["ready"].(bool); ok {
+				isReady = r
 			}
 		}
 		nodeName, _ := ep["nodeName"].(string)

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -92,7 +92,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 			// Workflow steps: collected separately for STEPS section.
 			continue
 		}
-		if kv.Key == "Labels" || kv.Key == "Finalizers" || kv.Key == "Annotations" || kv.Key == "Used By" || kv.Key == "Selector" || kv.Key == "Taints" {
+		if kv.Key == "Labels" || kv.Key == "Finalizers" || kv.Key == "Annotations" || kv.Key == "Used By" || kv.Key == "Selector" || kv.Key == "Taints" || kv.Key == "Endpoints" {
 			multiLineFields = append(multiLineFields, kv)
 			continue
 		}
@@ -222,9 +222,12 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		renderRow(r)
 	}
 
-	// Render multi-line fields: Taints first (important for node scheduling
-	// decisions), then Labels and Annotations, then Finalizers/Selector/UsedBy.
-	multiOrder := []string{"Taints", "Labels", "Annotations", "Finalizers", "Selector", "Used By"}
+	// Render multi-line fields: Endpoints first (most actionable when
+	// debugging Service / EndpointSlice problems — broken endpoints are
+	// often what drives a user to look at the preview at all), then
+	// Taints (important for node scheduling decisions), then Labels and
+	// Annotations, then Finalizers/Selector/UsedBy.
+	multiOrder := []string{"Endpoints", "Taints", "Labels", "Annotations", "Finalizers", "Selector", "Used By"}
 	multiMap := make(map[string]model.KeyValue, len(multiLineFields))
 	for _, kv := range multiLineFields {
 		multiMap[kv.Key] = kv
@@ -239,7 +242,14 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		}
 		lines = append(lines, "")
 		lines = append(lines, detailKeyStyle.Render(strings.ToUpper(kv.Key)))
-		for entry := range strings.SplitSeq(kv.Value, ", ") {
+		// Endpoints emits one entry per line with `\n` as separator so
+		// the per-endpoint render stays readable; everything else uses
+		// the legacy `, ` split so existing fields render unchanged.
+		sep := ", "
+		if kv.Key == "Endpoints" {
+			sep = "\n"
+		}
+		for entry := range strings.SplitSeq(kv.Value, sep) {
 			if len(lines) >= height {
 				break
 			}


### PR DESCRIPTION
## Summary

Replaces the summary-only \`Addresses: ip1, ip2 +N more\` line in the right-pane preview with a per-endpoint multi-line block that shows target pod, node, and ready state for every endpoint:

\`\`\`
READY      3
NOT READY  1
PORTS      http:80/TCP

ENDPOINTS
  192.168.1.5  → pod/foo-7d9         on node-a
  192.168.1.6  → pod/foo-7d9-9fr     on node-b
  192.168.1.7  → pod/foo-7d9-2qx     on node-a
  192.168.1.8  → pod/foo-7d9-broken  on node-c   (NotReady)
\`\`\`

Ready endpoints render with no status suffix; only \`(NotReady)\` is shown inline so the eye is drawn to the broken ones. Rows degrade gracefully when \`targetRef\` (no target pod) or \`nodeName\` (host-network endpoints) is absent. Multiple addresses on a single EndpointSlice entry (dual-stack IPv4/IPv6) each get their own line.

## Implementation notes

- New \`endpointEntry\` value type unifies the per-address payload extracted from v1 \`Endpoints\` (\`subsets[].addresses\` + \`notReadyAddresses\`) and \`discovery.k8s.io/v1\` \`EndpointSlices\` (\`endpoints[].conditions.ready\`), so both kinds emit identical preview blocks.
- \`formatEndpointLine\` assembles \`addr → kind/name on node (NotReady)\` with kind lowercased to match kubectl's \`pod/foo\` style.
- \`emitEndpointPreviewColumns\` is shared between \`populateEndpoints\` and \`populateEndpointSlice\` — both kinds get the same \`Ready\` / \`Not Ready\` / \`Endpoints\` / \`Ports\` columns.
- Renderer (\`internal/ui/explorer_resource.go\`) extended to recognise the new \`Endpoints\` multi-line key and split on \`\\n\` instead of the legacy \`, \` — long per-row text no longer gets artificially comma-split. Existing fields (Labels, Annotations, etc.) keep their \`, \` split. \`Endpoints\` is rendered first in the multi-line order because broken endpoints are typically what drives users to look at the preview at all.
- Removed the now-unused \`summarizeEndpointAddresses\` helper.

## Out of scope (deferred to follow-up)

**Service preview rollup** — adding the same endpoint info to the \`Service\` preview (so a broken Service is visible without drilling in) needs a substantial new lazy-fetch pattern:
1. New \`Client.GetServiceEndpoints(ctx, kubeCtx, ns, svcName)\` method that lists \`EndpointSlice\`s with the \`kubernetes.io/service-name\` label selector and reuses \`formatEndpointLine\`.
2. New \`serviceEndpointsCache map[string]string\` on \`Model\` mirroring \`secretPreviewCache\`'s shape.
3. New \`loadPreviewServiceEndpoints\` cmd that lazy-fetches on hover.
4. New \`previewServiceEndpointsLoadedMsg\` + handler that injects an \`Endpoints\` KV into matching \`middleItems\` entries.

Substantial enough to warrant its own PR. Filed as a separate todo. Until that lands, users press \`v\` (Describe) on a Service to see \`kubectl describe\`'s inline Endpoints listing.

## Tests

10 new tests in \`client_populate_endpoints_test.go\`:

- **\`formatEndpointLine\`**: ready / not-ready suffix, missing target ref, missing node, kind lowercasing.
- **\`populateEndpoints\` (v1)**: emits the multi-line block, preserves the legacy \`Ready\` / \`Not Ready\` / \`Ports\` rollup columns, falls back to \`<none>\` when subsets are absent.
- **\`populateEndpointSlice\` (discovery.k8s.io/v1)**: same multi-line emission, dual-stack multi-address per endpoint each get their own line.

## Test plan

- [ ] Open the \`Endpoints\` resource type and hover over a service's endpoint object → preview shows per-endpoint lines with target pods + nodes.
- [ ] Hover over an Endpoint with at least one not-ready address → that line shows \`(NotReady)\` in dim text; ready lines have no suffix.
- [ ] Same checks on an \`EndpointSlice\` (\`discovery.k8s.io\`).
- [ ] Hover over an Endpoint with \`subsets: null\` (DNS-only Service) → preview shows \`Endpoints: <none>\`.
- [ ] Hover over a Service → preview unchanged (no rollup yet — see "out of scope" above).