### PR TITLE
fix(tabs): persist right-pane footers per tab so metrics don't bleed

### DIFF
--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -150,6 +150,14 @@ type TabState struct {
 	dashboardPreview       string
 	dashboardEventsPreview string // warning events for two-column dashboard
 	monitoringPreview      string
+	// metricsContent and previewEventsContent are right-pane footers
+	// rendered below the children list. They have to live per-tab —
+	// otherwise switching from a Pods tab (which has metrics) to a
+	// Services tab (which doesn't) leaves the Pods metrics rendered
+	// at the bottom of the Services preview because no loader fires
+	// to clear them.
+	metricsContent       string
+	previewEventsContent string
 
 	// Toggle to show only Warning events in Event list view.
 	warningEventsOnly bool

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -414,6 +414,8 @@ func (m *Model) saveCurrentTab() {
 	t.dashboardPreview = m.dashboardPreview
 	t.dashboardEventsPreview = m.dashboardEventsPreview
 	t.monitoringPreview = m.monitoringPreview
+	t.metricsContent = m.metricsContent
+	t.previewEventsContent = m.previewEventsContent
 	t.warningEventsOnly = m.warningEventsOnly
 	t.eventGrouping = m.eventGrouping
 	t.expandedGroup = m.expandedGroup
@@ -521,6 +523,10 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.dashboardPreview = t.dashboardPreview
 	m.dashboardEventsPreview = t.dashboardEventsPreview
 	m.monitoringPreview = t.monitoringPreview
+	// Restore the right-pane footers so the new tab paints with its own
+	// metrics / events instead of leaking the previous tab's values.
+	m.metricsContent = t.metricsContent
+	m.previewEventsContent = t.previewEventsContent
 	m.warningEventsOnly = t.warningEventsOnly
 	m.eventGrouping = t.eventGrouping
 	m.expandedGroup = t.expandedGroup
@@ -670,6 +676,8 @@ func (m *Model) cloneCurrentTab() TabState {
 		dashboardPreview:       m.dashboardPreview,
 		dashboardEventsPreview: m.dashboardEventsPreview,
 		monitoringPreview:      m.monitoringPreview,
+		metricsContent:         m.metricsContent,
+		previewEventsContent:   m.previewEventsContent,
 		warningEventsOnly:      m.warningEventsOnly,
 		eventGrouping:          m.eventGrouping,
 		expandedGroup:          m.expandedGroup,

--- a/internal/app/tabs_metrics_bleed_test.go
+++ b/internal/app/tabs_metrics_bleed_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Regression for the bug where switching from a Pods tab (with metrics
+// rendered at the bottom of the right pane) to a Services tab left
+// the Pods metrics rendered. Root cause: m.metricsContent and
+// m.previewEventsContent were Model-level fields, so saveCurrentTab /
+// loadTab didn't preserve them per-tab — the next tab inherited
+// whatever the previous tab had set, and Service has no metrics
+// loader to overwrite it.
+//
+// Fix: both fields now live on TabState. This test pins the per-tab
+// round-trip so a future refactor can't silently drop them again.
+func TestSaveAndLoadTab_PreservesMetricsAndEventsFootersPerTab(t *testing.T) {
+	m := Model{
+		tabs: []TabState{
+			{nav: model.NavigationState{Context: "kctx"}}, // tab 0: pods
+			{nav: model.NavigationState{Context: "kctx"}}, // tab 1: services
+		},
+		activeTab: 0,
+		// Tab 0 (Pods) has rendered metrics + an events footer.
+		metricsContent:       "POD METRICS BAR",
+		previewEventsContent: "warning: ImagePullBackoff",
+	}
+
+	// User switches from tab 0 to tab 1.
+	m.saveCurrentTab()
+	require.Equal(t, "POD METRICS BAR", m.tabs[0].metricsContent,
+		"metricsContent must persist into TabState so it survives tab switches")
+	require.Equal(t, "warning: ImagePullBackoff", m.tabs[0].previewEventsContent,
+		"previewEventsContent likewise")
+
+	cmd := m.loadTab(1)
+	_ = cmd // load may fire a refresh; we only care about state here.
+
+	assert.Empty(t, m.metricsContent,
+		"loadTab must not leak the previous tab's metricsContent into the new tab — Services has no metrics loader to clear it")
+	assert.Empty(t, m.previewEventsContent,
+		"same per-tab guarantee for the events footer")
+
+	// Switch back to tab 0 → Pods footers must come back from the cache
+	// so the user sees the values they had before the round-trip,
+	// pending the next watch tick refresh.
+	m.saveCurrentTab()
+	m.loadTab(0)
+	assert.Equal(t, "POD METRICS BAR", m.metricsContent,
+		"returning to a tab restores its previously-rendered metricsContent")
+	assert.Equal(t, "warning: ImagePullBackoff", m.previewEventsContent)
+}


### PR DESCRIPTION
## Summary

User-reported: open a **Pods** tab (which renders a CPU/MEM resource-usage bar at the bottom of the right pane), then switch to a **Services** tab. The Services tab's right pane re-renders correctly *except* the Pods metrics bar — it stays at the bottom because nothing on the Service path clears it.

## Root cause

\`m.metricsContent\` and \`m.previewEventsContent\` are Model-level fields. \`saveCurrentTab\` / \`loadTab\` persist per-tab state to \`TabState\`, but these two strings were never copied across the swap. So when \`loadTab\` swapped the active tab, every other right-pane piece (yaml content, dashboard preview, etc.) got restored from the new tab's \`TabState\` — but \`metricsContent\` and \`previewEventsContent\` kept whatever the previous tab left in them.

For **Pods → Services** this leaks the Pods metrics into Services (the bug the user hit). For **Services → Pods**, the leak is masked because \`loadMetrics\` fires on the Pod path and overwrites within ~100ms — but a user who switched away before the next tick would see the same flicker.

## Fix

Hoist both fields into \`TabState\` alongside the other right-pane caches (\`dashboardPreview\`, \`monitoringPreview\`, etc.). \`saveCurrentTab\`, \`loadTab\`, and \`cloneCurrentTab\` all copy them. Each tab now keeps its own footer state, and switching back restores the previously-rendered values until the next watch tick refresh — same SWR pattern the rest of the per-tab caches use.

## Tests

\`TestSaveAndLoadTab_PreservesMetricsAndEventsFootersPerTab\` pins the round-trip:

1. Pods tab is active, has metrics + events rendered → \`saveCurrentTab\` copies both into \`TabState[0]\`.
2. \`loadTab(1)\` (Services) → \`metricsContent\` and \`previewEventsContent\` clear (Services' \`TabState[1]\` has empty values).
3. Switch back to tab 0 → both restored to the Pod values.

Future refactors can't silently regress this.

## Test plan

- [x] Open a Pods tab in a busy namespace → metrics bar paints at the bottom of the right pane.
- [x] Press \`t\` to open a new tab; switch to the new tab and navigate to Services → metrics bar is GONE from the bottom.
- [x] Switch back to the Pods tab → metrics bar reappears with its previous values (refreshes on next watch tick).
- [x] Hover over a Pod with recent Events → events footer paints; switch to Services → events footer clears.