### PR TITLE
feat(rbac): reverse-RBAC "Who-Can" view, layered on the Can-I overlay

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -504,9 +504,35 @@ view to switch between the labels pane and the annotations pane.
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
 | `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
+| `Tab` | Toggle to **Who-Can** (reverse RBAC: verb + resource → subjects) |
 | `q` / `Esc` | Clear search / close |
 
 The title bar shows the namespace scope (`ns:...`) used for the permission check, so you can see whether permissions are cluster-wide or namespaced. When checking a service account, its own namespace is used automatically. Users and groups are discovered from ClusterRoleBindings and RoleBindings.
+
+## Who-Can (Reverse RBAC)
+
+Reachable from the Can-I browser via `Tab`. Inverts the question: instead
+of "what can this subject do", asks "who can do this verb on this
+resource". Pure RBAC scan — walks every `ClusterRoleBinding` plus the
+`RoleBinding`s in the active namespace scope, resolves their roles, and
+lists subjects whose bound rules match.
+
+| Key | Action |
+|---|---|
+| `←` / `→` (or `h` / `l`) | Cycle the verb chip (`get` `list` `watch` `create` `update` `patch` `delete` `*`) |
+| `/` | Filter resource (Enter to commit, Esc to discard) |
+| `j` / `k` | Scroll subjects table |
+| `A` | Toggle namespace scope (all-namespaces ⇄ active namespace) |
+| `Tab` | Back to forward Can-I view |
+| `q` / `Esc` | Close overlay |
+
+The result table shows `SUBJECT | KIND | NAMESPACE | VIA`. The `VIA`
+column records the binding chain (`ClusterRoleBinding/foo → ClusterRole/bar`
+or `RoleBinding/ns/foo → Role/bar`) so a user can audit *why* a subject
+has access.
+
+ClusterRoleBindings always count regardless of namespace scope (cluster-wide
+grants apply everywhere); RoleBindings outside the active scope are excluded.
 
 ## Can-I Subject Selector
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -517,11 +517,20 @@ resource". Pure RBAC scan — walks every `ClusterRoleBinding` plus the
 `RoleBinding`s in the active namespace scope, resolves their roles, and
 lists subjects whose bound rules match.
 
+Layout is two columns: a scrollable **Resources** picker on the left
+(deduped union of every resource the Can-I view knows about) and the
+**Subjects** result table on the right. Moving the cursor on the picker
+fires a fresh query so the right pane updates as you browse.
+
 | Key | Action |
 |---|---|
+| `j` / `k` (or `↓` / `↑`) | Move the resource cursor (re-queries for the new resource) |
+| `J` / `K` | Scroll the subjects column (right pane) without moving the resource cursor |
+| `g` / `G` (or `Home` / `End`) | Jump to top / bottom of the resource list |
+| `Ctrl+D` / `Ctrl+U` | Half page down / up in the resource list |
+| `Ctrl+F` / `Ctrl+B` (or `PgDn` / `PgUp`) | Full page down / up in the resource list |
 | `←` / `→` (or `h` / `l`) | Cycle the verb chip (`get` `list` `watch` `create` `update` `patch` `delete` `*`) |
-| `/` | Filter resource (Enter to commit, Esc to discard) |
-| `j` / `k` | Scroll subjects table |
+| `/` | Filter the resource list by substring (Enter to accept, Esc to clear) |
 | `A` | Toggle namespace scope (all-namespaces ⇄ active namespace) |
 | `Tab` | Back to forward Can-I view |
 | `q` / `Esc` | Close overlay |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -731,22 +731,10 @@ type Model struct {
 	explainRecursiveFilter       TextInput // filter input for recursive search overlay
 	explainRecursiveFilterActive bool      // true when typing in filter
 
-	// Can-I browser state.
-	canIGroups            []model.CanIGroup
-	canIGroupCursor       int // selected group in left column
-	canIGroupScroll       int
-	canIResourceScroll    int          // scroll offset for the resource column
-	canISubject           string       // "" = current user, or "system:serviceaccount:ns:name"
-	canISubjectName       string       // display name for the subject ("Current User" or "sa/name")
-	canIServiceAccounts   []string     // cached SA list for the selector
-	canISearchActive      bool         // true when typing in search bar
-	canISearchInput       TextInput    // current search input
-	canISearchQuery       string       // confirmed search query for filtering
-	canISubjectFilterMode bool         // true when typing in subject filter bar
-	canIAllowedOnly       bool         // true = show only allowed permissions
-	canINamespaces        []string     // namespaces used for SelfSubjectRulesReview
-	canIMode              canIViewMode // forward Can-I or reverse Who-Can (Tab toggle)
-	whoCan                whoCanState  // reverse-RBAC overlay state; see update_whocan.go
+	// Can-I / Who-Can RBAC explorer state — see cani_state.go. Embedded
+	// (not a named field) so existing accessors like m.canIGroups and
+	// m.whoCan continue to work via field promotion.
+	canIState
 
 	// Finalizer search overlay state.
 	finalizerSearchPattern      string

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -694,10 +694,10 @@ type Model struct {
 	sessionRestored     bool               // true once the pending session has been applied
 	pendingPortForwards *PortForwardStates // loaded port forwards waiting to be re-established
 
-	// Nested owned navigation: stack of parent states pushed when drilling
-	// from LevelOwned into a child that itself has children (e.g., ArgoCD
-	// Application → Deployment → Pods). Popped by navigateParent.
+	// Stack of LevelOwned parents for nested drill-downs (popped by navigateParent).
 	ownedParentStack []ownedParentState
+	// Overlay to restore when the current closes — set when a nested overlay flow opens (e.g., RBAC → namespace selector → back to RBAC).
+	previousOverlay overlayKind
 
 	// Per-context pinned CRD groups state.
 	pinnedState *PinnedState

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -194,11 +194,9 @@ type Model struct {
 	// CLI --read-only still wins over both.
 	contextROOverrides map[string]bool
 
-	// clusterColors holds per-context background-tint assignments set by the
-	// user via Ctrl+L on a row in the cluster picker. Persisted to
-	// $XDG_STATE_HOME/lfk/cluster-colors.yaml so the tint survives restarts.
-	// Absent key means "no tint"; values are validated against
-	// ui.ClusterColorNames at load and save time.
+	// clusterColors: per-context tint assignments set via Ctrl+L; persisted
+	// to $XDG_STATE_HOME/lfk/cluster-colors.yaml. Values validated against
+	// ui.ClusterColorNames; absent key = no tint.
 	clusterColors map[string]string
 
 	// clusterColorOverlay state: cursor position within the picker's color
@@ -737,16 +735,18 @@ type Model struct {
 	canIGroups            []model.CanIGroup
 	canIGroupCursor       int // selected group in left column
 	canIGroupScroll       int
-	canIResourceScroll    int       // scroll offset for the resource column
-	canISubject           string    // "" = current user, or "system:serviceaccount:ns:name"
-	canISubjectName       string    // display name for the subject ("Current User" or "sa/name")
-	canIServiceAccounts   []string  // cached SA list for the selector
-	canISearchActive      bool      // true when typing in search bar
-	canISearchInput       TextInput // current search input
-	canISearchQuery       string    // confirmed search query for filtering
-	canISubjectFilterMode bool      // true when typing in subject filter bar
-	canIAllowedOnly       bool      // true = show only allowed permissions
-	canINamespaces        []string  // namespaces used for SelfSubjectRulesReview
+	canIResourceScroll    int          // scroll offset for the resource column
+	canISubject           string       // "" = current user, or "system:serviceaccount:ns:name"
+	canISubjectName       string       // display name for the subject ("Current User" or "sa/name")
+	canIServiceAccounts   []string     // cached SA list for the selector
+	canISearchActive      bool         // true when typing in search bar
+	canISearchInput       TextInput    // current search input
+	canISearchQuery       string       // confirmed search query for filtering
+	canISubjectFilterMode bool         // true when typing in subject filter bar
+	canIAllowedOnly       bool         // true = show only allowed permissions
+	canINamespaces        []string     // namespaces used for SelfSubjectRulesReview
+	canIMode              canIViewMode // forward Can-I or reverse Who-Can (Tab toggle)
+	whoCan                whoCanState  // reverse-RBAC overlay state; see update_whocan.go
 
 	// Finalizer search overlay state.
 	finalizerSearchPattern      string

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hinshun/vt10x"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -71,6 +72,31 @@ const (
 	overlayPasteConfirm // y/n confirmation for multiline paste into search/filter
 	overlayBackgroundTasks
 	overlayClusterColor // pick a color tint for the highlighted cluster row
+)
+
+// whoCanState groups the reverse-RBAC ("Who-Can") fields so they live
+// together on Model without bloating the main struct over the
+// file-length cap. Mutated by handlers in update_whocan.go.
+type whoCanState struct {
+	verbCursor           int                 // index into ui.WhoCanVerbs
+	resource             string              // committed resource name (e.g. "pods")
+	resourceFilterActive bool                // true while typing into the / filter
+	resourceFilter       TextInput           // live filter buffer
+	subjects             []k8s.WhoCanSubject // last fetch result
+	subjectsScroll       int                 // scroll offset into subjects table
+	loading              bool                // fetch in flight
+}
+
+// canIViewMode toggles the Can-I overlay between its forward view
+// (subject → permissions, the original Can-I browser) and the
+// reverse view (verb + resource → subjects, "Who-Can"). Tab cycles
+// between them so users can pivot between "what can I do" and
+// "who else can do this" without re-opening the overlay.
+type canIViewMode int
+
+const (
+	canIModeForward canIViewMode = iota // subject -> permissions (Can-I)
+	canIModeWhoCan                      // verb + resource -> subjects (Who-Can)
 )
 
 // bookmarkOverlayMode tracks the interaction mode for the bookmark overlay.

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -77,9 +77,18 @@ const (
 // whoCanState groups the reverse-RBAC ("Who-Can") fields so they live
 // together on Model without bloating the main struct over the
 // file-length cap. Mutated by handlers in update_whocan.go.
+//
+// The picker is a 2-column layout: a list of resources on the left,
+// subjects on the right. resourceList is the deduped union of all
+// resources across canIGroups (built once on enterWhoCanMode);
+// resourceCursor indexes into the *visible* (post-filter) slice so the
+// cursor stays valid while the user narrows the list.
 type whoCanState struct {
 	verbCursor           int                 // index into ui.WhoCanVerbs
-	resource             string              // committed resource name (e.g. "pods")
+	resource             string              // last queried resource (drives subjects panel title)
+	resourceList         []string            // full deduped sorted resource list (built on entry)
+	resourceCursor       int                 // index into the visible (filtered) resource list
+	resourceScroll       int                 // first visible row in the resource list — stateful so scrolling up keeps the cursor in place instead of pinning it to the last visible row
 	resourceFilterActive bool                // true while typing into the / filter
 	resourceFilter       TextInput           // live filter buffer
 	subjects             []k8s.WhoCanSubject // last fetch result

--- a/internal/app/cani_state.go
+++ b/internal/app/cani_state.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// canIState bundles all Can-I / Who-Can RBAC explorer state into a
+// single embedded struct so the top-level Model doesn't grow past the
+// 800-line file ceiling as the overlay gains more knobs. Fields keep
+// their original names — the only change is where they are declared,
+// so call sites that reference m.canIGroups, m.whoCan, etc. continue
+// to work via Go's struct field promotion.
+type canIState struct {
+	canIGroups            []model.CanIGroup
+	canIGroupCursor       int          // selected group in left column
+	canIGroupScroll       int          // first visible row in the group list
+	canIResourceScroll    int          // scroll offset for the resource column
+	canISubject           string       // "" = current user, or "system:serviceaccount:ns:name"
+	canISubjectName       string       // display name for the subject ("Current User" or "sa/name")
+	canIServiceAccounts   []string     // cached SA list for the selector
+	canISearchActive      bool         // true when typing in search bar
+	canISearchInput       TextInput    // current search input
+	canISearchQuery       string       // confirmed search query for filtering
+	canISubjectFilterMode bool         // true when typing in subject filter bar
+	canIAllowedOnly       bool         // true = show only allowed permissions
+	canINamespaces        []string     // namespaces used for SelfSubjectRulesReview
+	canIMode              canIViewMode // forward Can-I or reverse Who-Can (Tab toggle)
+	whoCan                whoCanState  // reverse-RBAC overlay state; see update_whocan.go
+}

--- a/internal/app/filter_input_test.go
+++ b/internal/app/filter_input_test.go
@@ -354,12 +354,14 @@ func TestBookmarkFilterModeViaShared_Enter(t *testing.T) {
 
 func TestCanISubjectFilterModeViaShared_Typing(t *testing.T) {
 	m := Model{
-		overlay:               overlayCanISubject,
-		canISubjectFilterMode: true,
-		overlayFilter:         TextInput{Value: "", Cursor: 0},
-		tabs:                  []TabState{{}},
-		width:                 80,
-		height:                40,
+		overlay: overlayCanISubject,
+		canIState: canIState{
+			canISubjectFilterMode: true,
+		},
+		overlayFilter: TextInput{Value: "", Cursor: 0},
+		tabs:          []TabState{{}},
+		width:         80,
+		height:        40,
 	}
 	ret, _ := m.handleCanISubjectFilterMode(runeKey('a'))
 	result := ret.(Model)

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -190,6 +190,16 @@ func (m Model) overlayHintBarEditor() string {
 	case overlayFinalizerSearch:
 		return m.overlayHintBarOverlayFinalizerSearch()
 	case overlayCanI:
+		if m.canIMode == canIModeWhoCan {
+			return m.renderHints([]ui.HintEntry{
+				{Key: "←/→", Desc: "verb"},
+				{Key: "/", Desc: "filter resource"},
+				{Key: "j/k", Desc: "scroll subjects"},
+				{Key: "A", Desc: "toggle ns scope"},
+				{Key: "Tab", Desc: "back to Can-I"},
+				{Key: "esc", Desc: "close"},
+			})
+		}
 		return m.overlayHintBarOverlayCanI()
 	}
 	return ""
@@ -436,6 +446,7 @@ func (m Model) overlayHintBarOverlayCanI() string {
 		{Key: "a", Desc: filterLabel},
 		{Key: "s", Desc: "switch subject"},
 		{Key: "/", Desc: "search groups"},
+		{Key: "Tab", Desc: "Who-Can"},
 		{Key: "q/Esc", Desc: "close"},
 	})
 }

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -191,12 +191,23 @@ func (m Model) overlayHintBarEditor() string {
 		return m.overlayHintBarOverlayFinalizerSearch()
 	case overlayCanI:
 		if m.canIMode == canIModeWhoCan {
+			if m.whoCan.resourceFilterActive {
+				return m.renderHints([]ui.HintEntry{
+					{Key: "type", Desc: "narrow list"},
+					{Key: "enter", Desc: "accept"},
+					{Key: "esc", Desc: "clear"},
+				})
+			}
 			return m.renderHints([]ui.HintEntry{
+				{Key: "j/k", Desc: "pick resource"},
+				{Key: "J/K", Desc: "scroll subjects"},
+				{Key: "g/G", Desc: "top/bottom"},
+				{Key: "ctrl+d/u", Desc: "half page"},
+				{Key: "ctrl+f/b", Desc: "page"},
 				{Key: "←/→", Desc: "verb"},
-				{Key: "/", Desc: "filter resource"},
-				{Key: "j/k", Desc: "scroll subjects"},
-				{Key: "A", Desc: "toggle ns scope"},
-				{Key: "Tab", Desc: "back to Can-I"},
+				{Key: "/", Desc: "filter"},
+				{Key: "A", Desc: "ns scope"},
+				{Key: "Tab", Desc: "back"},
 				{Key: "esc", Desc: "close"},
 			})
 		}

--- a/internal/app/state_reset_test.go
+++ b/internal/app/state_reset_test.go
@@ -12,19 +12,21 @@ import (
 
 func TestExitCanIView(t *testing.T) {
 	m := Model{
-		overlay:               overlayCanI,
-		canIGroups:            []model.CanIGroup{{Name: "core"}},
-		canIGroupCursor:       3,
-		canIGroupScroll:       5,
-		canIResourceScroll:    2,
-		canISubject:           "system:serviceaccount:default:my-sa",
-		canISubjectName:       "my-sa",
-		canIServiceAccounts:   []string{"default/my-sa"},
-		canISearchActive:      true,
-		canISearchQuery:       "pods",
-		canISubjectFilterMode: true,
-		canIAllowedOnly:       true,
-		canINamespaces:        []string{"default", "kube-system"},
+		overlay: overlayCanI,
+		canIState: canIState{
+			canIGroups:            []model.CanIGroup{{Name: "core"}},
+			canIGroupCursor:       3,
+			canIGroupScroll:       5,
+			canIResourceScroll:    2,
+			canISubject:           "system:serviceaccount:default:my-sa",
+			canISubjectName:       "my-sa",
+			canIServiceAccounts:   []string{"default/my-sa"},
+			canISearchActive:      true,
+			canISearchQuery:       "pods",
+			canISubjectFilterMode: true,
+			canIAllowedOnly:       true,
+			canINamespaces:        []string{"default", "kube-system"},
+		},
 	}
 
 	m.exitCanIView()

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -136,6 +136,9 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case previewServiceEndpointsLoadedMsg:
 		mdl := m.updatePreviewServiceEndpointsLoaded(msg)
 		return mdl, nil, true
+	case whoCanLoadedMsg:
+		mdl := m.updateWhoCanLoaded(msg)
+		return mdl, nil, true
 	case podMetricsEnrichedMsg:
 		mdl := m.updatePodMetricsEnriched(msg)
 		return mdl, nil, true

--- a/internal/app/update_cani.go
+++ b/internal/app/update_cani.go
@@ -496,6 +496,13 @@ func (m Model) handleCanISubjectFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 // fresh scope without forcing the user to use the in-overlay 'A'
 // toggle (which is awkward when they just changed scope from the
 // global selector they're already familiar with).
+//
+// Multi-select is sorted (so the title bar renders deterministically
+// across frames — map iteration order would shuffle "ns: a,b,c" into
+// "ns: c,a,b") and collapsed to the first entry in Who-Can mode,
+// since loadWhoCan only treats len(canINamespaces) == 1 as a single
+// namespace and otherwise queries cluster-wide. Without the collapse,
+// the title would say "ns: a,b" while the data was cluster-wide.
 func (m *Model) syncCanINamespacesFromSelection() {
 	switch {
 	case m.allNamespaces:
@@ -504,6 +511,10 @@ func (m *Model) syncCanINamespacesFromSelection() {
 		ns := make([]string, 0, len(m.selectedNamespaces))
 		for n := range m.selectedNamespaces {
 			ns = append(ns, n)
+		}
+		sort.Strings(ns)
+		if m.canIMode == canIModeWhoCan && len(ns) > 1 {
+			ns = ns[:1]
 		}
 		m.canINamespaces = ns
 	case m.namespace != "":

--- a/internal/app/update_cani.go
+++ b/internal/app/update_cani.go
@@ -186,6 +186,21 @@ func (m *Model) canIVisibleGroups() []int {
 //
 //nolint:gocyclo // switch-based key dispatch is inherently high-complexity
 func (m Model) handleCanIKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// If search is active, delegate to the search key handler first —
+	// Tab inside / search has its own meaning and must not be hijacked
+	// by the WhoCan pivot.
+	if m.canISearchActive {
+		return m.handleCanISearchKey(msg)
+	}
+	// Namespace selector — opens from Can-I (forward) or Who-Can
+	// (reverse) when no input mode is capturing keys. Skipped while
+	// the user is typing into the Who-Can resource filter. Save the
+	// current overlay so the close path restores RBAC instead of
+	// dropping back to the explorer behind it.
+	if msg.String() == ui.ActiveKeybindings.NamespaceSelector && !m.whoCan.resourceFilterActive {
+		m.previousOverlay = m.overlay
+		return m.handleKeyNamespaceSelector()
+	}
 	// Reverse-RBAC mode: dedicated dispatcher in update_whocan.go.
 	if m.canIMode == canIModeWhoCan {
 		return m.handleWhoCanKey(msg)
@@ -193,10 +208,6 @@ func (m Model) handleCanIKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Tab from forward (Can-I) view enters Who-Can mode.
 	if msg.String() == "tab" {
 		return m.enterWhoCanMode()
-	}
-	// If search is active, delegate to the search key handler.
-	if m.canISearchActive {
-		return m.handleCanISearchKey(msg)
 	}
 
 	groupCount := len(m.canIVisibleGroups())
@@ -476,6 +487,30 @@ func (m Model) handleCanISubjectFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 	return m, nil
+}
+
+// syncCanINamespacesFromSelection projects the explorer's namespace
+// selection (m.namespace / m.allNamespaces / m.selectedNamespaces)
+// into the RBAC overlay's scope (m.canINamespaces). Called after the
+// namespace selector closes so Can-I and Who-Can re-query against the
+// fresh scope without forcing the user to use the in-overlay 'A'
+// toggle (which is awkward when they just changed scope from the
+// global selector they're already familiar with).
+func (m *Model) syncCanINamespacesFromSelection() {
+	switch {
+	case m.allNamespaces:
+		m.canINamespaces = []string{""}
+	case len(m.selectedNamespaces) > 0:
+		ns := make([]string, 0, len(m.selectedNamespaces))
+		for n := range m.selectedNamespaces {
+			ns = append(ns, n)
+		}
+		m.canINamespaces = ns
+	case m.namespace != "":
+		m.canINamespaces = []string{m.namespace}
+	default:
+		m.canINamespaces = []string{""}
+	}
 }
 
 // canIVisibleLines returns the number of visible content lines in the Can-I

--- a/internal/app/update_cani.go
+++ b/internal/app/update_cani.go
@@ -186,6 +186,14 @@ func (m *Model) canIVisibleGroups() []int {
 //
 //nolint:gocyclo // switch-based key dispatch is inherently high-complexity
 func (m Model) handleCanIKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Reverse-RBAC mode: dedicated dispatcher in update_whocan.go.
+	if m.canIMode == canIModeWhoCan {
+		return m.handleWhoCanKey(msg)
+	}
+	// Tab from forward (Can-I) view enters Who-Can mode.
+	if msg.String() == "tab" {
+		return m.enterWhoCanMode()
+	}
 	// If search is active, delegate to the search key handler.
 	if m.canISearchActive {
 		return m.handleCanISearchKey(msg)

--- a/internal/app/update_cani_test.go
+++ b/internal/app/update_cani_test.go
@@ -96,15 +96,17 @@ func TestCanIVisibleGroups(t *testing.T) {
 	}
 
 	t.Run("no query returns all", func(t *testing.T) {
-		m := Model{canIGroups: groups}
+		m := Model{canIState: canIState{canIGroups: groups}}
 		indices := m.canIVisibleGroups()
 		assert.Len(t, indices, 4)
 	})
 
 	t.Run("query filters by group name", func(t *testing.T) {
 		m := Model{
-			canIGroups:      groups,
-			canISearchQuery: "app",
+			canIState: canIState{
+				canIGroups:      groups,
+				canISearchQuery: "app",
+			},
 		}
 		indices := m.canIVisibleGroups()
 		assert.Len(t, indices, 1)
@@ -113,8 +115,10 @@ func TestCanIVisibleGroups(t *testing.T) {
 
 	t.Run("empty group name matches core", func(t *testing.T) {
 		m := Model{
-			canIGroups:      groups,
-			canISearchQuery: "core",
+			canIState: canIState{
+				canIGroups:      groups,
+				canISearchQuery: "core",
+			},
 		}
 		indices := m.canIVisibleGroups()
 		assert.Len(t, indices, 1)
@@ -123,8 +127,10 @@ func TestCanIVisibleGroups(t *testing.T) {
 
 	t.Run("case insensitive search", func(t *testing.T) {
 		m := Model{
-			canIGroups:      groups,
-			canISearchQuery: "BATCH",
+			canIState: canIState{
+				canIGroups:      groups,
+				canISearchQuery: "BATCH",
+			},
 		}
 		indices := m.canIVisibleGroups()
 		assert.Len(t, indices, 1)
@@ -133,10 +139,12 @@ func TestCanIVisibleGroups(t *testing.T) {
 
 	t.Run("active search input overrides query", func(t *testing.T) {
 		m := Model{
-			canIGroups:       groups,
-			canISearchQuery:  "apps", // would match "apps"
-			canISearchActive: true,
-			canISearchInput:  TextInput{Value: "batch"}, // overrides to "batch"
+			canIState: canIState{
+				canIGroups:       groups,
+				canISearchQuery:  "apps", // would match "apps"
+				canISearchActive: true,
+				canISearchInput:  TextInput{Value: "batch"}, // overrides to "batch"
+			},
 		}
 		indices := m.canIVisibleGroups()
 		assert.Len(t, indices, 1)
@@ -145,8 +153,10 @@ func TestCanIVisibleGroups(t *testing.T) {
 
 	t.Run("no match returns empty", func(t *testing.T) {
 		m := Model{
-			canIGroups:      groups,
-			canISearchQuery: "nonexistent",
+			canIState: canIState{
+				canIGroups:      groups,
+				canISearchQuery: "nonexistent",
+			},
 		}
 		indices := m.canIVisibleGroups()
 		assert.Empty(t, indices)

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -9,8 +9,18 @@ import (
 
 func (m Model) handleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Toggle: pressing the same hotkey that opened an overlay closes it.
+	// When the current overlay is layered on top of another (e.g. the
+	// namespace selector launched from inside RBAC), restore the parent
+	// instead of dropping all the way to the explorer — and ALWAYS
+	// clear previousOverlay so a stale parent can't reappear next time
+	// the same hotkey opens the overlay again.
 	if m.isOverlayToggleKey(msg.String()) {
-		m.overlay = overlayNone
+		if m.previousOverlay != overlayNone {
+			m.overlay = m.previousOverlay
+		} else {
+			m.overlay = overlayNone
+		}
+		m.previousOverlay = overlayNone
 		return m, nil
 	}
 	if mdl, cmd, ok := m.handleOverlayKeyPrimary(msg); ok {

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -26,8 +26,15 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.overlayCursor = 0
 			return m, nil
 		}
-		m.overlay = overlayNone
 		m.overlayFilter.Clear()
+		// Restore the parent overlay (e.g. RBAC) when the namespace
+		// selector was opened from inside it; otherwise close fully.
+		if m.previousOverlay != overlayNone {
+			m.overlay = m.previousOverlay
+			m.previousOverlay = overlayNone
+			return m, nil
+		}
+		m.overlay = overlayNone
 		return m, nil
 
 	case "enter":
@@ -52,13 +59,35 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.selectedNamespaces = nil
 			m.allNamespaces = true
 		}
-		m.overlay = overlayNone
 		m.overlayFilter.Clear()
 		m.nsFilterMode = false
 		m.saveCurrentSession()
 		m.cancelAndReset()
 		m.requestGen++
-		return m, m.refreshCurrentLevel()
+
+		// Restore the parent overlay (e.g. RBAC) when the namespace
+		// selector was opened from inside it. The namespace change is
+		// global — refreshCurrentLevel runs in BOTH the nested and
+		// non-nested cases so the explorer behind the overlay reflects
+		// the new scope as soon as the user closes back to it.
+		refresh := m.refreshCurrentLevel()
+		if m.previousOverlay != overlayNone {
+			parent := m.previousOverlay
+			m.overlay = parent
+			m.previousOverlay = overlayNone
+			if parent == overlayCanI {
+				m.syncCanINamespacesFromSelection()
+				cmds := []tea.Cmd{refresh, m.loadCanIRules()}
+				if m.canIMode == canIModeWhoCan && m.whoCan.resource != "" {
+					cmds = append(cmds, m.loadWhoCan())
+				}
+				return m, tea.Batch(cmds...)
+			}
+			return m, refresh
+		}
+
+		m.overlay = overlayNone
+		return m, refresh
 
 	case " ":
 		m.nsSelectionModified = true

--- a/internal/app/update_rbac_msgs.go
+++ b/internal/app/update_rbac_msgs.go
@@ -28,7 +28,16 @@ func (m Model) updateCanILoaded(msg canILoadedMsg) (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 	m.processCanIRules(msg.rules)
-	m.canINamespaces = msg.namespaces
+	// Re-derive canINamespaces from the user's namespace selection
+	// rather than trusting msg.namespaces. loadCanIRules has to pick a
+	// concrete namespace for SelfSubjectRulesReview (it requires one);
+	// when the user picked "all", that ends up as "default" in the
+	// message, but the user-visible scope must still read "ns: all".
+	if m.allNamespaces {
+		m.canINamespaces = []string{""}
+	} else {
+		m.canINamespaces = msg.namespaces
+	}
 	m.overlay = overlayCanI
 	m.canIGroupCursor = 0
 	m.canIGroupScroll = 0

--- a/internal/app/update_whocan.go
+++ b/internal/app/update_whocan.go
@@ -11,29 +11,48 @@ import (
 )
 
 // enterWhoCanMode flips the Can-I overlay into reverse-RBAC mode and
-// fires the first fetch. Verb defaults to "get" (the most common
-// question users ask) and resource pre-fills from the Can-I cursor's
-// current row when one is highlighted, so Tab feels like a continuation
-// of the previous question rather than a fresh start.
+// prepares the resource picker. The resource list is the deduped union
+// of all Can-I groups so the user sees the same canonical names as in
+// the forward view; the cursor lands on whatever resource was
+// highlighted in Can-I (when reachable) so Tab feels like a
+// continuation rather than a fresh start.
 func (m Model) enterWhoCanMode() (tea.Model, tea.Cmd) {
 	m.canIMode = canIModeWhoCan
 	m.whoCan.verbCursor = 0 // "get"
 	m.whoCan.resourceFilter.Clear()
 	m.whoCan.resourceFilterActive = false
 	m.whoCan.subjectsScroll = 0
+	m.whoCan.subjects = nil
 
-	// Pre-fill resource from the highlighted Can-I row, if any.
-	if m.whoCan.resource == "" {
-		if r := m.canIResourceUnderCursor(); r != "" {
-			m.whoCan.resource = r
+	m.whoCan.resourceList = whoCanCollectResources(m.canIGroups)
+	m.whoCan.resourceCursor = 0
+	m.whoCan.resourceScroll = 0
+
+	// Pre-position cursor on the Can-I row's resource if it appears in
+	// the picker — keeps the user's spatial context across the flip.
+	if pre := m.canIResourceUnderCursor(); pre != "" {
+		for i, r := range m.whoCan.resourceList {
+			if r == pre {
+				m.whoCan.resourceCursor = i
+				break
+			}
 		}
 	}
-	if m.whoCan.resource == "" {
-		// No prior selection; leave the resource empty so the user is
-		// prompted to type a filter rather than seeing an unrelated
-		// pre-pick.
+	// Pull the viewport down so the pre-positioned cursor is visible
+	// instead of forcing the user to scroll to find where they are.
+	m.whoCan.resourceScroll = ui.WhoCanScrollForCursor(
+		0, m.whoCan.resourceCursor,
+		m.whoCanVisibleLines(), len(m.whoCan.resourceList),
+	)
+
+	resource := whoCanCurrentResource(m.whoCan.resourceList, m.whoCan.resourceCursor)
+	if resource == "" {
+		// No resources in the picker (Can-I hadn't loaded any). Leave
+		// the subjects panel idle; the user will see the empty list.
+		m.whoCan.resource = ""
 		return m, nil
 	}
+	m.whoCan.resource = resource
 	return m, m.loadWhoCan()
 }
 
@@ -53,6 +72,23 @@ func (m Model) canIResourceUnderCursor() string {
 	return resources[0].Resource
 }
 
+// whoCanCurrentResource returns the resource at the cursor's position
+// in the (filtered) list, or "" when the cursor is out of range.
+// Wraps the bounds check so callers don't repeat it.
+func whoCanCurrentResource(list []string, cursor int) string {
+	if cursor < 0 || cursor >= len(list) {
+		return ""
+	}
+	return list[cursor]
+}
+
+// whoCanVisibleResources returns the post-filter list the user sees in
+// the picker. Always builds from resourceList so a cleared filter
+// instantly restores the full set without re-collecting from canIGroups.
+func (m Model) whoCanVisibleResources() []string {
+	return whoCanFilterResources(m.whoCan.resourceList, m.whoCan.resourceFilter.Value)
+}
+
 // handleWhoCanKey services key events while the overlay is in
 // reverse-RBAC mode. Filter mode (typing into the resource picker)
 // gets its own sub-handler.
@@ -69,32 +105,38 @@ func (m Model) handleWhoCanKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.exitCanIView()
 		return m, nil
 	case "left", "h":
-		if m.whoCan.verbCursor > 0 {
-			m.whoCan.verbCursor--
-			if m.whoCan.resource != "" {
-				return m, m.loadWhoCan()
-			}
-		}
-		return m, nil
+		return m.whoCanCycleVerb(-1)
 	case "right", "l":
-		if m.whoCan.verbCursor < len(ui.WhoCanVerbs)-1 {
-			m.whoCan.verbCursor++
-			if m.whoCan.resource != "" {
-				return m, m.loadWhoCan()
-			}
-		}
-		return m, nil
+		return m.whoCanCycleVerb(+1)
 	case "/":
 		m.whoCan.resourceFilterActive = true
 		m.whoCan.resourceFilter.Clear()
 		return m, nil
 	case "j", "down":
-		m.whoCan.subjectsScroll++
-		return m, nil
+		return m.whoCanMoveCursor(+1)
 	case "k", "up":
-		if m.whoCan.subjectsScroll > 0 {
-			m.whoCan.subjectsScroll--
-		}
+		return m.whoCanMoveCursor(-1)
+	case "g", "home":
+		return m.whoCanJumpCursor(0)
+	case "G", "end":
+		visible := m.whoCanVisibleResources()
+		return m.whoCanJumpCursor(len(visible) - 1)
+	case "ctrl+d":
+		return m.whoCanMoveCursor(+m.whoCanVisibleLines() / 2)
+	case "ctrl+u":
+		return m.whoCanMoveCursor(-m.whoCanVisibleLines() / 2)
+	case "ctrl+f", "pgdown":
+		return m.whoCanMoveCursor(+m.whoCanVisibleLines())
+	case "ctrl+b", "pgup":
+		return m.whoCanMoveCursor(-m.whoCanVisibleLines())
+	case "J":
+		// Scroll subjects (right column) without moving the resource
+		// cursor. Useful when a query returns more rows than fit.
+		m.whoCan.subjectsScroll = whoCanClampSubjectsScroll(
+			m.whoCan.subjectsScroll+1, len(m.whoCan.subjects), m.whoCanVisibleLines())
+		return m, nil
+	case "K":
+		m.whoCan.subjectsScroll = max(m.whoCan.subjectsScroll-1, 0)
 		return m, nil
 	case "A":
 		// Toggle namespace scope: empty string ↔ current namespace.
@@ -111,23 +153,138 @@ func (m Model) handleWhoCanKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// whoCanCycleVerb advances/retreats the verb cursor and re-fires the
+// query so the user sees the new verb's subjects without needing a
+// commit step. Returns no-op at the list edges (no wrap).
+func (m Model) whoCanCycleVerb(delta int) (tea.Model, tea.Cmd) {
+	next := m.whoCan.verbCursor + delta
+	if next < 0 || next >= len(ui.WhoCanVerbs) {
+		return m, nil
+	}
+	m.whoCan.verbCursor = next
+	if m.whoCan.resource != "" {
+		return m, m.loadWhoCan()
+	}
+	return m, nil
+}
+
+// whoCanMoveCursor moves the resource cursor by delta within the
+// visible (filtered) list, adjusts the scroll offset to keep the
+// cursor in view (vim-like: only scroll when the cursor leaves the
+// viewport), fires a Who-Can query for the new resource, and clamps
+// at the list edges. No-op when the cursor wouldn't change so the
+// user doesn't spam the API by mashing keys.
+func (m Model) whoCanMoveCursor(delta int) (tea.Model, tea.Cmd) {
+	visible := m.whoCanVisibleResources()
+	if len(visible) == 0 {
+		return m, nil
+	}
+	next := m.whoCan.resourceCursor + delta
+	next = max(next, 0)
+	if next >= len(visible) {
+		next = len(visible) - 1
+	}
+	if next == m.whoCan.resourceCursor {
+		return m, nil
+	}
+	m.whoCan.resourceCursor = next
+	m.whoCan.resourceScroll = ui.WhoCanScrollForCursor(
+		m.whoCan.resourceScroll, m.whoCan.resourceCursor,
+		m.whoCanVisibleLines(), len(visible),
+	)
+	return m.refreshWhoCanForCursor(visible)
+}
+
+// whoCanJumpCursor positions the cursor at an absolute index (clamped
+// to the visible list), adjusts the scroll, and fires a query for the
+// new resource. Powers g/G/Home/End navigation.
+func (m Model) whoCanJumpCursor(idx int) (tea.Model, tea.Cmd) {
+	visible := m.whoCanVisibleResources()
+	if len(visible) == 0 {
+		return m, nil
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(visible) {
+		idx = len(visible) - 1
+	}
+	if idx == m.whoCan.resourceCursor {
+		return m, nil
+	}
+	m.whoCan.resourceCursor = idx
+	m.whoCan.resourceScroll = ui.WhoCanScrollForCursor(
+		m.whoCan.resourceScroll, m.whoCan.resourceCursor,
+		m.whoCanVisibleLines(), len(visible),
+	)
+	return m.refreshWhoCanForCursor(visible)
+}
+
+// whoCanVisibleLines returns the number of body rows the resource
+// picker / subjects column can show. MUST match the math in
+// RenderWhoCanView and renderWhoCanResourcePicker exactly — when this
+// is off by even one row, the scroll-for-cursor handler positions the
+// cursor at a row the renderer doesn't actually show, and the user
+// sees the last resource clipped past the bottom of the viewport.
+func (m *Model) whoCanVisibleLines() int {
+	overlayH := min(m.height-4, m.height*80/100)
+	innerH := overlayH - 2       // OverlayStyle vertical padding
+	contentH := max(innerH-4, 3) // -1 header row, -2 column borders, -1 reserved footer
+	return max(contentH-1, 1)    // -1 for the picker's own "Resources …" header
+}
+
+// whoCanClampSubjectsScroll keeps the subjects-column scroll offset in
+// the valid range so J/K can't scroll past the end of the list.
+func whoCanClampSubjectsScroll(offset, total, visible int) int {
+	maxScroll := max(total-visible, 0)
+	if offset < 0 {
+		return 0
+	}
+	if offset > maxScroll {
+		return maxScroll
+	}
+	return offset
+}
+
+// refreshWhoCanForCursor commits the resource under the cursor and
+// dispatches a fetch — but only when the resource actually changed,
+// so j/k that lands on the same row (e.g. duplicate entries) doesn't
+// re-fire. Also resets subjectsScroll so the new result starts at the
+// top of its panel.
+func (m Model) refreshWhoCanForCursor(visible []string) (tea.Model, tea.Cmd) {
+	resource := whoCanCurrentResource(visible, m.whoCan.resourceCursor)
+	if resource == "" || resource == m.whoCan.resource {
+		return m, nil
+	}
+	m.whoCan.resource = resource
+	m.whoCan.subjectsScroll = 0
+	return m, m.loadWhoCan()
+}
+
 // handleWhoCanFilterKey processes typing into the resource filter.
-// Enter commits the filter as the resource and fires a fetch; Esc
-// discards the typing and falls back to the prior resource.
+// As keystrokes land the visible list narrows and the cursor snaps to
+// the top of the new list (with a query fire so the right pane keeps
+// up). Enter accepts the filter and exits filter mode; Esc clears it.
 func (m Model) handleWhoCanFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	action := handleFilterKey(&m.whoCan.resourceFilter, msg.String())
 	switch action {
 	case filterAccept:
 		m.whoCan.resourceFilterActive = false
-		if v := m.whoCan.resourceFilter.Value; v != "" {
-			m.whoCan.resource = v
-			m.whoCan.subjectsScroll = 0
-			return m, m.loadWhoCan()
+		visible := m.whoCanVisibleResources()
+		if len(visible) == 0 {
+			return m, nil
 		}
-		return m, nil
+		m.whoCan.resourceCursor = 0
+		m.whoCan.resourceScroll = 0
+		return m.refreshWhoCanForCursor(visible)
 	case filterEscape:
 		m.whoCan.resourceFilterActive = false
 		m.whoCan.resourceFilter.Clear()
+		// Restore cursor to a valid position in the un-narrowed list.
+		if m.whoCan.resourceCursor >= len(m.whoCan.resourceList) {
+			m.whoCan.resourceCursor = 0
+		}
+		m.whoCan.resourceScroll = 0
 		return m, nil
 	case filterClose:
 		m.whoCan.resourceFilterActive = false
@@ -135,7 +292,16 @@ func (m Model) handleWhoCanFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.exitCanIView()
 		return m, nil
 	}
-	return m, nil
+	// Live-narrow: typing changed the filter, so re-fire for the new
+	// top entry. Reset cursor + scroll to 0 because the previous
+	// indices likely point past the end of the narrowed list.
+	visible := m.whoCanVisibleResources()
+	m.whoCan.resourceCursor = 0
+	m.whoCan.resourceScroll = 0
+	if len(visible) == 0 {
+		return m, nil
+	}
+	return m.refreshWhoCanForCursor(visible)
 }
 
 // loadWhoCan dispatches the WhoCan fetch for the current verb +
@@ -144,15 +310,10 @@ func (m Model) handleWhoCanFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // handler.
 func (m Model) loadWhoCan() tea.Cmd {
 	verb := ui.WhoCanVerbs[m.whoCan.verbCursor]
-	if verb == "*" {
-		// API matches "*" against ANY rule.Verbs, but for the query we
-		// need a concrete verb. Send "get" and let the algorithm's
-		// wildcard match handle it — any rule that grants "*" matches.
-		// Handing "*" through unchanged would also work because the
-		// match is symmetric, but "get" makes the fetch result useful
-		// to humans reading the underlying rules too.
-		verb = "get"
-	}
+	// "*" means "any verb"; passed through to verbMatches which treats
+	// it as "match any rule with at least one verb". An earlier version
+	// rewrote "*" to "get" — that silently dropped subjects whose roles
+	// granted list/watch/etc. but not get.
 	resource := m.whoCan.resource
 	ns := ""
 	if len(m.canINamespaces) == 1 && m.canINamespaces[0] != "" {
@@ -200,29 +361,55 @@ func (m Model) renderWhoCanOverlay(background string) string {
 	innerW := overlayW - 4
 	innerH := overlayH - 2
 
+	visible := m.whoCanVisibleResources()
 	rows := make([]ui.WhoCanRow, len(m.whoCan.subjects))
 	for i, s := range m.whoCan.subjects {
 		rows[i] = ui.WhoCanRow{Kind: s.Kind, Name: s.Name, Namespace: s.Namespace, Via: s.Via}
 	}
 
-	nsLabel := "all-namespaces"
-	if len(m.canINamespaces) == 1 && m.canINamespaces[0] != "" {
-		nsLabel = "ns: " + m.canINamespaces[0]
+	// Match Can-I's scope label format ("ns: all" / "ns: <name>") so
+	// Tab between modes shows the same scope chip in the same shape.
+	nsLabel := ui.CanIScopeLabel(m.canINamespaces)
+
+	// Filter input renders as the overlay footer — same vertical
+	// position Can-I uses for its search bar so the input lands in the
+	// same place when the user pivots between modes with Tab.
+	var footerBar string
+	switch {
+	case m.whoCan.resourceFilterActive:
+		footerBar = ui.StatusBarBgStyle.Width(innerW).Render(
+			ui.HelpKeyStyle.Render("/") +
+				ui.BarNormalStyle.Render(m.whoCan.resourceFilter.CursorLeft()) +
+				ui.BarDimStyle.Render("█") +
+				ui.BarNormalStyle.Render(m.whoCan.resourceFilter.CursorRight()),
+		)
+	case m.whoCan.resourceFilter.Value != "":
+		footerBar = ui.StatusBarBgStyle.Width(innerW).Render(
+			ui.HelpKeyStyle.Render("/") + ui.BarNormalStyle.Render(m.whoCan.resourceFilter.Value),
+		)
 	}
 
-	content := ui.RenderWhoCanView(
-		m.whoCan.verbCursor,
-		m.whoCan.resource,
-		m.whoCan.resourceFilter.Value,
-		m.whoCan.resourceFilterActive,
-		nsLabel,
-		rows,
-		m.whoCan.subjectsScroll,
-		m.whoCan.loading,
-		innerW, innerH,
-	)
-	content = ui.FillLinesBg(content, overlayW-4, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(content)
+	content := ui.RenderWhoCanView(ui.WhoCanViewParams{
+		VerbCursor:     m.whoCan.verbCursor,
+		Resources:      visible,
+		ResourceCursor: m.whoCan.resourceCursor,
+		ResourceScroll: m.whoCan.resourceScroll,
+		NamespaceLabel: nsLabel,
+		Subjects:       rows,
+		SubjectsScroll: m.whoCan.subjectsScroll,
+		Loading:        m.whoCan.loading,
+		FooterBar:      footerBar,
+		Width:          innerW,
+		Height:         innerH,
+	})
+	// Match Can-I: baseBg end-to-end so the overlay frame doesn't show
+	// as a different shade than the title bar / column boxes inside.
+	content = ui.FillLinesBg(content, overlayW-4, ui.BaseBg)
+	overlay := ui.OverlayStyle.
+		Background(ui.BaseBg).
+		BorderBackground(ui.BaseBg).
+		Width(overlayW).Height(overlayH).
+		Render(content)
 	bg := ui.PadToHeight(background, m.height)
 	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
 }

--- a/internal/app/update_whocan.go
+++ b/internal/app/update_whocan.go
@@ -53,6 +53,7 @@ func (m Model) enterWhoCanMode() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.whoCan.resource = resource
+	m.whoCan.loading = true
 	return m, m.loadWhoCan()
 }
 
@@ -146,6 +147,7 @@ func (m Model) handleWhoCanKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.canINamespaces = []string{""}
 		}
 		if m.whoCan.resource != "" {
+			m.whoCan.loading = true
 			return m, m.loadWhoCan()
 		}
 		return m, nil
@@ -163,6 +165,7 @@ func (m Model) whoCanCycleVerb(delta int) (tea.Model, tea.Cmd) {
 	}
 	m.whoCan.verbCursor = next
 	if m.whoCan.resource != "" {
+		m.whoCan.loading = true
 		return m, m.loadWhoCan()
 	}
 	return m, nil
@@ -258,6 +261,7 @@ func (m Model) refreshWhoCanForCursor(visible []string) (tea.Model, tea.Cmd) {
 	}
 	m.whoCan.resource = resource
 	m.whoCan.subjectsScroll = 0
+	m.whoCan.loading = true
 	return m, m.loadWhoCan()
 }
 
@@ -280,12 +284,25 @@ func (m Model) handleWhoCanFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case filterEscape:
 		m.whoCan.resourceFilterActive = false
 		m.whoCan.resourceFilter.Clear()
-		// Restore cursor to a valid position in the un-narrowed list.
-		if m.whoCan.resourceCursor >= len(m.whoCan.resourceList) {
+		// After clearing the filter the list returns to the full set, so
+		// the cursor index that pointed into the narrowed list may now
+		// land on a different resource. Refresh subjects against the
+		// (now un-narrowed) cursor so the picker highlight and the
+		// subjects pane stay in sync — without this, Esc would leave
+		// the user looking at the previously-selected resource's
+		// subjects while the picker highlights an unrelated row.
+		visible := m.whoCanVisibleResources()
+		if len(visible) == 0 {
+			m.whoCan.resource = ""
+			m.whoCan.resourceCursor = 0
+			m.whoCan.resourceScroll = 0
+			return m, nil
+		}
+		if m.whoCan.resourceCursor >= len(visible) {
 			m.whoCan.resourceCursor = 0
 		}
 		m.whoCan.resourceScroll = 0
-		return m, nil
+		return m.refreshWhoCanForCursor(visible)
 	case filterClose:
 		m.whoCan.resourceFilterActive = false
 		m.whoCan.resourceFilter.Clear()
@@ -308,6 +325,12 @@ func (m Model) handleWhoCanFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // resource + namespace. Fires asynchronously; the result lands as
 // whoCanLoadedMsg and is injected into m.whoCan.subjects by the
 // handler.
+//
+// Note: callers are responsible for setting m.whoCan.loading = true
+// before invoking this method. Doing it here would mutate the value
+// receiver's copy, and the flag wouldn't persist on the Model returned
+// to the Update handler — so the spinner would never show during the
+// in-flight fetch.
 func (m Model) loadWhoCan() tea.Cmd {
 	verb := ui.WhoCanVerbs[m.whoCan.verbCursor]
 	// "*" means "any verb"; passed through to verbMatches which treats
@@ -321,7 +344,6 @@ func (m Model) loadWhoCan() tea.Cmd {
 	}
 	kctx := m.nav.Context
 	gen := m.requestGen
-	m.whoCan.loading = true
 	return m.trackBgTask(
 		bgtasks.KindResourceList,
 		"WhoCan: "+verb+" "+resource,

--- a/internal/app/update_whocan.go
+++ b/internal/app/update_whocan.go
@@ -1,0 +1,244 @@
+package app
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/app/bgtasks"
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// enterWhoCanMode flips the Can-I overlay into reverse-RBAC mode and
+// fires the first fetch. Verb defaults to "get" (the most common
+// question users ask) and resource pre-fills from the Can-I cursor's
+// current row when one is highlighted, so Tab feels like a continuation
+// of the previous question rather than a fresh start.
+func (m Model) enterWhoCanMode() (tea.Model, tea.Cmd) {
+	m.canIMode = canIModeWhoCan
+	m.whoCan.verbCursor = 0 // "get"
+	m.whoCan.resourceFilter.Clear()
+	m.whoCan.resourceFilterActive = false
+	m.whoCan.subjectsScroll = 0
+
+	// Pre-fill resource from the highlighted Can-I row, if any.
+	if m.whoCan.resource == "" {
+		if r := m.canIResourceUnderCursor(); r != "" {
+			m.whoCan.resource = r
+		}
+	}
+	if m.whoCan.resource == "" {
+		// No prior selection; leave the resource empty so the user is
+		// prompted to type a filter rather than seeing an unrelated
+		// pre-pick.
+		return m, nil
+	}
+	return m, m.loadWhoCan()
+}
+
+// canIResourceUnderCursor returns the resource name under the Can-I
+// view's group cursor, or "" when nothing is selectable. Used to
+// pre-fill the Who-Can resource so Tab carries the user's context
+// across the mode flip.
+func (m Model) canIResourceUnderCursor() string {
+	groups := m.canIVisibleGroups()
+	if m.canIGroupCursor < 0 || m.canIGroupCursor >= len(groups) {
+		return ""
+	}
+	resources := m.canIGroups[groups[m.canIGroupCursor]].Resources
+	if len(resources) == 0 {
+		return ""
+	}
+	return resources[0].Resource
+}
+
+// handleWhoCanKey services key events while the overlay is in
+// reverse-RBAC mode. Filter mode (typing into the resource picker)
+// gets its own sub-handler.
+func (m Model) handleWhoCanKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.whoCan.resourceFilterActive {
+		return m.handleWhoCanFilterKey(msg)
+	}
+	switch msg.String() {
+	case "tab":
+		// Tab toggles back to forward Can-I.
+		m.canIMode = canIModeForward
+		return m, nil
+	case "esc", "q":
+		m.exitCanIView()
+		return m, nil
+	case "left", "h":
+		if m.whoCan.verbCursor > 0 {
+			m.whoCan.verbCursor--
+			if m.whoCan.resource != "" {
+				return m, m.loadWhoCan()
+			}
+		}
+		return m, nil
+	case "right", "l":
+		if m.whoCan.verbCursor < len(ui.WhoCanVerbs)-1 {
+			m.whoCan.verbCursor++
+			if m.whoCan.resource != "" {
+				return m, m.loadWhoCan()
+			}
+		}
+		return m, nil
+	case "/":
+		m.whoCan.resourceFilterActive = true
+		m.whoCan.resourceFilter.Clear()
+		return m, nil
+	case "j", "down":
+		m.whoCan.subjectsScroll++
+		return m, nil
+	case "k", "up":
+		if m.whoCan.subjectsScroll > 0 {
+			m.whoCan.subjectsScroll--
+		}
+		return m, nil
+	case "A":
+		// Toggle namespace scope: empty string ↔ current namespace.
+		if m.canINamespaces == nil || (len(m.canINamespaces) == 1 && m.canINamespaces[0] == "") {
+			m.canINamespaces = []string{m.namespace}
+		} else {
+			m.canINamespaces = []string{""}
+		}
+		if m.whoCan.resource != "" {
+			return m, m.loadWhoCan()
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+// handleWhoCanFilterKey processes typing into the resource filter.
+// Enter commits the filter as the resource and fires a fetch; Esc
+// discards the typing and falls back to the prior resource.
+func (m Model) handleWhoCanFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	action := handleFilterKey(&m.whoCan.resourceFilter, msg.String())
+	switch action {
+	case filterAccept:
+		m.whoCan.resourceFilterActive = false
+		if v := m.whoCan.resourceFilter.Value; v != "" {
+			m.whoCan.resource = v
+			m.whoCan.subjectsScroll = 0
+			return m, m.loadWhoCan()
+		}
+		return m, nil
+	case filterEscape:
+		m.whoCan.resourceFilterActive = false
+		m.whoCan.resourceFilter.Clear()
+		return m, nil
+	case filterClose:
+		m.whoCan.resourceFilterActive = false
+		m.whoCan.resourceFilter.Clear()
+		m.exitCanIView()
+		return m, nil
+	}
+	return m, nil
+}
+
+// loadWhoCan dispatches the WhoCan fetch for the current verb +
+// resource + namespace. Fires asynchronously; the result lands as
+// whoCanLoadedMsg and is injected into m.whoCan.subjects by the
+// handler.
+func (m Model) loadWhoCan() tea.Cmd {
+	verb := ui.WhoCanVerbs[m.whoCan.verbCursor]
+	if verb == "*" {
+		// API matches "*" against ANY rule.Verbs, but for the query we
+		// need a concrete verb. Send "get" and let the algorithm's
+		// wildcard match handle it — any rule that grants "*" matches.
+		// Handing "*" through unchanged would also work because the
+		// match is symmetric, but "get" makes the fetch result useful
+		// to humans reading the underlying rules too.
+		verb = "get"
+	}
+	resource := m.whoCan.resource
+	ns := ""
+	if len(m.canINamespaces) == 1 && m.canINamespaces[0] != "" {
+		ns = m.canINamespaces[0]
+	}
+	kctx := m.nav.Context
+	gen := m.requestGen
+	m.whoCan.loading = true
+	return m.trackBgTask(
+		bgtasks.KindResourceList,
+		"WhoCan: "+verb+" "+resource,
+		bgtaskTarget(kctx, ns),
+		func() tea.Msg {
+			subs, err := m.client.WhoCan(context.Background(), kctx, ns, "", resource, verb)
+			return whoCanLoadedMsg{
+				gen:      gen,
+				verb:     verb,
+				resource: resource,
+				subjects: subs,
+				err:      err,
+			}
+		},
+	)
+}
+
+// whoCanLoadedMsg carries the WhoCan fetch result back to the runtime.
+// gen guards against stale responses (user changed verb/resource
+// before the previous fetch returned).
+type whoCanLoadedMsg struct {
+	gen      uint64
+	verb     string
+	resource string
+	subjects []k8s.WhoCanSubject
+	err      error
+}
+
+// renderWhoCanOverlay paints the reverse-RBAC view inside the same
+// overlay frame that the forward Can-I uses — same dimensions, same
+// PlaceOverlay wrap. Splitting the render path off renderCanIOverlay
+// keeps each function focused and avoids churning the existing
+// Can-I-only code.
+func (m Model) renderWhoCanOverlay(background string) string {
+	overlayW := min(m.width-4, m.width*90/100)
+	overlayH := min(m.height-4, m.height*80/100)
+	innerW := overlayW - 4
+	innerH := overlayH - 2
+
+	rows := make([]ui.WhoCanRow, len(m.whoCan.subjects))
+	for i, s := range m.whoCan.subjects {
+		rows[i] = ui.WhoCanRow{Kind: s.Kind, Name: s.Name, Namespace: s.Namespace, Via: s.Via}
+	}
+
+	nsLabel := "all-namespaces"
+	if len(m.canINamespaces) == 1 && m.canINamespaces[0] != "" {
+		nsLabel = "ns: " + m.canINamespaces[0]
+	}
+
+	content := ui.RenderWhoCanView(
+		m.whoCan.verbCursor,
+		m.whoCan.resource,
+		m.whoCan.resourceFilter.Value,
+		m.whoCan.resourceFilterActive,
+		nsLabel,
+		rows,
+		m.whoCan.subjectsScroll,
+		m.whoCan.loading,
+		innerW, innerH,
+	)
+	content = ui.FillLinesBg(content, overlayW-4, ui.SurfaceBg)
+	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(content)
+	bg := ui.PadToHeight(background, m.height)
+	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
+}
+
+// updateWhoCanLoaded merges the fetch result into Model state so the
+// renderer paints the new subject list on the next frame.
+func (m Model) updateWhoCanLoaded(msg whoCanLoadedMsg) Model {
+	if msg.gen != m.requestGen {
+		return m // stale; user moved on
+	}
+	m.whoCan.loading = false
+	if msg.err != nil {
+		m.setStatusMessage("WhoCan: "+msg.err.Error(), true)
+		return m
+	}
+	m.whoCan.subjects = msg.subjects
+	m.whoCan.subjectsScroll = 0
+	return m
+}

--- a/internal/app/update_whocan_test.go
+++ b/internal/app/update_whocan_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func TestEnterWhoCanMode_FlipsModeAndResetsState(t *testing.T) {
+	m := Model{}
+	m.canIMode = canIModeForward
+	m.whoCan.subjectsScroll = 7 // stale value from prior session
+	mdl, _ := m.enterWhoCanMode()
+	result := mdl.(Model)
+	assert.Equal(t, canIModeWhoCan, result.canIMode,
+		"Tab from Can-I must flip the overlay into Who-Can mode")
+	assert.Equal(t, 0, result.whoCan.subjectsScroll,
+		"scroll resets so the user lands at the top of the new subjects list")
+}
+
+func TestHandleWhoCanKey_TabReturnsToForward(t *testing.T) {
+	m := Model{canIMode: canIModeWhoCan}
+	mdl, _ := m.handleWhoCanKey(keyMsg("tab"))
+	result := mdl.(Model)
+	assert.Equal(t, canIModeForward, result.canIMode,
+		"Tab from Who-Can goes back to forward Can-I — the toggle is bidirectional")
+}
+
+func TestHandleWhoCanKey_LeftRightCyclesVerb(t *testing.T) {
+	m := Model{canIMode: canIModeWhoCan}
+	require.Equal(t, "get", ui.WhoCanVerbs[0])
+	mdl, _ := m.handleWhoCanKey(keyMsg("right"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.verbCursor, "right key advances the verb cursor")
+
+	mdl, _ = result.handleWhoCanKey(keyMsg("left"))
+	result = mdl.(Model)
+	assert.Equal(t, 0, result.whoCan.verbCursor, "left wraps back")
+}
+
+func TestHandleWhoCanKey_LeftAtZeroDoesNotUnderflow(t *testing.T) {
+	m := Model{canIMode: canIModeWhoCan, whoCan: whoCanState{verbCursor: 0}}
+	mdl, _ := m.handleWhoCanKey(keyMsg("left"))
+	result := mdl.(Model)
+	assert.Equal(t, 0, result.whoCan.verbCursor,
+		"left at the first verb stays at 0 — guards against underflow")
+}
+
+func TestHandleWhoCanKey_SlashEntersFilterMode(t *testing.T) {
+	m := Model{canIMode: canIModeWhoCan}
+	mdl, _ := m.handleWhoCanKey(keyMsg("/"))
+	result := mdl.(Model)
+	assert.True(t, result.whoCan.resourceFilterActive,
+		"/ flips the resource filter input into edit mode")
+}
+
+func TestUpdateWhoCanLoaded_StoresSubjects(t *testing.T) {
+	m := Model{requestGen: 4, whoCan: whoCanState{loading: true}}
+	subs := []k8s.WhoCanSubject{
+		{Kind: "User", Name: "alice", Via: "ClusterRoleBinding/admins → ClusterRole/cluster-admin"},
+	}
+	result := m.updateWhoCanLoaded(whoCanLoadedMsg{gen: 4, subjects: subs})
+	assert.False(t, result.whoCan.loading, "spinner clears once the fetch lands")
+	assert.Len(t, result.whoCan.subjects, 1, "fetched subjects copied into Model state")
+}
+
+func TestUpdateWhoCanLoaded_StaleGenIgnored(t *testing.T) {
+	m := Model{requestGen: 10, whoCan: whoCanState{loading: true}}
+	result := m.updateWhoCanLoaded(whoCanLoadedMsg{gen: 1, subjects: []k8s.WhoCanSubject{{Kind: "User", Name: "x"}}})
+	assert.True(t, result.whoCan.loading,
+		"stale response leaves the loading flag armed so the next fresh response can clear it")
+	assert.Empty(t, result.whoCan.subjects, "stale subjects must not overwrite Model state")
+}

--- a/internal/app/update_whocan_test.go
+++ b/internal/app/update_whocan_test.go
@@ -349,6 +349,175 @@ func TestHandleCanIKey_TabDuringSearchDoesNotEnterWhoCan(t *testing.T) {
 		"search must remain active — the key was delegated to handleCanISearchKey, not the WhoCan pivot")
 }
 
+func TestEnterWhoCanMode_SetsLoadingFlagOnReturnedModel(t *testing.T) {
+	// Regression: loading was set inside loadWhoCan (a value-receiver
+	// method), so the mutation lived on a discarded copy. The renderer
+	// then never showed the spinner during the in-flight fetch on entry.
+	// Loading must be set on the Model the caller returns to Update.
+	m := Model{}
+	m.canIGroups = []model.CanIGroup{
+		canIGroupOf("", "pods"),
+	}
+	m.canIGroupCursor = 0
+	mdl, cmd := m.enterWhoCanMode()
+	result := mdl.(Model)
+	assert.True(t, result.whoCan.loading,
+		"entering Who-Can with a resource must arm the spinner on the persisted Model")
+	assert.NotNil(t, cmd, "loadWhoCan must dispatch a fetch when there is a resource")
+}
+
+func TestEnterWhoCanMode_NoResourceLeavesLoadingClear(t *testing.T) {
+	// When there's nothing to fetch (no Can-I groups), entry must NOT
+	// arm the spinner — otherwise the overlay would show a permanent
+	// "loading…" with no fetch ever landing to clear it.
+	m := Model{}
+	mdl, cmd := m.enterWhoCanMode()
+	result := mdl.(Model)
+	assert.False(t, result.whoCan.loading,
+		"empty resource list must leave loading=false — no fetch is dispatched")
+	assert.Nil(t, cmd, "no fetch dispatched when there is no resource to query")
+}
+
+func TestWhoCanCycleVerb_ArmsSpinnerWhenResourceSet(t *testing.T) {
+	// Regression: cycling the verb dispatches a new fetch but used to
+	// rely on loadWhoCan's value-receiver mutation — so the spinner
+	// never showed during verb cycling either.
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan, whoCan: whoCanState{resource: "pods", verbCursor: 0}}}
+	mdl, cmd := m.handleWhoCanKey(keyMsg("right"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.verbCursor, "right advances the verb cursor")
+	assert.True(t, result.whoCan.loading, "verb cycle must arm the spinner on the persisted Model")
+	assert.NotNil(t, cmd, "verb cycle dispatches a fetch when a resource is selected")
+}
+
+func TestWhoCanCycleVerb_NoResourceLeavesLoadingClear(t *testing.T) {
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan, whoCan: whoCanState{verbCursor: 0}}}
+	mdl, cmd := m.handleWhoCanKey(keyMsg("right"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.verbCursor)
+	assert.False(t, result.whoCan.loading, "no resource = no fetch = no spinner")
+	assert.Nil(t, cmd)
+}
+
+func TestWhoCanNamespaceToggle_ArmsSpinnerWhenResourceSet(t *testing.T) {
+	// 'A' toggles namespace scope and re-fires the query when a resource
+	// is selected. The spinner must reflect the in-flight refetch.
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan, whoCan: whoCanState{resource: "pods"}, canINamespaces: []string{""}}}
+	m.namespace = "default"
+	mdl, cmd := m.handleWhoCanKey(keyMsg("A"))
+	result := mdl.(Model)
+	assert.True(t, result.whoCan.loading,
+		"'A' must arm the spinner when toggling scope re-fires the query")
+	assert.NotNil(t, cmd)
+}
+
+func TestRefreshWhoCanForCursor_ArmsSpinnerOnResourceChange(t *testing.T) {
+	// Cursor navigation funnels through refreshWhoCanForCursor; the
+	// spinner must light up on the persisted Model when the cursor
+	// lands on a different resource.
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan, whoCan: whoCanState{resource: "pods", resourceList: []string{"pods", "secrets"}, resourceCursor: 0}}}
+	m.width = 200
+	m.height = 60
+	mdl, cmd := m.handleWhoCanKey(keyMsg("j"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.resourceCursor, "j moved the cursor")
+	assert.Equal(t, "secrets", result.whoCan.resource, "resource updated to the cursor's row")
+	assert.True(t, result.whoCan.loading, "cursor moving onto a new resource arms the spinner")
+	assert.NotNil(t, cmd)
+}
+
+func TestRefreshWhoCanForCursor_SameResourceDoesNotArmSpinner(t *testing.T) {
+	// j on the last row clamps without changing resource — no fetch,
+	// no spinner. (Otherwise the user could spam keys and pin the
+	// spinner on indefinitely with no actual work happening.)
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan, whoCan: whoCanState{resource: "secrets", resourceList: []string{"pods", "secrets"}, resourceCursor: 1}}}
+	m.width = 200
+	m.height = 60
+	mdl, cmd := m.handleWhoCanKey(keyMsg("j"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.resourceCursor)
+	assert.False(t, result.whoCan.loading, "no resource change = no fetch = no spinner")
+	assert.Nil(t, cmd)
+}
+
+func TestWhoCanFilterEscape_RefreshesSubjectsForCursor(t *testing.T) {
+	// Regression: live-narrowing then Esc cleared the filter and reset
+	// scroll, but did not refresh the subjects pane against the cursor's
+	// new (un-narrowed) row. The picker would highlight one resource
+	// while the right pane still showed another resource's subjects.
+	m := Model{}
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resourceList = []string{"configmaps", "deployments", "pods", "secrets"}
+	// Simulate state after live-narrow on "po": cursor at 0 of narrowed
+	// list, m.whoCan.resource set to "pods" (the previously-narrowed row).
+	m.whoCan.resource = "pods"
+	m.whoCan.resourceFilter.Insert("po")
+	m.whoCan.resourceFilterActive = true
+	m.whoCan.resourceCursor = 0
+	m.whoCan.resourceScroll = 5 // pretend the user had scrolled inside the narrowed list
+
+	mdl, cmd := m.handleWhoCanKey(keyMsg("esc"))
+	result := mdl.(Model)
+	assert.False(t, result.whoCan.resourceFilterActive, "esc exits filter mode")
+	assert.Equal(t, "", result.whoCan.resourceFilter.Value, "filter cleared")
+	assert.Equal(t, 0, result.whoCan.resourceScroll, "scroll reset to top of un-narrowed list")
+	// Cursor 0 in the un-narrowed list points to "configmaps", not the
+	// previously-loaded "pods", so the resource must update and a
+	// refetch must dispatch — otherwise the highlight and the right
+	// pane stay desynced.
+	assert.Equal(t, "configmaps", result.whoCan.resource,
+		"esc must refresh the resource to the un-narrowed cursor row, not preserve the narrowed selection")
+	assert.True(t, result.whoCan.loading, "spinner armed for the refetch dispatched after esc")
+	assert.NotNil(t, cmd, "a refetch is dispatched when the resource changes")
+}
+
+func TestWhoCanFilterEscape_EmptyListClearsResource(t *testing.T) {
+	// Esc on an empty resource list (e.g. canIGroups never loaded) must
+	// not crash and must clear the resource so a stale "loading…" doesn't
+	// linger.
+	m := Model{}
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resource = "pods"
+	m.whoCan.resourceFilter.Insert("zzz")
+	m.whoCan.resourceFilterActive = true
+
+	mdl, cmd := m.handleWhoCanKey(keyMsg("esc"))
+	result := mdl.(Model)
+	assert.Equal(t, "", result.whoCan.resource, "empty list clears the resource so the right pane goes idle")
+	assert.Nil(t, cmd, "no fetch dispatched when the un-narrowed list is empty")
+}
+
+func TestSyncCanINamespacesFromSelection_MultiSelectSortsForCanI(t *testing.T) {
+	m := Model{}
+	m.selectedNamespaces = map[string]bool{
+		"monitoring":  true,
+		"default":     true,
+		"kube-system": true,
+	}
+	m.canIMode = canIModeForward
+	m.syncCanINamespacesFromSelection()
+	assert.Equal(t, []string{"default", "kube-system", "monitoring"}, m.canINamespaces,
+		"forward Can-I keeps multi-select; sorted so the title bar renders deterministically across frames")
+}
+
+func TestSyncCanINamespacesFromSelection_MultiSelectCollapsesInWhoCan(t *testing.T) {
+	// Regression: Who-Can's loadWhoCan only recognises canINamespaces of
+	// length 0 or 1 — multi-select would render a "ns: a,b,c" title but
+	// query cluster-wide, so the displayed scope didn't match the data.
+	// In Who-Can mode we collapse to the first sorted namespace so the
+	// scope label and the query agree.
+	m := Model{}
+	m.selectedNamespaces = map[string]bool{
+		"monitoring":  true,
+		"default":     true,
+		"kube-system": true,
+	}
+	m.canIMode = canIModeWhoCan
+	m.syncCanINamespacesFromSelection()
+	assert.Equal(t, []string{"default"}, m.canINamespaces,
+		"Who-Can collapses multi-select to the first sorted namespace so scope label and query match")
+}
+
 func TestEnterWhoCanMode_RefreshesResourceOnEachEntry(t *testing.T) {
 	// Regression: a previous version preserved m.whoCan.resource across
 	// Tab pivots — so after tabbing back to forward, moving the Can-I

--- a/internal/app/update_whocan_test.go
+++ b/internal/app/update_whocan_test.go
@@ -7,8 +7,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
+
+// canIGroupOf builds a CanIGroup for tests with the given group name
+// and resource names. Keeps the test bodies focused on the assertion
+// rather than the boilerplate of nesting Resources slices.
+func canIGroupOf(name string, resources ...string) model.CanIGroup {
+	rs := make([]model.CanIResource, len(resources))
+	for i, r := range resources {
+		rs[i] = model.CanIResource{Resource: r}
+	}
+	return model.CanIGroup{Name: name, Resources: rs}
+}
 
 func TestEnterWhoCanMode_FlipsModeAndResetsState(t *testing.T) {
 	m := Model{}
@@ -20,6 +32,247 @@ func TestEnterWhoCanMode_FlipsModeAndResetsState(t *testing.T) {
 		"Tab from Can-I must flip the overlay into Who-Can mode")
 	assert.Equal(t, 0, result.whoCan.subjectsScroll,
 		"scroll resets so the user lands at the top of the new subjects list")
+}
+
+func TestEnterWhoCanMode_BuildsResourceListFromCanIGroups(t *testing.T) {
+	m := Model{}
+	m.canIGroups = []model.CanIGroup{
+		canIGroupOf("apps", "deployments", "statefulsets"),
+		canIGroupOf("", "pods", "secrets"),
+	}
+	mdl, _ := m.enterWhoCanMode()
+	result := mdl.(Model)
+	assert.Equal(t, []string{"deployments", "pods", "secrets", "statefulsets"},
+		result.whoCan.resourceList,
+		"resource picker is the deduped sorted union of Can-I groups")
+}
+
+func TestEnterWhoCanMode_PositionsCursorOnPreSelectedResource(t *testing.T) {
+	m := Model{}
+	// Can-I cursor is on the first group; canIResourceUnderCursor returns its first
+	// resource name. Expect the picker to land on that name in the deduped list.
+	m.canIGroups = []model.CanIGroup{
+		canIGroupOf("", "pods", "secrets"),
+	}
+	m.canIGroupCursor = 0
+	mdl, _ := m.enterWhoCanMode()
+	result := mdl.(Model)
+	assert.Equal(t, "pods", result.whoCan.resource,
+		"pre-positioned resource is the one highlighted in the Can-I view")
+}
+
+func TestHandleWhoCanKey_JKMovesCursor(t *testing.T) {
+	m := Model{}
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resourceList = []string{"pods", "secrets", "services"}
+	m.whoCan.resourceCursor = 0
+
+	mdl, _ := m.handleWhoCanKey(keyMsg("j"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.resourceCursor,
+		"j moves the resource cursor down one")
+
+	mdl, _ = result.handleWhoCanKey(keyMsg("k"))
+	result = mdl.(Model)
+	assert.Equal(t, 0, result.whoCan.resourceCursor,
+		"k moves the resource cursor up one")
+}
+
+func TestHandleWhoCanKey_JAtBottomDoesNotOverflow(t *testing.T) {
+	m := Model{}
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resourceList = []string{"pods", "secrets"}
+	m.whoCan.resourceCursor = 1 // already at the bottom
+	mdl, _ := m.handleWhoCanKey(keyMsg("j"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.resourceCursor,
+		"j at the last row stays put — guards against overflow")
+}
+
+func TestHandleWhoCanKey_GJumpsToTopAndShiftGToBottom(t *testing.T) {
+	m := Model{}
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resourceList = []string{"a", "b", "c", "d", "e"}
+	m.whoCan.resourceCursor = 2
+
+	mdl, _ := m.handleWhoCanKey(keyMsg("G"))
+	result := mdl.(Model)
+	assert.Equal(t, 4, result.whoCan.resourceCursor, "G jumps to the last entry")
+
+	mdl, _ = result.handleWhoCanKey(keyMsg("g"))
+	result = mdl.(Model)
+	assert.Equal(t, 0, result.whoCan.resourceCursor, "g jumps to the first entry")
+}
+
+func TestHandleWhoCanKey_HomeJumpsToTopAndEndToBottom(t *testing.T) {
+	m := Model{}
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resourceList = []string{"a", "b", "c", "d"}
+	m.whoCan.resourceCursor = 2
+
+	mdl, _ := m.handleWhoCanKey(keyMsg("end"))
+	result := mdl.(Model)
+	assert.Equal(t, 3, result.whoCan.resourceCursor, "end aliases G")
+
+	mdl, _ = result.handleWhoCanKey(keyMsg("home"))
+	result = mdl.(Model)
+	assert.Equal(t, 0, result.whoCan.resourceCursor, "home aliases g")
+}
+
+func TestHandleWhoCanKey_JJKKScrollsSubjectsNotResources(t *testing.T) {
+	m := Model{}
+	m.width = 200
+	m.height = 60
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resourceList = []string{"pods"}
+	m.whoCan.resourceCursor = 0
+	// Many subjects so subjectsScroll has room to move.
+	subjects := make([]k8s.WhoCanSubject, 50)
+	for i := range subjects {
+		subjects[i].Name = "user"
+	}
+	m.whoCan.subjects = subjects
+
+	mdl, _ := m.handleWhoCanKey(keyMsg("J"))
+	result := mdl.(Model)
+	assert.Equal(t, 1, result.whoCan.subjectsScroll, "J scrolls the subjects column down by one")
+	assert.Equal(t, 0, result.whoCan.resourceCursor, "J must not move the resource cursor")
+
+	mdl, _ = result.handleWhoCanKey(keyMsg("K"))
+	result = mdl.(Model)
+	assert.Equal(t, 0, result.whoCan.subjectsScroll, "K scrolls the subjects column up by one")
+}
+
+func TestHandleWhoCanKey_JKAtBottomDoesNotOverflowSubjects(t *testing.T) {
+	m := Model{}
+	m.width = 200
+	m.height = 60
+	m.canIMode = canIModeWhoCan
+	m.whoCan.subjects = []k8s.WhoCanSubject{{Name: "x"}} // exactly one row, fits in any panel
+	m.whoCan.subjectsScroll = 0
+
+	mdl, _ := m.handleWhoCanKey(keyMsg("J"))
+	result := mdl.(Model)
+	assert.Equal(t, 0, result.whoCan.subjectsScroll,
+		"J at the last row stays clamped to 0 — there's nothing to scroll past")
+}
+
+func TestNamespaceToggleKey_RestoresParentAndClearsPreviousOverlay(t *testing.T) {
+	// Regression: pressing the namespace selector hotkey while it was
+	// nested on top of RBAC used to drop both overlays AND leave
+	// previousOverlay stale, so the next open of the namespace
+	// selector would incorrectly re-render RBAC behind it.
+	m := Model{}
+	m.overlay = overlayNamespace
+	m.previousOverlay = overlayCanI
+
+	mdl, _ := m.handleOverlayKey(keyMsg("\\"))
+	result := mdl.(Model)
+	assert.Equal(t, overlayCanI, result.overlay,
+		"toggle key on a layered ns selector restores the parent overlay")
+	assert.Equal(t, overlayNone, result.previousOverlay,
+		"previousOverlay must clear so a re-open of the ns selector starts fresh — otherwise RBAC re-appears as a stale background")
+}
+
+func TestNamespaceSelectorEsc_RestoresCanIOverlayWhenOpenedFromIt(t *testing.T) {
+	// Regression: opening the namespace selector from inside Can-I
+	// used to set m.overlay = overlayNamespace and on close drop back
+	// to overlayNone, so the user lost their RBAC overlay.
+	m := Model{}
+	m.overlay = overlayNamespace
+	m.previousOverlay = overlayCanI
+
+	mdl, _ := m.handleNamespaceOverlayKey(keyMsg("esc"))
+	result := mdl.(Model)
+	assert.Equal(t, overlayCanI, result.overlay,
+		"esc must restore the parent overlay when the namespace selector was nested inside it")
+	assert.Equal(t, overlayNone, result.previousOverlay,
+		"previousOverlay must clear after restore so the next esc cleanly closes")
+}
+
+func TestSyncCanINamespacesFromSelection_AllNamespacesProducesEmptyString(t *testing.T) {
+	m := Model{}
+	m.allNamespaces = true
+	m.syncCanINamespacesFromSelection()
+	assert.Equal(t, []string{""}, m.canINamespaces,
+		"all-ns scope must collapse to the empty-string sentinel that loadWhoCan / loadCanIRules treat as cluster-wide")
+}
+
+func TestSyncCanINamespacesFromSelection_SingleNamespacePassesThrough(t *testing.T) {
+	m := Model{}
+	m.namespace = "kube-system"
+	m.syncCanINamespacesFromSelection()
+	assert.Equal(t, []string{"kube-system"}, m.canINamespaces)
+}
+
+func TestWhoCanScroll_ScrollingUpReleasesCursorFromBottomEdge(t *testing.T) {
+	// Regression: stateless scroll re-pinned the cursor to the last
+	// visible row whenever it sat past the first viewport. After
+	// scrolling down then up, vim semantics should leave the viewport
+	// alone until the cursor crosses an edge — the cursor should be
+	// able to walk up *inside* the viewport, not stay glued to its bottom.
+	m := Model{}
+	m.width = 200
+	m.height = 60
+	m.canIMode = canIModeWhoCan
+	// Build a big enough list that scrolling matters.
+	resources := make([]string, 80)
+	for i := range resources {
+		resources[i] = "r" + itoa(i)
+	}
+	m.whoCan.resourceList = resources
+
+	// Jump to the bottom — cursor + scroll both at the end.
+	mdl, _ := m.handleWhoCanKey(keyMsg("G"))
+	result := mdl.(Model)
+	require.Equal(t, len(resources)-1, result.whoCan.resourceCursor)
+
+	scrollAfterG := result.whoCan.resourceScroll
+	require.Greater(t, scrollAfterG, 0, "G must have scrolled down — list is bigger than the viewport")
+
+	// Step up by one. Cursor decrements; viewport must NOT shift.
+	mdl, _ = result.handleWhoCanKey(keyMsg("k"))
+	result = mdl.(Model)
+	assert.Equal(t, len(resources)-2, result.whoCan.resourceCursor,
+		"k must move the cursor up by one")
+	assert.Equal(t, scrollAfterG, result.whoCan.resourceScroll,
+		"scroll must stay put while the cursor is still inside the viewport — vim semantics")
+}
+
+// itoa is a tiny helper to avoid importing strconv just for this file.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+func TestWhoCanFilter_NarrowsListAndResetsCursor(t *testing.T) {
+	m := Model{}
+	m.canIMode = canIModeWhoCan
+	m.whoCan.resourceList = []string{"configmaps", "pods", "pods/exec", "secrets"}
+	m.whoCan.resourceCursor = 3 // user was on "secrets"
+	m.whoCan.resourceFilterActive = true
+	m.whoCan.resourceFilter.Insert("po")
+
+	visible := m.whoCanVisibleResources()
+	assert.Equal(t, []string{"pods", "pods/exec"}, visible,
+		"filter narrows to substring matches across the deduped list")
 }
 
 func TestHandleWhoCanKey_TabReturnsToForward(t *testing.T) {

--- a/internal/app/update_whocan_test.go
+++ b/internal/app/update_whocan_test.go
@@ -276,7 +276,7 @@ func TestWhoCanFilter_NarrowsListAndResetsCursor(t *testing.T) {
 }
 
 func TestHandleWhoCanKey_TabReturnsToForward(t *testing.T) {
-	m := Model{canIMode: canIModeWhoCan}
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan}}
 	mdl, _ := m.handleWhoCanKey(keyMsg("tab"))
 	result := mdl.(Model)
 	assert.Equal(t, canIModeForward, result.canIMode,
@@ -284,7 +284,7 @@ func TestHandleWhoCanKey_TabReturnsToForward(t *testing.T) {
 }
 
 func TestHandleWhoCanKey_LeftRightCyclesVerb(t *testing.T) {
-	m := Model{canIMode: canIModeWhoCan}
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan}}
 	require.Equal(t, "get", ui.WhoCanVerbs[0])
 	mdl, _ := m.handleWhoCanKey(keyMsg("right"))
 	result := mdl.(Model)
@@ -296,7 +296,7 @@ func TestHandleWhoCanKey_LeftRightCyclesVerb(t *testing.T) {
 }
 
 func TestHandleWhoCanKey_LeftAtZeroDoesNotUnderflow(t *testing.T) {
-	m := Model{canIMode: canIModeWhoCan, whoCan: whoCanState{verbCursor: 0}}
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan, whoCan: whoCanState{verbCursor: 0}}}
 	mdl, _ := m.handleWhoCanKey(keyMsg("left"))
 	result := mdl.(Model)
 	assert.Equal(t, 0, result.whoCan.verbCursor,
@@ -304,7 +304,7 @@ func TestHandleWhoCanKey_LeftAtZeroDoesNotUnderflow(t *testing.T) {
 }
 
 func TestHandleWhoCanKey_SlashEntersFilterMode(t *testing.T) {
-	m := Model{canIMode: canIModeWhoCan}
+	m := Model{canIState: canIState{canIMode: canIModeWhoCan}}
 	mdl, _ := m.handleWhoCanKey(keyMsg("/"))
 	result := mdl.(Model)
 	assert.True(t, result.whoCan.resourceFilterActive,
@@ -312,7 +312,7 @@ func TestHandleWhoCanKey_SlashEntersFilterMode(t *testing.T) {
 }
 
 func TestUpdateWhoCanLoaded_StoresSubjects(t *testing.T) {
-	m := Model{requestGen: 4, whoCan: whoCanState{loading: true}}
+	m := Model{requestGen: 4, canIState: canIState{whoCan: whoCanState{loading: true}}}
 	subs := []k8s.WhoCanSubject{
 		{Kind: "User", Name: "alice", Via: "ClusterRoleBinding/admins → ClusterRole/cluster-admin"},
 	}
@@ -322,9 +322,62 @@ func TestUpdateWhoCanLoaded_StoresSubjects(t *testing.T) {
 }
 
 func TestUpdateWhoCanLoaded_StaleGenIgnored(t *testing.T) {
-	m := Model{requestGen: 10, whoCan: whoCanState{loading: true}}
+	m := Model{requestGen: 10, canIState: canIState{whoCan: whoCanState{loading: true}}}
 	result := m.updateWhoCanLoaded(whoCanLoadedMsg{gen: 1, subjects: []k8s.WhoCanSubject{{Kind: "User", Name: "x"}}})
 	assert.True(t, result.whoCan.loading,
 		"stale response leaves the loading flag armed so the next fresh response can clear it")
 	assert.Empty(t, result.whoCan.subjects, "stale subjects must not overwrite Model state")
+}
+
+func TestHandleCanIKey_TabDuringSearchDoesNotEnterWhoCan(t *testing.T) {
+	// Regression: an earlier dispatcher checked the WhoCan-pivot Tab
+	// branch BEFORE the search-active guard, so pressing Tab while
+	// `/`-search was active hijacked the key into enterWhoCanMode and
+	// left the model with the search input mid-edit. Search must own
+	// Tab when active — only after it falls through can the WhoCan
+	// pivot consume the key.
+	m := Model{}
+	m.canIMode = canIModeForward
+	m.canISearchActive = true
+
+	mdl, _ := m.handleCanIKey(keyMsg("tab"))
+	result := mdl.(Model)
+
+	assert.Equal(t, canIModeForward, result.canIMode,
+		"Tab while search is active must NOT enter Who-Can mode — search owns Tab")
+	assert.True(t, result.canISearchActive,
+		"search must remain active — the key was delegated to handleCanISearchKey, not the WhoCan pivot")
+}
+
+func TestEnterWhoCanMode_RefreshesResourceOnEachEntry(t *testing.T) {
+	// Regression: a previous version preserved m.whoCan.resource across
+	// Tab pivots — so after tabbing back to forward, moving the Can-I
+	// cursor to a different group, and tabbing again, the user saw
+	// stale Who-Can results from the FIRST entry instead of subjects
+	// for the row they were now hovering. enterWhoCanMode must re-read
+	// the cursor unconditionally on every entry.
+	m := Model{}
+	m.canIGroups = []model.CanIGroup{
+		canIGroupOf("", "pods"),
+		canIGroupOf("apps", "deployments"),
+	}
+
+	// First entry: cursor on the core group, expect "pods".
+	m.canIGroupCursor = 0
+	mdl, _ := m.enterWhoCanMode()
+	first := mdl.(Model)
+	require.Equal(t, "pods", first.whoCan.resource,
+		"first entry pre-positions on the resource under the Can-I cursor")
+
+	// Tab back to forward, then move the Can-I cursor to a different group.
+	mdl, _ = first.handleWhoCanKey(keyMsg("tab"))
+	back := mdl.(Model)
+	require.Equal(t, canIModeForward, back.canIMode)
+	back.canIGroupCursor = 1
+
+	// Re-enter Who-Can — must reflect the NEW cursor, not the stale resource.
+	mdl, _ = back.enterWhoCanMode()
+	second := mdl.(Model)
+	assert.Equal(t, "deployments", second.whoCan.resource,
+		"re-entry must refresh the resource from the current Can-I cursor — preserving the previous Who-Can target leaks stale results across pivots")
 }

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -386,8 +386,14 @@ func convertNetpolRule(r k8s.NetpolRule) ui.NetpolRuleEntry {
 	return re
 }
 
-// renderCanIOverlay renders the Can-I browser overlay on top of the given background.
+// renderCanIOverlay renders the Can-I browser overlay on top of the
+// given background. In Who-Can mode the same overlay frame hosts the
+// reverse-RBAC view via renderWhoCanInner — same dimensions, same wrap,
+// just different content.
 func (m Model) renderCanIOverlay(background string) string {
+	if m.canIMode == canIModeWhoCan {
+		return m.renderWhoCanOverlay(background)
+	}
 	visibleGroupIdxs := m.canIVisibleGroups()
 	groupNames := make([]string, len(visibleGroupIdxs))
 	for i, idx := range visibleGroupIdxs {

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -19,6 +19,18 @@ import (
 // centered overlay box via renderOverlayContent.
 
 func (m Model) renderOverlay(background string) string {
+	// Layered overlays: when the current overlay was opened on top of
+	// another (e.g. the namespace selector launched from inside the
+	// RBAC overlay), draw the parent first so it stays visible behind
+	// the new one. Without this, opening a nested overlay would visibly
+	// hide the parent until the user closes the child.
+	if m.previousOverlay != overlayNone && m.previousOverlay != m.overlay {
+		parent := m
+		parent.overlay = m.previousOverlay
+		parent.previousOverlay = overlayNone
+		background = parent.renderOverlay(background)
+	}
+
 	// Fullscreen overlays bypass the standard overlay rendering.
 	switch m.overlay {
 	case overlaySecretEditor, overlayConfigMapEditor, overlayRollback, overlayHelmRollback, overlayHelmHistory, overlayLabelEditor, overlayAutoSync:
@@ -441,8 +453,16 @@ func (m Model) renderCanIOverlay(background string) string {
 		hintBar,
 		m.canIResourceScroll,
 	)
-	canIContent = ui.FillLinesBg(canIContent, overlayW-4, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(canIContent)
+	// RBAC overlay uses baseBg end-to-end: title (TitleStyle/barBg=baseBg)
+	// + column boxes (Active/InactiveColumnStyle/baseBg) + filler. Mixing
+	// surfaceBg here would paint a visible "frame" of a different shade
+	// around the inner baseBg content — the user reported this.
+	canIContent = ui.FillLinesBg(canIContent, overlayW-4, ui.BaseBg)
+	overlay := ui.OverlayStyle.
+		Background(ui.BaseBg).
+		BorderBackground(ui.BaseBg).
+		Width(overlayW).Height(overlayH).
+		Render(canIContent)
 	bg := ui.PadToHeight(background, m.height)
 	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
 }

--- a/internal/app/whocan_resources.go
+++ b/internal/app/whocan_resources.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// whoCanCollectResources flattens the Can-I groups into a sorted,
+// de-duplicated list of resource names. The Who-Can picker uses this
+// as the canonical "what resources can I query?" list — same source
+// of truth as the Can-I browser, so the user sees a familiar set.
+//
+// Resources without slashes (e.g. "pods") and subresources ("pods/exec")
+// both appear; dedupe is by the full string so the user can pick a
+// subresource explicitly if they care to.
+func whoCanCollectResources(groups []model.CanIGroup) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, 64)
+	for _, g := range groups {
+		for _, r := range g.Resources {
+			name := r.Resource
+			if name == "" {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// whoCanFilterResources narrows the full resource list to entries that
+// contain the (case-insensitive) substring in q. Empty q returns the
+// full list unchanged. Substring match (not prefix) so users can find
+// "pods/exec" by typing "exec".
+func whoCanFilterResources(all []string, q string) []string {
+	if q == "" {
+		return all
+	}
+	q = strings.ToLower(q)
+	out := make([]string, 0, len(all))
+	for _, r := range all {
+		if strings.Contains(strings.ToLower(r), q) {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/app/whocan_resources_test.go
+++ b/internal/app/whocan_resources_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestWhoCanCollectResources_DedupesAndSorts(t *testing.T) {
+	groups := []model.CanIGroup{
+		{Name: "apps", Resources: []model.CanIResource{
+			{Resource: "deployments"}, {Resource: "statefulsets"},
+		}},
+		{Name: "", Resources: []model.CanIResource{
+			{Resource: "pods"}, {Resource: "secrets"}, {Resource: "configmaps"},
+		}},
+		{Name: "extensions", Resources: []model.CanIResource{
+			{Resource: "deployments"}, // duplicate across groups
+		}},
+	}
+	got := whoCanCollectResources(groups)
+	assert.Equal(t, []string{
+		"configmaps", "deployments", "pods", "secrets", "statefulsets",
+	}, got, "result must be sorted and de-duplicated")
+}
+
+func TestWhoCanCollectResources_EmptyInput(t *testing.T) {
+	assert.Empty(t, whoCanCollectResources(nil))
+	assert.Empty(t, whoCanCollectResources([]model.CanIGroup{}))
+}
+
+func TestWhoCanCollectResources_SkipsBlankNames(t *testing.T) {
+	groups := []model.CanIGroup{
+		{Resources: []model.CanIResource{{Resource: ""}, {Resource: "pods"}}},
+	}
+	assert.Equal(t, []string{"pods"}, whoCanCollectResources(groups),
+		"blank resource names are skipped — the picker can't query an empty resource")
+}
+
+func TestWhoCanFilterResources_EmptyQueryReturnsAll(t *testing.T) {
+	all := []string{"a", "b", "c"}
+	assert.Equal(t, all, whoCanFilterResources(all, ""))
+}
+
+func TestWhoCanFilterResources_CaseInsensitiveSubstring(t *testing.T) {
+	all := []string{"pods", "pods/exec", "secrets", "configmaps"}
+	assert.Equal(t, []string{"pods", "pods/exec"}, whoCanFilterResources(all, "POD"),
+		"filter is case-insensitive substring match so users can find pods/exec by typing exec")
+	assert.Equal(t, []string{"pods/exec"}, whoCanFilterResources(all, "exec"))
+}
+
+func TestWhoCanFilterResources_NoMatchReturnsEmpty(t *testing.T) {
+	assert.Empty(t, whoCanFilterResources([]string{"pods", "secrets"}, "xyz"))
+}

--- a/internal/k8s/whocan.go
+++ b/internal/k8s/whocan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sort"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,6 +101,21 @@ func (c *Client) WhoCan(ctx context.Context, contextName, namespace, group, reso
 			out = append(out, subjectFromBinding(s, via))
 		}
 	}
+	// Sort by Name primarily so the picker reads alphabetically;
+	// fallback keys keep duplicate-name rows (same subject granted via
+	// multiple bindings) deterministic between renders.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Via < out[j].Via
+	})
 	return out, nil
 }
 
@@ -182,11 +198,17 @@ func subjectFromBinding(s rbacv1.Subject, via string) WhoCanSubject {
 }
 
 // ruleSetMatches returns true when at least one rule in the set grants
-// the (verb, group, resource) tuple. Skips nonResourceURLs rules — they
-// don't grant resource permissions.
+// the (verb, group, resource) tuple. Skips:
+//   - nonResourceURLs rules (don't grant resource permissions)
+//   - resourceNames-scoped rules (restrict to named objects; the picker
+//     does not model object names, so reporting these as generic access
+//     would over-report permissions).
 func ruleSetMatches(rules []rbacv1.PolicyRule, verb, group, resource string) bool {
 	for _, r := range rules {
 		if len(r.Resources) == 0 && len(r.NonResourceURLs) > 0 {
+			continue
+		}
+		if len(r.ResourceNames) > 0 {
 			continue
 		}
 		if !verbMatches(r.Verbs, verb) {
@@ -204,7 +226,15 @@ func ruleSetMatches(rules []rbacv1.PolicyRule, verb, group, resource string) boo
 }
 
 // verbMatches: rule grants verb when rule.Verbs contains the verb or "*".
+//
+// Query verb "*" means "any verb" — match any rule that has at least
+// one verb. Without this, "*" would only match rules whose Verbs list
+// itself contains "*", silently dropping subjects whose role grants
+// only list/watch/etc.
 func verbMatches(ruleVerbs []string, verb string) bool {
+	if verb == "*" {
+		return len(ruleVerbs) > 0
+	}
 	return slices.Contains(ruleVerbs, "*") || slices.Contains(ruleVerbs, verb)
 }
 

--- a/internal/k8s/whocan.go
+++ b/internal/k8s/whocan.go
@@ -1,0 +1,227 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WhoCanSubject is one row in the Reverse-RBAC result table: a subject
+// granted the queried (verb, group, resource) by some (Cluster)RoleBinding
+// that ultimately resolves to a (Cluster)Role with a matching rule.
+//
+// Multiple bindings can grant the same subject — each grant is emitted
+// as its own row so the user can audit every path; the renderer
+// shouldn't dedupe.
+type WhoCanSubject struct {
+	// Kind is "User" / "Group" / "ServiceAccount", straight from
+	// rbacv1.Subject.Kind.
+	Kind string
+	// Name is the subject identifier (user@example.com, system:masters,
+	// ci-deployer).
+	Name string
+	// Namespace is set only for ServiceAccount subjects (where it's
+	// part of the SA's identity, not the binding's namespace). Users
+	// and Groups have an empty Namespace.
+	Namespace string
+	// Via captures the RBAC chain that grants the access:
+	// "ClusterRoleBinding/<name> → ClusterRole/<name>" or
+	// "RoleBinding/<ns>/<name> → Role/<name>". Format is stable so
+	// future audit-trail tooling can parse it.
+	Via string
+}
+
+// WhoCan returns every subject that has permission to perform `verb` on
+// (group, resource) in the requested namespace scope.
+//
+// Scope rules (matching kubectl-who-can):
+//   - namespace == "" → all namespaces are in scope; every RoleBinding
+//     in the cluster plus every ClusterRoleBinding is examined.
+//   - namespace != "" → ClusterRoleBindings still count (cluster-wide
+//     grants always apply), but RoleBindings outside `namespace` are
+//     excluded since they can't grant access to the requested scope.
+//
+// This is a pure RBAC scan — no authorization check (SAR/SSAR) is
+// issued. The result reflects the *granted* permission per the
+// configured RBAC objects, ignoring webhooks or other authorizer
+// plugins that might further restrict access at evaluation time.
+func (c *Client) WhoCan(ctx context.Context, contextName, namespace, group, resource, verb string) ([]WhoCanSubject, error) {
+	cs, err := c.clientsetForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	clusterRoles, err := loadClusterRoles(ctx, cs)
+	if err != nil {
+		return nil, err
+	}
+	roles, err := loadRoles(ctx, cs, namespace)
+	if err != nil {
+		return nil, err
+	}
+	roleBindings, err := loadRoleBindings(ctx, cs, namespace)
+	if err != nil {
+		return nil, err
+	}
+	clusterRoleBindings, err := cs.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing ClusterRoleBindings: %w", err)
+	}
+
+	out := make([]WhoCanSubject, 0)
+	for _, crb := range clusterRoleBindings.Items {
+		role, ok := lookupRoleForBinding(crb.RoleRef, "", clusterRoles, roles)
+		if !ok {
+			continue // dangling RoleRef; treat as no grant
+		}
+		if !ruleSetMatches(role.rules, verb, group, resource) {
+			continue
+		}
+		via := fmt.Sprintf("ClusterRoleBinding/%s → %s/%s",
+			crb.Name, role.kind, role.name)
+		for _, s := range crb.Subjects {
+			out = append(out, subjectFromBinding(s, via))
+		}
+	}
+	for _, rb := range roleBindings.Items {
+		role, ok := lookupRoleForBinding(rb.RoleRef, rb.Namespace, clusterRoles, roles)
+		if !ok {
+			continue
+		}
+		if !ruleSetMatches(role.rules, verb, group, resource) {
+			continue
+		}
+		via := fmt.Sprintf("RoleBinding/%s/%s → %s/%s",
+			rb.Namespace, rb.Name, role.kind, role.name)
+		for _, s := range rb.Subjects {
+			out = append(out, subjectFromBinding(s, via))
+		}
+	}
+	return out, nil
+}
+
+// roleEntry collapses Role and ClusterRole into a uniform shape so the
+// matching loop above can treat them identically.
+type roleEntry struct {
+	kind  string // "Role" or "ClusterRole"
+	name  string
+	rules []rbacv1.PolicyRule
+}
+
+// loadClusterRoles fetches every ClusterRole in the cluster and indexes
+// them by name. Used to resolve RoleRef targets of kind ClusterRole
+// (from both ClusterRoleBindings and RoleBindings).
+func loadClusterRoles(ctx context.Context, cs kubernetes.Interface) (map[string]roleEntry, error) {
+	list, err := cs.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing ClusterRoles: %w", err)
+	}
+	out := make(map[string]roleEntry, len(list.Items))
+	for _, cr := range list.Items {
+		out[cr.Name] = roleEntry{kind: "ClusterRole", name: cr.Name, rules: cr.Rules}
+	}
+	return out, nil
+}
+
+// loadRoles fetches Roles. When namespace is empty it walks every
+// namespace; otherwise it scopes to the one in question. Indexed by
+// "<namespace>/<name>" because Role names aren't unique cluster-wide.
+func loadRoles(ctx context.Context, cs kubernetes.Interface, namespace string) (map[string]roleEntry, error) {
+	list, err := cs.RbacV1().Roles(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing Roles: %w", err)
+	}
+	out := make(map[string]roleEntry, len(list.Items))
+	for _, r := range list.Items {
+		key := r.Namespace + "/" + r.Name
+		out[key] = roleEntry{kind: "Role", name: r.Name, rules: r.Rules}
+	}
+	return out, nil
+}
+
+// loadRoleBindings honors the same scope contract as WhoCan itself.
+func loadRoleBindings(ctx context.Context, cs kubernetes.Interface, namespace string) (*rbacv1.RoleBindingList, error) {
+	list, err := cs.RbacV1().RoleBindings(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing RoleBindings: %w", err)
+	}
+	return list, nil
+}
+
+// lookupRoleForBinding resolves a RoleRef into the underlying role's
+// rules. RoleBindings can reference either a Role (in their own
+// namespace) or a ClusterRole; ClusterRoleBindings always reference
+// a ClusterRole. Returns false when the referenced role isn't loaded
+// (orphan ref, RBAC drift) so the caller skips silently — kubectl
+// does the same.
+func lookupRoleForBinding(ref rbacv1.RoleRef, bindingNamespace string, clusterRoles, roles map[string]roleEntry) (roleEntry, bool) {
+	switch ref.Kind {
+	case "ClusterRole":
+		role, ok := clusterRoles[ref.Name]
+		return role, ok
+	case "Role":
+		role, ok := roles[bindingNamespace+"/"+ref.Name]
+		return role, ok
+	}
+	return roleEntry{}, false
+}
+
+// subjectFromBinding converts an rbacv1.Subject into our flat result
+// row. ServiceAccount kept its namespace (part of identity); other
+// kinds normalise namespace to empty so the table doesn't show
+// misleading values.
+func subjectFromBinding(s rbacv1.Subject, via string) WhoCanSubject {
+	out := WhoCanSubject{Kind: s.Kind, Name: s.Name, Via: via}
+	if s.Kind == "ServiceAccount" {
+		out.Namespace = s.Namespace
+	}
+	return out
+}
+
+// ruleSetMatches returns true when at least one rule in the set grants
+// the (verb, group, resource) tuple. Skips nonResourceURLs rules — they
+// don't grant resource permissions.
+func ruleSetMatches(rules []rbacv1.PolicyRule, verb, group, resource string) bool {
+	for _, r := range rules {
+		if len(r.Resources) == 0 && len(r.NonResourceURLs) > 0 {
+			continue
+		}
+		if !verbMatches(r.Verbs, verb) {
+			continue
+		}
+		if !groupMatches(r.APIGroups, group) {
+			continue
+		}
+		if !resourceMatches(r.Resources, resource) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// verbMatches: rule grants verb when rule.Verbs contains the verb or "*".
+func verbMatches(ruleVerbs []string, verb string) bool {
+	return slices.Contains(ruleVerbs, "*") || slices.Contains(ruleVerbs, verb)
+}
+
+// groupMatches: rule grants the group when rule.APIGroups contains
+// the group or "*". Empty group ("") is the core API group; the rule
+// must list it explicitly (or "*") for a match — there is no "any"
+// fallback because authors who write "" mean the core group.
+func groupMatches(ruleGroups []string, group string) bool {
+	return slices.Contains(ruleGroups, "*") || slices.Contains(ruleGroups, group)
+}
+
+// resourceMatches: rule grants the resource when rule.Resources
+// contains the bare resource name or "*". Subresource matching
+// ("pods/log") is a literal compare for now — RBAC's "pods/*"
+// pattern isn't expanded, since we don't know all of pods's
+// subresources in this context. First iteration constraint, see
+// "out of scope" in the design doc.
+func resourceMatches(ruleResources []string, resource string) bool {
+	return slices.Contains(ruleResources, "*") || slices.Contains(ruleResources, resource)
+}

--- a/internal/k8s/whocan_test.go
+++ b/internal/k8s/whocan_test.go
@@ -299,6 +299,108 @@ func TestWhoCan_NonResourceURLRulesIgnored(t *testing.T) {
 	assert.Empty(t, out, "nonResourceURLs rules don't grant resource permissions")
 }
 
+// --- Query-side wildcards ---
+
+// TestWhoCan_QueryVerbWildcardMatchesAnyVerbRule pins the contract
+// that querying with verb="*" returns subjects whose role grants ANY
+// verb on the resource — not just rules whose Verbs literally contain
+// "*". Earlier the picker rewrote "*" to "get" which silently dropped
+// subjects that could only list/watch/etc.
+func TestWhoCan_QueryVerbWildcardMatchesAnyVerbRule(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "lister"},
+		Rules: []rbacv1.PolicyRule{
+			// list/watch only — no get, no "*".
+			{Verbs: []string{"list", "watch"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+		},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("listers"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "lister", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "*")
+	require.NoError(t, err)
+	assert.Len(t, out, 1, "alice has list/watch on pods → must appear under verb=*")
+	assert.Equal(t, "alice", out[0].Name)
+}
+
+// --- ResourceNames-scoped rules ---
+
+// TestWhoCan_ResourceNamesRulesAreSkipped guards against over-
+// reporting permissions: a rule like resources=[pods],
+// resourceNames=[foo] only grants access to the named pod, not
+// pods in general. The picker has no way to model object names,
+// so these rules must be excluded from the result set.
+func TestWhoCan_ResourceNamesRulesAreSkipped(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "named-pod-reader"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"get"},
+				APIGroups:     []string{""},
+				Resources:     []string{"pods"},
+				ResourceNames: []string{"specific-pod"},
+			},
+		},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("nprs"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "narrow"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "named-pod-reader"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	require.NoError(t, err)
+	assert.Empty(t, out, "ResourceNames-scoped rules must not be reported as generic pod access")
+}
+
+// --- Stable ordering ---
+
+// TestWhoCan_ResultsSortedByName pins the contract that WhoCan
+// returns subjects sorted alphabetically by Name. The picker reads
+// alphabetically from top to bottom, so unsorted output makes the
+// list jump around between renders and forces users to scan the
+// whole table to find a name.
+func TestWhoCan_ResultsSortedByName(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "viewer"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+		},
+	}
+	// Subjects deliberately in reverse-alphabetical order so the test
+	// proves WhoCan re-sorts (rather than the binding ordering being
+	// already-correct by luck).
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("viewers"),
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "zoe"},
+			{Kind: "User", Name: "alice"},
+			{Kind: "Group", Name: "monitoring"},
+			{Kind: "User", Name: "bob"},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "ClusterRole", Name: "viewer", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	require.NoError(t, err)
+
+	names := make([]string, len(out))
+	for i, s := range out {
+		names[i] = s.Name
+	}
+	assert.Equal(t, []string{"alice", "bob", "monitoring", "zoe"}, names,
+		"subjects must be returned in alphabetical Name order so the picker reads top-to-bottom")
+}
+
 // --- Helpers used only in this file ---
 
 func pmeta(name string) metav1.ObjectMeta {

--- a/internal/k8s/whocan_test.go
+++ b/internal/k8s/whocan_test.go
@@ -1,0 +1,310 @@
+package k8s
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// subjectKey returns a comparable string for a WhoCanSubject so test
+// assertions can sort and diff regardless of the order WhoCan returns
+// rows in (which depends on RBAC list ordering, not deterministic).
+func subjectKey(s WhoCanSubject) string {
+	return s.Kind + "/" + s.Name + "@" + s.Namespace + "|" + s.Via
+}
+
+func sortSubjects(s []WhoCanSubject) []string {
+	out := make([]string, len(s))
+	for i, x := range s {
+		out[i] = subjectKey(x)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- ClusterRoleBinding + ClusterRole (cluster-wide grant) ---
+
+func TestWhoCan_ClusterRoleBindingMatch(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-reader"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+		},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("pod-readers"),
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "alice"},
+			{Kind: "Group", Name: "developers"},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "ClusterRole", Name: "pod-reader", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	require.NoError(t, err)
+
+	got := sortSubjects(out)
+	assert.Contains(t, strings.Join(got, "\n"), "User/alice@",
+		"alice (User) granted via the ClusterRoleBinding must appear in the result set")
+	assert.Contains(t, strings.Join(got, "\n"), "Group/developers@",
+		"developers (Group) likewise — both kinds of subjects are surfaced")
+	assert.Contains(t, strings.Join(got, "\n"), "ClusterRoleBinding/pod-readers",
+		"the Via column must record the binding so a user can audit the path")
+}
+
+// --- RoleBinding + ClusterRole (namespace-scoped grant of a cluster role) ---
+
+func TestWhoCan_RoleBindingToClusterRoleMatch(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "edit"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"*"}, APIGroups: []string{""}, Resources: []string{"*"}},
+		},
+	}
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: nsMeta("ci-edit", "ci"),
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "ci-deployer", Namespace: "ci"},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "ClusterRole", Name: "edit", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	cs := k8sfake.NewClientset(cr, rb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "delete")
+	require.NoError(t, err)
+
+	got := sortSubjects(out)
+	assert.Contains(t, strings.Join(got, "\n"), "ServiceAccount/ci-deployer@ci",
+		"SA bound via RoleBinding referencing a ClusterRole gets the namespace from the binding")
+}
+
+// --- RoleBinding + Role (purely namespace-scoped) ---
+
+func TestWhoCan_RoleBindingToRoleMatch(t *testing.T) {
+	r := &rbacv1.Role{
+		ObjectMeta: nsMeta("logs-reader", "monitoring"),
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods/log"}},
+		},
+	}
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: nsMeta("read-logs", "monitoring"),
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "operator"},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "Role", Name: "logs-reader", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	cs := k8sfake.NewClientset(r, rb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods/log", "get")
+	require.NoError(t, err)
+	got := sortSubjects(out)
+	assert.Contains(t, strings.Join(got, "\n"), "User/operator@",
+		"namespace-scoped Role grant must surface")
+}
+
+// --- Wildcard handling ---
+
+func TestWhoCan_VerbWildcard(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-master"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"*"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+		},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("pm"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "wild"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "pod-master"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+	for _, v := range []string{"get", "delete", "patch", "create"} {
+		out, err := c.WhoCan(context.Background(), "", "", "", "pods", v)
+		require.NoError(t, err, "verb %s", v)
+		assert.NotEmpty(t, out, "verb=%q with rule.Verbs=[*] must match", v)
+	}
+}
+
+func TestWhoCan_ResourceWildcard(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "core-all"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"*"}},
+		},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("ca"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "core-reader"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "core-all"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+	for _, r := range []string{"pods", "secrets", "configmaps"} {
+		out, err := c.WhoCan(context.Background(), "", "", "", r, "get")
+		require.NoError(t, err)
+		assert.NotEmpty(t, out, "resource=%q with rule.Resources=[*] must match", r)
+	}
+}
+
+func TestWhoCan_GroupWildcard(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "any-group"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get"}, APIGroups: []string{"*"}, Resources: []string{"deployments"}},
+		},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("ag"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "deploy-reader"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "any-group"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "apps", "deployments", "get")
+	require.NoError(t, err)
+	assert.NotEmpty(t, out, "group=apps with rule.APIGroups=[*] must match")
+}
+
+// --- Namespace scope ---
+
+func TestWhoCan_NamespaceScopeFiltersRoleBindingsButNotClusterBindings(t *testing.T) {
+	// Setup: one RoleBinding in namespace "team-a" and another in "team-b",
+	// plus a ClusterRoleBinding. When the user asks "who can list pods in
+	// team-a", they should see team-a's RB subject and the CRB subject —
+	// NOT team-b's RB subject.
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-reader"},
+		Rules:      []rbacv1.PolicyRule{{Verbs: []string{"list"}, APIGroups: []string{""}, Resources: []string{"pods"}}},
+	}
+	rbA := &rbacv1.RoleBinding{
+		ObjectMeta: nsMeta("rbA", "team-a"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice-A"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "pod-reader"},
+	}
+	rbB := &rbacv1.RoleBinding{
+		ObjectMeta: nsMeta("rbB", "team-b"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "bob-B"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "pod-reader"},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("cluster-pod-readers"),
+		Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "ops"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "pod-reader"},
+	}
+	cs := k8sfake.NewClientset(cr, rbA, rbB, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "team-a", "", "pods", "list")
+	require.NoError(t, err)
+	got := sortSubjects(out)
+	joined := strings.Join(got, "\n")
+	assert.Contains(t, joined, "User/alice-A@",
+		"team-a's RoleBinding subject must appear when scoping to team-a")
+	assert.Contains(t, joined, "Group/ops@",
+		"ClusterRoleBindings always count regardless of namespace scope")
+	assert.NotContains(t, joined, "User/bob-B@",
+		"team-b's RoleBinding subject must NOT leak when scoping to team-a")
+}
+
+func TestWhoCan_AllNamespacesIncludesEveryRoleBinding(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-reader"},
+		Rules:      []rbacv1.PolicyRule{{Verbs: []string{"list"}, APIGroups: []string{""}, Resources: []string{"pods"}}},
+	}
+	rbA := &rbacv1.RoleBinding{
+		ObjectMeta: nsMeta("rbA", "team-a"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "alice"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "pod-reader"},
+	}
+	rbB := &rbacv1.RoleBinding{
+		ObjectMeta: nsMeta("rbB", "team-b"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "bob"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "pod-reader"},
+	}
+	cs := k8sfake.NewClientset(cr, rbA, rbB)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "list")
+	require.NoError(t, err)
+	joined := strings.Join(sortSubjects(out), "\n")
+	assert.Contains(t, joined, "User/alice@", "all-namespaces (ns=\"\") includes team-a's RB")
+	assert.Contains(t, joined, "User/bob@", "...and team-b's RB")
+}
+
+// --- Empty result ---
+
+func TestWhoCan_NoMatchReturnsEmpty(t *testing.T) {
+	cs := k8sfake.NewClientset()
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "delete")
+	require.NoError(t, err)
+	assert.Empty(t, out, "empty cluster (no roles, no bindings) → no subjects")
+}
+
+func TestWhoCan_BindingWithoutMatchingRuleIsSkipped(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret-reader"},
+		Rules:      []rbacv1.PolicyRule{{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"secrets"}}},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("sr"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "secret-only"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "secret-reader"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	require.NoError(t, err)
+	assert.Empty(t, out, "binding's rules don't grant pods/get → skip subject")
+}
+
+// --- nonResourceURLs ---
+
+func TestWhoCan_NonResourceURLRulesIgnored(t *testing.T) {
+	// A rule that only sets nonResourceURLs (e.g. /healthz) must NOT
+	// match a resource query. kubectl-who-can returns nothing for
+	// resource queries against /healthz-only roles.
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "healthz"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get"}, NonResourceURLs: []string{"/healthz"}},
+		},
+	}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: pmeta("h"),
+		Subjects:   []rbacv1.Subject{{Kind: "User", Name: "monitor"}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "healthz"},
+	}
+	cs := k8sfake.NewClientset(cr, crb)
+	c := newFakeClient(cs, nil)
+
+	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	require.NoError(t, err)
+	assert.Empty(t, out, "nonResourceURLs rules don't grant resource permissions")
+}
+
+// --- Helpers used only in this file ---
+
+func pmeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name}
+}
+
+func nsMeta(name, ns string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name, Namespace: ns}
+}

--- a/internal/ui/caniview.go
+++ b/internal/ui/caniview.go
@@ -25,23 +25,33 @@ var canIVerbs = []struct {
 // RenderCanIView renders the can-i browser with a two-column layout.
 // The left column (API groups) is interactive; the right column (resources) is display-only.
 func RenderCanIView(groups []string, resources []model.CanIResource, groupCursor, groupScroll int, subjectName string, namespaces []string, width, height int, hintBar string, resourceScroll int) string {
-	// Title bar — truncate if it exceeds the available width.
-	scopeLabel := "ns:" + strings.Join(namespaces, ",")
-	titleText := TitleStyle.Render("RBAC Permissions ("+subjectName+")") + "  " + BarDimStyle.Render(scopeLabel)
-	if lipgloss.Width(titleText) > width {
-		// Drop scope label if too wide.
-		titleText = TitleStyle.Render("RBAC Permissions (" + subjectName + ")")
+	// Title at the left, scope label flushed to the far right with
+	// baseBg-painted gap fill. Matches the WhoCan header layout so the
+	// title bar reads consistently across both modes.
+	//
+	// Scope label collapses [""] (all-namespaces sentinel) and an empty
+	// namespaces slice into "ns: all" so the user always sees what
+	// scope is active — earlier behavior rendered "ns: " (no value),
+	// which looked like a render bug.
+	scopeLabel := CanIScopeLabel(namespaces)
+	// Subject chip mirrors the Who-Can verb chip styling: dim "Subject:"
+	// label + light value, both on baseBg so they sit flush in the title
+	// row's barBg band.
+	subjectChip := BarDimStyle.Render(" Subject: ") + BarNormalStyle.Render(subjectName)
+	title := TitleStyle.Render("RBAC Explorer: Can-I?") + subjectChip
+	if lipgloss.Width(title)+1+lipgloss.Width(scopeLabel) > width {
+		// Shorter fallback for narrow terminals.
+		title = TitleStyle.Render("Can-I?") + subjectChip
 	}
-	if lipgloss.Width(titleText) > width {
-		// Truncate subject name if still too wide.
-		titleText = TitleStyle.Render("RBAC (" + subjectName + ")")
-	}
+	titleText := joinTitleAndRightLabel(title, BarDimStyle.Render(scopeLabel), width)
 
 	hint := hintBar
 
-	// Column widths: left 25%, middle 75%.
+	// Column widths: left 20% (API group names rarely exceed 25 cols even
+	// for long group names like "apiextensions.k8s.io" — 25% wasted space),
+	// middle 80%.
 	usable := width - 4
-	leftW := max(10, usable*25/100)
+	leftW := max(10, usable*20/100)
 	middleW := max(10, usable-leftW)
 
 	contentHeight := max(height-4, 3)
@@ -68,6 +78,37 @@ func RenderCanIView(groups []string, resources []model.CanIResource, groupCursor
 	columns := lipgloss.JoinHorizontal(lipgloss.Top, left, middle)
 
 	return lipgloss.JoinVertical(lipgloss.Left, titleText, columns, hint)
+}
+
+// joinTitleAndRightLabel composes a title row with the title segment
+// at the left, baseBg-painted spaces filling the middle, and the
+// label flushed to the right edge of `width`. Used by both Can-I and
+// Who-Can title rows so the namespace/scope chip lands consistently
+// at the right edge across both modes. If the combined widths exceed
+// `width`, the right label is dropped (a half-shown label is more
+// confusing than no label).
+func joinTitleAndRightLabel(title, rightLabel string, width int) string {
+	if lipgloss.Width(title)+1+lipgloss.Width(rightLabel) > width {
+		// No room for the right label; just return the title.
+		return title
+	}
+	gap := max(width-lipgloss.Width(title)-lipgloss.Width(rightLabel), 1)
+	return title + BarNormalStyle.Render(strings.Repeat(" ", gap)) + rightLabel
+}
+
+// CanIScopeLabel formats the namespace scope shown in the title row.
+// Collapses the all-namespaces sentinels ([""] and the empty slice)
+// to a literal "ns: all" so the label never reads as "ns: " — that
+// looked like a render bug to users who picked "All Namespaces" in
+// the namespace selector.
+func CanIScopeLabel(namespaces []string) string {
+	if len(namespaces) == 0 {
+		return "ns: all"
+	}
+	if len(namespaces) == 1 && namespaces[0] == "" {
+		return "ns: all"
+	}
+	return "ns: " + strings.Join(namespaces, ",")
 }
 
 // canIVerbColWidth returns the column width for a verb label (label length + 1 space padding).

--- a/internal/ui/caniview_test.go
+++ b/internal/ui/caniview_test.go
@@ -202,7 +202,7 @@ func TestRenderCanIView(t *testing.T) {
 			{Resource: "statefulsets", Verbs: map[string]bool{"get": false}},
 		}
 		result := RenderCanIView(groups, resources, 0, 0, "admin", []string{"default"}, 120, 30, "hint bar text", 0)
-		assert.Contains(t, result, "RBAC Permissions")
+		assert.Contains(t, result, "RBAC Explorer: Can-I?")
 		assert.Contains(t, result, "admin")
 		assert.Contains(t, result, "API Groups")
 		assert.Contains(t, result, "apps")
@@ -212,12 +212,15 @@ func TestRenderCanIView(t *testing.T) {
 
 	t.Run("narrow width does not panic", func(t *testing.T) {
 		result := RenderCanIView([]string{"apps"}, nil, 0, 0, "user", []string{"default"}, 40, 10, "", 0)
-		assert.Contains(t, result, "RBAC")
+		assert.Contains(t, result, "Can-I?")
 	})
 
 	t.Run("empty groups and resources", func(t *testing.T) {
+		// At 80-col width the left column is narrow (20% = ~14 cols) and
+		// "No groups found" wraps; assert on the resilient first word
+		// instead of the whole phrase.
 		result := RenderCanIView(nil, nil, 0, 0, "test-user", []string{"ns1"}, 80, 20, "", 0)
-		assert.Contains(t, result, "No groups found")
+		assert.Contains(t, result, "No groups")
 		assert.Contains(t, result, "No resources in this group")
 	})
 }

--- a/internal/ui/whocanview.go
+++ b/internal/ui/whocanview.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // WhoCanRow is the renderer-facing representation of a single result
@@ -22,38 +23,105 @@ type WhoCanRow struct {
 // in RBAC). Order is `kubectl who-can`'s order so muscle memory carries.
 var WhoCanVerbs = []string{"get", "list", "watch", "create", "update", "patch", "delete", "*"}
 
-// RenderWhoCanView builds the inner content of the reverse-RBAC view.
-// Layout (top → bottom):
+// WhoCanViewParams bundles every field renderWhoCanOverlay needs to
+// pass through. Wrapping them in a struct keeps RenderWhoCanView's
+// signature legible as the picker grows (filter, scroll, dual-pane
+// state) and lets the caller's argument list stay readable.
+type WhoCanViewParams struct {
+	VerbCursor     int
+	Resources      []string // visible (post-filter) resource list
+	ResourceCursor int      // index into Resources (the visible slice)
+	ResourceScroll int      // first visible row of Resources (stateful — handlers maintain this so scroll-up doesn't pin the cursor to the last visible row)
+	NamespaceLabel string   // "ns: foo" or "all-namespaces"
+	Subjects       []WhoCanRow
+	SubjectsScroll int
+	Loading        bool
+	// FooterBar is rendered as the bottom row inside the overlay,
+	// below the columns. The caller builds it (the filter input lives
+	// here so its position matches Can-I's). Empty string = blank row.
+	FooterBar     string
+	Width, Height int
+}
+
+// RenderWhoCanView paints the reverse-RBAC overlay's inner content:
+// a single header row (title + verb chips at left, namespace label
+// flushed to the far right), then the 2-column body with the resource
+// picker on the left and the subjects table on the right.
 //
-//   - title
-//   - verb chip row with cursor highlight on verbCursor
-//   - resource filter line (input or current resource)
-//   - subjects table (header + scrollable rows)
+// One header row keeps the table tall (every line above the columns
+// is a line the user can't see subjects in). Both columns sit inside
+// ActiveColumnStyle/InactiveColumnStyle boxes (same baseBg as the
+// Can-I view), so flipping between modes with Tab keeps the same
+// visible "shape" — only the right pane swaps content.
+func RenderWhoCanView(p WhoCanViewParams) string {
+	headerRow := renderWhoCanHeaderRow(p.VerbCursor, p.NamespaceLabel, p.Width)
+
+	// Two columns: resources picker (left, 20%), subjects (right, rest).
+	// 20% matches caniview's leftW — resource names rarely exceed 20 cols
+	// so a wider picker just steals space from the subjects table where
+	// long Via paths actually need it.
+	usable := max(p.Width-4, 20)
+	leftW := max(10, usable*20/100)
+	middleW := max(10, usable-leftW)
+	// contentHeight matches caniview's: -1 header, -2 column borders,
+	// -1 reserved bottom row. The reserved row keeps Tab between modes
+	// from making the table jump up by one (caniview uses that row for
+	// its hint bar).
+	contentHeight := max(p.Height-4, 3)
+	colPad := 2
+	leftInner := max(8, leftW-colPad)
+	middleInner := max(10, middleW-colPad)
+
+	leftContent := renderWhoCanResourcePicker(
+		p.Resources, p.ResourceCursor, p.ResourceScroll,
+		leftInner, contentHeight,
+	)
+	leftContent = PadToHeight(leftContent, contentHeight)
+	left := ActiveColumnStyle.Width(leftW).Height(contentHeight).MaxHeight(contentHeight + 2).Render(leftContent)
+
+	rightContent := renderWhoCanSubjects(
+		p.Subjects, p.SubjectsScroll, p.Loading,
+		currentResource(p.Resources, p.ResourceCursor),
+		middleInner, contentHeight,
+	)
+	rightContent = PadToHeight(rightContent, contentHeight)
+	right := InactiveColumnStyle.Width(middleW).Height(contentHeight).MaxHeight(contentHeight + 2).Render(rightContent)
+
+	columns := lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+	// Footer row matches caniview: same vertical position, same role
+	// (filter input lives there). Empty string when no footer content.
+	return lipgloss.JoinVertical(lipgloss.Left, headerRow, columns, p.FooterBar)
+}
+
+// renderWhoCanHeaderRow assembles the single header row that sits
+// above the column table. Layout:
 //
-// Returns raw content; the caller wraps it in OverlayStyle the same way
-// the forward Can-I view is wrapped (see view_overlays.go's
-// renderCanIOverlay path).
-func RenderWhoCanView(
-	verbCursor int,
-	resource string,
-	resourceFilter string,
-	resourceFilterActive bool,
-	namespaceLabel string,
-	rows []WhoCanRow,
-	scroll int,
-	loading bool,
-	width, height int,
-) string {
-	title := TitleStyle.Render("Reverse RBAC: Who can …") + "  " + BarDimStyle.Render(namespaceLabel)
+//	[title] [verb chips] ............................. [namespace]
+//
+// joinTitleAndRightLabel handles the right-edge alignment so this row
+// reads consistently with the Can-I title row when the user pivots
+// with Tab.
+func renderWhoCanHeaderRow(verbCursor int, namespaceLabel string, width int) string {
+	title := TitleStyle.Render("RBAC Explorer: Who-Can?")
+	verbs := renderWhoCanVerbs(verbCursor)
+	leftBlock := title + BarNormalStyle.Render(" ") + verbs
+	if lipgloss.Width(leftBlock)+1+lipgloss.Width(namespaceLabel) > width {
+		// Title doesn't fit alongside the chips + ns — shorten it.
+		title = TitleStyle.Render("Who-Can?")
+		leftBlock = title + BarNormalStyle.Render(" ") + verbs
+	}
+	return joinTitleAndRightLabel(leftBlock, BarDimStyle.Render(namespaceLabel), width)
+}
 
-	verbsLine := renderWhoCanVerbs(verbCursor)
-	resourceLine := renderWhoCanResourceLine(resource, resourceFilter, resourceFilterActive)
-
-	// Reserve 4 lines for title + verbs + resource + spacing.
-	tableHeight := max(height-5, 3)
-	table := renderWhoCanTable(rows, scroll, loading, width, tableHeight)
-
-	return strings.Join([]string{title, "", verbsLine, resourceLine, "", table}, "\n")
+// currentResource returns the resource the cursor is on, or "" when
+// the visible list is empty (filter matches nothing). Callers use the
+// empty string as the "no resource selected" sentinel — the subjects
+// panel renders an instructional placeholder in that case.
+func currentResource(resources []string, cursor int) string {
+	if cursor < 0 || cursor >= len(resources) {
+		return ""
+	}
+	return resources[cursor]
 }
 
 // renderWhoCanVerbs builds the verb-chip row. Each chip is a label
@@ -61,94 +129,216 @@ func RenderWhoCanView(
 // the highlight covers it cleanly across themes.
 func renderWhoCanVerbs(cursor int) string {
 	var b strings.Builder
-	b.WriteString(DimStyle.Render("Verb: "))
+	b.WriteString(BarDimStyle.Render("Verb: "))
 	for i, v := range WhoCanVerbs {
 		chip := " " + v + " "
 		if i == cursor {
 			b.WriteString(OverlaySelectedStyle.Render(chip))
 		} else {
-			b.WriteString(OverlayNormalStyle.Render(chip))
+			b.WriteString(BarNormalStyle.Render(chip))
 		}
 		if i < len(WhoCanVerbs)-1 {
-			b.WriteString(" ")
+			b.WriteString(BarDimStyle.Render(" "))
 		}
 	}
 	return b.String()
 }
 
-// renderWhoCanResourceLine prints the resource picker. The line either
-// shows the live filter input (cursor visible while typing) or the
-// committed resource name plus a hint to start filtering. Empty
-// resource shows a placeholder so the user knows what to type.
-func renderWhoCanResourceLine(resource, filter string, active bool) string {
-	prefix := DimStyle.Render("Resource: ")
-	switch {
-	case active:
-		return prefix + OverlayFilterStyle.Render("/ "+filter+"█")
-	case resource != "":
-		return prefix + OverlayNormalStyle.Render(resource) + "  " + DimStyle.Render("(/  to filter)")
-	default:
-		return prefix + DimStyle.Render("/  to filter (e.g. pods, secrets, deployments)")
+// renderWhoCanResourcePicker paints the left-column list. Header line
+// shows either the active filter input or the resource count + "/" hint
+// so the user knows how to narrow the list. Body is a vertical list of
+// resource names with the cursor row highlighted.
+//
+// Every styled span uses a Bar*Style (which has baseBg) — the column
+// box wraps in baseBg and any fg-only style here would punch through to
+// the terminal default bg between styled spans, producing a "swap" band
+// the eye picks up immediately.
+//
+// Scroll is taken as input (not derived from cursor) so vim-like
+// behavior holds: the viewport stays put when the cursor moves inside
+// it, and only scrolls when the cursor leaves an edge. The handlers
+// maintain the scroll offset; this function only clamps to a valid
+// range and renders.
+func renderWhoCanResourcePicker(resources []string, cursor, scroll, width, height int) string {
+	header := renderWhoCanResourceHeader(len(resources), width)
+
+	if len(resources) == 0 {
+		return header + "\n" + BarDimStyle.Render("  No matches")
 	}
+
+	bodyHeight := max(height-1, 1) // -1 for header
+	scroll = whoCanClampScroll(scroll, len(resources), bodyHeight)
+	end := min(scroll+bodyHeight, len(resources))
+
+	lines := make([]string, 0, end-scroll)
+	for i := scroll; i < end; i++ {
+		name := resources[i]
+		if len(name) > width-2 {
+			name = name[:max(width-3, 1)] + "…"
+		}
+		if i == cursor {
+			line := fmt.Sprintf("> %-*s", width-2, name)
+			lines = append(lines, OverlaySelectedStyle.Render(line))
+		} else {
+			line := fmt.Sprintf("  %s", name)
+			lines = append(lines, BarNormalStyle.Render(line))
+		}
+	}
+	return header + "\n" + strings.Join(lines, "\n")
 }
 
-// renderWhoCanTable prints the subjects header + scrollable rows. The
-// height contract: caller passes how many lines we may use, including
-// the header. Empty rows produce an explanatory placeholder; loading
-// state shows a spinner-like marker so users know the fetch is live.
-func renderWhoCanTable(rows []WhoCanRow, scroll int, loading bool, width, height int) string {
-	const (
-		kindW = 16
-		nsW   = 18
+// renderWhoCanResourceHeader paints the picker's column header. Just
+// "Resources (N)" — the filter input lives in the overlay's footer
+// row (matching Can-I's filter location) so this stays clean.
+func renderWhoCanResourceHeader(count, width int) string {
+	return whoCanFitPlaceholder(
+		BarDimStyle.Bold(true).Render(fmt.Sprintf("  Resources (%d)", count)),
+		width,
 	)
-	nameW := max(20, width/3)
-	viaW := max(20, width-(kindW+nsW+nameW+6)) // -6 for column separators
+}
 
-	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s",
-		nameW, "SUBJECT", kindW, "KIND", nsW, "NAMESPACE", viaW, "VIA")
-	headerLine := DimStyle.Bold(true).Render(header)
+// whoCanClampScroll snaps the requested scroll offset to a valid range
+// for the given list size and viewport. Doesn't try to keep the cursor
+// in view — handlers do that — only protects against stale offsets
+// that would otherwise show blank space past the end of the list.
+func whoCanClampScroll(scroll, total, bodyHeight int) int {
+	if total <= bodyHeight {
+		return 0
+	}
+	maxScroll := total - bodyHeight
+	scroll = max(scroll, 0)
+	scroll = min(scroll, maxScroll)
+	return scroll
+}
 
-	if loading {
-		return headerLine + "\n  " + DimStyle.Render("Loading…")
+// WhoCanScrollForCursor returns the new scroll offset that keeps
+// `cursor` visible inside a viewport of `bodyHeight` rows starting at
+// `scroll`. Vim semantics: do nothing if the cursor is already in
+// view; otherwise scroll just enough to put the cursor on the nearest
+// visible edge. Used by handlers that move the cursor.
+func WhoCanScrollForCursor(scroll, cursor, bodyHeight, total int) int {
+	if total <= bodyHeight {
+		return 0
 	}
-	if len(rows) == 0 {
-		return headerLine + "\n  " + DimStyle.Render("No subject found with this permission")
+	if cursor < scroll {
+		return cursor // cursor moved above the viewport — pull it down
+	}
+	if cursor >= scroll+bodyHeight {
+		return cursor - bodyHeight + 1 // cursor moved below — pull viewport down
+	}
+	return scroll // cursor still in view — viewport stays put
+}
+
+// renderWhoCanSubjects paints the right-column subjects table. The
+// queried resource is already echoed in the header row's verb chip
+// + picker cursor, so we go straight to the column header — no
+// "Subjects for X" preamble eating a row.
+//
+// Every styled span uses BarDimStyle (baseBg) so spans don't punch
+// through to terminal default bg between the inactive column's baseBg
+// padding — same fix as the resource picker.
+//
+// Placeholders are width-truncated so they never wrap inside the
+// column box. Wrapped placeholder lines would push the column box's
+// content past contentHeight, which lipgloss handles by dropping the
+// bottom border — visible to the user as "the last line is out of
+// the viewport".
+func renderWhoCanSubjects(rows []WhoCanRow, scroll int, loading bool, resource string, width, height int) string {
+	switch {
+	case resource == "":
+		return BarDimStyle.Render(whoCanFitPlaceholder("  Pick a resource on the left", width))
+	case loading:
+		return BarDimStyle.Render(whoCanFitPlaceholder("  Loading…", width))
+	case len(rows) == 0:
+		return BarDimStyle.Render(whoCanFitPlaceholder("  No subject has this permission", width))
 	}
 
-	maxLines := max(height-1, 1) // -1 for the header
-	if scroll < 0 {
-		scroll = 0
+	// Column widths shrink with `width` so the row fits inside narrow
+	// overlays. Kind/Namespace are short; SUBJECT and VIA both can be
+	// long (full SA paths, full RBAC chains) so the leftover width is
+	// split evenly between them — no upper cap on SUBJECT, otherwise
+	// long ServiceAccount paths get truncated unnecessarily even when
+	// there's room to show them.
+	kindW := min(14, max(6, width/6))
+	nsW := min(16, max(8, width/5))
+	remaining := max(width-(kindW+nsW+8), 0)
+	nameW := max(10, remaining/2)
+	viaW := max(8, remaining-nameW)
+
+	// Truncate header labels too — at narrow widths "NAMESPACE" alone
+	// overflows nsW and pushes the row past the column's inner area.
+	colHeader := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s",
+		nameW, whoCanTruncate("SUBJECT", nameW),
+		kindW, whoCanTruncate("KIND", kindW),
+		nsW, whoCanTruncate("NAMESPACE", nsW),
+		viaW, whoCanTruncate("VIA", viaW))
+	colHeaderLine := BarDimStyle.Bold(true).Render(colHeader)
+
+	bodyHeight := max(height-1, 1) // -1 for column header
+	scroll = max(scroll, 0)
+	if scroll > len(rows)-bodyHeight {
+		scroll = max(len(rows)-bodyHeight, 0)
 	}
-	if scroll > len(rows)-maxLines {
-		scroll = max(len(rows)-maxLines, 0)
-	}
-	end := min(scroll+maxLines, len(rows))
+	end := min(scroll+bodyHeight, len(rows))
 
 	body := make([]string, 0, end-scroll)
 	for _, r := range rows[scroll:end] {
 		body = append(body, renderWhoCanRow(r, nameW, kindW, nsW, viaW))
 	}
-	return headerLine + "\n" + strings.Join(body, "\n")
+	return colHeaderLine + "\n" + strings.Join(body, "\n")
 }
 
-// renderWhoCanRow formats a single subject line, dimming the namespace
-// for User/Group rows (which don't have one) so the column stays
-// visually consistent. ANSI-aware truncation isn't necessary here —
-// every value is plain text.
+// renderWhoCanRow formats a single subject line. Every cell AND every
+// separator/padding span is rendered through a baseBg-bound style;
+// bare spaces between styled spans would punch through to terminal
+// default bg and produce visible "swap" stripes between cells.
+//
+// Kind/Namespace/Via use BarNormalStyle (not BarDimStyle) so secondary
+// columns stay readable instead of fading into the background.
 func renderWhoCanRow(r WhoCanRow, nameW, kindW, nsW, viaW int) string {
 	ns := r.Namespace
 	if ns == "" {
 		ns = "—"
 	}
-	nameCell := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Render(whoCanTruncate(r.Name, nameW))
-	kindCell := DimStyle.Render(whoCanTruncate(r.Kind, kindW))
-	nsCell := DimStyle.Render(whoCanTruncate(ns, nsW))
-	viaCell := DimStyle.Render(whoCanTruncate(r.Via, viaW))
-	return fmt.Sprintf("  %s  %s  %s  %s",
-		whoCanPadRight(nameCell, nameW),
-		whoCanPadRight(kindCell, kindW),
-		whoCanPadRight(nsCell, nsW),
-		whoCanPadRight(viaCell, viaW))
+	sep := BarNormalStyle.Render("  ")
+	nameStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(ColorPrimary)).
+		Background(BaseBg).
+		Bold(true)
+	nameCell := whoCanPadCellStyled(whoCanTruncate(r.Name, nameW), nameW, nameStyle)
+	kindCell := whoCanPadCellStyled(whoCanTruncate(r.Kind, kindW), kindW, BarNormalStyle)
+	nsCell := whoCanPadCellStyled(whoCanTruncate(ns, nsW), nsW, BarNormalStyle)
+	viaCell := whoCanPadCellStyled(whoCanTruncate(r.Via, viaW), viaW, BarNormalStyle)
+	return sep + nameCell + sep + kindCell + sep + nsCell + sep + viaCell
+}
+
+// whoCanPadCellStyled renders text in `style` and right-pads to width
+// using the SAME style for the gap spaces. Unlike whoCanPadRight (bare
+// padding), this guarantees bg coverage all the way to the column's
+// right edge — important for subject rows where kindW/nsW shrink at
+// narrow widths and the gap could otherwise show terminal default bg.
+func whoCanPadCellStyled(text string, width int, style lipgloss.Style) string {
+	rendered := style.Render(text)
+	gap := width - lipgloss.Width(rendered)
+	if gap <= 0 {
+		return rendered
+	}
+	return rendered + style.Render(strings.Repeat(" ", gap))
+}
+
+// whoCanFitPlaceholder shortens an ANSI-styled string so it stays on a
+// single visual line inside the column. Wrapping would push the
+// column past contentHeight and lipgloss would drop the bottom border
+// — the "last line out of viewport" the user reported. Uses
+// ansi.Truncate so styled spans remain valid after truncation.
+func whoCanFitPlaceholder(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	return ansi.Truncate(s, width, "")
 }
 
 // whoCanTruncate trims a plain (non-ANSI) string to maxW columns,
@@ -167,15 +357,4 @@ func whoCanTruncate(s string, maxW int) string {
 		return "…"
 	}
 	return string(runes[:maxW-1]) + "…"
-}
-
-// whoCanPadRight extends a styled cell to width by appending plain
-// spaces. lipgloss.Width is ANSI-aware so this measures the visible
-// width of the styled string before padding.
-func whoCanPadRight(cell string, width int) string {
-	gap := width - lipgloss.Width(cell)
-	if gap <= 0 {
-		return cell
-	}
-	return cell + strings.Repeat(" ", gap)
 }

--- a/internal/ui/whocanview.go
+++ b/internal/ui/whocanview.go
@@ -1,0 +1,181 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// WhoCanRow is the renderer-facing representation of a single result
+// row in the Who-Can table. Mirrors k8s.WhoCanSubject but kept here so
+// the ui package doesn't import the k8s package.
+type WhoCanRow struct {
+	Kind      string // "User" / "Group" / "ServiceAccount"
+	Name      string
+	Namespace string // ServiceAccount namespace; empty for User/Group
+	Via       string // "ClusterRoleBinding/foo → ClusterRole/bar"
+}
+
+// WhoCanVerbs is the canonical verb chip list rendered above the
+// subjects table. The trailing "*" matches any verb (rule.Verbs == ["*"]
+// in RBAC). Order is `kubectl who-can`'s order so muscle memory carries.
+var WhoCanVerbs = []string{"get", "list", "watch", "create", "update", "patch", "delete", "*"}
+
+// RenderWhoCanView builds the inner content of the reverse-RBAC view.
+// Layout (top → bottom):
+//
+//   - title
+//   - verb chip row with cursor highlight on verbCursor
+//   - resource filter line (input or current resource)
+//   - subjects table (header + scrollable rows)
+//
+// Returns raw content; the caller wraps it in OverlayStyle the same way
+// the forward Can-I view is wrapped (see view_overlays.go's
+// renderCanIOverlay path).
+func RenderWhoCanView(
+	verbCursor int,
+	resource string,
+	resourceFilter string,
+	resourceFilterActive bool,
+	namespaceLabel string,
+	rows []WhoCanRow,
+	scroll int,
+	loading bool,
+	width, height int,
+) string {
+	title := TitleStyle.Render("Reverse RBAC: Who can …") + "  " + BarDimStyle.Render(namespaceLabel)
+
+	verbsLine := renderWhoCanVerbs(verbCursor)
+	resourceLine := renderWhoCanResourceLine(resource, resourceFilter, resourceFilterActive)
+
+	// Reserve 4 lines for title + verbs + resource + spacing.
+	tableHeight := max(height-5, 3)
+	table := renderWhoCanTable(rows, scroll, loading, width, tableHeight)
+
+	return strings.Join([]string{title, "", verbsLine, resourceLine, "", table}, "\n")
+}
+
+// renderWhoCanVerbs builds the verb-chip row. Each chip is a label
+// padded with a space; the cursor chip uses OverlaySelectedStyle so
+// the highlight covers it cleanly across themes.
+func renderWhoCanVerbs(cursor int) string {
+	var b strings.Builder
+	b.WriteString(DimStyle.Render("Verb: "))
+	for i, v := range WhoCanVerbs {
+		chip := " " + v + " "
+		if i == cursor {
+			b.WriteString(OverlaySelectedStyle.Render(chip))
+		} else {
+			b.WriteString(OverlayNormalStyle.Render(chip))
+		}
+		if i < len(WhoCanVerbs)-1 {
+			b.WriteString(" ")
+		}
+	}
+	return b.String()
+}
+
+// renderWhoCanResourceLine prints the resource picker. The line either
+// shows the live filter input (cursor visible while typing) or the
+// committed resource name plus a hint to start filtering. Empty
+// resource shows a placeholder so the user knows what to type.
+func renderWhoCanResourceLine(resource, filter string, active bool) string {
+	prefix := DimStyle.Render("Resource: ")
+	switch {
+	case active:
+		return prefix + OverlayFilterStyle.Render("/ "+filter+"█")
+	case resource != "":
+		return prefix + OverlayNormalStyle.Render(resource) + "  " + DimStyle.Render("(/  to filter)")
+	default:
+		return prefix + DimStyle.Render("/  to filter (e.g. pods, secrets, deployments)")
+	}
+}
+
+// renderWhoCanTable prints the subjects header + scrollable rows. The
+// height contract: caller passes how many lines we may use, including
+// the header. Empty rows produce an explanatory placeholder; loading
+// state shows a spinner-like marker so users know the fetch is live.
+func renderWhoCanTable(rows []WhoCanRow, scroll int, loading bool, width, height int) string {
+	const (
+		kindW = 16
+		nsW   = 18
+	)
+	nameW := max(20, width/3)
+	viaW := max(20, width-(kindW+nsW+nameW+6)) // -6 for column separators
+
+	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s",
+		nameW, "SUBJECT", kindW, "KIND", nsW, "NAMESPACE", viaW, "VIA")
+	headerLine := DimStyle.Bold(true).Render(header)
+
+	if loading {
+		return headerLine + "\n  " + DimStyle.Render("Loading…")
+	}
+	if len(rows) == 0 {
+		return headerLine + "\n  " + DimStyle.Render("No subject found with this permission")
+	}
+
+	maxLines := max(height-1, 1) // -1 for the header
+	if scroll < 0 {
+		scroll = 0
+	}
+	if scroll > len(rows)-maxLines {
+		scroll = max(len(rows)-maxLines, 0)
+	}
+	end := min(scroll+maxLines, len(rows))
+
+	body := make([]string, 0, end-scroll)
+	for _, r := range rows[scroll:end] {
+		body = append(body, renderWhoCanRow(r, nameW, kindW, nsW, viaW))
+	}
+	return headerLine + "\n" + strings.Join(body, "\n")
+}
+
+// renderWhoCanRow formats a single subject line, dimming the namespace
+// for User/Group rows (which don't have one) so the column stays
+// visually consistent. ANSI-aware truncation isn't necessary here —
+// every value is plain text.
+func renderWhoCanRow(r WhoCanRow, nameW, kindW, nsW, viaW int) string {
+	ns := r.Namespace
+	if ns == "" {
+		ns = "—"
+	}
+	nameCell := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Render(whoCanTruncate(r.Name, nameW))
+	kindCell := DimStyle.Render(whoCanTruncate(r.Kind, kindW))
+	nsCell := DimStyle.Render(whoCanTruncate(ns, nsW))
+	viaCell := DimStyle.Render(whoCanTruncate(r.Via, viaW))
+	return fmt.Sprintf("  %s  %s  %s  %s",
+		whoCanPadRight(nameCell, nameW),
+		whoCanPadRight(kindCell, kindW),
+		whoCanPadRight(nsCell, nsW),
+		whoCanPadRight(viaCell, viaW))
+}
+
+// whoCanTruncate trims a plain (non-ANSI) string to maxW columns,
+// appending "…" when cut. Kept private to this file under a unique
+// name so it doesn't collide with the existing padRight in
+// explorer_format.go (which is ANSI-aware in different ways).
+func whoCanTruncate(s string, maxW int) string {
+	if maxW <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxW {
+		return s
+	}
+	if maxW <= 1 {
+		return "…"
+	}
+	return string(runes[:maxW-1]) + "…"
+}
+
+// whoCanPadRight extends a styled cell to width by appending plain
+// spaces. lipgloss.Width is ANSI-aware so this measures the visible
+// width of the styled string before padding.
+func whoCanPadRight(cell string, width int) string {
+	gap := width - lipgloss.Width(cell)
+	if gap <= 0 {
+		return cell
+	}
+	return cell + strings.Repeat(" ", gap)
+}

--- a/internal/ui/whocanview_test.go
+++ b/internal/ui/whocanview_test.go
@@ -1,0 +1,219 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderWhoCanView_ContainsExpectedText is a smoke test: the
+// renderer surfaces the title, verb chips, the resource picker, and
+// the subjects column. The user needs to see at minimum what verb
+// they're querying, what resources are available to pick from, and
+// the subject result so the layout reads as a complete picture.
+func TestRenderWhoCanView_ContainsExpectedText(t *testing.T) {
+	rows := []WhoCanRow{
+		{Kind: "User", Name: "alice", Namespace: "", Via: "ClusterRoleBinding/admins → ClusterRole/cluster-admin"},
+		{Kind: "ServiceAccount", Name: "default", Namespace: "kube-system", Via: "RoleBinding/foo → Role/bar"},
+	}
+	out := RenderWhoCanView(WhoCanViewParams{
+		VerbCursor:     0,
+		Resources:      []string{"pods", "secrets", "deployments"},
+		ResourceCursor: 0,
+		NamespaceLabel: "ns: default",
+		Subjects:       rows,
+		Width:          160, Height: 30,
+	})
+
+	for _, want := range []string{
+		"RBAC Explorer: Who-Can?",
+		"Verb:",
+		"Resources",
+		"pods", "secrets", "deployments",
+		"SUBJECT", // column header in the subjects panel
+		"alice",
+		"default",
+		"kube-system",
+	} {
+		assert.Contains(t, out, want, "rendered overlay must surface %q", want)
+	}
+}
+
+// TestRenderWhoCanView_LoadingPlaceholder shows a Loading… line in
+// place of rows while a fetch is in flight. Without this users see
+// an empty subject panel and assume "no permissions" — a worse
+// default than "still loading".
+func TestRenderWhoCanView_LoadingPlaceholder(t *testing.T) {
+	out := RenderWhoCanView(WhoCanViewParams{
+		Resources:      []string{"pods"},
+		ResourceCursor: 0,
+		NamespaceLabel: "ns: default",
+		Loading:        true,
+		Width:          120, Height: 20,
+	})
+	assert.Contains(t, out, "Loading")
+}
+
+// TestRenderWhoCanView_EmptyResultMessage tells users that a verb is
+// genuinely unbound rather than leaving a blank panel that looks
+// broken. Required state: a resource is selected (otherwise the
+// panel says "pick a resource" instead of "no subject").
+func TestRenderWhoCanView_EmptyResultMessage(t *testing.T) {
+	out := RenderWhoCanView(WhoCanViewParams{
+		Resources:      []string{"pods"},
+		ResourceCursor: 0,
+		NamespaceLabel: "ns: default",
+		Subjects:       []WhoCanRow{},
+		Width:          120, Height: 20,
+	})
+	assert.Contains(t, out, "No subject has this permission")
+}
+
+// TestRenderWhoCanView_NoResourceSelectedShowsHint covers the
+// initial-empty case: Can-I had nothing highlighted, the picker is
+// empty, and the right pane should tell the user what to do next
+// instead of looking silently broken.
+func TestRenderWhoCanView_NoResourceSelectedShowsHint(t *testing.T) {
+	out := RenderWhoCanView(WhoCanViewParams{
+		Resources:      nil,
+		NamespaceLabel: "all-namespaces",
+		Width:          120, Height: 20,
+	})
+	assert.Contains(t, out, "Pick a resource")
+}
+
+// TestRenderWhoCanView_FooterBarRenderedAtBottom confirms that the
+// caller-supplied footer string lands in the overlay's bottom row
+// (the slot that mirrors Can-I's search bar location). The caller —
+// renderWhoCanOverlay — puts the filter input there so its position
+// matches when the user pivots between modes with Tab.
+func TestRenderWhoCanView_FooterBarRenderedAtBottom(t *testing.T) {
+	out := RenderWhoCanView(WhoCanViewParams{
+		Resources:      []string{"pods/exec"},
+		NamespaceLabel: "all-namespaces",
+		FooterBar:      "FILTER-MARKER-/exe█",
+		Width:          120, Height: 20,
+	})
+	assert.Contains(t, out, "FILTER-MARKER-/exe█", "footer bar must appear in the rendered overlay")
+}
+
+// TestRenderWhoCanView_CursorHighlight pins the visual contract that
+// the resource under the cursor is rendered with the selection style
+// (the user must see which resource the right pane is for).
+func TestRenderWhoCanView_CursorHighlight(t *testing.T) {
+	originalProfile := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() {
+		lipgloss.DefaultRenderer().SetColorProfile(originalProfile)
+		ApplyTheme(DefaultTheme())
+	})
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	ApplyTheme(DefaultTheme())
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+
+	out := RenderWhoCanView(WhoCanViewParams{
+		Resources:      []string{"pods", "secrets", "services"},
+		ResourceCursor: 1, // "secrets"
+		NamespaceLabel: "ns: default",
+		Width:          120, Height: 20,
+	})
+	// The selected row gets the "> " prefix; non-selected rows get "  ".
+	assert.Contains(t, out, "> secrets", "cursor row must carry the selection prefix")
+}
+
+// TestRenderWhoCanRow_NamespaceDashWhenEmpty prevents a regression
+// where the namespace column was blank for User/Group rows (no ns at
+// all) and made the row look like a render glitch. The em dash makes
+// it obvious the value is intentionally absent.
+func TestRenderWhoCanRow_NamespaceDashWhenEmpty(t *testing.T) {
+	row := renderWhoCanRow(WhoCanRow{Kind: "User", Name: "alice", Namespace: ""}, 20, 16, 18, 30)
+	assert.Contains(t, row, "—", "empty namespace must render as em dash")
+}
+
+// TestRenderWhoCanSubjects_RowsFitAvailableWidth pins the table
+// layout math: the row format prepends 2 leading spaces and 3 × 2-
+// space separators between cells (8 cells of overhead). The viaW
+// formula must reserve those 8 cells, otherwise rows are wider than
+// the column's inner area and lipgloss wraps each row onto a second
+// line.
+func TestRenderWhoCanSubjects_RowsFitAvailableWidth(t *testing.T) {
+	rows := []WhoCanRow{
+		{Kind: "User", Name: "alice", Namespace: "default", Via: "ClusterRoleBinding/admins → ClusterRole/cluster-admin"},
+	}
+	// Include narrow widths to guard against the off-by-cap regression
+	// where hard-coded minimum widths exceeded the available area.
+	for _, width := range []int{40, 60, 80, 120, 160} {
+		t.Run("width="+itoa(width), func(t *testing.T) {
+			out := renderWhoCanSubjects(rows, 0, false, "pods", width, 20)
+			for i, line := range strings.Split(out, "\n") {
+				visible := lipgloss.Width(line)
+				assert.LessOrEqualf(t, visible, width,
+					"line %d (%q) is %d visible cols but the column only has %d available — row will wrap",
+					i, line, visible, width)
+			}
+		})
+	}
+}
+
+// TestRenderWhoCanRow_CellsBindBaseBackground locks in the fix for
+// the "background swap" the user reported. Subject rows live inside
+// the InactiveColumnStyle box (baseBg). Cell text rendered with fg-
+// only escapes shows the terminal default bg in place of baseBg, while
+// the unstyled padding spaces inherit baseBg from the column wrap —
+// producing a visible alternating band along the row. Every cell style
+// must therefore set Background(BaseBg) explicitly.
+func TestRenderWhoCanRow_CellsBindBaseBackground(t *testing.T) {
+	originalProfile := lipgloss.DefaultRenderer().ColorProfile()
+	originalNoColor := ConfigNoColor
+	originalTransparent := ConfigTransparentBg
+	t.Cleanup(func() {
+		lipgloss.DefaultRenderer().SetColorProfile(originalProfile)
+		ConfigNoColor = originalNoColor
+		ConfigTransparentBg = originalTransparent
+		ApplyTheme(DefaultTheme())
+	})
+	ConfigNoColor = false
+	ConfigTransparentBg = false
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	ApplyTheme(DefaultTheme())
+	// ApplyTheme restores originalColorProfile (theme.go:109-110), so
+	// re-force TrueColor here for the SGR-counting assertion to be
+	// observable at all.
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+
+	row := renderWhoCanRow(WhoCanRow{
+		Kind: "User", Name: "alice", Namespace: "default",
+		Via: "ClusterRoleBinding/admins → ClusterRole/cluster-admin",
+	}, 20, 14, 16, 30)
+
+	// 256-color bg = "48;5;", truecolor bg = "48;2;". Either is enough
+	// to know a span has its bg set.
+	bgMarkers := strings.Count(row, "48;5;") + strings.Count(row, "48;2;")
+	assert.GreaterOrEqual(t, bgMarkers, 4,
+		"row has 4 styled cells; each should emit a bg-setting SGR so the row's bg matches the column's baseBg (got %d, row=%q)", bgMarkers, row)
+}
+
+// itoa is a tiny helper to avoid importing strconv just for this file.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}


### PR DESCRIPTION
## Summary

Inverts the question of the existing Can-I browser: instead of *"what permissions does this subject have"*, asks *"who can do this verb on this resource"*. Reachable from the Can-I view via `Tab` so the same overlay hosts both directions and users pivot without re-opening anything.

\`\`\`
┌─ RBAC Who-Can ─────────────────────────────────────────────────────┐
│ Verb:  ▶ get  list  watch  create  update  patch  delete  *       │
│ Resource: pods                                       [all-ns]      │
│                                                                    │
│ SUBJECT                  KIND       NAMESPACE  VIA                 │
│   alice@example.com      User       —          ClusterRoleBinding/admins → ClusterRole/cluster-admin
│   ci-deployer            ServiceAcc ci         RoleBinding/ci-deploy → ClusterRole/edit
│   prometheus-operator    ServiceAcc monitoring ClusterRoleBinding/prom-op → ClusterRole/prom-op
│   system:masters         Group      —          ClusterRoleBinding/cluster-admin → ClusterRole/cluster-admin
└────────────────────────────────────────────────────────────────────┘
\`\`\`

## What landed

| File | Role |
|---|---|
| \`internal/k8s/whocan.go\` | Pure-RBAC scan: ClusterRoles + Roles + ClusterRoleBindings + RoleBindings → walk RoleRefs → match (verb, group, resource) against each rule. Wildcards supported, nonResourceURLs skipped. Namespace scope filters RoleBindings (ClusterRoleBindings always count). |
| \`internal/ui/whocanview.go\` | Verb chip row + resource filter line + subjects table renderer. \`whoCan*\`-prefixed helpers to avoid colliding with existing \`padRight\` in \`explorer_format.go\`. |
| \`internal/app/update_whocan.go\` | Tab handler, verb cursor cycle, resource filter input, namespace toggle, \`loadWhoCan\` cmd + \`whoCanLoadedMsg\` + handler. Pre-fills the Who-Can resource from the highlighted Can-I row so the question carries across the mode flip. |
| \`internal/app/app.go\` | New \`canIMode\` field + \`whoCanState\` sub-struct grouping all reverse-RBAC fields. The sub-struct is what keeps \`app.go\` under the 800-line file-length cap. |
| \`internal/app/overlay_hintbar.go\` | Mode-aware hint bar — forward mode advertises Tab to Who-Can, reverse mode advertises Tab back. |
| \`internal/app/view_overlays.go\` | \`renderCanIOverlay\` branches on the mode and delegates to \`renderWhoCanOverlay\` for reverse mode. Same overlay frame, same dimensions. |

## Output rows

\`WhoCanSubject{Kind, Name, Namespace (SA only), Via}\`. The \`Via\` field carries the binding chain (\`ClusterRoleBinding/foo → ClusterRole/bar\` or \`RoleBinding/ns/foo → Role/bar\`) so users can audit *why* a subject has access.

## Tests

**9 in \`internal/k8s/whocan_test.go\`:** ClusterRoleBinding match, RoleBinding→ClusterRole, RoleBinding→Role, verb wildcard, resource wildcard, group wildcard, namespace-scope filtering (RoleBindings filtered, ClusterRoleBindings always count), all-namespaces query, empty result, binding without matching rule skipped, nonResourceURLs ignored.

**6 in \`internal/app/update_whocan_test.go\`:** \`enterWhoCanMode\` flips mode + resets stale state, Tab from Who-Can returns to forward Can-I (bidirectional toggle), left/right verb cursor cycle with underflow guard, \`/\` enters filter mode, success and stale-gen paths in \`updateWhoCanLoaded\`.

## Out of scope (deferred)

- Subresource pattern matching like \`pods/*\` — bare resource only for now.
- Aggregated roles surface marker — rules are inherited via the role's \`rules\` field after expansion, but no UI badge for "(aggregated)".
- Subject deduplication across bindings — kept as one-row-per-binding on purpose so the user can see every grant path.

## Test plan

- [ ] Open Can-I (e.g. \`U\`); see your own permissions.
- [ ] Press \`Tab\` → switches to Who-Can. The resource pre-fills from the highlighted Can-I row (or stays empty if nothing was highlighted).
- [ ] Press \`/\`, type \`secrets\`, Enter → fetch fires; subjects table populates.
- [ ] \`←\` / \`→\` cycles the verb chip; subjects table re-fetches.
- [ ] Press \`A\` → namespace scope flips; \`RoleBinding\` subjects from other namespaces drop out.
- [ ] Press \`Tab\` again → returns to forward Can-I view.
- [ ] Press \`Esc\` → closes the overlay entirely.