### PR TITLE
feat(resource-map): traverse Pod refs with MissingRef detection

### DIFF
--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -213,6 +213,16 @@ func (m Model) loadResourceTree() tea.Cmd {
 		if sel.Namespace != "" {
 			ns = sel.Namespace
 		}
+	case model.LevelContainers:
+		// At the containers level, M means "show the parent Pod's tree".
+		// The Container itself has no refs distinct from its Pod, and the
+		// user's mental model of "the resource map for what I'm looking at"
+		// is the surrounding Pod.
+		name = m.nav.OwnedName
+		if name == "" {
+			return nil
+		}
+		kind = "Pod"
 	default:
 		return nil
 	}

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -223,6 +223,12 @@ func (m Model) loadResourceTree() tea.Cmd {
 			return nil
 		}
 		kind = "Pod"
+		// effectiveNamespace returns "" in all-namespaces mode; fall back
+		// to the navigation namespace so the typed Pod GET resolves —
+		// same pattern as loadContainers above.
+		if ns == "" && m.nav.Namespace != "" {
+			ns = m.nav.Namespace
+		}
 	default:
 		return nil
 	}

--- a/internal/app/commands_load_test.go
+++ b/internal/app/commands_load_test.go
@@ -252,6 +252,22 @@ func TestCov80LoadResourceTreeClusters(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
+func TestCov80LoadResourceTreeContainersUsesPodOwner(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelContainers
+	m.nav.OwnedName = "my-pod"
+	cmd := m.loadResourceTree()
+	require.NotNil(t, cmd, "M at LevelContainers should resolve to the parent Pod's tree")
+}
+
+func TestCov80LoadResourceTreeContainersNoOwnedName(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelContainers
+	m.nav.OwnedName = ""
+	cmd := m.loadResourceTree()
+	assert.Nil(t, cmd, "no Pod selected → no command")
+}
+
 func TestCov80ResolveNamespace(t *testing.T) {
 	m := basePush80Model()
 	m.nav.Namespace = "nav-ns"

--- a/internal/app/commands_load_test.go
+++ b/internal/app/commands_load_test.go
@@ -268,6 +268,18 @@ func TestCov80LoadResourceTreeContainersNoOwnedName(t *testing.T) {
 	assert.Nil(t, cmd, "no Pod selected → no command")
 }
 
+func TestCov80LoadResourceTreeContainersAllNamespacesFallback(t *testing.T) {
+	// In all-namespaces mode effectiveNamespace returns "" — the loader
+	// must fall back to nav.Namespace so the typed Pod GET resolves.
+	m := basePush80Model()
+	m.nav.Level = model.LevelContainers
+	m.nav.OwnedName = "database-0"
+	m.nav.Namespace = "lfk-test"
+	m.allNamespaces = true
+	cmd := m.loadResourceTree()
+	require.NotNil(t, cmd, "all-namespaces mode must fall back to nav.Namespace")
+}
+
 func TestCov80ResolveNamespace(t *testing.T) {
 	m := basePush80Model()
 	m.nav.Namespace = "nav-ns"

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -2378,6 +2378,11 @@ func TestGetResourceTree_DeploymentRefsMissingAndPresent(t *testing.T) {
 		"apiVersion": "apps/v1",
 		"kind":       "Deployment",
 		"metadata":   map[string]any{"name": "myapp", "namespace": "default", "uid": "dep-uid"},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Available", "status": "True"},
+			},
+		},
 	}}
 	rs := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",
@@ -2413,6 +2418,15 @@ func TestGetResourceTree_DeploymentRefsMissingAndPresent(t *testing.T) {
 				},
 			},
 		},
+		"status": map[string]any{
+			"containerStatuses": []any{
+				map[string]any{
+					"name":  "app",
+					"ready": true,
+					"state": map[string]any{"running": map[string]any{}},
+				},
+			},
+		},
 	}}
 	presentSecret := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
@@ -2426,6 +2440,10 @@ func TestGetResourceTree_DeploymentRefsMissingAndPresent(t *testing.T) {
 	root, err := c.GetResourceTree(context.Background(), "", "default", "Deployment", "myapp")
 	require.NoError(t, err)
 	require.NotNil(t, root)
+
+	// Root status now comes from the central GET in GetResourceTree —
+	// the Available condition resolves to "Available".
+	assert.Equal(t, "Available", root.Status, "root deployment should carry status extracted from its Available condition")
 
 	// Deployment → ReplicaSet → Pod → (Container, present Secret, missing Secret).
 	require.Len(t, root.Children, 1, "expected one ReplicaSet under Deployment")
@@ -2446,6 +2464,19 @@ func TestGetResourceTree_DeploymentRefsMissingAndPresent(t *testing.T) {
 	assert.Equal(t, "", byName["present"].Status, "existing ref must not be flagged")
 	assert.Equal(t, model.MissingRefStatus, byName["missing"].Status,
 		"missing required ref must surface as MissingRef through GetResourceTree")
+
+	// Container under the unstructured tree path now carries status from
+	// pod.status.containerStatuses (matches the typed buildPodTree path).
+	var ctNode *model.ResourceNode
+	for _, ch := range podNode.Children {
+		if ch.Kind == "Container" {
+			ctNode = ch
+			break
+		}
+	}
+	require.NotNil(t, ctNode, "expected a Container child")
+	assert.Equal(t, "Running", ctNode.Status,
+		"container status from pod.status.containerStatuses should propagate through buildDeploymentTree")
 }
 
 // --- getHelmManagedResources ---

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -2311,7 +2311,141 @@ func TestBuildPodTree(t *testing.T) {
 	err := c.buildPodTree(context.Background(), "", "default", "my-pod", root)
 	require.NoError(t, err)
 	assert.Equal(t, "Running", root.Status)
-	assert.Len(t, root.Children, 2) // init + app containers
+	// init + app containers, plus the default ServiceAccount ref attached by appendPodRefs.
+	require.Len(t, root.Children, 3)
+	assert.Equal(t, "Container", root.Children[0].Kind)
+	assert.Equal(t, "Container", root.Children[1].Kind)
+	assert.Equal(t, "ServiceAccount", root.Children[2].Kind)
+	assert.Equal(t, "default", root.Children[2].Name)
+	assert.Equal(t, "refs", root.Children[2].Group)
+}
+
+func TestBuildPodTree_RefsMissingAndPresent(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: new(false), // suppress the default SA child to keep the assertion focused
+			Containers: []corev1.Container{{
+				Name: "app",
+				EnvFrom: []corev1.EnvFromSource{
+					{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "present"}}},
+					{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}}},
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "missing-but-optional"},
+							Optional:             new(true),
+						},
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	presentSecret := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]any{"name": "present", "namespace": "default"},
+	}}
+
+	cs := k8sfake.NewClientset(pod)
+	dc := newFakeDynClient(presentSecret)
+	c := newFakeClient(cs, dc)
+
+	root := &model.ResourceNode{Name: "my-pod", Kind: "Pod", Namespace: "default"}
+	err := c.buildPodTree(context.Background(), "", "default", "my-pod", root)
+	require.NoError(t, err)
+
+	byName := map[string]*model.ResourceNode{}
+	for _, ch := range root.Children {
+		if ch.Kind == "Secret" {
+			byName[ch.Name] = ch
+		}
+	}
+	require.Contains(t, byName, "present")
+	require.Contains(t, byName, "missing")
+	require.Contains(t, byName, "missing-but-optional")
+	assert.Equal(t, "", byName["present"].Status, "existing ref must not be flagged")
+	assert.Equal(t, model.MissingRefStatus, byName["missing"].Status, "missing required ref must be flagged")
+	assert.Equal(t, "", byName["missing-but-optional"].Status, "missing optional ref must not be flagged")
+}
+
+// TestGetResourceTree_DeploymentRefsMissingAndPresent exercises the full
+// Deployment → ReplicaSet → Pod path through GetResourceTree to confirm the
+// shared existsFn is wired through buildDeploymentTree and that a missing
+// required Secret surfaces as MissingRef on the Pod's children.
+func TestGetResourceTree_DeploymentRefsMissingAndPresent(t *testing.T) {
+	deploy := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "myapp", "namespace": "default", "uid": "dep-uid"},
+	}}
+	rs := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "ReplicaSet",
+		"metadata": map[string]any{
+			"name":      "myapp-abc",
+			"namespace": "default",
+			"uid":       "rs-uid",
+			"ownerReferences": []any{
+				map[string]any{"kind": "Deployment", "name": "myapp", "uid": "dep-uid", "apiVersion": "apps/v1"},
+			},
+		},
+	}}
+	pod := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "myapp-abc-xyz",
+			"namespace": "default",
+			"ownerReferences": []any{
+				map[string]any{"kind": "ReplicaSet", "name": "myapp-abc", "uid": "rs-uid", "apiVersion": "apps/v1"},
+			},
+		},
+		"spec": map[string]any{
+			"automountServiceAccountToken": false, // suppress the default SA child to keep the assertion focused
+			"containers": []any{
+				map[string]any{
+					"name": "app",
+					"envFrom": []any{
+						map[string]any{"secretRef": map[string]any{"name": "present"}},
+						map[string]any{"secretRef": map[string]any{"name": "missing"}},
+					},
+				},
+			},
+		},
+	}}
+	presentSecret := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]any{"name": "present", "namespace": "default"},
+	}}
+
+	dc := newFakeDynClient(deploy, rs, pod, presentSecret)
+	c := newFakeClient(nil, dc)
+
+	root, err := c.GetResourceTree(context.Background(), "", "default", "Deployment", "myapp")
+	require.NoError(t, err)
+	require.NotNil(t, root)
+
+	// Deployment → ReplicaSet → Pod → (Container, present Secret, missing Secret).
+	require.Len(t, root.Children, 1, "expected one ReplicaSet under Deployment")
+	rsNode := root.Children[0]
+	assert.Equal(t, "ReplicaSet", rsNode.Kind)
+	require.Len(t, rsNode.Children, 1, "expected one Pod under ReplicaSet")
+	podNode := rsNode.Children[0]
+	assert.Equal(t, "Pod", podNode.Kind)
+
+	byName := map[string]*model.ResourceNode{}
+	for _, ch := range podNode.Children {
+		if ch.Kind == "Secret" {
+			byName[ch.Name] = ch
+		}
+	}
+	require.Contains(t, byName, "present")
+	require.Contains(t, byName, "missing")
+	assert.Equal(t, "", byName["present"].Status, "existing ref must not be flagged")
+	assert.Equal(t, model.MissingRefStatus, byName["missing"].Status,
+		"missing required ref must surface as MissingRef through GetResourceTree")
 }
 
 // --- getHelmManagedResources ---

--- a/internal/k8s/resources_appendcontainer_test.go
+++ b/internal/k8s/resources_appendcontainer_test.go
@@ -211,6 +211,151 @@ func TestAppendContainerNodes(t *testing.T) {
 		assert.Nil(t, podNode.Children)
 	})
 
+	t.Run("status block populates Container Status from running+ready", func(t *testing.T) {
+		podNode := &model.ResourceNode{Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "app"}},
+			},
+			"status": map[string]any{
+				"containerStatuses": []any{
+					map[string]any{
+						"name":  "app",
+						"ready": true,
+						"state": map[string]any{"running": map[string]any{"startedAt": "2024-01-01T00:00:00Z"}},
+					},
+				},
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 1)
+		assert.Equal(t, "Running", podNode.Children[0].Status)
+	})
+
+	t.Run("running but not ready becomes NotReady", func(t *testing.T) {
+		podNode := &model.ResourceNode{Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "app"}},
+			},
+			"status": map[string]any{
+				"containerStatuses": []any{
+					map[string]any{
+						"name":  "app",
+						"ready": false,
+						"state": map[string]any{"running": map[string]any{}},
+					},
+				},
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 1)
+		assert.Equal(t, "NotReady", podNode.Children[0].Status)
+	})
+
+	t.Run("waiting state becomes Waiting", func(t *testing.T) {
+		podNode := &model.ResourceNode{Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "app"}},
+			},
+			"status": map[string]any{
+				"containerStatuses": []any{
+					map[string]any{
+						"name":  "app",
+						"state": map[string]any{"waiting": map[string]any{"reason": "ContainerCreating"}},
+					},
+				},
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 1)
+		assert.Equal(t, "Waiting", podNode.Children[0].Status)
+	})
+
+	t.Run("terminated with Completed reason becomes Completed", func(t *testing.T) {
+		podNode := &model.ResourceNode{Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"initContainers": []any{map[string]any{"name": "init"}},
+			},
+			"status": map[string]any{
+				"initContainerStatuses": []any{
+					map[string]any{
+						"name":  "init",
+						"state": map[string]any{"terminated": map[string]any{"reason": "Completed"}},
+					},
+				},
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 1)
+		assert.Equal(t, "Completed", podNode.Children[0].Status)
+	})
+
+	t.Run("terminated with non-Completed reason becomes Terminated", func(t *testing.T) {
+		podNode := &model.ResourceNode{Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "app"}},
+			},
+			"status": map[string]any{
+				"containerStatuses": []any{
+					map[string]any{
+						"name":  "app",
+						"state": map[string]any{"terminated": map[string]any{"reason": "Error"}},
+					},
+				},
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 1)
+		assert.Equal(t, "Terminated", podNode.Children[0].Status)
+	})
+
+	t.Run("missing status block leaves Status empty", func(t *testing.T) {
+		podNode := &model.ResourceNode{Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "app"}},
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 1)
+		assert.Equal(t, "", podNode.Children[0].Status)
+	})
+
+	t.Run("status block present but container missing defaults to Waiting", func(t *testing.T) {
+		// Mirrors containerStatusFromPod's typed default — a pod that has a
+		// status block but the kubelet hasn't reported this container yet.
+		podNode := &model.ResourceNode{Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "app"}},
+			},
+			"status": map[string]any{
+				"containerStatuses": []any{}, // empty list
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 1)
+		assert.Equal(t, "Waiting", podNode.Children[0].Status)
+	})
+
 	t.Run("preserves existing children", func(t *testing.T) {
 		existing := &model.ResourceNode{Name: "existing", Kind: "Volume"}
 		podNode := &model.ResourceNode{

--- a/internal/k8s/resources_pod_refs.go
+++ b/internal/k8s/resources_pod_refs.go
@@ -1,0 +1,264 @@
+package k8s
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// refKey identifies a unique reference target within a Pod's namespace.
+type refKey struct {
+	kind, name string
+}
+
+// refEntry tracks a unique pod reference plus whether any reference site is
+// non-optional. Required wins on dedup — if the same Secret is referenced once
+// as required and once as optional, we treat it as required so a missing
+// object surfaces as MissingRef.
+type refEntry struct {
+	kind, name string
+	required   bool
+}
+
+// existsFn reports whether a namespaced object of the given kind+name exists.
+// Returning true on uncertain errors (RBAC, network) avoids false-flagging.
+type existsFn func(kind, name string) bool
+
+// appendPodRefs walks a Pod's spec and appends Secret/ConfigMap/PVC/ServiceAccount
+// child nodes for every distinct reference. Refs are deduped by (kind, name) and
+// emitted in a stable order: ServiceAccount, ConfigMap, Secret, PersistentVolumeClaim.
+//
+// podObj is the unstructured pod representation (same shape consumed by
+// appendContainerNodes). namespace is the pod's namespace — Secrets, ConfigMaps,
+// PVCs, and ServiceAccounts are all namespace-scoped, so cross-namespace refs
+// can't occur via env/volume/SA fields.
+//
+// If exists is non-nil, required refs whose target is reported missing get
+// Status=model.MissingRefStatus. Optional refs (env.valueFrom.*.optional=true,
+// envFrom.*.optional=true, volume.*.optional=true) are never flagged. A nil
+// exists skips the check entirely (used by tests and callers that don't need it).
+//
+// At large scale (e.g. a Deployment with N replicas) the same Secret will be
+// emitted under each Pod and existence-checked once per pod. Cross-pod dedup is
+// intentionally deferred — if it ever becomes a perf issue, batch a LIST per
+// kind at GetResourceTree level.
+func appendPodRefs(podNode *model.ResourceNode, podObj map[string]any, namespace string, exists existsFn) {
+	spec, _ := podObj["spec"].(map[string]any)
+	if spec == nil {
+		return
+	}
+
+	// Per-bucket ordered slices preserve stable emit order while the seen map
+	// dedupes by (kind, name) and lets a later required reference upgrade an
+	// earlier optional one.
+	seen := map[refKey]int{}
+	var sas, cms, secrets, pvcs []refEntry
+
+	add := func(kind, name string, optional bool) {
+		if name == "" {
+			return
+		}
+		k := refKey{kind: kind, name: name}
+		var bucket *[]refEntry
+		switch kind {
+		case "ServiceAccount":
+			bucket = &sas
+		case "ConfigMap":
+			bucket = &cms
+		case "Secret":
+			bucket = &secrets
+		case "PersistentVolumeClaim":
+			bucket = &pvcs
+		default:
+			return
+		}
+		if idx, ok := seen[k]; ok {
+			if !optional {
+				(*bucket)[idx].required = true
+			}
+			return
+		}
+		seen[k] = len(*bucket)
+		*bucket = append(*bucket, refEntry{kind: kind, name: name, required: !optional})
+	}
+
+	// ServiceAccount: skip if automountServiceAccountToken is explicitly false.
+	// Empty serviceAccountName defaults to "default". Always required.
+	if automount, ok := spec["automountServiceAccountToken"].(bool); !ok || automount {
+		saName, _ := spec["serviceAccountName"].(string)
+		if saName == "" {
+			saName = "default"
+		}
+		add("ServiceAccount", saName, false)
+	}
+
+	// imagePullSecrets are required at pull time; treat as non-optional.
+	if pull, ok := spec["imagePullSecrets"].([]any); ok {
+		for _, p := range pull {
+			if m, ok := p.(map[string]any); ok {
+				if n, _ := m["name"].(string); n != "" {
+					add("Secret", n, false)
+				}
+			}
+		}
+	}
+
+	for _, key := range []string{"initContainers", "containers", "ephemeralContainers"} {
+		containers, _ := spec[key].([]any)
+		for _, c := range containers {
+			cMap, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			collectContainerRefs(cMap, add)
+		}
+	}
+
+	if vols, ok := spec["volumes"].([]any); ok {
+		for _, v := range vols {
+			vMap, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			collectVolumeRefs(vMap, add)
+		}
+	}
+
+	for _, bucket := range [][]refEntry{sas, cms, secrets, pvcs} {
+		for _, r := range bucket {
+			status := ""
+			if r.required && exists != nil && !exists(r.kind, r.name) {
+				status = model.MissingRefStatus
+			}
+			podNode.Children = append(podNode.Children, &model.ResourceNode{
+				Name:      r.name,
+				Kind:      r.kind,
+				Namespace: namespace,
+				Status:    status,
+				Group:     "refs",
+			})
+		}
+	}
+}
+
+func collectContainerRefs(c map[string]any, add func(kind, name string, optional bool)) {
+	if env, ok := c["env"].([]any); ok {
+		for _, e := range env {
+			eMap, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			vf, _ := eMap["valueFrom"].(map[string]any)
+			if vf == nil {
+				continue
+			}
+			if sk, ok := vf["secretKeyRef"].(map[string]any); ok {
+				name, _ := sk["name"].(string)
+				opt, _ := sk["optional"].(bool)
+				add("Secret", name, opt)
+			}
+			if ck, ok := vf["configMapKeyRef"].(map[string]any); ok {
+				name, _ := ck["name"].(string)
+				opt, _ := ck["optional"].(bool)
+				add("ConfigMap", name, opt)
+			}
+		}
+	}
+	if envFrom, ok := c["envFrom"].([]any); ok {
+		for _, e := range envFrom {
+			eMap, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			if sr, ok := eMap["secretRef"].(map[string]any); ok {
+				name, _ := sr["name"].(string)
+				opt, _ := sr["optional"].(bool)
+				add("Secret", name, opt)
+			}
+			if cr, ok := eMap["configMapRef"].(map[string]any); ok {
+				name, _ := cr["name"].(string)
+				opt, _ := cr["optional"].(bool)
+				add("ConfigMap", name, opt)
+			}
+		}
+	}
+}
+
+func collectVolumeRefs(v map[string]any, add func(kind, name string, optional bool)) {
+	// SecretVolumeSource uses secretName; SecretProjection uses name.
+	if s, ok := v["secret"].(map[string]any); ok {
+		name, _ := s["secretName"].(string)
+		opt, _ := s["optional"].(bool)
+		add("Secret", name, opt)
+	}
+	if cm, ok := v["configMap"].(map[string]any); ok {
+		name, _ := cm["name"].(string)
+		opt, _ := cm["optional"].(bool)
+		add("ConfigMap", name, opt)
+	}
+	if pvc, ok := v["persistentVolumeClaim"].(map[string]any); ok {
+		// PVC volume source has no optional concept — always required.
+		name, _ := pvc["claimName"].(string)
+		add("PersistentVolumeClaim", name, false)
+	}
+	if proj, ok := v["projected"].(map[string]any); ok {
+		if sources, ok := proj["sources"].([]any); ok {
+			for _, src := range sources {
+				sMap, ok := src.(map[string]any)
+				if !ok {
+					continue
+				}
+				if s, ok := sMap["secret"].(map[string]any); ok {
+					name, _ := s["name"].(string)
+					opt, _ := s["optional"].(bool)
+					add("Secret", name, opt)
+				}
+				if cm, ok := sMap["configMap"].(map[string]any); ok {
+					name, _ := cm["name"].(string)
+					opt, _ := cm["optional"].(bool)
+					add("ConfigMap", name, opt)
+				}
+				// Skip serviceAccountToken and downwardAPI sources.
+			}
+		}
+	}
+}
+
+// newRefExistsFn returns an existsFn that resolves Secret/ConfigMap/PVC/SA
+// existence via the dynamic client in the given namespace. The returned
+// closure caches results so repeated lookups for the same (kind, name) within
+// a single tree build cost one GET. Errors other than IsNotFound are treated
+// as "exists" so transient RBAC/network failures don't false-flag refs.
+//
+// The cache map is not safe for concurrent use; the closure assumes
+// sequential calls within a single tree build (which is how
+// build*Tree paths invoke it today).
+func newRefExistsFn(ctx context.Context, dynClient dynamic.Interface, namespace string) existsFn {
+	gvrFor := map[string]schema.GroupVersionResource{
+		"Secret":                {Group: "", Version: "v1", Resource: "secrets"},
+		"ConfigMap":             {Group: "", Version: "v1", Resource: "configmaps"},
+		"PersistentVolumeClaim": {Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+		"ServiceAccount":        {Group: "", Version: "v1", Resource: "serviceaccounts"},
+	}
+	cache := map[refKey]bool{}
+	return func(kind, name string) bool {
+		k := refKey{kind: kind, name: name}
+		if v, ok := cache[k]; ok {
+			return v
+		}
+		gvr, ok := gvrFor[kind]
+		if !ok {
+			cache[k] = true
+			return true
+		}
+		_, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		exists := err == nil || !apierrors.IsNotFound(err)
+		cache[k] = exists
+		return exists
+	}
+}

--- a/internal/k8s/resources_pod_refs.go
+++ b/internal/k8s/resources_pod_refs.go
@@ -235,6 +235,10 @@ func collectVolumeRefs(v map[string]any, add func(kind, name string, optional bo
 // a single tree build cost one GET. Errors other than IsNotFound are treated
 // as "exists" so transient RBAC/network failures don't false-flag refs.
 //
+// The provided ctx is reused for every kube GET the closure issues — it does
+// not impose its own timeout, so callers should pass a context with a
+// deadline or cancellation to avoid indefinite blocking on a slow apiserver.
+//
 // The cache map is not safe for concurrent use; the closure assumes
 // sequential calls within a single tree build (which is how
 // build*Tree paths invoke it today).

--- a/internal/k8s/resources_pod_refs_test.go
+++ b/internal/k8s/resources_pod_refs_test.go
@@ -1,0 +1,633 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// kindNames flattens the children's (Kind, Name) pairs in order — the helper
+// many of the table-driven cases below want.
+func kindNames(children []*model.ResourceNode) [][2]string {
+	out := make([][2]string, 0, len(children))
+	for _, ch := range children {
+		out = append(out, [2]string{ch.Kind, ch.Name})
+	}
+	return out
+}
+
+func TestAppendPodRefs_ServiceAccount(t *testing.T) {
+	t.Run("default SA when serviceAccountName empty", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{"spec": map[string]any{}}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "ServiceAccount", node.Children[0].Kind)
+		assert.Equal(t, "default", node.Children[0].Name)
+		assert.Equal(t, "refs", node.Children[0].Group)
+		assert.Equal(t, "ns", node.Children[0].Namespace)
+	})
+
+	t.Run("custom serviceAccountName is used", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{"serviceAccountName": "my-sa"},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "my-sa", node.Children[0].Name)
+	})
+
+	t.Run("automountServiceAccountToken=false suppresses SA", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"serviceAccountName":           "my-sa",
+				"automountServiceAccountToken": false,
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		assert.Empty(t, node.Children)
+	})
+
+	t.Run("automountServiceAccountToken=true keeps SA", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"serviceAccountName":           "my-sa",
+				"automountServiceAccountToken": true,
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "my-sa", node.Children[0].Name)
+	})
+}
+
+func TestAppendPodRefs_EnvAndEnvFrom(t *testing.T) {
+	t.Run("env.valueFrom.secretKeyRef and configMapKeyRef", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"env": []any{
+							map[string]any{
+								"name": "DB_PASS",
+								"valueFrom": map[string]any{
+									"secretKeyRef": map[string]any{"name": "db-secret", "key": "pass"},
+								},
+							},
+							map[string]any{
+								"name": "CFG",
+								"valueFrom": map[string]any{
+									"configMapKeyRef": map[string]any{"name": "app-cm", "key": "cfg"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		assert.ElementsMatch(t, [][2]string{
+			{"ConfigMap", "app-cm"},
+			{"Secret", "db-secret"},
+		}, kindNames(node.Children))
+	})
+
+	t.Run("envFrom.secretRef and configMapRef", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"envFrom": []any{
+							map[string]any{"secretRef": map[string]any{"name": "envsec"}},
+							map[string]any{"configMapRef": map[string]any{"name": "envcm"}},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		assert.ElementsMatch(t, [][2]string{
+			{"ConfigMap", "envcm"},
+			{"Secret", "envsec"},
+		}, kindNames(node.Children))
+	})
+
+	t.Run("ephemeralContainers env refs are also collected", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"ephemeralContainers": []any{
+					map[string]any{
+						"name": "debugger",
+						"envFrom": []any{
+							map[string]any{"configMapRef": map[string]any{"name": "debug-cm"}},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "ConfigMap", node.Children[0].Kind)
+		assert.Equal(t, "debug-cm", node.Children[0].Name)
+	})
+
+	t.Run("initContainers env refs are also collected", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"initContainers": []any{
+					map[string]any{
+						"name": "init",
+						"env": []any{
+							map[string]any{
+								"valueFrom": map[string]any{
+									"secretKeyRef": map[string]any{"name": "init-secret"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "Secret", node.Children[0].Kind)
+		assert.Equal(t, "init-secret", node.Children[0].Name)
+	})
+
+	t.Run("env without valueFrom is skipped", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"env": []any{
+							map[string]any{"name": "FOO", "value": "bar"},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		assert.Empty(t, node.Children)
+	})
+}
+
+func TestAppendPodRefs_Volumes(t *testing.T) {
+	t.Run("secret volume uses secretName", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"volumes": []any{
+					map[string]any{
+						"name":   "secrets",
+						"secret": map[string]any{"secretName": "vol-secret"},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "Secret", node.Children[0].Kind)
+		assert.Equal(t, "vol-secret", node.Children[0].Name)
+	})
+
+	t.Run("configMap volume uses name", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"volumes": []any{
+					map[string]any{
+						"name":      "cfg",
+						"configMap": map[string]any{"name": "vol-cm"},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "ConfigMap", node.Children[0].Kind)
+		assert.Equal(t, "vol-cm", node.Children[0].Name)
+	})
+
+	t.Run("PVC volume uses claimName", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"volumes": []any{
+					map[string]any{
+						"name":                  "data",
+						"persistentVolumeClaim": map[string]any{"claimName": "data-pvc"},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "PersistentVolumeClaim", node.Children[0].Kind)
+		assert.Equal(t, "data-pvc", node.Children[0].Name)
+	})
+
+	t.Run("projected volume sources collect secret and configMap", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"volumes": []any{
+					map[string]any{
+						"name": "proj",
+						"projected": map[string]any{
+							"sources": []any{
+								map[string]any{"secret": map[string]any{"name": "proj-secret"}},
+								map[string]any{"configMap": map[string]any{"name": "proj-cm"}},
+								map[string]any{"serviceAccountToken": map[string]any{"path": "token"}},
+								map[string]any{"downwardAPI": map[string]any{}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		assert.ElementsMatch(t, [][2]string{
+			{"ConfigMap", "proj-cm"},
+			{"Secret", "proj-secret"},
+		}, kindNames(node.Children))
+	})
+}
+
+func TestAppendPodRefs_ImagePullSecrets(t *testing.T) {
+	node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+	obj := map[string]any{
+		"spec": map[string]any{
+			"automountServiceAccountToken": false,
+			"imagePullSecrets": []any{
+				map[string]any{"name": "regcred"},
+				map[string]any{"name": "regcred-backup"},
+			},
+		},
+	}
+
+	appendPodRefs(node, obj, "ns", nil)
+
+	assert.ElementsMatch(t, [][2]string{
+		{"Secret", "regcred"},
+		{"Secret", "regcred-backup"},
+	}, kindNames(node.Children))
+}
+
+func TestAppendPodRefs_DedupAndOrder(t *testing.T) {
+	t.Run("same secret via env and envFrom emits once", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "a",
+						"env": []any{
+							map[string]any{
+								"valueFrom": map[string]any{
+									"secretKeyRef": map[string]any{"name": "shared"},
+								},
+							},
+						},
+						"envFrom": []any{
+							map[string]any{"secretRef": map[string]any{"name": "shared"}},
+						},
+					},
+					map[string]any{
+						"name": "b",
+						"envFrom": []any{
+							map[string]any{"secretRef": map[string]any{"name": "shared"}},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "shared", node.Children[0].Name)
+	})
+
+	t.Run("emission order: SA, ConfigMap, Secret, PVC", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"serviceAccountName": "sa1",
+				"volumes": []any{
+					map[string]any{"persistentVolumeClaim": map[string]any{"claimName": "p1"}},
+					map[string]any{"secret": map[string]any{"secretName": "s1"}},
+					map[string]any{"configMap": map[string]any{"name": "c1"}},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		got := kindNames(node.Children)
+		require.Equal(t, [][2]string{
+			{"ServiceAccount", "sa1"},
+			{"ConfigMap", "c1"},
+			{"Secret", "s1"},
+			{"PersistentVolumeClaim", "p1"},
+		}, got)
+	})
+}
+
+func TestAppendPodRefs_Edges(t *testing.T) {
+	t.Run("nil spec emits no refs", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		appendPodRefs(node, map[string]any{}, "ns", nil)
+		assert.Empty(t, node.Children)
+	})
+
+	t.Run("empty ref names are skipped", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"imagePullSecrets": []any{
+					map[string]any{"name": ""},
+					map[string]any{"name": "ok"},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "ok", node.Children[0].Name)
+	})
+
+	t.Run("non-map ref maps are tolerated", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"volumes": []any{
+					"not-a-map",
+					map[string]any{"secret": map[string]any{"secretName": "ok"}},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "ok", node.Children[0].Name)
+	})
+
+	t.Run("preserves existing children", func(t *testing.T) {
+		existing := &model.ResourceNode{Name: "app", Kind: "Container"}
+		node := &model.ResourceNode{
+			Kind:      "Pod",
+			Namespace: "ns",
+			Children:  []*model.ResourceNode{existing},
+		}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"envFrom": []any{
+							map[string]any{"secretRef": map[string]any{"name": "s"}},
+						},
+					},
+				},
+			},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 2)
+		assert.Equal(t, "Container", node.Children[0].Kind)
+		assert.Equal(t, "Secret", node.Children[1].Kind)
+		assert.Equal(t, "refs", node.Children[1].Group)
+	})
+}
+
+// --- existsFn behavior: required vs optional, MissingRef ---
+
+func TestAppendPodRefs_ExistenceCheck(t *testing.T) {
+	t.Run("missing required ref gets MissingRef status", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"envFrom": []any{
+							map[string]any{"secretRef": map[string]any{"name": "missing"}},
+						},
+					},
+				},
+			},
+		}
+		exists := func(kind, name string) bool { return false }
+
+		appendPodRefs(node, obj, "ns", exists)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "missing", node.Children[0].Name)
+		assert.Equal(t, model.MissingRefStatus, node.Children[0].Status)
+	})
+
+	t.Run("missing optional ref is not flagged", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"envFrom": []any{
+							map[string]any{
+								"secretRef": map[string]any{
+									"name":     "soft",
+									"optional": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		exists := func(kind, name string) bool { return false }
+
+		appendPodRefs(node, obj, "ns", exists)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "", node.Children[0].Status)
+	})
+
+	t.Run("existing ref has empty status", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"envFrom": []any{
+							map[string]any{"secretRef": map[string]any{"name": "ok"}},
+						},
+					},
+				},
+			},
+		}
+		exists := func(kind, name string) bool { return true }
+
+		appendPodRefs(node, obj, "ns", exists)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "", node.Children[0].Status)
+	})
+
+	t.Run("required wins when same ref appears as both required and optional", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"containers": []any{
+					map[string]any{
+						"name": "app",
+						"envFrom": []any{
+							// Optional first.
+							map[string]any{
+								"secretRef": map[string]any{
+									"name":     "shared",
+									"optional": true,
+								},
+							},
+							// Required second — should upgrade the entry.
+							map[string]any{"secretRef": map[string]any{"name": "shared"}},
+						},
+					},
+				},
+			},
+		}
+		exists := func(kind, name string) bool { return false }
+
+		appendPodRefs(node, obj, "ns", exists)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, model.MissingRefStatus, node.Children[0].Status,
+			"required reference must dominate optional dedup partner")
+	})
+
+	t.Run("PVC has no optional concept and is always required", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"volumes": []any{
+					map[string]any{
+						"persistentVolumeClaim": map[string]any{"claimName": "data"},
+					},
+				},
+			},
+		}
+		exists := func(kind, name string) bool { return false }
+
+		appendPodRefs(node, obj, "ns", exists)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, model.MissingRefStatus, node.Children[0].Status)
+	})
+
+	t.Run("ServiceAccount is always required", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{"serviceAccountName": "ghost"},
+		}
+		exists := func(kind, name string) bool { return false }
+
+		appendPodRefs(node, obj, "ns", exists)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "ServiceAccount", node.Children[0].Kind)
+		assert.Equal(t, model.MissingRefStatus, node.Children[0].Status)
+	})
+
+	t.Run("imagePullSecret missing is flagged", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"automountServiceAccountToken": false,
+				"imagePullSecrets": []any{
+					map[string]any{"name": "regcred"},
+				},
+			},
+		}
+		exists := func(kind, name string) bool { return false }
+
+		appendPodRefs(node, obj, "ns", exists)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, model.MissingRefStatus, node.Children[0].Status)
+	})
+
+	t.Run("nil existsFn skips checks entirely", func(t *testing.T) {
+		node := &model.ResourceNode{Kind: "Pod", Namespace: "ns"}
+		obj := map[string]any{
+			"spec": map[string]any{"serviceAccountName": "anything"},
+		}
+
+		appendPodRefs(node, obj, "ns", nil)
+
+		require.Len(t, node.Children, 1)
+		assert.Equal(t, "", node.Children[0].Status,
+			"a nil existsFn must never produce MissingRef")
+	})
+}

--- a/internal/k8s/resources_tree.go
+++ b/internal/k8s/resources_tree.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -374,7 +375,14 @@ func (c *Client) buildPodTree(ctx context.Context, contextName, namespace, podNa
 		})
 	}
 
-	dynClient, _ := c.dynamicForContext(contextName)
+	dynClient, dynErr := c.dynamicForContext(contextName)
+	if dynErr != nil {
+		// Tree build proceeds without ref existence checks and without an
+		// owner chain. Log so operators can see why MissingRef flags and
+		// owner ancestors aren't appearing.
+		logger.Warn("Resource tree: dynamic client unavailable; ref existence checks and owner chain skipped",
+			"context", contextName, "error", dynErr)
+	}
 
 	if obj, convErr := runtime.DefaultUnstructuredConverter.ToUnstructured(pod); convErr == nil {
 		var exists existsFn

--- a/internal/k8s/resources_tree.go
+++ b/internal/k8s/resources_tree.go
@@ -6,12 +6,32 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
+
+// rootGVRForKind maps a Kind that GetResourceTree accepts as an entry point
+// to the GVR used to fetch the root resource for status extraction. It is
+// also reused by wrapWithOwners for owner-chain lookups (a strict superset
+// of what owners can be — Service and Node never appear as owners but their
+// presence here is harmless).
+//
+// Pod is intentionally absent: buildPodTree fetches it via the typed
+// clientset and sets root.Status from pod.Status.Phase directly.
+var rootGVRForKind = map[string]schema.GroupVersionResource{
+	"Deployment":  {Group: "apps", Version: "v1", Resource: "deployments"},
+	"ReplicaSet":  {Group: "apps", Version: "v1", Resource: "replicasets"},
+	"StatefulSet": {Group: "apps", Version: "v1", Resource: "statefulsets"},
+	"DaemonSet":   {Group: "apps", Version: "v1", Resource: "daemonsets"},
+	"Job":         {Group: "batch", Version: "v1", Resource: "jobs"},
+	"CronJob":     {Group: "batch", Version: "v1", Resource: "cronjobs"},
+	"Service":     {Group: "", Version: "v1", Resource: "services"},
+	"Node":        {Group: "", Version: "v1", Resource: "nodes"},
+}
 
 func (c *Client) GetResourceTree(ctx context.Context, contextName, namespace, kind, name string) (*model.ResourceNode, error) {
 	dynClient, err := c.dynamicForContext(contextName)
@@ -23,6 +43,23 @@ func (c *Client) GetResourceTree(ctx context.Context, contextName, namespace, ki
 		Name:      name,
 		Kind:      kind,
 		Namespace: namespace,
+	}
+
+	// Fetch the root resource so the tree's root node renders with a status
+	// consistent with how owner-chain ancestors are rendered by wrapWithOwners.
+	// Skipped for Pod (buildPodTree handles it) and unknown CRD kinds (no
+	// GVR mapping). Errors are non-fatal — empty status is the legacy default.
+	if gvr, ok := rootGVRForKind[kind]; ok {
+		var obj *unstructured.Unstructured
+		var getErr error
+		if kind == "Node" {
+			obj, getErr = dynClient.Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+		} else {
+			obj, getErr = dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		}
+		if getErr == nil && obj != nil {
+			root.Status = extractStatus(obj.Object)
+		}
 	}
 
 	switch kind {
@@ -355,14 +392,8 @@ func (c *Client) buildPodTree(ctx context.Context, contextName, namespace, podNa
 }
 
 func (c *Client) wrapWithOwners(ctx context.Context, dynClient dynamic.Interface, namespace, ownerKind, ownerName string, root *model.ResourceNode) {
-	gvrForKind := map[string]schema.GroupVersionResource{
-		"ReplicaSet":  {Group: "apps", Version: "v1", Resource: "replicasets"},
-		"Deployment":  {Group: "apps", Version: "v1", Resource: "deployments"},
-		"StatefulSet": {Group: "apps", Version: "v1", Resource: "statefulsets"},
-		"DaemonSet":   {Group: "apps", Version: "v1", Resource: "daemonsets"},
-		"Job":         {Group: "batch", Version: "v1", Resource: "jobs"},
-		"CronJob":     {Group: "batch", Version: "v1", Resource: "cronjobs"},
-	}
+	// Reuse rootGVRForKind — it is a superset of legitimate owner kinds.
+	gvrForKind := rootGVRForKind
 
 	type ownerInfo struct {
 		kind, name, status   string
@@ -443,23 +474,100 @@ func appendContainerNodes(podNode *model.ResourceNode, obj map[string]any) {
 	if spec == nil {
 		return
 	}
+	// Pull container statuses from pod.status so Container nodes built from
+	// the unstructured tree path render Running/Waiting/etc. consistently
+	// with the typed buildPodTree path. extractContainerStatusMap returns
+	// nil when the status block is absent, in which case Status is left
+	// empty rather than defaulting to "Waiting".
+	status, _ := obj["status"].(map[string]any)
+	statusByKey := map[string]map[string]string{
+		"initContainers": extractContainerStatusMap(status, "initContainerStatuses"),
+		"containers":     extractContainerStatusMap(status, "containerStatuses"),
+	}
 	for _, key := range []string{"initContainers", "containers"} {
 		containers, _ := spec[key].([]any)
+		lookup := statusByKey[key]
 		for _, c := range containers {
 			cMap, ok := c.(map[string]any)
 			if !ok {
 				continue
 			}
 			name, _ := cMap["name"].(string)
-			if name != "" {
-				podNode.Children = append(podNode.Children, &model.ResourceNode{
-					Name:      name,
-					Kind:      "Container",
-					Namespace: podNode.Namespace,
-				})
+			if name == "" {
+				continue
 			}
+			ctStatus := ""
+			if lookup != nil {
+				ctStatus = lookup[name]
+				if ctStatus == "" {
+					// Status block exists but this container isn't listed yet
+					// (e.g., just-created pod) — match the typed default.
+					ctStatus = "Waiting"
+				}
+			}
+			podNode.Children = append(podNode.Children, &model.ResourceNode{
+				Name:      name,
+				Kind:      "Container",
+				Namespace: podNode.Namespace,
+				Status:    ctStatus,
+			})
 		}
 	}
+}
+
+// extractContainerStatusMap walks pod.status[key] (an array of container
+// status entries) and returns a name → state-string map mirroring
+// containerStateString's typed semantics. Returns nil when the entry is
+// missing or not a list, so callers can distinguish "no status info" from
+// "container missing from status list".
+func extractContainerStatusMap(podStatus map[string]any, key string) map[string]string {
+	if podStatus == nil {
+		return nil
+	}
+	list, ok := podStatus[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			continue
+		}
+		ready, _ := m["ready"].(bool)
+		state, _ := m["state"].(map[string]any)
+		out[name] = containerStateFromUnstructured(state, ready)
+	}
+	return out
+}
+
+// containerStateFromUnstructured mirrors containerStateString for the
+// unstructured shape: examines the running/waiting/terminated one-of inside
+// container status.state.
+func containerStateFromUnstructured(state map[string]any, ready bool) string {
+	if state == nil {
+		return "Unknown"
+	}
+	if _, ok := state["running"].(map[string]any); ok {
+		if ready {
+			return "Running"
+		}
+		return "NotReady"
+	}
+	if _, ok := state["waiting"].(map[string]any); ok {
+		return "Waiting"
+	}
+	if term, ok := state["terminated"].(map[string]any); ok {
+		if reason, _ := term["reason"].(string); reason == "Completed" {
+			return "Completed"
+		}
+		return "Terminated"
+	}
+	return "Unknown"
 }
 
 func containerStatusFromPod(name string, statuses []corev1.ContainerStatus) string {

--- a/internal/k8s/resources_tree.go
+++ b/internal/k8s/resources_tree.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
@@ -91,6 +92,10 @@ func (c *Client) buildDeploymentTree(ctx context.Context, dynClient dynamic.Inte
 		return fmt.Errorf("listing pods: %w", err)
 	}
 
+	// Single existsFn shared across all pods in this loop so the cache
+	// dedupes ref lookups across replicas of the same Deployment.
+	existsFn := newRefExistsFn(ctx, dynClient, namespace)
+
 	for _, pod := range podList.Items {
 		for _, ref := range pod.GetOwnerReferences() {
 			if ref.Kind == "ReplicaSet" {
@@ -102,6 +107,7 @@ func (c *Client) buildDeploymentTree(ctx context.Context, dynClient dynamic.Inte
 						Status:    extractStatus(pod.Object),
 					}
 					appendContainerNodes(podNode, pod.Object)
+					appendPodRefs(podNode, pod.Object, pod.GetNamespace(), existsFn)
 					rsNode.Children = append(rsNode.Children, podNode)
 				}
 			}
@@ -118,6 +124,8 @@ func (c *Client) buildPodOwnerTree(ctx context.Context, dynClient dynamic.Interf
 		return fmt.Errorf("listing pods: %w", err)
 	}
 
+	existsFn := newRefExistsFn(ctx, dynClient, namespace)
+
 	for _, pod := range podList.Items {
 		for _, ref := range pod.GetOwnerReferences() {
 			if ref.Kind == ownerKind && ref.Name == ownerName {
@@ -128,6 +136,7 @@ func (c *Client) buildPodOwnerTree(ctx context.Context, dynClient dynamic.Interf
 					Status:    extractStatus(pod.Object),
 				}
 				appendContainerNodes(podNode, pod.Object)
+				appendPodRefs(podNode, pod.Object, pod.GetNamespace(), existsFn)
 				root.Children = append(root.Children, podNode)
 				break
 			}
@@ -183,6 +192,8 @@ func (c *Client) buildGenericOwnerTree(ctx context.Context, dynClient dynamic.In
 		intermediateMap[n.Name] = n
 	}
 
+	existsFn := newRefExistsFn(ctx, dynClient, namespace)
+
 	for _, pod := range podList.Items {
 		for _, ref := range pod.GetOwnerReferences() {
 			podNode := &model.ResourceNode{
@@ -192,6 +203,7 @@ func (c *Client) buildGenericOwnerTree(ctx context.Context, dynClient dynamic.In
 				Status:    extractStatus(pod.Object),
 			}
 			appendContainerNodes(podNode, pod.Object)
+			appendPodRefs(podNode, pod.Object, pod.GetNamespace(), existsFn)
 			if parent, ok := intermediateMap[ref.Name]; ok {
 				parent.Children = append(parent.Children, podNode)
 				break
@@ -325,11 +337,18 @@ func (c *Client) buildPodTree(ctx context.Context, contextName, namespace, podNa
 		})
 	}
 
-	if len(pod.OwnerReferences) > 0 {
-		dynClient, dynErr := c.dynamicForContext(contextName)
-		if dynErr == nil {
-			c.wrapWithOwners(ctx, dynClient, namespace, pod.OwnerReferences[0].Kind, pod.OwnerReferences[0].Name, root)
+	dynClient, _ := c.dynamicForContext(contextName)
+
+	if obj, convErr := runtime.DefaultUnstructuredConverter.ToUnstructured(pod); convErr == nil {
+		var exists existsFn
+		if dynClient != nil {
+			exists = newRefExistsFn(ctx, dynClient, namespace)
 		}
+		appendPodRefs(root, obj, namespace, exists)
+	}
+
+	if len(pod.OwnerReferences) > 0 && dynClient != nil {
+		c.wrapWithOwners(ctx, dynClient, namespace, pod.OwnerReferences[0].Kind, pod.OwnerReferences[0].Name, root)
 	}
 
 	return nil

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -133,13 +133,26 @@ type Item struct {
 	GroupedRefs   []GroupedRef     // For grouped rows (Events): all underlying resource identifiers
 }
 
+// MissingRefStatus is the Status string assigned to a ResourceNode whose
+// referenced object (Secret/ConfigMap/PVC/ServiceAccount) does not exist on
+// the cluster. The k8s package writes it; the ui package matches on it in
+// StatusStyle to render the node red. Keep these two callers in sync via
+// this single constant.
+const MissingRefStatus = "MissingRef"
+
 // ResourceNode represents a node in a resource relationship tree.
 type ResourceNode struct {
 	Name      string
 	Kind      string
 	Namespace string
 	Status    string
-	Children  []*ResourceNode
+	// Group categorizes children for rendering. Empty (default) and "owned"
+	// behave the same — owner-chain descendants like ReplicaSet/Pod/Container.
+	// "refs" marks Secret/ConfigMap/PVC/ServiceAccount nodes attached to a
+	// Pod via env, envFrom, volumes, or serviceAccountName. The renderer
+	// uses this to emit a mixed-kind badge like "(2 Container, 3 refs)".
+	Group    string
+	Children []*ResourceNode
 }
 
 // NavigationState holds the full state of where the user is in the hierarchy.

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -661,10 +661,32 @@ func renderTreeNodeLabel(node *model.ResourceNode, parentNamespace string) strin
 		label += " " + DimStyle.Render("(ns: "+node.Namespace+")")
 	}
 
-	// Show child count for nodes that have children.
+	// Show child count for nodes that have children. Pods can have a mix of
+	// "owned" children (Containers) and "refs" children (Secret/ConfigMap/PVC/SA);
+	// emit a two-bucket badge in that case.
 	if len(node.Children) > 0 {
-		childKind := node.Children[0].Kind
-		label += " " + DimStyle.Render(fmt.Sprintf("(%d %s)", len(node.Children), childKind))
+		var ownedCount, refsCount int
+		var ownedKind string
+		for _, ch := range node.Children {
+			if ch.Group == "refs" {
+				refsCount++
+				continue
+			}
+			ownedCount++
+			if ownedKind == "" {
+				ownedKind = ch.Kind
+			}
+		}
+		var parts []string
+		if ownedCount > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", ownedCount, ownedKind))
+		}
+		if refsCount > 0 {
+			parts = append(parts, fmt.Sprintf("%d refs", refsCount))
+		}
+		if len(parts) > 0 {
+			label += " " + DimStyle.Render("("+strings.Join(parts, ", ")+")")
+		}
 	}
 
 	if node.Status != "" {

--- a/internal/ui/explorer_resource_test.go
+++ b/internal/ui/explorer_resource_test.go
@@ -285,3 +285,51 @@ func TestRenderResourceSummary(t *testing.T) {
 		assert.Contains(t, result, "abc123")
 	})
 }
+
+// --- RenderResourceTree (badge buckets) ---
+
+func TestRenderResourceTree_BadgeBuckets(t *testing.T) {
+	t.Run("homogeneous owned children render single-kind badge", func(t *testing.T) {
+		root := &model.ResourceNode{
+			Name: "my-pod", Kind: "Pod", Namespace: "ns",
+			Children: []*model.ResourceNode{
+				{Name: "init", Kind: "Container", Namespace: "ns"},
+				{Name: "app", Kind: "Container", Namespace: "ns"},
+			},
+		}
+
+		out := RenderResourceTree(root, 120, 30)
+
+		assert.Contains(t, out, "(2 Container)")
+		assert.NotContains(t, out, "refs")
+	})
+
+	t.Run("mixed owned and refs children render two-bucket badge", func(t *testing.T) {
+		root := &model.ResourceNode{
+			Name: "my-pod", Kind: "Pod", Namespace: "ns",
+			Children: []*model.ResourceNode{
+				{Name: "app", Kind: "Container", Namespace: "ns"},
+				{Name: "default", Kind: "ServiceAccount", Namespace: "ns", Group: "refs"},
+				{Name: "regcred", Kind: "Secret", Namespace: "ns", Group: "refs"},
+			},
+		}
+
+		out := RenderResourceTree(root, 120, 30)
+
+		assert.Contains(t, out, "(1 Container, 2 refs)")
+	})
+
+	t.Run("only refs children render refs-only badge", func(t *testing.T) {
+		root := &model.ResourceNode{
+			Name: "my-pod", Kind: "Pod", Namespace: "ns",
+			Children: []*model.ResourceNode{
+				{Name: "default", Kind: "ServiceAccount", Namespace: "ns", Group: "refs"},
+				{Name: "vol-cm", Kind: "ConfigMap", Namespace: "ns", Group: "refs"},
+			},
+		}
+
+		out := RenderResourceTree(root, 120, 30)
+
+		assert.Contains(t, out, "(2 refs)")
+	})
+}

--- a/internal/ui/explorer_test.go
+++ b/internal/ui/explorer_test.go
@@ -265,6 +265,7 @@ func TestStatusStyle(t *testing.T) {
 		"Running", "Active", "Bound", "Available", "Ready",
 		"Pending", "ContainerCreating", "Terminating",
 		"Failed", "CrashLoopBackOff", "Error", "OOMKilled",
+		"MissingRef",
 		"Succeeded", "Completed",
 		"Warning", "Normal",
 		"default", "", "UnknownStatus",

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
 
 // Tokyonight Storm color palette default values. These back the mutable
@@ -440,6 +442,7 @@ func StatusStyle(status string) lipgloss.Style {
 		"Missing/Synced",
 		"OOMKilled", "ErrImagePull", "CreateContainerConfigError",
 		"SecretSyncedError", "SecretMissing", "MissingProviderSecret",
+		model.MissingRefStatus,
 		"UpdateFailed", "FailedScheduling",
 		"InvalidStoreConfiguration", "InvalidProviderConfig", "ValidationFailed":
 		return StatusFailed


### PR DESCRIPTION
## Summary

Pod references (Secret / ConfigMap / PVC / ServiceAccount) now appear as children of Pod nodes in the Resource Map (M-key). Required references whose target is missing on the cluster surface as `MissingRef` (red). A polish commit on top closes two pre-existing rendering gaps so Container nodes and the root resource show their status badge in tree paths that previously rendered them empty. A separate fix commit makes M actually load the parent Pod's tree when pressed at the Containers level (was a stuck "Resource map" status with nothing rendered).

## Type of change

- [x] feat: new user-facing feature
- [x] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

<!-- e.g. Closes #123 -->

## Changes

- Walker collects unique Secret / ConfigMap / PVC / SA refs from `env`, `envFrom`, `volumes` (incl. projected sources), `serviceAccountName`, and `imagePullSecrets`. Init + ephemeral containers covered. `automountServiceAccountToken: false` suppresses the SA child.
- Existence resolved via the dynamic client per tree build with a shared `(kind,name)` cache. `IsNotFound` → `MissingRef`; other errors treated as exists to avoid false positives on RBAC / network blips.
- Optional refs (`optional: true` on env / envFrom / volume sources) are emitted but never flagged. Required wins on dedup when the same ref is referenced both ways.
- `ResourceNode.Group` distinguishes "owned" (containers) from "refs" so the renderer can emit a mixed badge `(N Container, M refs)` instead of the old single-kind count.
- Polish: `appendContainerNodes` now reads `pod.status.{init,}containerStatuses` so Container nodes render `Running` / `Waiting` / `Completed` / etc. in the unstructured tree path, matching the typed `buildPodTree` path.
- Polish: `GetResourceTree` fetches the root resource and applies `extractStatus` before dispatching, so the root node carries the same status badge that owner-chain ancestors already get from `wrapWithOwners`. Reuses a new package-level `rootGVRForKind` map (also dedupes the local copy that `wrapWithOwners` had).
- Fix: `loadResourceTree` handles `LevelContainers` and resolves M to the parent Pod's tree via `m.nav.OwnedName`. Previously the M handler accepted the keypress at this level but the loader didn't, so the cmd was nil and the view sat on a "Resource map" status with no tree.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (via pre-commit hook on each commit)
- [x] Manually verified against a real cluster (kind-lfk-test, 8 scenarios)

End-to-end live verification via `GetResourceTree` against a fresh kind cluster:

- Deployment with present + optional-missing refs → all six refs visible per pod; optional-missing NOT flagged.
- Deployment with missing required Secret → `Secret/does-not-exist [MissingRef]`.
- StatefulSet, DaemonSet, CronJob → containers + refs render under all three.
- Pod with missing `imagePullSecret` → flagged.
- Pod with `automountServiceAccountToken: false` → no SA child, no projected `kube-root-ca.crt`.
- Service tree → still shallow Pod children (no regression).
- Container `[Running]` and root `[Available]` now render in the deployment-rooted view (both were empty before the polish commit).

## Checklist

- [x] Commits follow conventional commit style
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->
