### PR TITLE
fix(preview): clear previewLoading when resource list arrives empty

### DIFF
--- a/internal/app/update_msg_test.go
+++ b/internal/app/update_msg_test.go
@@ -1174,6 +1174,50 @@ func TestFinal2UpdateResourcesLoadedMsgPreviewLoadingArmed(t *testing.T) {
 	assert.True(t, rm.previewLoading, "previewLoading must be armed when main list arrives so the right pane keeps showing the spinner")
 }
 
+// TestUpdateResourcesLoadedEmpty_ClearsPreviewLoading locks in the fix for
+// the endless-loading bug: when a namespace has no resources of the selected
+// kind (e.g., empty namespace + Secrets), the main list arrives empty so
+// loadPreview() returns nil because there is nothing to preview. The flag
+// must be cleared in that branch — otherwise it stays armed from the
+// preceding clearRight() / invalidatePreviewForCursorChange() and the right
+// pane renders the spinner forever.
+func TestUpdateResourcesLoadedEmpty_ClearsPreviewLoading(t *testing.T) {
+	m := baseFinalModel()
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Secret", Resource: "secrets", Namespaced: true,
+	}
+	m.middleItems = nil
+	m.loading = true
+	m.previewLoading = true // armed by clearRight on navigation
+	m.requestGen = 1
+	result, _ := m.Update(resourcesLoadedMsg{items: nil, gen: 1})
+	rm := result.(Model)
+	assert.False(t, rm.previewLoading,
+		"previewLoading must clear when no items arrive — otherwise the right pane spins forever in empty namespaces")
+}
+
+// TestUpdateOwnedLoadedEmpty_ClearsPreviewLoading is the LevelOwned twin of
+// the above: when a Helm release / Deployment has no children of the active
+// owned kind, the same pattern applies — loadPreview() returns nil because
+// there is nothing to preview, and the flag must be cleared so the right
+// pane stops spinning.
+func TestUpdateOwnedLoadedEmpty_ClearsPreviewLoading(t *testing.T) {
+	m := baseFinalModel()
+	m.nav.Level = model.LevelOwned
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Deployment", Resource: "deployments", Namespaced: true,
+	}
+	m.nav.ResourceName = "empty-deploy"
+	m.middleItems = nil
+	m.loading = true
+	m.previewLoading = true // armed by clearRight on drill-in
+	m.requestGen = 1
+	result, _ := m.Update(ownedLoadedMsg{items: nil, gen: 1})
+	rm := result.(Model)
+	assert.False(t, rm.previewLoading,
+		"previewLoading must clear when no owned items arrive — same root cause as the LevelResources empty-namespace bug")
+}
+
 func TestFinal2UpdateResourcesLoadedMsgStale(t *testing.T) {
 	m := baseFinalModel()
 	m.requestGen = 2

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -382,13 +382,17 @@ func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea
 		m.suppressBgtasks = true
 	}
 	var cmds []tea.Cmd
-	// Mark the preview pane as loading so the right column shows the
-	// spinner during the gap between the main list arriving (which cleared
-	// the global loading flag) and the preview load completing. Without
-	// this the right pane briefly renders "No resources found".
+	// Align previewLoading with whether a preview fetch is actually in
+	// flight. clearRight() / invalidatePreviewForCursorChange() armed the
+	// flag to true on navigation so the right pane keeps showing the
+	// spinner across the main-list arrival; if no preview cmd is
+	// dispatched (e.g., empty namespace, so selectedMiddleItem is nil and
+	// loadPreview returns nil), leaving the flag armed would render
+	// "Loading..." forever instead of letting the right pane fall through
+	// to its empty/details branches.
 	previewCmd := m.loadPreview()
+	m.previewLoading = previewCmd != nil
 	if previewCmd != nil {
-		m.previewLoading = true
 		cmds = append(cmds, previewCmd)
 	}
 	switch kind {
@@ -509,11 +513,12 @@ func (m Model) updateOwnedLoaded(msg ownedLoadedMsg) (tea.Model, tea.Cmd) {
 	if msg.silent {
 		m.suppressBgtasks = true
 	}
-	// Mark the preview pane as loading (see updateResourcesLoadedMain).
+	// Align previewLoading with whether a preview fetch is actually in
+	// flight (see updateResourcesLoadedMain for rationale). At LevelOwned,
+	// kinds without further owned children (or empty Helm releases) make
+	// loadPreview return nil; without this the right pane spins forever.
 	previewCmd := m.loadPreview()
-	if previewCmd != nil {
-		m.previewLoading = true
-	}
+	m.previewLoading = previewCmd != nil
 	m.suppressBgtasks = savedSuppress
 	return m, previewCmd
 }


### PR DESCRIPTION
## Summary

Fixes the endless-spinner bug: selecting a namespace with no Secrets (or any kind+namespace combo with zero rows) made the right pane spin forever while the middle column correctly showed "No resources found".

**Root cause**: `previewLoading` is armed by `clearRight()` / `invalidatePreviewForCursorChange()` on navigation so the right pane keeps showing the spinner across the gap between the main list arriving and the preview load completing. But `updateResourcesLoadedMain` only ever flipped the flag *to* `true` (when `previewCmd != nil`), never to `false`. When the list arrived empty, `selectedMiddleItem()` returned `nil`, `loadPreview()` returned `nil`, the `if previewCmd != nil` block was skipped, and the flag stayed armed. `renderRightResources` for non-Pod kinds then rendered `spinner + " Loading..."` forever.

**Fix**: align `previewLoading` with whether a preview cmd is actually in flight (`m.previewLoading = previewCmd != nil`) — the same pattern `updateContainersLoaded` already used at the LevelContainers boundary for the identical root cause. Same one-line change applied to `updateOwnedLoaded`, which had the matching bug for empty Helm releases / Deployments with zero of an owned kind.

## Changes
- `internal/app/update_resources_loaded.go`: tighten `previewLoading` assignment in `updateResourcesLoadedMain` and `updateOwnedLoaded` so it always reflects whether a preview fetch is in flight
- `internal/app/update_msg_test.go`: two regression tests (`TestUpdateResourcesLoadedEmpty_ClearsPreviewLoading`, `TestUpdateOwnedLoadedEmpty_ClearsPreviewLoading`) that fail on `main` and pass with the fix

## Test plan
- [x] `go test -race ./...` passes
- [x] Both new regression tests fail on `main` (verified by running RED before the fix)
- [x] Existing `TestFinal2UpdateResourcesLoadedMsgPreviewLoadingArmed` still passes (non-empty Pod loads still dispatch a preview cmd, so the flag stays true through the gap)
- [x] `go vet ./...` clean
- [x] `gofumpt -d` clean
- [ ] Manual smoke: select an empty namespace, drill into Secrets — middle shows "No resources found", right pane no longer spins