### PR TITLE
fix(release): migrate cosign signing to Sigstore bundle output

### DIFF
--- a/.goreleaser.nightly.yaml
+++ b/.goreleaser.nightly.yaml
@@ -109,13 +109,22 @@ checksum:
 
 # Keyless cosign signing via Sigstore + GitHub OIDC.
 # Requires `id-token: write` permission and `sigstore/cosign-installer` in CI.
+#
+# Output is a single Sigstore bundle (cert + signature + transparency-log
+# entry combined). The previous --output-certificate / --output-signature
+# pair was deprecated in cosign v2.5 and broken in v2.6 (the sign-blob
+# code path always emits a bundle internally; without --bundle the path
+# is empty and the open() call fails). Verify with:
+#   cosign verify-blob \
+#     --bundle checksums.txt.cosign.bundle \
+#     --certificate-identity-regexp 'https://github\.com/janosmiko/lfk/.*' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     checksums.txt
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${artifact}.cosign.bundle"
       - "${artifact}"
       - "--yes"
     artifacts: checksum

--- a/.goreleaser.stable.yaml
+++ b/.goreleaser.stable.yaml
@@ -108,13 +108,22 @@ checksum:
 
 # Keyless cosign signing via Sigstore + GitHub OIDC.
 # Requires `id-token: write` permission and `sigstore/cosign-installer` in CI.
+#
+# Output is a single Sigstore bundle (cert + signature + transparency-log
+# entry combined). The previous --output-certificate / --output-signature
+# pair was deprecated in cosign v2.5 and broken in v2.6 (the sign-blob
+# code path always emits a bundle internally; without --bundle the path
+# is empty and the open() call fails). Verify with:
+#   cosign verify-blob \
+#     --bundle checksums.txt.cosign.bundle \
+#     --certificate-identity-regexp 'https://github\.com/janosmiko/lfk/.*' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     checksums.txt
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${artifact}.cosign.bundle"
       - "${artifact}"
       - "--yes"
     artifacts: checksum


### PR DESCRIPTION
## Summary

- Switch `sign-blob` to `--bundle=\${artifact}.cosign.bundle` in both stable + nightly goreleaser configs
- Remove deprecated `--output-certificate` / `--output-signature` (and the corresponding `certificate:` field)
- Add inline comment with the matching `cosign verify-blob --bundle ...` command for downstream consumers

## Why

Cosign v2.6 broke the deprecated `--output-signature` / `--output-certificate` flags in `sign-blob`. Internally `sign-blob` now always writes a bundle, and without `--bundle=PATH` the path is empty so the `open(\"\", ...)` call fails. The v0.9.39 release run failed with:

> Error: signing dist/checksums.txt: create bundle file: open : no such file or directory

See failed run: https://github.com/janosmiko/lfk/actions/runs/25343752698/job/74307808976

The bundle is a single file containing the cert, signature, and transparency-log entry — it is the modern `verify-blob` input and is forward-compatible with cosign v2.5+.

## Test plan

- [x] `goreleaser check --config .goreleaser.stable.yaml` passes
- [x] `goreleaser check --config .goreleaser.nightly.yaml` passes
- [ ] After merge: re-tag v0.9.39 and confirm the release workflow completes through the cosign step
- [ ] Verify the published bundle with `cosign verify-blob --bundle checksums.txt.cosign.bundle ...` against the released `checksums.txt`