### PR TITLE
fix(ui): stop selector overlays from shrinking on filter

### DIFF
--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -67,8 +67,16 @@ func (m Model) renderOverlay(background string) string {
 func (m Model) renderOverlayContent() (string, int, int, bool) {
 	switch m.overlay {
 	case overlayNamespace:
-		content := ui.RenderNamespaceOverlay(m.filteredOverlayItems(), m.overlayFilter.Value, m.overlayCursor, m.namespace, m.allNamespaces, m.selectedNamespaces, m.nsFilterMode)
-		return content, min(60, m.width-10), min(20, m.height-6), true
+		// Pass the same height to the renderer that we declare on the
+		// overlay box, so the renderer's visible-item cap matches what
+		// fits. Otherwise on a list of 30+ namespaces the renderer
+		// emits ~21 lines into a 20-tall box; lipgloss grows the box
+		// on overflow, and the user sees it "shrink" back to 20 the
+		// moment a filter narrows the list.
+		overlayW := min(60, m.width-10)
+		overlayH := min(20, m.height-6)
+		content := ui.RenderNamespaceOverlay(m.filteredOverlayItems(), m.overlayFilter.Value, m.overlayCursor, m.namespace, m.allNamespaces, m.selectedNamespaces, m.nsFilterMode, overlayH)
+		return content, overlayW, overlayH, true
 	case overlayAction:
 		w := min(70, m.width-10)
 		return ui.RenderActionOverlay(m.overlayItems, m.overlayCursor, w), w, min(15, m.height-6), true

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -155,7 +155,16 @@ type NetpolPeerEntry struct {
 const bookmarkModeFilter = 1
 
 // RenderNamespaceOverlay renders the namespace selection overlay content.
-func RenderNamespaceOverlay(items []model.Item, filter string, cursor int, currentNs string, allNs bool, selectedNamespaces map[string]bool, filterMode bool) string {
+//
+// The height parameter is the overlay box height the caller will pass to
+// OverlayStyle.Height(). The renderer caps its visible-item count to fit
+// inside that budget so lipgloss never has to grow the box on overflow \u2014
+// without this, a list of 30+ namespaces overflows a 20-tall box (the
+// renderer used to emit ~21 lines), and as the user typed into the
+// filter the box visibly "shrank" back to its declared size when fewer
+// items fit. Mirrors the layout contract enforced for the column toggle
+// overlay.
+func RenderNamespaceOverlay(items []model.Item, filter string, cursor int, currentNs string, allNs bool, selectedNamespaces map[string]bool, filterMode bool, height int) string {
 	var b strings.Builder
 	b.WriteString(OverlayTitleStyle.Render("Select Namespace"))
 	b.WriteString("\n")
@@ -180,7 +189,21 @@ func RenderNamespaceOverlay(items []model.Item, filter string, cursor int, curre
 		return b.String()
 	}
 
-	maxVisible := min(15, len(items))
+	// Reserve rows the rendered overlay needs that the caller's `height`
+	// must absorb:
+	//   chrome: title (1 + 1 bottom padding) + filter (1) + blank
+	//           separator (1) + scroll-above (1) + scroll-below (1) = 6
+	//   lipgloss vertical padding from OverlayStyle.Padding(1,2):     2
+	// so the item budget is `height - 8`.
+	//
+	// Reserving only 6 (the obvious chrome) is wrong: lipgloss
+	// `Height(h)` measures the *content area including padding*, so
+	// padding eats 2 rows out of `height` — content over `height-2`
+	// makes lipgloss grow the box on overflow, and as the filter
+	// narrows the list the box visibly "shrinks" back to its nominal
+	// size (the 21→20→…→22 cascade the user reported, observed right
+	// as the "↓ N below" indicator turns into its placeholder row).
+	maxVisible := min(max(height-8, 1), len(items))
 	scrollOff := ConfigScrollOff
 	// Disable or reduce scrolloff when all items fit the visible area.
 	if len(items) <= maxVisible {

--- a/internal/ui/overlay_columns.go
+++ b/internal/ui/overlay_columns.go
@@ -48,9 +48,19 @@ func RenderColumnToggleOverlay(entries []ColumnToggleEntry, cursor int, filter s
 
 	innerW := max(width-6, 20)
 
-	// Reserve rows for title (1) + filter (1) + blank separator (1) +
-	// overlay border/padding (~3) so the visible-item count is honest.
-	maxVisible := max(height-6, 1)
+	// Reserve rows the rendered overlay needs that the caller's `height`
+	// must absorb:
+	//   chrome: title (1 + 1 bottom padding) + filter (1) + blank
+	//           separator (1) + scroll-above (1) + scroll-below (1) = 6
+	//   lipgloss vertical padding from OverlayStyle.Padding(1,2):     2
+	// so the item budget is `height - 8`.
+	//
+	// Reserving only 6 (the obvious chrome) is wrong: lipgloss
+	// `Height(h)` measures the content area inclusive of padding, so
+	// padding eats 2 rows out of `height` — content >`height-2` makes
+	// lipgloss grow the box on overflow, and as the filter narrows the
+	// list the box visibly shrinks back to its nominal size.
+	maxVisible := max(height-8, 1)
 	scrollOff := ConfigScrollOff
 	if maxVisible < 8 {
 		scrollOff = 0

--- a/internal/ui/overlay_columns_filter_layout_test.go
+++ b/internal/ui/overlay_columns_filter_layout_test.go
@@ -67,17 +67,17 @@ func TestColumnToggleOverlay_FilterActiveShowsCursor(t *testing.T) {
 }
 
 // As the user types and filter narrows, the renderer must NOT emit
-// more lines than the box can hold. Bug repro: with 30 entries and
-// height=20, the renderer used to emit ~34 lines (it computed
-// maxVisible from full screen height instead of the box height the
-// caller passes in), overflowing the box. Then as filter narrowed,
-// the content shrank back below 20 and the visible box appeared to
-// "shrink" from overflow size back to the nominal box size.
+// more lines than lipgloss can absorb inside the declared box. Bug
+// repro: with 30 entries and height=20, the renderer used to emit 20
+// content lines, but lipgloss `OverlayStyle.Height(20)` only fits 18
+// rows of content (the remaining 2 are vertical padding from
+// Padding(1,2)). Lipgloss grew the box on overflow; as filter narrowed,
+// the content fit again and the box shrank back to its nominal size.
 //
-// The number of content lines must stay <= height regardless of how
-// many entries are present, so lipgloss can pad the rendered overlay
-// to the same fixed size every time.
-func TestColumnToggleOverlay_LineCountFitsHeightBudget(t *testing.T) {
+// The renderer must keep its content within the lipgloss-padded budget
+// (height - 2 for vertical padding), so the final rendered box has the
+// same row count for every filter state.
+func TestColumnToggleOverlay_LineCountFitsPaddedBudget(t *testing.T) {
 	manyEntries := make([]ColumnToggleEntry, 30)
 	for i := range manyEntries {
 		manyEntries[i] = ColumnToggleEntry{Key: "col" + string(rune('A'+i%26))}
@@ -85,6 +85,33 @@ func TestColumnToggleOverlay_LineCountFitsHeightBudget(t *testing.T) {
 	const height = 20
 	out := RenderColumnToggleOverlay(manyEntries, 0, "", false, 50, height)
 	lines := strings.Count(out, "\n") + 1
-	assert.LessOrEqual(t, lines, height,
-		"renderer must respect the height budget — overflow makes the overlay box grow past its target dimensions")
+	assert.LessOrEqual(t, lines, height-2,
+		"content must fit the lipgloss-padded inner area (height - 2 for OverlayStyle.Padding(1,2)); otherwise the box grows on overflow and visibly shrinks back when the filter narrows the list")
+}
+
+// Pin the user-visible symptom: the OUTER box (after FillLinesBg +
+// OverlayStyle.Height) must have the same row count across every
+// filter state, so the box doesn't visibly shrink as the user types.
+func TestColumnToggleOverlay_FullBoxHeightStableAcrossFilterStates(t *testing.T) {
+	entries := make([]ColumnToggleEntry, 30)
+	for i := range entries {
+		entries[i] = ColumnToggleEntry{Key: "col" + string(rune('A'+i%26))}
+	}
+	const height = 20
+	const width = 50
+
+	render := func(slice []ColumnToggleEntry, filter string, fActive bool) int {
+		content := RenderColumnToggleOverlay(slice, 0, filter, fActive, width, height)
+		filled := FillLinesBg(content, width-4, SurfaceBg)
+		full := OverlayStyle.Width(width).Height(height).Render(filled)
+		return strings.Count(full, "\n") + 1
+	}
+
+	baseline := render(entries, "", false)
+	for _, n := range []int{30, 15, 14, 13, 12, 11, 5, 1} {
+		got := render(entries[:n], "col", true)
+		assert.Equal(t, baseline, got,
+			"full overlay box must be the same height for entries=%d (baseline=%d, got=%d)",
+			n, baseline, got)
+	}
 }

--- a/internal/ui/overlay_namespace_filter_empty_test.go
+++ b/internal/ui/overlay_namespace_filter_empty_test.go
@@ -13,7 +13,7 @@ import (
 // matches). Callers must pass an empty slice for the no-match case, not
 // nil, otherwise the user sees the loading spinner forever.
 func TestRenderNamespaceOverlay_EmptySliceShowsNoMatch(t *testing.T) {
-	out := RenderNamespaceOverlay([]model.Item{}, "weird-text", 0, "default", false, nil, false)
+	out := RenderNamespaceOverlay([]model.Item{}, "weird-text", 0, "default", false, nil, false, 20)
 	plain := stripANSI(out)
 	assert.NotContains(t, plain, "Loading",
 		"empty slice with active filter must not look like the pre-fetch loader")

--- a/internal/ui/overlay_namespace_layout_test.go
+++ b/internal/ui/overlay_namespace_layout_test.go
@@ -1,0 +1,84 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// As the user types and the filter narrows the namespace list, the
+// renderer must NOT emit more lines than lipgloss can pad inside the
+// declared box. The user-visible bug pattern: with 30 namespaces and a
+// height=20 box the renderer used to emit 20–21 content lines, which
+// is more than lipgloss can absorb in `OverlayStyle.Height(20)` (the
+// content area inside Padding(1,2) is only 18 rows). Lipgloss grew the
+// box on overflow; as the filter narrowed the list, the content fit
+// inside 18 again and the box "shrank" back — the user noticed this
+// transition right as the "↓ N below" indicator turned into its
+// placeholder row.
+//
+// The renderer must keep its content within the lipgloss-padded budget
+// (height - 2 for vertical padding), so the final rendered box has the
+// same row count for every filter state.
+func TestRenderNamespaceOverlay_LineCountFitsPaddedBudget(t *testing.T) {
+	manyItems := make([]model.Item, 30)
+	for i := range manyItems {
+		manyItems[i] = model.Item{Name: fmt.Sprintf("ns-%d", i)}
+	}
+	const height = 20
+	out := RenderNamespaceOverlay(manyItems, "", 0, "default", false, nil, false, height)
+	lines := strings.Count(out, "\n") + 1
+	assert.LessOrEqual(t, lines, height-2,
+		"content must fit the lipgloss-padded inner area (height - 2 for OverlayStyle.Padding(1,2)); otherwise the box grows on overflow and visibly shrinks back when the filter narrows the list")
+}
+
+// The visible symptom the user reports is the OUTER box changing size
+// across filter states. This pins it: render the full overlay (the
+// same path renderOverlay walks — FillLinesBg + OverlayStyle.Height) at
+// every interesting list size and verify the row count is identical.
+// Without this, the renderer can pass `lines <= height` while still
+// allowing lipgloss to expand the box on a near-overflow input.
+func TestRenderNamespaceOverlay_FullBoxHeightStableAcrossFilterStates(t *testing.T) {
+	items := make([]model.Item, 30)
+	for i := range items {
+		items[i] = model.Item{Name: fmt.Sprintf("ns-%d", i)}
+	}
+	const height = 20
+	const width = 60
+
+	render := func(slice []model.Item, filter string, fmode bool) int {
+		content := RenderNamespaceOverlay(slice, filter, 0, "default", false, nil, fmode, height)
+		filled := FillLinesBg(content, width-4, SurfaceBg)
+		full := OverlayStyle.Width(width).Height(height).Render(filled)
+		return strings.Count(full, "\n") + 1
+	}
+
+	baseline := render(items, "", false)
+	// Walk the filter through the boundaries that historically moved
+	// the box: full list, just over the visible cap, exactly the cap,
+	// just under the cap (where "↓ N below" turns into placeholder),
+	// and well below.
+	cases := []struct {
+		label string
+		slice []model.Item
+	}{
+		{"30", items},
+		{"15", items[:15]},
+		{"14", items[:14]},
+		{"13", items[:13]},
+		{"12", items[:12]},
+		{"5", items[:5]},
+		{"3", items[:3]},
+		{"1", items[:1]},
+	}
+	for _, c := range cases {
+		got := render(c.slice, "ns", true)
+		assert.Equal(t, baseline, got,
+			"full overlay box height must be identical for items=%s (baseline=%d, got=%d) — otherwise the user sees the box shrink as they type",
+			c.label, baseline, got)
+	}
+}

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestRenderNamespaceOverlay(t *testing.T) {
 	t.Run("nil items shows loading", func(t *testing.T) {
-		result := RenderNamespaceOverlay(nil, "", 0, "default", false, nil, false)
+		result := RenderNamespaceOverlay(nil, "", 0, "default", false, nil, false, 20)
 		assert.Contains(t, result, "Loading namespaces")
 	})
 
 	t.Run("empty items shows no matching", func(t *testing.T) {
-		result := RenderNamespaceOverlay([]model.Item{}, "", 0, "default", false, nil, false)
+		result := RenderNamespaceOverlay([]model.Item{}, "", 0, "default", false, nil, false, 20)
 		assert.Contains(t, result, "No matching namespaces")
 	})
 
@@ -30,7 +30,7 @@ func TestRenderNamespaceOverlay(t *testing.T) {
 			{Name: "kube-system"},
 			{Name: "production"},
 		}
-		result := RenderNamespaceOverlay(items, "", 0, "default", false, nil, false)
+		result := RenderNamespaceOverlay(items, "", 0, "default", false, nil, false, 20)
 		assert.Contains(t, result, "default")
 		assert.Contains(t, result, "kube-system")
 		assert.Contains(t, result, "production")
@@ -42,7 +42,7 @@ func TestRenderNamespaceOverlay(t *testing.T) {
 			{Name: "staging"},
 		}
 		selected := map[string]bool{"staging": true}
-		result := RenderNamespaceOverlay(items, "", 0, "default", false, selected, false)
+		result := RenderNamespaceOverlay(items, "", 0, "default", false, selected, false, 20)
 		assert.Contains(t, result, "\u2713")
 	})
 
@@ -50,27 +50,27 @@ func TestRenderNamespaceOverlay(t *testing.T) {
 		items := []model.Item{
 			{Name: "All Namespaces", Status: "all"},
 		}
-		result := RenderNamespaceOverlay(items, "", 0, "", true, nil, false)
+		result := RenderNamespaceOverlay(items, "", 0, "", true, nil, false, 20)
 		assert.Contains(t, result, "\u2713")
 	})
 
 	t.Run("filter mode shows cursor", func(t *testing.T) {
 		items := []model.Item{{Name: "default"}}
-		result := RenderNamespaceOverlay(items, "def", 0, "", false, nil, true)
+		result := RenderNamespaceOverlay(items, "def", 0, "", false, nil, true, 20)
 		assert.Contains(t, result, "def")
 		assert.Contains(t, result, "\u2588") // block cursor
 	})
 
 	t.Run("shows filter hint when not in filter mode", func(t *testing.T) {
 		items := []model.Item{{Name: "default"}}
-		result := RenderNamespaceOverlay(items, "", 0, "", false, nil, false)
+		result := RenderNamespaceOverlay(items, "", 0, "", false, nil, false, 20)
 		assert.Contains(t, result, "/ to filter")
 	})
 
 	t.Run("footer hints removed from overlay body", func(t *testing.T) {
 		// Hints now live in the main status bar, not inline.
 		items := []model.Item{{Name: "default"}}
-		result := RenderNamespaceOverlay(items, "", 0, "", false, nil, false)
+		result := RenderNamespaceOverlay(items, "", 0, "", false, nil, false, 20)
 		assert.NotContains(t, result, "space: select")
 		assert.NotContains(t, result, "enter: apply")
 		assert.NotContains(t, result, "esc: close")


### PR DESCRIPTION
## Summary
- Namespace and column-toggle overlays were resizing as the user typed in the filter, with the most jarring transition right as the "↓ N below" indicator turned into its placeholder row.
- Two compounding issues: (1) `RenderNamespaceOverlay` ignored the box height the caller declared and capped its visible-item count at a hardcoded 15, so 30 namespaces emitted ~21 lines into a 20-tall box; (2) the existing column-toggle fix used `height-6`, but `OverlayStyle.Height(h)` measures the content area inclusive of `Padding(1,2)`, so the real content budget is `h-2` and the renderer was still over the inner budget at full list — lipgloss grew the box on overflow and shrank it back as the filter trimmed the list.
- Fix: both renderers now compute `maxVisible = max(height-8, 1)` (chrome 6 + vertical padding 2) and the namespace caller passes the box height into `RenderNamespaceOverlay`. Full overlay box renders at the same row count for every filter state.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/ui/... ./internal/app/... -count=1 -race`
- [x] New `TestRenderNamespaceOverlay_FullBoxHeightStableAcrossFilterStates` and `TestColumnToggleOverlay_FullBoxHeightStableAcrossFilterStates` assert the OUTER box height (after `FillLinesBg` + `OverlayStyle.Height`) is identical across filter sizes — replaces the previous `lines <= height` checks, which were a false-pass that allowed the lipgloss-padding overflow.
- [ ] Smoke-test in a live cluster: open namespace selector with 20+ namespaces, type into the filter, confirm the overlay box stays the same size as items narrow.