### PR TITLE
fix(metrics): stop ~1Hz column-order blink on PodInitializing rows

### DIFF
--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -339,6 +339,12 @@ func (m Model) updatePodMetricsEnriched(msg podMetricsEnrichedMsg) Model {
 // supplied by an earlier tick. Raw "CPU Req"/"CPU Lim"/"Mem Req"/"Mem Lim"
 // values are preserved so the next successful tick can recompute the
 // percentage columns.
+//
+// Column order MUST match updatePodMetricsEnriched and
+// carryOverMetricsColumns (CPU/MEM first, everything else after) — otherwise
+// every watch tick on PodInitializing/CrashLoopBackOff pods (where metrics-
+// server has no data) flips Reason/QoS/etc. between two positions, producing
+// a visible ~1Hz layout blink.
 func clearStalePodMetricsColumns(item *model.Item) {
 	removeCols := map[string]bool{
 		"CPU":     true,
@@ -347,21 +353,20 @@ func clearStalePodMetricsColumns(item *model.Item) {
 		"Mem Use": true,
 		"CPU/R":   true, "CPU/L": true, "MEM/R": true, "MEM/L": true,
 	}
-	filtered := item.Columns[:0]
+	newCols := []model.KeyValue{
+		{Key: "CPU", Value: "n/a"},
+		{Key: "CPU/R", Value: "n/a"},
+		{Key: "CPU/L", Value: "n/a"},
+		{Key: "MEM", Value: "n/a"},
+		{Key: "MEM/R", Value: "n/a"},
+		{Key: "MEM/L", Value: "n/a"},
+	}
 	for _, kv := range item.Columns {
 		if !removeCols[kv.Key] {
-			filtered = append(filtered, kv)
+			newCols = append(newCols, kv)
 		}
 	}
-	filtered = append(filtered,
-		model.KeyValue{Key: "CPU", Value: "n/a"},
-		model.KeyValue{Key: "CPU/R", Value: "n/a"},
-		model.KeyValue{Key: "CPU/L", Value: "n/a"},
-		model.KeyValue{Key: "MEM", Value: "n/a"},
-		model.KeyValue{Key: "MEM/R", Value: "n/a"},
-		model.KeyValue{Key: "MEM/L", Value: "n/a"},
-	)
-	item.Columns = filtered
+	item.Columns = newCols
 }
 
 // ensureNodeMetricsColumnsPlaceholder adds CPU/CPU%/MEM/MEM% columns to a node

--- a/internal/app/update_msg_extra_test.go
+++ b/internal/app/update_msg_extra_test.go
@@ -1713,6 +1713,99 @@ func TestUpdatePodMetricsEnrichedClearsStaleRowOnMissingPod(t *testing.T) {
 	assert.Equal(t, "100m", col("CPU Req"), "raw request column must survive so the next successful tick can recompute")
 }
 
+// Regression: PodInitializing/CrashLoopBackOff pods saw the Reason column
+// hop between two positions every watch tick because the three paths that
+// rebuild item.Columns disagreed on order. carryOverMetricsColumns and
+// updatePodMetricsEnriched put CPU/MEM first then everything else;
+// clearStalePodMetricsColumns used to put everything else first then CPU/MEM,
+// so each tick flipped the column order and the user saw a ~1 Hz layout blink.
+// Pin the order: CPU/MEM block first, all other columns after, identical
+// across all three paths.
+func TestPodMetricsColumnOrderIsStableAcrossAllPaths(t *testing.T) {
+	metricsKeys := []string{"CPU", "CPU/R", "CPU/L", "MEM", "MEM/R", "MEM/L"}
+	keysOf := func(cols []model.KeyValue) []string {
+		ks := make([]string, len(cols))
+		for i, kv := range cols {
+			ks[i] = kv.Key
+		}
+		return ks
+	}
+	assertCPUMemFirst := func(t *testing.T, label string, cols []model.KeyValue) {
+		t.Helper()
+		require.GreaterOrEqual(t, len(cols), len(metricsKeys), "%s: too few columns", label)
+		for i, want := range metricsKeys {
+			assert.Equal(t, want, cols[i].Key, "%s: column %d must be %q (CPU/MEM block before other columns); full order=%v", label, i, want, keysOf(cols))
+		}
+	}
+
+	// Path 1: clearStalePodMetricsColumns (no metrics for this pod).
+	t.Run("clearStalePodMetricsColumns", func(t *testing.T) {
+		m := baseModel()
+		m.middleItems = []model.Item{{
+			Name: "pod-x", Namespace: "default",
+			Columns: []model.KeyValue{
+				{Key: "Reason", Value: "PodInitializing"},
+				{Key: "QoS", Value: "BestEffort"},
+				{Key: "CPU Req", Value: "100m"},
+				{Key: "CPU", Value: "42m"}, // stale prior-tick value
+			},
+		}}
+		result, _ := m.Update(podMetricsEnrichedMsg{
+			metrics: map[string]model.PodMetrics{"default/other": {Name: "other"}},
+			gen:     0,
+		})
+		assertCPUMemFirst(t, "clearStale", result.(Model).middleItems[0].Columns)
+	})
+
+	// Path 2: updatePodMetricsEnriched with real metrics for this pod.
+	t.Run("updatePodMetricsEnriched", func(t *testing.T) {
+		m := baseModel()
+		m.middleItems = []model.Item{{
+			Name: "pod-x", Namespace: "default",
+			Columns: []model.KeyValue{
+				{Key: "Reason", Value: "Running"},
+				{Key: "QoS", Value: "BestEffort"},
+				{Key: "CPU Req", Value: "100m"},
+			},
+		}}
+		result, _ := m.Update(podMetricsEnrichedMsg{
+			metrics: map[string]model.PodMetrics{
+				"default/pod-x": {Name: "pod-x", CPU: 50, Memory: 100 * 1024 * 1024},
+			},
+			gen: 0,
+		})
+		assertCPUMemFirst(t, "enriched", result.(Model).middleItems[0].Columns)
+	})
+
+	// Path 3: carryOverMetricsColumns (watch tick replacing items).
+	t.Run("carryOverMetricsColumns", func(t *testing.T) {
+		m := baseModel()
+		m.middleItems = []model.Item{{
+			Name: "pod-x", Namespace: "default",
+			Columns: []model.KeyValue{
+				{Key: "CPU", Value: "n/a"},
+				{Key: "CPU/R", Value: "n/a"},
+				{Key: "CPU/L", Value: "n/a"},
+				{Key: "MEM", Value: "n/a"},
+				{Key: "MEM/R", Value: "n/a"},
+				{Key: "MEM/L", Value: "n/a"},
+				{Key: "Reason", Value: "PodInitializing"},
+				{Key: "QoS", Value: "BestEffort"},
+			},
+		}}
+		newItems := []model.Item{{
+			Name: "pod-x", Namespace: "default",
+			Columns: []model.KeyValue{
+				{Key: "Reason", Value: "PodInitializing"},
+				{Key: "QoS", Value: "BestEffort"},
+				{Key: "CPU Req", Value: "100m"},
+			},
+		}}
+		m.carryOverMetricsColumns(newItems)
+		assertCPUMemFirst(t, "carryOver", newItems[0].Columns)
+	})
+}
+
 // --- nodeMetricsEnrichedMsg ---
 
 func TestUpdateNodeMetricsEnrichedStaleGen(t *testing.T) {


### PR DESCRIPTION
## Summary

The pod list visibly blinks every watch tick when any visible row is in a state metrics-server can't report on (`PodInitializing`, `CrashLoopBackOff`, evicted, etc.). The `REASON` (and any other extra column) hops between two positions, shifting the entire middle-column layout.

## Root cause

Three functions rebuild `item.Columns` and disagreed on the order of the CPU/MEM block:

| Path | File | Old order |
|---|---|---|
| `updatePodMetricsEnriched` (metrics found) | `update_metrics_msgs.go:311` | CPU/MEM **first** |
| `carryOverMetricsColumns` (watch-tick carry) | `cursor.go:174` | CPU/MEM **first** |
| `clearStalePodMetricsColumns` (no metrics) | `update_metrics_msgs.go:342` | CPU/MEM **last** |

Cycle every watch tick:
1. Watch tick lands → `carryOverMetricsColumns` prepends CPU/MEM → `[CPU…, Reason, …]` (brief layout)
2. ~100 ms later, metrics response arrives empty for the row → `clearStalePodMetricsColumns` appends CPU/MEM → `[Reason, …, CPU…]` (steady layout)
3. Repeat → ~1 Hz blink.

Confirmed by dumping every `View()` frame to disk and finding REASON oscillating between two column positions on a 1 s cadence.

## Fix

Make `clearStalePodMetricsColumns` build columns in the same order as the other two paths (CPU/MEM first, everything else after). Pin the invariant with a comment.

## Test plan

- [x] New regression test `TestPodMetricsColumnOrderIsStableAcrossAllPaths` exercises all three rebuild entry points and asserts CPU/MEM occupy slots 0-5
- [x] Confirmed the test fails before the fix (only the `clearStalePodMetricsColumns` subtest) and passes after
- [x] `go test ./...` green
- [x] `golangci-lint` clean (pre-commit hook)