### PR TITLE
fix(release): declare cosign bundle as signature artifact

### DIFF
--- a/.goreleaser.nightly.yaml
+++ b/.goreleaser.nightly.yaml
@@ -122,9 +122,10 @@ checksum:
 #     checksums.txt
 signs:
   - cmd: cosign
+    signature: "${artifact}.cosign.bundle"
     args:
       - sign-blob
-      - "--bundle=${artifact}.cosign.bundle"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum

--- a/.goreleaser.stable.yaml
+++ b/.goreleaser.stable.yaml
@@ -121,9 +121,10 @@ checksum:
 #     checksums.txt
 signs:
   - cmd: cosign
+    signature: "${artifact}.cosign.bundle"
     args:
       - sign-blob
-      - "--bundle=${artifact}.cosign.bundle"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum


### PR DESCRIPTION
## Summary

The v0.10.0 release publish failed at the very end with:

```
failed to upload checksums.txt.sig: open dist/checksums.txt.sig: no such file or directory
```

([failed run](https://github.com/janosmiko/lfk/actions/runs/25378651557/job/74420950105))

After #141 migrated cosign signing to `--bundle=${artifact}.cosign.bundle`, cosign no longer writes `${artifact}.sig`. But the `signs:` block didn't update GoReleaser's `signature:` field, which still defaults to `${artifact}.sig` — so GoReleaser registers the wrong filename for upload, succeeds at signing, then errors out trying to upload a file that was never produced.

Fix: set `signature: "${artifact}.cosign.bundle"` in both stable and nightly configs, and reuse `${signature}` in the cosign args so the path is defined once.

## Test plan

- [x] `goreleaser check -f .goreleaser.stable.yaml` passes
- [x] `goreleaser check -f .goreleaser.nightly.yaml` passes
- [ ] Cut a patch release (e.g. v0.10.1) after merge and confirm the publish step uploads `checksums.txt.cosign.bundle` to the GitHub release
- [ ] Verify with: `cosign verify-blob --bundle checksums.txt.cosign.bundle --certificate-identity-regexp 'https://github\.com/janosmiko/lfk/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt`

## Notes on the existing v0.10.0 release

The v0.10.0 GitHub release was created and all artifacts before `checksums.txt.sig` uploaded successfully (archives, packages, SBOMs, `checksums.txt`). Only the signature is missing. Options after this PR merges:

1. Cut v0.10.1 with this fix and let users move forward
2. Manually upload the bundle to the existing v0.10.0 release using `gh release upload v0.10.0 dist/checksums.txt.cosign.bundle` (requires running the same commit through goreleaser locally with the same OIDC identity, which isn't reproducible — option 1 is cleaner)