### PR TITLE
fix(release): rename cosign bundle to .sigstore for Scorecard

### DIFF
--- a/.goreleaser.nightly.yaml
+++ b/.goreleaser.nightly.yaml
@@ -114,15 +114,21 @@ checksum:
 # entry combined). The previous --output-certificate / --output-signature
 # pair was deprecated in cosign v2.5 and broken in v2.6 (the sign-blob
 # code path always emits a bundle internally; without --bundle the path
-# is empty and the open() call fails). Verify with:
+# is empty and the open() call fails).
+#
+# The `.sigstore` extension is the Sigstore bundle convention and is the
+# extension OpenSSF Scorecard recognises as a release signature (see
+# probes/releasesAreSigned in github.com/ossf/scorecard). A previous
+# `.cosign.bundle` name uploaded successfully but Scorecard reported the
+# release as unsigned. Verify with:
 #   cosign verify-blob \
-#     --bundle checksums.txt.cosign.bundle \
+#     --bundle checksums.txt.sigstore \
 #     --certificate-identity-regexp 'https://github\.com/janosmiko/lfk/.*' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
 #     checksums.txt
 signs:
   - cmd: cosign
-    signature: "${artifact}.cosign.bundle"
+    signature: "${artifact}.sigstore"
     args:
       - sign-blob
       - "--bundle=${signature}"

--- a/.goreleaser.stable.yaml
+++ b/.goreleaser.stable.yaml
@@ -113,15 +113,21 @@ checksum:
 # entry combined). The previous --output-certificate / --output-signature
 # pair was deprecated in cosign v2.5 and broken in v2.6 (the sign-blob
 # code path always emits a bundle internally; without --bundle the path
-# is empty and the open() call fails). Verify with:
+# is empty and the open() call fails).
+#
+# The `.sigstore` extension is the Sigstore bundle convention and is the
+# extension OpenSSF Scorecard recognises as a release signature (see
+# probes/releasesAreSigned in github.com/ossf/scorecard). A previous
+# `.cosign.bundle` name uploaded successfully but Scorecard reported the
+# release as unsigned. Verify with:
 #   cosign verify-blob \
-#     --bundle checksums.txt.cosign.bundle \
+#     --bundle checksums.txt.sigstore \
 #     --certificate-identity-regexp 'https://github\.com/janosmiko/lfk/.*' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
 #     checksums.txt
 signs:
   - cmd: cosign
-    signature: "${artifact}.cosign.bundle"
+    signature: "${artifact}.sigstore"
     args:
       - sign-blob
       - "--bundle=${signature}"


### PR DESCRIPTION
## Summary

- Rename the cosign signature artifact from `${artifact}.cosign.bundle` to `${artifact}.sigstore` in both `.goreleaser.stable.yaml` and `.goreleaser.nightly.yaml` so OpenSSF Scorecard's `releasesAreSigned` check recognises the upload.
- Expand the inline doc-comment to record the Scorecard constraint and update the `cosign verify-blob` example to the new filename so the rename does not regress.

## Why

Scorecard's `releasesAreSigned` probe only counts an asset as a signature when its name ends in `.asc`, `.minisig`, `.sig`, `.sign`, `.sigstore`, or `.sigstore.json` (`probes/releasesAreSigned/impl.go` in github.com/ossf/scorecard). After #141 migrated cosign to a Sigstore bundle and #150 wired the bundle into the upload set, the asset is uploaded correctly (verified `checksums.txt.cosign.bundle` is present on v0.10.1) but Scorecard ignores the `.cosign.bundle` extension. Result:

> 3 out of the last 5 releases have a total of 3 signed artifacts.
> Warn: release artifact v0.10.1 not signed

`.sigstore` is the standard Sigstore bundle extension, produces the same bundle bytes (only `--bundle=${signature}` path changes), and is on Scorecard's allowlist.

## Test plan

- [x] `goreleaser check --config .goreleaser.stable.yaml` passes
- [x] `goreleaser check --config .goreleaser.nightly.yaml` passes
- [ ] Cut the next release tag and confirm `checksums.txt.sigstore` appears in the release assets
- [ ] Re-run / wait for the Scorecard workflow and confirm the signed-releases warning clears once two releases ship under the new name (so v0.10.0 / v0.10.1 roll out of the 5-release window)
- [ ] Spot-check verification: `cosign verify-blob --bundle checksums.txt.sigstore --certificate-identity-regexp 'https://github\.com/janosmiko/lfk/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt`