### PR TITLE
fix(filter): clear active filter preset on Esc

### DIFF
--- a/internal/app/explorer_esc_clears_filter_preset_test.go
+++ b/internal/app/explorer_esc_clears_filter_preset_test.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Applying a quick filter preset (e.g. "Failing pods" via .) sets
+// m.activeFilterPreset and stashes the pre-filter list in
+// m.unfilteredMiddleItems. Esc must peel that layer off the same way it
+// already peels selection / search / filterText, so users don't have to
+// reach for . a second time just to undo a preset.
+func TestExplorerEscClearsActiveFilterPreset(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "test-ctx"
+	full := []model.Item{
+		{Name: "pod-a", Kind: "Pod"},
+		{Name: "pod-b", Kind: "Pod"},
+		{Name: "pod-c", Kind: "Pod"},
+	}
+	filtered := []model.Item{{Name: "pod-b", Kind: "Pod"}}
+	m.setMiddleItems(filtered)
+	m.unfilteredMiddleItems = full
+	m.activeFilterPreset = &FilterPreset{Name: "Failing"}
+
+	r, _ := m.handleExplorerEsc()
+	rm := r.(Model)
+
+	assert.Nil(t, rm.activeFilterPreset,
+		"Esc must clear the active filter preset")
+	assert.Nil(t, rm.unfilteredMiddleItems,
+		"Esc must drop the saved unfiltered snapshot once the preset is cleared")
+	assert.Equal(t, full, rm.middleItems,
+		"Esc must restore the pre-preset middle items")
+	assert.Contains(t, rm.statusMessage, "Failing",
+		"Esc clearing a preset should announce which preset was dropped")
+}
+
+// Esc cascade: filterText is the most recently-typed state, so it peels
+// before activeFilterPreset. With both layers present, the first Esc
+// clears the typed filter, leaving the preset intact for a second Esc.
+func TestExplorerEscClearsFilterTextBeforeFilterPreset(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "test-ctx"
+	m.filterText = "nginx"
+	m.activeFilterPreset = &FilterPreset{Name: "Failing"}
+	m.unfilteredMiddleItems = []model.Item{{Name: "pod-a"}}
+
+	r, _ := m.handleExplorerEsc()
+	rm := r.(Model)
+
+	assert.Empty(t, rm.filterText, "first Esc clears the typed filter")
+	assert.NotNil(t, rm.activeFilterPreset,
+		"first Esc must NOT clear the preset while typed filter is present")
+}
+
+// Esc cascade priority: filter preset must peel before fullscreen,
+// matching the documented selection → search → filter → fullscreen
+// order so a user inspecting failing pods in fullscreen doesn't have
+// to leave fullscreen just to drop the preset.
+func TestExplorerEscClearsFilterPresetBeforeExitingFullscreen(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "test-ctx"
+	m.activeFilterPreset = &FilterPreset{Name: "Failing"}
+	m.unfilteredMiddleItems = []model.Item{{Name: "pod-a"}}
+	m.fullscreenDashboard = true
+
+	r, _ := m.handleExplorerEsc()
+	rm := r.(Model)
+
+	assert.Nil(t, rm.activeFilterPreset, "first Esc clears the preset")
+	assert.True(t, rm.fullscreenDashboard,
+		"first Esc must NOT exit fullscreen when a preset is still in place")
+}

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -163,6 +163,19 @@ func (m Model) handleExplorerEsc() (tea.Model, tea.Cmd) {
 		m.clampCursor()
 		return m, m.loadPreview()
 	}
+	if m.activeFilterPreset != nil {
+		// Mirror handleExplorerActionKeyFilterPresets so Esc and a second
+		// press of `.` are interchangeable: drop the preset, restore the
+		// pre-filter list, and tell the user which preset was cleared.
+		name := m.activeFilterPreset.Name
+		m.activeFilterPreset = nil
+		m.setMiddleItems(m.unfilteredMiddleItems)
+		m.unfilteredMiddleItems = nil
+		m.setCursor(0)
+		m.clampCursor()
+		m.setStatusMessage("Filter cleared: "+name, false)
+		return m, tea.Batch(scheduleStatusClear(), m.loadPreview())
+	}
 	if m.fullscreenDashboard {
 		m.fullscreenDashboard = false
 		m.previewScroll = 0


### PR DESCRIPTION
## Summary
- `handleExplorerEsc` cascaded through selection → search → `filterText` → fullscreen → close-tab, but never cleared `activeFilterPreset`. Applying a quick filter preset via `.` (e.g. "Failing pods") could only be undone by pressing `.` again.
- Added an `activeFilterPreset != nil` branch between the `filterText` and `fullscreen` branches that mirrors the existing clear logic in `handleExplorerActionKeyFilterPresets`: drop the preset, restore `unfilteredMiddleItems`, reset cursor, surface `Filter cleared: <name>` status.
- Cascade order: typed filter still peels first; the preset peels before fullscreen exits.

## Test plan
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofumpt -d` — no diff
- [x] New tests in `internal/app/explorer_esc_clears_filter_preset_test.go`:
  - `TestExplorerEscClearsActiveFilterPreset` — single Esc clears preset and restores the unfiltered list
  - `TestExplorerEscClearsFilterTextBeforeFilterPreset` — typed filter peels before preset when both are present
  - `TestExplorerEscClearsFilterPresetBeforeExitingFullscreen` — preset peels before fullscreen exits
- [x] Manual: apply `Failing` preset on Pods, press Esc, verify list restores and status reads `Filter cleared: Failing`