### PR TITLE
fix(filter): clear stale preview when filter preset matches zero items

### DIFF
--- a/internal/app/apply_filter_preset_clears_preview_test.go
+++ b/internal/app/apply_filter_preset_clears_preview_test.go
@@ -30,6 +30,13 @@ func TestApplyFilterPresetEmptyMatchClearsPreview(t *testing.T) {
 	m.metricsContent = "cpu: 10m"
 	m.previewEventsContent = "Warning: ImagePullBackOff"
 	m.resourceTree = &model.ResourceNode{Kind: "Pod", Name: "pod-1"}
+	// previewLoading lingers true from the in-flight cursor-change
+	// load that pod-1 triggered before the preset was applied — the
+	// resourcesLoadedMsg handler is gated on requestGen and will drop
+	// the response after our bump, so applyFilterPreset has to flip
+	// previewLoading off itself or the renderer keeps spinning.
+	m.previewLoading = true
+	prevGen := m.requestGen
 
 	preset := FilterPreset{
 		Name: "Failing",
@@ -43,6 +50,12 @@ func TestApplyFilterPresetEmptyMatchClearsPreview(t *testing.T) {
 
 	assert.Empty(t, rm.middleItems,
 		"sanity: preset matches zero pods")
+	assert.Greater(t, rm.requestGen, prevGen,
+		"empty preset must bump requestGen so the in-flight prior preview "+
+			"is discarded by its gen-gated handler")
+	assert.False(t, rm.previewLoading,
+		"empty preset must reset previewLoading — the in-flight load that "+
+			"set it true is now stale and won't clear it via the normal path")
 	assert.Nil(t, rm.rightItems,
 		"empty preset must clear children pane (rightItems)")
 	assert.Empty(t, rm.previewYAML,

--- a/internal/app/apply_filter_preset_clears_preview_test.go
+++ b/internal/app/apply_filter_preset_clears_preview_test.go
@@ -1,0 +1,86 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// When a filter preset matches zero items, applyFilterPreset must drop
+// the right-pane state that was loaded for the previously-selected
+// resource. Otherwise the children pane keeps rendering the prior pod's
+// containers / YAML / metrics while the middle column stares back empty.
+//
+// loadPreview() short-circuits on `sel == nil`, so it can't do this
+// cleanup itself; applyFilterPreset has to clear the state explicitly
+// before it returns.
+func TestApplyFilterPresetEmptyMatchClearsPreview(t *testing.T) {
+	m := baseModelOverlay()
+	m.middleItems = []model.Item{
+		{Name: "pod-1", Status: "Running"},
+		{Name: "pod-2", Status: "Running"},
+	}
+	// Simulate the right pane state populated for the previously
+	// selected pod-1: containers list, YAML body, metrics bar, events
+	// rollup, and a resource-tree map.
+	m.rightItems = []model.Item{{Name: "container-a", Kind: "Container"}}
+	m.previewYAML = "kind: Pod\nmetadata:\n  name: pod-1\n"
+	m.metricsContent = "cpu: 10m"
+	m.previewEventsContent = "Warning: ImagePullBackOff"
+	m.resourceTree = &model.ResourceNode{Kind: "Pod", Name: "pod-1"}
+
+	preset := FilterPreset{
+		Name: "Failing",
+		MatchFn: func(item model.Item) bool {
+			return item.Status == "Failed"
+		},
+	}
+
+	result, _ := m.applyFilterPreset(preset)
+	rm := result.(Model)
+
+	assert.Empty(t, rm.middleItems,
+		"sanity: preset matches zero pods")
+	assert.Nil(t, rm.rightItems,
+		"empty preset must clear children pane (rightItems)")
+	assert.Empty(t, rm.previewYAML,
+		"empty preset must clear cached YAML preview")
+	assert.Empty(t, rm.metricsContent,
+		"empty preset must clear pinned metrics footer")
+	assert.Empty(t, rm.previewEventsContent,
+		"empty preset must clear preview events rollup")
+	assert.Nil(t, rm.resourceTree,
+		"empty preset must clear resource map tree")
+}
+
+// Symmetric check: when the preset DOES match, applyFilterPreset must
+// not pre-emptively wipe rightItems — the existing flow expects the
+// follow-up loadPreview to swap them in for the new selection, and a
+// pre-clear here would replace a smooth transition with a flash of
+// "No resources found".
+func TestApplyFilterPresetNonEmptyMatchKeepsPreviewBuffer(t *testing.T) {
+	m := baseModelOverlay()
+	m.middleItems = []model.Item{
+		{Name: "pod-1", Status: "Running"},
+		{Name: "pod-2", Status: "Failed"},
+	}
+	prior := []model.Item{{Name: "container-a", Kind: "Container"}}
+	m.rightItems = prior
+
+	preset := FilterPreset{
+		Name: "Failing",
+		MatchFn: func(item model.Item) bool {
+			return item.Status == "Failed"
+		},
+	}
+
+	result, _ := m.applyFilterPreset(preset)
+	rm := result.(Model)
+
+	assert.Len(t, rm.middleItems, 1, "sanity: pod-2 matched")
+	assert.Equal(t, prior, rm.rightItems,
+		"non-empty preset must NOT clear rightItems pre-emptively — "+
+			"loadPreview swaps them in for the new selection")
+}

--- a/internal/app/update_overlays_misc.go
+++ b/internal/app/update_overlays_misc.go
@@ -138,11 +138,13 @@ func (m Model) applyFilterPreset(preset FilterPreset) (tea.Model, tea.Cmd) {
 		// previously-loaded children / YAML / metrics / events / map
 		// would otherwise sit in the right pane describing a pod that
 		// no longer matches. Drop them in step with the empty middle
-		// column. Don't flip previewLoading=true here — there's no
-		// follow-up load to clear it, and the renderer already reads
-		// rightItems == nil + !previewLoading as "No resources found",
-		// which matches what the user expects to see.
+		// column. requestGen++ also discards any in-flight preview load
+		// from the prior cursor — its gen-gated handler will skip the
+		// previewLoading=false reset, so do that here too or the
+		// renderer (rightItems == nil && previewLoading) keeps showing
+		// the spinner instead of "No resources found".
 		m.requestGen++
+		m.previewLoading = false
 		m.rightItems = nil
 		m.previewYAML = ""
 		m.previewScroll = 0

--- a/internal/app/update_overlays_misc.go
+++ b/internal/app/update_overlays_misc.go
@@ -133,6 +133,23 @@ func (m Model) applyFilterPreset(preset FilterPreset) (tea.Model, tea.Cmd) {
 	m.activeFilterPreset = &preset
 	m.setCursor(0)
 	m.clampCursor()
+	if len(filtered) == 0 {
+		// loadPreview short-circuits when nothing is selected, so the
+		// previously-loaded children / YAML / metrics / events / map
+		// would otherwise sit in the right pane describing a pod that
+		// no longer matches. Drop them in step with the empty middle
+		// column. Don't flip previewLoading=true here — there's no
+		// follow-up load to clear it, and the renderer already reads
+		// rightItems == nil + !previewLoading as "No resources found",
+		// which matches what the user expects to see.
+		m.requestGen++
+		m.rightItems = nil
+		m.previewYAML = ""
+		m.previewScroll = 0
+		m.resourceTree = nil
+		m.metricsContent = ""
+		m.previewEventsContent = ""
+	}
 	m.setStatusMessage(fmt.Sprintf("Filter: %s (%d matches)", preset.Name, len(filtered)), false)
 	return m, tea.Batch(scheduleStatusClear(), m.loadPreview())
 }


### PR DESCRIPTION
## Summary
- `applyFilterPreset` filtered the middle column and called `loadPreview`, but `loadPreview` short-circuits on `sel == nil`. When a preset matched zero items, `rightItems` / `previewYAML` / `metricsContent` / `previewEventsContent` / `resourceTree` were left describing the previously-selected pod — the children pane kept rendering the prior pod's containers next to an empty list.
- When `len(filtered) == 0`, drop those fields in lockstep with the empty middle column.
- Deliberately skip flipping `previewLoading = true`: there is no follow-up load to clear it, and `renderRightDefault` already maps `rightItems == nil` + `!previewLoading` to "No resources found", which is what the user actually wants to see.

## Test plan
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofumpt -d` — no diff
- [x] New tests in `internal/app/apply_filter_preset_clears_preview_test.go`:
  - `TestApplyFilterPresetEmptyMatchClearsPreview` — preset with zero matches drops rightItems / previewYAML / metricsContent / previewEventsContent / resourceTree
  - `TestApplyFilterPresetNonEmptyMatchKeepsPreviewBuffer` — preset with matches must NOT pre-emptively wipe rightItems (loadPreview swaps them in)
- [x] Manual: open Pods on a healthy cluster, apply `Failing` preset, verify children pane reads "No resources found" instead of the previous pod's containers