### PR TITLE
fix(theme): keep parent highlight readable on themes with near-text border

### DIFF
--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -408,7 +408,7 @@ func ApplyTheme(t Theme) {
 	ParentHighlightStyle = lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color(t.Text)).
-		Background(lipgloss.Color(t.Border))
+		Background(lipgloss.Color(derivedParentHighlightBg(t)))
 
 	StatusMessageOkStyle = lipgloss.NewStyle().
 		Foreground(lipgloss.Color(t.Secondary)).

--- a/internal/ui/theme_contrast.go
+++ b/internal/ui/theme_contrast.go
@@ -148,6 +148,62 @@ func hslToRGB(h, s, l float64) (r, g, b float64) {
 	return r, g, b
 }
 
+// derivedParentHighlightBg returns the background color to use for
+// ParentHighlightStyle (the LEFT pane's selected-row highlight, which
+// renders bold Text on top of the returned color).
+//
+// In most themes Border is a subtle mid-luminance color (terminal
+// "bright black"), giving Text-on-Border enough contrast to read. A
+// few themes (e.g. synthwave-everything) set their bright-black
+// palette entry to a near-white color, which collapses Text-on-Border
+// into invisibility. Border itself is intentionally not subject to
+// fg-readability enforcement because it has a decorative role on
+// column outlines — pushing it toward the foreground spectrum makes
+// other things unreadable. Instead we pick a substitute bg here:
+// blend Border toward Base via binary search until Text-on-bg meets
+// the WCAG AA large-text contrast floor (3.0:1).
+//
+// When Text-on-Border already clears the floor, Border is returned
+// unchanged so themes that work today keep their designer-chosen
+// highlight color.
+func derivedParentHighlightBg(t Theme) string {
+	const target = 3.0
+
+	tr, tg, tb, okT := parseHexColor(t.Text)
+	br, bg, bb, okB := parseHexColor(t.Border)
+	baseR, baseG, baseB, okBase := parseHexColor(t.Base)
+	if !okT || !okB || !okBase {
+		return t.Border
+	}
+
+	lText := relativeLuminance(tr, tg, tb)
+	if contrastRatio(lText, relativeLuminance(br, bg, bb)) >= target {
+		return t.Border
+	}
+
+	// Binary search the blend amount in [0, 1] (0 = Border, 1 = Base).
+	// 30 iterations converges to far below 1/255 in each channel, more
+	// precision than hex-truncation can represent.
+	const iterations = 30
+	lerp := func(a, b, t float64) float64 { return a*(1-t) + b*t }
+	lo, hi := 0.0, 1.0
+	for range iterations {
+		mid := (lo + hi) / 2.0
+		r := lerp(br, baseR, mid)
+		g := lerp(bg, baseG, mid)
+		b := lerp(bb, baseB, mid)
+		if contrastRatio(lText, relativeLuminance(r, g, b)) >= target {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	r := lerp(br, baseR, hi)
+	g := lerp(bg, baseG, hi)
+	b := lerp(bb, baseB, hi)
+	return formatHexColor(r, g, b)
+}
+
 // EnforceMinContrast nudges the fg hex color's HSL lightness so it meets a
 // minimum WCAG contrast ratio against the bg hex color. The value parameter is
 // the user-facing normalized knob in [0, 1]:

--- a/internal/ui/theme_contrast_test.go
+++ b/internal/ui/theme_contrast_test.go
@@ -338,6 +338,55 @@ func TestApplyThemePreservesParentHighlightReadability(t *testing.T) {
 		ratio, ActiveTheme.Text, ActiveTheme.Border)
 }
 
+// TestDerivedParentHighlightBg_DimsWhenBorderTooCloseToText reproduces a
+// readability bug where the synthwave-everything theme's bright-black
+// palette entry is set to near-white (#fefefe), making it visually
+// identical to Text (#f0eff1). ParentHighlightStyle renders Text on
+// Border, so the LEFT pane's selected-row text collapses into its own
+// background and becomes invisible.
+//
+// Border is intentionally not subject to fg-readability enforcement
+// (see ApplyTheme — it has a decorative role on column outlines and
+// pushing it toward the foreground spectrum makes other things
+// unreadable). Instead, the parent-highlight bg is derived from Border
+// at apply time, blending toward Base when Text-on-Border contrast is
+// below the WCAG large-text floor. The result is a "dimmer" highlight
+// the user can actually read.
+func TestDerivedParentHighlightBg_DimsWhenBorderTooCloseToText(t *testing.T) {
+	const target = 3.0 // WCAG AA large-text contrast floor.
+
+	schemes := BuiltinSchemes()
+	theme, ok := schemes["synthwave-everything"]
+	require.True(t, ok, "synthwave-everything must be present in built-in schemes")
+
+	bg := derivedParentHighlightBg(theme)
+
+	tr, tg, tb, okT := parseHexColor(theme.Text)
+	br, bgG, bb, okB := parseHexColor(bg)
+	require.True(t, okT, "Text must be a valid hex")
+	require.True(t, okB, "derived parent-highlight bg must be a valid hex (got %q)", bg)
+
+	ratio := contrastRatio(
+		relativeLuminance(tr, tg, tb),
+		relativeLuminance(br, bgG, bb),
+	)
+	assert.GreaterOrEqual(t, ratio, target,
+		"Text on derived parent-highlight bg must clear the WCAG large-text floor; got ratio %.2f (Text=%s Border=%s derived=%s)",
+		ratio, theme.Text, theme.Border, bg)
+}
+
+// TestDerivedParentHighlightBg_PreservesBorderWhenContrastIsAdequate
+// guards the no-op path: themes with a properly subtle Border (like
+// the default Tokyonight Storm) must keep their designer-chosen
+// Border as the parent-highlight bg, not get rewritten by the
+// contrast-fallback logic.
+func TestDerivedParentHighlightBg_PreservesBorderWhenContrastIsAdequate(t *testing.T) {
+	theme := DefaultTheme()
+	bg := derivedParentHighlightBg(theme)
+	assert.Equal(t, theme.Border, bg,
+		"default theme has adequate Text-on-Border contrast; derived bg must equal Border untouched")
+}
+
 func TestEnforceMinContrastPreservesFgBgRelationship(t *testing.T) {
 	cases := []struct {
 		name  string


### PR DESCRIPTION
## Summary

- `ParentHighlightStyle` (LEFT pane's selected-row highlight) renders bold `Text` on `Border`. A few ghostty themes (notably `synthwave-everything`) map their bright-black palette entry to a near-white color, so `Text` and `Border` collapse into the same luminance and the highlighted row becomes unreadable.
- `Border` is intentionally not subject to fg-readability enforcement (it doubles as the decorative column-outline color). Instead, derive the parent-highlight bg at apply time: when `Text`-on-`Border` falls below the WCAG AA large-text floor (3.0:1), binary-search a blend toward `Base` until the floor is met. Themes with adequate contrast keep their designer-chosen `Border` untouched.
- For `synthwave-everything`: `Text=#f0eff1` on `Border=#fefefe` (1.04:1, invisible) → `Text=#f0eff1` on derived `#8d8895` (3.01:1, readable).

## Test plan

- [x] `TestDerivedParentHighlightBg_DimsWhenBorderTooCloseToText` — synthwave-everything reaches the 3.0:1 floor after derivation.
- [x] `TestDerivedParentHighlightBg_PreservesBorderWhenContrastIsAdequate` — default theme's derived bg equals `Border` untouched.
- [x] Pre-existing `TestApplyThemePreservesParentHighlightReadability` still passes (no regression on the existing min-contrast path).
- [x] Full `go test ./... -race` is green.
- [x] Manual: switch theme to `synthwave-everything` (`T` → pick) and verify the parent-pane highlight is now readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)