### PR TITLE
feat(release): add scoop, winget, chocolatey channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,14 @@ jobs:
       - name: Install syft (SBOM)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
+      # GoReleaser's chocolateys publisher invokes `choco pack` and `choco push`.
+      # crazy-max/ghaction-chocolatey is the standard community action and runs
+      # the choco CLI in a Docker container so it works on Linux runners.
+      - name: Install Chocolatey CLI
+        uses: crazy-max/ghaction-chocolatey@dff3862348493b11fba2fbc49147b6d2dfe09b66 # v4.0.0
+        with:
+          args: --version
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
@@ -155,6 +163,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Preflight: verify every required secret is present before GoReleaser
+      # starts. Without this, a missing secret causes a confusing mid-publish
+      # failure deep in GoReleaser's output.
+      - name: Preflight - assert release secrets present
+        env:
+          RELEASE_TAP_TOKEN: ${{ secrets.RELEASE_TAP_TOKEN }}
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          missing=()
+          for s in RELEASE_TAP_TOKEN WINGET_TOKEN CHOCOLATEY_API_KEY DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+            if [ -z "${!s}" ]; then missing+=("$s"); fi
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+          echo "All required secrets present."
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
@@ -164,6 +193,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAP_TOKEN: ${{ secrets.RELEASE_TAP_TOKEN }}
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
       # Generates SLSA build provenance attestations for every release artifact.
       # GitHub publishes the attestations alongside the release so downstream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,27 +163,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Preflight: verify every required secret is present before GoReleaser
-      # starts. Without this, a missing secret causes a confusing mid-publish
-      # failure deep in GoReleaser's output.
-      - name: Preflight - assert release secrets present
-        env:
-          RELEASE_TAP_TOKEN: ${{ secrets.RELEASE_TAP_TOKEN }}
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          missing=()
-          for s in RELEASE_TAP_TOKEN WINGET_TOKEN CHOCOLATEY_API_KEY DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
-            if [ -z "${!s}" ]; then missing+=("$s"); fi
-          done
-          if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing required secrets: ${missing[*]}"
-            exit 1
-          fi
-          echo "All required secrets present."
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Preflight: verify every required secret is present before GoReleaser
+      # starts. Without this, a missing secret causes a confusing mid-publish
+      # failure deep in GoReleaser's output.
+      - name: Preflight - assert release secrets present
+        env:
+          RELEASE_TAP_TOKEN: ${{ secrets.RELEASE_TAP_TOKEN }}
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          missing=()
+          for s in RELEASE_TAP_TOKEN WINGET_TOKEN CHOCOLATEY_API_KEY DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+            if [ -z "${!s}" ]; then missing+=("$s"); fi
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+          echo "All required secrets present."
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,6 +98,19 @@ brews:
     test: |
       system "#{bin}/lfk", "--version"
 
+scoops:
+  - repository:
+      owner: janosmiko
+      name: scoop-bucket
+      branch: main
+      token: "{{ .Env.RELEASE_TAP_TOKEN }}"
+    directory: bucket
+    name: lfk
+    homepage: "https://github.com/janosmiko/lfk"
+    description: "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters"
+    license: MIT
+    commit_msg_template: "chore: bump lfk to {{ .Tag }}"
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -111,6 +111,41 @@ scoops:
     license: MIT
     commit_msg_template: "chore: bump lfk to {{ .Tag }}"
 
+winget:
+  - name: lfk
+    publisher: janosmiko
+    license: MIT
+    homepage: "https://github.com/janosmiko/lfk"
+    short_description: "Lightning Fast Kubernetes navigator"
+    description: |
+      LFK is a lightning-fast, keyboard-focused, yazi-inspired terminal user
+      interface for navigating and managing Kubernetes clusters. Built for
+      speed and efficiency, it brings a three-column Miller columns layout
+      with an owner-based resource hierarchy to your terminal.
+    license_url: "https://github.com/janosmiko/lfk/blob/main/LICENSE"
+    package_identifier: janosmiko.lfk
+    publisher_url: "https://github.com/janosmiko"
+    publisher_support_url: "https://github.com/janosmiko/lfk/issues"
+    release_notes_url: "https://github.com/janosmiko/lfk/releases/tag/v{{ .Version }}"
+    tags:
+      - kubernetes
+      - tui
+      - devops
+      - k8s
+      - cli
+    repository:
+      owner: janosmiko
+      name: winget-pkgs
+      branch: "lfk-{{ .Version }}"
+      token: "{{ .Env.WINGET_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,6 +146,30 @@ winget:
           name: winget-pkgs
           branch: master
 
+chocolateys:
+  - name: lfk
+    title: "lfk"
+    authors: janosmiko
+    project_url: "https://github.com/janosmiko/lfk"
+    icon_url: "https://raw.githubusercontent.com/janosmiko/lfk/main/docs/imgs/github-header.png"
+    copyright: "2026 janosmiko"
+    license_url: "https://github.com/janosmiko/lfk/blob/main/LICENSE"
+    require_license_acceptance: false
+    project_source_url: "https://github.com/janosmiko/lfk"
+    docs_url: "https://github.com/janosmiko/lfk/blob/main/docs/usage.md"
+    bug_tracker_url: "https://github.com/janosmiko/lfk/issues"
+    tags: "kubernetes tui devops k8s cli"
+    summary: "Lightning Fast Kubernetes navigator"
+    description: |
+      LFK is a lightning-fast, keyboard-focused, yazi-inspired terminal user
+      interface for navigating and managing Kubernetes clusters. Built for
+      speed and efficiency, it brings a three-column Miller columns layout
+      with an owner-based resource hierarchy to your terminal.
+    release_notes: "https://github.com/janosmiko/lfk/releases/tag/v{{ .Version }}"
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+    source_repo: "https://push.chocolatey.org/"
+    skip_publish: false
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -152,7 +152,7 @@ chocolateys:
     authors: janosmiko
     project_url: "https://github.com/janosmiko/lfk"
     icon_url: "https://raw.githubusercontent.com/janosmiko/lfk/main/docs/imgs/github-header.png"
-    copyright: "2026 janosmiko"
+    copyright: "{{ .Now.Format \"2006\" }} janosmiko"
     license_url: "https://github.com/janosmiko/lfk/blob/main/LICENSE"
     require_license_acceptance: false
     project_source_url: "https://github.com/janosmiko/lfk"

--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@
 # Homebrew (macOS / Linux)
 brew install janosmiko/tap/lfk
 
+# Windows: Scoop
+scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket && scoop install lfk
+# or: winget install janosmiko.lfk
+# or: choco install lfk
+
 # Go
 go install github.com/janosmiko/lfk@latest
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,13 +47,32 @@ Download pre-built binaries from the [GitHub Releases](https://github.com/janosm
 
 ## Windows
 
-Windows binaries (amd64, arm64) are attached as `.zip` files to each [GitHub release](https://github.com/janosmiko/lfk/releases). Until package-manager support lands (Scoop, Winget, Chocolatey), the recommended Windows install is:
+### Scoop
 
-1. Download `lfk_<version>_windows_<arch>.zip`.
-2. Extract `lfk.exe` to a directory in your `PATH` (e.g. `%USERPROFILE%\bin`).
-3. Verify with `lfk --version`.
+```powershell
+scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket
+scoop install lfk
+```
 
-Each archive is covered by the same cosign Sigstore bundle (`checksums.txt.sigstore`) as Linux/macOS builds; verify with `cosign verify-blob` (see release notes for the exact command).
+### Winget
+
+```powershell
+winget install janosmiko.lfk
+```
+
+> The first release after a tag opens an automatic PR to `microsoft/winget-pkgs`. The package becomes installable once that PR is merged by the Winget maintainers — typically within hours.
+
+### Chocolatey
+
+```powershell
+choco install lfk
+```
+
+> First-time installs from Chocolatey may show "Pending" while the package goes through chocolatey.org moderation. Subsequent versions usually become available immediately after publish.
+
+### Manual binary
+
+Download `lfk_<version>_windows_<arch>.zip` from [GitHub Releases](https://github.com/janosmiko/lfk/releases), extract `lfk.exe` into a directory in your `PATH`, and verify with `lfk --version`. Each archive is covered by the same cosign Sigstore bundle as Linux/macOS builds.
 
 ## From source
 


### PR DESCRIPTION
## Summary

Adds three Windows package-manager publish channels for \`lfk\`:

- **Scoop** — every release pushes a manifest to [janosmiko/scoop-bucket](https://github.com/janosmiko/scoop-bucket).
- **Winget** — every release opens a PR against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) from [janosmiko/winget-pkgs](https://github.com/janosmiko/winget-pkgs).
- **Chocolatey** — every release pushes a \`.nupkg\` to [chocolatey.org](https://chocolatey.org/packages/lfk).

Plus the supporting CI wiring:
- \`crazy-max/ghaction-chocolatey@v4.0.0\` step (provides \`choco\` CLI on the Linux runner via Docker).
- \`Preflight - assert release secrets present\` step that fails fast on any empty required secret.
- \`WINGET_TOKEN\` and \`CHOCOLATEY_API_KEY\` env vars threaded through to GoReleaser.

User-facing docs (\`docs/installation.md\`, \`README.md\`) updated with the new channel commands.

Builds on PR #159 (foundation: Windows builds + nightly removal + token rename).

## Pre-requisites in place (manual)

- [x] \`janosmiko/scoop-bucket\` repo created and seeded with README + LICENSE on \`main\`.
- [x] \`janosmiko/winget-pkgs\` fork created.
- [x] Chocolatey publisher account \`janosmiko\` registered.
- [x] Secrets set: \`WINGET_TOKEN\`, \`CHOCOLATEY_API_KEY\`.
- [x] \`RELEASE_TAP_TOKEN\` PAT scope extended to cover \`scoop-bucket\`.

## Test plan

- [ ] CI green on this PR (build, test, lint, govulncheck, flake build).
- [ ] After merge + release tag (release-please will propose the next bump):
  - [ ] \`dist/scoop/bucket/lfk.json\` is generated and pushed to \`janosmiko/scoop-bucket/bucket/lfk.json\`.
  - [ ] A PR opens automatically against \`microsoft/winget-pkgs\` from \`janosmiko/winget-pkgs:lfk-<version>\`.
  - [ ] A \`.nupkg\` is built and \`choco push\` succeeds against chocolatey.org. **First-package moderation may put it in "Pending" state — that's expected.**
- [ ] On a clean Windows VM:
  - [ ] \`scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket && scoop install lfk\` works.
  - [ ] \`winget install janosmiko.lfk\` works once the upstream PR is merged.
  - [ ] \`choco install lfk\` works once Chocolatey moderation clears.

## Out of scope (later PRs)

- AUR, Snap (Phase 3, PR 3) — gated on Snap classic-confinement approval.
- Cloudsmith DEB/DNF (Phase 4, PR 4).