### PR TITLE
feat(release): add cloudsmith deb+rpm channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,15 @@ jobs:
         with:
           args: --version
 
+      # GoReleaser's publishers: block invokes the `cloudsmith` CLI to push
+      # .deb and .rpm artifacts to cloudsmith.io/janosmiko/lfk. pipx isolates
+      # the install from the runner's system Python and is the recommended
+      # path per Cloudsmith's docs.
+      - name: Install Cloudsmith CLI
+        run: |
+          pipx install cloudsmith-cli
+          cloudsmith --version
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
@@ -195,6 +204,7 @@ jobs:
           RELEASE_TAP_TOKEN: ${{ secrets.RELEASE_TAP_TOKEN }}
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 
       # Generates SLSA build provenance attestations for every release artifact.
       # GitHub publishes the attestations alongside the release so downstream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,11 +180,12 @@ jobs:
           RELEASE_TAP_TOKEN: ${{ secrets.RELEASE_TAP_TOKEN }}
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           missing=()
-          for s in RELEASE_TAP_TOKEN WINGET_TOKEN CHOCOLATEY_API_KEY DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+          for s in RELEASE_TAP_TOKEN WINGET_TOKEN CHOCOLATEY_API_KEY CLOUDSMITH_API_KEY DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
             if [ -z "${!s}" ]; then missing+=("$s"); fi
           done
           if [ ${#missing[@]} -ne 0 ]; then

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -175,7 +175,7 @@ publishers:
     ids:
       - lfk
     cmd: |
-      sh -c '
+      bash -c '
         set -euo pipefail
         case "${ARTIFACT_PATH##*.}" in
           deb)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -170,6 +170,28 @@ chocolateys:
     source_repo: "https://push.chocolatey.org/"
     skip_publish: false
 
+publishers:
+  - name: cloudsmith
+    ids:
+      - lfk
+    cmd: |
+      sh -c '
+        set -euo pipefail
+        case "${ARTIFACT_PATH##*.}" in
+          deb)
+            cloudsmith push deb janosmiko/lfk/any-distro/any-version "${ARTIFACT_PATH}" --republish
+            ;;
+          rpm)
+            cloudsmith push rpm janosmiko/lfk/any-distro/any-version "${ARTIFACT_PATH}" --republish
+            ;;
+          *)
+            echo "skipping ${ARTIFACT_PATH} (not deb or rpm)"
+            ;;
+        esac
+      '
+    env:
+      - CLOUDSMITH_API_KEY={{ .Env.CLOUDSMITH_API_KEY }}
+
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket && scoop in
 # or: winget install janosmiko.lfk
 # or: choco install lfk
 
+# Linux: Debian / Ubuntu (Cloudsmith APT)
+curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.deb.sh' | sudo -E bash && sudo apt install lfk
+
+# Linux: Fedora / RHEL (Cloudsmith DNF)
+curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.rpm.sh' | sudo -E bash && sudo dnf install lfk
+
 # Go
 go install github.com/janosmiko/lfk@latest
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket && scoop in
 # or: choco install lfk
 
 # Linux: Debian / Ubuntu (Cloudsmith APT)
-curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.deb.sh' | sudo -E bash && sudo apt install lfk
+curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.deb.sh' | sudo -E bash && sudo apt update && sudo apt install lfk
 
 # Linux: Fedora / RHEL (Cloudsmith DNF)
 curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.rpm.sh' | sudo -E bash && sudo dnf install lfk

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,31 @@
 brew install janosmiko/tap/lfk
 ```
 
+## Linux
+
+### Debian / Ubuntu (Cloudsmith APT)
+
+Add the Cloudsmith repository, then install:
+
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.deb.sh' | sudo -E bash
+sudo apt update
+sudo apt install lfk
+```
+
+The setup script imports the Cloudsmith GPG key and writes `/etc/apt/sources.list.d/janosmiko-lfk.list`. Manual setup steps are also documented at https://cloudsmith.io/~janosmiko/repos/lfk/setup/#formats-deb.
+
+### Fedora / RHEL / CentOS (Cloudsmith DNF)
+
+Add the Cloudsmith repository, then install:
+
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.rpm.sh' | sudo -E bash
+sudo dnf install lfk
+```
+
+Manual setup steps are documented at https://cloudsmith.io/~janosmiko/repos/lfk/setup/#formats-rpm.
+
 ## Nix (flake)
 
 Requires Nix ≥ 2.4 with flakes enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`).


### PR DESCRIPTION
## Summary

Adds the final medium-leverage channel for \`lfk\`: a hosted [Cloudsmith](https://cloudsmith.io/~janosmiko/repos/lfk) DEB+RPM repository so users can \`apt install lfk\` / \`dnf install lfk\` after adding the repo source.

- New \`publishers:\` block in \`.goreleaser.yaml\` invokes \`cloudsmith push deb\` / \`cloudsmith push rpm\` per artifact built by the existing \`nfpms:\` block.
- \`Install Cloudsmith CLI\` step in \`release.yml\` (\`pipx install cloudsmith-cli\`).
- \`CLOUDSMITH_API_KEY\` threaded into both the GoReleaser env block and the preflight secret check.
- User-facing docs: new \`## Linux\` section in \`docs/installation.md\` with APT and DNF subsections; corresponding entries in the README install snippet.

## Stacked PR

This PR is stacked on top of #161 (Phase 2: scoop+winget+chocolatey). GitHub auto-updates the base to \`main\` once #161 merges. Do not merge this PR before #161.

## Pre-requisites in place (manual)

- [x] Cloudsmith OSS account active.
- [x] Repository \`janosmiko/lfk\` created on Cloudsmith with DEB + RPM enabled.
- [x] Secret \`CLOUDSMITH_API_KEY\` set on the lfk repo.

## Test plan

- [x] CI green on this PR (build, test, lint, govulncheck, flake build).
- [x] After #161 merges and this PR rebases onto main, merge this and tag a release.
- [x] On release: \`.deb\` and \`.rpm\` for both linux/amd64 and linux/arm64 are pushed to \`cloudsmith.io/~janosmiko/repos/lfk\`.
- [x] On a clean Ubuntu container:
      \`\`\`
      curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.deb.sh' | sudo -E bash
      sudo apt update && sudo apt install lfk && lfk --version
      \`\`\`
- [x] On a clean Fedora container:
      \`\`\`
      curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.rpm.sh' | sudo -E bash
      sudo dnf install lfk && lfk --version
      \`\`\`

## Out of scope (Phase 3, separate PR)

- AUR (\`lfk-bin\`) and Snap (classic confinement) channels — held until Snap classic approval comes back.