### PR TITLE
fix(release): use pip --user for cloudsmith-cli (unblocks v0.10.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,13 +152,16 @@ jobs:
           args: --version
 
       # GoReleaser's publishers: block invokes the `cloudsmith` CLI to push
-      # .deb and .rpm artifacts to cloudsmith.io/janosmiko/lfk. pipx isolates
-      # the install from the runner's system Python and is the recommended
-      # path per Cloudsmith's docs.
+      # .deb and .rpm artifacts to cloudsmith.io/janosmiko/lfk. We use
+      # `pip install --user` (not pipx) because pipx on the GitHub-hosted
+      # runner image resolved its bin dir relative to the workspace and
+      # left an `opt/` directory in the checkout, which dirtied the
+      # working tree and made GoReleaser refuse to run.
       - name: Install Cloudsmith CLI
         run: |
-          pipx install cloudsmith-cli
-          cloudsmith --version
+          python3 -m pip install --user --quiet cloudsmith-cli
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/cloudsmith" --version
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4


### PR DESCRIPTION
## Hotfix

The v0.10.4 release run failed with \`git is in a dirty state ?? opt\`: https://github.com/janosmiko/lfk/actions/runs/25440637971/job/74631060879

Root cause: \`pipx install cloudsmith-cli\` resolved \`PIPX_BIN_DIR\` as a relative path on the GitHub-hosted runner image, leaving an \`opt/\` directory in \`\$GITHUB_WORKSPACE\`. GoReleaser refused to run because of the resulting dirty git state.

## Fix

Switch to \`python3 -m pip install --user --quiet cloudsmith-cli\` (and add \`\$HOME/.local/bin\` to \`\$GITHUB_PATH\`). \`pip --user\` always installs to \`~/.local/\`, never to the workspace.

## Test plan

- [x] CI green on this PR.
- [x] After merge, re-tag v0.10.4 (delete the failed release + tag, then \`git tag v0.10.4 <commit>\` and push) — or wait for the next release.
- [x] Confirm release workflow passes the GoReleaser step (no "git is in a dirty state").
- [x] Confirm Cloudsmith DEB+RPM packages appear at https://cloudsmith.io/~janosmiko/repos/lfk/packages/.

## Out of scope

- Investigating why pipx's bin dir resolves relatively on this runner image — replaced with pip-user instead, which is more portable.