### PR TITLE
fix(release): replace chocolatey docker action with mono wrapper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,13 +143,22 @@ jobs:
       - name: Install syft (SBOM)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
-      # GoReleaser's chocolateys publisher invokes `choco pack` and `choco push`.
-      # crazy-max/ghaction-chocolatey is the standard community action and runs
-      # the choco CLI in a Docker container so it works on Linux runners.
+      # GoReleaser's chocolateys publisher invokes `choco pack` and `choco push`,
+      # which require `choco` on PATH. On Linux runners we install the official
+      # chocolatey tarball and a tiny `mono` wrapper (the pattern used by
+      # twpayne/chezmoi and golangci/golangci-lint). This avoids the
+      # workspace-bind-mounting docker action that left an `opt/` directory
+      # in the checkout and dirtied git state, and it doesn't require a
+      # separate windows-latest job.
       - name: Install Chocolatey CLI
-        uses: crazy-max/ghaction-chocolatey@dff3862348493b11fba2fbc49147b6d2dfe09b66 # v4.0.0
-        with:
-          args: --version
+        env:
+          CHOCOLATEY_VERSION: 2.7.1
+        run: |
+          mkdir -p /opt/chocolatey
+          wget -q -O - "https://github.com/chocolatey/choco/releases/download/${CHOCOLATEY_VERSION}/chocolatey.v${CHOCOLATEY_VERSION}.tar.gz" | tar -xz -C /opt/chocolatey
+          printf '#!/bin/bash\nmono /opt/chocolatey/choco.exe "$@"\n' | sudo tee /usr/local/bin/choco > /dev/null
+          sudo chmod +x /usr/local/bin/choco
+          choco --version
 
       # GoReleaser's publishers: block invokes the `cloudsmith` CLI to push
       # .deb and .rpm artifacts to cloudsmith.io/janosmiko/lfk. We use


### PR DESCRIPTION
## Hotfix

Follow-up to #164 — that PR was supposed to also replace the chocolatey docker action with a mono+wrapper install, but only the pip-user fix made it into the squash merge. The chocolatey docker action is still on main and continues to fail every release with `git is in a dirty state ?? opt`.

## Why the docker action fails

`crazy-max/ghaction-chocolatey@v4.0.0` runs:

```
docker run --workdir /wksp --volume /home/runner/work/lfk/lfk:/wksp ghcr.io/crazy-max/chocolatey ...
```

It bind-mounts the workspace at `/wksp`. Choco writes log files to relative `./opt/...` paths inside the container, which resolve to host's `$GITHUB_WORKSPACE/opt/`. GoReleaser's pre-flight `git status` check sees `?? opt` and refuses to run.

A second issue: the docker action runs choco inside a container; it doesn't put `choco` on the runner's PATH. GoReleaser's `chocolateys:` block needs `choco pack` / `choco push` available — which the docker action doesn't provide.

## Fix

Replace the docker action with the proven Linux pattern from [twpayne/chezmoi](https://github.com/twpayne/chezmoi/blob/master/.github/workflows/main.yml) and [golangci/golangci-lint](https://github.com/golangci/golangci-lint/blob/main/.github/workflows/release.yml):

- Download the official Chocolatey tarball from [chocolatey/choco GitHub releases](https://github.com/chocolatey/choco/releases) (pinned to v2.7.1).
- Extract to `/opt/chocolatey`.
- Install a 2-line shell wrapper at `/usr/local/bin/choco` that execs `mono /opt/chocolatey/choco.exe "$@"`.
- Mono is preinstalled on `ubuntu-latest` runners.

Result: `choco` is on PATH for GoReleaser, no workspace pollution, no docker bind-mount.

## Test plan

- [x] CI green on this PR.
- [x] After merge, re-tag v0.10.4 (delete current tag, retag on the merge commit, push). The release workflow should pass the `Run GoReleaser` step.
- [x] Confirm `.nupkg` is built and pushed to chocolatey.org. (First-time submission may sit in "Pending" moderation — that's expected.)
- [x] Confirm Scoop, Winget, Cloudsmith publishes still work (no regression on the other channels).

## Out of scope

- Investigating the chocolatey-docker bind-mount choco-log-path bug upstream — replaced with native mono pattern instead.