### PR TITLE
fix(release): apt install mono-devel before choco wrapper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,16 +144,18 @@ jobs:
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       # GoReleaser's chocolateys publisher invokes `choco pack` and `choco push`,
-      # which require `choco` on PATH. On Linux runners we install the official
-      # chocolatey tarball and a tiny `mono` wrapper (the pattern used by
-      # twpayne/chezmoi and golangci/golangci-lint). This avoids the
-      # workspace-bind-mounting docker action that left an `opt/` directory
-      # in the checkout and dirtied git state, and it doesn't require a
-      # separate windows-latest job.
+      # which require `choco` on PATH. On Linux runners we install mono +
+      # the official chocolatey tarball + a tiny `mono` wrapper (the pattern
+      # used by twpayne/chezmoi and golangci/golangci-lint). Mono is no longer
+      # preinstalled on ubuntu-24.04, so we apt-install mono-devel here.
+      # This avoids the workspace-bind-mounting docker action that left an
+      # `opt/` directory in the checkout and dirtied git state.
       - name: Install Chocolatey CLI
         env:
           CHOCOLATEY_VERSION: 2.7.1
         run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mono-devel
           mkdir -p /opt/chocolatey
           wget -q -O - "https://github.com/chocolatey/choco/releases/download/${CHOCOLATEY_VERSION}/chocolatey.v${CHOCOLATEY_VERSION}.tar.gz" | tar -xz -C /opt/chocolatey
           printf '#!/bin/bash\nmono /opt/chocolatey/choco.exe "$@"\n' | sudo tee /usr/local/bin/choco > /dev/null


### PR DESCRIPTION
## Hotfix #3

Follow-up to #166. The mono-wrapper from #166 is correct, but `mono` is not preinstalled on `ubuntu-latest` (which is `ubuntu-24.04` since late 2024). The chezmoi reference workflow we copied uses `ubuntu-22.04` where mono WAS preinstalled.

Failing run for context: https://github.com/janosmiko/lfk/actions/runs/25443672133/job/74642091803

```
/usr/local/bin/choco: line 2: mono: command not found
Error: Process completed with exit code 127.
```

## Fix

Add `sudo apt-get install -y --no-install-recommends mono-devel` before unpacking choco. `mono-devel` is the documented minimum per https://docs.chocolatey.org/en-us/choco/setup/#linux — smaller than `mono-complete` but includes the runtime + assemblies choco needs for `pack` and `push`.

## Test plan

- [x] CI green on this PR.
- [x] After merge, re-tag v0.10.4 (delete current tag, retag on the merge commit, push). The release workflow should pass through Install Chocolatey CLI without "mono: command not found", and Run GoReleaser should succeed.
- [x] Confirm \`.nupkg\` builds and pushes to chocolatey.org (first-time submission may sit in "Pending" — that's expected).