### PR TITLE
fix(release): use ArtifactPath template in cloudsmith publisher

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -177,15 +177,16 @@ publishers:
     cmd: |
       bash -c '
         set -euo pipefail
-        case "${ARTIFACT_PATH##*.}" in
+        artifact="{{ .ArtifactPath }}"
+        case "${artifact##*.}" in
           deb)
-            cloudsmith push deb janosmiko/lfk/any-distro/any-version "${ARTIFACT_PATH}" --republish
+            cloudsmith push deb janosmiko/lfk/any-distro/any-version "${artifact}" --republish
             ;;
           rpm)
-            cloudsmith push rpm janosmiko/lfk/any-distro/any-version "${ARTIFACT_PATH}" --republish
+            cloudsmith push rpm janosmiko/lfk/any-distro/any-version "${artifact}" --republish
             ;;
           *)
-            echo "skipping ${ARTIFACT_PATH} (not deb or rpm)"
+            echo "skipping ${artifact} (not deb or rpm)"
             ;;
         esac
       '


### PR DESCRIPTION
## Hotfix

The v0.10.4 release made it past Chocolatey (now installs cleanly via mono-devel + tarball, per #168) but failed at the Cloudsmith custom publisher:

\`\`\`
custom publisher: failed to publish artifacts: exit status 1
output:
  bash: line 3: ARTIFACT_PATH: unbound variable
\`\`\`

Failing run: https://github.com/janosmiko/lfk/actions/runs/25444488863/job/74645042915

## Root cause

The publishers block used \`\${ARTIFACT_PATH}\` (shell env var). GoReleaser's custom publishers expose the artifact path via Go template (\`{{ .ArtifactPath }}\`), not as a shell env var. With \`set -u\`, the unbound shell variable aborted the script before any \`cloudsmith push\` ran.

## Fix

Assign \`{{ .ArtifactPath }}\` (resolved at GoReleaser template time) to a bash variable \`artifact\` once, and reference \`\${artifact}\` from the case statement. This is the pattern used in GoReleaser's own publishers documentation.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, re-tag v0.10.4 (delete current tag, retag, push). The release workflow should pass through the cloudsmith publisher and successfully push the four nfpm artifacts (.deb amd64/arm64, .rpm amd64/arm64) to https://cloudsmith.io/~janosmiko/repos/lfk/packages/.