### PR TITLE
fix: stop infinite Loading spinner on permission errors

### DIFF
--- a/internal/app/update_msg_test.go
+++ b/internal/app/update_msg_test.go
@@ -2666,3 +2666,75 @@ func TestUpdateResourcesLoadedPreviewNoPrimeWhenMissingRT(t *testing.T) {
 	assert.False(t, hasEmptyKey, "must not prime cache under an empty-resource key")
 	assert.Empty(t, rm.cacheFingerprints, "must not record a fingerprint without an rt")
 }
+
+// TestUpdateResourcesLoaded_ErrorClearsPreviewLoading_ForPreview verifies that
+// a permission error on a preview fetch clears previewLoading so the right pane
+// stops showing the infinite spinner.
+func TestUpdateResourcesLoaded_ErrorClearsPreviewLoading_ForPreview(t *testing.T) {
+	m := baseFinalModel()
+	m.previewLoading = true
+	m.requestGen = 1
+	result, cmd := m.Update(resourcesLoadedMsg{
+		err:        fmt.Errorf("listing servicecidrs: forbidden"),
+		forPreview: true,
+		gen:        1,
+	})
+	rm := result.(Model)
+	assert.False(t, rm.previewLoading,
+		"previewLoading must clear on error for preview fetch so the right pane stops spinning")
+	assert.NotNil(t, rm.err)
+	assert.NotNil(t, cmd)
+}
+
+// TestUpdateResourcesLoaded_ErrorClearsPreviewLoading_ForMain verifies that
+// a permission error on a main-list fetch also clears previewLoading since no
+// follow-up preview will be dispatched from the error path.
+func TestUpdateResourcesLoaded_ErrorClearsPreviewLoading_ForMain(t *testing.T) {
+	m := baseFinalModel()
+	m.previewLoading = true
+	m.requestGen = 1
+	result, cmd := m.Update(resourcesLoadedMsg{
+		err: fmt.Errorf("listing servicecidrs: forbidden"),
+		gen: 1,
+	})
+	rm := result.(Model)
+	assert.False(t, rm.previewLoading,
+		"previewLoading must clear on error for main fetch — no preview will be dispatched")
+	assert.NotNil(t, rm.err)
+	assert.NotNil(t, cmd)
+}
+
+// TestUpdateOwnedLoaded_ErrorClearsPreviewLoading verifies that a permission
+// error on an owned-resource fetch clears previewLoading.
+func TestUpdateOwnedLoaded_ErrorClearsPreviewLoading(t *testing.T) {
+	m := baseFinalModel()
+	m.nav.Level = model.LevelOwned
+	m.previewLoading = true
+	m.requestGen = 1
+	result, cmd := m.Update(ownedLoadedMsg{
+		err: fmt.Errorf("listing pods: forbidden"),
+		gen: 1,
+	})
+	rm := result.(Model)
+	assert.False(t, rm.previewLoading,
+		"previewLoading must clear on ownedLoadedMsg error so the right pane stops spinning")
+	assert.NotNil(t, rm.err)
+	assert.NotNil(t, cmd)
+}
+
+// TestUpdateContainersLoaded_ErrorClearsPreviewLoading verifies that a
+// permission error on a containers fetch clears previewLoading.
+func TestUpdateContainersLoaded_ErrorClearsPreviewLoading(t *testing.T) {
+	m := baseFinalModel()
+	m.previewLoading = true
+	m.requestGen = 1
+	result, cmd := m.Update(containersLoadedMsg{
+		err: fmt.Errorf("listing containers: forbidden"),
+		gen: 1,
+	})
+	rm := result.(Model)
+	assert.False(t, rm.previewLoading,
+		"previewLoading must clear on containersLoadedMsg error so the right pane stops spinning")
+	assert.NotNil(t, rm.err)
+	assert.NotNil(t, cmd)
+}

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -253,6 +253,7 @@ func (m Model) updateResourcesLoaded(msg resourcesLoadedMsg) (tea.Model, tea.Cmd
 	}
 	if msg.err != nil {
 		m.err = msg.err
+		m.previewLoading = false
 		m.setErrorFromErr("Warning: ", msg.err)
 		return m, scheduleStatusClear()
 	}
@@ -467,6 +468,7 @@ func (m Model) updateOwnedLoaded(msg ownedLoadedMsg) (tea.Model, tea.Cmd) {
 	}
 	if msg.err != nil {
 		m.err = msg.err
+		m.previewLoading = false
 		m.setErrorFromErr("Warning: ", msg.err)
 		return m, scheduleStatusClear()
 	}
@@ -548,6 +550,7 @@ func (m Model) updateContainersLoaded(msg containersLoadedMsg) (tea.Model, tea.C
 	}
 	if msg.err != nil {
 		m.err = msg.err
+		m.previewLoading = false
 		m.setErrorFromErr("Warning: ", msg.err)
 		return m, scheduleStatusClear()
 	}

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -292,6 +292,9 @@ func (m Model) renderRightResources(width, height int) string {
 		if m.loading || m.previewLoading {
 			return ui.DimStyle.Render(m.spinner.View() + " Loading...")
 		}
+		if m.err != nil {
+			return ui.DimStyle.Render("Unable to load resources")
+		}
 		return m.renderFallbackYAML(width, height)
 	}
 	return m.renderRightDefault(width, height)
@@ -318,6 +321,9 @@ func (m Model) renderRightDefault(width, height int) string {
 	if len(m.rightItems) == 0 {
 		if m.loading || m.previewLoading {
 			return ui.DimStyle.Render(m.spinner.View() + " Loading...")
+		}
+		if m.err != nil {
+			return ui.DimStyle.Render("Unable to load resources")
 		}
 		return ui.DimStyle.Render("No resources found")
 	}

--- a/internal/app/view_right_coverage_test.go
+++ b/internal/app/view_right_coverage_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -379,4 +380,35 @@ func TestRenderRightColumnContentMapView(t *testing.T) {
 	}
 	result := m.renderRightColumnContent(80, 20)
 	assert.Contains(t, result, "Loading resource tree")
+}
+
+// TestRenderRightDefault_ErrorShowsMessage verifies that when an error occurs
+// and previewLoading is false, the right pane shows an error message instead of
+// "No resources found".
+func TestRenderRightDefault_ErrorShowsMessage(t *testing.T) {
+	m := Model{
+		nav: model.NavigationState{
+			Level:        model.LevelOwned,
+			ResourceType: model.ResourceTypeEntry{Kind: "Deployment"},
+		},
+		err: fmt.Errorf("forbidden: user cannot list pods"),
+	}
+	result := m.renderRightDefault(80, 20)
+	assert.Contains(t, result, "Unable to load")
+	assert.NotContains(t, result, "Loading")
+}
+
+// TestRenderRightResources_ErrorShowsMessage verifies the same behavior in
+// the resources-level rendering path.
+func TestRenderRightResources_ErrorShowsMessage(t *testing.T) {
+	m := Model{
+		nav: model.NavigationState{
+			Level:        model.LevelResources,
+			ResourceType: model.ResourceTypeEntry{Kind: "ServiceCIDR"},
+		},
+		err: fmt.Errorf("forbidden: user cannot list servicecidrs"),
+	}
+	result := m.renderRightColumnContent(80, 20)
+	assert.Contains(t, result, "Unable to load")
+	assert.NotContains(t, result, "Loading")
 }


### PR DESCRIPTION
## Summary

<img width="1911" height="1033" alt="Screenshot 2026-05-06 at 12 26 30 PM" src="https://github.com/user-attachments/assets/35b4a522-33f9-4dac-9358-253320f70d6d" />
The animation that accompanies the "Loading..." text continues spinning even when the program is unable to retrieve resources.

- Clear `previewLoading` flag in error paths of `updateResourcesLoaded`, `updateOwnedLoaded`, and `updateContainersLoaded` so the right pane stops spinning when a Kubernetes API error (e.g., forbidden) occurs
- Display "Unable to load resources" in the right pane instead of "No resources found" when an error is present
- Add 6 regression tests covering both the flag-clearing fix and the error-aware rendering

## Test plan

- [ ] Run `go test ./internal/app/...` — all tests pass
- [ ] Connect to a cluster where you lack permissions on a resource (e.g., servicecidrs), select it, confirm right pane shows "Unable to load resources" instead of infinite spinner
- [ ] Verify normal resources still load correctly (no regression in spinner behavior)