### PR TITLE
feat(release): add AUR channel (lfk-bin)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,11 +195,12 @@ jobs:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           missing=()
-          for s in RELEASE_TAP_TOKEN WINGET_TOKEN CHOCOLATEY_API_KEY CLOUDSMITH_API_KEY DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+          for s in RELEASE_TAP_TOKEN WINGET_TOKEN CHOCOLATEY_API_KEY CLOUDSMITH_API_KEY AUR_SSH_PRIVATE_KEY DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
             if [ -z "${!s}" ]; then missing+=("$s"); fi
           done
           if [ ${#missing[@]} -ne 0 ]; then
@@ -220,6 +221,7 @@ jobs:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
 
       # Generates SLSA build provenance attestations for every release artifact.
       # GitHub publishes the attestations alongside the release so downstream

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -170,6 +170,25 @@ chocolateys:
     source_repo: "https://push.chocolatey.org/"
     skip_publish: false
 
+aurs:
+  - name: lfk-bin
+    homepage: "https://github.com/janosmiko/lfk"
+    description: "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters"
+    maintainers:
+      - 'janosmiko <janosmiko@users.noreply.github.com>'
+    license: MIT
+    private_key: "{{ .Env.AUR_SSH_PRIVATE_KEY }}"
+    git_url: "ssh://aur@aur.archlinux.org/lfk-bin.git"
+    commit_msg_template: "chore: bump lfk-bin to {{ .Tag }}"
+    package: |-
+      install -Dm755 "./lfk" "${pkgdir}/usr/bin/lfk"
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/lfk/LICENSE"
+      install -Dm644 "./README.md" "${pkgdir}/usr/share/doc/lfk/README.md"
+    optdepends:
+      - 'kubectl: Kubernetes CLI integration'
+      - 'helm: Helm release management'
+      - 'trivy: Container image vulnerability scanning'
+
 publishers:
   - name: cloudsmith
     ids:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ nfpms:
     homepage: "https://github.com/janosmiko/lfk"
     maintainer: "janosmiko <janosmiko@users.noreply.github.com>"
     description: "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters"
-    license: MIT
+    license: Apache-2.0
     formats:
       - deb
       - rpm
@@ -87,7 +87,7 @@ brews:
     name: lfk
     homepage: "https://github.com/janosmiko/lfk"
     description: "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters"
-    license: "MIT"
+    license: "Apache-2.0"
     dependencies:
       - name: kubectl
         type: optional
@@ -108,13 +108,13 @@ scoops:
     name: lfk
     homepage: "https://github.com/janosmiko/lfk"
     description: "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters"
-    license: MIT
+    license: Apache-2.0
     commit_msg_template: "chore: bump lfk to {{ .Tag }}"
 
 winget:
   - name: lfk
     publisher: janosmiko
-    license: MIT
+    license: Apache-2.0
     homepage: "https://github.com/janosmiko/lfk"
     short_description: "Lightning Fast Kubernetes navigator"
     description: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -176,14 +176,14 @@ aurs:
     description: "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters"
     maintainers:
       - 'janosmiko <janosmiko@users.noreply.github.com>'
-    license: MIT
+    license: Apache-2.0
     private_key: "{{ .Env.AUR_SSH_PRIVATE_KEY }}"
     git_url: "ssh://aur@aur.archlinux.org/lfk-bin.git"
     commit_msg_template: "chore: bump lfk-bin to {{ .Tag }}"
     package: |-
       install -Dm755 "./lfk" "${pkgdir}/usr/bin/lfk"
-      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/lfk/LICENSE"
-      install -Dm644 "./README.md" "${pkgdir}/usr/share/doc/lfk/README.md"
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/lfk-bin/LICENSE"
+      install -Dm644 "./README.md" "${pkgdir}/usr/share/doc/lfk-bin/README.md"
     optdepends:
       - 'kubectl: Kubernetes CLI integration'
       - 'helm: Helm release management'

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket && scoop in
 # or: winget install janosmiko.lfk
 # or: choco install lfk
 
+# Linux: Arch / AUR
+yay -S lfk-bin
+
 # Linux: Debian / Ubuntu (Cloudsmith APT)
 curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.deb.sh' | sudo -E bash && sudo apt update && sudo apt install lfk
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,18 @@ brew install janosmiko/tap/lfk
 
 ## Linux
 
+### AUR (Arch, Manjaro, EndeavourOS)
+
+```bash
+yay -S lfk-bin
+# or
+paru -S lfk-bin
+# or, manually:
+git clone https://aur.archlinux.org/lfk-bin.git && cd lfk-bin && makepkg -si
+```
+
+The `lfk-bin` package installs the prebuilt binary from the GitHub release. There is no source-build (`lfk` AUR) package; if you want to build from source, use `go install github.com/janosmiko/lfk@latest`.
+
 ### Debian / Ubuntu (Cloudsmith APT)
 
 Add the Cloudsmith repository, then install:


### PR DESCRIPTION
## Summary

Adds the AUR publish channel for `lfk`. Users on Arch / Manjaro / EndeavourOS install with:

\`\`\`
yay -S lfk-bin
\`\`\`

- New \`aurs:\` block in \`.goreleaser.yaml\` publishes \`lfk-bin\` to \`ssh://aur@aur.archlinux.org/lfk-bin.git\` on every release tag.
- The AUR PKGBUILD installs the prebuilt binary + LICENSE + README into standard paths.
- \`optdepends\` mirror the brew formula: kubectl (Kubernetes integration), helm (release management), trivy (image scanning).
- \`AUR_SSH_PRIVATE_KEY\` secret threaded through preflight + GoReleaser step.
- Docs updated: new \`### AUR\` subsection in \`docs/installation.md\` Linux section + AUR one-liner in README install snippet.

This is the AUR portion of Phase 3; Snap (\`snapcrafts:\`) is deferred to PR 3b pending classic-confinement approval from Snapcraft.

## Pre-requisites in place

- [x] AUR account \`janosmiko\` with SSH public key uploaded.
- [x] \`lfk-bin\` package name reserved (or will auto-create on first push).
- [x] \`AUR_SSH_PRIVATE_KEY\` secret set on the lfk repo (multi-line PEM).

## Test plan

- [ ] CI green on this PR.
- [ ] After merge + release tag (e.g. v0.10.5): GoReleaser pushes a PKGBUILD commit to \`aur.archlinux.org/packages/lfk-bin\`.
- [ ] On a clean Arch VM: \`yay -S lfk-bin\` installs successfully and \`lfk --version\` reports the new tag.

## Out of scope

- Snap (PR 3b) — gated on Snapcraft classic-confinement approval.