### PR TITLE
chore: untrack .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8c44ebdf-d65c-4493-8058-c76913408b7f","pid":99167,"procStart":"Thu May  7 06:55:29 2026","acquiredAt":1778223626556}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ themes/ghostty/
 # Worktrees
 .worktrees/
 
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock
+
 # Superpowers planning scratch (per-feature plans + design specs are
 # local working notes, not shipped artifacts).
 docs/superpowers/


### PR DESCRIPTION
## Summary

- Removes `.claude/scheduled_tasks.lock`, accidentally committed via #175.
- Adds a `.gitignore` entry so the Claude Code runtime lock file can't sneak back in.

## Test plan

- [x] `git status` clean against this branch
- [x] pre-commit hook (`golangci-lint run ./...`) passes