### PR TITLE
fix(nodeshell): land on DiskPressure/MemoryPressure/PIDPressure nodes

### DIFF
--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -214,6 +214,15 @@ func (m Model) runDebugPodWithPVC() tea.Cmd {
 	return runInteractiveShellExec(cmd, title, "Debug pod", true)
 }
 
+// nodeShellNamespace is the namespace nodeshell pods are always created in.
+//
+// nodeshell needs system-node-critical priority so the kubelet admits the pod
+// on nodes with DiskPressure / MemoryPressure / PIDPressure conditions
+// (admission rejects non-critical pods regardless of tolerations). The
+// built-in Priority admission plugin restricts that priority class to pods
+// in kube-system, so the namespace is pinned here.
+const nodeShellNamespace = "kube-system"
+
 func nodeShellOverrides(podName, nodeName string) (string, error) {
 	spec := map[string]any{
 		"apiVersion": "v1",
@@ -222,7 +231,23 @@ func nodeShellOverrides(podName, nodeName string) (string, error) {
 			"hostIPC":     true,
 			"hostNetwork": true,
 			"nodeName":    nodeName,
-			"tolerations": []map[string]any{{"operator": "Exists"}},
+			// system-node-critical lifts the pod above the kubelet eviction
+			// manager's admission gate so it can land on nodes reporting
+			// DiskPressure / PIDPressure / MemoryPressure conditions. The
+			// priority class is built into Kubernetes since 1.11 and is
+			// reserved for the kube-system namespace (see nodeShellNamespace).
+			"priorityClassName": "system-node-critical",
+			// Tolerate every taint on every effect so the pod can land on
+			// control-plane, NotReady, Unschedulable, or pressure-tainted
+			// nodes. {operator: Exists} with no key/effect already matches
+			// all taints per the Kubernetes spec; the per-effect entries are
+			// kept for readability and to make the intent grep-able.
+			"tolerations": []map[string]any{
+				{"operator": "Exists"},
+				{"operator": "Exists", "effect": "NoSchedule"},
+				{"operator": "Exists", "effect": "PreferNoSchedule"},
+				{"operator": "Exists", "effect": "NoExecute"},
+			},
 			"containers": []map[string]any{{
 				"name":  podName,
 				"image": "busybox",
@@ -280,7 +305,7 @@ func (m Model) execKubectlNodeShell() tea.Cmd {
 		}
 	}
 
-	args := nodeShellArgs(podName, m.actionNamespace(), m.kubectlContext(ctx), overrides)
+	args := nodeShellArgs(podName, nodeShellNamespace, m.kubectlContext(ctx), overrides)
 	cmd := exec.Command(kubectlPath, args...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 	logExecCmd("Running kubectl command", cmd)

--- a/internal/app/commands_exec_test.go
+++ b/internal/app/commands_exec_test.go
@@ -163,12 +163,16 @@ func TestNodeShellArgsUseRunWithCleanOverrides(t *testing.T) {
 
 	var spec struct {
 		Spec struct {
-			HostPID     bool   `json:"hostPID"`
-			HostIPC     bool   `json:"hostIPC"`
-			HostNetwork bool   `json:"hostNetwork"`
-			NodeName    string `json:"nodeName"`
-			Tolerations []struct {
+			HostPID           bool   `json:"hostPID"`
+			HostIPC           bool   `json:"hostIPC"`
+			HostNetwork       bool   `json:"hostNetwork"`
+			NodeName          string `json:"nodeName"`
+			PriorityClassName string `json:"priorityClassName"`
+			Tolerations       []struct {
+				Key      string `json:"key"`
 				Operator string `json:"operator"`
+				Value    string `json:"value"`
+				Effect   string `json:"effect"`
 			} `json:"tolerations"`
 			Containers []struct {
 				Name            string   `json:"name"`
@@ -188,8 +192,36 @@ func TestNodeShellArgsUseRunWithCleanOverrides(t *testing.T) {
 	assert.True(t, spec.Spec.HostIPC, "hostIPC required for nsenter --ipc")
 	assert.True(t, spec.Spec.HostNetwork)
 	assert.Equal(t, "node-1", spec.Spec.NodeName, "pod must pin to the target node")
-	require.Len(t, spec.Spec.Tolerations, 1, "must tolerate all taints to land on control-plane nodes")
-	assert.Equal(t, "Exists", spec.Spec.Tolerations[0].Operator)
+
+	// system-node-critical lifts the pod above the kubelet eviction manager's
+	// admission gate so it can run on DiskPressure / MemoryPressure /
+	// PIDPressure nodes (admission rejects non-critical pods regardless of
+	// tolerations). Reserved for kube-system, hence nodeShellNamespace.
+	assert.Equal(t, "system-node-critical", spec.Spec.PriorityClassName,
+		"priorityClassName must lift pod above kubelet eviction admission gate")
+
+	// Must tolerate every taint on every effect — control-plane, NotReady,
+	// Unschedulable, and the four pressure taints all use distinct keys/effects.
+	require.NotEmpty(t, spec.Spec.Tolerations, "must tolerate all taints")
+	for _, tol := range spec.Spec.Tolerations {
+		assert.Equal(t, "Exists", tol.Operator,
+			"every toleration must use operator Exists to match all values")
+		assert.Empty(t, tol.Key,
+			"every toleration must have empty key to match all taint keys")
+		assert.Empty(t, tol.Value,
+			"operator Exists forbids value")
+		assert.Contains(t, []string{"", "NoSchedule", "PreferNoSchedule", "NoExecute"}, tol.Effect,
+			"effect must be empty or one of the three valid taint effects")
+	}
+	// Per-effect coverage: an empty effect already matches all, but the
+	// explicit per-effect entries make the intent grep-able.
+	effects := map[string]bool{}
+	for _, tol := range spec.Spec.Tolerations {
+		effects[tol.Effect] = true
+	}
+	for _, want := range []string{"", "NoSchedule", "PreferNoSchedule", "NoExecute"} {
+		assert.True(t, effects[want], "missing toleration entry for effect %q", want)
+	}
 
 	require.Len(t, spec.Spec.Containers, 1)
 	c := spec.Spec.Containers[0]
@@ -209,6 +241,16 @@ func TestNodeShellArgsUseRunWithCleanOverrides(t *testing.T) {
 	for _, short := range []string{"-t", "-m", "-u", "-i", "-n", "-p"} {
 		assert.NotContains(t, c.Command, short, "expected long flag instead of %s", short)
 	}
+}
+
+// system-node-critical is the only built-in priority class that lifts a pod
+// above the kubelet eviction manager's admission gate, and it is reserved by
+// the Priority admission plugin to pods in kube-system. Pinning the namespace
+// here is what lets `lfk` open a node shell on a DiskPressure-tainted node.
+func TestNodeShellNamespaceIsKubeSystem(t *testing.T) {
+	assert.Equal(t, "kube-system", nodeShellNamespace,
+		"system-node-critical priorityClass is restricted to kube-system; "+
+			"changing this namespace will break node shell on tainted/pressured nodes")
 }
 
 // nodeShellArgs falls back to the "default" namespace when the caller passes

--- a/internal/app/update_actions_helm_misc.go
+++ b/internal/app/update_actions_helm_misc.go
@@ -13,7 +13,7 @@ import (
 func (m Model) executeActionShell() (tea.Model, tea.Cmd) {
 	name := m.actionCtx.name
 	ctx := m.actionCtx.context
-	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl run lfk-node-shell-<rand> -n default --rm -it --restart=Never --image=busybox --context %s --overrides='<spec pinned to %s with hostPID/IPC/Net + privileged + nsenter>'", ctx, name))
+	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl run lfk-node-shell-<rand> -n kube-system --rm -it --restart=Never --image=busybox --context %s --overrides='<spec pinned to %s with hostPID/IPC/Net + privileged + nsenter + system-node-critical + tolerate-everything>'", ctx, name))
 	return m, m.execKubectlNodeShell()
 }
 


### PR DESCRIPTION
## Summary

- Node shell pods couldn't start on nodes reporting `DiskPressure` (or memory/PID pressure) conditions even though the spec already tolerated every taint. Once `nodeName` is pinned the scheduler is bypassed, but the kubelet's eviction-manager admission then rejects any non-critical pod regardless of tolerations.
- Add `priorityClassName: system-node-critical` so the kubelet's `IsCriticalPod` check passes, lifting the pod above the eviction admission gate.
- Pin the pod's namespace to `kube-system` (new `nodeShellNamespace` constant). The built-in Priority admission plugin reserves `system-node-critical` for that namespace, and the previous `m.actionNamespace()` value wasn't meaningful for a cluster-scoped node anyway.
- Expand tolerations into explicit per-effect entries (`""`, `NoSchedule`, `PreferNoSchedule`, `NoExecute`) so the "tolerate everything" intent is grep-able. Functionally equivalent to the prior canonical `[{operator: Exists}]`.

## Test plan

- [x] `go test -race ./internal/app/...` (all green)
- [x] `golangci-lint run ./internal/app/...` (0 issues)
- [x] Updated test asserts `priorityClassName == system-node-critical`, walks every toleration (operator/key/value/effect), and verifies per-effect coverage
- [x] New `TestNodeShellNamespaceIsKubeSystem` locks the namespace constant in
- [ ] Manual: open a node shell on a node with `node.kubernetes.io/disk-pressure:NoSchedule` taint and confirm the pod admits and `nsenter` lands in the host shell