### PR TITLE
fix(ui): keep pinned resource-usage footer on screen when events have a high count

### DIFF
--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -479,9 +479,10 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 	}
 
 	// Calculate column widths for alignment.
-	// Format: AGE  TYPE  REASON  MESSAGE
+	// Format: AGE  TYPE  REASON  MESSAGE  (xCount)?
 	maxAgeW := 0
 	maxReasonW := 0
+	maxCountW := 0
 	for _, e := range events {
 		ageStr := RelativeTime(e.Timestamp)
 		if len(ageStr) > maxAgeW {
@@ -490,14 +491,29 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 		if len(e.Reason) > maxReasonW {
 			maxReasonW = len(e.Reason)
 		}
+		if e.Count > 1 {
+			countStr := fmt.Sprintf(" (x%d)", e.Count)
+			if len(countStr) > maxCountW {
+				maxCountW = len(countStr)
+			}
+		}
 	}
 	// Cap reason column width.
 	if maxReasonW > 25 {
 		maxReasonW = 25
 	}
 
-	// Message width: total width minus age, type indicator, reason, spacing.
-	msgWidth := max(width-maxAgeW-3-maxReasonW-4, 20) // 3 for " ● ", 4 for spacing
+	// Message width: total width minus age, type indicator, reason, count
+	// suffix, and inter-column spacing.
+	//
+	// maxCountW MUST be reserved up-front (even on rows whose own Count is 0)
+	// so every rendered line stays within `width`. Skipping it lets a line
+	// like " 2m ago ● FailedMount MountVolume.MountDevice failed... (x61)"
+	// exceed the right-column's lipgloss wrap point — lipgloss then wraps it
+	// onto a second visual row, the right column overflows MaxHeight, and
+	// the pinned resource-usage footer at the bottom of the pane gets
+	// clipped off the screen.
+	msgWidth := max(width-maxAgeW-3-maxReasonW-4-maxCountW, 20) // 3 for " ● ", 4 for spacing
 
 	for _, e := range events {
 		ageStr := RelativeTime(e.Timestamp)

--- a/internal/ui/explorer_resource_test.go
+++ b/internal/ui/explorer_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/janosmiko/lfk/internal/model"
@@ -146,6 +147,46 @@ func TestRenderPreviewEvents(t *testing.T) {
 		}
 		result := RenderPreviewEvents(events, 80)
 		assert.Contains(t, result, "Pulled")
+	})
+
+	// Regression: a high count suffix like "(x61)" used to push the rendered
+	// line past `width`, so lipgloss would wrap it inside the right-column
+	// style. The wrap added a visual row, the right pane overflowed
+	// MaxHeight, and the pinned resource-usage footer got clipped off-screen.
+	// Assert every visible event line stays within `width` for any count.
+	t.Run("event lines with high count fit within width", func(t *testing.T) {
+		now := time.Now()
+		cases := []struct {
+			name  string
+			width int
+			count int32
+			msg   string
+		}{
+			{"short message x63", 80, 63, "MountVolume.SetUp failed for volume \"argocd-dex-server-tls\""},
+			{"long message x61", 80, 61, "MountVolume.MountDevice failed for volume \"pvc-e5942d48-d121-46b0-85a6-3f6ce9d3026f\" : timed out waiting for the condition"},
+			{"narrow column x9999", 60, 9999, "MountVolume.SetUp failed"},
+			{"single digit count x2", 80, 2, "Back-off restarting failed container"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				events := []EventTimelineEntry{{
+					Timestamp: now.Add(-2 * time.Hour),
+					Type:      "Warning",
+					Reason:    "FailedMount",
+					Message:   tc.msg,
+					Count:     tc.count,
+				}}
+				result := RenderPreviewEvents(events, tc.width)
+				for line := range strings.SplitSeq(result, "\n") {
+					if line == "" {
+						continue
+					}
+					assert.LessOrEqual(t, lipgloss.Width(line), tc.width,
+						"event line exceeds width=%d (would force lipgloss wrap and clip the resource-usage footer): %q (visible width %d)",
+						tc.width, line, lipgloss.Width(line))
+				}
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

- The right pane's pinned `RESOURCE USAGE` footer was being clipped (the memory bar in particular) whenever a preview event carried a high `Count` like `(x61)`.
- Root cause: `RenderPreviewEvents` reserves message-column space as `width - maxAge - maxReason - 7` but never accounts for the trailing `(xN)` suffix. With a count present the rendered line ends up `width - 2 + countLen` cells wide — 4 cells past the right column's lipgloss wrap point of `Width - Padding = rightW - 2`. Lipgloss wraps the line onto a second visual row, the right column overflows `MaxHeight(contentHeight + 2)`, and since `MaxHeight` clips from the bottom the pinned footer is what gets cut. From the user's seat the children pane "got oversized randomly" — really the entire right column did because of one wrapped event line.
- Fix: walk events once up front to compute `maxCountW`, then deduct it from `msgWidth` so every rendered line stays within `width` regardless of which events carry counts. The worst-case suffix is reserved for every line, so columns stay aligned even when only some events have a count > 1.

## Test plan

- [x] New `event_lines_with_high_count_fit_within_width` subtest with 4 cases (x63 short, x61 long, x9999 narrow column, x2 minimum). Verified it fails on the pre-fix code (line width 84 vs column 80) and passes after.
- [x] `go test -race ./internal/ui/... ./internal/app/...` (all green)
- [x] `golangci-lint run ./internal/ui/... ./internal/app/...` (0 issues)
- [x] Manual: open a pod whose events include a `FailedMount` with `(x60+)` and confirm the memory bar in `RESOURCE USAGE` is fully visible at the bottom of the right column