### PR TITLE
feat(k8s): surface ephemeral containers in pod views

### DIFF
--- a/internal/k8s/client_crd.go
+++ b/internal/k8s/client_crd.go
@@ -104,7 +104,10 @@ func extractCRDPrinterColumns(spec map[string]any, preferredVersion string) []mo
 }
 
 // buildContainerItem creates a model.Item for a container with enriched details.
-func buildContainerItem(c corev1.Container, statuses []corev1.ContainerStatus, isInit, isSidecar bool) model.Item {
+// At most one of isInit, isSidecar, isEphemeral should be true. Sidecar implies
+// init (a sidecar is an initContainer with restartPolicy=Always); ephemeral is
+// independent (it lives in pod.Spec.EphemeralContainers).
+func buildContainerItem(c corev1.Container, statuses []corev1.ContainerStatus, isInit, isSidecar, isEphemeral bool) model.Item {
 	item := model.Item{
 		Name:  c.Name,
 		Kind:  "Container",
@@ -112,6 +115,9 @@ func buildContainerItem(c corev1.Container, statuses []corev1.ContainerStatus, i
 	}
 
 	switch {
+	case isEphemeral:
+		item.Category = "Ephemeral Containers"
+		item.Status = "Waiting"
 	case isSidecar:
 		item.Category = "Sidecar Containers"
 		item.Status = "Waiting"

--- a/internal/k8s/client_crd_test.go
+++ b/internal/k8s/client_crd_test.go
@@ -423,7 +423,7 @@ func TestBuildContainerItem(t *testing.T) {
 			},
 		}
 
-		item := buildContainerItem(c, statuses, false, false)
+		item := buildContainerItem(c, statuses, false, false, false)
 
 		assert.Equal(t, "app", item.Name)
 		assert.Equal(t, "Container", item.Kind)
@@ -445,7 +445,7 @@ func TestBuildContainerItem(t *testing.T) {
 
 	t.Run("init container", func(t *testing.T) {
 		c := corev1.Container{Name: "init-db", Image: "busybox"}
-		item := buildContainerItem(c, nil, true, false)
+		item := buildContainerItem(c, nil, true, false, false)
 
 		assert.Equal(t, "Init Containers", item.Category)
 		assert.Equal(t, "Init", item.Status)
@@ -453,10 +453,23 @@ func TestBuildContainerItem(t *testing.T) {
 
 	t.Run("sidecar container", func(t *testing.T) {
 		c := corev1.Container{Name: "envoy", Image: "envoyproxy/envoy:v1.28"}
-		item := buildContainerItem(c, nil, false, true)
+		item := buildContainerItem(c, nil, false, true, false)
 
 		assert.Equal(t, "Sidecar Containers", item.Category)
 		assert.Equal(t, "Waiting", item.Status)
+	})
+
+	t.Run("ephemeral container", func(t *testing.T) {
+		c := corev1.Container{Name: "debugger", Image: "busybox:latest"}
+		statuses := []corev1.ContainerStatus{
+			{Name: "debugger", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+		}
+		item := buildContainerItem(c, statuses, false, false, true)
+
+		assert.Equal(t, "Ephemeral Containers", item.Category)
+		assert.Equal(t, "Container", item.Kind)
+		assert.Equal(t, "Running", item.Status)
+		assert.Equal(t, "true", item.Ready)
 	})
 
 	t.Run("container with waiting state", func(t *testing.T) {
@@ -475,7 +488,7 @@ func TestBuildContainerItem(t *testing.T) {
 			},
 		}
 
-		item := buildContainerItem(c, statuses, false, false)
+		item := buildContainerItem(c, statuses, false, false, false)
 
 		assert.Equal(t, "CrashLoopBackOff", item.Status)
 		assert.Equal(t, "false", item.Ready)
@@ -503,7 +516,7 @@ func TestBuildContainerItem(t *testing.T) {
 			},
 		}
 
-		item := buildContainerItem(c, statuses, false, false)
+		item := buildContainerItem(c, statuses, false, false, false)
 
 		assert.Equal(t, "OOMKilled", item.Status)
 		colMap := columnsToMap(item.Columns)
@@ -531,7 +544,7 @@ func TestBuildContainerItem(t *testing.T) {
 			},
 		}
 
-		item := buildContainerItem(c, statuses, false, false)
+		item := buildContainerItem(c, statuses, false, false, false)
 
 		assert.Equal(t, "Running", item.Status)
 		colMap := columnsToMap(item.Columns)
@@ -551,7 +564,7 @@ func TestBuildContainerItem(t *testing.T) {
 			},
 		}
 
-		item := buildContainerItem(c, statuses, false, false)
+		item := buildContainerItem(c, statuses, false, false, false)
 
 		assert.Equal(t, "Waiting", item.Status)
 		assert.Empty(t, item.Ready)
@@ -569,7 +582,7 @@ func TestBuildContainerItem(t *testing.T) {
 			},
 		}
 
-		item := buildContainerItem(c, nil, false, false)
+		item := buildContainerItem(c, nil, false, false, false)
 
 		colMap := columnsToMap(item.Columns)
 		assert.Equal(t, "http:80/TCP, 443/TCP, metrics:9090/TCP", colMap["Ports"])
@@ -593,7 +606,7 @@ func TestBuildContainerItem(t *testing.T) {
 			},
 		}
 
-		item := buildContainerItem(c, statuses, false, false)
+		item := buildContainerItem(c, statuses, false, false, false)
 
 		colMap := columnsToMap(item.Columns)
 		assert.Equal(t, "Completed", colMap["Last Terminated"])

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -2371,6 +2371,8 @@ func TestBuildPodTree_WithEphemeralContainers(t *testing.T) {
 	for _, ch := range root.Children {
 		if ch.Kind == "Container" && ch.Name == "debugger" {
 			ephemeralFound = true
+			// Verify status flows from pod.Status.EphemeralContainerStatuses, not just spec presence.
+			assert.Equal(t, "Running", ch.Status)
 			break
 		}
 	}

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -313,6 +313,51 @@ func TestGetContainers_NotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestGetContainers_WithEphemeralContainers(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "myapp:v1"},
+			},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{
+					EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+						Name:  "debugger",
+						Image: "busybox:latest",
+					},
+					TargetContainerName: "app",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debugger", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+	cs := k8sfake.NewClientset(pod)
+	c := newFakeClient(cs, nil)
+
+	items, err := c.GetContainers(context.Background(), "", "default", "my-pod")
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	// App containers come before ephemerals (ephemerals are runtime-attached).
+	assert.Equal(t, "app", items[0].Name)
+	assert.Equal(t, "Containers", items[0].Category)
+
+	assert.Equal(t, "debugger", items[1].Name)
+	assert.Equal(t, "Container", items[1].Kind)
+	assert.Equal(t, "Ephemeral Containers", items[1].Category)
+	assert.Equal(t, "Running", items[1].Status)
+	assert.Equal(t, "true", items[1].Ready)
+	assert.Equal(t, "busybox:latest", items[1].Extra)
+}
+
 // --- GetContainerPorts ---
 
 func TestGetContainerPorts(t *testing.T) {
@@ -2285,6 +2330,52 @@ func TestGetPodsForService_NoSelector(t *testing.T) {
 }
 
 // --- buildPodTree ---
+
+func TestBuildPodTree_WithEphemeralContainers(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: new(false), // suppress the default SA child to keep assertion focused
+			Containers:                   []corev1.Container{{Name: "app"}},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{
+					EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+						Name:  "debugger",
+						Image: "busybox:latest",
+					},
+					TargetContainerName: "app",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debugger", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+	cs := k8sfake.NewClientset(pod)
+	dc := newFakeDynClient()
+	c := newFakeClient(cs, dc)
+
+	root := &model.ResourceNode{Name: "my-pod", Kind: "Pod", Namespace: "default"}
+	err := c.buildPodTree(context.Background(), "", "default", "my-pod", root)
+	require.NoError(t, err)
+
+	// Exactly 2 container children: app + debugger. AutomountServiceAccountToken=false suppresses the SA ref.
+	require.Len(t, root.Children, 2)
+	var ephemeralFound bool
+	for _, ch := range root.Children {
+		if ch.Kind == "Container" && ch.Name == "debugger" {
+			ephemeralFound = true
+			break
+		}
+	}
+	assert.True(t, ephemeralFound, "ephemeral container 'debugger' should appear as a Container child of the pod")
+}
 
 func TestBuildPodTree(t *testing.T) {
 	pod := &corev1.Pod{

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -53,16 +53,27 @@ func (c *Client) GetContainers(ctx context.Context, contextName, namespace, podN
 		return nil, fmt.Errorf("getting pod %s: %w", podName, err)
 	}
 
-	items := make([]model.Item, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
+	items := make([]model.Item, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers)+len(pod.Spec.EphemeralContainers))
 
 	for _, c := range pod.Spec.InitContainers {
 		isSidecar := c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
-		item := buildContainerItem(c, pod.Status.InitContainerStatuses, true, isSidecar)
+		item := buildContainerItem(c, pod.Status.InitContainerStatuses, true, isSidecar, false)
 		items = append(items, item)
 	}
 
 	for _, c := range pod.Spec.Containers {
-		item := buildContainerItem(c, pod.Status.ContainerStatuses, false, false)
+		item := buildContainerItem(c, pod.Status.ContainerStatuses, false, false, false)
+		items = append(items, item)
+	}
+
+	// Ephemeral containers live in their own spec/status arrays and are
+	// runtime-attached (kubectl debug). We project only Name/Image into a
+	// corev1.Container shell because Resources and Ports are disallowed by
+	// the API for ephemeral containers, and buildContainerItem reads only
+	// those four fields plus statuses.
+	for _, ec := range pod.Spec.EphemeralContainers {
+		c := corev1.Container{Name: ec.Name, Image: ec.Image}
+		item := buildContainerItem(c, pod.Status.EphemeralContainerStatuses, false, false, true)
 		items = append(items, item)
 	}
 

--- a/internal/k8s/resources_appendcontainer_test.go
+++ b/internal/k8s/resources_appendcontainer_test.go
@@ -42,6 +42,49 @@ func TestAppendContainerNodes(t *testing.T) {
 		assert.Equal(t, "sidecar", podNode.Children[3].Name)
 	})
 
+	t.Run("includes ephemeral containers with status", func(t *testing.T) {
+		podNode := &model.ResourceNode{
+			Name:      "my-pod",
+			Kind:      "Pod",
+			Namespace: "default",
+		}
+		obj := map[string]any{
+			"spec": map[string]any{
+				"containers": []any{
+					map[string]any{"name": "app"},
+				},
+				"ephemeralContainers": []any{
+					map[string]any{"name": "debugger"},
+				},
+			},
+			"status": map[string]any{
+				"containerStatuses": []any{
+					map[string]any{
+						"name":  "app",
+						"ready": true,
+						"state": map[string]any{"running": map[string]any{}},
+					},
+				},
+				"ephemeralContainerStatuses": []any{
+					map[string]any{
+						"name":  "debugger",
+						"ready": true,
+						"state": map[string]any{"running": map[string]any{}},
+					},
+				},
+			},
+		}
+
+		appendContainerNodes(podNode, obj)
+
+		require.Len(t, podNode.Children, 2)
+		assert.Equal(t, "app", podNode.Children[0].Name)
+		assert.Equal(t, "Running", podNode.Children[0].Status)
+		assert.Equal(t, "debugger", podNode.Children[1].Name)
+		assert.Equal(t, "Container", podNode.Children[1].Kind)
+		assert.Equal(t, "Running", podNode.Children[1].Status)
+	})
+
 	t.Run("no spec returns without adding children", func(t *testing.T) {
 		podNode := &model.ResourceNode{
 			Name:      "my-pod",

--- a/internal/k8s/resources_tree.go
+++ b/internal/k8s/resources_tree.go
@@ -498,10 +498,11 @@ func appendContainerNodes(podNode *model.ResourceNode, obj map[string]any) {
 	// empty rather than defaulting to "Waiting".
 	status, _ := obj["status"].(map[string]any)
 	statusByKey := map[string]map[string]string{
-		"initContainers": extractContainerStatusMap(status, "initContainerStatuses"),
-		"containers":     extractContainerStatusMap(status, "containerStatuses"),
+		"initContainers":      extractContainerStatusMap(status, "initContainerStatuses"),
+		"containers":          extractContainerStatusMap(status, "containerStatuses"),
+		"ephemeralContainers": extractContainerStatusMap(status, "ephemeralContainerStatuses"),
 	}
-	for _, key := range []string{"initContainers", "containers"} {
+	for _, key := range []string{"initContainers", "containers", "ephemeralContainers"} {
 		containers, _ := spec[key].([]any)
 		lookup := statusByKey[key]
 		for _, c := range containers {

--- a/internal/k8s/resources_tree.go
+++ b/internal/k8s/resources_tree.go
@@ -375,6 +375,15 @@ func (c *Client) buildPodTree(ctx context.Context, contextName, namespace, podNa
 		})
 	}
 
+	for _, ec := range pod.Spec.EphemeralContainers {
+		root.Children = append(root.Children, &model.ResourceNode{
+			Name:      ec.Name,
+			Kind:      "Container",
+			Namespace: namespace,
+			Status:    containerStatusFromPod(ec.Name, pod.Status.EphemeralContainerStatuses),
+		})
+	}
+
 	dynClient, dynErr := c.dynamicForContext(contextName)
 	if dynErr != nil {
 		// Tree build proceeds without ref existence checks and without an


### PR DESCRIPTION
## Summary

- `pod.Spec.EphemeralContainers` (kubectl debug attachments) is a first-class K8s API field but was being ignored by `GetContainers` and `buildPodTree`. Ephemeral containers now appear as a third category — `Ephemeral Containers` — in the children pane, log filter overlay, and resource tree.
- `buildContainerItem` gained an `isEphemeral` bool mutually exclusive with `isInit`/`isSidecar`. `GetContainers` projects only `Name`/`Image` into a `corev1.Container` shell because `Resources`/`Ports` are disallowed by the API for ephemeral containers.
- Native sidecars (`initContainer.restartPolicy: Always`, KEP-753) were already handled. Traditional sidecars are deliberately not detected — there is no native API signal for them.

## Out of scope

- Crash investigator integration. Ephemeral containers are runtime-attached debug tools that don't typically crashloop, and full integration would touch ~5 files across k8s/app/ui layers — separate slice if needed.

## Test plan

- [x] `go test ./... -race` passes
- [x] `go vet ./...` clean
- [x] `make lint` clean (0 issues)
- [x] Manual: attach a debug container via `kubectl debug -it <pod> --image=busybox`, then in lfk:
  - [x] Open the pod's children pane — debug container appears under "Ephemeral Containers"
  - [x] Open log viewer (`l`), press `c` for container picker — debug container appears in the list
  - [x] Open resource tree — debug container appears as a `Container` child of the pod