### PR TITLE
fix(tabs): refresh middle column on tab switch (stale-while-revalidate)

### DIFF
--- a/internal/app/tab_switch_refresh_test.go
+++ b/internal/app/tab_switch_refresh_test.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	clientfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/janosmiko/lfk/internal/app/bgtasks"
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestPostTabSwitch_RefreshesMiddleColumnAtLevelResources locks in the fix
+// for the cross-tab stale-data bug: a mutation on Tab A (e.g., deleting a
+// pod that had 10 restarts) used to leave Tab B's saved middleItems
+// untouched until manual refresh. Now switching tabs at LevelResources
+// fires a background refresh so cached data is replaced when the fresh
+// fetch returns.
+//
+// middleItems is left empty so loadPreview's per-selection sub-cmds
+// (containers / metrics / events) short-circuit; the test then proves
+// that postTabSwitchCmd still returns a cmd whose result includes a
+// non-preview resourcesLoadedMsg — i.e. refreshCurrentLevel was added.
+func TestPostTabSwitch_RefreshesMiddleColumnAtLevelResources(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs)
+
+	m := newTabSwitchTestModel(model.LevelResources)
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1", Namespaced: true}
+	m.client = k8s.NewTestClient(clientfake.NewClientset(), dyn)
+
+	cmd := m.postTabSwitchCmd()
+	if cmd == nil {
+		t.Fatal("postTabSwitchCmd returned nil at LevelResources/modeExplorer")
+	}
+
+	sawRefresh := false
+	for _, c := range flattenBatch(cmd) {
+		if loaded, ok := c().(resourcesLoadedMsg); ok && !loaded.forPreview {
+			sawRefresh = true
+		}
+	}
+	assert.True(t, sawRefresh,
+		"postTabSwitchCmd at LevelResources must fire a non-preview refresh fetch")
+}
+
+// TestPostTabSwitch_RefreshesAtLevelOwned covers the LevelOwned variant.
+func TestPostTabSwitch_RefreshesAtLevelOwned(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}:            "PodList",
+		{Group: "apps", Version: "v1", Resource: "replicasets"}: "ReplicaSetList",
+	}
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs)
+
+	m := newTabSwitchTestModel(model.LevelOwned)
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Deployment", Resource: "deployments", APIVersion: "apps/v1", Namespaced: true}
+	m.nav.ResourceName = "my-deploy"
+	m.client = k8s.NewTestClient(clientfake.NewClientset(), dyn)
+
+	cmd := m.postTabSwitchCmd()
+	if cmd == nil {
+		t.Fatal("postTabSwitchCmd returned nil at LevelOwned/modeExplorer")
+	}
+
+	sawRefresh := false
+	for _, c := range flattenBatch(cmd) {
+		if loaded, ok := c().(ownedLoadedMsg); ok && !loaded.forPreview {
+			sawRefresh = true
+		}
+	}
+	assert.True(t, sawRefresh,
+		"postTabSwitchCmd at LevelOwned must fire a non-preview owned-refresh fetch")
+}
+
+// TestPostTabSwitch_RefreshesAtLevelContainers covers the LevelContainers
+// variant — the parent pod's containers may have changed (e.g., pod
+// restarted with a different image after a deployment edit on another tab).
+func TestPostTabSwitch_RefreshesAtLevelContainers(t *testing.T) {
+	t.Parallel()
+
+	m := newTabSwitchTestModel(model.LevelContainers)
+	m.nav.OwnedName = "my-pod"
+	m.client = k8s.NewTestClient(clientfake.NewClientset(), nil)
+
+	cmd := m.postTabSwitchCmd()
+	if cmd == nil {
+		t.Fatal("postTabSwitchCmd returned nil at LevelContainers/modeExplorer")
+	}
+
+	sawRefresh := false
+	for _, c := range flattenBatch(cmd) {
+		if loaded, ok := c().(containersLoadedMsg); ok && !loaded.forPreview {
+			sawRefresh = true
+		}
+	}
+	assert.True(t, sawRefresh,
+		"postTabSwitchCmd at LevelContainers must fire a non-preview containers-refresh fetch")
+}
+
+// TestPostTabSwitch_DoesNotRefreshAtLevelClusters keeps the cluster picker
+// view passive on tab switch — the cluster list itself doesn't go stale
+// within a session and discovery is heavy.
+func TestPostTabSwitch_DoesNotRefreshAtLevelClusters(t *testing.T) {
+	t.Parallel()
+
+	m := newTabSwitchTestModel(model.LevelClusters)
+	m.client = k8s.NewTestClient(clientfake.NewClientset(), nil)
+
+	cmd := m.postTabSwitchCmd()
+	for _, c := range flattenBatch(cmd) {
+		msg := c()
+		if _, ok := msg.(resourcesLoadedMsg); ok {
+			t.Errorf("LevelClusters tab switch must not fire resourcesLoadedMsg")
+		}
+		if _, ok := msg.(ownedLoadedMsg); ok {
+			t.Errorf("LevelClusters tab switch must not fire ownedLoadedMsg")
+		}
+		if _, ok := msg.(containersLoadedMsg); ok {
+			t.Errorf("LevelClusters tab switch must not fire containersLoadedMsg")
+		}
+	}
+}
+
+// newTabSwitchTestModel builds a Model wired for postTabSwitchCmd tests.
+// Empty middleItems means loadPreview's selection-gated sub-cmds short-
+// circuit, so each test can focus on whether the refresh-on-switch was
+// added without false signals from preview fetches.
+func newTabSwitchTestModel(level model.Level) Model {
+	return Model{
+		nav: model.NavigationState{
+			Level:   level,
+			Context: "test-ctx",
+		},
+		tabs:                []TabState{{}},
+		selectedItems:       make(map[string]bool),
+		cursorMemory:        make(map[string]int),
+		itemCache:           make(map[string][]model.Item),
+		cacheFingerprints:   make(map[string]string),
+		discoveredResources: make(map[string][]model.ResourceTypeEntry),
+		execMu:              &sync.Mutex{},
+		namespace:           "default",
+		bgtasks:             bgtasks.New(0),
+		reqCtx:              context.Background(),
+		mode:                modeExplorer,
+	}
+}

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -117,9 +117,27 @@ func (m Model) handleTabSwitchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 }
 
 // postTabSwitchCmd returns the appropriate command after switching tabs.
+//
+// In modeExplorer at the resource-data levels (LevelResources, LevelOwned,
+// LevelContainers) it batches the right-pane preview load with a
+// background refresh of the middle column. The cached middleItems
+// restored by loadTab are shown immediately; the refresh result replaces
+// them when the fetch returns. This is stale-while-revalidate — without
+// it, a mutation on tab A (e.g. deleting a pod whose restart count was
+// 10) leaves tab B's saved list stale until the next watch tick or
+// manual refresh.
+//
+// LevelClusters / LevelResourceTypes are intentionally excluded: contexts
+// and resource-type discovery don't go stale during a session, and
+// re-running discovery on every tab switch would be wasteful.
 func (m Model) postTabSwitchCmd() tea.Cmd {
 	if m.mode == modeExplorer {
-		return m.loadPreview()
+		cmds := []tea.Cmd{m.loadPreview()}
+		switch m.nav.Level {
+		case model.LevelResources, model.LevelOwned, model.LevelContainers:
+			cmds = append(cmds, m.refreshCurrentLevel())
+		}
+		return tea.Batch(cmds...)
 	}
 	if m.mode == modeLogs && m.logCh != nil {
 		return m.waitForLogLine()


### PR DESCRIPTION
## Summary
- Each tab kept an isolated copy of `middleItems` and per-tab `requestGen`. A mutation on tab A (delete pod, scale, restart) only invalidated tab A's caches — tab B's saved list stayed frozen until a watch tick (which only fires for the active tab) or a manual refresh. Reproduced in the user's "pod with 10 restarts" example: after delete on A, tab B still showed `10 restarts` until the user pressed `R`.
- In `modeExplorer` at `LevelResources` / `LevelOwned` / `LevelContainers`, `postTabSwitchCmd` now batches `loadPreview` with `refreshCurrentLevel`. Cached `middleItems` restored by `loadTab` paint immediately; the refresh result replaces them when the fetch returns — stale-while-revalidate, no flicker.
- `LevelClusters` / `LevelResourceTypes` excluded: contexts and resource-type discovery don't go stale within a session and re-running discovery on every tab switch would be wasteful (watch tick still covers them periodically).
- `modeLogs` / `modeExec` paths unchanged. The captured `requestGen` still gates the response — if the user navigates within the new tab before the refresh returns, the bumped gen correctly discards the in-flight result.

## Test plan
- [x] `TestPostTabSwitch_RefreshesMiddleColumnAtLevelResources` — Pods list refreshes
- [x] `TestPostTabSwitch_RefreshesAtLevelOwned` — Deployment children refresh
- [x] `TestPostTabSwitch_RefreshesAtLevelContainers` — parent pod's containers refresh
- [x] `TestPostTabSwitch_DoesNotRefreshAtLevelClusters` — cluster picker stays passive
- [x] `go test ./... -race` clean
- [x] `go vet ./...` clean
- [x] `make lint` clean