### PR TITLE
docs: audit cleanup + `:export json` real implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Contributions are welcome! Here is how to get started.
 
 ## Prerequisites
 
-- Go 1.26.2 or later
+- Go 1.26.3 or later
 - Access to a Kubernetes cluster (for testing)
 - `kubectl` configured and working
-- `golangci-lint` ([install](https://golangci-lint.run/welcome/install/))
+- `golangci-lint`
 
 ## Development Setup
 
@@ -36,16 +36,14 @@ go build -o lfk .
 # Run tests (if available)
 go test ./...
 
-# Run with race detector
-go build -race -o lfk . && ./lfk
+# Run tests with race detector
+go test -race ./...
 
 # Lint (if you have golangci-lint installed)
 golangci-lint run
 ```
 
 ## Project Structure
-
-The application follows a standard Go project layout:
 
 - `main.go` - Entry point, initializes the Kubernetes client, loads config, and starts the Bubbletea program
 - `internal/app/` - Core application logic: the Bubbletea model, update loop, async commands, and bookmarks

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Release](https://img.shields.io/github/v/release/janosmiko/lfk)](https://github.com/janosmiko/lfk/releases) [![CI](https://img.shields.io/github/actions/workflow/status/janosmiko/lfk/ci.yml?branch=main&label=CI)](https://github.com/janosmiko/lfk/actions/workflows/ci.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/janosmiko/lfk)](https://goreportcard.com/report/github.com/janosmiko/lfk) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=janosmiko_lfk&metric=security_rating)](https://sonarcloud.io/dashboard?id=janosmiko_lfk) [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=janosmiko_lfk&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=janosmiko_lfk) [![codecov](https://codecov.io/gh/janosmiko/lfk/graph/badge.svg)](https://codecov.io/gh/janosmiko/lfk) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/janosmiko/lfk/badge)](https://scorecard.dev/viewer/?uri=github.com/janosmiko/lfk) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12677/badge)](https://www.bestpractices.dev/projects/12677) 
 
-**LFK** is a lightning-fast, keyboard-focused, yazi-inspired terminal user interface for navigating and managing Kubernetes clusters. Built for speed and efficiency, it brings a three-column Miller columns layout with an owner-based resource hierarchy to your terminal.
+**LFK** is a keyboard-focused, yazi-inspired terminal user interface for navigating and managing Kubernetes clusters. It brings a three-column Miller columns layout with an owner-based resource hierarchy to your terminal.
 
 ## Screenshots
 
@@ -115,7 +115,6 @@
 - **Bookmarks**: Save favorite resource paths for quick navigation
 - **Orphan detection**: Press `Shift+O` (or run bare `:orphans`) to open the cluster-wide orphan overview across 11 kinds — Pods, Secrets, ConfigMaps, Services, PVCs, HPAs, PDBs, NetworkPolicies, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings. Per-list filters are still available via the filter-preset overlay (`.`) on each kind, or jump straight to a filtered view with `:orphans <kind>` (e.g., `:orphans secrets`). A strict / lenient toggle (`s`) flips between "truly unused" and "currently idle but referenced by workload templates" (e.g. CronJob between firings). Auto-excludes Helm release Secrets, ServiceAccount tokens, owner-managed resources, and `kube-root-ca.crt`.
 - **Session persistence**: Remembers last context/namespace/resource across restarts
-- **Command bar**: Press `:` for shell/kubectl commands with autocompletion
 
 ### Integrations
 
@@ -231,7 +230,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `Enter` | Open full-screen YAML view / navigate into |
 | `z` | Toggle expand/collapse all resource groups / toggle event grouping (Events view) |
 | `p` | Pin/unpin CRD group (at resource types level) |
-| `H` | Toggle rarely used resource types (CSI internals, webhooks, leases, advanced core) in the sidebar |
+| `H` | Toggle rarely used resource types (CSI internals, webhooks, APF, leases, advanced core) in the sidebar |
 | `0` / `1` / `2` | Jump to clusters / types / resources level |
 | `J` / `K` | Scroll preview pane down/up |
 | `o` | Jump to owner/controller of selected resource |

--- a/TESTS.md
+++ b/TESTS.md
@@ -45,7 +45,7 @@ Wait until `kubectl get pod crashy` shows `STATUS=CrashLoopBackOff` and `RESTART
 kind delete cluster --name crashinv-test
 ```
 
-## Sync Wave Timeline (`feat/sync-wave-timeline`)
+## Sync Wave Timeline
 
 Prerequisites: a kube-context with at least one ArgoCD Application
 managed by argo-cd >= 2.0. Examples below assume `my-app` in `argocd`.
@@ -118,9 +118,9 @@ managed by argo-cd >= 2.0. Examples below assume `my-app` in `argocd`.
 
 ## Regression checks
 
-10. With the overlay closed, run an existing flow (Crash Investigator
-    on a Pod, Sync on an Application via action menu). All should still
-    work — no overlay-state bleed.
+- With the overlay closed, run an existing flow (Crash Investigator
+  on a Pod, Sync on an Application via action menu). All should still
+  work — no overlay-state bleed.
 
 ## Sync Wave Timeline — two-pane layout
 
@@ -156,11 +156,7 @@ managed by argo-cd >= 2.0. Examples below assume `my-app` in `argocd`.
 20. Trigger a sync (s on Application). Reopen Sync Wave Timeline.
     - Expected: spinner animates in header during wave-annotation fetch;
       cursor + scroll preserved across the 3s refresh ticks.
-## Traffic Capture (`feat/traffic-capture`)
-
-Verifies the configuration / live / stopped phases, the `__captures__`
-pseudo-resource, and the on-node cleanup path that prevents disk-pressure
-from orphaned ephemeral containers.
+## Traffic Capture
 
 ### Prerequisites
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 Press `:` to open the command bar. Input is classified by the first word:
 
-- `!<cmd>` — shell command
+- `:!<cmd>` — shell command (e.g. `:! kubectl top nodes`)
 - `:ns`, `:ctx`, `:sort`, … — built-in command
 - `:k`, `:kubectl`, `:get`, … — kubectl command
 - `:pod`, `:svc`, … — resource jump
@@ -17,8 +17,12 @@ Press `:` to open the command bar. Input is classified by the first word:
 | `:context <ctx>` &nbsp;·&nbsp; `:ctx <ctx>` | Switch kube context |
 | `:sort <column>` | Sort the current list by column name |
 | `:set <option>` | Toggle log viewer option (see below) |
-| `:export [yaml\|json]` | Copy selected resource YAML to clipboard |
+| `:export [yaml\|json]` | Copy selected resource(s) to clipboard |
 | `:tasks` | Open background-tasks overlay |
+| `:bookmarks` | Open bookmarks overlay |
+| `:reload` &nbsp;·&nbsp; `:refresh` | Force refresh of the current list |
+| `:errors` &nbsp;·&nbsp; `:warnings` | Toggle warnings-only filter on the Events list |
+| `:orphans [<kind>]` | Open cluster-wide orphan resource overview |
 | `:quit` &nbsp;·&nbsp; `:q` &nbsp;·&nbsp; `:q!` | Exit |
 | `:nyan` | Toggle Nyan mode |
 | `:kubetris` | Play Kubetris |
@@ -36,7 +40,7 @@ Column names match the table headers (case-sensitive): `Name`, `Namespace`, `Age
 | `linenumbers` / `nolinenumbers` | Line numbers |
 | `timestamps` / `notimestamps` | Timestamps |
 | `follow` / `nofollow` | Auto-scroll to tail |
-| `ansi` / `noansi` | Render ANSI SGR colours (bold, foreground, background) emitted by log producers. On by default. Turn off to replace every ESC byte with U+FFFD — useful if an application is emitting malformed sequences that misalign the viewer. Non-SGR CSI sequences (cursor movement, screen erase) are always replaced regardless of this flag. |
+| `ansi` / `noansi` | Render ANSI SGR colors from log output. Off replaces ESC bytes with U+FFFD (see config-reference.md `log_render_ansi`). |
 
 ### `:tasks`
 

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -5,9 +5,9 @@
 # ─── Color Scheme ──────────────────────────────────────────────────────────────
 # Built-in color scheme. 460+ themes are available (generated from ghostty themes).
 # Press T in-app to browse and preview all themes interactively.
-# Popular options: tokyonight (default), dracula, nord, catppuccin-mocha,
+# Popular options: tokyonight-storm (default), dracula, nord, catppuccin-mocha,
 #   rose-pine, gruvbox-dark, everforest-dark, one-half-dark, ayu-dark, nightfox
-colorscheme: tokyonight
+colorscheme: tokyonight-storm
 
 # ─── Auto Dark/Light Mode ─────────────────────────────────────────────────────
 # Use Ghostty-style "dark:X,light:Y" syntax in the colorscheme field to enable
@@ -394,3 +394,25 @@ confirm_on_exit: true
 # Legacy bool form: true → "always", false → "off".
 # Default: auto
 # informer_cache: auto
+
+# ─── Mouse Support ────────────────────────────────────────────────────────────
+# Capture mouse input for click navigation, scroll, and tab switching.
+# Set to false to disable; equivalent to --no-mouse on the command line.
+# mouse: true
+
+# ─── Scrolloff ────────────────────────────────────────────────────────────────
+# Lines to keep visible above/below the cursor when scrolling. Used by all
+# views with cursor-based navigation.
+# scrolloff: 5
+
+# ─── Secret Lazy Loading ──────────────────────────────────────────────────────
+# When true, Secret listing fetches metadata only; decoded values load on
+# hover. Useful in clusters with many Helm release Secrets or large TLS
+# payloads, at the cost of an extra GET per hovered Secret.
+# secret_lazy_loading: false
+
+# ─── Minimum Contrast Ratio ───────────────────────────────────────────────────
+# Normalized [0.0, 1.0] knob. When > 0, foreground colors are nudged in HSL
+# lightness space to meet a minimum WCAG contrast against their backgrounds.
+# 0.175 ≈ WCAG AA (4.5:1); 0.3 ≈ WCAG AAA (7:1).
+# min_contrast_ratio: 0.0

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -395,11 +395,6 @@ confirm_on_exit: true
 # Default: auto
 # informer_cache: auto
 
-# ─── Mouse Support ────────────────────────────────────────────────────────────
-# Capture mouse input for click navigation, scroll, and tab switching.
-# Set to false to disable; equivalent to --no-mouse on the command line.
-# mouse: true
-
 # ─── Scrolloff ────────────────────────────────────────────────────────────────
 # Lines to keep visible above/below the cursor when scrolling. Used by all
 # views with cursor-based navigation.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -6,7 +6,7 @@ The configuration file is located at `~/.config/lfk/config.yaml`. All fields are
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `colorscheme` | string | `"tokyonight"` | Built-in color scheme name (460+ available). Press `T` to browse. Supports dual-mode syntax for auto dark/light switching: `"dark:X,light:Y"`. Custom `theme` overrides are applied on top. |
+| `colorscheme` | string | `"tokyonight-storm"` | Built-in color scheme name (460+ available). Press `T` to browse. Supports dual-mode syntax for auto dark/light switching: `"dark:X,light:Y"`. Custom `theme` overrides are applied on top. |
 | `transparent_background` | bool | `false` | Use the terminal's own background for bars. Selection highlights remain opaque. |
 | `icons` | string | `"auto"` | Icon display mode. One of: `"auto"` (detects Nerd Font terminals; default), `"unicode"`, `"nerdfont"` (Material Design Icons; requires Nerd Font in terminal), `"simple"` (ASCII labels), `"emoji"`, or `"none"`. Unknown values fall back to `"unicode"`. Can be overridden at runtime by the `LFK_ICONS` environment variable. |
 | `log_path` | string | `"~/.local/share/lfk/lfk.log"` | Path to the application log file. |
@@ -19,12 +19,12 @@ The configuration file is located at `~/.config/lfk/config.yaml`. All fields are
 | `abbreviations` | map[string]string | *(see Abbreviations section)* | Custom search abbreviation overrides/extensions. |
 | `custom_actions` | map[string]list | `{}` | User-defined actions per resource type. |
 | `filter_presets` | map[string]list | `{}` | User-defined quick filter presets per resource type. |
-| `terminal` | string | `"pty"` | How exec/shell commands run: `"pty"` (embedded in TUI) or `"exec"` (takes over terminal). |
+| `terminal` | string | `"pty"` | How exec/shell commands run: `"pty"` (embedded in TUI), `"exec"` (takes over terminal), or `"mux"` (opens in a new tmux/zellij window/pane; errors out if no multiplexer is detected). |
 | `pinned_groups` | list[string] | `[]` | CRD API groups to pin after built-in categories. Also manageable in-app with `p` key (stored per-context in `~/.local/state/lfk/pinned.yaml`). |
 | `tips` | bool | `true` | Show a random tip in the status bar on startup. Set to `false` to disable. |
 | `log_tail_lines` | int | `1000` | Number of log lines to load initially via `--tail`. Scrolling to the top loads older history. |
 | `log_tail_lines_short` | int | `10` | Number of log lines loaded by the action menu "Tail Logs" entry (`l` key). Intended for lightweight peeks without the full history hit. Non-positive values are ignored. |
-| `log_render_ansi` | bool | `true` | Render ANSI SGR sequences (colour, bold, underline) emitted by log producers. Set to `false` to strip them — the viewer replaces every ESC byte with `U+FFFD`, matching the original safe-but-noisy behaviour. Non-SGR CSI sequences (cursor movement, screen erase) are always stripped regardless. Toggle at runtime with `:set ansi` / `:set noansi`. |
+| `log_render_ansi` | bool | `true` | Render ANSI SGR sequences (color, bold, underline) emitted by log producers. Set to `false` to strip them — the viewer replaces every ESC byte with `U+FFFD`, matching the original safe-but-noisy behavior. Non-SGR CSI sequences (cursor movement, screen erase) are always stripped regardless. Toggle at runtime with `:set ansi` / `:set noansi`. |
 | `confirm_on_exit` | bool | `true` | Show quit confirmation when pressing `ctrl+c` on the last tab. Set to `false` to exit immediately. |
 | `dim_overlay` | bool | `true` | Fade the rest of the screen while any overlay is up. Set to `false` for terminals where SGR faint looks awkward; no-op when `no_color: true`. |
 | `scrolloff` | int | `5` | Number of lines to keep visible above/below the cursor when scrolling. Used by all views with cursor-based navigation. |
@@ -139,6 +139,7 @@ Currently supported per-cluster overrides:
 | Field | Type | Description |
 |---|---|---|
 | `resource_columns` | map[string]list | Per-resource-type column overrides for this cluster. Same format as the global `resource_columns`. |
+| `read_only` | bool | Per-context read-only override. Same semantics as the top-level `read_only`. |
 
 Per-cluster `resource_columns` take precedence over the global `resource_columns` setting.
 
@@ -327,7 +328,7 @@ custom_actions:
 | `command` | Yes | Shell command to execute (supports template variables) |
 | `key` | Yes | Shortcut key in the action menu |
 | `description` | No | Description shown next to the action |
-| `read_only_safe` | No | When `true`, the action remains available in read-only mode. Defaults to `false` (treated as mutating and blocked) so destructive shell commands don't silently bypass the read-only gate. Set to `true` for view-only commands like `kubectl describe`, `kubectl logs`, `kubectl rollout history`. |
+| `read_only_safe` | No | When `true`, available in read-only mode. Defaults to `false` (treated as mutating). Set `true` for view-only commands (e.g. `kubectl describe`, `kubectl logs`). |
 
 ### Template Variables
 
@@ -444,7 +445,7 @@ The `informer_cache` knob has three modes:
 
 - **`off`** — every list round-trips to the API server, matching kubectl
   semantics. Pick this when the apiserver is sensitive to extra watch
-  connections or when you are debugging server-side behaviour.
+  connections or when you are debugging server-side behavior.
 - **`auto`** (default) — start in `off` mode per `(context, resource type)`,
   but the moment a list returns ≥ 1000 items, promote that resource type
   to a [shared informer](https://pkg.go.dev/k8s.io/client-go/dynamic/dynamicinformer).
@@ -546,10 +547,8 @@ drive it toward `text`'s luminance and collapse that highlight.
 
 ### When to use this
 
-Turn it on when you notice text is hard to read with a particular colorscheme
-on your terminal. Start with `0.175` (WCAG AA) — it is a good balance between
-readability and color fidelity. Increase toward `0.3` if you still find the
-text too dim.
+Enable when text is hard to read on your terminal. Start at `0.175` (WCAG
+AA); raise toward `0.3` if still too dim.
 
 ```yaml
 min_contrast_ratio: 0.175
@@ -644,9 +643,9 @@ omitted from the backend picker.
 
 ## Color Schemes
 
-Over 460 built-in color schemes are available, generated from [ghostty terminal themes](https://github.com/ghostty-org/ghostty). Popular schemes include:
+Over 460 built-in color schemes are available, generated from [ghostty terminal themes](https://github.com/ghostty-org/ghostty). Sample list:
 
-`tokyonight` (default), `dracula`, `nord`, `catppuccin-mocha`, `catppuccin-latte`, `rose-pine`, `gruvbox-dark`, `gruvbox-light`, `everforest-dark`, `one-half-dark`, `ayu-dark`, `nightfox`, `monokai-pro`, `github-dark`, `github-light`, `solarized-dark`, `solarized-light`, and many more.
+`tokyonight-storm` (default), `dracula`, `nord`, `catppuccin-mocha`, `catppuccin-latte`, `rose-pine`, `gruvbox-dark`, `gruvbox-light`, `everforest-dark`, `one-half-dark`, `ayu-dark`, `nightfox`, `monokai-pro`, `github-dark`, `github-light`, `solarized-dark`, `solarized-light`, and many more.
 
 Switch themes at runtime with `T` to browse all available themes interactively with live preview. Runtime changes are not persisted — set `colorscheme` in your config to make it permanent.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,7 +97,7 @@ scoop install lfk
 winget install janosmiko.lfk
 ```
 
-> The first release after a tag opens an automatic PR to `microsoft/winget-pkgs`. The package becomes installable once that PR is merged by the Winget maintainers — typically within hours.
+> The first release after a tag opens an automatic PR to `microsoft/winget-pkgs`. The package becomes installable once that PR is merged by the Winget maintainers.
 
 ### Chocolatey
 
@@ -105,7 +105,7 @@ winget install janosmiko.lfk
 choco install lfk
 ```
 
-> First-time installs from Chocolatey may show "Pending" while the package goes through chocolatey.org moderation. Subsequent versions usually become available immediately after publish.
+> First-time installs from Chocolatey show "Pending" until chocolatey.org moderation completes. Subsequent versions are available immediately after publish.
 
 ### Manual binary
 
@@ -113,11 +113,13 @@ Download `lfk_<version>_windows_<arch>.zip` from [GitHub Releases](https://githu
 
 ## From source
 
+Using `go install` (fetches via the Go module proxy):
+
 ```bash
 go install github.com/janosmiko/lfk@latest
 ```
 
-## Build from source
+From a local clone:
 
 ```bash
 git clone https://github.com/janosmiko/lfk.git

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -40,7 +40,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `Ctrl+G` | Finalizer search and remove |
 | `!` | Error log |
 | `@` | Monitoring overview (active Prometheus alerts) |
-| `Ctrl+N` | Open the **Local Clusters Manager** overlay (only at LevelClusters). |
+| `Ctrl+N` | Open the Local Clusters Manager overlay (only at LevelClusters) |
 | `Q` | Namespace resource quota dashboard |
 | `` ` `` | Background tasks overlay (Tab toggles running / completed history) |
 | `:` | Command bar: resource jumps (`:pod`, `:dep`), built-ins (`:ns`, `:ctx`, `:set`, `:sort`, `:export`, `:tasks`), kubectl (`:k get pod`), shell (`:! cmd`) |
@@ -106,7 +106,7 @@ Auto-excluded from "Unmounted" results:
 Auto-excluded from Pod "Orphans":
 - Static / mirror pods (kubelet-managed via `kubernetes.io/config.mirror` annotation)
 
-Note: terminal pods (Succeeded/Failed) older than 1h are still flagged but the reason is `"no owner (terminal)"` to distinguish them from live workloads.
+Terminal pods (Succeeded/Failed) older than 1h are still flagged but the reason is `"no owner (terminal)"` to distinguish them from live workloads.
 
 ## Search and Filter
 
@@ -175,30 +175,14 @@ When items are selected, press `x` to open the bulk action menu (delete, force d
 
 ## Bookmarks
 
-lfk supports vim-style named marks for quick navigation. A bookmark stores a
-resource path (context + namespace + resource type + optional resource name)
-under a single-character slot. The namespace is always persisted; slot case
-only controls whether the jump switches clusters.
+Vim-style named marks for quick navigation. A bookmark stores a resource
+path (context + namespace + resource type + optional resource name) under
+a single-character slot.
 
-Bookmarks come in two flavors depending on the slot case you choose:
-
-- **Context-aware** (lowercase `a-z` / digit `0-9`): remembers the kube
-  context you were in. Jumping switches clusters as needed. Use this
-  when the bookmark should return you to a specific environment.
-- **Context-free** (uppercase `A-Z`): doesn't remember a context.
-  Jumping uses the tab's current cluster. Use this for
-  cluster-agnostic shortcuts (e.g., `P` for "go to Pods in whatever
-  cluster I'm looking at").
-
-**Namespace on jump.** By default *no* bookmark overwrites the tab's
-current namespace scope — you always land on the bookmarked resource
-type in the namespace you were already viewing. The saved namespace
-stays in the record and can be replayed on demand: open the bookmarks
-list with `'`, press `Tab` to arm a `[LOAD NAMESPACE]` chip in the
-title, then press Enter (or the slot key) to jump with the saved
-namespace applied. The flag is consumed after the jump and cleared
-when you close the overlay, so every open starts in the default "keep
-my namespace" mode.
+- **Context-aware** (`a-z` / `0-9`): remembers the kube context; jumping
+  switches clusters.
+- **Context-free** (`A-Z`): uses the tab's current cluster; for
+  cluster-agnostic shortcuts.
 
 | Key | Context | Action |
 |---|---|---|
@@ -211,6 +195,10 @@ my namespace" mode.
 | `Tab` | Bookmark overlay | Toggle `[LOAD NAMESPACE]` — apply the bookmark's saved namespace scope on the next jump |
 | `Ctrl+X` | Bookmark overlay | Delete selected bookmark (with confirmation) |
 | `Alt+X` | Bookmark overlay | Delete all bookmarks (with confirmation) |
+
+> Namespace on jump: by default the tab's current namespace is kept. Press
+> `Tab` in the overlay to arm `[LOAD NAMESPACE]`; the saved namespace is
+> then applied on the next jump and the flag is cleared on close.
 
 ## Help View
 
@@ -340,9 +328,9 @@ my namespace" mode.
 
 The log viewer's `/` keeps its own persistent history at `$XDG_STATE_HOME/lfk/log-search-history` (default `~/.local/state/lfk/log-search-history`), separate from the explorer's `query-history`. Log search matches raw log lines (substring/regex over arbitrary text) rather than resource names, so pooling the two would surface irrelevant entries on Up/Down in either context.
 
-> **Tail-first loading**: Full Logs (`L` key or action menu `L`) load the last 1000 lines initially (configurable via `log_tail_lines`). Tail Logs (action menu `l`) load only the last 10 lines (configurable via `log_tail_lines_short`) — useful for a quick peek without the full history hit. Scrolling to the top automatically loads older log history in both modes.
+Tail-first loading: Full Logs (`L` key or action menu `L`) load the last 1000 lines initially (configurable via `log_tail_lines`). Tail Logs (action menu `l`) load only the last 10 lines (configurable via `log_tail_lines_short`). Scrolling to the top loads older history.
 
-> **Auto-reconnect across init containers**: When viewing logs for a single Pod in all-containers mode (no specific container selected via `\`), the stream automatically reconnects each time kubectl exits — for example as each init container finishes and the next one starts. The reconnect is silent: no sentinel markers are inserted into the log buffer. After several consecutive empty reconnects the viewer stops retrying (the pod is terminated).
+Auto-reconnect across init containers: when viewing logs for a single Pod in all-containers mode (no specific container selected via `\`), the stream automatically reconnects each time kubectl exits — e.g. as init containers transition. The reconnect is silent. After several consecutive empty reconnects the viewer stops retrying.
 
 ## Exec Mode (embedded terminal)
 
@@ -709,13 +697,7 @@ existing recommendations stay visually similar after the upgrade).
 
 ### Defaults & stickiness
 
-Strategy and headroom selections are **sticky for the duration of the session**.
-Open `pod1`, press `]` to switch to `prom_max_1d`, press `>` to bump headroom to `1.5`,
-close the overlay, then open `pod2` — the overlay reopens with `prom_max_1d` + `1.5`
-already selected (provided `pod2` also supports `prom_max_1d`; otherwise the strategy
-falls back to the workload's first available, but the headroom still sticks).
-
-For the very first overlay open of a session — when there's no sticky value yet — the
+Strategy and headroom selections are sticky for the session. The first-open
 seed comes from two optional config keys:
 
 ```yaml
@@ -724,16 +706,9 @@ rightsizing_defaults:
   headroom: 1.25      # 1.0 | 1.1 | 1.25 | 1.5 | 1.75 | 2.0
 ```
 
-Both fields are optional. Invalid values (e.g. `strategy: garbage`, `headroom: 1.337`)
-are dropped at startup with a warning in the lfk error log; the picker then uses the
-built-in defaults (highest-priority available strategy + `1.25` headroom). A configured
-default that turns out to be unavailable for a specific workload (e.g. `vpa` set in
-config but no VPA targets the workload) also falls back to the first available strategy
-for that workload.
-
-The fallback chain in priority order: **sticky session value → config default → built-in
-default**. Restarting lfk wipes the sticky state, so the config defaults take over again
-on the next session's first overlay open.
+Fallback chain (highest priority first): sticky session value → config
+default → built-in default (first available strategy + `1.25` headroom).
+Invalid config values are dropped at startup with a warning in the error log.
 
 ## Error Log (`!`)
 
@@ -784,7 +759,7 @@ and global config.
 
 | Key | Action |
 |---|---|
-| `L` (Shift+L) (at the cluster picker) | Open the color picker overlay for the highlighted cluster row. Pick one of 8 named colors (`red`, `yellow`, `green`, `blue`, `magenta`, `cyan`, `white`, `gray`) or `None` to clear. The selection is saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml` and survives restarts. Same overlay is reachable from the action menu (`x` → "Set color…") at the cluster picker. |
+| `L` (Shift+L) (at the cluster picker) | Open color picker for the highlighted cluster (saved to `$XDG_STATE_HOME/lfk/cluster-colors.yaml`). Also reachable via `x` → "Set color…". |
 
 When a context has a color assigned, the cluster picker row shows a
 small background-tinted suffix swatch on the right edge in that color,
@@ -793,7 +768,7 @@ the entire title bar so it's impossible to miss which environment you're
 acting on. Contexts without a color render a neutral placeholder in the
 swatch column so all rows stay aligned.
 
-Four colours (`red`, `yellow`, `green`, `blue`) follow lfk's active
+Four colors (`red`, `yellow`, `green`, `blue`) follow lfk's active
 theme tokens (`theme.Error`, `theme.Warning`, `theme.Secondary`,
 `theme.Primary`) so a colorscheme switch re-skins them. The remaining
 four (`magenta`, `cyan`, `white`, `gray`) stay on ANSI bright codes
@@ -902,34 +877,34 @@ Press `:` to open the command bar. It supports four types of input:
 The action menu (`x` key) shows context-specific actions based on the resource type:
 
 ### Pod Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `D` Delete, `X` Force Delete, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `V` Events
 
 ### Deployment Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `R` Rollback, `p` Port Forward, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `R` Rollback, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
 ### StatefulSet Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
 ### DaemonSet Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
 ### Service Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `c` Capture Traffic, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
 
 ### Secret Actions
-`e` Secret Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `b` Debug Pod, `V` Events
+`e` Secret Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
 
 ### ConfigMap Actions
-`e` ConfigMap Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `b` Debug Pod, `V` Events
+`e` ConfigMap Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
 
 ### Node Actions
 `c` Cordon, `u` Uncordon, `n` Drain, `t` Taint, `T` Untaint, `s` Shell, `v` Describe, `E` Edit, `b` Debug Pod, `V` Events
 
 ### Job Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `v` Describe, `E` Edit, `D` Delete, `X` Force Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `b` Debug Pod, `V` Events
 
 ### CronJob Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `t` Trigger (create Job), `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `t` Trigger (create Job), `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
 ### ArgoCD Application Actions
 `s` Sync, `a` Sync (Apply Only), `f` Diff, `R` Refresh, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
@@ -944,7 +919,7 @@ The action menu (`x` key) shows context-specific actions based on the resource t
 `g` Go to Pod, `b` Debug Mount, `B` Debug Pod, `v` Describe, `E` Edit, `D` Delete, `V` Events
 
 ### Default Actions (all other resources)
-`v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `b` Debug Pod, `V` Events
+`v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
 
 ### Bulk Actions (when items multi-selected)
 `D` Delete, `X` Force Delete, `S` Scale, `r` Restart

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -106,9 +106,9 @@ helm-history pickers, the auto-sync dialog, the Can-I browser, and the
 NetworkPolicy viewer) cover the entire screen, so there is no "outside" to
 click; press `Esc` to close them.
 
-> **Note:** macOS Terminal.app does not support shift+click text selection while
-> mouse capture is active. Use `--no-mouse` or switch to a terminal that handles
-> this correctly (iTerm2, Kitty, Alacritty, WezTerm, Ghostty).
+> macOS Terminal.app does not support shift+click text selection while mouse
+> capture is active. Use `--no-mouse` or switch to a terminal that handles this
+> correctly (iTerm2, Kitty, Alacritty, WezTerm, Ghostty).
 
 ## No-Color Mode
 
@@ -195,6 +195,19 @@ context; it does not scope the read-only flag.
 The cluster picker hint bar advertises `Ctrl+R toggle RO` so users
 can find the row toggle without reading docs.
 
+## Node Shell
+
+From the Node action menu (`x` → `s`), lfk launches a privileged debug pod
+that `nsenter`s into PID 1 on the selected node, giving an interactive shell
+with the host's mount, network, PID, and IPC namespaces.
+
+The pod runs in `kube-system` with `priorityClassName: system-node-critical`
+so it can land on nodes reporting DiskPressure / MemoryPressure / PIDPressure,
+and tolerates all taints. It is created with `--rm --restart=Never`, so it
+is removed when the shell exits.
+
+Node shell is a mutating action and is gated by the read-only check.
+
 ## Cluster Color Coding
 
 Tag any cluster with a background color so the title bar tints the
@@ -219,7 +232,7 @@ when a stray `D` would do real damage.
   Unknown color names in the file are ignored on load (with a warning
   written to the lfk log) so a typo doesn't poison neighbouring entries.
 
-Four of the colours follow lfk's active theme so they re-skin when you
+Four of the colors follow lfk's active theme so they re-skin when you
 switch colorschemes:
 
 | Picker name | Theme token             |
@@ -231,7 +244,7 @@ switch colorschemes:
 
 The remaining four (`magenta`, `cyan`, `white`, `gray`) stay on ANSI
 bright codes so they look the same regardless of which lfk theme is
-active — useful when none of the theme accent colours fit a particular
+active — useful when none of the theme accent colors fit a particular
 cluster's identity.
 
 ## Watch-Mode Interval
@@ -253,8 +266,8 @@ API discovery (the list of resource types and CRDs the server exposes) is
 cached on disk under `~/.kube/cache/discovery/<host>/` with a 5-minute TTL.
 Layout matches `kubectl` and `k9s` so the same cache is shared across all
 three tools — a cold start hits zero discovery round-trips when the cache
-is warm. On busy clusters with many CRDs this is a measurable launch-time
-win and removes redundant load on the API server.
+is warm. On busy clusters with many CRDs this eliminates redundant
+discovery round-trips on the API server and reduces startup time.
 
 - **Override location:** Set `KUBECACHEDIR` (same env var `kubectl`
   honors) to relocate `<KUBECACHEDIR>/discovery/...` and
@@ -302,13 +315,9 @@ ENDPOINTS
   10.0.0.4  → pod/foo-7d9-broken  on node-c   (NotReady)
 ```
 
-The fetch follows a stale-while-revalidate pattern: on every hover or
-watch-tick refresh, the cached rollup is painted instantly so the row
-doesn't blank during the rebuild, *and* a fresh fetch fires in parallel
-so pod churn (delete + recreate, rolling updates, HPA scale) is always
-reflected within one watch tick. Pure cache-only would show stale
-ready state after pod restart; pure fetch-only would flash a blank
-row every watch tick.
+The fetch is stale-while-revalidate: the cached rollup paints instantly
+and a fresh fetch fires in parallel, so pod churn is reflected within one
+watch tick without blanking the row mid-rebuild.
 
 Headless Services (`clusterIP: None`) and `ExternalName` Services are
 skipped — they have no backing EndpointSlices to roll up.

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -1,11 +1,6 @@
 # Views and Overlays
 
 Reference list of every view, fullscreen flag, and overlay lfk renders.
-Use this when:
-
-- finding the responsible code path while changing UI behavior,
-- keeping the help screen in sync, or
-- remembering which mode owns which keymap.
 
 ## Concepts
 
@@ -28,8 +23,8 @@ lfk's UI is built from three layered concepts:
 
 Source of truth for the enums:
 [`internal/app/app_types.go`](../internal/app/app_types.go) — `viewMode`
-(line ~14) and `overlayKind` (line ~31). When those enums change, update
-this doc and [`internal/ui/help.go`](../internal/ui/help.go).
+and `overlayKind`. When those enums change, update this doc and
+[`internal/ui/help.go`](../internal/ui/help.go).
 
 Default trigger keys below come from
 [`internal/ui/config_keybindings.go`](../internal/ui/config_keybindings.go);
@@ -49,7 +44,7 @@ Listed in `viewMode` declaration order.
 | `modeDescribe`    | `v` on a resource                     | `kubectl describe`-style detail view.                                  |
 | `modeDiff`        | `d` between two selected resources    | Side-by-side diff (e.g. ArgoCD live vs. desired).                      |
 | `modeExec`        | action menu → `s`                     | Embedded PTY shell session.                                            |
-| `modeExplain`     | `I`, `:explain <type>`                | `kubectl explain` field tree.                                          |
+| `modeExplain`     | `I`                                   | `kubectl explain` field tree.                                          |
 | `modeEventViewer` | event timeline overlay → drill-in     | Full-screen event viewer with grouping.                                |
 | `modeKubetris`    | `:kubetris`                           | Easter-egg game.                                                       |
 | `modeCredits`     | `:credits`                            | Scrolling credits screen.                                              |
@@ -84,12 +79,12 @@ category, and every entry maps to a constant in `app_types.go`.
 | Overlay                     | Default trigger                  | Purpose                                                                                                                                                                                                              |
 | --------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `overlayNamespace`          | `\`, `:namespace`                | Pick / multi-select namespaces.                                                                                                                                                                                      |
-| `overlayContainerSelect`    | `c` in pod log view              | Pick container when a pod has multiples.                                                                                                                                                                             |
-| `overlayPodSelect`          | `\` in log view                  | Switch to a sibling pod's logs.                                                                                                                                                                                      |
+| `overlayContainerSelect`    | action menu → exec / attach / port-forward (multi-container pod) | Pick container when a pod has multiples.                                                                                                                                                |
+| `overlayPodSelect`          | action menu → exec / attach / port-forward / Helm (Service → backing pod) | Pick a backing pod when an action targets a Service / Deployment.                                                                                                  |
 | `overlayTemplates`          | template-create flow             | Pick a built-in resource template.                                                                                                                                                                                   |
 | `overlayColorscheme`        | `T`                              | Theme picker (search + preview).                                                                                                                                                                                     |
 | `overlayFilterPreset`       | `.`                              | Saved filter expressions.                                                                                                                                                                                            |
-| `overlayCanISubject`        | `:can-i` flow                    | Pick the user / SA to evaluate as.                                                                                                                                                                                   |
+| `overlayCanISubject`        | `U` → can-i flow                 | Pick the user / SA to evaluate as.                                                                                                                                                                                   |
 | `overlayExplainSearch`      | search inside `modeExplain`      | Type / field search for `kubectl explain`.                                                                                                                                                                           |
 | `overlayLogPodSelect`       | `\` in fullscreen log mode       | Switch pods within fullscreen log mode.                                                                                                                                                                              |
 | `overlayLogContainerSelect` | container key in fullscreen logs | Container picker within log mode.                                                                                                                                                                                    |
@@ -137,14 +132,15 @@ category, and every entry maps to a constant in `app_types.go`.
 | `overlayRollback`        | action menu → `R` on Deploy/STS | Pick revision to roll back to.                                 |
 | `overlayHelmRollback`    | action menu → `R` on Helm       | Pick Helm revision to roll back.                               |
 | `overlayHelmHistory`     | action menu → `h` on Helm       | Browse Helm release history.                                   |
-| `overlayRBAC`            | `U`                             | RBAC subject / role browser.                                   |
+| `overlayRBAC`            | action menu → `P` on Secret / ConfigMap / NetworkPolicy | RBAC subject / role browser.                              |
 | `overlayPodStartup`      | action menu → `S` on Pod        | Pod init / readiness gantt.                                    |
 | `overlayCrashInvestigator` | action menu → `I` on Pod      | Per-pod CrashLoopBackOff investigator.                          |
+| `overlayRightsizing`     | action menu → Right-sizing, `z` | Right-sizing advisor with strategy / headroom pickers.          |
 | `overlayQuotaDashboard`  | `Q`, `:quota`                   | Per-namespace ResourceQuota usage.                              |
 | `overlayEventTimeline`   | `V`                             | Cluster-wide events grouped by object.                          |
 | `overlayAlerts`          | from monitoring view            | Active Prometheus alerts.                                       |
 | `overlayNetworkPolicy`   | from netpol view                | Visualize selected NetworkPolicy.                               |
-| `overlayCanI`            | `:can-i` flow (after subject)   | Display can-i evaluation results.                               |
+| `overlayCanI`            | `U` → can-i flow (after subject) | Display can-i evaluation results.                               |
 | `overlayAutoSync`        | ArgoCD app                      | Toggle auto-sync settings.                                      |
 | `overlaySyncWave`        | action menu → `W` on Application | Per-Application ArgoCD sync wave timeline.                      |
 | `overlayBackgroundTasks` | `` ` ``, `:tasks`               | In-flight + recent background tasks.                            |

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -1,12 +1,15 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"sigs.k8s.io/yaml"
+
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -194,12 +197,19 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 
 	case "export":
 		lower := strings.ToLower(arg)
-		if lower == "yaml" || lower == "json" || lower == "" {
+		switch lower {
+		case "", "yaml":
 			// Share the bulk-or-cursor dispatcher with the `Y` keybinding
 			// so multi-selection (cap, "Fetching N..." status, level gating)
 			// behaves the same whether the user types `:export yaml` or
 			// hits `Y`.
 			return m.dispatchYAMLClipboardCopy()
+		case "json":
+			mdl, cmd := m.dispatchYAMLClipboardCopy()
+			if cmd == nil {
+				return mdl, nil
+			}
+			return mdl, wrapYAMLCmdAsJSON(cmd)
 		}
 		m.setStatusMessage(fmt.Sprintf("Unknown export format: %s", arg), true)
 		return m, scheduleStatusClear()
@@ -711,4 +721,45 @@ func orphanPresetNameForKind(kind string) string {
 		return "Unbound"
 	}
 	return "Unmounted"
+}
+
+// wrapYAMLCmdAsJSON converts the YAML payload of an inner yamlClipboardMsg
+// into JSON. A single-document payload becomes a JSON object; a multi-document
+// payload (separated by `\n---\n` per copyYAMLToClipboard's joiner) becomes a
+// JSON array. The bulk-fetch wiring, status messages, and error envelope are
+// reused unchanged.
+func wrapYAMLCmdAsJSON(cmd tea.Cmd) tea.Cmd {
+	return func() tea.Msg {
+		msg := cmd()
+		yc, ok := msg.(yamlClipboardMsg)
+		if !ok || yc.err != nil {
+			return msg
+		}
+		if yc.count <= 1 {
+			jsonBytes, err := yaml.YAMLToJSON([]byte(yc.content))
+			if err != nil {
+				yc.err = fmt.Errorf("converting YAML to JSON: %w", err)
+				return yc
+			}
+			yc.content = string(jsonBytes) + "\n"
+			return yc
+		}
+		docs := strings.Split(strings.TrimRight(yc.content, "\n"), "\n---\n")
+		objects := make([]json.RawMessage, 0, len(docs))
+		for _, doc := range docs {
+			jsonBytes, err := yaml.YAMLToJSON([]byte(doc))
+			if err != nil {
+				yc.err = fmt.Errorf("converting YAML to JSON: %w", err)
+				return yc
+			}
+			objects = append(objects, jsonBytes)
+		}
+		arrayBytes, err := json.Marshal(objects)
+		if err != nil {
+			yc.err = fmt.Errorf("marshaling JSON array: %w", err)
+			return yc
+		}
+		yc.content = string(arrayBytes) + "\n"
+		return yc
+	}
 }

--- a/internal/app/commandbar_execute_test.go
+++ b/internal/app/commandbar_execute_test.go
@@ -1,14 +1,18 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -428,9 +432,10 @@ func TestExecuteBuiltinCommand(t *testing.T) {
 		assert.NotNil(t, cmd)
 	})
 
-	// `:export json` is treated as an alias for yaml in the existing impl
-	// (the format toggle is a no-op today). Pin the alias to keep the bulk
-	// hookup symmetric.
+	// `:export json` reuses the same bulk-or-cursor dispatcher as `yaml`,
+	// then post-processes the YAML payload into JSON. Pin the bulk-status
+	// hookup so a future refactor that swaps the dispatcher doesn't silently
+	// drop the over-cap / "Fetching N..." UI.
 	t.Run("export_json_with_selection_shows_fetching_status", func(t *testing.T) {
 		m := basePush80Model()
 		m.toggleSelection(m.middleItems[0])
@@ -471,6 +476,80 @@ func TestExecuteBuiltinCommand(t *testing.T) {
 		rm := result.(Model)
 		assert.Contains(t, rm.statusMessage, "Unknown export format")
 		assert.True(t, rm.statusMessageErr)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// wrapYAMLCmdAsJSON
+// ---------------------------------------------------------------------------
+
+func TestWrapYAMLCmdAsJSON(t *testing.T) {
+	t.Run("single_doc_becomes_json_object", func(t *testing.T) {
+		inner := func() tea.Msg {
+			return yamlClipboardMsg{
+				content: "apiVersion: v1\nkind: Pod\nmetadata:\n  name: foo\n",
+				count:   1,
+			}
+		}
+
+		out := wrapYAMLCmdAsJSON(inner)().(yamlClipboardMsg)
+		require.NoError(t, out.err)
+		assert.Equal(t, 1, out.count)
+		assert.Contains(t, out.content, `"apiVersion":"v1"`)
+		assert.Contains(t, out.content, `"kind":"Pod"`)
+		assert.Contains(t, out.content, `"name":"foo"`)
+	})
+
+	t.Run("multi_doc_becomes_json_array", func(t *testing.T) {
+		inner := func() tea.Msg {
+			return yamlClipboardMsg{
+				content: "kind: Pod\nmetadata:\n  name: a\n" +
+					"\n---\n" +
+					"kind: Pod\nmetadata:\n  name: b\n",
+				count: 2,
+			}
+		}
+
+		out := wrapYAMLCmdAsJSON(inner)().(yamlClipboardMsg)
+		require.NoError(t, out.err)
+		assert.Equal(t, 2, out.count)
+
+		var arr []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out.content)), &arr))
+		require.Len(t, arr, 2)
+		assert.Equal(t, "a", arr[0]["metadata"].(map[string]any)["name"])
+		assert.Equal(t, "b", arr[1]["metadata"].(map[string]any)["name"])
+	})
+
+	t.Run("inner_error_passes_through_unchanged", func(t *testing.T) {
+		inner := func() tea.Msg {
+			return yamlClipboardMsg{err: assert.AnError}
+		}
+
+		out := wrapYAMLCmdAsJSON(inner)().(yamlClipboardMsg)
+		assert.ErrorIs(t, out.err, assert.AnError)
+		assert.Empty(t, out.content)
+	})
+
+	t.Run("non_yaml_message_passes_through_unchanged", func(t *testing.T) {
+		marker := struct{ note string }{note: "not-a-yaml-msg"}
+		inner := func() tea.Msg { return marker }
+
+		out := wrapYAMLCmdAsJSON(inner)()
+		assert.Equal(t, marker, out)
+	})
+
+	t.Run("malformed_yaml_surfaces_as_error_envelope", func(t *testing.T) {
+		inner := func() tea.Msg {
+			return yamlClipboardMsg{
+				content: "kind: Pod\nmetadata:\n  name: a\nbadly_formed: : :\n",
+				count:   1,
+			}
+		}
+
+		out := wrapYAMLCmdAsJSON(inner)().(yamlClipboardMsg)
+		require.Error(t, out.err)
+		assert.Contains(t, out.err.Error(), "converting YAML to JSON")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Reconciles documentation against actual code (default colorscheme, terminal modes, overlay triggers, missing built-in commands and action-menu keys).
- Cleans up pattern consistency, oversized table rows, marketing language, AI-tells, and ephemeral branch names in section headings.
- Adds a real implementation for `:export json` (was previously accepted as a no-op alias for YAML).

Driven by a multi-pass documentation audit. Two commits:

1. `feat(commandbar): :export json emits real JSON` — wraps the YAML clipboard dispatcher; converts via `sigs.k8s.io/yaml.YAMLToJSON`. Single doc → JSON object; multi-select → JSON array. Five new unit tests.
2. `docs: audit cleanup pass` — 10 files, factual fixes + quality/pattern fixes. Net diff is roughly balanced (+121 / -121) thanks to trimming oversized rows while adding genuinely missing coverage (Node Shell section, missing action-menu keys, `read_only` per-cluster, `terminal: mux`, etc).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/app/...` passes (full suite)
- [x] New `TestWrapYAMLCmdAsJSON` covers single, multi, error passthrough, non-YAML passthrough, malformed YAML
- [x] Spot-check `:export json` in a real cluster: single resource, multi-select, mixed-namespace
- [x] Verify `:export yaml` and bare `:export` are unaffected
- [x] Render docs locally and skim — keybindings.md action-menu sections, views-and-overlays.md tables, config-reference.md Clusters section