### PR TITLE
chore: release 0.11.0 (retry — config-based release-as)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "release-as": "0.11.0",
       "draft": false,
       "prerelease": false,
       "extra-files": [


### PR DESCRIPTION
## Summary
- Retry of #188. That PR was auto-merged with rebase, but git rebase drops empty commits — \`cb8179a\` never landed on main, so release-please never ran.
- This PR adds \`"release-as": "0.11.0"\` to \`release-please-config.json\` so the bump comes from a real file diff (survives any merge method).

## Why config-based instead of \`Release-As:\` footer
- Empty commits are dropped by both squash-merge and rebase-merge.
- Merge-commits would preserve them, but that option is disabled on this repo.
- A 1-line config diff is preserved by every merge method.

## Effect when merged
1. Real diff lands on main (squash or rebase, either is fine).
2. \`release-please.yml\` triggers on the push.
3. release-please reads \`release-as\` and computes the next version as 0.11.0 (instead of 0.10.5 from the default).
4. release-please opens \`chore(main): release 0.11.0\` and removes \`release-as\` from the config in that same PR.
5. Merging the release PR tags \`v0.11.0\` and triggers GoReleaser.

## Test plan
- [ ] Merge with any method (squash or rebase, doesn't matter)
- [ ] Confirm \`release-please.yml\` runs on the resulting push to main
- [ ] Confirm release-please opens \`chore(main): release 0.11.0\`
- [ ] Verify the release PR also removes the \`release-as\` field
- [ ] Merge the release PR; verify \`v0.11.0\` tag and GoReleaser artifacts