### PR TITLE
feat(clipboard): support Windows and Wayland via atotto/clipboard

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -188,7 +188,7 @@ kubectl exec client -- /bin/sh -c 'while true; do curl -s web > /dev/null; sleep
 | 7 | `Ctrl+U` / `Ctrl+B` / `PgUp` | Half-page / full-page back into history |
 | 8 | `Ctrl+D` / `Ctrl+F` / `PgDn` | Half-page / full-page toward latest, clamps at 0 |
 | 9 | `g` then `G` | `g` jumps to the oldest packet; `G` returns to live (latest at bottom) |
-| 10 | `Y` | Status: `pcap path copied to clipboard: <path>`; verify with `pbpaste` (macOS) / `xclip -o -selection clipboard` (Linux) |
+| 10 | `Y` | Status: `pcap path copied to clipboard: <path>`; verify with `pbpaste` (macOS) / `xclip -o -selection clipboard` or `wl-paste` (Linux) / `Get-Clipboard` (Windows PowerShell) |
 | 11 | `Esc` | Capture stops; overlay **stays open** in stopped phase; badge `■ stopped`; second `Esc` dismisses |
 | 12 | Re-open via `c`, start a fresh capture, `s` to stop, `e` | Edit-filter path: returns to config phase with previous filter pre-filled; `Enter` restarts |
 | 13 | Restart-cleanup: do step 12 WITHOUT pressing Y on the first capture | First capture's pcap file deleted from `$XDG_STATE_HOME/lfk/captures/` when the second starts |

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/janosmiko/lfk
 go 1.26.3
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -24,7 +25,6 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
@@ -125,7 +126,11 @@ func openInBrowser(url string) tea.Cmd {
 	}
 }
 
-// copyToSystemClipboard copies text to the system clipboard using platform-specific tools.
+// copyToSystemClipboard copies text to the system clipboard.
+//
+// Backed by atotto/clipboard so macOS (pbcopy), Linux X11 (xsel/xclip),
+// Linux Wayland (wl-copy) and Windows (native syscall) all work without
+// per-platform branches here.
 //
 // Returns nil on success: every caller already calls setStatusMessage with a
 // context-specific message (e.g. "Copied 1 line", "Copied value of <key>")
@@ -134,17 +139,7 @@ func openInBrowser(url string) tea.Cmd {
 // useful caller message — visible to the user as a flicker.
 func copyToSystemClipboard(text string) tea.Cmd {
 	return func() tea.Msg {
-		var cmd *exec.Cmd
-		switch runtime.GOOS {
-		case "darwin":
-			cmd = exec.Command("pbcopy")
-		case "linux":
-			cmd = exec.Command("xclip", "-selection", "clipboard")
-		default:
-			return actionResultMsg{err: fmt.Errorf("clipboard not supported on %s", runtime.GOOS)}
-		}
-		cmd.Stdin = strings.NewReader(text)
-		if err := cmd.Run(); err != nil {
+		if err := clipboard.WriteAll(text); err != nil {
 			return actionResultMsg{err: fmt.Errorf("clipboard: %w", err)}
 		}
 		return nil

--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"time"
 
+	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
@@ -20,27 +20,16 @@ func (m Model) applyFromClipboard() tea.Cmd {
 		ns = "default"
 	}
 
-	// Read from clipboard.
-	var clipCmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		clipCmd = exec.Command("pbpaste")
-	case "linux":
-		clipCmd = exec.Command("xclip", "-selection", "clipboard", "-o")
-	default:
-		return func() tea.Msg {
-			return actionResultMsg{err: fmt.Errorf("clipboard not supported on %s", runtime.GOOS)}
-		}
-	}
-
-	clipContent, err := clipCmd.Output()
+	// Read from clipboard. atotto/clipboard covers macOS, Linux (X11 + Wayland)
+	// and Windows uniformly.
+	clipContent, err := clipboard.ReadAll()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("reading clipboard: %w", err)}
 		}
 	}
 
-	if len(strings.TrimSpace(string(clipContent))) == 0 {
+	if len(strings.TrimSpace(clipContent)) == 0 {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("clipboard is empty")}
 		}
@@ -53,7 +42,7 @@ func (m Model) applyFromClipboard() tea.Cmd {
 			return actionResultMsg{err: fmt.Errorf("creating temp file: %w", err)}
 		}
 	}
-	if _, err := tmpFile.Write(clipContent); err != nil {
+	if _, err := tmpFile.WriteString(clipContent); err != nil {
 		_ = tmpFile.Close()
 		_ = os.Remove(tmpFile.Name())
 		return func() tea.Msg {

--- a/internal/app/copy_feedback_test.go
+++ b/internal/app/copy_feedback_test.go
@@ -289,8 +289,10 @@ func TestCopyToSystemClipboardSuccessIsSilent(t *testing.T) {
 		t.Fatal("copyToSystemClipboard returned nil cmd")
 	}
 	msg := cmd()
-	// On platforms without pbcopy/xclip, an error is expected — only
-	// assert success-path silence when the subprocess actually ran.
+	// On hosts where atotto/clipboard can't reach a clipboard (Linux CI
+	// without xsel/xclip/wl-copy installed, headless containers, etc.) an
+	// error is expected — only assert success-path silence when the write
+	// actually succeeded.
 	if msg == nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- Routes `copyToSystemClipboard` (write) and `applyFromClipboard` (read) through `github.com/atotto/clipboard`, replacing the hard-coded `pbcopy` / `xclip` exec branches that returned `clipboard not supported on $GOOS` on Windows and Wayland sessions.
- Promotes `atotto/clipboard v0.1.4` from indirect to direct in `go.mod` (it was already in `go.sum` via the bubbletea dep tree).
- Refreshes the matching test comment in `copy_feedback_test.go` and the manual-test verification command in `TESTS.md` to mention `wl-paste` / `Get-Clipboard`.

Closes #193.

### Platform coverage after the change

| OS | Write (`y`, `Y`, copy YAML, etc.) | Read (`Apply from clipboard`) |
|---|---|---|
| macOS | pbcopy | pbpaste |
| Linux X11 | xsel/xclip | xsel/xclip |
| Linux Wayland | wl-copy (new) | wl-paste (new) |
| Windows | native user32 syscall (new) | native user32 syscall (new) |

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 9 packages green
- [x] `make lint` (golangci-lint) — 0 issues
- [x] Existing `TestCopyToSystemClipboardSuccessIsSilent` regression guard still passes (asserts non-nil cmd; tolerates either nil-on-success or `actionResultMsg{err: ...}` when the host has no clipboard backend).
- [x] Manual: on Windows, run `lfk`, navigate to a pod, press `y` to copy the name → paste with `Ctrl+V` in another app; copy a YAML with `Y` and `Apply from clipboard` round-trips.
- [x] Manual: on a Wayland Linux session with `wl-copy`/`wl-paste` installed, repeat the above.