### PR TITLE
fix(exec,browser): make interactive shell + browser-open actions work on Windows

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -259,6 +259,19 @@ func (m Model) loadContainersForLogFilter() tea.Cmd {
 // clearBeforeExec wraps cmd to clear the terminal screen before running it.
 // This ensures the TUI artifacts are removed when switching to interactive mode.
 func clearBeforeExec(cmd *exec.Cmd) *exec.Cmd {
+	return clearBeforeExecForOS(cmd, runtime.GOOS)
+}
+
+// clearBeforeExecForOS is the testable inner form. On Windows the sh -c
+// wrap is skipped because sh.exe is not on a standard PATH there —
+// wrapping kubectl in `sh -c "printf '\033c' && exec kubectl …"` would
+// make the parent process fail to start (issue #194: "exit status 2",
+// terminal flashes and closes). The cost is one cosmetic clear-screen
+// on the way into an interactive shell on Windows.
+func clearBeforeExecForOS(cmd *exec.Cmd, goos string) *exec.Cmd {
+	if goos == "windows" {
+		return cmd
+	}
 	// Build a shell command: clear screen with ANSI reset, then exec the original command.
 	quoted := make([]string, 0, len(cmd.Args))
 	for _, arg := range cmd.Args {

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -104,22 +104,18 @@ func scheduleDescribeRefresh() tea.Cmd {
 	})
 }
 
-// openInBrowser opens the given URL in the user's default browser using
-// platform-specific commands (open on macOS, xdg-open on Linux, start on Windows).
+// openInBrowser opens the given URL in the user's default browser.
+//
+// Delegates to ui.OpenBrowser, which routes Windows through
+// `rundll32 url.dll,FileProtocolHandler` instead of `cmd /c start`.
+// The earlier `cmd /c start` path here re-parsed the URL through
+// cmd.exe metacharacter semantics, so a single `&` in a query
+// string (e.g. `?a=1&b=2`) would split the URL and execute the
+// remainder as a shell command — both a correctness and a security
+// issue for URLs derived from cluster data.
 func openInBrowser(url string) tea.Cmd {
 	return func() tea.Msg {
-		var cmd *exec.Cmd
-		switch runtime.GOOS {
-		case "darwin":
-			cmd = exec.Command("open", url)
-		case "linux":
-			cmd = exec.Command("xdg-open", url)
-		case "windows":
-			cmd = exec.Command("cmd", "/c", "start", url)
-		default:
-			return actionResultMsg{err: fmt.Errorf("browser open not supported on %s", runtime.GOOS)}
-		}
-		if err := cmd.Start(); err != nil {
+		if err := ui.OpenBrowser(url); err != nil {
 			return actionResultMsg{err: fmt.Errorf("failed to open browser: %w", err)}
 		}
 		return actionResultMsg{message: "Opened " + url}

--- a/internal/app/commands_extra_test.go
+++ b/internal/app/commands_extra_test.go
@@ -12,7 +12,7 @@ import (
 func TestClearBeforeExec(t *testing.T) {
 	t.Run("wraps simple command", func(t *testing.T) {
 		original := exec.Command("kubectl", "get", "pods")
-		wrapped := clearBeforeExec(original)
+		wrapped := clearBeforeExecForOS(original, "linux")
 
 		assert.Equal(t, "sh", wrapped.Path[len(wrapped.Path)-2:])
 		assert.Equal(t, "sh", wrapped.Args[0])
@@ -27,7 +27,7 @@ func TestClearBeforeExec(t *testing.T) {
 		original := exec.Command("kubectl", "get", "pods")
 		original.Env = []string{"KUBECONFIG=/tmp/config"}
 		original.Dir = "/some/dir"
-		wrapped := clearBeforeExec(original)
+		wrapped := clearBeforeExecForOS(original, "linux")
 
 		assert.Equal(t, []string{"KUBECONFIG=/tmp/config"}, wrapped.Env)
 		assert.Equal(t, "/some/dir", wrapped.Dir)
@@ -35,14 +35,14 @@ func TestClearBeforeExec(t *testing.T) {
 
 	t.Run("quotes args with special chars", func(t *testing.T) {
 		original := exec.Command("kubectl", "get", "pods", "-l", "app=my app")
-		wrapped := clearBeforeExec(original)
+		wrapped := clearBeforeExecForOS(original, "linux")
 
 		assert.Contains(t, wrapped.Args[2], "'app=my app'")
 	})
 
 	t.Run("handles args with single quotes", func(t *testing.T) {
 		original := exec.Command("echo", "it's")
-		wrapped := clearBeforeExec(original)
+		wrapped := clearBeforeExecForOS(original, "linux")
 
 		// shellQuote replaces ' with '"'"'
 		assert.Contains(t, wrapped.Args[2], `'it'"'"'s'`)

--- a/internal/app/commands_extra_test.go
+++ b/internal/app/commands_extra_test.go
@@ -49,6 +49,34 @@ func TestClearBeforeExec(t *testing.T) {
 	})
 }
 
+// On Windows, sh.exe is not on a standard PATH, so wrapping a kubectl
+// command in `sh -c "printf '\033c' && exec kubectl …"` makes the parent
+// process exit immediately — that's what bug #194 surfaced as
+// "exit status 2" with the terminal flashing and closing. Returning the
+// original cmd unchanged on Windows lets tea.ExecProcess hand kubectl
+// the host terminal directly, losing only the cosmetic clear-screen.
+func TestClearBeforeExecForOS(t *testing.T) {
+	t.Run("linux wraps with sh -c", func(t *testing.T) {
+		cmd := exec.Command("kubectl", "exec", "-it", "pod")
+		wrapped := clearBeforeExecForOS(cmd, "linux")
+		assert.Equal(t, "sh", wrapped.Args[0])
+		assert.Equal(t, "-c", wrapped.Args[1])
+		assert.Contains(t, wrapped.Args[2], `printf '\033c'`)
+	})
+
+	t.Run("darwin wraps with sh -c", func(t *testing.T) {
+		cmd := exec.Command("kubectl", "exec", "-it", "pod")
+		wrapped := clearBeforeExecForOS(cmd, "darwin")
+		assert.Equal(t, "sh", wrapped.Args[0])
+	})
+
+	t.Run("windows returns cmd unchanged because sh is not reliably available", func(t *testing.T) {
+		cmd := exec.Command("kubectl", "exec", "-it", "pod")
+		wrapped := clearBeforeExecForOS(cmd, "windows")
+		assert.Same(t, cmd, wrapped, "windows path must not wrap — sh -c would fail before kubectl ever starts")
+	})
+}
+
 // --- SetVersion ---
 
 func TestSetVersion(t *testing.T) {

--- a/internal/app/multiplexer_test.go
+++ b/internal/app/multiplexer_test.go
@@ -212,23 +212,36 @@ func TestMultiplexerWrap(t *testing.T) {
 
 func TestNextTerminalMode(t *testing.T) {
 	cases := []struct {
-		name   string
-		from   string
-		hasMux bool
-		want   string
+		name      string
+		from      string
+		hasMux    bool
+		isWindows bool
+		want      string
 	}{
-		{"pty -> exec (no mux)", ui.TerminalModePTY, false, ui.TerminalModeExec},
-		{"pty -> exec (mux available)", ui.TerminalModePTY, true, ui.TerminalModeExec},
-		{"exec -> mux when mux available", ui.TerminalModeExec, true, ui.TerminalModeMux},
-		{"exec -> pty when no mux (skip mux)", ui.TerminalModeExec, false, ui.TerminalModePTY},
-		{"mux -> pty (no mux)", ui.TerminalModeMux, false, ui.TerminalModePTY},
-		{"mux -> pty (mux available)", ui.TerminalModeMux, true, ui.TerminalModePTY},
-		{"unrecognised value resets to pty", "garbage", false, ui.TerminalModePTY},
-		{"unrecognised value resets to pty even with mux", "garbage", true, ui.TerminalModePTY},
+		// Non-Windows cycle: pty -> exec -> (mux if available) -> pty.
+		{"pty -> exec (no mux)", ui.TerminalModePTY, false, false, ui.TerminalModeExec},
+		{"pty -> exec (mux available)", ui.TerminalModePTY, true, false, ui.TerminalModeExec},
+		{"exec -> mux when mux available", ui.TerminalModeExec, true, false, ui.TerminalModeMux},
+		{"exec -> pty when no mux (skip mux)", ui.TerminalModeExec, false, false, ui.TerminalModePTY},
+		{"mux -> pty (no mux)", ui.TerminalModeMux, false, false, ui.TerminalModePTY},
+		{"mux -> pty (mux available)", ui.TerminalModeMux, true, false, ui.TerminalModePTY},
+		{"unrecognised value resets to pty", "garbage", false, false, ui.TerminalModePTY},
+		{"unrecognised value resets to pty even with mux", "garbage", true, false, ui.TerminalModePTY},
+
+		// Windows: pty is unreachable because creack/pty has no Windows
+		// backend. The cycle must never produce pty, otherwise Ctrl+T
+		// becomes a trap that drops users into a broken state where
+		// every interactive action fails.
+		{"windows: exec -> mux when mux available", ui.TerminalModeExec, true, true, ui.TerminalModeMux},
+		{"windows: exec stays exec when no mux (no other valid target)", ui.TerminalModeExec, false, true, ui.TerminalModeExec},
+		{"windows: mux -> exec (never pty)", ui.TerminalModeMux, true, true, ui.TerminalModeExec},
+		{"windows: stale pty resets to exec (recovery path)", ui.TerminalModePTY, false, true, ui.TerminalModeExec},
+		{"windows: stale pty resets to exec even with mux", ui.TerminalModePTY, true, true, ui.TerminalModeExec},
+		{"windows: unrecognised value resets to exec, not pty", "garbage", false, true, ui.TerminalModeExec},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, nextTerminalMode(tc.from, tc.hasMux))
+			assert.Equal(t, tc.want, nextTerminalMode(tc.from, tc.hasMux, tc.isWindows))
 		})
 	}
 }

--- a/internal/app/ptyexec.go
+++ b/internal/app/ptyexec.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -48,11 +49,24 @@ func startPTYExecCmd(cmd *exec.Cmd, title string, cols, rows int) tea.Cmd {
 		})
 		if err != nil {
 			logger.Error("Failed to start PTY", "error", err)
-			return actionResultMsg{err: fmt.Errorf("failed to start PTY: %w", err)}
+			return actionResultMsg{err: ptyStartErrorForOS(err, runtime.GOOS)}
 		}
 
 		return execPTYStartMsg{ptmx: ptmx, term: term, title: title, cmd: cmd}
 	}
+}
+
+// ptyStartErrorForOS converts the pty.StartWithSize failure into a
+// user-visible error. On Windows the underlying creack/pty error is the
+// bare "unsupported" (ErrUnsupported) — useless on its own. The Windows
+// branch trades that for an actionable hint about Exec mode while
+// keeping the original error reachable via errors.Is for callers that
+// log it.
+func ptyStartErrorForOS(err error, goos string) error {
+	if goos == "windows" {
+		return fmt.Errorf("PTY mode is not supported on Windows; press Ctrl+T to switch to exec mode or set `terminal: exec` in your config (%w)", err)
+	}
+	return fmt.Errorf("failed to start PTY: %w", err)
 }
 
 // scheduleExecTick schedules the next terminal refresh tick.

--- a/internal/app/ptyexec_test.go
+++ b/internal/app/ptyexec_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -9,6 +10,35 @@ import (
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/stretchr/testify/assert"
 )
+
+// On Windows the embedded PTY driver returns an opaque "unsupported"
+// error (creack/pty's ErrUnsupported), which surfaced in lfk as
+// "failed to start PTY: unsupported" — useless to users who haven't
+// read the bug tracker. The Windows branch translates it into an
+// actionable hint pointing at Exec mode (Ctrl+T or `terminal: exec`).
+// Non-Windows hosts keep the bare wrap so the original cause stays
+// visible for debugging.
+func TestPTYStartErrorForOS(t *testing.T) {
+	underlying := errors.New("unsupported")
+
+	t.Run("windows surfaces an actionable hint about exec mode", func(t *testing.T) {
+		err := ptyStartErrorForOS(underlying, "windows")
+		msg := err.Error()
+		assert.Contains(t, msg, "not supported on Windows")
+		assert.Contains(t, msg, "exec")
+		assert.ErrorIs(t, err, underlying, "must still wrap the original error for callers that inspect it")
+	})
+
+	t.Run("linux keeps the bare wrap", func(t *testing.T) {
+		err := ptyStartErrorForOS(underlying, "linux")
+		assert.Equal(t, "failed to start PTY: unsupported", err.Error())
+	})
+
+	t.Run("darwin keeps the bare wrap", func(t *testing.T) {
+		err := ptyStartErrorForOS(underlying, "darwin")
+		assert.Equal(t, "failed to start PTY: unsupported", err.Error())
+	})
+}
 
 // --- keyToBytes ---
 

--- a/internal/app/terminal_mode.go
+++ b/internal/app/terminal_mode.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"runtime"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// nextTerminalMode computes the next mode in the Ctrl+T cycle. Split out
+// from the handler so the rotation logic can be unit-tested without
+// stubbing OS lookups: hasMux is whether a tmux/zellij multiplexer is
+// currently detected; isWindows is runtime.GOOS == "windows".
+//
+// On non-Windows hosts the cycle is pty -> exec -> mux -> pty when a
+// multiplexer is available, and pty -> exec -> pty otherwise — Ctrl+T
+// never lands the user in mux when it would just error on the next
+// interactive shell.
+//
+// On Windows pty is excluded entirely (creack/pty has no Windows
+// backend, so it would just trap the user in a broken state). The
+// cycle is exec -> mux -> exec when a multiplexer is available, and
+// exec -> exec otherwise — the Ctrl+T status message still updates,
+// but the mode never silently transitions into something that fails
+// on the next interactive action.
+func nextTerminalMode(current string, hasMux, isWindows bool) string {
+	if isWindows {
+		switch current {
+		case ui.TerminalModeExec:
+			if hasMux {
+				return ui.TerminalModeMux
+			}
+			return ui.TerminalModeExec
+		case ui.TerminalModeMux:
+			return ui.TerminalModeExec
+		default:
+			// Includes a stale pty value (e.g. left over before this
+			// guard existed) and any unrecognised mode.
+			return ui.TerminalModeExec
+		}
+	}
+	switch current {
+	case ui.TerminalModePTY:
+		return ui.TerminalModeExec
+	case ui.TerminalModeExec:
+		if hasMux {
+			return ui.TerminalModeMux
+		}
+		return ui.TerminalModePTY
+	case ui.TerminalModeMux:
+		return ui.TerminalModePTY
+	default:
+		return ui.TerminalModePTY
+	}
+}
+
+func (m Model) handleExplorerActionKeyTerminalToggle() (tea.Model, tea.Cmd, bool) {
+	mx := detectMultiplexer(nil, nil)
+	ui.ConfigTerminalMode = nextTerminalMode(ui.ConfigTerminalMode, mx != nil, runtime.GOOS == "windows")
+
+	switch ui.ConfigTerminalMode {
+	case ui.TerminalModeExec:
+		m.setStatusMessage("Terminal mode: exec (takes over the terminal)", false)
+	case ui.TerminalModeMux:
+		// nextTerminalMode only returns mux when hasMux was true, so mx
+		// is non-nil here. Guard anyway so a future refactor that
+		// bypasses nextTerminalMode can't trip a nil deref.
+		muxName := "multiplexer"
+		if mx != nil {
+			muxName = mx.name
+		}
+		m.setStatusMessage("Terminal mode: mux (new "+muxName+" window or pane)", false)
+	default:
+		m.setStatusMessage("Terminal mode: pty (embedded in lfk)", false)
+	}
+	return m, scheduleStatusClear(), true
+}

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -716,52 +716,6 @@ func (m Model) handleExplorerActionKeyErrorLog() (tea.Model, tea.Cmd, bool) {
 	return m, nil, true
 }
 
-// nextTerminalMode computes the next mode in the Ctrl+T cycle. Split out
-// from the handler so the rotation logic can be unit-tested without
-// stubbing OS lookups: hasMux is whether a tmux/zellij multiplexer is
-// currently detected.
-//
-// The cycle is pty -> exec -> mux -> pty when a multiplexer is available,
-// and pty -> exec -> pty otherwise — Ctrl+T never lands the user in mux
-// when it would just error on the next interactive shell.
-func nextTerminalMode(current string, hasMux bool) string {
-	switch current {
-	case ui.TerminalModePTY:
-		return ui.TerminalModeExec
-	case ui.TerminalModeExec:
-		if hasMux {
-			return ui.TerminalModeMux
-		}
-		return ui.TerminalModePTY
-	case ui.TerminalModeMux:
-		return ui.TerminalModePTY
-	default:
-		return ui.TerminalModePTY
-	}
-}
-
-func (m Model) handleExplorerActionKeyTerminalToggle() (tea.Model, tea.Cmd, bool) {
-	mx := detectMultiplexer(nil, nil)
-	ui.ConfigTerminalMode = nextTerminalMode(ui.ConfigTerminalMode, mx != nil)
-
-	switch ui.ConfigTerminalMode {
-	case ui.TerminalModeExec:
-		m.setStatusMessage("Terminal mode: exec (takes over the terminal)", false)
-	case ui.TerminalModeMux:
-		// nextTerminalMode only returns mux when hasMux was true, so mx
-		// is non-nil here. Guard anyway so a future refactor that
-		// bypasses nextTerminalMode can't trip a nil deref.
-		muxName := "multiplexer"
-		if mx != nil {
-			muxName = mx.name
-		}
-		m.setStatusMessage("Terminal mode: mux (new "+muxName+" window or pane)", false)
-	default:
-		m.setStatusMessage("Terminal mode: pty (embedded in lfk)", false)
-	}
-	return m, scheduleStatusClear(), true
-}
-
 func (m Model) handleExplorerActionKeyMonitoring() (tea.Model, tea.Cmd, bool) {
 	if m.nav.Level < model.LevelResourceTypes {
 		m.setStatusMessage("Select a cluster first", true)

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -344,7 +344,11 @@ func resolveTerminalMode(configValue, goos, currentMode string) (mode string, wa
 	case TerminalModeExec, TerminalModeMux:
 		return normalized, ""
 	default:
-		return currentMode, "unrecognised terminal mode: " + configValue + "; using " + currentMode
+		// The raw configValue is intentionally NOT embedded in the
+		// warning — log redaction policy. Users can check their config
+		// file to see what they typed; the "valid" list logged by the
+		// caller tells them what is accepted.
+		return currentMode, "unrecognised terminal mode; using " + currentMode
 	}
 }
 

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -293,8 +294,28 @@ const (
 )
 
 // ConfigTerminalMode controls how exec/shell commands run. One of
-// TerminalModePTY, TerminalModeExec, TerminalModeMux.
-var ConfigTerminalMode = TerminalModePTY
+// TerminalModePTY, TerminalModeExec, TerminalModeMux. Initialised from
+// defaultTerminalMode() so Windows users — where the embedded PTY
+// driver (github.com/creack/pty) has no working backend — start in
+// Exec mode by default and don't hit "failed to start PTY: unsupported"
+// the first time they trigger an interactive shell (issue #194).
+var ConfigTerminalMode = defaultTerminalMode()
+
+// defaultTerminalMode returns the package-level default for
+// ConfigTerminalMode based on the current runtime OS.
+func defaultTerminalMode() string {
+	return defaultTerminalModeForOS(runtime.GOOS)
+}
+
+// defaultTerminalModeForOS is the testable inner form. Windows must
+// default to Exec because creack/pty's Windows StartWithSize returns
+// ErrUnsupported; every other platform gets the richer embedded PTY.
+func defaultTerminalModeForOS(goos string) string {
+	if goos == "windows" {
+		return TerminalModeExec
+	}
+	return TerminalModePTY
+}
 
 // ScrollbackLines clamps for the embedded PTY scrollback ring. The
 // default of 5000 covers an extended interactive session without

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -331,10 +331,10 @@ func defaultTerminalModeForOS(goos string) string {
 // implementation — accepting the option would just trap users in a
 // state where every interactive action fails (issue #194).
 func resolveTerminalMode(configValue, goos, currentMode string) (mode string, warning string) {
-	if configValue == "" {
+	normalized := strings.ToLower(strings.TrimSpace(configValue))
+	if normalized == "" {
 		return currentMode, ""
 	}
-	normalized := strings.ToLower(configValue)
 	switch normalized {
 	case TerminalModePTY:
 		if goos == "windows" {

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -317,6 +317,37 @@ func defaultTerminalModeForOS(goos string) string {
 	return TerminalModePTY
 }
 
+// resolveTerminalMode validates the `terminal:` config value against the
+// runtime OS. It returns (effectiveMode, warning):
+//   - effectiveMode is always a valid mode the caller can assign to
+//     ConfigTerminalMode. When the input is empty or unrecognised the
+//     caller's currentMode is returned unchanged.
+//   - warning is non-empty when a fallback was applied; the caller is
+//     expected to log it at Warn level so the user sees why their
+//     configured value didn't stick.
+//
+// `pty` on Windows is silently downgraded to `exec` because the embedded
+// PTY backend (github.com/creack/pty) has no working Windows
+// implementation — accepting the option would just trap users in a
+// state where every interactive action fails (issue #194).
+func resolveTerminalMode(configValue, goos, currentMode string) (mode string, warning string) {
+	if configValue == "" {
+		return currentMode, ""
+	}
+	normalized := strings.ToLower(configValue)
+	switch normalized {
+	case TerminalModePTY:
+		if goos == "windows" {
+			return TerminalModeExec, "terminal: pty is not supported on Windows (no PTY backend); using exec"
+		}
+		return TerminalModePTY, ""
+	case TerminalModeExec, TerminalModeMux:
+		return normalized, ""
+	default:
+		return currentMode, "unrecognised terminal mode: " + configValue + "; using " + currentMode
+	}
+}
+
 // ScrollbackLines clamps for the embedded PTY scrollback ring. The
 // default of 5000 covers an extended interactive session without
 // running the parent process out of memory; the floor stops a typo in

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"math"
 	"os"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -103,16 +104,14 @@ func applyConfigOptions(cfg configFile) {
 		ConfigDashboard = *cfg.Dashboard
 	}
 	if cfg.Terminal != "" {
-		mode := strings.ToLower(cfg.Terminal)
-		switch mode {
-		case TerminalModePTY, TerminalModeExec, TerminalModeMux:
-			ConfigTerminalMode = mode
-		default:
-			logger.Warn("unrecognised terminal mode in config; falling back to default",
+		mode, warning := resolveTerminalMode(cfg.Terminal, runtime.GOOS, ConfigTerminalMode)
+		if warning != "" {
+			logger.Warn(warning,
 				"value", cfg.Terminal,
 				"valid", []string{TerminalModePTY, TerminalModeExec, TerminalModeMux},
-				"default", ConfigTerminalMode)
+				"applied", mode)
 		}
+		ConfigTerminalMode = mode
 	}
 	if cfg.ScrollbackLines != 0 {
 		v := cfg.ScrollbackLines

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -106,8 +106,11 @@ func applyConfigOptions(cfg configFile) {
 	if cfg.Terminal != "" {
 		mode, warning := resolveTerminalMode(cfg.Terminal, runtime.GOOS, ConfigTerminalMode)
 		if warning != "" {
+			// Raw cfg.Terminal is intentionally not logged — log
+			// redaction policy. The "valid" list tells the user what
+			// is accepted; their own config file is the source of
+			// truth for what they typed.
 			logger.Warn(warning,
-				"value", cfg.Terminal,
 				"valid", []string{TerminalModePTY, TerminalModeExec, TerminalModeMux},
 				"applied", mode)
 		}

--- a/internal/ui/terminal_mode_default_test.go
+++ b/internal/ui/terminal_mode_default_test.go
@@ -71,6 +71,20 @@ func TestResolveTerminalMode(t *testing.T) {
 			wantMode:    TerminalModePTY,
 		},
 		{
+			name:        "leading and trailing whitespace is trimmed (no spurious warning)",
+			configValue: "  pty\n",
+			goos:        "linux",
+			currentMode: TerminalModeExec,
+			wantMode:    TerminalModePTY,
+		},
+		{
+			name:        "whitespace-only value treated as empty",
+			configValue: "   ",
+			goos:        "linux",
+			currentMode: TerminalModePTY,
+			wantMode:    TerminalModePTY,
+		},
+		{
 			name:        "unrecognised value keeps current with warning",
 			configValue: "garbage",
 			goos:        "linux",

--- a/internal/ui/terminal_mode_default_test.go
+++ b/internal/ui/terminal_mode_default_test.go
@@ -106,6 +106,18 @@ func TestResolveTerminalMode(t *testing.T) {
 	}
 }
 
+// resolveTerminalMode must not echo the raw config value into its
+// warning string — global log-redaction policy. Even though the
+// `terminal:` field is structurally an enum, a misplaced secret in
+// that key would otherwise land in the log stream verbatim.
+func TestResolveTerminalMode_WarningDoesNotLeakRawValue(t *testing.T) {
+	const sentinel = "super-secret-token-do-not-leak"
+	_, warning := resolveTerminalMode(sentinel, "linux", TerminalModePTY)
+	assert.NotEmpty(t, warning, "an unrecognised value must produce a warning")
+	assert.NotContains(t, warning, sentinel,
+		"warning string must not embed the raw configValue (log redaction policy)")
+}
+
 // On Windows, github.com/creack/pty (the embedded PTY driver behind
 // TerminalModePTY) returns ErrUnsupported from StartWithSize, so the
 // embedded-terminal path can never succeed. The package-level default

--- a/internal/ui/terminal_mode_default_test.go
+++ b/internal/ui/terminal_mode_default_test.go
@@ -6,6 +6,92 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// resolveTerminalMode is the testable kernel behind applyConfigOptions'
+// terminal-mode handling. The Windows branch must downgrade an explicit
+// `terminal: pty` to exec because pty is unreachable there (creack/pty
+// has no Windows backend) — letting the option through would just trap
+// users in a state where every interactive action fails.
+func TestResolveTerminalMode(t *testing.T) {
+	cases := []struct {
+		name        string
+		configValue string
+		goos        string
+		currentMode string
+		wantMode    string
+		wantWarn    bool
+	}{
+		{
+			name:        "empty config keeps current default",
+			configValue: "",
+			goos:        "linux",
+			currentMode: TerminalModePTY,
+			wantMode:    TerminalModePTY,
+		},
+		{
+			name:        "pty on linux is honoured",
+			configValue: "pty",
+			goos:        "linux",
+			currentMode: TerminalModeExec,
+			wantMode:    TerminalModePTY,
+		},
+		{
+			name:        "pty on darwin is honoured",
+			configValue: "pty",
+			goos:        "darwin",
+			currentMode: TerminalModeExec,
+			wantMode:    TerminalModePTY,
+		},
+		{
+			name:        "pty on windows is rejected and falls back to exec",
+			configValue: "pty",
+			goos:        "windows",
+			currentMode: TerminalModeExec,
+			wantMode:    TerminalModeExec,
+			wantWarn:    true,
+		},
+		{
+			name:        "exec on windows is honoured",
+			configValue: "exec",
+			goos:        "windows",
+			currentMode: TerminalModeExec,
+			wantMode:    TerminalModeExec,
+		},
+		{
+			name:        "mux on windows is honoured (user can opt in if they run tmux/zellij)",
+			configValue: "mux",
+			goos:        "windows",
+			currentMode: TerminalModeExec,
+			wantMode:    TerminalModeMux,
+		},
+		{
+			name:        "case-insensitive normalisation",
+			configValue: "PTY",
+			goos:        "linux",
+			currentMode: TerminalModeExec,
+			wantMode:    TerminalModePTY,
+		},
+		{
+			name:        "unrecognised value keeps current with warning",
+			configValue: "garbage",
+			goos:        "linux",
+			currentMode: TerminalModePTY,
+			wantMode:    TerminalModePTY,
+			wantWarn:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, warning := resolveTerminalMode(tc.configValue, tc.goos, tc.currentMode)
+			assert.Equal(t, tc.wantMode, mode)
+			if tc.wantWarn {
+				assert.NotEmpty(t, warning, "expected a fallback warning")
+			} else {
+				assert.Empty(t, warning, "no warning expected for an honoured value")
+			}
+		})
+	}
+}
+
 // On Windows, github.com/creack/pty (the embedded PTY driver behind
 // TerminalModePTY) returns ErrUnsupported from StartWithSize, so the
 // embedded-terminal path can never succeed. The package-level default

--- a/internal/ui/terminal_mode_default_test.go
+++ b/internal/ui/terminal_mode_default_test.go
@@ -109,13 +109,36 @@ func TestResolveTerminalMode(t *testing.T) {
 // resolveTerminalMode must not echo the raw config value into its
 // warning string — global log-redaction policy. Even though the
 // `terminal:` field is structurally an enum, a misplaced secret in
-// that key would otherwise land in the log stream verbatim.
+// that key would otherwise land in the log stream verbatim. Both
+// warning-producing branches must hold the line: the unrecognised
+// fallback (any value the switch doesn't match) and the Windows
+// pty-downgrade. The downgrade path's warning is currently a fixed
+// string by construction, but pinning the policy in a test prevents
+// a future refactor from quietly weakening it.
 func TestResolveTerminalMode_WarningDoesNotLeakRawValue(t *testing.T) {
 	const sentinel = "super-secret-token-do-not-leak"
-	_, warning := resolveTerminalMode(sentinel, "linux", TerminalModePTY)
-	assert.NotEmpty(t, warning, "an unrecognised value must produce a warning")
-	assert.NotContains(t, warning, sentinel,
-		"warning string must not embed the raw configValue (log redaction policy)")
+
+	t.Run("unrecognised value branch", func(t *testing.T) {
+		_, warning := resolveTerminalMode(sentinel, "linux", TerminalModePTY)
+		assert.NotEmpty(t, warning, "an unrecognised value must produce a warning")
+		assert.NotContains(t, warning, sentinel,
+			"warning string must not embed the raw configValue (log redaction policy)")
+	})
+
+	t.Run("windows pty downgrade branch", func(t *testing.T) {
+		// Raw value normalises to "pty" (TrimSpace + ToLower) so the
+		// Windows downgrade branch fires; the original carries a tab
+		// and mixed case that the static warning never produces. A
+		// future refactor that interpolates configValue into the
+		// warning would re-introduce the tab and fail NotContains.
+		raw := "\t  PtY  \t"
+		_, warning := resolveTerminalMode(raw, "windows", TerminalModeExec)
+		assert.NotEmpty(t, warning, "windows pty downgrade must produce a warning")
+		assert.NotContains(t, warning, raw,
+			"windows downgrade warning must not embed the raw configValue")
+		assert.NotContains(t, warning, "\t",
+			"windows downgrade warning must not echo whitespace from the raw input")
+	})
 }
 
 // On Windows, github.com/creack/pty (the embedded PTY driver behind

--- a/internal/ui/terminal_mode_default_test.go
+++ b/internal/ui/terminal_mode_default_test.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// On Windows, github.com/creack/pty (the embedded PTY driver behind
+// TerminalModePTY) returns ErrUnsupported from StartWithSize, so the
+// embedded-terminal path can never succeed. The package-level default
+// must therefore be TerminalModeExec on Windows so a first-time user
+// with no config file gets a working `Exec` action instead of the
+// cryptic "failed to start PTY: unsupported" message that issue #194
+// stems from. Linux and macOS keep the embedded PTY default.
+func TestDefaultTerminalModeForOS(t *testing.T) {
+	cases := []struct {
+		goos string
+		want string
+	}{
+		{"windows", TerminalModeExec},
+		{"linux", TerminalModePTY},
+		{"darwin", TerminalModePTY},
+		{"freebsd", TerminalModePTY},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			assert.Equal(t, tc.want, defaultTerminalModeForOS(tc.goos))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three Windows-only bugs in the interactive shell and browser-open paths, all stacked behind the same `x → Exec` failure mode reported in #194.

### 1. `clearBeforeExec` wrapped kubectl in `sh -c …` (issue #194)
`sh.exe` is not on a standard Windows PATH, so the parent process exited before kubectl ever started — surfaced as `exit status 2` with the terminal flashing and closing. The wrap is now skipped on Windows; we lose only the cosmetic clear-screen on the way into the interactive session.

### 2. PTY mode is now fully gated off on Windows
`github.com/creack/pty` v1.1.24's `StartWithSize` returns `ErrUnsupported` on Windows, so the embedded PTY path can never succeed there. Previously the package default `ConfigTerminalMode = TerminalModePTY` would surface as `failed to start PTY: unsupported` for first-time Windows users, and a config `terminal: pty` (or a Ctrl+T cycle landing on pty) would silently drop them back into the same broken state. PTY is now blocked at every entry point on Windows:

| Entry point | Behavior on Windows |
|---|---|
| Package-level default | `TerminalModeExec` instead of `TerminalModePTY` (`defaultTerminalModeForOS`). |
| Config file (`terminal: pty`) | Downgraded to `exec` with a logged warning (`resolveTerminalMode` inside `applyConfigOptions`). |
| Ctrl+T cycle | `nextTerminalMode(current, hasMux, isWindows)` — cycle is `exec → mux → exec` when a multiplexer is detected, otherwise stays on `exec`. Stale/garbage values also fall back to `exec`, never to `pty`. |
| Defense-in-depth | If `startPTYExecCmd` is somehow reached on Windows (e.g. future code path), `ptyStartErrorForOS` returns an actionable hint instead of the bare `unsupported`. |

`nextTerminalMode` + `handleExplorerActionKeyTerminalToggle` were moved out of `update_keys_actions.go` into `internal/app/terminal_mode.go` so the file stays under the 800-line `revive` limit after the Windows branch was added.

### 3. `openInBrowser` ran `cmd /c start <url>` on Windows
`cmd.exe` re-parses arguments after `start` with shell metacharacter semantics, so a `&` in a query string (`?a=1&b=2`) splits the URL and runs the remainder as a command — both a correctness and a security issue for URLs derived from cluster data. `openInBrowser` now delegates to `internal/ui.OpenBrowser`, which already routes Windows through `rundll32 url.dll,FileProtocolHandler` (the shell-free path documented in `internal/ui/openbrowser.go:23-26`). The existing `TestBrowserCommand_Windows_NoShellInvocation` already guards against regressions to `cmd /c start`.

Closes #194.

## Testing approach

Each helper takes an OS flag so the Windows path is covered by table-driven tests on Linux/macOS CI — same pattern as the existing `browserCommand(goos, url)` and the original `nextTerminalMode(current, hasMux)`.

| Helper | Test |
|---|---|
| `clearBeforeExecForOS(cmd, goos)` | `TestClearBeforeExecForOS` |
| `defaultTerminalModeForOS(goos)` | `TestDefaultTerminalModeForOS` |
| `resolveTerminalMode(configValue, goos, current)` | `TestResolveTerminalMode` (8 cases) |
| `nextTerminalMode(current, hasMux, isWindows)` | `TestNextTerminalMode` (existing cases + 6 new Windows cases) |
| `ptyStartErrorForOS(err, goos)` | `TestPTYStartErrorForOS` |

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 9 packages green
- [x] `make lint` (golangci-lint) — 0 issues (incl. the `file-length-limit` revive check)
- [x] Existing `TestNextTerminalMode` non-Windows cases unchanged
- [x] Existing `TestClearBeforeExec` regression tests still pass — Linux/macOS behavior unchanged
- [x] Existing `TestCovOpenInBrowser` still passes against the refactored delegate
- [x] Manual on Windows: with default config, `x → Exec` opens the pod shell and survives Ctrl+] then `]` for tab cycling; exit is clean.
- [x] Manual on Windows: set `terminal: pty` in `lfk.yaml`, start lfk, confirm the log warning fires and the runtime mode is `exec`.
- [x] Manual on Windows: press Ctrl+T repeatedly; cycle stays on `exec` (or alternates `exec ↔ mux` inside tmux/zellij), never reports `pty`.
- [x] Manual on Windows: open an Ingress with a `&` in its URL via `Ctrl+O`; browser receives the full URL, no shell command spawned.