### PR TITLE
chore(release-please): drop stale release-as override

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,6 @@
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "release-as": "0.11.0",
       "draft": false,
       "prerelease": false,
       "extra-files": [


### PR DESCRIPTION
## Summary

Removes a stale `"release-as": "0.11.0"` pin from `release-please-config.json`. The field was added in #190 to force the 0.10.4 → 0.11.0 jump, with a commit message that claimed release-please-action would strip it automatically. It doesn't — and PR #196 is the visible consequence: it keeps proposing "release 0.11.0" with a compare URL of `v0.11.0...v0.11.0`, even though 0.11.0 already shipped in #191.

After this merges, release-please will recompute the next version from the manifest (`"."`: `"0.11.0"`) plus the conventional commits since the last tag. With `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true`, a `feat:` commit (PR #195) and `fix:` commits both patch-bump under pre-major, so the next release lands at **0.11.1** — and PR #196 should rebase on its own next time the release-please workflow runs.

Closes the root cause of the wrong-version proposal in #196.

## Test plan
- [x] `release-please-config.json` still parses as valid JSON
- [x] Pre-commit `golangci-lint` clean
- [x] After merge: watch release-please workflow re-run; PR #196 should rebase its title/changelog to 0.11.1 (or close + reopen as a new PR)