### PR TITLE
fix(flake): Fix building with nix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are welcome! Here is how to get started.
 
 ## Prerequisites
 
-- Go 1.26.3 or later
+- Go 1.26.2 or later
 - Access to a Kubernetes cluster (for testing)
 - `kubectl` configured and working
 - `golangci-lint`

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-nEMHImlytPq9FhN6Rb5mmBMpZ7d+II1MirD0xLLZv+A=";
+            vendorHash = "sha256-D3ra3CpmQG+CD+upI0S8fv+1iTZd/4VSeAtnEq26VnI=";
 
             subPackages = [ "." ];
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/janosmiko/lfk
 
-go 1.26.3
+go 1.26.2
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
Current nixpkgs ships go 1.26.2, so if go.mod required 1.26.3 it doesn't build at all. Changing the version helps, the projects builds and runs just fine.

## Summary

<!-- Brief description of what this PR does and why. -->

## Type of change

- [ ] feat: new user-facing feature
- [x] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

<!-- e.g. Closes #123 -->

## Changes

* Just changed the required go version from 1.26.3 to 1.26.2.

## Testing

<!-- How did you verify this works? Include the cluster / terminal you tested against when relevant. -->

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [ ] `golangci-lint run` passes (didn't check, no golang code changed)
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->
