### PR TITLE
fix(release): skip Chocolatey publish until first version is moderated

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -168,7 +168,10 @@ chocolateys:
     release_notes: "https://github.com/janosmiko/lfk/releases/tag/v{{ .Version }}"
     api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
     source_repo: "https://push.chocolatey.org/"
-    skip_publish: false
+    # Push.chocolatey.org returns 403 while no version of `lfk` has been approved
+    # by a human moderator yet (0.10.4 is in the queue). Flip back to false once
+    # the first version is approved.
+    skip_publish: true
 
 aurs:
   - name: lfk-bin


### PR DESCRIPTION
## Summary
- v0.11.0 release pipeline failed because `push.chocolatey.org` returned **403 Forbidden** for the Chocolatey publisher.
- Per Chocolatey's [common-errors doc](https://docs.chocolatey.org/en-us/community-repository/maintainers/common-errors/), a 403 with a valid API key on an owned package means: **"Package has a version in moderation and no approved versions."** `lfk 0.10.4` is currently in the moderation queue and no version of `lfk` has been approved yet, so every subsequent push will 403 until a moderator reviews it.
- This change sets `skip_publish: true` for the `chocolateys` block in `.goreleaser.yaml`. The `.nupkg` is still built locally (and ends up in the GitHub Release artifacts), but the push step is skipped — so a stuck moderation queue can't fail the release.

## Reverting once moderation passes
Flip `skip_publish` back to `false` once any version of `lfk` has been approved on [community.chocolatey.org/packages/lfk](https://community.chocolatey.org/packages/lfk).

## Test plan
- [x] CI passes (lint, build, govulncheck, tests)
- [x] `goreleaser check` validates the config
- [ ] Next release tag builds without attempting a Chocolatey push