### PR TITLE
fix(describe): route keys to search input, not global tab handler (#203)

### DIFF
--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -61,7 +61,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // handleTabSwitchKey handles tab switching keys (next/prev/new tab).
 func (m Model) handleTabSwitchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	kb := ui.ActiveKeybindings
-	if m.mode == modeExplorer || m.mode == modeExec || m.yamlSearchMode || m.logSearchActive || m.helpSearchActive || m.explainSearchActive || m.diffSearchMode {
+	if m.mode == modeExplorer || m.mode == modeExec || m.yamlSearchMode || m.logSearchActive || m.helpSearchActive || m.explainSearchActive || m.diffSearchMode || m.describeSearchActive {
 		return m, nil, false
 	}
 	switch msg.String() {

--- a/internal/app/update_keys_test.go
+++ b/internal/app/update_keys_test.go
@@ -1408,6 +1408,21 @@ func TestCovHandleKeyExplainSearch(t *testing.T) {
 	assert.False(t, rm.explainSearchActive)
 }
 
+// Regression for #203: typing a letter that happens to be the NewTab
+// keybinding (default "t") while the Describe panel's search input is
+// active must reach the search input, not the global tab handler.
+func TestDescribeSearchSwallowsNewTabKey(t *testing.T) {
+	m := baseModelDescribe()
+	m.describeSearchActive = true
+
+	result, _ := m.handleKey(runeKey('t'))
+	rm := result.(Model)
+
+	assert.Len(t, rm.tabs, 1, "no new tab should be created while describe search is active")
+	assert.True(t, rm.describeSearchActive, "describe search should remain active")
+	assert.Equal(t, "t", rm.describeSearchInput.Value, "'t' should be inserted into the search input")
+}
+
 // --- Cancellation of active mutations ---
 
 func TestCtrlCCancelsMutationsInsteadOfClosingTab(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #203.

**Bug**: In the Describe panel, pressing `/` to search and then typing any word containing `t` (e.g. `prometheus`) spawned a new tab on every `t` keypress. The search input still received the rest of the characters, leaving a stale search tab behind.

**Cause**: `handleTabSwitchKey` (`internal/app/update_keys.go:62`) short-circuits when the user is in any fullscreen search sub-mode — YAML, logs, help, explain, diff — but `describeSearchActive` was missing from that guard. The `t` keypress reached the global tab handler before describe's own search-mode key handler ever saw it.

The comment at the caller already documented the intent:
> Tab switching keys work in all fullscreen modes (YAML, Logs, Describe, Diff, Help) as long as the user is not in a text input sub-mode (search, etc.).

This PR brings the guard in line with that documented behavior — one term added to the existing condition.

## Test plan
- [x] Red: new test `TestDescribeSearchSwallowsNewTabKey` drives `t` through `handleKey` with `describeSearchActive = true` and asserts no new tab + keystroke lands in `describeSearchInput`. Verified failing on `main` (2 tabs, empty input).
- [x] Green: after the one-line fix, the test passes.
- [x] `go test -race ./...` passes (full suite, no regressions).
- [x] `golangci-lint run ./...` is clean.
- [x] Manual verification: open Describe view, press `/`, type `prometheus`, confirm no new tabs and the search bar shows `prometheus`.

## Reproduction (from #203)
1. Start lfk
2. Navigate to any resource, press `x v` to open the Describe panel
3. Press `/` to start search
4. Type `prometheus` — was: a new tab opened on each `t`; now: text appears in the search input.