### PR TITLE
fix(app,scheduler): drop idle CPU from ~145% to ~0% (closes #206)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -781,9 +781,9 @@ type Model struct {
 	kubetrisGame   *kubetrisGame
 }
 
-// Init loads the initial context list.
+// Init loads the initial context list. Spinner starts lazily via Update's spinnerWanted gate (#206).
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{m.loadContexts(), m.spinner.Tick}
+	cmds := []tea.Cmd{m.loadContexts()}
 	if m.stderrChan != nil {
 		cmds = append(cmds, m.waitForStderr())
 	}

--- a/internal/app/scheduler/scheduler.go
+++ b/internal/app/scheduler/scheduler.go
@@ -155,6 +155,26 @@ func (q *ctxQueue) dequeueByPriorityLocked() (*queuedTask, bool) {
 	return nil, false
 }
 
+// hasPendingWork reports whether any priority lane is non-empty. Used by
+// the worker loop to decide whether to re-signal q.wake after a failed
+// pickTask: if the queue is truly empty we must NOT re-signal, otherwise
+// a stale wake left over from a previous drain creates a hot loop in
+// which the same worker repeatedly receives and resends the signal
+// without parking (issue #206 — observed as 2.26M goroutine
+// block/unblock events per second). Caller does not need to hold q.mu;
+// the read is racy but only used as a hint and the worst case is one
+// extra empty wake which the workers tolerate by parking again.
+func (q *ctxQueue) hasPendingWork() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for prio := range q.lanes {
+		if len(q.lanes[prio]) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // Submit queues a unit of K8s work. Returns a buffered Future. If the
 // Registry is nil or has been closed, the Future immediately receives
 // Result{Err: ErrContextSwitched}.

--- a/internal/app/scheduler/scheduler_busy_loop_test.go
+++ b/internal/app/scheduler/scheduler_busy_loop_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package scheduler
 
 import (

--- a/internal/app/scheduler/scheduler_busy_loop_test.go
+++ b/internal/app/scheduler/scheduler_busy_loop_test.go
@@ -1,0 +1,81 @@
+package scheduler
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestWorkerLoop_DoesNotBusyLoopOnStaleWake exercises the regression
+// fixed for issue #206. After the inner drain loop empties the queue,
+// any wake signal that arrived during the drain stays in q.wake. The
+// previous code would consume it on the next outer-select iteration,
+// pickTask would return (nil, false) for the empty queue, the worker
+// would unconditionally re-signal, and the same goroutine would race
+// its way back to the receive — feeding itself stale wakes in a hot
+// loop. Production symptom: 2.26M goroutine block/unblock events per
+// second, ~145% idle CPU on macOS.
+//
+// The bug requires a wake signal to land in q.wake while the queue is
+// empty. We inject one directly so the test is deterministic (a
+// burst-submit test races against the runtime and the bug may not
+// surface in the test window). The fix gates the re-signal on
+// q.hasPendingWork(), so the injected stale wake should be consumed
+// once and the loop should park.
+func TestWorkerLoop_DoesNotBusyLoopOnStaleWake(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(4, 1) // matches prod defaults: 1 critical + 3 general
+
+	// Create the ctxQueue for "c1" and start the worker pool against
+	// it WITHOUT submitting any task. ensurePoolFor walks ctxQueues
+	// when r.started, so we need the queue to exist before
+	// StartWorkers.
+	r.mu.Lock()
+	q := newCtxQueue()
+	r.ctxQueues["c1"] = q
+	r.mu.Unlock()
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	// Wait briefly for workers to park on the empty queue.
+	time.Sleep(20 * time.Millisecond)
+
+	// Inject a stale wake — simulating a leftover signal from a prior
+	// drain. The queue is empty, so on the buggy code a worker will
+	// pick it up, fail pickTask, re-signal, and hot-loop indefinitely.
+	q.wake <- struct{}{}
+
+	// Sample CPU over 300 ms of wall time. Use kernel rusage so the
+	// measurement reflects real CPU burn, independent of Go's
+	// scheduler accounting (which the busy loop would distort).
+	const window = 300 * time.Millisecond
+	cpuStart := rusageCPU(t)
+	time.Sleep(window)
+	cpuUsed := rusageCPU(t) - cpuStart
+
+	// Pre-fix: cpuUsed ~ 400-700 ms (1+ core burning the whole window).
+	// Post-fix: a few ms at most. 50 ms gives plenty of headroom for
+	// loaded CI runners.
+	const ceiling = 50 * time.Millisecond
+	if cpuUsed > ceiling {
+		t.Fatalf("scheduler busy-loops on stale wake: used %v of CPU in %v of wall time (ceiling %v)",
+			cpuUsed, window, ceiling)
+	}
+}
+
+// rusageCPU returns this process's combined user+sys CPU time so far.
+// Used by the busy-loop regression test so the measurement is taken
+// from the kernel rather than Go's runtime accounting.
+func rusageCPU(t *testing.T) time.Duration {
+	t.Helper()
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		t.Fatalf("getrusage: %v", err)
+	}
+	return tvToDur(ru.Utime) + tvToDur(ru.Stime)
+}
+
+func tvToDur(tv syscall.Timeval) time.Duration {
+	return time.Duration(tv.Sec)*time.Second + time.Duration(tv.Usec)*time.Microsecond
+}

--- a/internal/app/scheduler/scheduler_workers.go
+++ b/internal/app/scheduler/scheduler_workers.go
@@ -115,13 +115,18 @@ func (r *Registry) workerLoop(q *ctxQueue, isCritical bool) {
 			// Try to pick a task for this worker class. If none is found
 			// (e.g. a Critical-only worker woke up but only non-Critical
 			// tasks are queued), re-signal so the appropriate worker picks
-			// it up.
+			// it up — but ONLY if the queue actually has pending work.
+			// A stale wake left over from the inner drain loop below
+			// would otherwise feed itself: this worker re-signals, the
+			// same goroutine wins the receive race, fails pickTask
+			// again, re-signals, ad infinitum (issue #206).
 			task, ok := r.pickTask(q, isCritical)
 			if !ok {
-				// Re-signal so another worker class can pick up the work.
-				select {
-				case q.wake <- struct{}{}:
-				default:
+				if q.hasPendingWork() {
+					select {
+					case q.wake <- struct{}{}:
+					default:
+					}
 				}
 				continue
 			}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -29,8 +29,36 @@ func isContextCanceled(err error) bool {
 	return strings.Contains(msg, "context canceled") || strings.Contains(msg, "context deadline exceeded")
 }
 
-// Update handles messages.
+// Update handles messages. It wraps dispatchMessage with a spinner-activation
+// hook: when the dispatched handler transitions the model from "spinner not
+// wanted" to "spinner wanted", we kick the tick chain in the same turn so
+// the indicator actually animates. The wanted state is tracked implicitly
+// via this transition rather than with a separate active-flag, so unit tests
+// that drive Update directly with a pre-built `m.loading = true` model don't
+// get a surprise spinner.Tick attached to their cmd assertion. In real flow,
+// m.loading only flips false → true inside an Update, so this transition
+// edge fires reliably. Without this gate the spinner would tick at 10 Hz
+// forever and burn a core's worth of CPU on idle re-renders (issue #206).
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	wasWanted := m.spinnerWanted()
+	newModel, cmd := m.dispatchMessage(msg)
+	nm, ok := newModel.(Model)
+	if !ok {
+		return newModel, cmd
+	}
+	if !wasWanted && nm.spinnerWanted() {
+		if cmd == nil {
+			return nm, nm.spinner.Tick
+		}
+		return nm, tea.Batch(cmd, nm.spinner.Tick)
+	}
+	return nm, cmd
+}
+
+// dispatchMessage is the original Update body: a flat type-switch that routes
+// each tea.Msg to its handler. Split out from Update so the spinner-activation
+// hook can wrap the result without duplicating the dispatch table.
+func (m Model) dispatchMessage(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		return m.updateWindowSize(msg)
@@ -56,6 +84,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+// spinnerWanted reports whether anything currently visible to the user
+// requires the spinner frame to keep advancing. When this returns false,
+// updateTick drops the tick chain so the bubbletea event loop and View()
+// stop running at 10 Hz on idle. Update re-kicks the chain when this flips
+// back to true.
+//
+// Conditions mirror every site in view.go / view_right.go that calls
+// m.spinner.View(): the main loading flag, the right-pane preview load, any
+// non-silent scheduler task in the title-bar indicator, and any in-flight
+// API-resource discovery for a context.
+func (m Model) spinnerWanted() bool {
+	if m.loading || m.previewLoading {
+		return true
+	}
+	if m.scheduler != nil && m.scheduler.LenIndicator() > 0 {
+		return true
+	}
+	for _, v := range m.discoveringContexts {
+		if v {
+			return true
+		}
+	}
+	return false
 }
 
 // updateResourceMsg handles resource-loading and navigation-related messages.
@@ -451,6 +504,13 @@ func (m Model) updateWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateTick(msg spinner.TickMsg) (tea.Model, tea.Cmd) {
+	if !m.spinnerWanted() {
+		// Nothing on screen needs the spinner — let the tick chain die.
+		// Update will kick it back when m.loading / scheduler tasks /
+		// discovery flip the wanted check the next time a message comes
+		// through.
+		return m, nil
+	}
 	var cmd tea.Cmd
 	m.spinner, cmd = m.spinner.Update(msg)
 	return m, cmd

--- a/internal/app/update_spinner_gate_test.go
+++ b/internal/app/update_spinner_gate_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
 
 // TestSpinnerWantedConditions documents every state that pulls the spinner
@@ -78,5 +81,25 @@ func TestUpdateKicksSpinnerOnWantedTransition(t *testing.T) {
 		// returns (m, nil), wanted stays true, no transition → no kick.
 		_, cmd := m.Update(previewDebounceTickMsg{gen: m.previewDebounceGen + 99})
 		assert.Nil(t, cmd, "stale tick with no wanted transition must not attach a spinner kick")
+	})
+
+	t.Run("false→true transition attaches kick", func(t *testing.T) {
+		m := basePush80Model()
+		m.middleItems = []model.Item{
+			{Name: "pod-1", Namespace: "default", Kind: "Pod"},
+			{Name: "pod-2", Namespace: "default", Kind: "Pod"},
+		}
+		m.setCursor(0)
+		// Pre-state: idle, spinner is not wanted.
+		require := assert.New(t)
+		require.False(m.spinnerWanted(), "test setup precondition: spinner must start unwanted")
+
+		// Press 'down' — moveCursor flips m.loading / m.previewLoading
+		// to true via invalidatePreviewForCursorChange, so the wrapper
+		// should detect the false→true transition and attach a kick.
+		newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		nm := newModel.(Model)
+		require.True(nm.spinnerWanted(), "down arrow must transition spinner-wanted to true")
+		require.NotNil(cmd, "false→true transition must attach a spinner kick command")
 	})
 }

--- a/internal/app/update_spinner_gate_test.go
+++ b/internal/app/update_spinner_gate_test.go
@@ -1,0 +1,82 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSpinnerWantedConditions documents every state that pulls the spinner
+// onto the screen. Keep this in sync with view.go / view_right.go: if a new
+// site calls m.spinner.View() under a flag we don't check here, the spinner
+// will appear frozen in that state because updateTick lets the tick chain
+// die when spinnerWanted returns false (issue #206).
+func TestSpinnerWantedConditions(t *testing.T) {
+	t.Run("idle returns false", func(t *testing.T) {
+		m := basePush80Model()
+		assert.False(t, m.spinnerWanted(), "fresh model with no loading should not need the spinner")
+	})
+
+	t.Run("loading flag triggers true", func(t *testing.T) {
+		m := basePush80Model()
+		m.loading = true
+		assert.True(t, m.spinnerWanted())
+	})
+
+	t.Run("previewLoading triggers true", func(t *testing.T) {
+		m := basePush80Model()
+		m.previewLoading = true
+		assert.True(t, m.spinnerWanted())
+	})
+
+	// Scheduler LenIndicator only counts tasks that have been picked up by
+	// a worker, not queued submissions. Exercising that path requires a
+	// running pool which the existing scheduler / title-bar tests already
+	// cover; replicating it here would just duplicate setup.
+
+	t.Run("discovering context triggers true", func(t *testing.T) {
+		m := basePush80Model()
+		if m.discoveringContexts == nil {
+			m.discoveringContexts = make(map[string]bool)
+		}
+		m.discoveringContexts["test-ctx"] = true
+		assert.True(t, m.spinnerWanted())
+	})
+}
+
+// TestUpdateTickGatesOnSpinnerWanted is the core of the fix: when nothing
+// wants the spinner, the tick handler must drop the chain (return nil) so
+// the bubbletea event loop goes quiet. When something does want it, the
+// handler keeps the chain alive by returning a non-nil command (the next
+// tick).
+func TestUpdateTickGatesOnSpinnerWanted(t *testing.T) {
+	t.Run("idle drops the tick chain", func(t *testing.T) {
+		m := basePush80Model()
+		_, cmd := m.updateTick(spinner.TickMsg{})
+		assert.Nil(t, cmd, "idle tick must not reschedule")
+	})
+
+	t.Run("loading keeps the tick chain alive", func(t *testing.T) {
+		m := basePush80Model()
+		m.loading = true
+		_, cmd := m.updateTick(spinner.TickMsg{})
+		assert.NotNil(t, cmd, "loading must keep the spinner ticking")
+	})
+}
+
+// TestUpdateKicksSpinnerOnWantedTransition verifies the wrapper in Update:
+// when a dispatched message flips the model from "spinner not wanted" to
+// "spinner wanted", the wrapper attaches a kick command so the chain
+// actually starts. Stale or no-op messages where the wanted state is
+// unchanged must not attach a kick, even if loading is currently true.
+func TestUpdateKicksSpinnerOnWantedTransition(t *testing.T) {
+	t.Run("no transition, no kick", func(t *testing.T) {
+		m := basePush80Model()
+		m.loading = true
+		// previewDebounceTickMsg with a stale gen is a no-op: dispatch
+		// returns (m, nil), wanted stays true, no transition → no kick.
+		_, cmd := m.Update(previewDebounceTickMsg{gen: m.previewDebounceGen + 99})
+		assert.Nil(t, cmd, "stale tick with no wanted transition must not attach a spinner kick")
+	})
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof/* under DefaultServeMux when LFK_PPROF_ADDR is set
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -122,6 +124,21 @@ func runTUI(opts app.StartupOptions) error {
 		"secret_lazy_loading", ui.ConfigSecretLazyLoading,
 		"config_path", opts.Config,
 	)
+
+	// Optional pprof endpoint for debugging hot CPU paths (issue #206).
+	// Off by default; set LFK_PPROF_ADDR=localhost:6060 to enable. Bind
+	// only to loopback to avoid exposing process internals on the network.
+	// Capture an idle profile with:
+	//   go tool pprof -seconds=30 http://localhost:6060/debug/pprof/profile
+	if addr := os.Getenv("LFK_PPROF_ADDR"); addr != "" {
+		go func() {
+			logger.Info("starting pprof", "addr", addr)
+			srv := &http.Server{Addr: addr} //nolint:gosec // debug-only, loopback-bound by convention
+			if err := srv.ListenAndServe(); err != nil {
+				logger.Warn("pprof server stopped", "error", err)
+			}
+		}()
+	}
 
 	// Redirect os.Stderr to capture output from exec credential plugins (e.g., AWS SSO
 	// errors from `aws eks get-token`). Without this, subprocess stderr output goes

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	_ "net/http/pprof" // registers /debug/pprof/* under DefaultServeMux when LFK_PPROF_ADDR is set
 	"os"
@@ -126,14 +127,19 @@ func runTUI(opts app.StartupOptions) error {
 	)
 
 	// Optional pprof endpoint for debugging hot CPU paths (issue #206).
-	// Off by default; set LFK_PPROF_ADDR=localhost:6060 to enable. Bind
-	// only to loopback to avoid exposing process internals on the network.
+	// Off by default; set LFK_PPROF_ADDR=127.0.0.1:6060 to enable. The
+	// address MUST resolve to a loopback host — anything else exposes
+	// process internals (heap, goroutines, credentials in symbols) on
+	// the network and we refuse to start.
 	// Capture an idle profile with:
-	//   go tool pprof -seconds=30 http://localhost:6060/debug/pprof/profile
+	//   go tool pprof -seconds=30 http://127.0.0.1:6060/debug/pprof/profile
 	if addr := os.Getenv("LFK_PPROF_ADDR"); addr != "" {
+		if err := validatePprofAddr(addr); err != nil {
+			return fmt.Errorf("LFK_PPROF_ADDR: %w", err)
+		}
 		go func() {
 			logger.Info("starting pprof", "addr", addr)
-			srv := &http.Server{Addr: addr} //nolint:gosec // debug-only, loopback-bound by convention
+			srv := &http.Server{Addr: addr} //nolint:gosec // validated loopback-only above
 			if err := srv.ListenAndServe(); err != nil {
 				logger.Warn("pprof server stopped", "error", err)
 			}
@@ -168,5 +174,33 @@ func runTUI(opts app.StartupOptions) error {
 		return fmt.Errorf("running application: %w", err)
 	}
 
+	return nil
+}
+
+// validatePprofAddr ensures LFK_PPROF_ADDR points at a loopback host so
+// the debug pprof endpoint never gets exposed on the network. Accepts
+// `localhost`, `127.0.0.1`, `::1`, and any other IP whose IsLoopback
+// reports true. Rejects bind-all forms like `:6060`, `0.0.0.0:...`,
+// and `[::]:...` because pprof leaks process internals (heap profile,
+// goroutine stacks, env strings in binaries) and must not be reachable
+// off-box.
+func validatePprofAddr(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid host:port %q: %w", addr, err)
+	}
+	if host == "" {
+		return fmt.Errorf("must specify an explicit loopback host (got %q — bind-all form is refused)", addr)
+	}
+	if host == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("host %q is not an IP or 'localhost'", host)
+	}
+	if !ip.IsLoopback() {
+		return fmt.Errorf("host %q is not a loopback address", host)
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Idle CPU on lfk was sitting at 145%+ on the reporter's Win11 box (10% of 20 cores). Reproduced locally on macOS at the same magnitude. Traced to two independent issues, with one dominant cause.

**Root cause** — `scheduler/workerLoop` re-signaled `q.wake` unconditionally when `pickTask` returned false, so leftover wake signals from the inner drain loop fed back into the same goroutine in a tight cycle (~2.26M goroutine block/unblock events per second per the runtime trace). CPU profile pinned 100% of the budget on `pthread_cond_signal` / `pthread_cond_wait` / `usleep` with nothing on the application side — pure scheduler thrash.

**Secondary** — the bubbletea spinner ticked at 10 Hz forever, driving full `View()` re-renders even when nothing was loading. Modest contributor on its own (~10 percentage points) but the right shape regardless.

## Measurements

Local Mac, real cluster, session restored, 4 worker / 1 critical-reserved scheduler:

| State | Pre-fix | After spinner gate only | After both fixes |
|---|---|---|---|
| Watch OFF | 145% | 145% | **0.0%** |
| Watch ON  | 200%+ | ~150% | 30-50% (real K8s list work) |

## Changes

- `fix(app)` — `spinnerWanted()` gates the spinner tick chain on `m.loading`, `m.previewLoading`, `scheduler.LenIndicator()`, and any in-flight context discovery. `updateTick` lets the chain die when nothing wants the spinner; `Update` re-kicks it on the wasWanted-false → isWanted-true edge. Init no longer starts the chain unconditionally.
- `fix(scheduler)` — `workerLoop` now only re-signals `q.wake` if `q.hasPendingWork()` returns true. Stale wakes left over from a drain die instead of feeding the same worker forever.
- `chore(debug)` — opt-in pprof endpoint behind `LFK_PPROF_ADDR` so future hot-path investigations don't need a custom build. Off by default; loopback-bound by convention.

Plus regression tests:
- `update_spinner_gate_test.go` — covers `spinnerWanted` conditions, `updateTick` idle/loading paths, and the no-transition-no-kick rule.
- `scheduler_busy_loop_test.go` — injects a stale wake, then asserts < 50 ms of CPU consumed in a 300 ms idle window via `syscall.Getrusage`. Confirmed to fail on the pre-fix code (430 ms of CPU in the window) and pass after the fix.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] Manual: idle-CPU sample on macOS with watch off → 0%; watch on → 30-50%
- [x] Regression test fails on reverted scheduler logic, passes with the fix
- [ ] Reporter (@artisticcheese) to confirm Win11 idle CPU drop

Fixes #206
