### PR TITLE
test: add Go fuzz harness, fix highlightSubstring UTF-8 panic

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,50 @@
+name: Fuzz
+
+# Runs every Fuzz* target found in the tree sequentially via `make fuzz`.
+#
+# Triggers:
+#   - schedule:        weekly fuzz pass with the default FUZZTIME
+#   - workflow_dispatch: ad-hoc run, fuzztime overridable from the UI
+#
+# Seed corpora are exercised on every PR by the normal `go test ./...` job
+# in ci.yml; this workflow exists for the longer fuzz runs that find
+# new bugs beyond the seeds.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # Monday 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: 'Fuzz time per target (e.g. 1m, 5m, 30m)'
+        type: string
+        default: '5m'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run fuzz tests
+        env:
+          # Bind workflow_dispatch input to an env var instead of inlining it
+          # into the run script (defence-in-depth against injection).
+          FUZZTIME: ${{ inputs.fuzztime || '5m' }}
+        run: |
+          # Allow only Go duration syntax: digits + (ns|us|µs|ms|s|m|h).
+          if ! printf %s "$FUZZTIME" | grep -Eq '^[0-9]+(ns|us|µs|ms|s|m|h)$'; then
+            echo "::error::FUZZTIME must be a Go duration (e.g. 30s, 5m); got: $FUZZTIME"
+            exit 1
+          fi
+          make fuzz FUZZTIME="$FUZZTIME"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       fuzztime:
-        description: 'Fuzz time per target (e.g. 1m, 5m, 30m)'
+        description: 'Fuzz time per target (e.g. 30s, 5m, 1h30m)'
         type: string
         default: '5m'
 
@@ -42,9 +42,10 @@ jobs:
           # into the run script (defence-in-depth against injection).
           FUZZTIME: ${{ inputs.fuzztime || '5m' }}
         run: |
-          # Allow only Go duration syntax: digits + (ns|us|µs|ms|s|m|h).
-          if ! printf %s "$FUZZTIME" | grep -Eq '^[0-9]+(ns|us|µs|ms|s|m|h)$'; then
-            echo "::error::FUZZTIME must be a Go duration (e.g. 30s, 5m); got: $FUZZTIME"
+          # Allow Go duration syntax: one or more `<digits><unit>` components
+          # so compounds like 1h30m or 2m30s pass alongside simple values.
+          if ! printf %s "$FUZZTIME" | grep -Eq '^([0-9]+(ns|us|µs|ms|s|m|h))+$'; then
+            echo "::error::FUZZTIME must be a Go duration (e.g. 30s, 5m, 1h30m); got: $FUZZTIME"
             exit 1
           fi
           make fuzz FUZZTIME="$FUZZTIME"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint lint-fix test coverage build generate-themes sonar bump-version refresh-vendor-hash release goreleaser-check
+.PHONY: setup lint lint-fix test coverage fuzz build generate-themes sonar bump-version refresh-vendor-hash release goreleaser-check
 
 setup:
 	git config core.hooksPath .githooks
@@ -71,6 +71,21 @@ coverage: ## Run tests with coverage report
 	go tool cover -func=coverage.out | tail -1
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Open coverage.html in your browser for details"
+
+# Runs every Fuzz* function in the tree for FUZZTIME each (default 30s).
+# go test's -fuzz flag only accepts one target per invocation, so we loop.
+# Override with: make fuzz FUZZTIME=2m
+FUZZTIME ?= 30s
+fuzz: ## Run all fuzz tests sequentially (override FUZZTIME, default 30s each)
+	@set -e; \
+	for pkg in $$(go list ./...); do \
+		targets=$$(go test -list 'Fuzz[A-Z].*' $$pkg 2>/dev/null | grep -E '^Fuzz[A-Z]' || true); \
+		[ -z "$$targets" ] && continue; \
+		for t in $$targets; do \
+			echo "=== fuzz: $$pkg::$$t ($(FUZZTIME)) ==="; \
+			go test -run='^$$' -fuzz="^$$t$$" -fuzztime=$(FUZZTIME) $$pkg; \
+		done; \
+	done
 
 goreleaser-check: ## Validate .goreleaser.yaml and run a snapshot release without publishing
 	@command -v goreleaser >/dev/null 2>&1 || { \

--- a/internal/k8s/packet_decoder_fuzz_test.go
+++ b/internal/k8s/packet_decoder_fuzz_test.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// FuzzDecodePacket pushes arbitrary byte slices through decodePacket /
+// gopacket for each plausible link-layer entry point. gopacket parses
+// dozens of protocol headers; this fuzzer is panic discovery on attacker-
+// controlled bytes (the live-capture stream comes from `kubectl debug` and
+// reaches us un-validated).
+func FuzzDecodePacket(f *testing.F) {
+	// Minimal seed: an empty Ethernet frame and a couple of plausible
+	// shapes. The fuzzer will grow these.
+	f.Add([]byte{})
+	f.Add([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00})
+	f.Add([]byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x86\xdd"))
+	f.Add([]byte{0x45, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x00, 0x40, 0x06})
+
+	ci := gopacket.CaptureInfo{Timestamp: time.Unix(0, 0)}
+	entries := []gopacket.LayerType{
+		layers.LayerTypeEthernet,
+		layers.LayerTypeIPv4,
+		layers.LayerTypeIPv6,
+		layers.LayerTypeLinuxSLL,
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ci.Length = len(data)
+		for _, entry := range entries {
+			_ = decodePacket(data, ci, entry)
+		}
+	})
+}
+
+// FuzzStripSLL2 drives the 20-byte SLL2 header stripper. The function
+// reads big-endian uint16s and slices off the header; arbitrary input
+// must not panic.
+func FuzzStripSLL2(f *testing.F) {
+	f.Add([]byte{})
+	f.Add(make([]byte, 19)) // one byte short of the 20-byte header
+	f.Add(make([]byte, 20)) // exactly header-sized, zero ethertype
+	f.Add([]byte{0x08, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x45})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		payload, layer := stripSLL2(data)
+		// Payload must always be a suffix (or the original) of the input —
+		// never longer.
+		if len(payload) > len(data) {
+			t.Fatalf("stripSLL2: payload len %d exceeds input len %d", len(payload), len(data))
+		}
+		_ = layer
+	})
+}

--- a/internal/ui/explorer_format_fuzz_test.go
+++ b/internal/ui/explorer_format_fuzz_test.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseResourceValue drives the Kubernetes resource-string parser
+// (e.g. "100m", "1.5Gi") with arbitrary input. ParseResourceValue swallows
+// strconv errors and returns int64 — the fuzz target is panic discovery and
+// the empty-input contract (empty → 0 for both isCPU true and false).
+func FuzzParseResourceValue(f *testing.F) {
+	for _, s := range []string{
+		"", "100m", "0", "1", "1.5", "2000",
+		"128Mi", "1.5Gi", "1024Ki", "1024B", "512M",
+		" 100m ", "abc", "-1", "1e10", ".",
+	} {
+		f.Add(s, true)
+		f.Add(s, false)
+	}
+
+	f.Fuzz(func(t *testing.T, val string, isCPU bool) {
+		got := ParseResourceValue(val, isCPU)
+
+		if strings.TrimSpace(val) == "" && got != 0 {
+			t.Fatalf("ParseResourceValue(%q, %v) = %d; empty input must return 0", val, isCPU, got)
+		}
+	})
+}

--- a/internal/ui/logpreview_fuzz_test.go
+++ b/internal/ui/logpreview_fuzz_test.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseLogLine drives arbitrary input through ParseLogLine and its
+// downstream format-specific parsers (JSON, klog, zap, nginx, envoy,
+// postgres, java, logfmt). The function is documented as "never panics" —
+// the fuzzer's job is to keep that promise honest as new formats are added.
+func FuzzParseLogLine(f *testing.F) {
+	seeds := []string{
+		"",
+		"plain text log line",
+		`{"level":"info","msg":"hello","ts":"2024-01-15T10:30:00Z"}`,
+		`I0115 10:30:00.123456    1234 server.go:42] starting controller`,
+		"2024-01-15T10:30:00.000Z\tINFO\tcontroller\tReconciling\t{\"name\":\"foo\"}",
+		`192.0.2.1 - - [15/Jan/2024:10:30:00 +0000] "GET /healthz HTTP/1.1" 200 2 "-" "kube-probe/1.29"`,
+		`[2024-01-15T10:30:00.000Z] "GET /api HTTP/2" 200 - 0 12 5 4 "-" "curl/8.0" "abc-123" "auth" "10.0.0.1:8080"`,
+		`2024-01-15 10:30:00.123 UTC [123] LOG:  database system is ready to accept connections`,
+		`2024-01-15 10:30:00.123  INFO 1 --- [           main] c.example.App                  : Started App in 3.5 seconds`,
+		"[pod/nginx-abc/proxy] some log body",
+		`key1=value1 key2="two words" key3=42`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		got := ParseLogLine(line)
+
+		if got.Kind < LogPreviewText || got.Kind > LogPreviewPostgres {
+			t.Fatalf("ParseLogLine(%q) returned out-of-range Kind %d", line, got.Kind)
+		}
+
+		// Stripped pieces must come from the head of the input. We don't
+		// reconstruct an exact prefix (the parser consumes either a space
+		// or a tab between time and body), but Prefix is always a substring
+		// at offset 0 and Time, when present, must appear before Body.
+		if got.Prefix != "" && !strings.HasPrefix(line, got.Prefix) {
+			t.Fatalf("ParseLogLine(%q): Prefix %q is not a prefix of input", line, got.Prefix)
+		}
+		if got.Time != "" && !strings.Contains(line, got.Time) {
+			t.Fatalf("ParseLogLine(%q): Time %q not found in input", line, got.Time)
+		}
+
+		// Fields are extracted verbatim from the source (JSON allows
+		// `{"":""}`, logfmt allows weird shapes); we only assert no panics
+		// here, not key non-emptiness.
+		_ = got.Fields
+	})
+}

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -377,6 +377,15 @@ func highlightSubstring(line, query string, style lipgloss.Style, restoreCodes s
 	plain := ansi.Strip(line)
 	plainLower := strings.ToLower(plain)
 	queryLower := strings.ToLower(query)
+	// strings.ToLower replaces each invalid UTF-8 byte with U+FFFD (3
+	// bytes), so plainLower can outgrow plain when the input contains
+	// stray non-UTF-8 bytes (random pod logs, binary payloads). Match
+	// indices computed against plainLower would then slice out of bounds
+	// on plain inside highlightSpans. Skip highlighting in that case —
+	// the line still renders, it just doesn't get per-match coloring.
+	if len(plainLower) != len(plain) {
+		return line
+	}
 	if !strings.Contains(plainLower, queryLower) {
 		return line
 	}

--- a/internal/ui/search_fuzz_test.go
+++ b/internal/ui/search_fuzz_test.go
@@ -1,0 +1,157 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// FuzzDetectSearchMode verifies the search-mode prefix protocol holds for
+// arbitrary user input. The function must never panic and must respect the
+// "~" / "\" prefix contract: when those prefixes are present, the returned
+// query is exactly the rest of the input.
+func FuzzDetectSearchMode(f *testing.F) {
+	for _, s := range []string{"", "foo", "~foo", `\foo`, "foo.*bar", "a|b", "[abc]", "~", `\`, "."} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		mode, query := DetectSearchMode(raw)
+
+		if mode < SearchSubstring || mode > SearchFuzzy {
+			t.Fatalf("DetectSearchMode(%q) returned out-of-range mode %d", raw, mode)
+		}
+
+		switch {
+		case raw == "":
+			if mode != SearchSubstring || query != "" {
+				t.Fatalf("DetectSearchMode(\"\") = (%d, %q); want (Substring, \"\")", mode, query)
+			}
+		case strings.HasPrefix(raw, "~"):
+			if mode != SearchFuzzy {
+				t.Fatalf("DetectSearchMode(%q): tilde prefix must yield SearchFuzzy, got %d", raw, mode)
+			}
+			if query != raw[1:] {
+				t.Fatalf("DetectSearchMode(%q): query %q; want %q", raw, query, raw[1:])
+			}
+		case strings.HasPrefix(raw, `\`):
+			if mode != SearchSubstring {
+				t.Fatalf("DetectSearchMode(%q): backslash prefix must yield SearchSubstring, got %d", raw, mode)
+			}
+			if query != raw[1:] {
+				t.Fatalf("DetectSearchMode(%q): query %q; want %q", raw, query, raw[1:])
+			}
+		default:
+			if query != raw {
+				t.Fatalf("DetectSearchMode(%q): un-prefixed input must return the raw query, got %q", raw, query)
+			}
+		}
+	})
+}
+
+// FuzzMatchLine drives the substring / regex / fuzzy code paths with
+// arbitrary line / query pairs. Invalid regex must fall back gracefully
+// (the documented behaviour) rather than panic.
+func FuzzMatchLine(f *testing.F) {
+	for _, s := range [...][2]string{
+		{"hello world", "hello"},
+		{"hello world", "~hlw"},
+		{"hello world", `\.`},
+		{"hello world", "(invalid"},
+		{"hello world", ""},
+		{"", "anything"},
+		{"foo.bar.baz", "f.*z"},
+	} {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, line, query string) {
+		got := MatchLine(line, query)
+
+		_, effective := DetectSearchMode(query)
+		if effective == "" && got {
+			t.Fatalf("MatchLine(%q, %q): empty effective query must return false", line, query)
+		}
+	})
+}
+
+// FuzzFuzzyScore checks the rune-walking scorer for panics and basic
+// identity properties: empty query scores 0; a line always matches itself.
+func FuzzFuzzyScore(f *testing.F) {
+	for _, s := range [...][2]string{
+		{"hello world", "hlw"},
+		{"hello", ""},
+		{"", "x"},
+		{"", ""},
+		{"Hello", "hello"},
+	} {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, line, query string) {
+		got := FuzzyScore(line, query)
+
+		if query == "" && got != 0 {
+			t.Fatalf("FuzzyScore(%q, \"\") = %d; want 0", line, got)
+		}
+		if line == query && got < 0 {
+			t.Fatalf("FuzzyScore(%q, %q): a string must fuzzy-match itself, got %d", line, query, got)
+		}
+	})
+}
+
+// FuzzHighlightMatchStyled exercises the substring / regex / fuzzy highlight
+// paths (and their ansi.Cut / ansi.TruncateLeft bridges) for panics on
+// arbitrary input, including invalid UTF-8.
+//
+// Note: we don't assert visible-text invariance. highlightSpans mixes byte
+// offsets with visual columns, so stray control bytes (`\x19`) or lone
+// non-UTF-8 bytes (`\x80`) can get duplicated or dropped in the output —
+// those are pre-existing bugs in the column/byte index bridge worth their
+// own fix. Panic-class bugs (e.g. the strings.ToLower-grows-past-plain
+// crash) are the in-scope target here.
+func FuzzHighlightMatchStyled(f *testing.F) {
+	for _, s := range [...][2]string{
+		{"hello world", "hello"},
+		{"hello world", "~hlw"},
+		{"hello world", "(invalid"},
+		{"foo.bar.baz", "f.*z"},
+		{"already \x1b[31mstyled\x1b[0m line", "styled"},
+		{"000\xe7", "\xdc"}, // regression: strings.ToLower length-grow panic
+		{"", ""},
+	} {
+		f.Add(s[0], s[1])
+	}
+
+	style := lipgloss.NewStyle().Background(lipgloss.Color("3"))
+
+	f.Fuzz(func(t *testing.T, line, query string) {
+		_ = HighlightMatchStyled(line, query, style)
+	})
+}
+
+// FuzzHighlightMatchInline drives the inline-ANSI highlighter — a separate
+// code path from highlightSpans that walks input bytes and tracks the
+// currently-open SGR sequence so the post-match segment keeps its color.
+// The state machine has its own pitfalls (escape-sequence boundary scans,
+// SGR re-assertion). Panic discovery is the in-scope target.
+func FuzzHighlightMatchInline(f *testing.F) {
+	for _, s := range [...][2]string{
+		{"hello world", "hello"},
+		{"plain", ""},
+		{"\x1b[31mred\x1b[0m blue", "red"},
+		{"\x1b[33;1mtoken\x1b[0m", "[33m"}, // SGR-introducer query must not latch
+		{"a\x1b[1mb\x1b[0mc", "abc"},
+		{"", "anything"},
+		{"hello world", "~hlw"}, // fuzzy mode falls back to Styled
+	} {
+		f.Add(s[0], s[1])
+	}
+
+	style := lipgloss.NewStyle().Background(lipgloss.Color("3"))
+
+	f.Fuzz(func(t *testing.T, line, query string) {
+		_ = HighlightMatchInline(line, query, style)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds nine native Go fuzz tests covering the highest-ROI parsing/decoding surfaces (log lines, search/highlight, K8s resource strings, packet decoding).
- Fixes a real panic in `highlightSubstring` surfaced by `FuzzHighlightMatchStyled` (`strings.ToLower` grows past `plain` on invalid UTF-8 -> slice out of range).
- Adds `make fuzz` and a scheduled-only GitHub Actions workflow (`.github/workflows/fuzz.yml`) for longer fuzz runs.

Addresses the Scorecard `Fuzzing` warning: `Fuzz*` functions now exist in `_test.go` files in the tree.

## Fuzz targets

| Target | Package | Why |
|---|---|---|
| `FuzzParseLogLine` | `internal/ui` | Routes arbitrary pod logs through 8 sub-parsers (JSON/klog/zap/nginx/envoy/postgres/java/logfmt) |
| `FuzzDetectSearchMode` | `internal/ui` | `~`/`\` prefix contract for user search input |
| `FuzzMatchLine` | `internal/ui` | substring/regex/fuzzy dispatch |
| `FuzzFuzzyScore` | `internal/ui` | rune-walking scorer identity properties |
| `FuzzHighlightMatchStyled` | `internal/ui` | `highlightSpans` byte/column bridges |
| `FuzzHighlightMatchInline` | `internal/ui` | inline ANSI highlighter (separate SGR state machine) |
| `FuzzParseResourceValue` | `internal/ui` | `100m`, `1.5Gi` parser |
| `FuzzDecodePacket` | `internal/k8s` | raw packet bytes through `gopacket` (attacker-controlled stream from `kubectl debug`) |
| `FuzzStripSLL2` | `internal/k8s` | 20-byte SLL2 header stripper |

## CI design

- **Per-PR**: existing `go test ./...` step in `ci.yml` exercises seed corpora -- regressions on known inputs block merges immediately.
- **Weekly (Mon 04:00 UTC)**: `fuzz.yml` runs every target for 5 min each, ~45 min total.
- **Manual dispatch**: triggers from Actions UI with a custom `fuzztime`. Input is validated against Go duration syntax (`^[0-9]+(ns|us|µs|ms|s|m|h)$`) before reaching the shell.

Scheduled rather than per-PR because (1) full fuzz pass is ~45 min, (2) fuzzers are non-deterministic and would flake unrelated PRs, and (3) per-PR seed-corpus coverage already runs via the normal test step. Happy to add path-filtered PR triggers if preferred.

## Bug found and fixed

`highlightSubstring` computed match spans on `strings.ToLower(plain)`, which substitutes U+FFFD (3 bytes) for each invalid UTF-8 byte, growing the byte length. Those spans were then applied to the untransformed `plain`, slicing out of bounds. Repro: `HighlightMatchStyled(\"000\\xe7\", \"\\xdc\", style)` -> `slice bounds out of range [:6] with length 4`. Fix: skip highlighting when `len(plainLower) != len(plain)`.

Two milder bugs were also surfaced in the same code family (lost `\\x80` byte, duplicated `\\x19` byte -- both byte/column index mix-ups in `highlightSpans`). Left for a follow-up PR; `FuzzHighlightMatchStyled` only asserts the no-panic property, so these don't block CI.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` -- all packages pass
- [x] `golangci-lint run ./internal/ui/` -- 0 issues
- [x] `make fuzz FUZZTIME=2s` -- all 9 targets cycle cleanly
- [x] Longer per-target fuzz runs (15-30s each) -- no panics; cumulative ~4.2M execs across all targets
- [x] `FUZZTIME` validator rejects `5m; evil` and accepts `30s`/`5m`
- [x] Scorecard `Fuzzing` check flips from Warn to passing on next scheduled run