### PR TITLE
fix(app): refresh right-pane preview at LevelResourceTypes on tab switch and watch tick

### DIFF
--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -99,8 +99,9 @@ func (m Model) loadResourceTypesFor(kctx string) tea.Cmd {
 		items = model.BuildSidebarItems(model.SeedResources())
 		seeded = true
 	}
+	silent := m.suppressBgtasks
 	return func() tea.Msg {
-		return resourceTypesMsg{items: items, seeded: seeded}
+		return resourceTypesMsg{items: items, seeded: seeded, silent: silent}
 	}
 }
 

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -31,6 +31,13 @@ type resourceTypesMsg struct {
 	// preview at LevelClusters still displays seeded items so the user
 	// sees *something* while hovering a context.
 	seeded bool
+	// silent mirrors resourcesLoadedMsg.silent: captured from
+	// suppressBgtasks at construction time so updateResourceTypes can
+	// propagate it into the loadPreview cascade. Without this, the watch
+	// tick at LevelResourceTypes would flash the title-bar indicator on
+	// every refresh once the preview cache shortcut is bypassed for
+	// cluster-side mutations to surface.
+	silent bool
 }
 
 type resourcesLoadedMsg struct {

--- a/internal/app/tab_switch_refresh_test.go
+++ b/internal/app/tab_switch_refresh_test.go
@@ -111,6 +111,71 @@ func TestPostTabSwitch_RefreshesAtLevelContainers(t *testing.T) {
 		"postTabSwitchCmd at LevelContainers must fire a non-preview containers-refresh fetch")
 }
 
+// TestPostTabSwitch_RefreshesPreviewAtLevelResourceTypes covers the
+// LevelResourceTypes variant: at this level the right-pane preview is a
+// list of actual resources (e.g. pods) for the hovered resource type.
+// loadResources(forPreview=true) has a cache shortcut that returns
+// cached items synchronously when itemCache + cacheFingerprints match.
+// itemCache is per-tab, so mutations on a sibling tab (delete a pod)
+// don't propagate, and loadPreview after a tab switch serves stale
+// items. The user-visible symptom: switching back to a tab that's on
+// "Pods" shows the deleted pod until the user drills in, because
+// neither tab switch nor cursor-move-and-back refresh the preview.
+//
+// Fix is to drop the cache-freshness fingerprint for the hovered
+// resource type before loadPreview runs, so the shortcut misses and a
+// real K8s fetch happens. The itemCache entry itself is preserved so
+// other code paths (e.g. instant-paint on navigate-back) still hit.
+func TestPostTabSwitch_RefreshesPreviewAtLevelResourceTypes(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs)
+
+	m := newTabSwitchTestModel(t, model.LevelResourceTypes)
+	m.client = k8s.NewTestClient(clientfake.NewClientset(), dyn)
+
+	podsRT := model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1", Namespaced: true}
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{podsRT}
+	m.middleItems = []model.Item{
+		{Name: "Pods", Kind: "Pod", Extra: podsRT.ResourceRef()},
+	}
+	m.setCursor(0)
+
+	// Pre-populate the per-tab cache to mimic the state left behind on
+	// this tab after the user hovered Pods, then switched away. The
+	// fingerprint matches the current model so loadResources' shortcut
+	// would normally fire.
+	cacheKey := "test-ctx/pods"
+	m.itemCache[cacheKey] = []model.Item{{Name: "stale-pod"}}
+	m.cacheFingerprints[cacheKey] = m.fetchFingerprint()
+
+	cmd := m.postTabSwitchCmd()
+	if cmd == nil {
+		t.Fatal("postTabSwitchCmd returned nil at LevelResourceTypes/modeExplorer")
+	}
+
+	// Behavior assertion: the resulting batch must not produce a
+	// preview resourcesLoadedMsg containing the stale items. The fake
+	// client has no pods, so a real fetch yields an empty list; only
+	// the cache shortcut would yield "stale-pod".
+	sawStaleReturn := false
+	for _, c := range flattenBatch(cmd) {
+		if loaded, ok := c().(resourcesLoadedMsg); ok && loaded.forPreview {
+			for _, item := range loaded.items {
+				if item.Name == "stale-pod" {
+					sawStaleReturn = true
+				}
+			}
+		}
+	}
+	assert.False(t, sawStaleReturn,
+		"postTabSwitchCmd at LevelResourceTypes must not serve cached stale preview items — mutations on a sibling tab leave the per-tab cache out of date; loadPreview must re-fetch")
+}
+
 // TestPostTabSwitch_DoesNotRefreshAtLevelClusters keeps the cluster picker
 // view passive on tab switch — the cluster list itself doesn't go stale
 // within a session and discovery is heavy.

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -657,6 +657,15 @@ func (m Model) refreshCurrentLevel() tea.Cmd {
 			m.client.InvalidateDiscoveryCache(m.nav.Context)
 			cmds = append(cmds, m.discoverAPIResources(m.nav.Context))
 		}
+		// Drop the preview-cache fingerprint for the hovered resource type
+		// so updateResourceTypes' cascade through loadPreview misses the
+		// hover-cycle shortcut and fetches fresh data. Without this, a
+		// kubectl delete (or any external mutation) leaves the right-pane
+		// list stuck on the cached pre-mutation snapshot until the user
+		// tab-switches or drills in. The cascade carries the silent flag
+		// (set by loadResourceTypesFor from suppressBgtasks) so the watch
+		// tick doesn't flash the title-bar indicator on the resulting fetch.
+		m.invalidatePreviewFingerprintForCurrentSelection()
 		// Always emit the current cached list too so the UI repaints
 		// immediately while the fresh discovery runs in the background.
 		// updateAPIResourceDiscovery overwrites middleItems on completion.

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -127,11 +127,24 @@ func (m Model) handleTabSwitchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 // 10) leaves tab B's saved list stale until the next watch tick or
 // manual refresh.
 //
-// LevelClusters / LevelResourceTypes are intentionally excluded: contexts
-// and resource-type discovery don't go stale during a session, and
+// At LevelResourceTypes the middle column (the list of resource types
+// itself) doesn't go stale during a session, but the right-pane preview
+// is a live resource list for the hovered type — those items DO go stale
+// when another tab mutates the cluster. loadResources(forPreview=true)
+// has a fresh-cache shortcut for hover-cycles that returns cached items
+// synchronously; the per-tab itemCache means mutations on a sibling tab
+// never invalidate it. Drop the cache-freshness fingerprint for the
+// hovered resource type so the shortcut misses and a real fetch runs.
+// The itemCache entry itself is left in place so navigation-history
+// instant-paint still works.
+//
+// LevelClusters stays excluded: the context list doesn't go stale and
 // re-running discovery on every tab switch would be wasteful.
 func (m Model) postTabSwitchCmd() tea.Cmd {
 	if m.mode == modeExplorer {
+		if m.nav.Level == model.LevelResourceTypes {
+			m.invalidatePreviewFingerprintForCurrentSelection()
+		}
 		cmds := []tea.Cmd{m.loadPreview()}
 		switch m.nav.Level {
 		case model.LevelResources, model.LevelOwned, model.LevelContainers:

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -75,6 +75,28 @@ func (m *Model) invalidatePreviewForCursorChange() {
 	m.previewLoading = true
 }
 
+// invalidatePreviewFingerprintForCurrentSelection drops the cache-freshness
+// fingerprint for the resource type currently under the cursor at
+// LevelResourceTypes. loadResources(forPreview=true) keys its hover-cycle
+// cache shortcut on a (cache entry exists) AND (fingerprint matches)
+// check; clearing the fingerprint forces the next loadPreview through
+// the real fetch path. The cache entry itself is preserved so
+// navigation-history instant-paint still hits.
+//
+// No-op if the cursor is not on a discovered resource type (e.g. a
+// pseudo-resource like __overview__ or a collapsed group).
+func (m *Model) invalidatePreviewFingerprintForCurrentSelection() {
+	sel := m.selectedMiddleItem()
+	if sel == nil {
+		return
+	}
+	rt, ok := model.FindResourceTypeIn(sel.Extra, m.discoveredResources[m.nav.Context])
+	if !ok || rt.Resource == "" {
+		return
+	}
+	delete(m.cacheFingerprints, m.nav.Context+"/"+rt.Resource)
+}
+
 func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 	m.cancelAndReset()
 	m.requestGen++

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -87,7 +87,18 @@ func (m Model) updateResourceTypes(msg resourceTypesMsg) (tea.Model, tea.Cmd) {
 	m.setMiddleItems(msg.items)
 	m.itemCache[m.navKey()] = m.middleItems
 	m.clampCursor()
-	return m, m.loadPreview()
+	// Propagate the watch-tick silent flag into the preview cascade so a
+	// freshly-invalidated cache (refreshCurrentLevel at LevelResourceTypes
+	// drops the preview fingerprint to surface cluster-side mutations)
+	// doesn't flash the title-bar indicator every 2s. Matches the pattern
+	// in updateResourcesLoadedMain.
+	savedSuppress := m.suppressBgtasks
+	if msg.silent {
+		m.suppressBgtasks = true
+	}
+	cmd := m.loadPreview()
+	m.suppressBgtasks = savedSuppress
+	return m, cmd
 }
 
 func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) (Model, tea.Cmd) {

--- a/internal/app/watch_tick_e2e_test.go
+++ b/internal/app/watch_tick_e2e_test.go
@@ -115,6 +115,133 @@ func TestWatchTickRemovesDeletedPodFromList(t *testing.T) {
 		"fake API has no pods after delete; middleItems must be empty")
 }
 
+// TestWatchTickRefreshesPreviewAtLevelResourceTypes covers the extension
+// of the per-tab cache fix: the right-pane preview at LevelResourceTypes
+// must refresh on every watch tick, not just on tab switch. Without this,
+// any external cluster mutation (kubectl delete, an operator, another
+// process) leaves the hovered resource type's preview stuck on the old
+// snapshot until the user tab-switches or drills in.
+//
+// Setup: model at LevelResourceTypes hovering Pods; cache pre-populated
+// with a "stale-pod" snapshot + a matching fingerprint, so the
+// hover-cycle shortcut in loadResources(forPreview=true) would normally
+// serve the stale items synchronously. Fake K8s has a single "live-pod".
+// One watch tick must drive the cascade through resourceTypesMsg →
+// loadPreview → real fetch and land "live-pod" in rightItems.
+func TestWatchTickRefreshesPreviewAtLevelResourceTypes(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}:                     "PodList",
+		{Group: "", Version: "v1", Resource: "events"}:                   "EventList",
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}:  "PodMetricsList",
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}: "NodeMetricsList",
+	}
+	livePod := &unstructured.Unstructured{}
+	livePod.SetUnstructuredContent(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":              "live-pod",
+			"namespace":         "default",
+			"creationTimestamp": time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+		},
+		"status": map[string]any{"phase": "Running"},
+	})
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, livePod)
+
+	podsRT := model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1", Namespaced: true}
+	m := Model{
+		nav: model.NavigationState{
+			Level:   model.LevelResourceTypes,
+			Context: "test-ctx",
+		},
+		tabs:                []TabState{{}},
+		selectedItems:       make(map[string]bool),
+		cursorMemory:        make(map[string]int),
+		itemCache:           make(map[string][]model.Item),
+		cacheFingerprints:   make(map[string]string),
+		discoveredResources: map[string][]model.ResourceTypeEntry{"test-ctx": {podsRT}},
+		// Tell refreshCurrentLevel that CRD discovery is already in flight
+		// so it doesn't fire a second discoverAPIResources call — the fake
+		// dynamic client only knows about Pod/Event/Metrics GVRs (the test
+		// is focused on the preview fetch, not CRD discovery).
+		discoveringContexts: map[string]bool{"test-ctx": true},
+		execMu:              &sync.Mutex{},
+		namespace:           "default",
+		scheduler:           scheduler.New(0),
+		reqCtx:              context.Background(),
+		watchMode:           true,
+	}
+	// middleItems must mirror BuildSidebarItems' output so updateResourceTypes
+	// (which overwrites middleItems with that result) doesn't move our cursor
+	// onto a synthetic dashboard / group-header row. The cursor indexes into
+	// visibleMiddleItems (which injects group headers and may collapse
+	// groups), not middleItems directly.
+	m.middleItems = model.BuildSidebarItems([]model.ResourceTypeEntry{podsRT})
+	m.allGroupsExpanded = true // keep groups expanded so visibleMiddleItems contains Pods
+	visible := m.visibleMiddleItems()
+	cursorSet := false
+	for i, item := range visible {
+		if item.Extra == podsRT.ResourceRef() {
+			m.setCursor(i)
+			cursorSet = true
+			break
+		}
+	}
+	if !cursorSet {
+		t.Fatalf("test setup: Pods row not found in visibleMiddleItems; visible=%+v", visible)
+	}
+	m.client = k8s.NewTestClient(clientfake.NewClientset(), dyn)
+	m.scheduler.StartWorkers()
+	t.Cleanup(m.scheduler.StopWorkers)
+
+	// Mimic the state of a tab where the user previously hovered Pods
+	// and the per-tab cache locked in a since-stale snapshot.
+	cacheKey := "test-ctx/pods"
+	m.itemCache[cacheKey] = []model.Item{{Name: "stale-pod"}}
+	m.cacheFingerprints[cacheKey] = m.fetchFingerprint()
+	m.rightItems = []model.Item{{Name: "stale-pod"}}
+
+	// Run one watch tick through the full message pipeline. The cascade
+	// is resourceTypesMsg → updateResourceTypes → loadPreview → fetch →
+	// resourcesLoadedMsg{forPreview} → updateResourcesLoadedPreview, so
+	// the test drains both message kinds.
+	mAny, cmd := m.updateWatchTick(watchTickMsg{})
+	m = mAny.(Model)
+	for _, c := range flattenBatch(cmd) {
+		switch typed := c().(type) {
+		case resourceTypesMsg:
+			modelAny, follow := m.updateResourceTypes(typed)
+			m = modelAny.(Model)
+			for _, fc := range flattenBatch(follow) {
+				if loaded, ok := fc().(resourcesLoadedMsg); ok {
+					modelAny, _ = m.updateResourcesLoaded(loaded)
+					m = modelAny.(Model)
+				}
+			}
+		case resourcesLoadedMsg:
+			modelAny, _ := m.updateResourcesLoaded(typed)
+			m = modelAny.(Model)
+		}
+	}
+
+	for _, item := range m.rightItems {
+		assert.NotEqual(t, "stale-pod", item.Name,
+			"watch tick at LevelResourceTypes must replace cached stale preview items, not serve them")
+	}
+	sawLive := false
+	for _, item := range m.rightItems {
+		if item.Name == "live-pod" {
+			sawLive = true
+			break
+		}
+	}
+	assert.True(t, sawLive,
+		"watch tick at LevelResourceTypes must surface live pods into the preview (rightItems=%+v)", m.rightItems)
+}
+
 // flattenBatch unwraps a tea.Cmd that may be a tea.Batch into a slice of
 // individual commands. Bubble Tea's BatchMsg holds a list of cmds; we
 // invoke each to drive the test pipeline manually.


### PR DESCRIPTION
## Summary

Cursor on \"Pods\" at the resource-types level + any mutation (another tab, kubectl delete, an operator, a script) used to leave the right-pane list stuck on the cached snapshot. Cursor-moving away and back didn't help. Only drilling in pulled fresh data.

The fix invalidates the preview cache-freshness fingerprint at two trigger points:
- Tab switch (commit 1).
- Watch tick + shift+R (commit 2).

## Root cause

\`loadResources(forPreview=true)\` has a hover-cycle cache shortcut that returns cached items synchronously when (cacheKey, fingerprint) match. The fingerprint reflects model state (namespace, filters), not cluster state, so external/cross-tab mutations never invalidate it. Drilling in works only because \`loadResources(forPreview=false)\` deliberately skips the shortcut.

At \`LevelResourceTypes\`, every refresh path was hitting this shortcut:
- **Tab switch**: \`postTabSwitchCmd\` already called \`loadPreview\` after \`loadTab\`, but the cache shortcut served stale items.
- **Watch tick**: \`refreshCurrentLevel\` → \`loadResourceTypes\` (synchronous) → \`resourceTypesMsg\` → \`updateResourceTypes\` cascades into \`m.loadPreview()\`. Same cache shortcut → same stale items.

## Fix

### Commit 1 — tab switch
At \`LevelResourceTypes\` on tab switch, \`postTabSwitchCmd\` now calls \`invalidatePreviewFingerprintForCurrentSelection()\` before \`loadPreview\`. The cache entry stays for navigation-history instant paint; only the fingerprint drops, so the shortcut misses and a real fetch runs.

### Commit 2 — watch tick (and shift+R)
- \`refreshCurrentLevel\` at \`LevelResourceTypes\` runs the same fingerprint invalidation. Both watch tick and shift+R go through this function.
- \`resourceTypesMsg\` grows a \`silent\` field, captured by \`loadResourceTypesFor\` from \`suppressBgtasks\` at construction time. \`updateResourceTypes\` temporarily applies \`msg.silent\` to \`m.suppressBgtasks\` while building the cascade's \`loadPreview\` cmd, so a watch-tick refresh stays silent and doesn't flash the title-bar indicator every 2 s. This mirrors the pattern that \`updateResourcesLoadedMain\` already uses for \`resourcesLoadedMsg\`.
- shift+R's cascade is non-silent (it's a user action; visible feedback is correct).

## Test plan

- [x] \`TestPostTabSwitch_RefreshesPreviewAtLevelResourceTypes\` — tab-switch path: pre-populates a stale cache entry, asserts \`postTabSwitchCmd\` does not serve cached items.
- [x] \`TestWatchTickRefreshesPreviewAtLevelResourceTypes\` — full watch-tick pipeline: pre-populates a stale-pod cache entry with matching fingerprint, runs the cascade through \`resourceTypesMsg → updateResourceTypes → loadPreview → fetch → resourcesLoadedMsg → updateResourcesLoadedPreview\`, asserts \`live-pod\` lands in \`m.rightItems\`.
- [x] All existing \`TestPostTabSwitch_*\` and \`TestWatchTick*\` tests still pass.
- [x] \`go test ./internal/app/... -race -count=1\` clean.
- [x] \`go build ./...\` and \`go vet ./...\` clean.
- [x] \`golangci-lint run\` clean.