### PR TITLE
fix(ui): drop blank line between RESOURCE USAGE header and bars

### DIFF
--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -378,9 +378,8 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 func RenderResourceUsage(cpuUsed, cpuReq, cpuLim, memUsed, memReq, memLim int64, width int) string {
 	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Bold(true).Background(BaseBg)
 
-	lines := make([]string, 0, 4)
+	lines := make([]string, 0, 3)
 	lines = append(lines, DimStyle.Bold(true).Render("RESOURCE USAGE"))
-	lines = append(lines, "")
 
 	// CPU bar.
 	cpuLabel := labelStyle.Render("CPU: ")


### PR DESCRIPTION
## Summary

The RESOURCE USAGE section in the right-pane footer (visible when a pod is selected at LevelResources) had an extra blank line directly between the header and the CPU / Memory bars.

\`RenderResourceUsage\` (\`internal/ui/explorer_resource.go\`) builds its output as a \`[]string\` joined with \`\\n\` and explicitly appended \`\"\"\` right after the section header. Removed the empty append and corrected the slice capacity hint from \`4\` to \`3\` (1 header + 2 bars).

## Diff

\`\`\`go
// before
lines := make([]string, 0, 4)
lines = append(lines, DimStyle.Bold(true).Render(\"RESOURCE USAGE\"))
lines = append(lines, \"\")

// after
lines := make([]string, 0, 3)
lines = append(lines, DimStyle.Bold(true).Render(\"RESOURCE USAGE\"))
\`\`\`

The horizontal separator drawn above the section by \`view_right.go\` is unchanged — only the in-section blank line is removed.

## Test plan

- [x] \`go test ./internal/ui/... -race\` — including \`TestRenderResourceUsage\` (no test asserted on the blank line, no goldens to update)
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean