### PR TITLE
fix(scheduler): recover panics in task Fn so registry entries don't leak

### DIFF
--- a/internal/app/scheduler/runtask_panic_test.go
+++ b/internal/app/scheduler/runtask_panic_test.go
@@ -1,0 +1,83 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunTask_RecoversPanicInFn locks in the recover-and-Finish semantics
+// the worker loop must apply when a task's Fn panics. Without the
+// recovery, the worker goroutine dies mid-flight and the registry entry
+// stays in r.tasks with FinishedAt zero — lenLocked counts it as a
+// running task forever, so LenIndicator never drops to zero and the
+// title-bar spinner spins endlessly. The future also stays unresolved,
+// so the caller's scheduleK8sCall closure blocks forever on the channel
+// receive. Both symptoms are user-visible (frozen spinner, leaked
+// goroutine).
+//
+// The fix wraps Fn in a defer-recover that converts a panic to an error,
+// then runs the normal cleanup (unregisterRunning, Finish, deliver to
+// future, close future) so the worker survives and the registry stays
+// consistent.
+func TestRunTask_RecoversPanicInFn(t *testing.T) {
+	r := New(0)
+	r.SetWorkersForTest(2, 0)
+	r.StartWorkers()
+	defer r.StopWorkers()
+	r.SetLingerDurationForTest(20 * time.Millisecond)
+
+	future := r.Submit(SubmitReq{
+		KubeContext: "c1",
+		Kind:        KindResourceList,
+		Priority:    PriorityHigh,
+		Name:        "panicker",
+		Target:      "tgt",
+		Fn: func(ctx context.Context) (any, error) {
+			panic("simulated client crash")
+		},
+	})
+
+	// The future MUST resolve. Pre-fix, the worker dies from the
+	// panic and this select hits the timeout (test detects the leak).
+	select {
+	case res := <-future:
+		require.Error(t, res.Err, "panicking Fn must deliver a non-nil error to the future")
+		assert.Contains(t, res.Err.Error(), "simulated client crash",
+			"panic value should be surfaced in the error")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("future never resolved — worker goroutine presumably died from the panic and Finish was skipped")
+	}
+
+	// Past linger: the recovered task's registry entry must be Finished
+	// and prunable, so LenIndicator drops to zero. Pre-fix the entry is
+	// still "running" (FinishedAt zero) and lenLocked counts it forever.
+	time.Sleep(40 * time.Millisecond)
+	assert.Equal(t, 0, r.LenIndicator(),
+		"panicking task must not leak a registry entry past its linger window")
+
+	// Worker pool must still be functional: submit a second task and
+	// confirm it runs. Pre-fix the worker that handled the panicker
+	// goroutine has died, reducing the pool by one (and on a 1-worker
+	// pool this would hang forever).
+	future2 := r.Submit(SubmitReq{
+		KubeContext: "c1",
+		Kind:        KindResourceList,
+		Priority:    PriorityHigh,
+		Name:        "follower",
+		Target:      "tgt",
+		Fn: func(ctx context.Context) (any, error) {
+			return "ok", nil
+		},
+	})
+	select {
+	case res := <-future2:
+		assert.NoError(t, res.Err, "follow-up task must run on a surviving worker")
+		assert.Equal(t, "ok", res.Value)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("follow-up task did not run — worker pool drained by the unrecovered panic")
+	}
+}

--- a/internal/app/scheduler/scheduler_workers.go
+++ b/internal/app/scheduler/scheduler_workers.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 )
 
@@ -264,7 +265,7 @@ func (r *Registry) runTask(task *queuedTask) {
 
 	visID := r.startWithPriority(task.req.Kind, task.req.Priority, task.req.Name, task.req.Target, task.req.SilentTrack)
 	r.registerRunning(task.req.KubeContext, rt)
-	value, err := task.req.Fn(ctx)
+	value, err := safeRunFn(ctx, task.req.Fn)
 	cancel()
 	r.unregisterRunning(task.req.KubeContext, rt)
 
@@ -312,4 +313,22 @@ func (r *Registry) queueFor(kctx string) *ctxQueue {
 		return nil
 	}
 	return r.ctxQueues[kctx]
+}
+
+// safeRunFn calls fn with the given context and converts any panic into
+// an error. Without this guard, a panic in user-provided Fn unwinds
+// through runTask, skipping unregisterRunning + Finish + future delivery
+// — the registry entry stays in r.tasks with FinishedAt zero, lenLocked
+// counts it forever, the title-bar spinner spins forever, and the
+// caller's scheduleK8sCall closure blocks on the unresolved future. The
+// worker goroutine also dies, draining the pool by one slot. Recovery
+// here lets runTask run its normal cleanup branches with err set to a
+// descriptive panic error.
+func safeRunFn(ctx context.Context, fn func(context.Context) (any, error)) (value any, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("task panic: %v", p)
+		}
+	}()
+	return fn(ctx)
 }


### PR DESCRIPTION
## Summary

User report: after disabling auto-watch and navigating to Pods, everything loads but the upper-right title-bar spinner keeps spinning. The user reports that opening the background-tasks overlay makes it stop.

## Root cause

\`runTask\` (\`internal/app/scheduler/scheduler_workers.go:267\`) calls \`task.req.Fn(ctx)\` inline without a panic recover. A panic in Fn unwinds the worker goroutine, skipping all four cleanup steps that follow:

1. \`r.unregisterRunning(...)\` — leaks an entry in \`r.runningTasks\` for that kube-context.
2. \`r.Finish(visID)\` — never called, so the registry entry stays with \`FinishedAt\` zero.
3. \`task.future <- Result{...}\` — never delivered, so callers blocking on the future leak.
4. \`close(task.future)\` — never closed.

\`lenLocked\` counts \"running\" entries (\`FinishedAt\` zero) without an expiry, so \`LenIndicator()\` never drops to zero and the title-bar spinner spins forever. The future leak strands the \`scheduleK8sCall\` closure on a channel receive forever, which also leaks a Bubble Tea goroutine.

A third side-effect: the worker goroutine itself dies, so the worker pool shrinks by one slot per panic. On the 4-worker prod default it's invisible until enough panics accumulate.

## Fix

Wrap the Fn call in \`safeRunFn\`, a tiny helper that \`defer recover()\`s the panic and converts it into a descriptive error (\`task panic: <value>\`). \`runTask\`'s existing branches then run their normal cleanup with err set to the panic error — the worker survives, the registry stays consistent, and the future resolves.

## Test plan

- [x] New test \`TestRunTask_RecoversPanicInFn\` submits a deliberately panicking Fn and asserts:
   1. The future resolves with a non-nil error containing the panic value.
   2. \`LenIndicator\` drops to zero after the linger window.
   3. A follow-up \`Submit\` still runs on the surviving worker pool.
   Pre-fix: test crashes the test process (Go propagates the unrecovered goroutine panic). Post-fix: test passes.
- [x] \`go test ./... -race -count=1 -short\` clean.
- [x] \`go build ./...\` and \`go vet ./...\` clean.
- [x] \`golangci-lint run\` clean.
- [ ] Manual: user to confirm the spinner stops on navigation now that panicking tasks (likely \`GetAllPodMetrics\` or an event-list edge case on their cluster) clean up properly.

## Notes

The exact panic source is opaque to lfk — the symptom is the leak, not the K8s call itself. If the user can reproduce reliably, adding a one-line logger.Warn inside \`safeRunFn\` (something like \`logger.Warn(\"scheduler task panicked\", \"kind\", kind, \"name\", name, \"panic\", p)\`) would surface the offending call site. Left out of this PR to keep the diff minimal — happy to follow up if useful.