### PR TITLE
fix(scheduler): stop title-bar spinner during 10s linger window after work completes

### DIFF
--- a/internal/app/scheduler/lenindicator_linger_test.go
+++ b/internal/app/scheduler/lenindicator_linger_test.go
@@ -1,0 +1,50 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLenIndicator_SkipsFinishedLingering locks in the title-bar
+// indicator's narrow semantic: LenIndicator must only count tasks
+// whose work is actually in progress. Finished tasks stay in r.tasks
+// for DefaultLingerDuration so the :tasks overlay's Running list can
+// show "what just ran" — but those entries are not work-in-progress
+// and the title-bar spinner must not spin for them.
+//
+// Before this fix lenLocked counted finished-within-linger entries,
+// so the spinner kept spinning for the full 10-second linger window
+// after every navigation, even though all the underlying K8s calls
+// had already returned. Reported by the user: "I select a pod. The
+// pod's details load, the metrics load, etc and after this the upper
+// right spinner still spins for additional ~10 seconds".
+//
+// Len() (overlay-facing) keeps its broader semantic — see the
+// existing TestRunTask_SilentTrackAppearsInHistoryButNotIndicator
+// assertion that "Len() returns the full count (overlay-facing)" for
+// the analogous silent-task split.
+func TestLenIndicator_SkipsFinishedLingering(t *testing.T) {
+	r := New(0)
+	r.SetLingerDurationForTest(500 * time.Millisecond)
+
+	id := r.Start(KindResourceList, "List Pods", "default")
+	assert.Equal(t, 1, r.LenIndicator(), "running task must count")
+	assert.Equal(t, 1, r.Len(), "running task must count via Len too")
+
+	r.Finish(id)
+
+	// Within the linger window: task is still in r.tasks so the overlay
+	// can render it under "Running", but the title bar must show no
+	// spinner — work is done, the linger is purely for UX history.
+	assert.Equal(t, 0, r.LenIndicator(),
+		"finished-lingering task must NOT count toward the title-bar indicator")
+	assert.Equal(t, 1, r.Len(),
+		"finished-lingering task still counts via Len (overlay-facing snapshot still includes it)")
+
+	// And of course past the linger window both drop to zero.
+	time.Sleep(600 * time.Millisecond)
+	assert.Equal(t, 0, r.LenIndicator(), "past-linger: nothing visible to the indicator")
+	assert.Equal(t, 0, r.Len(), "past-linger: nothing visible at all")
+}

--- a/internal/app/scheduler/lenindicator_linger_test.go
+++ b/internal/app/scheduler/lenindicator_linger_test.go
@@ -43,8 +43,12 @@ func TestLenIndicator_SkipsFinishedLingering(t *testing.T) {
 	assert.Equal(t, 1, r.Len(),
 		"finished-lingering task still counts via Len (overlay-facing snapshot still includes it)")
 
-	// And of course past the linger window both drop to zero.
-	time.Sleep(600 * time.Millisecond)
-	assert.Equal(t, 0, r.LenIndicator(), "past-linger: nothing visible to the indicator")
-	assert.Equal(t, 0, r.Len(), "past-linger: nothing visible at all")
+	// And of course past the linger window both drop to zero. Poll
+	// instead of a fixed Sleep so a slow CI runner doesn't flake on a
+	// near-miss timing window — the assertion is on the post-linger
+	// state, not on a specific deadline.
+	assert.Eventually(t, func() bool {
+		return r.LenIndicator() == 0 && r.Len() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"past-linger: both LenIndicator and Len must drop to zero")
 }

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -510,8 +510,12 @@ func (r *Registry) lenLocked(skipSilent, skipFinished bool) int {
 		}
 		// Past-linger entries are skipped unconditionally; we do not GC
 		// here (kept read-only style), Snapshot's prune handles eviction.
-		if !t.FinishedAt.IsZero() && r.lingerDuration > 0 && now.Sub(t.FinishedAt) > r.lingerDuration {
-			continue
+		// A non-positive lingerDuration means "do not linger" so finished
+		// tasks expire immediately for counting purposes.
+		if !t.FinishedAt.IsZero() {
+			if r.lingerDuration <= 0 || now.Sub(t.FinishedAt) > r.lingerDuration {
+				continue
+			}
 		}
 		// In-linger finished tasks: shown in the overlay (skipFinished
 		// false) but excluded from the title-bar indicator (skipFinished

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -452,9 +452,14 @@ func (r *Registry) Snapshot() []Task {
 	return out
 }
 
-// Len returns the number of tasks currently visible (above the threshold).
-// Cheaper than len(r.Snapshot()) because it doesn't allocate the slice.
-// Used by the title bar to decide whether to render the indicator at all.
+// Len returns the number of tasks currently visible — running plus
+// finished-within-linger, all priorities, including silent. Cheaper
+// than len(r.Snapshot()) because it doesn't allocate the slice. The
+// overlay-facing count.
+//
+// For the title-bar "is anything actually running right now" gate,
+// use LenIndicator() instead — it additionally drops silent and
+// finished-lingering entries.
 //
 // The result may differ from len(Snapshot()) by at most one task when a
 // task's age is crossing the threshold between the two calls, because
@@ -468,32 +473,50 @@ func (r *Registry) Len() int {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.lenLocked(false)
+	return r.lenLocked(false, false)
 }
 
-// LenIndicator returns the count of NON-silent visible tasks. Used by
-// the title-bar spinner gate: silent tasks (watch-mode auto-refresh)
-// must not activate the spinner because they fire every second.
+// LenIndicator returns the count of NON-silent, actually-running
+// tasks. Used by the title-bar spinner gate. Two filters:
+//   - silent tasks (watch-mode auto-refresh) are skipped so the spinner
+//     doesn't flicker every second.
+//   - finished-within-linger tasks are skipped so the spinner doesn't
+//     keep spinning for DefaultLingerDuration after every navigation.
+//     The linger window is for the :tasks overlay's Running list ("look
+//     at what just ran"), not for the title-bar "work in progress"
+//     indicator.
+//
+// Snapshot() / Len() retain the broader visible set (running +
+// finished-within-linger) so the overlay continues to render history.
 func (r *Registry) LenIndicator() int {
 	if r == nil {
 		return 0
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.lenLocked(true)
+	return r.lenLocked(true, true)
 }
 
-func (r *Registry) lenLocked(skipSilent bool) int {
+// lenLocked counts visible tasks under r.mu. skipSilent drops silent
+// tasks (watch-mode refresh). skipFinished drops finished-lingering
+// tasks; pass true for title-bar indicator semantics, false for the
+// overlay-facing count that includes the linger window.
+func (r *Registry) lenLocked(skipSilent, skipFinished bool) int {
 	now := time.Now()
 	n := 0
 	for _, t := range r.tasks {
 		if skipSilent && t.Silent {
 			continue
 		}
-		// Skip finished-lingering tasks past their linger window. We do
-		// not GC here (kept read-only style); Snapshot's prune handles
-		// eviction.
+		// Past-linger entries are skipped unconditionally; we do not GC
+		// here (kept read-only style), Snapshot's prune handles eviction.
 		if !t.FinishedAt.IsZero() && r.lingerDuration > 0 && now.Sub(t.FinishedAt) > r.lingerDuration {
+			continue
+		}
+		// In-linger finished tasks: shown in the overlay (skipFinished
+		// false) but excluded from the title-bar indicator (skipFinished
+		// true) so the spinner reflects actual in-flight work.
+		if skipFinished && !t.FinishedAt.IsZero() {
 			continue
 		}
 		// Apply the start-time threshold only to running tasks.

--- a/internal/app/view_titlebar_tasks.go
+++ b/internal/app/view_titlebar_tasks.go
@@ -37,19 +37,30 @@ func nonSilentTasks(snap []scheduler.Task) []scheduler.Task {
 
 // renderTasksIndicator returns the styled string that lives in the title
 // bar between the gap filler and the namespace badge. Empty string when
-// no tasks are visible — the title bar then renders no indicator at
-// all and the breadcrumb gets the full remaining width.
+// no in-flight tasks are visible — the title bar then renders no
+// indicator at all and the breadcrumb gets the full remaining width.
 //
 // The indicator is intentionally minimal: just the animated spinner
 // glyph. Users who want details open the :tasks overlay. The spinner
 // frame is passed in by the caller (typically m.spinner.View()), so the
 // indicator animates at whatever cadence the caller's spinner is
 // already running.
+//
+// Finished-within-linger tasks are skipped: they stay in Snapshot for
+// the :tasks overlay's Running list, but the title-bar "work in
+// progress" indicator must only reflect actually-running work. The
+// caller's gate (LenIndicator) already filters these out, but defending
+// here too keeps the function correct against future direct-snapshot
+// callers.
 func renderTasksIndicator(spinnerFrame string, snapshot []scheduler.Task) string {
 	// Count tasks that are NOT already shown by renderMutationProgress
-	// (mutation tasks with Total > 0 get their own progress indicator).
+	// (mutation tasks with Total > 0 get their own progress indicator)
+	// and are not lingering-finished entries.
 	n := 0
 	for _, t := range snapshot {
+		if t.IsFinished() {
+			continue
+		}
 		if t.Kind == scheduler.KindMutation && t.Total > 0 {
 			continue
 		}
@@ -85,10 +96,14 @@ func renderMutationProgress(spinnerFrame string, snapshot []scheduler.Task) stri
 // background colour swapped to bg. Used by the title-bar render path
 // when a cluster colour tint is active, so the background of the
 // indicator matches the rest of the bar instead of leaking the default
-// barBg through.
+// barBg through. See renderTasksIndicator for the finished/mutation
+// filter rationale — kept identical here.
 func renderTasksIndicatorOverrideBg(spinnerFrame string, snapshot []scheduler.Task, bg lipgloss.TerminalColor) string {
 	n := 0
 	for _, t := range snapshot {
+		if t.IsFinished() {
+			continue
+		}
 		if t.Kind == scheduler.KindMutation && t.Total > 0 {
 			continue
 		}

--- a/internal/app/view_titlebar_tasks.go
+++ b/internal/app/view_titlebar_tasks.go
@@ -80,8 +80,16 @@ func renderTasksIndicator(spinnerFrame string, snapshot []scheduler.Task) string
 // When multiple mutation tasks run concurrently, only the first one with
 // progress is shown (bulk operations are typically serial).
 // Returns empty string when no mutation task has progress.
+//
+// Finished-within-linger tasks are skipped (consistent with
+// renderTasksIndicator) so the progress label does not stay frozen after
+// a bulk operation completes — Snapshot still carries the entry for the
+// :tasks overlay, but the title-bar must only reflect running work.
 func renderMutationProgress(spinnerFrame string, snapshot []scheduler.Task) string {
 	for _, t := range snapshot {
+		if t.IsFinished() {
+			continue
+		}
 		if t.Kind != scheduler.KindMutation || t.Total == 0 {
 			continue
 		}
@@ -117,8 +125,13 @@ func renderTasksIndicatorOverrideBg(spinnerFrame string, snapshot []scheduler.Ta
 
 // renderMutationProgressOverrideBg is renderMutationProgress with the
 // background colour swapped to bg. See renderTasksIndicatorOverrideBg.
+// The finished-task filter mirrors renderMutationProgress so a tinted
+// title bar behaves identically.
 func renderMutationProgressOverrideBg(spinnerFrame string, snapshot []scheduler.Task, bg lipgloss.TerminalColor) string {
 	for _, t := range snapshot {
+		if t.IsFinished() {
+			continue
+		}
 		if t.Kind != scheduler.KindMutation || t.Total == 0 {
 			continue
 		}


### PR DESCRIPTION
## Summary

User report: \"I turn watch mode off. I select a pod. The pod's details load, the metrics load, etc and after this the upper right spinner still spins for additional ~10 seconds.\"

That ~10s matches \`DefaultLingerDuration\` exactly.

## Root cause

After a task \`Finish()\`es, the registry intentionally keeps the entry in \`r.tasks\` for \`DefaultLingerDuration\` (10s) so the \`:tasks\` overlay's Running list can show \"what just ran.\" \`lenLocked\` counted these finished-within-linger entries (only past-linger entries were skipped), so \`LenIndicator() > 0\` stayed true for the full 10 seconds after every navigation. The title-bar spinner gates on \`LenIndicator()\` and kept spinning even though all the underlying K8s calls had already returned.

The title-bar \"is anything actually running\" indicator should be narrower than the overlay's \"what's running plus what just ran\" view.

## Fix

Split the counters along the existing silent/non-silent precedent:

- \`LenIndicator()\` now also skips finished-within-linger entries. The one caller (\`view.go:430\`'s title-bar gate) was already the only intended user — the doc-comment \"Used by the title-bar spinner gate\" was telling the truth, this just teaches the implementation to match the intent.
- \`Len()\` retains the broader visible-set semantic so the overlay's count stays unchanged.
- \`renderTasksIndicator\` / \`renderTasksIndicatorOverrideBg\` also filter \`t.IsFinished()\` defensively, so a future direct-snapshot caller won't accidentally render a \"spinner\" for purely-historical entries.

\`lenLocked\` grew a \`skipFinished bool\` parameter — \`LenIndicator\` passes true, \`Len\` passes false. The new line mirrors the existing \`skipSilent\` carve-out one entry above it.

## Test plan

- [x] New \`TestLenIndicator_SkipsFinishedLingering\` — Start + Finish, assert \`LenIndicator\` drops to 0 immediately (within the linger window) while \`Len\` stays at 1. Past linger both go to zero. Pre-fix \`LenIndicator\` stayed at 1 for the full window.
- [x] All existing linger / silent tests still pass:
   - \`TestFinish_LingersInRunningSnapshot\`
   - \`TestFinish_LingerWindowExpiresAndEvicts\`
   - \`TestFinish_LingeringTaskCoexistsWithRunning\`
   - \`TestRunTask_SilentTrackAppearsInHistoryButNotIndicator\`
- [x] \`go test ./... -race -count=1 -short\` clean.
- [x] \`go build ./...\` and \`go vet ./...\` clean.
- [x] \`golangci-lint run\` clean.

## Notes

PR #219 (panic-recovery in \`runTask\`) was opened before this clarification arrived; it's a real latent defense-in-depth fix but does NOT address this specific symptom. Closing #219 unless we want to keep it as a separate defense-in-depth follow-up — happy to do whichever.