### PR TITLE
feat(karpenter): first-class actions for NodePool / NodeClaim / EC2NodeClass

### DIFF
--- a/internal/app/commands_karpenter.go
+++ b/internal/app/commands_karpenter.go
@@ -13,8 +13,8 @@ import (
 )
 
 // executeActionKarpenter dispatches the Karpenter-specific action
-// labels (Disrupt, Cordon Node, Drain Node) into the matching Tea
-// command. Returns ok=true when the label is handled here so
+// labels (Disrupt, Cordon / Uncordon / Drain Node) into the matching
+// Tea command. Returns ok=true when the label is handled here so
 // executeActionExtended can early-return without growing its switch.
 // Disrupt opens the type-to-confirm overlay; the deferred mutation
 // lives in update_overlays_confirm.go's "Disrupt" branch.
@@ -25,6 +25,9 @@ func (m Model) executeActionKarpenter(actionLabel string) (tea.Model, tea.Cmd, b
 		return mdl, cmd, true
 	case "Cordon Node":
 		mdl, cmd := m.executeActionSimpleLoading("Cordoning node from NodeClaim", m.cordonNodeFromClaim)
+		return mdl, cmd, true
+	case "Uncordon Node":
+		mdl, cmd := m.executeActionSimpleLoading("Uncordoning node from NodeClaim", m.uncordonNodeFromClaim)
 		return mdl, cmd, true
 	case "Drain Node":
 		mdl, cmd := m.executeActionSimpleLoading("Draining node from NodeClaim", m.drainNodeFromClaim)
@@ -62,6 +65,14 @@ func (m Model) disruptNodeClaim() tea.Cmd {
 // claim has no node bound yet (Karpenter still provisioning).
 func (m Model) cordonNodeFromClaim() tea.Cmd {
 	return m.kubectlNodeCmdFromClaim("cordon")
+}
+
+// uncordonNodeFromClaim mirrors cordonNodeFromClaim but runs
+// `kubectl uncordon <node>` against the resolved name. Provided so
+// users can re-mark a node as schedulable directly from the NodeClaim
+// row without bouncing through the Node view.
+func (m Model) uncordonNodeFromClaim() tea.Cmd {
+	return m.kubectlNodeCmdFromClaim("uncordon")
 }
 
 // drainNodeFromClaim mirrors cordonNodeFromClaim but runs

--- a/internal/app/commands_karpenter.go
+++ b/internal/app/commands_karpenter.go
@@ -110,7 +110,15 @@ func (m Model) kubectlNodeCmdFromClaim(subcmd string) tea.Cmd {
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			logger.Error("kubectl node command failed", "subcmd", subcmd, "claim", claimName, "node", nodeName, "context", ctx, "error", err)
-			return actionResultMsg{err: fmt.Errorf("%s %s (from NodeClaim %s): %s", subcmd, nodeName, claimName, strings.TrimSpace(string(output)))}
+			// kubectl sometimes exits non-zero with no stderr (e.g. context
+			// cancelled, kubeconfig path missing on disk). Fall back to the
+			// exec error so the user always sees concrete failure details
+			// instead of a trailing blank.
+			detail := strings.TrimSpace(string(output))
+			if detail == "" {
+				detail = err.Error()
+			}
+			return actionResultMsg{err: fmt.Errorf("%s %s (from NodeClaim %s): %s", subcmd, nodeName, claimName, detail)}
 		}
 		return actionResultMsg{message: fmt.Sprintf("%s %s (from NodeClaim %s): %s", subcmd, nodeName, claimName, strings.TrimSpace(string(output)))}
 	})

--- a/internal/app/commands_karpenter.go
+++ b/internal/app/commands_karpenter.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// executeActionKarpenter dispatches the Karpenter-specific action
+// labels (Disrupt, Cordon Node, Drain Node) into the matching Tea
+// command. Returns ok=true when the label is handled here so
+// executeActionExtended can early-return without growing its switch.
+// Disrupt opens the type-to-confirm overlay; the deferred mutation
+// lives in update_overlays_confirm.go's "Disrupt" branch.
+func (m Model) executeActionKarpenter(actionLabel string) (tea.Model, tea.Cmd, bool) {
+	switch actionLabel {
+	case "Disrupt":
+		mdl, cmd := m.executeActionDisruptNodeClaim()
+		return mdl, cmd, true
+	case "Cordon Node":
+		mdl, cmd := m.executeActionSimpleLoading("Cordoning node from NodeClaim", m.cordonNodeFromClaim)
+		return mdl, cmd, true
+	case "Drain Node":
+		mdl, cmd := m.executeActionSimpleLoading("Draining node from NodeClaim", m.drainNodeFromClaim)
+		return mdl, cmd, true
+	}
+	return m, nil, false
+}
+
+// disruptNodeClaim deletes the NodeClaim under the cursor. Karpenter
+// observes the deletion and terminates the underlying cloud instance
+// plus the matching core Node, so this is the Karpenter-native way to
+// take a single node out of service. Wrapped in trackBgTask so the
+// task indicator renders during the brief delete window.
+//
+// Type-to-confirm gating is done one level up in the overlay handler
+// (the action menu wires "Disrupt" through pendingAction so the user
+// must type DELETE + Enter before this command runs).
+func (m Model) disruptNodeClaim() tea.Cmd {
+	ctx := m.actionCtx.context
+	name := m.actionCtx.name
+	logger.Info("Karpenter NodeClaim disrupt requested", "context", ctx, "name", name)
+	return m.trackBgTask(scheduler.KindMutation, "Disrupt NodeClaim: "+name, ctx, func() tea.Msg {
+		if err := m.client.DisruptNodeClaim(ctx, name); err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: fmt.Sprintf("Disrupted NodeClaim %s (Karpenter will terminate the node)", name)}
+	})
+}
+
+// cordonNodeFromClaim resolves the NodeClaim's status.nodeName and
+// shells out `kubectl cordon <node>` against the resolved name. The
+// NodeClaim row is the user's chosen surface; the underlying Node row
+// would also offer a plain Cordon. Two errors short-circuit before the
+// shell-out: the resolve fails (NodeClaim missing / RBAC), or the
+// claim has no node bound yet (Karpenter still provisioning).
+func (m Model) cordonNodeFromClaim() tea.Cmd {
+	return m.kubectlNodeCmdFromClaim("cordon")
+}
+
+// drainNodeFromClaim mirrors cordonNodeFromClaim but runs
+// `kubectl drain <node> --ignore-daemonsets --delete-emptydir-data`,
+// matching the flags the standalone executeActionDrain path uses on a
+// plain Node row.
+func (m Model) drainNodeFromClaim() tea.Cmd {
+	return m.kubectlNodeCmdFromClaim("drain")
+}
+
+// kubectlNodeCmdFromClaim resolves the NodeClaim's status.nodeName and
+// runs kubectl <subcmd> against the resolved node. Tracked as a
+// mutation so the title-bar indicator surfaces the in-flight operation
+// and the :tasks overlay shows it in the history.
+//
+// subcmd must be either "cordon" or "drain"; drain adds the standard
+// eviction-safety flags. Anything else falls through to a plain
+// kubectl invocation with no extra args.
+func (m Model) kubectlNodeCmdFromClaim(subcmd string) tea.Cmd {
+	ctx := m.actionCtx.context
+	claimName := m.actionCtx.name
+	kctxArg := m.kubectlContext(ctx)
+	kubeconfigPath := m.client.KubeconfigPathForContext(ctx)
+	client := m.client
+
+	return m.trackBgTask(scheduler.KindMutation, fmt.Sprintf("%s node (NodeClaim %s)", subcmd, claimName), ctx, func() tea.Msg {
+		nodeName, err := client.GetNodeClaimNodeName(ctx, claimName)
+		if err != nil {
+			return actionResultMsg{err: err}
+		}
+		if nodeName == "" {
+			return actionResultMsg{err: fmt.Errorf("NodeClaim %s has no node bound yet (status.nodeName empty)", claimName)}
+		}
+
+		kubectlPath, err := exec.LookPath("kubectl")
+		if err != nil {
+			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
+		}
+		args := []string{subcmd, nodeName, "--context", kctxArg}
+		if subcmd == "drain" {
+			args = append(args, "--ignore-daemonsets", "--delete-emptydir-data")
+		}
+		cmd := exec.Command(kubectlPath, args...)
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
+		logExecCmd("Running kubectl command (resolved from NodeClaim)", cmd)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			logger.Error("kubectl node command failed", "subcmd", subcmd, "claim", claimName, "node", nodeName, "context", ctx, "error", err)
+			return actionResultMsg{err: fmt.Errorf("%s %s (from NodeClaim %s): %s", subcmd, nodeName, claimName, strings.TrimSpace(string(output)))}
+		}
+		return actionResultMsg{message: fmt.Sprintf("%s %s (from NodeClaim %s): %s", subcmd, nodeName, claimName, strings.TrimSpace(string(output)))}
+	})
+}

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -72,10 +72,12 @@ var mutatingActions = map[string]bool{
 	"Resume":        true,
 
 	// Karpenter NodeClaim mutations. Disrupt removes the underlying
-	// node; Cordon/Drain operate on the node bound to the NodeClaim.
-	"Disrupt":     true,
-	"Cordon Node": true,
-	"Drain Node":  true,
+	// node; Cordon / Uncordon / Drain Node operate on the node bound
+	// to the NodeClaim.
+	"Disrupt":       true,
+	"Cordon Node":   true,
+	"Uncordon Node": true,
+	"Drain Node":    true,
 
 	// Helm release mutations.
 	"Edit Values": true,

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -71,6 +71,12 @@ var mutatingActions = map[string]bool{
 	"Suspend":       true,
 	"Resume":        true,
 
+	// Karpenter NodeClaim mutations. Disrupt removes the underlying
+	// node; Cordon/Drain operate on the node bound to the NodeClaim.
+	"Disrupt":     true,
+	"Cordon Node": true,
+	"Drain Node":  true,
+
 	// Helm release mutations.
 	"Edit Values": true,
 	"Upgrade":     true,

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -491,60 +491,6 @@ func (m Model) executeActionCapture(actionLabel string) (tea.Model, tea.Cmd, boo
 	return m, nil, false
 }
 
-// executeActionExtended dispatches Argo, Helm, Flux, and other extended actions.
-// Returns the model, cmd, and true if the action was handled.
-func (m Model) executeActionExtended(actionLabel string) (tea.Model, tea.Cmd, bool) {
-	switch actionLabel {
-	case "Configure AutoSync", "Sync", "Sync (Apply Only)", "Refresh",
-		"Terminate Sync", "Watch Workflow", "Suspend Workflow",
-		"Resume Workflow", "Stop Workflow", "Terminate Workflow",
-		"Resubmit Workflow", "Submit Workflow",
-		"Suspend CronWorkflow", "Resume CronWorkflow":
-		mdl, cmd := m.executeActionArgo(actionLabel)
-		return mdl, cmd, true
-	case "Force Renew":
-		mdl, cmd := m.executeActionSimpleLoading("Triggering renewal for", m.forceRenewCertificate)
-		return mdl, cmd, true
-	case "Force Refresh":
-		mdl, cmd := m.executeActionSimpleLoading("Force refreshing", m.forceRefreshExternalSecret)
-		return mdl, cmd, true
-	case "Pause":
-		mdl, cmd := m.executeActionSimpleLoading("Pausing", m.pauseKEDAResource)
-		return mdl, cmd, true
-	case "Unpause":
-		mdl, cmd := m.executeActionSimpleLoading("Unpausing", m.unpauseKEDAResource)
-		return mdl, cmd, true
-	case "Reconcile":
-		mdl, cmd := m.executeActionSimpleLoading("Reconciling", m.reconcileFluxResource)
-		return mdl, cmd, true
-	case "Suspend":
-		mdl, cmd := m.executeActionSimpleLoading("Suspending", m.suspendFluxResource)
-		return mdl, cmd, true
-	case "Resume":
-		mdl, cmd := m.executeActionSimpleLoading("Resuming", m.resumeFluxResource)
-		return mdl, cmd, true
-	case "Values":
-		mdl, cmd := m.executeActionHelmValues(false)
-		return mdl, cmd, true
-	case "All Values":
-		mdl, cmd := m.executeActionHelmValues(true)
-		return mdl, cmd, true
-	case "Edit Values":
-		mdl, cmd := m.executeActionEditValues()
-		return mdl, cmd, true
-	case "Diff":
-		mdl, cmd := m.executeActionDiff()
-		return mdl, cmd, true
-	case "Upgrade":
-		mdl, cmd := m.executeActionUpgrade()
-		return mdl, cmd, true
-	case "History":
-		mdl, cmd := m.executeActionHelmHistory()
-		return mdl, cmd, true
-	}
-	return m, nil, false
-}
-
 // openBulkActionDirect sets up bulk mode and executes a bulk action directly
 // (bypassing the action menu overlay).
 func (m Model) openBulkActionDirect(actionLabel string) (tea.Model, tea.Cmd) {

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -400,6 +400,23 @@ func (m Model) executeActionForceFinalize() (tea.Model, tea.Cmd) { //nolint:unpa
 	return m, nil
 }
 
+// executeActionDisruptNodeClaim handles the "Disrupt" action on a
+// Karpenter NodeClaim row. Disrupting deletes the NodeClaim, and
+// Karpenter then terminates the underlying cloud instance. Routed
+// through the same type-to-confirm overlay (user types DELETE + Enter)
+// as Force Delete / Force Finalize because the cluster loses capacity
+// until Karpenter reprovisions. The deferred mutation runs in the
+// overlay handler's "Disrupt" branch.
+func (m Model) executeActionDisruptNodeClaim() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
+	m.confirmAction = m.actionCtx.name + " (DISRUPT)"
+	m.confirmTitle = "Confirm Disrupt NodeClaim"
+	m.confirmQuestion = fmt.Sprintf("Disrupt NodeClaim %s? Karpenter will terminate the underlying node.", m.actionCtx.name)
+	m.confirmTypeInput.Clear()
+	m.overlay = overlayConfirmType
+	m.pendingAction = "Disrupt"
+	return m, nil
+}
+
 // executeActionCordon handles the "Cordon" action.
 func (m Model) executeActionCordon() (tea.Model, tea.Cmd) {
 	name := m.actionCtx.name

--- a/internal/app/update_actions_extended.go
+++ b/internal/app/update_actions_extended.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// executeActionExtended dispatches Argo / Helm / Flux / cert-manager /
+// KEDA / ExternalSecrets / Karpenter action labels. Returns (model, cmd,
+// handled). Lives in its own file so update_actions.go stays under the
+// 800-line file cap (revive: file-length-limit); the original switch
+// was at the boundary before Karpenter labels were added.
+func (m Model) executeActionExtended(actionLabel string) (tea.Model, tea.Cmd, bool) {
+	switch actionLabel {
+	case "Disrupt", "Cordon Node", "Drain Node":
+		return m.executeActionKarpenter(actionLabel)
+	case "Configure AutoSync", "Sync", "Sync (Apply Only)", "Refresh",
+		"Terminate Sync", "Watch Workflow", "Suspend Workflow",
+		"Resume Workflow", "Stop Workflow", "Terminate Workflow",
+		"Resubmit Workflow", "Submit Workflow",
+		"Suspend CronWorkflow", "Resume CronWorkflow":
+		mdl, cmd := m.executeActionArgo(actionLabel)
+		return mdl, cmd, true
+	case "Force Renew":
+		mdl, cmd := m.executeActionSimpleLoading("Triggering renewal for", m.forceRenewCertificate)
+		return mdl, cmd, true
+	case "Force Refresh":
+		mdl, cmd := m.executeActionSimpleLoading("Force refreshing", m.forceRefreshExternalSecret)
+		return mdl, cmd, true
+	case "Pause":
+		mdl, cmd := m.executeActionSimpleLoading("Pausing", m.pauseKEDAResource)
+		return mdl, cmd, true
+	case "Unpause":
+		mdl, cmd := m.executeActionSimpleLoading("Unpausing", m.unpauseKEDAResource)
+		return mdl, cmd, true
+	case "Reconcile":
+		mdl, cmd := m.executeActionSimpleLoading("Reconciling", m.reconcileFluxResource)
+		return mdl, cmd, true
+	case "Suspend":
+		mdl, cmd := m.executeActionSimpleLoading("Suspending", m.suspendFluxResource)
+		return mdl, cmd, true
+	case "Resume":
+		mdl, cmd := m.executeActionSimpleLoading("Resuming", m.resumeFluxResource)
+		return mdl, cmd, true
+	case "Values":
+		mdl, cmd := m.executeActionHelmValues(false)
+		return mdl, cmd, true
+	case "All Values":
+		mdl, cmd := m.executeActionHelmValues(true)
+		return mdl, cmd, true
+	case "Edit Values":
+		mdl, cmd := m.executeActionEditValues()
+		return mdl, cmd, true
+	case "Diff":
+		mdl, cmd := m.executeActionDiff()
+		return mdl, cmd, true
+	case "Upgrade":
+		mdl, cmd := m.executeActionUpgrade()
+		return mdl, cmd, true
+	case "History":
+		mdl, cmd := m.executeActionHelmHistory()
+		return mdl, cmd, true
+	}
+	return m, nil, false
+}

--- a/internal/app/update_actions_extended.go
+++ b/internal/app/update_actions_extended.go
@@ -11,7 +11,7 @@ import (
 // was at the boundary before Karpenter labels were added.
 func (m Model) executeActionExtended(actionLabel string) (tea.Model, tea.Cmd, bool) {
 	switch actionLabel {
-	case "Disrupt", "Cordon Node", "Drain Node":
+	case "Disrupt", "Cordon Node", "Uncordon Node", "Drain Node":
 		return m.executeActionKarpenter(actionLabel)
 	case "Configure AutoSync", "Sync", "Sync (Apply Only)", "Refresh",
 		"Terminate Sync", "Watch Workflow", "Suspend Workflow",

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -132,6 +132,11 @@ func (m Model) handleConfirmTypeOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 				selectedCount := len(m.finalizerSearchSelected)
 				m.addLogEntry("DBG", fmt.Sprintf("Removing finalizer %q from %d resources", m.finalizerSearchPattern, selectedCount))
 				return m, m.bulkRemoveFinalizer()
+			case "Disrupt":
+				// Karpenter NodeClaim disrupt: kubectl delete nodeclaim.
+				// Cluster-scoped, so no -n flag; rt.Resource is "nodeclaims".
+				m.addLogEntry("DBG", fmt.Sprintf("$ kubectl delete %s %s --context %s", rt.Resource, name, ctx))
+				return m, m.disruptNodeClaim()
 			}
 		}
 		return m, nil

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -111,7 +111,11 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 		content := ui.RenderNamespaceOverlay(m.filteredOverlayItems(), m.overlayFilter.Value, m.overlayCursor, m.namespace, m.allNamespaces, m.selectedNamespaces, m.nsFilterMode, overlayH)
 		return content, overlayW, overlayH, true
 	case overlayAction:
-		w := min(70, m.width-10)
+		// Adaptive width: grow to fit the longest action line so Karpenter
+		// and other long descriptions never wrap, floored at 70 so short
+		// menus keep the historical width and capped at terminal-10 so the
+		// overlay leaves margin on each side.
+		w := ui.ActionOverlayWidth(m.overlayItems, m.width-10)
 		return ui.RenderActionOverlay(m.overlayItems, m.overlayCursor, w), w, min(15, m.height-6), true
 	case overlayQuitConfirm:
 		// Width: outer 32, inner = 32 − 2(border) − 4(left+right padding) = 26.

--- a/internal/k8s/karpenter.go
+++ b/internal/k8s/karpenter.go
@@ -1,0 +1,66 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// karpenterNodeClaimGVR is the v1 GroupVersionResource for
+// karpenter.sh/NodeClaim. Karpenter promoted the API to v1 in v0.32+;
+// earlier deployments are out of scope for this client surface.
+var karpenterNodeClaimGVR = schema.GroupVersionResource{
+	Group:    "karpenter.sh",
+	Version:  "v1",
+	Resource: "nodeclaims",
+}
+
+// GetNodeClaimNodeName reads the underlying node name from a
+// karpenter.sh/NodeClaim's status.nodeName. The TUI uses it to forward
+// Cordon Node / Drain Node actions from the NodeClaim row to the
+// kubectl helpers that expect a node name. Returns an empty string with
+// no error when the NodeClaim exists but hasn't been bound to a node
+// yet (Karpenter still provisioning) so callers can render a clean
+// "node not yet bound" message instead of an error toast.
+//
+// NodeClaim is cluster-scoped (no namespace argument).
+func (c *Client) GetNodeClaimNodeName(contextName, name string) (string, error) {
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return "", err
+	}
+	obj, err := dynClient.Resource(karpenterNodeClaimGVR).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting NodeClaim %s: %w", name, err)
+	}
+	nodeName, found, err := unstructured.NestedString(obj.Object, "status", "nodeName")
+	if err != nil {
+		return "", fmt.Errorf("reading NodeClaim %s status.nodeName: %w", name, err)
+	}
+	if !found {
+		return "", nil
+	}
+	return nodeName, nil
+}
+
+// DisruptNodeClaim deletes the NodeClaim, which is the Karpenter-native
+// way to terminate a single node (Karpenter's NodeClaim controller
+// observes the deletion and tears down the underlying cloud instance
+// plus the corresponding core Node object). Equivalent to
+// `kubectl delete nodeclaim <name>` but routes through the dynamic
+// client so callers don't pay shell-out cost. The TUI gates this behind
+// a type-to-confirm overlay because the cluster loses capacity until
+// Karpenter reprovisions.
+func (c *Client) DisruptNodeClaim(contextName, name string) error {
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return err
+	}
+	if err := dynClient.Resource(karpenterNodeClaimGVR).Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("disrupting NodeClaim %s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/k8s/karpenter_test.go
+++ b/internal/k8s/karpenter_test.go
@@ -13,6 +13,11 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
+// TestGetNodeClaimNodeName covers the happy path: a NodeClaim with
+// status.nodeName populated. The TUI relies on this value to forward
+// Cordon / Uncordon / Drain Node from the NodeClaim row to the
+// kubectl helpers, so the helper must return the literal string from
+// the API, not a derived form.
 func TestGetNodeClaimNodeName(t *testing.T) {
 	scheme := runtime.NewScheme()
 	gvrs := map[schema.GroupVersionResource]string{
@@ -58,6 +63,11 @@ func TestGetNodeClaimNodeName_NotYetBound(t *testing.T) {
 	assert.Empty(t, got, "unbound NodeClaim returns empty nodeName, not an error")
 }
 
+// TestGetNodeClaimNodeName_NotFound exercises the lookup-failure path:
+// the NodeClaim doesn't exist (deleted, never created, or RBAC denies
+// the Get). The helper must surface a wrapped error so callers can
+// distinguish "missing" from the legitimate ("", nil) "not bound yet"
+// state covered by TestGetNodeClaimNodeName_NotYetBound.
 func TestGetNodeClaimNodeName_NotFound(t *testing.T) {
 	scheme := runtime.NewScheme()
 	gvrs := map[schema.GroupVersionResource]string{
@@ -71,6 +81,12 @@ func TestGetNodeClaimNodeName_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "getting NodeClaim")
 }
 
+// TestDisruptNodeClaim asserts the happy path of the Karpenter
+// disrupt action: the NodeClaim is deleted from the API. Karpenter's
+// real-world cascade (terminating the underlying cloud instance and
+// the matching core Node) is not exercised here — the dynamic fake
+// only models the NodeClaim object — but the delete is the trigger
+// Karpenter watches for, so verifying the delete is sufficient.
 func TestDisruptNodeClaim(t *testing.T) {
 	scheme := runtime.NewScheme()
 	gvrs := map[schema.GroupVersionResource]string{
@@ -92,6 +108,11 @@ func TestDisruptNodeClaim(t *testing.T) {
 	require.Error(t, err, "DisruptNodeClaim must delete the NodeClaim from the API")
 }
 
+// TestDisruptNodeClaim_NotFound asserts that disrupting a NodeClaim
+// that no longer exists returns a wrapped error rather than silently
+// succeeding. The TUI relies on this so the type-to-confirm overlay's
+// status message accurately reports the failure instead of claiming
+// success on a no-op.
 func TestDisruptNodeClaim_NotFound(t *testing.T) {
 	scheme := runtime.NewScheme()
 	gvrs := map[schema.GroupVersionResource]string{

--- a/internal/k8s/karpenter_test.go
+++ b/internal/k8s/karpenter_test.go
@@ -1,0 +1,106 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestGetNodeClaimNodeName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		karpenterNodeClaimGVR: "NodeClaimList",
+	}
+	claim := &unstructured.Unstructured{}
+	claim.SetUnstructuredContent(map[string]any{
+		"apiVersion": "karpenter.sh/v1",
+		"kind":       "NodeClaim",
+		"metadata":   map[string]any{"name": "claim-1"},
+		"status":     map[string]any{"nodeName": "ip-10-0-0-1.ec2.internal"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, claim)
+	c := newFakeClient(nil, dyn)
+
+	got, err := c.GetNodeClaimNodeName("test-ctx", "claim-1")
+	require.NoError(t, err)
+	assert.Equal(t, "ip-10-0-0-1.ec2.internal", got)
+}
+
+// TestGetNodeClaimNodeName_NotYetBound covers the steady-state of a
+// freshly-created NodeClaim before Karpenter has bound it to a node:
+// status.nodeName is unset, but the resource exists. The TUI should
+// see ("", nil) so it can render "node not yet bound" cleanly without
+// surfacing a "field missing" error.
+func TestGetNodeClaimNodeName_NotYetBound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		karpenterNodeClaimGVR: "NodeClaimList",
+	}
+	claim := &unstructured.Unstructured{}
+	claim.SetUnstructuredContent(map[string]any{
+		"apiVersion": "karpenter.sh/v1",
+		"kind":       "NodeClaim",
+		"metadata":   map[string]any{"name": "claim-pending"},
+		// no status.nodeName yet
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, claim)
+	c := newFakeClient(nil, dyn)
+
+	got, err := c.GetNodeClaimNodeName("test-ctx", "claim-pending")
+	require.NoError(t, err)
+	assert.Empty(t, got, "unbound NodeClaim returns empty nodeName, not an error")
+}
+
+func TestGetNodeClaimNodeName_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		karpenterNodeClaimGVR: "NodeClaimList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs)
+	c := newFakeClient(nil, dyn)
+
+	_, err := c.GetNodeClaimNodeName("test-ctx", "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting NodeClaim")
+}
+
+func TestDisruptNodeClaim(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		karpenterNodeClaimGVR: "NodeClaimList",
+	}
+	claim := &unstructured.Unstructured{}
+	claim.SetUnstructuredContent(map[string]any{
+		"apiVersion": "karpenter.sh/v1",
+		"kind":       "NodeClaim",
+		"metadata":   map[string]any{"name": "doomed"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, claim)
+	c := newFakeClient(nil, dyn)
+
+	require.NoError(t, c.DisruptNodeClaim("test-ctx", "doomed"))
+
+	// Verify the NodeClaim is gone from the fake API.
+	_, err := dyn.Resource(karpenterNodeClaimGVR).Get(context.Background(), "doomed", metav1.GetOptions{})
+	require.Error(t, err, "DisruptNodeClaim must delete the NodeClaim from the API")
+}
+
+func TestDisruptNodeClaim_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		karpenterNodeClaimGVR: "NodeClaimList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs)
+	c := newFakeClient(nil, dyn)
+
+	err := c.DisruptNodeClaim("test-ctx", "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disrupting NodeClaim")
+}

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -56,6 +56,9 @@ func ActionsForKind(kind string) []ActionMenuItem {
 	if actions, ok := actionsForOperatorKind(kind); ok {
 		return actions
 	}
+	if actions, ok := actionsForKarpenterKind(kind); ok {
+		return actions
+	}
 	return actionsDefault()
 }
 
@@ -433,6 +436,48 @@ func actionsForOperatorKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this resource", Key: "D"},
 			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in namespace", Key: "b"},
+			{Label: "Events", Description: "Show related events", Key: "V"},
+		}, true
+	}
+	return nil, false
+}
+
+// actionsForKarpenterKind returns actions for Karpenter resource kinds.
+// NodeClaim represents a single provisioned node — Disrupt deletes the
+// claim (Karpenter then terminates the underlying instance), while
+// Cordon Node / Drain Node resolve the claim's status.nodeName and
+// forward to the standard kubectl helpers so the same UX as a plain
+// Node row works from the NodeClaim view. NodePool and EC2NodeClass
+// stick to the generic Describe/Edit/Delete/Events surface for now —
+// per-pool disruption controls (spec.disruption.budgets) overlap with
+// user-managed config and are deferred to a follow-up.
+func actionsForKarpenterKind(kind string) ([]ActionMenuItem, bool) {
+	switch kind {
+	case "NodeClaim":
+		return []ActionMenuItem{
+			{Label: "Disrupt", Description: "Delete this NodeClaim (Karpenter terminates the node)", Key: "X"},
+			{Label: "Cordon Node", Description: "Cordon the underlying node from status.nodeName", Key: "c"},
+			{Label: "Drain Node", Description: "Drain the underlying node from status.nodeName", Key: "n"},
+			{Label: "Describe", Description: "Describe resource", Key: "v"},
+			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
+			{Label: "Delete", Description: "Delete this NodeClaim", Key: "D"},
+			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in current namespace", Key: "b"},
+			{Label: "Events", Description: "Show related events", Key: "V"},
+		}, true
+	case "NodePool":
+		return []ActionMenuItem{
+			{Label: "Describe", Description: "Describe resource", Key: "v"},
+			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
+			{Label: "Delete", Description: "Delete this NodePool", Key: "D"},
+			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in current namespace", Key: "b"},
+			{Label: "Events", Description: "Show related events", Key: "V"},
+		}, true
+	case "EC2NodeClass":
+		return []ActionMenuItem{
+			{Label: "Describe", Description: "Describe resource", Key: "v"},
+			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
+			{Label: "Delete", Description: "Delete this EC2NodeClass", Key: "D"},
+			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in current namespace", Key: "b"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true
 	}

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -445,23 +445,24 @@ func actionsForOperatorKind(kind string) ([]ActionMenuItem, bool) {
 // actionsForKarpenterKind returns actions for Karpenter resource kinds.
 // NodeClaim represents a single provisioned node — Disrupt deletes the
 // claim (Karpenter then terminates the underlying instance), while
-// Cordon Node / Drain Node resolve the claim's status.nodeName and
-// forward to the standard kubectl helpers so the same UX as a plain
-// Node row works from the NodeClaim view. NodePool and EC2NodeClass
-// stick to the generic Describe/Edit/Delete/Events surface for now —
-// per-pool disruption controls (spec.disruption.budgets) overlap with
-// user-managed config and are deferred to a follow-up.
+// Cordon / Uncordon / Drain Node resolve the claim's status.nodeName
+// and forward to the standard kubectl helpers so the same UX as a
+// plain Node row works from the NodeClaim view. NodePool and
+// EC2NodeClass stick to the generic Describe/Edit/Delete/Events surface
+// for now — per-pool disruption controls (spec.disruption.budgets)
+// overlap with user-managed config and are deferred to a follow-up.
 func actionsForKarpenterKind(kind string) ([]ActionMenuItem, bool) {
 	switch kind {
 	case "NodeClaim":
 		return []ActionMenuItem{
-			{Label: "Disrupt", Description: "Delete this NodeClaim (Karpenter terminates the node)", Key: "X"},
-			{Label: "Cordon Node", Description: "Cordon the underlying node from status.nodeName", Key: "c"},
-			{Label: "Drain Node", Description: "Drain the underlying node from status.nodeName", Key: "n"},
+			{Label: "Disrupt", Description: "Delete claim; Karpenter terminates the node", Key: "X"},
+			{Label: "Cordon Node", Description: "Cordon the bound node", Key: "c"},
+			{Label: "Uncordon Node", Description: "Uncordon the bound node", Key: "u"},
+			{Label: "Drain Node", Description: "Drain the bound node (evict pods)", Key: "n"},
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this NodeClaim", Key: "D"},
-			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in current namespace", Key: "b"},
+			{Label: "Debug Pod", Description: "Run alpine debug pod in namespace", Key: "b"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true
 	case "NodePool":
@@ -469,7 +470,7 @@ func actionsForKarpenterKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this NodePool", Key: "D"},
-			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in current namespace", Key: "b"},
+			{Label: "Debug Pod", Description: "Run alpine debug pod in namespace", Key: "b"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true
 	case "EC2NodeClass":
@@ -477,7 +478,7 @@ func actionsForKarpenterKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this EC2NodeClass", Key: "D"},
-			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in current namespace", Key: "b"},
+			{Label: "Debug Pod", Description: "Run alpine debug pod in namespace", Key: "b"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true
 	}

--- a/internal/model/actions_karpenter_test.go
+++ b/internal/model/actions_karpenter_test.go
@@ -34,7 +34,9 @@ func TestKarpenterActions_NodeClaim(t *testing.T) {
 // TestKarpenterActions_NodePool keeps the action menu minimal for now —
 // Disable/Enable on spec.disruption.budgets has user-data overlap and
 // is deferred to a follow-up. Generic Describe/Edit/Delete/Events keep
-// the resource visible and editable.
+// the resource visible and editable. Disrupt / Cordon Node / Drain Node
+// are explicitly absent — those verbs only make sense from a NodeClaim
+// row where status.nodeName binds the action to a concrete node.
 func TestKarpenterActions_NodePool(t *testing.T) {
 	items := ActionsForKind("NodePool")
 	labels := make([]string, 0, len(items))
@@ -45,12 +47,17 @@ func TestKarpenterActions_NodePool(t *testing.T) {
 	assert.Contains(t, labels, "Edit")
 	assert.Contains(t, labels, "Delete")
 	assert.Contains(t, labels, "Events")
-	// Disrupt is for NodeClaim, not NodePool.
 	assert.NotContains(t, labels, "Disrupt",
 		"NodePool does not offer Disrupt — that verb only applies to a single NodeClaim")
+	assert.NotContains(t, labels, "Cordon Node",
+		"NodePool has no single underlying node to cordon")
+	assert.NotContains(t, labels, "Drain Node",
+		"NodePool has no single underlying node to drain")
 }
 
-// TestKarpenterActions_EC2NodeClass surfaces only generic actions.
+// TestKarpenterActions_EC2NodeClass surfaces only generic actions. The
+// node-bound verbs (Disrupt / Cordon Node / Drain Node) live on
+// NodeClaim where status.nodeName resolves to a concrete node.
 func TestKarpenterActions_EC2NodeClass(t *testing.T) {
 	items := ActionsForKind("EC2NodeClass")
 	labels := make([]string, 0, len(items))
@@ -61,4 +68,10 @@ func TestKarpenterActions_EC2NodeClass(t *testing.T) {
 	assert.Contains(t, labels, "Edit")
 	assert.Contains(t, labels, "Delete")
 	assert.Contains(t, labels, "Events")
+	assert.NotContains(t, labels, "Disrupt",
+		"EC2NodeClass is a node-launch template, not a node — Disrupt does not apply")
+	assert.NotContains(t, labels, "Cordon Node",
+		"EC2NodeClass is a node-launch template, not a node — Cordon Node does not apply")
+	assert.NotContains(t, labels, "Drain Node",
+		"EC2NodeClass is a node-launch template, not a node — Drain Node does not apply")
 }

--- a/internal/model/actions_karpenter_test.go
+++ b/internal/model/actions_karpenter_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 // TestKarpenterActions_NodeClaim locks in the per-kind action set for
-// karpenter.sh/NodeClaim. The three Karpenter-specific verbs — Disrupt,
-// Cordon Node, Drain Node — must be present; Disrupt is the
-// type-to-confirm path (delete the NodeClaim → Karpenter terminates the
-// underlying node), Cordon Node / Drain Node resolve status.nodeName
-// and forward to the standard kubectl helpers.
+// karpenter.sh/NodeClaim. The four Karpenter-specific verbs — Disrupt,
+// Cordon / Uncordon / Drain Node — must be present; Disrupt is the
+// type-to-confirm path (delete the NodeClaim → Karpenter terminates
+// the underlying node), and Cordon / Uncordon / Drain Node resolve
+// status.nodeName and forward to the standard kubectl helpers.
 func TestKarpenterActions_NodeClaim(t *testing.T) {
 	items := ActionsForKind("NodeClaim")
 	labels := make([]string, 0, len(items))
@@ -22,6 +22,8 @@ func TestKarpenterActions_NodeClaim(t *testing.T) {
 		"NodeClaim must offer Disrupt (type-to-confirm; deletes the NodeClaim so Karpenter terminates the node)")
 	assert.Contains(t, labels, "Cordon Node",
 		"NodeClaim must offer Cordon Node (resolves status.nodeName then runs kubectl cordon)")
+	assert.Contains(t, labels, "Uncordon Node",
+		"NodeClaim must offer Uncordon Node (resolves status.nodeName then runs kubectl uncordon)")
 	assert.Contains(t, labels, "Drain Node",
 		"NodeClaim must offer Drain Node (resolves status.nodeName then runs the drain flow)")
 	// Standard actions still present.
@@ -51,12 +53,14 @@ func TestKarpenterActions_NodePool(t *testing.T) {
 		"NodePool does not offer Disrupt — that verb only applies to a single NodeClaim")
 	assert.NotContains(t, labels, "Cordon Node",
 		"NodePool has no single underlying node to cordon")
+	assert.NotContains(t, labels, "Uncordon Node",
+		"NodePool has no single underlying node to uncordon")
 	assert.NotContains(t, labels, "Drain Node",
 		"NodePool has no single underlying node to drain")
 }
 
 // TestKarpenterActions_EC2NodeClass surfaces only generic actions. The
-// node-bound verbs (Disrupt / Cordon Node / Drain Node) live on
+// node-bound verbs (Disrupt / Cordon / Uncordon / Drain Node) live on
 // NodeClaim where status.nodeName resolves to a concrete node.
 func TestKarpenterActions_EC2NodeClass(t *testing.T) {
 	items := ActionsForKind("EC2NodeClass")
@@ -72,6 +76,8 @@ func TestKarpenterActions_EC2NodeClass(t *testing.T) {
 		"EC2NodeClass is a node-launch template, not a node — Disrupt does not apply")
 	assert.NotContains(t, labels, "Cordon Node",
 		"EC2NodeClass is a node-launch template, not a node — Cordon Node does not apply")
+	assert.NotContains(t, labels, "Uncordon Node",
+		"EC2NodeClass is a node-launch template, not a node — Uncordon Node does not apply")
 	assert.NotContains(t, labels, "Drain Node",
 		"EC2NodeClass is a node-launch template, not a node — Drain Node does not apply")
 }

--- a/internal/model/actions_karpenter_test.go
+++ b/internal/model/actions_karpenter_test.go
@@ -1,0 +1,64 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestKarpenterActions_NodeClaim locks in the per-kind action set for
+// karpenter.sh/NodeClaim. The three Karpenter-specific verbs — Disrupt,
+// Cordon Node, Drain Node — must be present; Disrupt is the
+// type-to-confirm path (delete the NodeClaim → Karpenter terminates the
+// underlying node), Cordon Node / Drain Node resolve status.nodeName
+// and forward to the standard kubectl helpers.
+func TestKarpenterActions_NodeClaim(t *testing.T) {
+	items := ActionsForKind("NodeClaim")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	assert.Contains(t, labels, "Disrupt",
+		"NodeClaim must offer Disrupt (type-to-confirm; deletes the NodeClaim so Karpenter terminates the node)")
+	assert.Contains(t, labels, "Cordon Node",
+		"NodeClaim must offer Cordon Node (resolves status.nodeName then runs kubectl cordon)")
+	assert.Contains(t, labels, "Drain Node",
+		"NodeClaim must offer Drain Node (resolves status.nodeName then runs the drain flow)")
+	// Standard actions still present.
+	assert.Contains(t, labels, "Describe")
+	assert.Contains(t, labels, "Edit")
+	assert.Contains(t, labels, "Delete")
+	assert.Contains(t, labels, "Events")
+}
+
+// TestKarpenterActions_NodePool keeps the action menu minimal for now —
+// Disable/Enable on spec.disruption.budgets has user-data overlap and
+// is deferred to a follow-up. Generic Describe/Edit/Delete/Events keep
+// the resource visible and editable.
+func TestKarpenterActions_NodePool(t *testing.T) {
+	items := ActionsForKind("NodePool")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	assert.Contains(t, labels, "Describe")
+	assert.Contains(t, labels, "Edit")
+	assert.Contains(t, labels, "Delete")
+	assert.Contains(t, labels, "Events")
+	// Disrupt is for NodeClaim, not NodePool.
+	assert.NotContains(t, labels, "Disrupt",
+		"NodePool does not offer Disrupt — that verb only applies to a single NodeClaim")
+}
+
+// TestKarpenterActions_EC2NodeClass surfaces only generic actions.
+func TestKarpenterActions_EC2NodeClass(t *testing.T) {
+	items := ActionsForKind("EC2NodeClass")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	assert.Contains(t, labels, "Describe")
+	assert.Contains(t, labels, "Edit")
+	assert.Contains(t, labels, "Delete")
+	assert.Contains(t, labels, "Events")
+}

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -275,10 +275,13 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"infrastructure.cluster.x-k8s.io/azuremanagedclusters":     {Category: "infrastructure.cluster.x-k8s.io", DisplayName: "AzureManagedClusters", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"infrastructure.cluster.x-k8s.io/azuremanagedmachinepools": {Category: "infrastructure.cluster.x-k8s.io", DisplayName: "AzureManagedMachinePools", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// Karpenter — ecosystem CRDs; use the generic fallback (core Node uses "⌹").
-	"karpenter.sh/nodepools":           {Category: "karpenter.sh", DisplayName: "NodePools", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
-	"karpenter.sh/nodeclaims":          {Category: "karpenter.sh", DisplayName: "NodeClaims", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
-	"karpenter.k8s.aws/ec2nodeclasses": {Category: "karpenter.k8s.aws", DisplayName: "EC2NodeClasses", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
+	// Karpenter — kind-specific glyphs so node-provisioning CRDs read
+	// at a glance against the surrounding generic-CR rows. Core Node
+	// uses "⌹"; we deliberately stay distinct so a NodePool / NodeClaim
+	// row never gets confused with a real Node row.
+	"karpenter.sh/nodepools":           {Category: "karpenter.sh", DisplayName: "NodePools", Icon: Icon{Unicode: "⏣", Simple: "[NP]", Emoji: "🗄️", NerdFont: "\U000f048b"}},
+	"karpenter.sh/nodeclaims":          {Category: "karpenter.sh", DisplayName: "NodeClaims", Icon: Icon{Unicode: "⌬", Simple: "[NC]", Emoji: "📦", NerdFont: "\U000f048b"}},
+	"karpenter.k8s.aws/ec2nodeclasses": {Category: "karpenter.k8s.aws", DisplayName: "EC2NodeClasses", Icon: Icon{Unicode: "⌶", Simple: "[EC]", Emoji: "🟧", NerdFont: "\U000f0174"}},
 
 	// Prometheus operator — ecosystem CRDs.
 	"monitoring.coreos.com/servicemonitors": {Category: "monitoring.coreos.com", DisplayName: "ServiceMonitors", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},

--- a/internal/model/metadata_test.go
+++ b/internal/model/metadata_test.go
@@ -221,6 +221,14 @@ var allowListedUnicodeCollisions = map[string]string{
 	"cert-manager.io/issuers":        "cert-issuer",
 	"cert-manager.io/clusterissuers": "cert-issuer",
 
+	// Core Node + Karpenter NodePool/NodeClaim share the node-server
+	// NerdFont glyph (nf-md-server) — they are all "node-y" things, and
+	// users scanning the sidebar benefit from a visual family. Distinct
+	// Unicode glyphs (⌹ / ⏣ / ⌬) keep the text-mode terminals readable.
+	"/nodes":                  "karpenter-node-family",
+	"karpenter.sh/nodepools":  "karpenter-node-family",
+	"karpenter.sh/nodeclaims": "karpenter-node-family",
+
 	// Cert-manager ACME flow shares (CertificateRequests, Orders, Challenges).
 	"cert-manager.io/certificaterequests": "cert-acme-flow",
 	"acme.cert-manager.io/orders":         "cert-acme-flow",

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -252,38 +252,6 @@ func RenderNamespaceOverlay(items []model.Item, filter string, cursor int, curre
 	return b.String()
 }
 
-// RenderActionOverlay renders the action menu overlay content.
-func RenderActionOverlay(items []model.Item, cursor int, width int) string {
-	// Account for overlay border (1 each side) + padding (2 each side) = 6 total.
-	innerW := max(width-6, 20)
-
-	var b strings.Builder
-	b.WriteString(OverlayTitleStyle.Render("Actions"))
-	b.WriteString("\n")
-
-	for i, item := range items {
-		keyHint := ""
-		if item.Status != "" {
-			keyHint = "[" + item.Status + "] "
-		}
-		label := fmt.Sprintf("  %s%s - %s", keyHint, item.Name, item.Extra)
-		// Pad label with spaces to fill the inner width.
-		if len(label) < innerW {
-			label += strings.Repeat(" ", innerW-len(label))
-		}
-		if i == cursor {
-			b.WriteString(OverlaySelectedStyle.Render(label))
-		} else {
-			b.WriteString(OverlayNormalStyle.Render(label))
-		}
-		if i < len(items)-1 {
-			b.WriteString("\n")
-		}
-	}
-
-	return b.String()
-}
-
 // RenderConfirmOverlay renders the y/n confirmation overlay content
 // for standard destructive actions (delete, drain).
 //

--- a/internal/ui/overlay_action.go
+++ b/internal/ui/overlay_action.go
@@ -54,9 +54,13 @@ func RenderActionOverlay(items []model.Item, cursor int, width int) string {
 			keyHint = "[" + item.Status + "] "
 		}
 		label := fmt.Sprintf("  %s%s - %s", keyHint, item.Name, item.Extra)
-		// Pad label with spaces to fill the inner width.
-		if len(label) < innerW {
-			label += strings.Repeat(" ", innerW-len(label))
+		// Pad label to fill the inner width. lipgloss.Width counts visual
+		// cells so wide glyphs (CJK, emoji) don't push the row past the
+		// box edge — len() counts bytes and would underfill on multi-byte
+		// runes, leaving a ragged right side under the inverse-video
+		// selection highlight.
+		if lw := lipgloss.Width(label); lw < innerW {
+			label += strings.Repeat(" ", innerW-lw)
 		}
 		if i == cursor {
 			b.WriteString(OverlaySelectedStyle.Render(label))

--- a/internal/ui/overlay_action.go
+++ b/internal/ui/overlay_action.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// ActionOverlayWidth returns the overlay box width needed to render
+// items without wrapping. Sized to fit the longest
+// "  [k] Label - Description" line plus border/padding (6 cells),
+// floored at 70 so short menus keep the historical width, and capped
+// at maxWidth so the overlay never overflows the terminal. The caller
+// passes m.width-10 as maxWidth so the box leaves 5 cells of margin on
+// each side, matching the prior min(70, m.width-10) behaviour.
+func ActionOverlayWidth(items []model.Item, maxWidth int) int {
+	const (
+		floor    = 70
+		overhead = 6 // OverlayStyle border (1+1) + padding (2+2)
+	)
+	contentW := 0
+	for _, item := range items {
+		prefix := ""
+		if item.Status != "" {
+			prefix = "[" + item.Status + "] "
+		}
+		line := "  " + prefix + item.Name + " - " + item.Extra
+		if w := lipgloss.Width(line); w > contentW {
+			contentW = w
+		}
+	}
+	w := max(contentW+overhead, floor)
+	if maxWidth > 0 && w > maxWidth {
+		w = maxWidth
+	}
+	return w
+}
+
+// RenderActionOverlay renders the action menu overlay content.
+func RenderActionOverlay(items []model.Item, cursor int, width int) string {
+	// Account for overlay border (1 each side) + padding (2 each side) = 6 total.
+	innerW := max(width-6, 20)
+
+	var b strings.Builder
+	b.WriteString(OverlayTitleStyle.Render("Actions"))
+	b.WriteString("\n")
+
+	for i, item := range items {
+		keyHint := ""
+		if item.Status != "" {
+			keyHint = "[" + item.Status + "] "
+		}
+		label := fmt.Sprintf("  %s%s - %s", keyHint, item.Name, item.Extra)
+		// Pad label with spaces to fill the inner width.
+		if len(label) < innerW {
+			label += strings.Repeat(" ", innerW-len(label))
+		}
+		if i == cursor {
+			b.WriteString(OverlaySelectedStyle.Render(label))
+		} else {
+			b.WriteString(OverlayNormalStyle.Render(label))
+		}
+		if i < len(items)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -130,6 +130,20 @@ func TestActionOverlayWidth(t *testing.T) {
 		items := []model.Item{{Name: "x", Extra: "y", Status: "z"}}
 		assert.Equal(t, 70, ActionOverlayWidth(items, 0))
 	})
+
+	t.Run("wide glyphs are measured by visual cells", func(t *testing.T) {
+		// CJK glyphs occupy two cells each; a byte-length implementation
+		// would compute 240 bytes for 80 runes and exceed the 90-wide
+		// cap, while the cell-width implementation correctly clamps to
+		// 90 because 80 runes × 2 cells = 160 visual cells. The test
+		// fails if the width helper regresses to len() semantics.
+		wide := strings.Repeat("你", 80) // "你" × 80
+		items := []model.Item{
+			{Name: "Wide", Extra: wide, Status: "W"},
+		}
+		assert.Equal(t, 90, ActionOverlayWidth(items, 90),
+			"wide glyphs must be clamped by visual width, not byte length")
+	})
 }
 
 // --- RenderConfirmOverlay ---

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -93,6 +93,45 @@ func TestRenderActionOverlay(t *testing.T) {
 	assert.Contains(t, result, "[D]")
 }
 
+// --- ActionOverlayWidth ---
+
+func TestActionOverlayWidth(t *testing.T) {
+	t.Run("short menu uses the 70-wide floor", func(t *testing.T) {
+		items := []model.Item{
+			{Name: "Delete", Extra: "Delete this resource", Status: "d"},
+			{Name: "Describe", Extra: "Describe resource", Status: "v"},
+		}
+		// Wide terminal, short content -> floor at 70.
+		assert.Equal(t, 70, ActionOverlayWidth(items, 200))
+	})
+
+	t.Run("long description grows the overlay", func(t *testing.T) {
+		// 80-char Extra forces the overlay past the 70-wide floor.
+		long := strings.Repeat("x", 80)
+		items := []model.Item{
+			{Name: "Long Action", Extra: long, Status: "L"},
+		}
+		got := ActionOverlayWidth(items, 200)
+		assert.Greater(t, got, 70, "menu must grow when content exceeds the 70-wide floor")
+	})
+
+	t.Run("clamps to terminal width", func(t *testing.T) {
+		long := strings.Repeat("x", 200)
+		items := []model.Item{
+			{Name: "Long Action", Extra: long, Status: "L"},
+		}
+		// Cap at 90 -> result must not exceed 90 even though content is wider.
+		assert.Equal(t, 90, ActionOverlayWidth(items, 90))
+	})
+
+	t.Run("non-positive max disables clamp", func(t *testing.T) {
+		// maxWidth <= 0 means "no terminal info"; the floor still applies
+		// so callers never get a tiny overlay even on an uninitialised model.
+		items := []model.Item{{Name: "x", Extra: "y", Status: "z"}}
+		assert.Equal(t, 70, ActionOverlayWidth(items, 0))
+	})
+}
+
 // --- RenderConfirmOverlay ---
 
 func TestRenderConfirmOverlay(t *testing.T) {


### PR DESCRIPTION
## Summary

First batch of the planned Karpenter / Knative / OpenCost work. This PR ships Karpenter; Knative Serving follows next.

### What changes

- **NodeClaim** gains three Karpenter-native actions on top of the standard Describe/Edit/Delete/Events:
  - **Disrupt** — routed through the existing type-to-confirm overlay (user types \`DELETE\` + Enter) before the NodeClaim is deleted. Karpenter observes the deletion and tears down the underlying cloud instance plus the matching core Node.
  - **Cordon Node** / **Drain Node** — resolve \`status.nodeName\` from the NodeClaim and shell out \`kubectl cordon / drain\` against the resolved node. Drain carries the same \`--ignore-daemonsets --delete-emptydir-data\` flags as the standalone Node Drain action. An unbound NodeClaim (Karpenter still provisioning) returns a clear \"status.nodeName empty\" error instead of a generic failure.
- **NodePool** and **EC2NodeClass** stay on the standard Describe/Edit/Delete/Events surface. Disable/Enable via \`spec.disruption.budgets\` is deferred — patching budgets overlaps with user-managed config and deserves its own UX pass.
- **Icons** distinguish the node-family in the sidebar: NodePool ⏣, NodeClaim ⌬, EC2NodeClass ⌶. Core Node keeps ⌹.
- **Read-only mode** gates the three new mutating labels.

### Mechanics

- New \`internal/k8s/karpenter.go\` exposes \`GetNodeClaimNodeName\` and \`DisruptNodeClaim\` on the dynamic client.
- New \`internal/app/commands_karpenter.go\` holds the Tea commands plus the sub-dispatcher \`executeActionKarpenter\` that routes the new labels.
- \`update_actions_extended.go\` (new) extracts the existing \`executeActionExtended\` so \`update_actions.go\` stays under the 800-line file cap (it was at the boundary before this change).

### Out of scope (follow-ups when justified)

- Disable/Enable NodePool via \`spec.disruption.budgets\`.
- Azure / GCP NodeClass curation (fall through to generic CRD path).
- \"Go to Node\" navigation from a NodeClaim row.

## Test plan

- [x] \`internal/model/actions_karpenter_test.go\` — action-menu shape for all three kinds.
- [x] \`internal/k8s/karpenter_test.go\` — dynamic-client tests for \`GetNodeClaimNodeName\` (bound / unbound / not-found) and \`DisruptNodeClaim\` (success / not-found).
- [x] All existing tests still pass (\`go test -race ./...\` clean).
- [x] \`go build ./...\` and \`go vet ./...\` clean.
- [x] \`golangci-lint run\` clean.
- [x] Manual smoke on a real Karpenter cluster (AWS recommended).