### PR TITLE
feat(knative): first-class Knative Serving (Activate) + Eventing icons

### DIFF
--- a/internal/app/commands_knative.go
+++ b/internal/app/commands_knative.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// executeActionKnative dispatches Knative Serving action labels to
+// their Tea commands. Returns ok=true when the label is handled here
+// so executeActionExtended can early-return without growing its
+// switch. Currently surfaces only the Activate verb on Revision; the
+// traffic-split overlay on Service is deferred to a follow-up.
+func (m Model) executeActionKnative(actionLabel string) (tea.Model, tea.Cmd, bool) {
+	if actionLabel == "Activate" {
+		mdl, cmd := m.executeActionSimpleLoading("Activating Revision", m.activateKnativeRevision)
+		return mdl, cmd, true
+	}
+	return m, nil, false
+}
+
+// activateKnativeRevision patches the Revision's parent Knative
+// Service so 100% of traffic routes to the selected Revision. Wrapped
+// in trackBgTask so the title-bar indicator surfaces the in-flight
+// patch and the :tasks overlay records it. The parent Service name is
+// resolved by Client.ActivateKnativeRevision via the standard
+// serving.knative.dev/service label on the Revision; an orphaned
+// Revision returns a clear error naming the missing label.
+func (m Model) activateKnativeRevision() tea.Cmd {
+	ctx := m.actionCtx.context
+	ns := m.actionCtx.namespace
+	name := m.actionCtx.name
+	logger.Info("Knative Revision activation requested", "context", ctx, "namespace", ns, "name", name)
+	return m.trackBgTask(scheduler.KindMutation, "Activate Revision: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+		parent, err := m.client.ActivateKnativeRevision(ctx, ns, name)
+		if err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: fmt.Sprintf("Activated Revision %s on Service %s (100%% traffic)", name, parent)}
+	})
+}

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -79,6 +79,10 @@ var mutatingActions = map[string]bool{
 	"Uncordon Node": true,
 	"Drain Node":    true,
 
+	// Knative Serving mutations. Activate patches the parent Service's
+	// spec.traffic to send 100% to a Revision.
+	"Activate": true,
+
 	// Helm release mutations.
 	"Edit Values": true,
 	"Upgrade":     true,

--- a/internal/app/update_actions_extended.go
+++ b/internal/app/update_actions_extended.go
@@ -5,11 +5,15 @@ import (
 )
 
 // executeActionExtended dispatches Argo / Helm / Flux / cert-manager /
-// KEDA / ExternalSecrets / Karpenter action labels. Returns (model, cmd,
-// handled). Lives in its own file so update_actions.go stays under the
-// 800-line file cap (revive: file-length-limit); the original switch
-// was at the boundary before Karpenter labels were added.
+// KEDA / ExternalSecrets / Karpenter / Knative action labels. Returns
+// (model, cmd, handled). Lives in its own file so update_actions.go
+// stays under the 800-line file cap (revive: file-length-limit); the
+// original switch was at the boundary before ecosystem labels were
+// added.
 func (m Model) executeActionExtended(actionLabel string) (tea.Model, tea.Cmd, bool) {
+	if mdl, cmd, ok := m.executeActionKnative(actionLabel); ok {
+		return mdl, cmd, true
+	}
 	switch actionLabel {
 	case "Disrupt", "Cordon Node", "Uncordon Node", "Drain Node":
 		return m.executeActionKarpenter(actionLabel)

--- a/internal/k8s/capture_backend_kubeshark_test.go
+++ b/internal/k8s/capture_backend_kubeshark_test.go
@@ -42,6 +42,7 @@ func TestDetectKubeshark_Found(t *testing.T) {
 	}
 	if info == nil {
 		t.Fatal("info nil, want populated")
+		return // unreachable; defensive return so staticcheck SA5011 doesn't flag the dereferences below as nilable
 	}
 	if info.Namespace != "kubeshark" || info.HubService != "kubeshark-hub" || info.HubPort != 80 {
 		t.Errorf("info = %+v, want ns=kubeshark name=kubeshark-hub port=80", *info)
@@ -85,6 +86,7 @@ func TestDetectKubeshark_HonoursOverrideNamespace(t *testing.T) {
 	}
 	if info == nil {
 		t.Fatal("info nil — probe did not find Service in the override namespace")
+		return // unreachable; defensive return so staticcheck SA5011 doesn't flag the dereference below
 	}
 	if info.Namespace != "trafcap" {
 		t.Errorf("info.Namespace = %q, want trafcap", info.Namespace)

--- a/internal/k8s/knative.go
+++ b/internal/k8s/knative.go
@@ -1,0 +1,79 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+// knativeRevisionGVR / knativeServiceGVR are the v1 GroupVersionResources
+// for Knative Serving. Knative promoted Serving to v1 in 0.16+; older
+// API versions are out of scope.
+var (
+	knativeRevisionGVR = schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "revisions"}
+	knativeServiceGVR  = schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}
+)
+
+// knativeServiceLabel is the standard Knative label on every Revision
+// (and the pods underneath) that names the parent Service. Knative's
+// own controller sets it; missing the label means the Revision is
+// orphaned (rare — usually a sign of a Service deletion in flight) and
+// the Activate verb cannot resolve a parent to patch.
+const knativeServiceLabel = "serving.knative.dev/service"
+
+// ActivateKnativeRevision sends 100% of traffic to a specific Revision
+// by patching the parent Knative Service's spec.traffic to a single
+// entry pinned to that Revision. This is the canonical Knative
+// rollback / promotion gesture; the controller propagates the new
+// traffic split to the Service's downstream Route within a few seconds.
+//
+// Resolves the parent Service via the standard
+// serving.knative.dev/service label on the Revision (Knative sets it on
+// every Revision; missing means the Revision is orphaned and cannot be
+// activated through the parent). Returns the parent Service name on
+// success so the caller can render a clear status message.
+//
+// The patch replaces spec.traffic — JSON merge-patch treats arrays as
+// atomic, which is the desired semantic here (Activate means "this
+// revision gets all of it, drop everything else"). Existing tags on the
+// previous traffic entries are intentionally dropped; users who need
+// fine-grained traffic management edit the Service YAML directly until
+// the dedicated traffic-split overlay lands (deferred follow-up).
+func (c *Client) ActivateKnativeRevision(contextName, namespace, revisionName string) (parentService string, err error) {
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return "", err
+	}
+	rev, err := dynClient.Resource(knativeRevisionGVR).Namespace(namespace).Get(context.Background(), revisionName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting Revision %s: %w", revisionName, err)
+	}
+	parent := rev.GetLabels()[knativeServiceLabel]
+	if parent == "" {
+		return "", fmt.Errorf("revision %s has no %s label — cannot resolve parent Knative Service", revisionName, knativeServiceLabel)
+	}
+
+	// Build the patch programmatically so the revisionName is safely
+	// JSON-escaped (revision names are alphanumeric+hyphens today but
+	// future Knative versions could relax that).
+	patchBody, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"traffic": []map[string]any{
+				{"revisionName": revisionName, "percent": 100, "latestRevision": false},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("building Activate patch for %s: %w", revisionName, err)
+	}
+	if _, err := dynClient.Resource(knativeServiceGVR).Namespace(namespace).Patch(
+		context.Background(), parent, k8stypes.MergePatchType, patchBody, metav1.PatchOptions{},
+	); err != nil {
+		return "", fmt.Errorf("activating Revision %s on Service %s: %w", revisionName, parent, err)
+	}
+	return parent, nil
+}

--- a/internal/k8s/knative.go
+++ b/internal/k8s/knative.go
@@ -4,11 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
+
+// knativeActivateTimeout bounds the two API calls (GET Revision + PATCH
+// Service) so a hung apiserver doesn't block the worker that ran the
+// Activate command. trackBgTask doesn't propagate the scheduler's
+// per-task timeout into its inner function (no ctx parameter), so the
+// mutation client method has to self-time-out. 30s matches
+// scheduler.DefaultRequestTimeout, the budget the worker pool would
+// otherwise honour.
+const knativeActivateTimeout = 30 * time.Second
 
 // knativeRevisionGVR / knativeServiceGVR are the v1 GroupVersionResources
 // for Knative Serving. Knative promoted Serving to v1 in 0.16+; older
@@ -48,7 +58,9 @@ func (c *Client) ActivateKnativeRevision(contextName, namespace, revisionName st
 	if err != nil {
 		return "", err
 	}
-	rev, err := dynClient.Resource(knativeRevisionGVR).Namespace(namespace).Get(context.Background(), revisionName, metav1.GetOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), knativeActivateTimeout)
+	defer cancel()
+	rev, err := dynClient.Resource(knativeRevisionGVR).Namespace(namespace).Get(ctx, revisionName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("getting Revision %s: %w", revisionName, err)
 	}
@@ -71,7 +83,7 @@ func (c *Client) ActivateKnativeRevision(contextName, namespace, revisionName st
 		return "", fmt.Errorf("building Activate patch for %s: %w", revisionName, err)
 	}
 	if _, err := dynClient.Resource(knativeServiceGVR).Namespace(namespace).Patch(
-		context.Background(), parent, k8stypes.MergePatchType, patchBody, metav1.PatchOptions{},
+		ctx, parent, k8stypes.MergePatchType, patchBody, metav1.PatchOptions{},
 	); err != nil {
 		return "", fmt.Errorf("activating Revision %s on Service %s: %w", revisionName, parent, err)
 	}

--- a/internal/k8s/knative_test.go
+++ b/internal/k8s/knative_test.go
@@ -1,0 +1,110 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestActivateKnativeRevision(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		knativeRevisionGVR: "RevisionList",
+		knativeServiceGVR:  "ServiceList",
+	}
+	rev := &unstructured.Unstructured{}
+	rev.SetUnstructuredContent(map[string]any{
+		"apiVersion": "serving.knative.dev/v1",
+		"kind":       "Revision",
+		"metadata": map[string]any{
+			"name":      "my-svc-00002",
+			"namespace": "default",
+			"labels":    map[string]any{knativeServiceLabel: "my-svc"},
+		},
+	})
+	svc := &unstructured.Unstructured{}
+	svc.SetUnstructuredContent(map[string]any{
+		"apiVersion": "serving.knative.dev/v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "my-svc", "namespace": "default"},
+		"spec": map[string]any{
+			"traffic": []any{
+				map[string]any{"revisionName": "my-svc-00001", "percent": int64(50)},
+				map[string]any{"revisionName": "my-svc-00002", "percent": int64(50)},
+			},
+		},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, rev, svc)
+	c := newFakeClient(nil, dyn)
+
+	parent, err := c.ActivateKnativeRevision("test-ctx", "default", "my-svc-00002")
+	require.NoError(t, err)
+	assert.Equal(t, "my-svc", parent, "must return the resolved parent Service name")
+
+	// Verify the Service's spec.traffic was replaced with a single
+	// 100% entry pointing at the activated Revision. JSON merge-patch
+	// treats arrays as atomic, which is the intended semantic.
+	got, err := dyn.Resource(knativeServiceGVR).Namespace("default").Get(context.Background(), "my-svc", metav1.GetOptions{})
+	require.NoError(t, err)
+	traffic, found, err := unstructured.NestedSlice(got.Object, "spec", "traffic")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, traffic, 1, "traffic should collapse to a single Revision entry")
+	entry, ok := traffic[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "my-svc-00002", entry["revisionName"])
+	// JSON unmarshals numeric literals into float64 through the fake
+	// client; compare via float to avoid spurious type-mismatch failures.
+	pct, _ := json.Marshal(entry["percent"])
+	assert.Equal(t, "100", string(pct))
+	assert.Equal(t, false, entry["latestRevision"],
+		"Activate pins traffic explicitly — latestRevision must NOT be true")
+}
+
+// TestActivateKnativeRevision_OrphanRevision exercises the (rare) case
+// where the Revision exists but carries no serving.knative.dev/service
+// label. The function should surface a clear error naming the missing
+// label rather than blindly attempting a patch with an empty parent.
+func TestActivateKnativeRevision_OrphanRevision(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		knativeRevisionGVR: "RevisionList",
+		knativeServiceGVR:  "ServiceList",
+	}
+	rev := &unstructured.Unstructured{}
+	rev.SetUnstructuredContent(map[string]any{
+		"apiVersion": "serving.knative.dev/v1",
+		"kind":       "Revision",
+		// no serving.knative.dev/service label
+		"metadata": map[string]any{"name": "orphan", "namespace": "default"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, rev)
+	c := newFakeClient(nil, dyn)
+
+	_, err := c.ActivateKnativeRevision("test-ctx", "default", "orphan")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), knativeServiceLabel,
+		"error must name the missing label so the user knows what's wrong")
+}
+
+func TestActivateKnativeRevision_RevisionNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		knativeRevisionGVR: "RevisionList",
+		knativeServiceGVR:  "ServiceList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs)
+	c := newFakeClient(nil, dyn)
+
+	_, err := c.ActivateKnativeRevision("test-ctx", "default", "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting Revision")
+}

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -40,6 +40,15 @@ func ActionsForBulk(kind string) []ActionMenuItem {
 }
 
 // ActionsForKind returns the action menu items appropriate for a given resource kind.
+//
+// Kind collision note: Knative's serving.knative.dev/Service has Kind="Service",
+// which matches the core /v1/Service handler in actionsForCoreKind. Because the
+// core Service menu (Tail Logs, Port Forward, etc.) is largely applicable to
+// Knative Services too — they expose pods underneath — we deliberately do NOT
+// route Knative Services through actionsForKnativeKind. Knative-specific verbs
+// (traffic split editing, scale-min/max via autoscaling.knative.dev annotations)
+// will land on a follow-up that distinguishes Service-by-APIGroup. Revision /
+// Configuration / Route are Knative-only kinds and route here.
 func ActionsForKind(kind string) []ActionMenuItem {
 	if actions, ok := actionsForCoreKind(kind); ok {
 		return actions
@@ -57,6 +66,9 @@ func ActionsForKind(kind string) []ActionMenuItem {
 		return actions
 	}
 	if actions, ok := actionsForKarpenterKind(kind); ok {
+		return actions
+	}
+	if actions, ok := actionsForKnativeKind(kind); ok {
 		return actions
 	}
 	return actionsDefault()
@@ -479,6 +491,50 @@ func actionsForKarpenterKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this EC2NodeClass", Key: "D"},
 			{Label: "Debug Pod", Description: "Run alpine debug pod in namespace", Key: "b"},
+			{Label: "Events", Description: "Show related events", Key: "V"},
+		}, true
+	}
+	return nil, false
+}
+
+// actionsForKnativeKind returns actions for Knative Serving resource
+// kinds. Revision exposes Activate — patching the parent Service's
+// spec.traffic to send 100% of traffic to the selected revision, the
+// canonical Knative rollback / promotion gesture. Configuration and
+// Route stay on the standard surface; their CRD printer columns (URL,
+// LatestReady, Ready) carry the operationally useful state and the
+// generic Describe/Edit/Delete/Events covers the rest.
+//
+// Knative Service (Kind="Service") is NOT routed here — see the
+// comment on ActionsForKind. The core Service menu (Tail Logs, Port
+// Forward, etc.) applies to Knative Services through the pods they
+// expose, and a Knative-specific Service overlay (traffic split, scale
+// min/max) is deferred to a follow-up.
+func actionsForKnativeKind(kind string) ([]ActionMenuItem, bool) {
+	switch kind {
+	case "Revision":
+		return []ActionMenuItem{
+			{Label: "Activate", Description: "Send 100% traffic to this revision (rolls the parent Service)", Key: "a"},
+			{Label: "Describe", Description: "Describe resource", Key: "v"},
+			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
+			{Label: "Delete", Description: "Delete this Revision", Key: "D"},
+			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in namespace", Key: "b"},
+			{Label: "Events", Description: "Show related events", Key: "V"},
+		}, true
+	case "Configuration":
+		return []ActionMenuItem{
+			{Label: "Describe", Description: "Describe resource", Key: "v"},
+			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
+			{Label: "Delete", Description: "Delete this Configuration", Key: "D"},
+			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in namespace", Key: "b"},
+			{Label: "Events", Description: "Show related events", Key: "V"},
+		}, true
+	case "Route":
+		return []ActionMenuItem{
+			{Label: "Describe", Description: "Describe resource", Key: "v"},
+			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
+			{Label: "Delete", Description: "Delete this Route", Key: "D"},
+			{Label: "Debug Pod", Description: "Run standalone alpine debug pod in namespace", Key: "b"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true
 	}

--- a/internal/model/actions_knative_test.go
+++ b/internal/model/actions_knative_test.go
@@ -72,3 +72,28 @@ func TestKnativeActions_Route(t *testing.T) {
 	assert.Contains(t, labels, "Events")
 	assert.NotContains(t, labels, "Activate")
 }
+
+// TestKnativeEventingActions covers the Eventing kinds curated in this
+// PR: Broker, Trigger, Channel, Subscription, EventType. Eventing has
+// no Activate-class promotion gesture (each kind is independent —
+// there's no "promote this Trigger" semantic equivalent to Knative
+// Serving's traffic split), so the menu intentionally stays on the
+// standard surface. Activate must remain absent on all five kinds.
+func TestKnativeEventingActions(t *testing.T) {
+	kinds := []string{"Broker", "Trigger", "Channel", "Subscription", "EventType"}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			items := ActionsForKind(kind)
+			labels := make([]string, 0, len(items))
+			for _, it := range items {
+				labels = append(labels, it.Label)
+			}
+			assert.Contains(t, labels, "Describe")
+			assert.Contains(t, labels, "Edit")
+			assert.Contains(t, labels, "Delete")
+			assert.Contains(t, labels, "Events")
+			assert.NotContains(t, labels, "Activate",
+				"%s is a Knative Eventing kind — Activate is Serving-only", kind)
+		})
+	}
+}

--- a/internal/model/actions_knative_test.go
+++ b/internal/model/actions_knative_test.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestKnativeActions_Revision locks in the Knative-specific verb on
+// Revision: Activate. Activate patches the parent Service's
+// spec.traffic to route 100% of traffic to the selected revision,
+// which is the standard Knative rollback / promotion gesture.
+func TestKnativeActions_Revision(t *testing.T) {
+	items := ActionsForKind("Revision")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	assert.Contains(t, labels, "Activate",
+		"Revision must offer Activate (patches parent Service to send 100% traffic to this revision)")
+	// Standard actions still present.
+	assert.Contains(t, labels, "Describe")
+	assert.Contains(t, labels, "Edit")
+	assert.Contains(t, labels, "Delete")
+	assert.Contains(t, labels, "Events")
+}
+
+// TestKnativeActions_Service surfaces standard actions for now. The
+// Edit Traffic Split overlay from the original plan is deferred to a
+// follow-up — Activate on Revision covers the common "promote this
+// revision" gesture in this PR.
+func TestKnativeActions_Service(t *testing.T) {
+	// "Knative Service" is the curated DisplayName; the dispatcher uses
+	// the Kind value "Service". Knative collides with the core Service
+	// Kind here — see comment in ActionsForKind for the resolution.
+	items := ActionsForKind("Service")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	// Activate is for Revision only — it makes no sense on the parent
+	// Service itself.
+	assert.NotContains(t, labels, "Activate",
+		"Service does not offer Activate — that verb only applies to a Revision")
+}
+
+// TestKnativeActions_Configuration / TestKnativeActions_Route surface
+// only generic actions; Activate lives on Revision, traffic-split
+// editing lives on Service (deferred).
+func TestKnativeActions_Configuration(t *testing.T) {
+	items := ActionsForKind("Configuration")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	assert.Contains(t, labels, "Describe")
+	assert.Contains(t, labels, "Edit")
+	assert.Contains(t, labels, "Delete")
+	assert.Contains(t, labels, "Events")
+	assert.NotContains(t, labels, "Activate")
+}
+
+func TestKnativeActions_Route(t *testing.T) {
+	items := ActionsForKind("Route")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	assert.Contains(t, labels, "Describe")
+	assert.Contains(t, labels, "Edit")
+	assert.Contains(t, labels, "Delete")
+	assert.Contains(t, labels, "Events")
+	assert.NotContains(t, labels, "Activate")
+}

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -351,8 +351,19 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"serving.knative.dev/routes":         {Category: "serving.knative.dev", DisplayName: "Routes", Icon: Icon{Unicode: "↦", Simple: "[Rt]", Emoji: "🛣️", NerdFont: "\U000f04d5"}},
 	"serving.knative.dev/revisions":      {Category: "serving.knative.dev", DisplayName: "Revisions", Icon: Icon{Unicode: "⟲", Simple: "[Rv]", Emoji: "🔁", NerdFont: "\U000f0451"}},
 	"serving.knative.dev/configurations": {Category: "serving.knative.dev", DisplayName: "Configurations", Icon: Icon{Unicode: "⌗", Simple: "[Cf]", Emoji: "📝", NerdFont: "\U000f0493"}},
-	"eventing.knative.dev/triggers":      {Category: "eventing.knative.dev", DisplayName: "Triggers", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
-	"eventing.knative.dev/brokers":       {Category: "eventing.knative.dev", DisplayName: "Brokers", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
+	// Knative Eventing — per-kind glyphs so the event-mesh primitives
+	// read at a glance in the sidebar. Broker ❖ (central hub),
+	// Trigger ↯ (fires events from a Broker to a sink — narrow
+	// lightning; the emoji ⚡ is double-width and breaks single-cell
+	// layout), EventType ❑ (schema/typed-event registry), Channel
+	// ⇉ (event pipe), Subscription ◎ (Channel listener).
+	// InMemoryChannel and the many Source / Flow CRDs stay on the
+	// generic CRD path until a follow-up curates them.
+	"eventing.knative.dev/triggers":   {Category: "eventing.knative.dev", DisplayName: "Triggers", Icon: Icon{Unicode: "↯", Simple: "[Tr]", Emoji: "⚡", NerdFont: "\U000f0241"}},
+	"eventing.knative.dev/brokers":    {Category: "eventing.knative.dev", DisplayName: "Brokers", Icon: Icon{Unicode: "❖", Simple: "[Br]", Emoji: "🎯", NerdFont: "\U000f1170"}},
+	"eventing.knative.dev/eventtypes": {Category: "eventing.knative.dev", DisplayName: "EventTypes", Icon: Icon{Unicode: "❑", Simple: "[Et]", Emoji: "📋", NerdFont: "\U000f0219"}},
+	"messaging.knative.dev/channels":      {Category: "messaging.knative.dev", DisplayName: "Channels", Icon: Icon{Unicode: "⇉", Simple: "[Ch]", Emoji: "📡", NerdFont: "\U000f0317"}},
+	"messaging.knative.dev/subscriptions": {Category: "messaging.knative.dev", DisplayName: "Subscriptions", Icon: Icon{Unicode: "◎", Simple: "[Sb]", Emoji: "📬", NerdFont: "\U000f02d8"}},
 }
 
 // BuiltInOrderRank maps "group/resource" keys to their display rank within

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -351,6 +351,7 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"serving.knative.dev/routes":         {Category: "serving.knative.dev", DisplayName: "Routes", Icon: Icon{Unicode: "↦", Simple: "[Rt]", Emoji: "🛣️", NerdFont: "\U000f04d5"}},
 	"serving.knative.dev/revisions":      {Category: "serving.knative.dev", DisplayName: "Revisions", Icon: Icon{Unicode: "⟲", Simple: "[Rv]", Emoji: "🔁", NerdFont: "\U000f0451"}},
 	"serving.knative.dev/configurations": {Category: "serving.knative.dev", DisplayName: "Configurations", Icon: Icon{Unicode: "⌗", Simple: "[Cf]", Emoji: "📝", NerdFont: "\U000f0493"}},
+
 	// Knative Eventing — per-kind glyphs so the event-mesh primitives
 	// read at a glance in the sidebar. Broker ❖ (central hub),
 	// Trigger ↯ (fires events from a Broker to a sink — narrow
@@ -359,9 +360,9 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	// ⇉ (event pipe), Subscription ◎ (Channel listener).
 	// InMemoryChannel and the many Source / Flow CRDs stay on the
 	// generic CRD path until a follow-up curates them.
-	"eventing.knative.dev/triggers":   {Category: "eventing.knative.dev", DisplayName: "Triggers", Icon: Icon{Unicode: "↯", Simple: "[Tr]", Emoji: "⚡", NerdFont: "\U000f0241"}},
-	"eventing.knative.dev/brokers":    {Category: "eventing.knative.dev", DisplayName: "Brokers", Icon: Icon{Unicode: "❖", Simple: "[Br]", Emoji: "🎯", NerdFont: "\U000f1170"}},
-	"eventing.knative.dev/eventtypes": {Category: "eventing.knative.dev", DisplayName: "EventTypes", Icon: Icon{Unicode: "❑", Simple: "[Et]", Emoji: "📋", NerdFont: "\U000f0219"}},
+	"eventing.knative.dev/triggers":       {Category: "eventing.knative.dev", DisplayName: "Triggers", Icon: Icon{Unicode: "↯", Simple: "[Tr]", Emoji: "⚡", NerdFont: "\U000f0241"}},
+	"eventing.knative.dev/brokers":        {Category: "eventing.knative.dev", DisplayName: "Brokers", Icon: Icon{Unicode: "❖", Simple: "[Br]", Emoji: "🎯", NerdFont: "\U000f1170"}},
+	"eventing.knative.dev/eventtypes":     {Category: "eventing.knative.dev", DisplayName: "EventTypes", Icon: Icon{Unicode: "❑", Simple: "[Et]", Emoji: "📋", NerdFont: "\U000f0219"}},
 	"messaging.knative.dev/channels":      {Category: "messaging.knative.dev", DisplayName: "Channels", Icon: Icon{Unicode: "⇉", Simple: "[Ch]", Emoji: "📡", NerdFont: "\U000f0317"}},
 	"messaging.knative.dev/subscriptions": {Category: "messaging.knative.dev", DisplayName: "Subscriptions", Icon: Icon{Unicode: "◎", Simple: "[Sb]", Emoji: "📬", NerdFont: "\U000f02d8"}},
 }

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -341,11 +341,16 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"kafka.strimzi.io/kafkausers":    {Category: "kafka.strimzi.io", DisplayName: "KafkaUsers", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"kafka.strimzi.io/kafkabridges":  {Category: "kafka.strimzi.io", DisplayName: "KafkaBridges", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// knative
-	"serving.knative.dev/services":       {Category: "serving.knative.dev", DisplayName: "Knative Services", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
-	"serving.knative.dev/routes":         {Category: "serving.knative.dev", DisplayName: "Routes", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
-	"serving.knative.dev/revisions":      {Category: "serving.knative.dev", DisplayName: "Revisions", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
-	"serving.knative.dev/configurations": {Category: "serving.knative.dev", DisplayName: "Configurations", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
+	// Knative Serving — per-kind glyphs so the four-piece Service /
+	// Revision / Configuration / Route mental model reads at a glance.
+	// Service ⌘ (command/orchestrator), Revision ⟲ (versioned snapshot),
+	// Configuration ⌗ (template Revisions are minted from), Route ↦
+	// (the URL → backend mapping). Eventing kinds keep the generic CR
+	// glyph for now — first-class support lands in a follow-up.
+	"serving.knative.dev/services":       {Category: "serving.knative.dev", DisplayName: "Knative Services", Icon: Icon{Unicode: "⌘", Simple: "[KS]", Emoji: "🚀", NerdFont: "\U000f0a07"}},
+	"serving.knative.dev/routes":         {Category: "serving.knative.dev", DisplayName: "Routes", Icon: Icon{Unicode: "↦", Simple: "[Rt]", Emoji: "🛣️", NerdFont: "\U000f04d5"}},
+	"serving.knative.dev/revisions":      {Category: "serving.knative.dev", DisplayName: "Revisions", Icon: Icon{Unicode: "⟲", Simple: "[Rv]", Emoji: "🔁", NerdFont: "\U000f0451"}},
+	"serving.knative.dev/configurations": {Category: "serving.knative.dev", DisplayName: "Configurations", Icon: Icon{Unicode: "⌗", Simple: "[Cf]", Emoji: "📝", NerdFont: "\U000f0493"}},
 	"eventing.knative.dev/triggers":      {Category: "eventing.knative.dev", DisplayName: "Triggers", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"eventing.knative.dev/brokers":       {Category: "eventing.knative.dev", DisplayName: "Brokers", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 }

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -343,23 +343,24 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 
 	// Knative Serving — per-kind glyphs so the four-piece Service /
 	// Revision / Configuration / Route mental model reads at a glance.
-	// Service ⌘ (command/orchestrator), Revision ⟲ (versioned snapshot),
-	// Configuration ⌗ (template Revisions are minted from), Route ↦
-	// (the URL → backend mapping). Eventing kinds keep the generic CR
-	// glyph for now — first-class support lands in a follow-up.
+	// Service "⌘" (command/orchestrator), Revision "⟲" (versioned
+	// snapshot), Configuration "⌗" (template Revisions are minted
+	// from), Route "↦" (URL-to-backend mapping). Eventing kinds get
+	// their own block immediately below.
 	"serving.knative.dev/services":       {Category: "serving.knative.dev", DisplayName: "Knative Services", Icon: Icon{Unicode: "⌘", Simple: "[KS]", Emoji: "🚀", NerdFont: "\U000f0a07"}},
 	"serving.knative.dev/routes":         {Category: "serving.knative.dev", DisplayName: "Routes", Icon: Icon{Unicode: "↦", Simple: "[Rt]", Emoji: "🛣️", NerdFont: "\U000f04d5"}},
 	"serving.knative.dev/revisions":      {Category: "serving.knative.dev", DisplayName: "Revisions", Icon: Icon{Unicode: "⟲", Simple: "[Rv]", Emoji: "🔁", NerdFont: "\U000f0451"}},
 	"serving.knative.dev/configurations": {Category: "serving.knative.dev", DisplayName: "Configurations", Icon: Icon{Unicode: "⌗", Simple: "[Cf]", Emoji: "📝", NerdFont: "\U000f0493"}},
 
 	// Knative Eventing — per-kind glyphs so the event-mesh primitives
-	// read at a glance in the sidebar. Broker ❖ (central hub),
-	// Trigger ↯ (fires events from a Broker to a sink — narrow
-	// lightning; the emoji ⚡ is double-width and breaks single-cell
-	// layout), EventType ❑ (schema/typed-event registry), Channel
-	// ⇉ (event pipe), Subscription ◎ (Channel listener).
-	// InMemoryChannel and the many Source / Flow CRDs stay on the
-	// generic CRD path until a follow-up curates them.
+	// read at a glance in the sidebar. Broker "❖" (central hub),
+	// Trigger "↯" (events fire from a Broker to a sink — narrow
+	// lightning, since the wider emoji-form lightning renders at
+	// width 2 and breaks single-cell layout), EventType "❑"
+	// (schema/typed-event registry), Channel "⇉" (event pipe),
+	// Subscription "◎" (Channel listener). InMemoryChannel and the
+	// many Source / Flow CRDs stay on the generic CRD path until a
+	// follow-up curates them.
 	"eventing.knative.dev/triggers":       {Category: "eventing.knative.dev", DisplayName: "Triggers", Icon: Icon{Unicode: "↯", Simple: "[Tr]", Emoji: "⚡", NerdFont: "\U000f0241"}},
 	"eventing.knative.dev/brokers":        {Category: "eventing.knative.dev", DisplayName: "Brokers", Icon: Icon{Unicode: "❖", Simple: "[Br]", Emoji: "🎯", NerdFont: "\U000f1170"}},
 	"eventing.knative.dev/eventtypes":     {Category: "eventing.knative.dev", DisplayName: "EventTypes", Icon: Icon{Unicode: "❑", Simple: "[Et]", Emoji: "📋", NerdFont: "\U000f0219"}},


### PR DESCRIPTION
## Summary

Second of the three planned ecosystem PRs. Covers Knative **Serving** and **Eventing** in one batch:

- **Serving** gains one Knative-native verb on Revision plus per-kind icons across Service / Revision / Configuration / Route.
- **Eventing** gets curated metadata + kind-specific icons across Trigger / Broker / EventType / Channel / Subscription. The default action menu already covers Eventing's surface, so this is icons + metadata only — there's no Eventing-equivalent of \"send all traffic here.\"

### Serving — Activate

**Revision** action menu adds:

- **Activate** — patches the parent Knative Service's \`spec.traffic\` to route 100% of traffic to the selected Revision. Canonical Knative rollback / promotion gesture. Parent Service resolved via the standard \`serving.knative.dev/service\` label that Knative sets on every Revision; an orphaned Revision (no such label, rare — usually mid-deletion) returns a clear error naming the missing label instead of attempting a blind patch.

The patch replaces \`spec.traffic\` with a single entry pinned to the chosen Revision (\`latestRevision: false\`). JSON merge-patch treats arrays as atomic, which is the intended semantic — \"this Revision gets all the traffic, drop everything else.\"

**Configuration** and **Route** stay on the standard surface; their CRD printer columns (URL, LatestReady, Ready) already carry the operationally useful state.

**Knative Service** (Kind=\"Service\") collides with the core \`/v1/Service\` handler. Because the core Service menu (Tail Logs, Port Forward, etc.) is largely applicable to Knative Services too — they expose pods underneath — Knative Services deliberately stay on the core menu. A Knative-specific Service overlay (traffic-split editor, scale-min/max annotations) is deferred to a follow-up that distinguishes Service-by-APIGroup.

### Eventing — icons only

Curated entries:

| Resource | Glyph | Note |
|---|---|---|
| \`eventing.knative.dev/triggers\` | ↯ | Lightning Down — narrow variant; ⚡ renders at width 2 and breaks single-cell sidebar |
| \`eventing.knative.dev/brokers\` | ❖ | Central event hub |
| \`eventing.knative.dev/eventtypes\` | ❑ | Typed-event schema registry (new curated entry) |
| \`messaging.knative.dev/channels\` | ⇉ | Event pipe (new curated entry) |
| \`messaging.knative.dev/subscriptions\` | ◎ | Channel listener (new curated entry) |

Triggers / Brokers were already in \`BuiltInMetadata\` with the generic ⧫ CR glyph; this swaps them to kind-specific glyphs that match the sidebar pattern. EventTypes / Channels / Subscriptions are new curated entries.

### Icons (Serving)

Per-kind glyphs distinguish the four-piece Service / Revision / Configuration / Route mental model: ⌘ ⟲ ⌗ ↦. (⚙ and ⊞ were candidates but collide with admission configs / PVCs respectively, so swapped before commit.)

### Read-only mode

Gates Activate. Eventing additions are icons-only, no new mutating verbs.

### Mechanics

- New \`internal/k8s/knative.go\` exposes \`ActivateKnativeRevision\` on the dynamic client (with a 30 s \`context.WithTimeout\` since \`trackBgTask\` doesn't propagate the scheduler's per-task timeout).
- New \`internal/app/commands_knative.go\` holds the Tea command plus the \`executeActionKnative\` sub-dispatcher.
- \`update_actions_extended.go\` extracted from \`update_actions.go\` so the file stays under the 800-line cap. Same extraction trick PR #223 (Karpenter) uses; whichever PR merges first sets up the shared file and the other rebases cleanly.

### Out of scope (follow-ups when justified)

- Traffic-split overlay on Service (multi-Revision edit).
- Scale Min/Max via \`autoscaling.knative.dev/min-scale\` and \`max-scale\` annotations.
- Service-by-APIGroup dispatch so Knative-specific Service verbs can coexist with the core Service menu.
- InMemoryChannel and other messaging implementations.
- Source CRDs (ApiServerSource, PingSource, ContainerSource, KafkaSource, etc.) — many shapes; benefit from per-Source curation.
- Flow CRDs (Sequence, Parallel).
- Eventing-specific verbs (resend-from-DLQ, test-filter, show-broker-URL) — none are obvious wins and all require significant new UI surface.

## Test plan

- [x] \`internal/model/actions_knative_test.go\`:
   - Serving: \`TestKnativeActions_Revision\` / \`_Service\` / \`_Configuration\` / \`_Route\` — \`Activate\` present on Revision, absent everywhere else.
   - Eventing: \`TestKnativeEventingActions\` — Broker / Trigger / Channel / Subscription / EventType each surface the standard Describe/Edit/Delete/Events set, and \`Activate\` is explicitly absent.
- [x] \`internal/k8s/knative_test.go\` — dynamic-client tests for \`ActivateKnativeRevision\` (happy path collapsing traffic to one entry, orphaned Revision, Revision-not-found).
- [x] All existing tests still pass (\`go test -race ./...\` clean).
- [x] \`go build ./...\` and \`go vet ./...\` clean.
- [x] \`golangci-lint run\` clean.
- [ ] Manual smoke on a real Knative cluster.