### PR TITLE
fix(app): respect KUBE_EDITOR and parse editor flags

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -188,7 +188,7 @@ All keybindings can be overridden. Only specify the keys you want to change -- d
 | `delete` | `D` | Delete resource (force delete Pod/Job if already deleting) |
 | `force_delete` | `X` | Force delete (Pod/Job only) |
 | `scale` | `S` | Scale resource (deployments, statefulsets, daemonsets) |
-| `edit` | `E` | Edit selected resource in $EDITOR |
+| `edit` | `E` | Edit selected resource in $KUBE_EDITOR or $EDITOR |
 | `label_editor` | `i` | Edit labels/annotations |
 | `secret_editor` | `e` | Secret/ConfigMap editor |
 | `column_toggle` | `,` | Column visibility toggle |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -134,7 +134,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `A` | Toggle all-namespaces mode (also works inside the namespace selector — clears individual selections and enables all-ns) | `all_namespaces` |
 | `L` | View logs for selected resource | `logs` |
 | `e` | Secret/ConfigMap editor (inline key-value editing) | `secret_editor` |
-| `E` | Edit selected resource in $EDITOR | `edit` |
+| `E` | Edit selected resource in $KUBE_EDITOR or $EDITOR | `edit` |
 | `R` | Refresh current view | `refresh` |
 | `v` | Describe selected resource | `describe` |
 | `D` | Delete resource (force delete Pod/Job if already deleting, force finalize others) | `delete` |
@@ -251,7 +251,7 @@ a single-character slot.
 | `z` | Toggle fold on section under cursor |
 | `Z` | Toggle all folds (collapse/expand all) |
 | `Ctrl+W` / `>` | Toggle line wrapping |
-| `Ctrl+E` | Edit resource in `$EDITOR` |
+| `Ctrl+E` | Edit resource in `$KUBE_EDITOR` or `$EDITOR` |
 | `q` / `Esc` | Back to explorer |
 
 ## Describe View
@@ -989,7 +989,7 @@ keybindings:
   refresh: "R"           # Refresh view
   restart: "r"           # Restart resource (action menu only)
   exec: "s"              # Exec into container (action menu only)
-  edit: "E"              # Edit in $EDITOR
+  edit: "E"              # Edit in $KUBE_EDITOR or $EDITOR
   describe: "v"          # Describe resource
   delete: "D"            # Delete resource
   force_delete: "X"      # Force delete

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/google/gopacket v1.1.19
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	github.com/muesli/termenv v0.16.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs104wLj8l5GEththEw6+F79YsIY=

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -60,7 +60,7 @@ var startupTips = []string{
 	"Press y to copy resource name, Y to copy YAML",
 	"Press . for quick filter presets (failing pods, not-ready, etc.)",
 	"Press T to preview different color themes, in preview mode press t to hide theme background",
-	"Press e to edit resources with your $EDITOR",
+	"Press e to edit resources with your $KUBE_EDITOR or $EDITOR",
 	"Press v to describe a resource (like kubectl describe)",
 	"Press p to pin/unpin CRD groups for quick access",
 	"Press Shift+H to surface rarely used resource types (CSI, webhooks, leases, advanced core)",

--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -52,10 +52,7 @@ func (m Model) applyFromClipboard() tea.Cmd {
 	_ = tmpFile.Close()
 
 	// Open in editor for review/editing before applying.
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "vi"
-	}
+	editor := editorCommand()
 	tmpPath := tmpFile.Name()
 
 	// Record modification time before opening editor.
@@ -64,7 +61,7 @@ func (m Model) applyFromClipboard() tea.Cmd {
 		origModTime = fi.ModTime()
 	}
 
-	cmd := exec.Command(editor, tmpPath)
+	cmd := exec.Command(editor[0], append(editor[1:], tmpPath)...)
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		if err != nil {
 			_ = os.Remove(tmpPath)
@@ -74,8 +71,8 @@ func (m Model) applyFromClipboard() tea.Cmd {
 	})
 }
 
-// applyTemplate creates a temp file with the template YAML, opens it in $EDITOR,
-// then applies it with kubectl after the editor exits.
+// applyTemplate creates a temp file with the template YAML, opens it in
+// $KUBE_EDITOR or $EDITOR, then applies it with kubectl after the editor exits.
 func (m Model) applyTemplate(tmpl model.ResourceTemplate) tea.Cmd {
 	ns := m.effectiveNamespace()
 	if ns == "" {
@@ -103,10 +100,7 @@ func (m Model) applyTemplate(tmpl model.ResourceTemplate) tea.Cmd {
 	_ = tmpFile.Close()
 
 	// Determine editor.
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "vi"
-	}
+	editor := editorCommand()
 
 	tmpPath := tmpFile.Name()
 
@@ -116,7 +110,7 @@ func (m Model) applyTemplate(tmpl model.ResourceTemplate) tea.Cmd {
 		origModTime = fi.ModTime()
 	}
 
-	cmd := exec.Command(editor, tmpPath)
+	cmd := exec.Command(editor[0], append(editor[1:], tmpPath)...)
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		if err != nil {
 			_ = os.Remove(tmpPath)

--- a/internal/app/commands_exec_helm.go
+++ b/internal/app/commands_exec_helm.go
@@ -68,7 +68,7 @@ fi
 # Save checksum before editing
 BEFORE=$(md5sum "$TMPFILE" 2>/dev/null || md5 -q "$TMPFILE" 2>/dev/null || cat "$TMPFILE")
 
-${EDITOR:-${VISUAL:-vi}} "$TMPFILE"
+${KUBE_EDITOR:-${EDITOR:-${VISUAL:-vi}}} "$TMPFILE"
 
 AFTER=$(md5sum "$TMPFILE" 2>/dev/null || md5 -q "$TMPFILE" 2>/dev/null || cat "$TMPFILE")
 

--- a/internal/app/editor.go
+++ b/internal/app/editor.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/google/shlex"
+)
+
+// editorCommand resolves the user's preferred editor following kubectl's
+// convention: KUBE_EDITOR takes precedence over EDITOR, with a
+// platform-specific fallback (notepad on Windows, vi elsewhere).
+//
+// The returned slice is split with shell-style quoting so values like
+// "code --wait" or "vim -p" pass flags correctly. The first element is
+// the binary to exec; remaining elements are args to prepend before the
+// caller's file argument.
+//
+// On parse failure (unbalanced quotes), falls back to the platform
+// default so the editor still launches.
+func editorCommand() []string {
+	raw := os.Getenv("KUBE_EDITOR")
+	if raw == "" {
+		raw = os.Getenv("EDITOR")
+	}
+	if raw == "" {
+		return []string{platformDefaultEditor()}
+	}
+	parts, err := shlex.Split(raw)
+	if err != nil || len(parts) == 0 {
+		return []string{platformDefaultEditor()}
+	}
+	return parts
+}
+
+func platformDefaultEditor() string {
+	if runtime.GOOS == "windows" {
+		return "notepad"
+	}
+	return "vi"
+}

--- a/internal/app/editor_test.go
+++ b/internal/app/editor_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestEditorCommand(t *testing.T) {
+	platformDefault := "vi"
+	if runtime.GOOS == "windows" {
+		platformDefault = "notepad"
+	}
+
+	tests := []struct {
+		name       string
+		kubeEditor string
+		editor     string
+		want       []string
+	}{
+		{
+			name:       "KUBE_EDITOR wins over EDITOR",
+			kubeEditor: "nano",
+			editor:     "emacs",
+			want:       []string{"nano"},
+		},
+		{
+			name:       "EDITOR used when KUBE_EDITOR empty",
+			kubeEditor: "",
+			editor:     "emacs",
+			want:       []string{"emacs"},
+		},
+		{
+			name:       "platform default when both empty",
+			kubeEditor: "",
+			editor:     "",
+			want:       []string{platformDefault},
+		},
+		{
+			name:       "splits editor with flags",
+			kubeEditor: "code --wait",
+			editor:     "",
+			want:       []string{"code", "--wait"},
+		},
+		{
+			name:       "preserves quoted path with spaces",
+			kubeEditor: `"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" --wait`,
+			editor:     "",
+			want:       []string{"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl", "--wait"},
+		},
+		{
+			name:       "malformed input falls back to platform default",
+			kubeEditor: `vim "unterminated`,
+			editor:     "",
+			want:       []string{platformDefault},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KUBE_EDITOR", tt.kubeEditor)
+			t.Setenv("EDITOR", tt.editor)
+			got := editorCommand()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("editorCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/update_actions_helm_misc.go
+++ b/internal/app/update_actions_helm_misc.go
@@ -134,7 +134,7 @@ func (m Model) executeActionEditValues() (tea.Model, tea.Cmd) {
 	ns := m.actionCtx.namespace
 	name := m.actionCtx.name
 	ctx := m.actionCtx.context
-	m.addLogEntry("DBG", fmt.Sprintf("$ helm get values %s -n %s --kube-context %s -o yaml → $EDITOR → helm upgrade --reuse-values", name, ns, ctx))
+	m.addLogEntry("DBG", fmt.Sprintf("$ helm get values %s -n %s --kube-context %s -o yaml → $KUBE_EDITOR/$EDITOR → helm upgrade --reuse-values", name, ns, ctx))
 	return m, m.editHelmValues()
 }
 

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -269,7 +269,7 @@ func actionsForWorkloadKind(kind string) ([]ActionMenuItem, bool) {
 		return []ActionMenuItem{
 			{Label: "Values", Description: "View user-supplied values", Key: "u"},
 			{Label: "All Values", Description: "View all values (including defaults)", Key: "A"},
-			{Label: "Edit Values", Description: "Edit values in $EDITOR", Key: "E"},
+			{Label: "Edit Values", Description: "Edit values in $KUBE_EDITOR or $EDITOR", Key: "E"},
 			{Label: "Diff", Description: "Compare default vs user-supplied values", Key: "d"},
 			{Label: "Upgrade", Description: "Upgrade release to latest chart version", Key: "U"},
 			{Label: "Rollback", Description: "Pick from revision history to apply rollback", Key: "R"},

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -88,7 +88,7 @@ func helpSections() []helpSection {
 				{kb.ActionMenu, "Action menu: l=tail logs (last 10 lines + follow), L=full logs, exec, debug, debug pod, describe, edit, delete, scale, port-forward, events, startup analysis, crash investigator, traffic capture, RBAC permissions"},
 				{kb.Logs, "View full logs for selected resource"},
 				{kb.Describe, "Describe selected resource"},
-				{kb.Edit, "Edit selected resource in $EDITOR"},
+				{kb.Edit, "Edit selected resource in $KUBE_EDITOR or $EDITOR"},
 				{kb.SecretEditor, "Secret/ConfigMap editor (inline key-value editing)"},
 				{kb.LabelEditor, "Edit labels/annotations for selected resource"},
 				{kb.Refresh, "Refresh current view"},


### PR DESCRIPTION
## Summary

- Match kubectl's editor precedence (`KUBE_EDITOR` → `EDITOR` → platform default: `notepad` on Windows, `vi` elsewhere) in the apply/create temp-file flow and the Helm "Edit Values" script.
- Fix a latent bug in the same path: editor strings with flags (`code --wait`, `vim -p`) or quoted paths with spaces failed because the entire env var was passed as one binary name. Now parsed with `google/shlex` (same lib kubectl uses).
- Falls back to the platform default on shlex parse errors so the editor still launches.

Closes #225.

## What was wrong

`a` (create resource) writes a temp YAML and opens `os.Getenv("EDITOR")` with a `vi` fallback. On Windows with only `KUBE_EDITOR` set, that fallback triggers and `vi` is missing — the reported failure mode.

The `e` (edit) keybinding wasn't affected because it shells out to `kubectl edit`, which already honors `KUBE_EDITOR`. This PR aligns lfk's other editor entry points with that convention.

## Test plan

- [x] `go test -race ./internal/app/... ./internal/model/... ./internal/ui/...` — all pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] New unit tests cover: KUBE_EDITOR precedence, EDITOR fallback, platform default, flag splitting, quoted paths with spaces, malformed-input fallback
- [ ] Manual: with `KUBE_EDITOR` set, press `a` and verify the configured editor opens (not `vi`)
- [ ] Manual on Windows: with both env vars unset, verify `notepad` opens instead of crashing on missing `vi`
- [ ] Manual: `KUBE_EDITOR="code --wait"` and press `a` — verify VS Code opens with the file

## Files

| File | Change |
|---|---|
| `internal/app/editor.go` (new) | `editorCommand()` helper returning `[]string` (cmd + args) |
| `internal/app/editor_test.go` (new) | 6 table-driven cases |
| `internal/app/commands_apply.go` | Both apply paths use the helper + `append` args |
| `internal/app/commands_exec_helm.go` | Bash script: `${KUBE_EDITOR:-${EDITOR:-${VISUAL:-vi}}}` |
| `internal/app/commands.go`, `internal/model/actions.go`, `internal/app/update_actions_helm_misc.go`, `internal/ui/help_sections.go` | Help/UI text mentions both env vars |
| `docs/keybindings.md`, `docs/config-reference.md` | Docs updated |
| `go.mod`, `go.sum` | `github.com/google/shlex` added |