### PR TITLE
fix(nix): build with Go 1.26.3 by overriding pkgs.go_1_26

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,17 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
 
+        # go.mod requires 1.26.3 (security). nixpkgs/master currently ships
+        # go_1_26 = 1.26.2; override the source to the official 1.26.3 tarball
+        # until nixpkgs catches up, then delete this block.
+        go_1_26_3 = pkgs.go_1_26.overrideAttrs (_: rec {
+          version = "1.26.3";
+          src = pkgs.fetchurl {
+            url = "https://go.dev/dl/go${version}.src.tar.gz";
+            hash = "sha256-HGRoddCqh5kTMYTtV895/yS97+jIggRwYCqdPW2Rkrg=";
+          };
+        });
+
         # Single source of truth for the release version. Updated automatically
         # by the release-please bot on every Release PR via the marker comment
         # below; release.yml then verifies this matches the pushed tag so the
@@ -29,13 +40,13 @@
       in
       {
         packages = {
-          default = pkgs.buildGoModule {
+          default = (pkgs.buildGoModule.override { go = go_1_26_3; }) {
             pname = "lfk";
             inherit version;
 
             src = ./.;
 
-            vendorHash = "sha256-nEMHImlytPq9FhN6Rb5mmBMpZ7d+II1MirD0xLLZv+A=";
+            vendorHash = "sha256-zUfHbY8zyQxKOuruwi0G6J+d5o3ihU96Hg1OqPRtB9g=";
 
             subPackages = [ "." ];
 


### PR DESCRIPTION
## Summary
- `go.mod` requires Go 1.26.3 (upstream security fixes); `nixpkgs/master` currently ships `go_1_26 = 1.26.2`, so `nix build .` fails with a toolchain version mismatch.
- Override `pkgs.go_1_26`'s `src` with the official 1.26.3 source tarball from `go.dev`. SHA verified against `https://go.dev/dl/?mode=json`.
- Refresh `vendorHash` to match the 1.26.3 vendor layout.

## Cleanup
Delete the `go_1_26_3` block and revert `(pkgs.buildGoModule.override { go = go_1_26_3; })` back to `pkgs.buildGoModule` once nixpkgs ships 1.26.3. `vendorHash` will likely change again at that point — `make refresh-vendor-hash`.

## Test plan
- [x] `nix flake check --no-build` passes
- [x] `nix build .#default` produces `result/bin/lfk`
- [x] `go version ./result/bin/lfk` prints `go1.26.3`
- [x] `./result/bin/lfk --version` reports `v0.11.4`