### PR TITLE
feat(filters): add Not Running / Not Bound presets and config invert flag

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -296,10 +296,14 @@ custom_actions:
 #     restarts_gt:  Match pods with restart count greater than this number
 #     column:       Column key to check (case-insensitive, e.g., "Node", "IP")
 #     column_value: Substring match against the column value (case-insensitive)
+#     invert:       true to negate the entire match (e.g., status=Bound + invert
+#                   matches anything that is NOT Bound)
 #
-# Built-in presets vary by kind (Pod gets Failing/Pending/NotReady/Restarting,
-# Deployment gets NotReady/Failing, etc.). Universal presets (Old, Recent)
-# are always shown. Your custom presets appear after the built-ins.
+# Built-in presets vary by kind. Pod: Failing/Pending/Not Ready/Restarting/
+# High Restarts/Not Running. Deployment/StatefulSet/DaemonSet: Not Ready/
+# Failing/Not Running. Job: Failed/Not Running. PVC: Pending/Lost/Not Bound.
+# Universal presets (Old, Recent) are always shown. Your custom presets appear
+# after the built-ins.
 filter_presets:
 # Pod:
 #   - name: "On GPU Nodes"

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -394,6 +394,27 @@ filter_presets:
 | `restarts_gt` | Match pods with restart count greater than this number |
 | `column` | Column key to check (case-insensitive, e.g., "Node", "IP") |
 | `column_value` | Substring match against the column value (case-insensitive) |
+| `invert` | `true` to negate the entire match. Other fields still AND together; the final boolean is flipped. Useful for "anything except X" filters, e.g., `status: Bound` + `invert: true` matches every PVC that is NOT Bound. |
+
+### Built-in Presets
+
+Press `.` on any resource list to see the presets available for that kind. The built-ins are:
+
+| Kind | Presets (key) |
+|---|---|
+| Pod | Failing (`f`), Pending (`p`), Not Ready (`n`), Restarting (`r`), High Restarts (`R`), **Not Running (`x`)** |
+| Deployment / StatefulSet / DaemonSet | Not Ready (`n`), Failing (`f`), **Not Running (`x`)** |
+| Job | Failed (`f`), **Not Running (`x`)** |
+| PersistentVolumeClaim | Pending (`p`), Lost (`l`), **Not Bound (`x`)** |
+| Node | Not Ready (`n`), Cordoned (`c`) |
+| Certificate / CertificateRequest | Not Ready (`n`), Expiring Soon (`e`) |
+| Service | LB No IP (`l`) |
+| CronJob | Suspended (`s`) |
+| Argo Application | Out of Sync (`s`), Degraded (`d`) |
+| Flux HelmRelease / Kustomization | Suspended (`s`), Not Ready (`n`) |
+| Event | Warnings (`w`) |
+
+The `x` key (Not Running / Not Bound) is the shared "show me anything not in a healthy state" mnemonic across the kinds where it applies — k9s `Ctrl-Z` equivalent. Universal presets `Old (>30d)` (`o`) and `Recent (<1h)` (`h`) are also available on every list.
 
 ## Secret lazy loading
 

--- a/internal/app/filters.go
+++ b/internal/app/filters.go
@@ -107,6 +107,12 @@ func kindFilterPresets(kind string) []FilterPreset {
 	}
 }
 
+// notRunningKey is the shared shortcut for "show me anything not in a
+// healthy / running state". Bound to the same letter across Pod, PVC,
+// Workload, and Job lists so the user has one mnemonic, mirroring the
+// orphan-preset shared-key pattern.
+const notRunningKey = "x"
+
 func podFilterPresets() []FilterPreset {
 	return []FilterPreset{
 		{
@@ -129,7 +135,28 @@ func podFilterPresets() []FilterPreset {
 		{Name: "Not Ready", Description: "Ready containers mismatch", Key: "n", MatchFn: matchReadyMismatch},
 		{Name: "Restarting", Description: "Restart count > 0", Key: "r", MatchFn: matchRestartsGt(0)},
 		{Name: "High Restarts", Description: "Restart count > 10", Key: "R", MatchFn: matchRestartsGt(10)},
+		{
+			Name: "Not Running", Description: "Pod phase != Running", Key: notRunningKey,
+			MatchFn: func(item model.Item) bool {
+				return item.Status != "" && !strings.EqualFold(item.Status, "Running")
+			},
+		},
 	}
+}
+
+// matchWorkloadNotRunning is the predicate behind both the workload `Failing`
+// and `Not Running` presets: replicas mismatch OR unavailable replicas OR a
+// failure status string. Shared so the two presets stay in sync; their names
+// differ only to fit different mental models (issue-tracking vs. health-check).
+func matchWorkloadNotRunning(item model.Item) bool {
+	s := strings.ToLower(item.Status)
+	if s == "failed" || s == "error" || s == "degraded" {
+		return true
+	}
+	if ua := columnValue(item, "Unavailable"); ua != "" && ua != "0" {
+		return true
+	}
+	return matchReadyMismatch(item)
 }
 
 func workloadFilterPresets() []FilterPreset {
@@ -137,16 +164,11 @@ func workloadFilterPresets() []FilterPreset {
 		{Name: "Not Ready", Description: "Ready replicas != desired", Key: "n", MatchFn: matchReadyMismatch},
 		{
 			Name: "Failing", Description: "Progressing=False or unavailable replicas", Key: "f",
-			MatchFn: func(item model.Item) bool {
-				s := strings.ToLower(item.Status)
-				if s == "failed" || s == "error" || s == "degraded" {
-					return true
-				}
-				if ua := columnValue(item, "Unavailable"); ua != "" && ua != "0" {
-					return true
-				}
-				return matchReadyMismatch(item)
-			},
+			MatchFn: matchWorkloadNotRunning,
+		},
+		{
+			Name: "Not Running", Description: "Not Ready or unavailable / failed replicas", Key: notRunningKey,
+			MatchFn: matchWorkloadNotRunning,
 		},
 	}
 }
@@ -173,6 +195,20 @@ func jobFilterPresets() []FilterPreset {
 			MatchFn: func(item model.Item) bool {
 				s := strings.ToLower(item.Status)
 				return strings.Contains(s, "failed") || strings.Contains(s, "backofflimit")
+			},
+		},
+		{
+			Name: "Not Running", Description: "Job is not active and not completed", Key: notRunningKey,
+			MatchFn: func(item model.Item) bool {
+				if item.Status == "" {
+					return false
+				}
+				s := strings.ToLower(item.Status)
+				switch s {
+				case "running", "active", "complete", "completed", "succeeded":
+					return false
+				}
+				return true
 			},
 		},
 	}
@@ -273,6 +309,12 @@ func pvcFilterPresets() []FilterPreset {
 		{
 			Name: "Lost", Description: "PVC lost its backing volume", Key: "l",
 			MatchFn: func(item model.Item) bool { return strings.EqualFold(item.Status, "lost") },
+		},
+		{
+			Name: "Not Bound", Description: "Phase != Bound (Pending / Lost / Released / Available)", Key: notRunningKey,
+			MatchFn: func(item model.Item) bool {
+				return item.Status != "" && !strings.EqualFold(item.Status, "Bound")
+			},
 		},
 	}
 }
@@ -524,8 +566,11 @@ func needsOrphanCache(kind string) bool {
 }
 
 // buildConfigMatchFn converts a ConfigFilterMatch into a MatchFn closure.
+// `m.Invert` negates the AND-result of all other fields, making it possible
+// to express "matches anything that does NOT satisfy these criteria"
+// (e.g. PVC `status: Bound` + `invert: true` => Not Bound).
 func buildConfigMatchFn(m ui.ConfigFilterMatch) func(model.Item) bool {
-	return func(item model.Item) bool {
+	core := func(item model.Item) bool {
 		// All non-zero fields must match (AND logic).
 		if m.Status != "" {
 			if !strings.Contains(strings.ToLower(item.Status), strings.ToLower(m.Status)) {
@@ -558,4 +603,8 @@ func buildConfigMatchFn(m ui.ConfigFilterMatch) func(model.Item) bool {
 		}
 		return true
 	}
+	if m.Invert {
+		return func(item model.Item) bool { return !core(item) }
+	}
+	return core
 }

--- a/internal/app/filters.go
+++ b/internal/app/filters.go
@@ -311,7 +311,7 @@ func pvcFilterPresets() []FilterPreset {
 			MatchFn: func(item model.Item) bool { return strings.EqualFold(item.Status, "lost") },
 		},
 		{
-			Name: "Not Bound", Description: "Phase != Bound (Pending / Lost / Released / Available)", Key: notRunningKey,
+			Name: "Not Bound", Description: "Phase != Bound", Key: notRunningKey,
 			MatchFn: func(item model.Item) bool {
 				return item.Status != "" && !strings.EqualFold(item.Status, "Bound")
 			},

--- a/internal/app/filters_test.go
+++ b/internal/app/filters_test.go
@@ -366,6 +366,27 @@ func TestBuildConfigMatchFn(t *testing.T) {
 			t.Error("expected status to fail")
 		}
 	})
+
+	t.Run("invert negates result", func(t *testing.T) {
+		// status=Bound + invert=true should match anything that is NOT Bound,
+		// and reject anything that IS Bound.
+		fn := buildConfigMatchFn(ui.ConfigFilterMatch{Status: "Bound", Invert: true})
+		if fn(model.Item{Status: "Bound"}) {
+			t.Error("expected Bound NOT to match an inverted status=Bound rule")
+		}
+		if !fn(model.Item{Status: "Pending"}) {
+			t.Error("expected Pending to match an inverted status=Bound rule")
+		}
+	})
+
+	t.Run("invert on empty match still rejects (matches all -> matches none)", func(t *testing.T) {
+		// Empty ConfigFilterMatch matches every item (no constraints).
+		// invert=true on it should then reject every item.
+		fn := buildConfigMatchFn(ui.ConfigFilterMatch{Invert: true})
+		if fn(model.Item{Status: "Running"}) {
+			t.Error("expected inverted empty rule to reject all items")
+		}
+	})
 }
 
 // --- helpers ---
@@ -540,5 +561,107 @@ func TestNeedsOrphanCache_OtherKinds(t *testing.T) {
 		t.Run(kind, func(t *testing.T) {
 			assert.False(t, needsOrphanCache(kind))
 		})
+	}
+}
+
+// --- Not Running / Not Bound presets ---
+
+func TestPodNotRunningPreset(t *testing.T) {
+	presets := builtinFilterPresets("Pod")
+	p := findPreset(presets, "Not Running")
+	require.NotNil(t, p, "Pod 'Not Running' preset missing")
+	assert.Equal(t, notRunningKey, p.Key)
+
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"Running", false},
+		{"running", false}, // case-insensitive
+		{"", false},        // empty status should not match
+		{"Pending", true},
+		{"Failed", true},
+		{"CrashLoopBackOff", true},
+		{"Completed", true}, // strict: anything != Running
+		{"Terminating", true},
+		{"ContainerCreating", true},
+	}
+	for _, tt := range tests {
+		item := model.Item{Status: tt.status}
+		assert.Equal(t, tt.want, p.MatchFn(item), "Pod Not Running(%q)", tt.status)
+	}
+}
+
+func TestPVCNotBoundPreset(t *testing.T) {
+	presets := builtinFilterPresets("PersistentVolumeClaim")
+	p := findPreset(presets, "Not Bound")
+	require.NotNil(t, p, "PVC 'Not Bound' preset missing")
+	assert.Equal(t, notRunningKey, p.Key)
+
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"Bound", false},
+		{"bound", false},
+		{"", false},
+		{"Pending", true},
+		{"Lost", true},
+		{"Available", true},
+		{"Released", true},
+	}
+	for _, tt := range tests {
+		item := model.Item{Status: tt.status}
+		assert.Equal(t, tt.want, p.MatchFn(item), "PVC Not Bound(%q)", tt.status)
+	}
+}
+
+func TestWorkloadNotRunningPreset(t *testing.T) {
+	for _, kind := range []string{"Deployment", "StatefulSet", "DaemonSet"} {
+		t.Run(kind, func(t *testing.T) {
+			presets := builtinFilterPresets(kind)
+			p := findPreset(presets, "Not Running")
+			require.NotNil(t, p, "%s 'Not Running' preset missing", kind)
+			assert.Equal(t, notRunningKey, p.Key)
+
+			// Healthy: Ready=3/3, no failure status, no unavailable column.
+			assert.False(t, p.MatchFn(model.Item{Ready: "3/3"}))
+			// Replicas mismatch -> Not Running.
+			assert.True(t, p.MatchFn(model.Item{Ready: "1/3"}))
+			// Degraded / failure status -> Not Running.
+			assert.True(t, p.MatchFn(model.Item{Ready: "3/3", Status: "Degraded"}))
+			assert.True(t, p.MatchFn(model.Item{Ready: "3/3", Status: "Failed"}))
+			// Unavailable column > 0 -> Not Running.
+			assert.True(t, p.MatchFn(model.Item{
+				Ready:   "3/3",
+				Columns: []model.KeyValue{{Key: "Unavailable", Value: "1"}},
+			}))
+		})
+	}
+}
+
+func TestJobNotRunningPreset(t *testing.T) {
+	presets := builtinFilterPresets("Job")
+	p := findPreset(presets, "Not Running")
+	require.NotNil(t, p, "Job 'Not Running' preset missing")
+	assert.Equal(t, notRunningKey, p.Key)
+
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"Running", false},
+		{"Complete", false},
+		{"Completed", false},
+		{"Succeeded", false},
+		{"Active", false},
+		{"", false},
+		{"Failed", true},
+		{"BackoffLimitExceeded", true},
+		{"Pending", true},
+	}
+	for _, tt := range tests {
+		item := model.Item{Status: tt.status}
+		assert.Equal(t, tt.want, p.MatchFn(item), "Job Not Running(%q)", tt.status)
 	}
 }

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -269,7 +269,10 @@ func (m Model) renderOverlayFilterPreset() (string, int, int) {
 	for i, p := range m.filterPresets {
 		entries[i] = ui.FilterPresetEntry{Name: p.Name, Description: p.Description, Key: p.Key}
 	}
-	overlayW := min(72, m.width-10)
+	// FilterPresetOverlayWidth floors at 72 (historical width) and grows to
+	// fit the longest preset row, capped at terminal-10 so the overlay leaves
+	// margin. Mirrors the adaptive sizing used by the action menu overlay.
+	overlayW := ui.FilterPresetOverlayWidth(entries, m.width-10)
 	// OverlayStyle reserves 4 cells horizontally for Padding(1, 2).
 	contentW := max(overlayW-4, 0)
 	return ui.RenderFilterPresetOverlay(entries, m.overlayCursor, activePresetName, contentW), overlayW, min(15, m.height-6)

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -176,12 +176,17 @@ var ConfigResourceColumns map[string][]string
 var ConfigClusterResourceColumns map[string]map[string][]string
 
 // ConfigFilterMatch defines the match criteria for a user-configured filter preset.
+// Fields are AND-ed together. When `Invert` is true the resulting boolean is
+// negated, so e.g. `status: Bound` + `invert: true` matches everything that is
+// NOT Bound. The pre-existing `ReadyNot` flag remains for fine-grained Ready
+// negation; rule-level `Invert` is the general escape hatch.
 type ConfigFilterMatch struct {
 	Status      string `json:"status" yaml:"status"`
 	ReadyNot    bool   `json:"ready_not" yaml:"ready_not"`
 	RestartsGt  int    `json:"restarts_gt" yaml:"restarts_gt"`
 	Column      string `json:"column" yaml:"column"`
 	ColumnValue string `json:"column_value" yaml:"column_value"`
+	Invert      bool   `json:"invert" yaml:"invert"`
 }
 
 // ConfigFilterPreset defines a single user-configured filter preset.

--- a/internal/ui/overlay_monitoring_extra_test.go
+++ b/internal/ui/overlay_monitoring_extra_test.go
@@ -110,6 +110,42 @@ func TestRenderFilterPresetOverlay(t *testing.T) {
 	})
 }
 
+// --- FilterPresetOverlayWidth ---
+
+func TestFilterPresetOverlayWidth(t *testing.T) {
+	t.Run("short presets use the 72-wide floor", func(t *testing.T) {
+		presets := []FilterPresetEntry{
+			{Name: "Failing", Description: "CrashLoop / Error", Key: "f"},
+			{Name: "Pending", Description: "Container starting", Key: "p"},
+		}
+		assert.Equal(t, 72, FilterPresetOverlayWidth(presets, 200))
+	})
+
+	t.Run("long description grows the overlay past the floor", func(t *testing.T) {
+		presets := []FilterPresetEntry{
+			{Name: "X", Description: strings.Repeat("y", 90), Key: "x"},
+		}
+		assert.Greater(t, FilterPresetOverlayWidth(presets, 200), 72,
+			"overlay must grow when content exceeds the 72-wide floor")
+	})
+
+	t.Run("clamps to maxWidth", func(t *testing.T) {
+		presets := []FilterPresetEntry{
+			{Name: "X", Description: strings.Repeat("y", 200), Key: "x"},
+		}
+		assert.Equal(t, 90, FilterPresetOverlayWidth(presets, 90))
+	})
+
+	t.Run("non-positive max disables clamp but keeps floor", func(t *testing.T) {
+		presets := []FilterPresetEntry{{Name: "a", Description: "b", Key: "c"}}
+		assert.Equal(t, 72, FilterPresetOverlayWidth(presets, 0))
+	})
+
+	t.Run("empty presets returns floor", func(t *testing.T) {
+		assert.Equal(t, 72, FilterPresetOverlayWidth(nil, 200))
+	})
+}
+
 // --- RenderRBACOverlay ---
 
 func TestRenderRBACOverlay(t *testing.T) {

--- a/internal/ui/overlay_monitoring_misc.go
+++ b/internal/ui/overlay_monitoring_misc.go
@@ -8,6 +8,35 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// FilterPresetOverlayWidth returns the overlay box width needed to render
+// the longest preset row without wrapping. Mirrors ActionOverlayWidth: floored
+// at 72 (the historical fixed width) so short menus keep their stable size,
+// capped at maxWidth so the overlay can't overflow the terminal. The caller
+// passes m.width-10 to leave 5 cells of margin on each side.
+func FilterPresetOverlayWidth(presets []FilterPresetEntry, maxWidth int) int {
+	const (
+		floor = 72
+		// OverlayStyle reserves 4 cells horizontally (Padding(1,2) = 2+2);
+		// the border itself is rendered outside the overlay's reported size,
+		// matching the existing -4 convention in renderOverlayFilterPreset.
+		overhead = 4
+	)
+	contentW := 0
+	for _, p := range presets {
+		// Worst-case layout: "  ✓ [key] Name  Description" (2 leading spaces,
+		// 2-cell marker, "[k] " = 4 cells, name, "  " gap, description).
+		line := "  ✓ [" + p.Key + "] " + p.Name + "  " + p.Description
+		if w := lipgloss.Width(line); w > contentW {
+			contentW = w
+		}
+	}
+	w := max(contentW+overhead, floor)
+	if maxWidth > 0 && w > maxWidth {
+		w = maxWidth
+	}
+	return w
+}
+
 // RenderFilterPresetOverlay renders the quick filter preset selection overlay content.
 // activePresetName is the name of the currently active preset (empty if none).
 // width is the inner content width used to pad the cursor row so the


### PR DESCRIPTION
Closes #227.

## Summary
- **New built-in quick-filter presets** bound to the same key `x` across kinds, so users have one mnemonic for "show me anything not in a healthy / running state" (k9s `Ctrl-Z` equivalent):

  | Kind | Preset | Predicate |
  |---|---|---|
  | Pod | Not Running | `phase != Running` (strict) |
  | PVC | Not Bound | `phase != Bound` (strict) |
  | Deployment / StatefulSet / DaemonSet | Not Running | replicas mismatch OR unavailable replicas OR failure status (shares helper with `Failing`) |
  | Job | Not Running | status not in `Running/Active/Complete/Succeeded` |

  Node, Certificate, and Flux already have an equivalent `Not Ready` preset and are intentionally not duplicated.

- **New `invert` flag** on user-defined filter presets in the config file. Composes with **every** match field — `status`, `ready_not`, `restarts_gt`, `column`, `column_value`. The other fields still AND together as before; `invert: true` flips the final boolean. Lets users express "anything except X" without per-field Not variants.

  Status-based example (PVC "Not Bound" as a user preset):
  ```yaml
  filter_presets:
    PersistentVolumeClaim:
      - name: Not Bound (custom)
        key: b
        match:
          status: Bound
          invert: true
  ```

  Column-based example (Pods NOT on GPU nodes):
  ```yaml
  filter_presets:
    Pod:
      - name: Off GPU Nodes
        key: G
        match:
          column: Node
          column_value: gpu
          invert: true
  ```

  Note: `invert` flips the AND-result, so combined-field rules express De Morgan's law — `A AND B + invert` matches `NOT A OR NOT B`, not `NOT A AND NOT B`. Use one constraint per rule for simple "anything except X" semantics. See `docs/config-reference.md` for the full match-field table.

## Test plan
- [x] New table-driven tests for all four built-in presets (status matrix covers strict / boundary / empty cases)
- [x] Subtests for `Invert` covering both negate-of-positive-match and negate-of-vacuous-match
- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Docs updated: `docs/config-reference.md` (invert field + built-in preset matrix), `docs/config-example.yaml` (invert field, refreshed kind summary)