### PR TITLE
feat(copy): open copy-as picker on Y with YAML / JSON / Table options

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@
 
 - **Resource templates**: Create resources from 25+ built-in templates (`a`, `/` to search); includes a Custom Resource template as a starting point
 - **Port forwarding** from the action menu (with local port setting and browser open); manage active forwards via the Networking group
-- **Clipboard support**: Copy resource name (`y`), YAML (`Y`), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
+- **Clipboard support**: Copy resource name (`y`), open copy-as picker (`Y`: YAML / JSON / Table), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
 - **Bookmarks**: Save favorite resource paths for quick navigation
 - **Orphan detection**: Press `Shift+O` (or run bare `:orphans`) to open the cluster-wide orphan overview across 11 kinds — Pods, Secrets, ConfigMaps, Services, PVCs, HPAs, PDBs, NetworkPolicies, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings. Per-list filters are still available via the filter-preset overlay (`.`) on each kind, or jump straight to a filtered view with `:orphans <kind>` (e.g., `:orphans secrets`). A strict / lenient toggle (`s`) flips between "truly unused" and "currently idle but referenced by workload templates" (e.g. CronJob between firings). Auto-excludes Helm release Secrets, ServiceAccount tokens, owner-managed resources, and `kube-root-ca.crt`.
 - **Session persistence**: Remembers last context/namespace/resource across restarts
@@ -273,7 +273,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `L` | View logs |
 | `v` | Describe resource |
 | `D` / `X` | Delete / force delete |
-| `y` / `Y` | Copy name / YAML to clipboard |
+| `y` / `Y` | Copy name / open copy-as picker (YAML / JSON / Table) |
 | `Space` | Toggle multi-selection (bulk actions via `x`) |
 | `m<slot>` / `'<slot>` | Set / jump to bookmark (lowercase = context-aware, uppercase = context-free) |
 | `t` / `]` / `[` | New tab / next / previous |

--- a/TESTS.md
+++ b/TESTS.md
@@ -214,3 +214,29 @@ kind delete cluster --name capture-test
 # If kubeshark was installed:
 helm uninstall kubeshark --namespace kubeshark 2>/dev/null || true
 ```
+
+## Copy-as picker (`Y`)
+
+The `Y` key opens an overlay picker offering YAML / JSON / Table output. Lowercase `y` still copies the resource name (unchanged).
+
+### Test matrix
+
+| # | Setup | Action | Expected |
+|---|---|---|---|
+| 1 | LevelClusters, cursor on a context row | Press `Y` → Enter | Clipboard contains an aligned-table view of the cluster row. Status: `Table copied to clipboard`. |
+| 2 | LevelResourceTypes, cursor on a kind row | Press `Y` → `t` | Same as #1, but Table-only picker (no YAML/JSON rows shown). |
+| 3 | LevelResources (Pods), 3 pods selected via Space | Press `Y` → `j` (cursor down) → Enter | Clipboard contains a JSON array of 3 Pod manifests. Status: `Copied 3 manifests as JSON`. |
+| 4 | LevelResources, no selection, cursor on a Deployment row | Press `Y` → `y` | Clipboard contains the single Deployment YAML. Status: `YAML copied to clipboard`. |
+| 5 | LevelResources, 51 items selected | Press `Y` | Picker does NOT open. Status: `Max 50 exceeded for bulk YAML/JSON copy`. |
+| 6 | LevelOwned (Pods of a Deployment), 4 selected | Press `Y` → Enter (YAML default cursor) | Clipboard has 4 Pod manifests joined with `---`. Status: `Copied 4 manifests as YAML`. |
+| 7 | LevelContainers, 2 init containers selected | Press `Y` → `y` | Clipboard has 2 container spec blocks joined with `---`, not the full Pod manifest. Status: `Copied 2 manifests as YAML`. |
+| 8 | LevelContainers, cursor on a container row, no selection | Press `Y` → Enter | Clipboard has just that container's spec block. |
+| 9 | Picker open (any level) | Press `Esc` | Picker closes. Clipboard unchanged. No status message. |
+| 10 | Picker open at LevelResources | Press `t` | Picker applies Table immediately (single keystroke). |
+
+### Notes
+
+- `j` is consumed as cursor-down inside the picker, so JSON requires Enter on the JSON row (not the `j` shortcut).
+- Table format never paginates — it renders the entire selection in one block. There is no 50-item cap on Table.
+- `:export yaml` and `:export json` in the command bar still work and bypass the picker (legacy entry points unchanged).
+

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -157,7 +157,7 @@ Resource-specific actions (exec, scale, restart, secret editor, etc.) are availa
 | Key | Action |
 |---|---|
 | `y` | Copy resource name to clipboard (with multi-selection: newline-joined names of all selected items) |
-| `Y` | Copy resource YAML to clipboard (with multi-selection: multi-doc YAML, items joined with `---`) |
+| `Y` | Open copy-as picker (YAML / JSON / Table). YAML/JSON support multi-selection (multi-doc YAML joined with `---`, JSON array). Table is a kubectl-style aligned plain-text view of the displayed columns. At LevelClusters and LevelResourceTypes only Table is offered. At LevelContainers, YAML and JSON extract the container spec block from the Pod manifest. |
 | `Ctrl+P` | Apply resource from clipboard (`kubectl apply`) |
 
 When items are multi-selected (`Space` / `Ctrl+Space` / `Ctrl+A`), `y` and `Y` operate on the selection rather than the cursor row — mirroring the precedence used by `D` (delete) and other bulk actions. `Y` is capped at 50 manifests per copy (client-go's default rate limiter serializes the per-item fetches).
@@ -998,7 +998,7 @@ keybindings:
   secret_editor: "e"     # Secret/configmap editor
   create_template: "a"   # Create from template
   copy_name: "y"         # Copy name
-  copy_yaml: "Y"         # Copy YAML
+  copy_yaml: "Y"         # Open copy-as picker (YAML / JSON / Table)
   paste_apply: "ctrl+p"  # Apply from clipboard
   open_browser: "ctrl+o" # Open in browser
   diff: "d"              # Diff resources

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,11 +91,11 @@ type Model struct {
 	// Current view mode.
 	mode viewMode
 
-	// Overlay state.
-	overlay       overlayKind
-	overlayItems  []model.Item // full list (e.g., all namespaces)
-	overlayFilter TextInput    // typed filter text
-	overlayCursor int
+	overlay          overlayKind  // active overlay kind (see overlayKind enum)
+	overlayItems     []model.Item // full list (e.g., all namespaces)
+	overlayFilter    TextInput    // typed filter text
+	overlayCursor    int
+	copyFormatPicker copyFormatPickerState // Y-key copy-as picker — see openCopyFormatPicker
 
 	// Namespace (not a navigation level; displayed in top-right).
 	namespace string

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -79,6 +79,7 @@ const (
 	overlaySyncWave       // per-Application sync wave timeline (action menu key W)
 	overlayLocalClusters  // local-cluster manager (Ctrl+N at LevelClusters)
 	overlayTrafficCapture // per-pod live packet capture (action menu key c)
+	overlayCopyFormat     // Y-key copy-as picker (YAML / JSON / Table)
 )
 
 // whoCanState groups the reverse-RBAC ("Who-Can") fields so they live

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -771,6 +771,7 @@ func wrapYAMLCmdAsJSON(cmd tea.Cmd) tea.Cmd {
 				return yc
 			}
 			yc.content = string(jsonBytes) + "\n"
+			yc.format = "json"
 			return yc
 		}
 		docs := strings.Split(strings.TrimRight(yc.content, "\n"), "\n---\n")
@@ -789,6 +790,7 @@ func wrapYAMLCmdAsJSON(cmd tea.Cmd) tea.Cmd {
 			return yc
 		}
 		yc.content = string(arrayBytes) + "\n"
+		yc.format = "json"
 		return yc
 	}
 }

--- a/internal/app/commandbar_execute_test.go
+++ b/internal/app/commandbar_execute_test.go
@@ -570,7 +570,7 @@ func TestExecuteBuiltinCommand(t *testing.T) {
 		result, cmd := m.executeBuiltinCommand("export yaml")
 		rm := result.(Model)
 
-		assert.Equal(t, fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), rm.statusMessage)
+		assert.Equal(t, fmt.Sprintf("Max %d exceeded for bulk YAML/JSON copy", maxBulkYAMLCopy), rm.statusMessage)
 		assert.True(t, rm.statusMessageErr, "must surface as error toast")
 		assert.NotNil(t, cmd, "auto-clear timer is still dispatched")
 	})
@@ -606,10 +606,11 @@ func TestExecuteBuiltinCommand(t *testing.T) {
 		assert.NotNil(t, cmd)
 	})
 
-	// LevelContainers must NOT show "Fetching N...": copyYAMLToClipboard
-	// fetches the parent Pod by OwnedName regardless of selection (containers
-	// don't have separate YAML), so the bulk indicator would be a lie.
-	t.Run("export_yaml_at_level_containers_falls_back_silently", func(t *testing.T) {
+	// LevelContainers now supports bulk: when N containers are selected,
+	// the dispatcher fetches the parent Pod once and extracts the matching
+	// container spec blocks, so "Fetching N manifests..." correctly reflects
+	// the N requested container blocks.
+	t.Run("export_yaml_at_level_containers_uses_bulk", func(t *testing.T) {
 		m := basePush80Model()
 		m.nav.Level = model.LevelContainers
 		m.nav.OwnedName = "pod-1"
@@ -623,8 +624,8 @@ func TestExecuteBuiltinCommand(t *testing.T) {
 		result, cmd := m.executeBuiltinCommand("export yaml")
 		rm := result.(Model)
 
-		assert.Empty(t, rm.statusMessage,
-			"LevelContainers cmd ignores selection; dispatcher must skip the bulk indicator")
+		assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage,
+			"LevelContainers now supports bulk; dispatcher must show the fetching toast")
 		assert.NotNil(t, cmd)
 	})
 

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -57,7 +57,7 @@ var startupTips = []string{
 	"Press @ to open the monitoring dashboard",
 	"Press o to jump to the parent/owner of a resource",
 	"Press m<key> to save a bookmark, ' to open bookmarks",
-	"Press y to copy resource name, Y to copy YAML",
+	"Press y to copy resource name, Y to open copy-as picker (YAML / JSON / Table)",
 	"Press . for quick filter presets (failing pods, not-ready, etc.)",
 	"Press T to preview different color themes, in preview mode press t to hide theme background",
 	"Press e to edit resources with your $KUBE_EDITOR or $EDITOR",

--- a/internal/app/commands_yaml.go
+++ b/internal/app/commands_yaml.go
@@ -142,9 +142,138 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 		}
 	case model.LevelContainers:
 		podName := m.nav.OwnedName
+		// Bulk path: if the user has selected N containers in this Pod,
+		// fetch the Pod manifest once and extract just those container
+		// spec blocks. Falls through to the whole-Pod cursor path when
+		// nothing is selected (back-compat with existing single-cursor
+		// behavior).
+		if items := m.selectedItemsList(); len(items) > 0 {
+			names := make([]string, len(items))
+			for i, it := range items {
+				names[i] = it.Name
+			}
+			return func() tea.Msg {
+				content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
+				if err != nil {
+					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+				}
+				out, err := ExtractContainerBlocksYAML(content, names)
+				if err != nil {
+					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+				}
+				return yamlClipboardMsg{content: out, count: len(names)}
+			}
+		}
 		return func() tea.Msg {
 			content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
 			return yamlClipboardMsg{content: content, count: 1, err: err}
+		}
+	}
+	return nil
+}
+
+// copyYAMLForScope is the scope-driven sibling of copyYAMLToClipboard.
+// It builds a YAML fetch tea.Cmd from the supplied items instead of
+// re-reading the live selection — used by the copy-as picker to honor
+// the snapshot captured at picker-open time. Returns nil for an empty
+// scope at any level. LevelContainers extracts each container spec
+// block from the Pod YAML.
+func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
+	if len(scope) == 0 {
+		return nil
+	}
+	kctx := m.nav.Context
+	ns := m.resolveNamespace()
+
+	switch m.nav.Level {
+	case model.LevelResources:
+		rt := m.nav.ResourceType
+		type fetchTarget struct {
+			ns, name string
+		}
+		targets := make([]fetchTarget, len(scope))
+		for i, it := range scope {
+			itemNs := ns
+			if it.Namespace != "" {
+				itemNs = it.Namespace
+			}
+			targets[i] = fetchTarget{ns: itemNs, name: it.Name}
+		}
+		return func() tea.Msg {
+			docs := make([]string, 0, len(targets))
+			for _, t := range targets {
+				content, err := m.client.GetResourceYAML(context.Background(), kctx, t.ns, rt, t.name)
+				if err != nil {
+					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+				}
+				docs = append(docs, strings.TrimRight(content, "\n"))
+			}
+			return yamlClipboardMsg{
+				content: strings.Join(docs, "\n---\n") + "\n",
+				count:   len(docs),
+			}
+		}
+	case model.LevelOwned:
+		type fetchTarget struct {
+			ns, name string
+			isPod    bool
+			rt       model.ResourceTypeEntry
+			resolved bool
+			kind     string
+		}
+		targets := make([]fetchTarget, len(scope))
+		for i, it := range scope {
+			itemNs := ns
+			if it.Namespace != "" {
+				itemNs = it.Namespace
+			}
+			t := fetchTarget{ns: itemNs, name: it.Name, kind: it.Kind, isPod: it.Kind == "Pod"}
+			if !t.isPod {
+				t.rt, t.resolved = m.resolveOwnedResourceType(&scope[i])
+			}
+			targets[i] = t
+		}
+		return func() tea.Msg {
+			docs := make([]string, 0, len(targets))
+			for _, t := range targets {
+				var (
+					content string
+					err     error
+				)
+				switch {
+				case t.isPod:
+					content, err = m.client.GetPodYAML(context.Background(), kctx, t.ns, t.name)
+				case t.resolved:
+					content, err = m.client.GetResourceYAML(context.Background(), kctx, t.ns, t.rt, t.name)
+				default:
+					err = fmt.Errorf("unknown resource type: %s", t.kind)
+				}
+				if err != nil {
+					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+				}
+				docs = append(docs, strings.TrimRight(content, "\n"))
+			}
+			return yamlClipboardMsg{
+				content: strings.Join(docs, "\n---\n") + "\n",
+				count:   len(docs),
+			}
+		}
+	case model.LevelContainers:
+		podName := m.nav.OwnedName
+		names := make([]string, len(scope))
+		for i, it := range scope {
+			names[i] = it.Name
+		}
+		return func() tea.Msg {
+			content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
+			if err != nil {
+				return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+			}
+			out, err := ExtractContainerBlocksYAML(content, names)
+			if err != nil {
+				return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+			}
+			return yamlClipboardMsg{content: out, count: len(names)}
 		}
 	}
 	return nil

--- a/internal/app/commands_yaml_test.go
+++ b/internal/app/commands_yaml_test.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestSupportsBulkYAMLCopy_IncludesContainers(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelContainers
+	assert.True(t, m.supportsBulkYAMLCopy(),
+		"LevelContainers must be in the bulk allowlist so Y → picker → YAML over multiple selected containers copies all of them rather than silently fetching one Pod's whole manifest")
+}

--- a/internal/app/copy_format.go
+++ b/internal/app/copy_format.go
@@ -1,0 +1,76 @@
+package app
+
+import (
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// CopyFormat enumerates the output formats offered by the Y-key
+// copy-as picker. Order is the picker's display order — keep YAML
+// first since it's the most kubectl-friendly default.
+type CopyFormat int
+
+const (
+	CopyFormatYAML CopyFormat = iota
+	CopyFormatJSON
+	CopyFormatTable
+)
+
+// Label returns the title-case display string ("YAML", "JSON",
+// "Table"). Used by the picker UI and the clipboard status text.
+func (f CopyFormat) Label() string {
+	switch f {
+	case CopyFormatYAML:
+		return "YAML"
+	case CopyFormatJSON:
+		return "JSON"
+	case CopyFormatTable:
+		return "Table"
+	}
+	return ""
+}
+
+// ShortcutKey returns the single-letter shortcut that selects this
+// format directly from the picker. JSON deliberately returns "" — the
+// natural shortcut would be "j", but the picker key router consumes
+// "j" for cursor-down navigation, so users apply JSON via Enter on
+// its row (or navigate to it and press Enter). Returning "" here is
+// the single source of truth: the picker view shows no [j] chip and
+// the key router skips JSON in its shortcut loop.
+func (f CopyFormat) ShortcutKey() string {
+	switch f {
+	case CopyFormatYAML:
+		return "y"
+	case CopyFormatTable:
+		return "t"
+	}
+	return ""
+}
+
+// statusKey returns the lowercase identifier stored in
+// yamlClipboardMsg.format so updateYamlClipboard can render the
+// right status text. Mirrors the values copyFormatStatusParts
+// switches on.
+func (f CopyFormat) statusKey() string {
+	switch f {
+	case CopyFormatYAML:
+		return "yaml"
+	case CopyFormatJSON:
+		return "json"
+	case CopyFormatTable:
+		return "table"
+	}
+	return ""
+}
+
+// availableCopyFormats returns the picker rows applicable at the
+// given navigation level. Clusters and ResourceTypes only support
+// Table (there is no manifest behind those rows). All other levels
+// offer the full YAML / JSON / Table set.
+func availableCopyFormats(level model.Level) []CopyFormat {
+	switch level {
+	case model.LevelClusters, model.LevelResourceTypes:
+		return []CopyFormat{CopyFormatTable}
+	default:
+		return []CopyFormat{CopyFormatYAML, CopyFormatJSON, CopyFormatTable}
+	}
+}

--- a/internal/app/copy_format_container.go
+++ b/internal/app/copy_format_container.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ExtractContainerBlocksYAML returns the YAML for the given container
+// names extracted from podYAML. Looks under spec.containers,
+// spec.initContainers, and spec.ephemeralContainers. Single name →
+// a single YAML document. Multiple names → YAML documents joined
+// with "\n---\n". Returns an error listing the first missing name
+// when any requested name resolves in none of the lists.
+func ExtractContainerBlocksYAML(podYAML string, names []string) (string, error) {
+	blocks, err := extractContainerBlocks(podYAML, names)
+	if err != nil {
+		return "", err
+	}
+	docs := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		out, err := yaml.Marshal(b)
+		if err != nil {
+			return "", fmt.Errorf("marshaling container %q: %w", b["name"], err)
+		}
+		docs = append(docs, strings.TrimRight(string(out), "\n"))
+	}
+	return strings.Join(docs, "\n---\n") + "\n", nil
+}
+
+// ExtractContainerBlocksJSON mirrors ExtractContainerBlocksYAML but
+// emits JSON. One name → a JSON object; multiple names → a JSON array.
+func ExtractContainerBlocksJSON(podYAML string, names []string) (string, error) {
+	blocks, err := extractContainerBlocks(podYAML, names)
+	if err != nil {
+		return "", err
+	}
+	if len(blocks) == 1 {
+		b, err := json.Marshal(blocks[0])
+		if err != nil {
+			return "", fmt.Errorf("marshaling container %q: %w", blocks[0]["name"], err)
+		}
+		return string(b) + "\n", nil
+	}
+	b, err := json.Marshal(blocks)
+	if err != nil {
+		return "", fmt.Errorf("marshaling container array: %w", err)
+	}
+	return string(b) + "\n", nil
+}
+
+// extractContainerBlocks parses podYAML and returns each requested
+// container's spec block (a map[string]any) in the requested order.
+// Looks across spec.containers, spec.initContainers, and
+// spec.ephemeralContainers. Returns an error on the first name that
+// resolves in none of the lists.
+func extractContainerBlocks(podYAML string, names []string) ([]map[string]any, error) {
+	var pod map[string]any
+	if err := yaml.Unmarshal([]byte(podYAML), &pod); err != nil {
+		return nil, fmt.Errorf("parsing Pod manifest: %w", err)
+	}
+	spec, _ := pod["spec"].(map[string]any)
+	if spec == nil {
+		return nil, fmt.Errorf("pod manifest has no spec")
+	}
+	index := indexContainers(spec)
+	out := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		block, ok := index[name]
+		if !ok {
+			meta, _ := pod["metadata"].(map[string]any)
+			podName, _ := meta["name"].(string)
+			return nil, fmt.Errorf("container %q not found in Pod %q", name, podName)
+		}
+		out = append(out, block)
+	}
+	return out, nil
+}
+
+// indexContainers walks spec.containers, spec.initContainers, and
+// spec.ephemeralContainers and returns a name → block map. First
+// occurrence wins; since K8s validation prevents duplicate names
+// across these lists this branch is never taken in practice.
+func indexContainers(spec map[string]any) map[string]map[string]any {
+	out := map[string]map[string]any{}
+	collect := func(key string) {
+		list, _ := spec[key].([]any)
+		for _, c := range list {
+			block, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, _ := block["name"].(string)
+			if name == "" {
+				continue
+			}
+			if _, exists := out[name]; exists {
+				continue
+			}
+			out[name] = block
+		}
+	}
+	collect("containers")
+	collect("initContainers")
+	collect("ephemeralContainers")
+	return out
+}

--- a/internal/app/copy_format_container_test.go
+++ b/internal/app/copy_format_container_test.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleContainerPodYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  namespace: default
+spec:
+  initContainers:
+    - name: init-db
+      image: busybox:1.36
+      command: ["sh", "-c", "wait-for-db"]
+  containers:
+    - name: app
+      image: nginx:1.25
+      ports:
+        - containerPort: 80
+    - name: sidecar
+      image: envoyproxy/envoy:v1.30
+  ephemeralContainers:
+    - name: debugger
+      image: busybox:1.36
+`
+
+func TestExtractContainerBlocksYAML_Single(t *testing.T) {
+	out, err := ExtractContainerBlocksYAML(sampleContainerPodYAML, []string{"app"})
+	require.NoError(t, err)
+	assert.Contains(t, out, "name: app")
+	assert.Contains(t, out, "image: nginx:1.25")
+	assert.NotContains(t, out, "sidecar")
+	assert.NotContains(t, out, "init-db")
+}
+
+func TestExtractContainerBlocksYAML_InitContainer(t *testing.T) {
+	out, err := ExtractContainerBlocksYAML(sampleContainerPodYAML, []string{"init-db"})
+	require.NoError(t, err)
+	assert.Contains(t, out, "name: init-db")
+	assert.Contains(t, out, "image: busybox:1.36")
+}
+
+func TestExtractContainerBlocksYAML_Multi(t *testing.T) {
+	out, err := ExtractContainerBlocksYAML(sampleContainerPodYAML, []string{"app", "sidecar"})
+	require.NoError(t, err)
+	// Two YAML docs joined with ---
+	assert.Equal(t, 1, strings.Count(out, "\n---\n"))
+	assert.Contains(t, out, "name: app")
+	assert.Contains(t, out, "name: sidecar")
+}
+
+func TestExtractContainerBlocksYAML_NotFound(t *testing.T) {
+	_, err := ExtractContainerBlocksYAML(sampleContainerPodYAML, []string{"missing"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
+	assert.Contains(t, err.Error(), "web") // Pod name from sampleContainerPodYAML
+}
+
+func TestExtractContainerBlocksYAML_EphemeralContainer(t *testing.T) {
+	out, err := ExtractContainerBlocksYAML(sampleContainerPodYAML, []string{"debugger"})
+	require.NoError(t, err)
+	assert.Contains(t, out, "name: debugger")
+	assert.Contains(t, out, "image: busybox:1.36")
+}
+
+func TestExtractContainerBlocksJSON_Single(t *testing.T) {
+	out, err := ExtractContainerBlocksJSON(sampleContainerPodYAML, []string{"app"})
+	require.NoError(t, err)
+	// JSON object for single container
+	assert.True(t, strings.HasPrefix(out, "{"))
+	assert.Contains(t, out, "\"name\":\"app\"")
+}
+
+func TestExtractContainerBlocksJSON_MultiIsArray(t *testing.T) {
+	out, err := ExtractContainerBlocksJSON(sampleContainerPodYAML, []string{"app", "init-db"})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(out, "["))
+	assert.Contains(t, out, "\"name\":\"app\"")
+	assert.Contains(t, out, "\"name\":\"init-db\"")
+}

--- a/internal/app/copy_format_picker.go
+++ b/internal/app/copy_format_picker.go
@@ -1,0 +1,238 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// copyFormatPickerState is the open/closed/cursor model for the
+// Y-key picker. scope is the selection snapshot taken at open time
+// so a watch refresh between open and apply can't change which
+// items are copied.
+type copyFormatPickerState struct {
+	active  bool
+	cursor  int
+	formats []CopyFormat
+	scope   []model.Item
+}
+
+// openCopyFormatPicker captures the current selection (or the cursor
+// row if nothing is selected) and switches the explorer into picker
+// mode. No-op when there is no item to copy.
+func (m *Model) openCopyFormatPicker() {
+	scope := m.copyFormatPickerScope()
+	if len(scope) == 0 {
+		return
+	}
+	m.copyFormatPicker = copyFormatPickerState{
+		active:  true,
+		cursor:  0,
+		formats: availableCopyFormats(m.nav.Level),
+		scope:   scope,
+	}
+	m.previousOverlay = m.overlay
+	m.overlay = overlayCopyFormat
+}
+
+// closeCopyFormatPicker clears picker state and restores the prior
+// overlay. Idempotent.
+func (m *Model) closeCopyFormatPicker() {
+	m.copyFormatPicker = copyFormatPickerState{}
+	if m.overlay == overlayCopyFormat {
+		m.overlay = m.previousOverlay
+		m.previousOverlay = overlayNone
+	}
+}
+
+// copyFormatPickerStep advances the cursor by delta with wrap-around.
+// Uses a two-step modulo so any integer delta (positive or negative,
+// any magnitude) wraps to a valid cursor index.
+func (m *Model) copyFormatPickerStep(delta int) {
+	if !m.copyFormatPicker.active || len(m.copyFormatPicker.formats) == 0 {
+		return
+	}
+	n := len(m.copyFormatPicker.formats)
+	m.copyFormatPicker.cursor = ((m.copyFormatPicker.cursor+delta)%n + n) % n
+}
+
+// copyFormatPickerScope returns the items the picker will operate on:
+// the visible selection if any, otherwise the cursor row. Returns nil
+// when neither is available — matches handleExplorerActionKeyCopyName's
+// fallthrough rules so the picker honors the same precedence today's
+// Y already follows.
+func (m *Model) copyFormatPickerScope() []model.Item {
+	if m.hasSelection() {
+		if items := m.selectedItemsList(); len(items) > 0 {
+			out := make([]model.Item, len(items))
+			copy(out, items)
+			return out
+		}
+	}
+	if sel := m.selectedMiddleItem(); sel != nil {
+		return []model.Item{*sel}
+	}
+	return nil
+}
+
+// applyCopyFormatPicker resolves the picker's current cursor row to
+// a tea.Cmd that produces a yamlClipboardMsg in the chosen format,
+// then closes the picker. Table dispatch builds the content inline
+// (no network); YAML and JSON reuse the existing dispatchYAMLClipboardCopy
+// path plus wrapYAMLCmdAsJSON for JSON.
+func (m Model) applyCopyFormatPicker() (tea.Model, tea.Cmd) {
+	if !m.copyFormatPicker.active || m.copyFormatPicker.cursor >= len(m.copyFormatPicker.formats) {
+		return m, nil
+	}
+	format := m.copyFormatPicker.formats[m.copyFormatPicker.cursor]
+	scope := m.copyFormatPicker.scope
+	m.closeCopyFormatPicker()
+
+	// All branches operate on the captured `scope` snapshot — a watch
+	// refresh between picker-open and apply cannot change what gets
+	// copied. Cap-exceeded is gated upstream at picker-open time
+	// (handleExplorerActionKeyCopyYAML).
+	switch format {
+	case CopyFormatTable:
+		columns := copyTableColumnsForLevel(m.nav.Level, scope)
+		content := BuildCopyTable(scope, columns)
+		return m, func() tea.Msg {
+			return yamlClipboardMsg{content: content, count: len(scope), format: "table"}
+		}
+	case CopyFormatYAML:
+		cmd := m.copyYAMLForScope(scope)
+		if cmd == nil {
+			return m, nil
+		}
+		if len(scope) > 1 {
+			m.setStatusMessage(fmt.Sprintf("Fetching %d manifests...", len(scope)), false)
+		}
+		return m, cmd
+	case CopyFormatJSON:
+		cmd := m.copyYAMLForScope(scope)
+		if cmd == nil {
+			return m, nil
+		}
+		if len(scope) > 1 {
+			m.setStatusMessage(fmt.Sprintf("Fetching %d manifests...", len(scope)), false)
+		}
+		return m, wrapYAMLCmdAsJSON(cmd)
+	}
+	return m, nil
+}
+
+// copyTableColumnsForLevel decides which columns the Table format
+// should emit for the current level. Mirrors what the explorer's
+// middle column shows: Name first, then the built-ins present in
+// items minus any the user hid, then the extras the user has visible
+// (per ui.ActiveSessionColumns) — finally reordered to match
+// ui.ActiveColumnOrder if the user reordered columns. The ui.Active*
+// globals are set on every render via applySessionColumnsForKind, so
+// reading them here returns the same column set the user just saw.
+func copyTableColumnsForLevel(level model.Level, items []model.Item) []string {
+	_ = level // reserved: a future per-level table column override (e.g., LevelClusters showing ClusterColor) would key off this param
+
+	hiddenBuiltin := ui.ActiveHiddenBuiltinColumns
+	cols := []string{"Name"}
+	addBuiltinIfPresent := func(key string, accessor func(model.Item) string) {
+		if hiddenBuiltin[key] {
+			return
+		}
+		if anyNonEmpty(items, accessor) {
+			cols = append(cols, key)
+		}
+	}
+	addBuiltinIfPresent("Namespace", func(it model.Item) string { return it.Namespace })
+	addBuiltinIfPresent("Ready", func(it model.Item) string { return it.Ready })
+	addBuiltinIfPresent("Status", func(it model.Item) string { return it.Status })
+	addBuiltinIfPresent("Restarts", func(it model.Item) string { return it.Restarts })
+	addBuiltinIfPresent("Age", func(it model.Item) string { return it.Age })
+
+	// Extras: if the user has explicitly configured a visible set via
+	// the column-toggle overlay, ui.ActiveSessionColumns lists them in
+	// the user-chosen order — restrict to that set. Otherwise fall back
+	// to the union of Columns keys discovered in items. Either way,
+	// drop the internal-prefixed keys the on-screen renderer also drops.
+	var sessionSet map[string]bool
+	if ui.ActiveSessionColumns != nil {
+		sessionSet = make(map[string]bool, len(ui.ActiveSessionColumns))
+		for _, k := range ui.ActiveSessionColumns {
+			sessionSet[k] = true
+		}
+	}
+	seen := map[string]bool{}
+	for _, it := range items {
+		for _, kv := range it.Columns {
+			if isInternalCopyColumnKey(kv.Key) {
+				continue
+			}
+			if sessionSet != nil && !sessionSet[kv.Key] {
+				continue
+			}
+			if !seen[kv.Key] {
+				cols = append(cols, kv.Key)
+				seen[kv.Key] = true
+			}
+		}
+	}
+
+	// Reorder to match the user's column order if set. Name always
+	// stays first; columns absent from ActiveColumnOrder fall to the
+	// end in their discovery order (defensive — normally every visible
+	// column is in the order list).
+	if len(ui.ActiveColumnOrder) == 0 {
+		return cols
+	}
+	present := make(map[string]bool, len(cols))
+	for _, c := range cols {
+		present[c] = true
+	}
+	ordered := []string{"Name"}
+	placed := map[string]bool{"Name": true}
+	for _, k := range ui.ActiveColumnOrder {
+		if present[k] && !placed[k] {
+			ordered = append(ordered, k)
+			placed[k] = true
+		}
+	}
+	for _, c := range cols {
+		if !placed[c] {
+			ordered = append(ordered, c)
+			placed[c] = true
+		}
+	}
+	return ordered
+}
+
+// isInternalCopyColumnKey reports whether an Item.Columns key is a
+// renderer-only annotation that should never appear in a user-facing
+// copy (matches the prefixes collectExtraToggleEntries already
+// filters out for the column-toggle overlay).
+func isInternalCopyColumnKey(key string) bool {
+	switch {
+	case strings.HasPrefix(key, "__"),
+		strings.HasPrefix(key, "secret:"),
+		strings.HasPrefix(key, "owner:"),
+		strings.HasPrefix(key, "data:"),
+		strings.HasPrefix(key, "condition:"),
+		strings.HasPrefix(key, "step:"),
+		strings.HasPrefix(key, "cond:"):
+		return true
+	}
+	return false
+}
+
+// anyNonEmpty reports whether any item has a non-empty value for the
+// field extracted by accessor.
+func anyNonEmpty(items []model.Item, accessor func(model.Item) string) bool {
+	for _, it := range items {
+		if accessor(it) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/copy_format_picker_hintbar_test.go
+++ b/internal/app/copy_format_picker_hintbar_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestOverlayHintBar_PickerActive(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	// overlay should now be overlayCopyFormat
+	assert.Equal(t, overlayCopyFormat, m.overlay)
+	hints := m.overlayHintBarSelector()
+	assert.NotEmpty(t, hints, "selector hint bar must render for the picker overlay")
+	// Spot-check key entries
+	for _, frag := range []string{"navigate", "shortcut", "apply", "cancel"} {
+		assert.Contains(t, hints, frag, "picker hint bar must contain %q", frag)
+	}
+}

--- a/internal/app/copy_format_picker_keys.go
+++ b/internal/app/copy_format_picker_keys.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// handleCopyFormatPickerKey routes key events to the active copy-as
+// picker. j/k/down/up cycle the cursor; enter applies the cursor row;
+// esc/q cancel; lowercase letter shortcuts apply the matching format
+// directly. The letter `j` is reserved for cursor-down navigation
+// (cursor movement wins over the shadow JSON shortcut), so JSON must
+// be applied via Enter or by typing the up arrow / k to navigate up
+// to its row.
+func (m Model) handleCopyFormatPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		m.closeCopyFormatPicker()
+		return m, nil
+	case "j", "down", "ctrl+n":
+		m.copyFormatPickerStep(1)
+		return m, nil
+	case "k", "up", "ctrl+p":
+		m.copyFormatPickerStep(-1)
+		return m, nil
+	case "enter":
+		return m.applyCopyFormatPicker()
+	}
+	// Letter shortcuts: apply the matching format directly. Formats
+	// that return an empty ShortcutKey (today: JSON, which would
+	// otherwise collide with cursor-down) are skipped.
+	pressed := msg.String()
+	for i, f := range m.copyFormatPicker.formats {
+		key := f.ShortcutKey()
+		if key == "" {
+			continue
+		}
+		if pressed == key {
+			m.copyFormatPicker.cursor = i
+			return m.applyCopyFormatPicker()
+		}
+	}
+	return m, nil
+}

--- a/internal/app/copy_format_picker_test.go
+++ b/internal/app/copy_format_picker_test.go
@@ -1,0 +1,406 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// findFormatIndex returns the index of f in formats, or -1 if not present.
+// Tests use this to avoid hard-coding cursor positions, so a future reorder
+// of availableCopyFormats can't silently dispatch the wrong format.
+func findFormatIndex(formats []CopyFormat, f CopyFormat) int {
+	for i, x := range formats {
+		if x == f {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestOpenCopyFormatPicker_AtResources_HasThreeRows(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	assert.True(t, m.copyFormatPicker.active)
+	assert.Equal(t, []CopyFormat{CopyFormatYAML, CopyFormatJSON, CopyFormatTable}, m.copyFormatPicker.formats)
+	assert.Equal(t, 0, m.copyFormatPicker.cursor)
+	assert.Len(t, m.copyFormatPicker.scope, 1)
+	assert.Equal(t, "a", m.copyFormatPicker.scope[0].Name)
+}
+
+func TestOpenCopyFormatPicker_AtClusters_TableOnly(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelClusters
+	m.middleItems = []model.Item{{Name: "kind-1"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	assert.True(t, m.copyFormatPicker.active)
+	assert.Equal(t, []CopyFormat{CopyFormatTable}, m.copyFormatPicker.formats)
+}
+
+func TestCopyFormatPicker_CycleCursor(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	m.copyFormatPickerStep(1)
+	assert.Equal(t, 1, m.copyFormatPicker.cursor)
+	m.copyFormatPickerStep(1)
+	assert.Equal(t, 2, m.copyFormatPicker.cursor)
+	m.copyFormatPickerStep(1)
+	assert.Equal(t, 0, m.copyFormatPicker.cursor, "wraps")
+	m.copyFormatPickerStep(-1)
+	assert.Equal(t, 2, m.copyFormatPicker.cursor, "wraps backward")
+}
+
+func TestCopyFormatPickerCancel(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	m.closeCopyFormatPicker()
+	assert.False(t, m.copyFormatPicker.active)
+	assert.Nil(t, m.copyFormatPicker.scope)
+	assert.Equal(t, overlayNone, m.overlay, "overlay restored to pre-open value")
+	assert.Equal(t, overlayNone, m.previousOverlay, "previousOverlay cleared")
+}
+
+func TestCopyFormatPickerStep_LargeNegativeDelta(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	// 3 formats: cursor at 0. delta -4 ≡ -1 mod 3 → cursor 2.
+	m.copyFormatPickerStep(-4)
+	assert.Equal(t, 2, m.copyFormatPicker.cursor, "large negative delta wraps correctly")
+	// delta +7 ≡ +1 mod 3 → cursor 0.
+	m.copyFormatPickerStep(7)
+	assert.Equal(t, 0, m.copyFormatPicker.cursor, "large positive delta wraps correctly")
+}
+
+func TestCopyFormatPicker_ScopeSnapshotIsStableUnderMutation(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}, {Name: "b"}}
+	m.selectedItems = map[string]bool{
+		selectionKey(m.middleItems[0]): true,
+		selectionKey(m.middleItems[1]): true,
+	}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	// Simulate a watch refresh dropping one item from the underlying list.
+	m.middleItems = m.middleItems[:1]
+	m.selectedItems = nil
+	assert.Len(t, m.copyFormatPicker.scope, 2, "snapshot survives later mutation")
+}
+
+func TestOpenCopyFormatPicker_NoItemsIsNoOp(t *testing.T) {
+	m := Model{}
+	m.nav.Level = model.LevelResources
+	m.middleItems = nil
+	m.openCopyFormatPicker()
+	assert.False(t, m.copyFormatPicker.active, "open with empty scope is a no-op")
+}
+
+func TestApplyCopyFormatPicker_TableDispatchesImmediately(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}, {Name: "b"}}
+	m.selectedItems = map[string]bool{
+		selectionKey(m.middleItems[0]): true,
+		selectionKey(m.middleItems[1]): true,
+	}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	tableIdx := findFormatIndex(m.copyFormatPicker.formats, CopyFormatTable)
+	require.NotEqual(t, -1, tableIdx)
+	m.copyFormatPicker.cursor = tableIdx
+	_, cmd := m.applyCopyFormatPicker()
+	assert.NotNil(t, cmd, "table dispatch must return a tea.Cmd")
+	msg := cmd()
+	yc, ok := msg.(yamlClipboardMsg)
+	assert.True(t, ok, "table dispatch must produce a yamlClipboardMsg")
+	assert.Equal(t, "table", yc.format)
+	assert.Equal(t, 2, yc.count, "table count equals number of rows in scope")
+	assert.Contains(t, yc.content, "NAME")
+}
+
+func TestApplyCopyFormatPicker_YAMLUsesExistingDispatcher(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a", Kind: "Pod"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	m.copyFormatPicker.cursor = 0 // YAML is documented as the first row.
+	mdl, cmd := m.applyCopyFormatPicker()
+	assert.NotNil(t, cmd, "yaml dispatch must return a tea.Cmd")
+	r := mdl.(Model)
+	assert.False(t, r.copyFormatPicker.active, "picker closes after apply (yaml path)")
+}
+
+func TestApplyCopyFormatPicker_ClosesAfterApply(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	tableIdx := findFormatIndex(m.copyFormatPicker.formats, CopyFormatTable)
+	require.NotEqual(t, -1, tableIdx)
+	m.copyFormatPicker.cursor = tableIdx // Table — pure, no network
+	mdl, _ := m.applyCopyFormatPicker()
+	m = mdl.(Model)
+	assert.False(t, m.copyFormatPicker.active, "picker closes after apply")
+}
+
+func TestApplyCopyFormatPicker_JSONWrapsExistingDispatcher(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a", Kind: "Pod"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	jsonIdx := findFormatIndex(m.copyFormatPicker.formats, CopyFormatJSON)
+	require.NotEqual(t, -1, jsonIdx)
+	m.copyFormatPicker.cursor = jsonIdx
+	_, cmd := m.applyCopyFormatPicker()
+	// Cmd should exist when there's a valid item to copy.
+	assert.NotNil(t, cmd, "JSON dispatch must return a tea.Cmd")
+}
+
+func TestAnyNonEmpty(t *testing.T) {
+	items := []model.Item{{Name: ""}, {Name: ""}, {Name: "x"}}
+	assert.True(t, anyNonEmpty(items, func(it model.Item) string { return it.Name }))
+
+	empty := []model.Item{{Name: ""}, {Name: ""}}
+	assert.False(t, anyNonEmpty(empty, func(it model.Item) string { return it.Name }))
+
+	assert.False(t, anyNonEmpty(nil, func(it model.Item) string { return it.Name }))
+}
+
+func TestCopyTableColumnsForLevel_OnlyNonEmptyBuiltins(t *testing.T) {
+	// Items have Namespace and Status populated, others empty.
+	items := []model.Item{
+		{Name: "a", Namespace: "default", Status: "Running"},
+		{Name: "b", Namespace: "default", Status: "Pending"},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Namespace", "Status"}, got,
+		"only Name plus populated built-ins; Ready/Restarts/Age skipped because empty")
+}
+
+func TestCopyTableColumnsForLevel_BuiltinOrder(t *testing.T) {
+	// All built-ins populated → spec-defined order: Name, Namespace, Ready, Status, Restarts, Age.
+	items := []model.Item{
+		{Name: "a", Namespace: "n", Ready: "1/1", Status: "Running", Restarts: "0", Age: "1d"},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Namespace", "Ready", "Status", "Restarts", "Age"}, got)
+}
+
+func TestCopyTableColumnsForLevel_ExtraColumnsDeduped(t *testing.T) {
+	items := []model.Item{
+		{Name: "a", Columns: []model.KeyValue{{Key: "Image", Value: "x:1"}}},
+		{Name: "b", Columns: []model.KeyValue{{Key: "Image", Value: "x:2"}, {Key: "Node", Value: "n1"}}},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Image", "Node"}, got, "extra columns deduped, original order preserved")
+}
+
+func TestCopyTableColumnsForLevel_LevelParamReserved(t *testing.T) {
+	// Same items at different levels should produce identical output today —
+	// `level` is reserved for future per-level customization.
+	items := []model.Item{{Name: "a", Status: "Running"}}
+	resources := copyTableColumnsForLevel(model.LevelResources, items)
+	clusters := copyTableColumnsForLevel(model.LevelClusters, items)
+	assert.Equal(t, resources, clusters, "level parameter is currently inert")
+}
+
+// withActiveColumnState sets the ui.Active* column-state globals for a test
+// and restores them on cleanup. The picker reads these to mirror what the
+// renderer last drew.
+func withActiveColumnState(t *testing.T, order []string, hidden map[string]bool, session []string) {
+	t.Helper()
+	prevOrder := ui.ActiveColumnOrder
+	prevHidden := ui.ActiveHiddenBuiltinColumns
+	prevSession := ui.ActiveSessionColumns
+	ui.ActiveColumnOrder = order
+	ui.ActiveHiddenBuiltinColumns = hidden
+	ui.ActiveSessionColumns = session
+	t.Cleanup(func() {
+		ui.ActiveColumnOrder = prevOrder
+		ui.ActiveHiddenBuiltinColumns = prevHidden
+		ui.ActiveSessionColumns = prevSession
+	})
+}
+
+func TestCopyTableColumnsForLevel_HiddenBuiltinExcluded(t *testing.T) {
+	withActiveColumnState(t, nil, map[string]bool{"Namespace": true, "Age": true}, nil)
+	items := []model.Item{
+		{Name: "a", Namespace: "n", Ready: "1/1", Status: "Running", Restarts: "0", Age: "1d"},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Ready", "Status", "Restarts"}, got,
+		"hidden built-ins (Namespace, Age) must not appear in the copied table")
+}
+
+func TestCopyTableColumnsForLevel_SessionExtrasRestrictsToVisible(t *testing.T) {
+	// User has hidden "Node" via the column-toggle overlay; only "Image" is visible.
+	withActiveColumnState(t, nil, nil, []string{"Image"})
+	items := []model.Item{
+		{Name: "a", Columns: []model.KeyValue{
+			{Key: "Image", Value: "x:1"},
+			{Key: "Node", Value: "n1"},
+		}},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Image"}, got,
+		"only extras in ActiveSessionColumns appear; Node hidden by user is excluded")
+}
+
+func TestCopyTableColumnsForLevel_OrderRespected(t *testing.T) {
+	// User moved Status to the front (after Name) and Namespace to the end.
+	withActiveColumnState(t, []string{"Status", "Ready", "Restarts", "Age", "Namespace"}, nil, nil)
+	items := []model.Item{
+		{Name: "a", Namespace: "n", Ready: "1/1", Status: "Running", Restarts: "0", Age: "1d"},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Status", "Ready", "Restarts", "Age", "Namespace"}, got,
+		"column order must follow ui.ActiveColumnOrder")
+}
+
+func TestCopyTableColumnsForLevel_OrderReorderExtras(t *testing.T) {
+	// User reordered extras: Node before Image.
+	withActiveColumnState(t, []string{"Namespace", "Node", "Image"}, nil, []string{"Image", "Node"})
+	items := []model.Item{
+		{Name: "a", Namespace: "n", Columns: []model.KeyValue{
+			{Key: "Image", Value: "x:1"},
+			{Key: "Node", Value: "n1"},
+		}},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Namespace", "Node", "Image"}, got,
+		"extras follow user reorder, not item-discovery order")
+}
+
+func TestCopyTableColumnsForLevel_InternalKeysFiltered(t *testing.T) {
+	items := []model.Item{
+		{Name: "a", Columns: []model.KeyValue{
+			{Key: "Image", Value: "x:1"},
+			{Key: "__internal", Value: "junk"},
+			{Key: "secret:tls", Value: "skip"},
+			{Key: "owner:rs", Value: "skip"},
+			{Key: "data:foo", Value: "skip"},
+			{Key: "condition:Ready", Value: "skip"},
+			{Key: "step:1", Value: "skip"},
+			{Key: "cond:Ready", Value: "skip"},
+		}},
+	}
+	got := copyTableColumnsForLevel(model.LevelResources, items)
+	assert.Equal(t, []string{"Name", "Image"}, got,
+		"internal-prefixed Columns keys must be filtered out of the copy")
+}
+
+func TestCopyFormatPicker_EscClosesViaRouter(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	mdl, _ := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyEsc})
+	r := mdl.(Model)
+	assert.False(t, r.copyFormatPicker.active, "esc cancels picker")
+}
+
+func TestCopyFormatPicker_DownKeyAdvancesCursor(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	mdl, _ := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	r := mdl.(Model)
+	assert.Equal(t, 1, r.copyFormatPicker.cursor, "j moves cursor down")
+}
+
+func TestCopyFormatPicker_UpKeyMovesCursor(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	m.copyFormatPicker.cursor = 2
+	mdl, _ := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	r := mdl.(Model)
+	assert.Equal(t, 1, r.copyFormatPicker.cursor, "k moves cursor up")
+}
+
+func TestCopyFormatPicker_TShortcutAppliesTable(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	mdl, cmd := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")})
+	r := mdl.(Model)
+	assert.False(t, r.copyFormatPicker.active, "t applies Table and closes picker")
+	require.NotNil(t, cmd, "table dispatch returns non-nil cmd")
+	msg := cmd().(yamlClipboardMsg)
+	assert.Equal(t, "table", msg.format)
+}
+
+func TestCopyFormatPicker_YShortcutAppliesYAML(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a", Kind: "Pod"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	mdl, cmd := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	r := mdl.(Model)
+	assert.False(t, r.copyFormatPicker.active, "y applies YAML and closes picker")
+	require.NotNil(t, cmd, "yaml dispatch returns non-nil cmd")
+}
+
+func TestCopyFormatPicker_EnterAppliesCursorRow(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	// Move cursor to Table (last row)
+	for i, f := range m.copyFormatPicker.formats {
+		if f == CopyFormatTable {
+			m.copyFormatPicker.cursor = i
+			break
+		}
+	}
+	mdl, cmd := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	r := mdl.(Model)
+	assert.False(t, r.copyFormatPicker.active, "enter applies and closes picker")
+	require.NotNil(t, cmd)
+	msg := cmd().(yamlClipboardMsg)
+	assert.Equal(t, "table", msg.format)
+}
+
+func TestCopyFormatPicker_UnhandledKeyIsNoOp(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	cursorBefore := m.copyFormatPicker.cursor
+	mdl, cmd := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	r := mdl.(Model)
+	assert.True(t, r.copyFormatPicker.active, "unhandled key leaves picker open")
+	assert.Equal(t, cursorBefore, r.copyFormatPicker.cursor, "unhandled key doesn't move cursor")
+	assert.Nil(t, cmd)
+}

--- a/internal/app/copy_format_picker_view_test.go
+++ b/internal/app/copy_format_picker_view_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestRenderOverlayCopyFormat_ShowsAllFormats(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	content, w, h := m.renderOverlayCopyFormat()
+	assert.NotEmpty(t, content, "render returns non-empty content")
+	assert.Greater(t, w, 0, "width must be positive")
+	assert.Greater(t, h, 0, "height must be positive")
+	// All three format labels should appear in the rendered output.
+	assert.Contains(t, content, "YAML")
+	assert.Contains(t, content, "JSON")
+	assert.Contains(t, content, "Table")
+	// Hints live on the bottom hint bar, not inside the overlay.
+	assert.NotContains(t, content, "apply")
+	assert.NotContains(t, content, "cancel")
+	assert.NotContains(t, content, "shortcut")
+}
+
+func TestRenderOverlayCopyFormat_ShowsSingleFormatAtClusters(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelClusters
+	m.middleItems = []model.Item{{Name: "kind-1"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	content, _, _ := m.renderOverlayCopyFormat()
+	assert.Contains(t, content, "Table")
+	assert.Contains(t, content, "[t]", "Table row marker present")
+	assert.NotContains(t, content, "[y]", "YAML row must not appear at cluster level")
+	assert.NotContains(t, content, "[j]", "JSON row must not appear at cluster level")
+}
+
+func TestRenderOverlayCopyFormat_NoActivePickerReturnsEmpty(t *testing.T) {
+	m := baseExplorerModel()
+	// Picker never opened
+	content, w, h := m.renderOverlayCopyFormat()
+	assert.Empty(t, content)
+	assert.Equal(t, 0, w)
+	assert.Equal(t, 0, h)
+}

--- a/internal/app/copy_format_table.go
+++ b/internal/app/copy_format_table.go
@@ -1,0 +1,118 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// BuildCopyTable renders items as a kubectl-style aligned plain-text
+// table. The supplied columns are emitted in order; widths are sized
+// to the widest value actually present (no terminal-width truncation).
+// Empty built-in values render as "<none>"; empty extras render as an
+// empty cell. Sort arrows (the leading "↑ " / "↓ " status decorations
+// produced by the on-screen renderer) are stripped so the copied
+// output is data, not display chrome.
+func BuildCopyTable(items []model.Item, columns []string) string {
+	if len(columns) == 0 {
+		return ""
+	}
+
+	// Pre-compute each row's per-column cell value, plus a per-column
+	// width across header + every row.
+	headers := make([]string, len(columns))
+	widths := make([]int, len(columns))
+	for i, key := range columns {
+		headers[i] = ui.ColumnHeaderLabel(key)
+		widths[i] = lipgloss.Width(headers[i])
+	}
+
+	rows := make([][]string, len(items))
+	for ri, item := range items {
+		row := make([]string, len(columns))
+		for ci, key := range columns {
+			val := copyTableCellValue(&item, key)
+			row[ci] = val
+			if w := lipgloss.Width(val); w > widths[ci] {
+				widths[ci] = w
+			}
+		}
+		rows[ri] = row
+	}
+
+	var b strings.Builder
+	writeCopyTableRow(&b, headers, widths)
+	for _, r := range rows {
+		writeCopyTableRow(&b, r, widths)
+	}
+	return b.String()
+}
+
+// copyTableCellValue resolves a column's value for one item. Built-in
+// columns read fields directly; extras fall back to the Columns
+// key/value list. Empty built-ins render as "<none>" so the copied
+// output stays self-explanatory.
+func copyTableCellValue(item *model.Item, key string) string {
+	var val string
+	switch key {
+	case "Name":
+		val = item.Name
+	case "Namespace":
+		val = item.Namespace
+	case "Ready":
+		val = item.Ready
+	case "Restarts":
+		val = item.Restarts
+	case "Status":
+		val = item.Status
+	case "Age":
+		val = item.Age
+	default:
+		val = ui.GetExtraColumnValue(item, key)
+	}
+	val = stripCopyTableOrnaments(val)
+	if val == "" && isBuiltinCopyColumn(key) {
+		return "<none>"
+	}
+	return val
+}
+
+// stripCopyTableOrnaments removes the leading sort-arrow decoration
+// ("↑ " / "↓ ") the explorer prepends to certain status values when
+// the column is the current sort key. The copied table is data, not
+// a screenshot of the display.
+func stripCopyTableOrnaments(val string) string {
+	if strings.HasPrefix(val, "↑ ") || strings.HasPrefix(val, "↓ ") {
+		return val[len("↑ "):]
+	}
+	return val
+}
+
+// isBuiltinCopyColumn reports whether the column is one of the
+// non-Name built-ins whose empty value should render as "<none>".
+// Extras stay empty so they don't pollute their column with "<none>"
+// repeats when the underlying KV is just missing.
+func isBuiltinCopyColumn(key string) bool {
+	switch key {
+	case "Namespace", "Ready", "Restarts", "Status", "Age":
+		return true
+	}
+	return false
+}
+
+// writeCopyTableRow writes one space-padded row terminated with "\n".
+// Two-space separator between cells; the trailing cell is padded only
+// implicitly (its trailing spaces are trimmed by the newline).
+func writeCopyTableRow(b *strings.Builder, cells []string, widths []int) {
+	for i, cell := range cells {
+		b.WriteString(cell)
+		if i < len(cells)-1 {
+			pad := widths[i] - lipgloss.Width(cell) + 2
+			b.WriteString(strings.Repeat(" ", pad))
+		}
+	}
+	b.WriteByte('\n')
+}

--- a/internal/app/copy_format_table_test.go
+++ b/internal/app/copy_format_table_test.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestBuildCopyTable_SingleRow(t *testing.T) {
+	items := []model.Item{
+		{Name: "nginx-abc", Namespace: "default", Ready: "1/1", Status: "Running", Restarts: "0", Age: "3d"},
+	}
+	got := BuildCopyTable(items, []string{"Namespace", "Name", "Ready", "Status", "Restarts", "Age"})
+	want := "NAMESPACE  NAME       READY  STATUS   RESTARTS  AGE\n" +
+		"default    nginx-abc  1/1    Running  0         3d\n"
+	assert.Equal(t, want, got)
+}
+
+func TestBuildCopyTable_WidthFromLongestValue(t *testing.T) {
+	items := []model.Item{
+		{Name: "short"},
+		{Name: "verylongresourcename"},
+	}
+	got := BuildCopyTable(items, []string{"Name"})
+	want := "NAME\n" +
+		"short\n" +
+		"verylongresourcename\n"
+	assert.Equal(t, want, got)
+}
+
+func TestBuildCopyTable_EmptyBuiltinAsNone(t *testing.T) {
+	items := []model.Item{{Name: "x"}}
+	got := BuildCopyTable(items, []string{"Name", "Namespace", "Ready"})
+	assert.Contains(t, got, "<none>")
+	// header still uppercased
+	assert.True(t, strings.HasPrefix(got, "NAME"))
+}
+
+func TestBuildCopyTable_StripsSortArrows(t *testing.T) {
+	items := []model.Item{{Name: "x", Status: "↑ Running"}}
+	got := BuildCopyTable(items, []string{"Name", "Status"})
+	assert.NotContains(t, got, "↑")
+	assert.Contains(t, got, "Running")
+}
+
+func TestBuildCopyTable_StripsDownArrow(t *testing.T) {
+	items := []model.Item{{Name: "x", Status: "↓ Pending"}}
+	got := BuildCopyTable(items, []string{"Name", "Status"})
+	assert.NotContains(t, got, "↓")
+	assert.Contains(t, got, "Pending")
+}
+
+func TestBuildCopyTable_MultibyteWidthAlignment(t *testing.T) {
+	items := []model.Item{
+		{Name: "ascii-only", Namespace: "default"},
+		{Name: "second-row", Namespace: "kube-système"},
+	}
+	got := BuildCopyTable(items, []string{"Namespace", "Name"})
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	// All lines should have the Name column starting at the same visual column.
+	// With lipgloss.Width-based padding, this means the rune-length of the
+	// prefix (Namespace cell + separator) is identical on every line.
+	require.Len(t, lines, 3, "header + 2 rows")
+	// Find the visual column position of the NAME header. LastIndex avoids
+	// matching the NAME prefix inside the NAMESPACE header in column 0.
+	headerIdx := strings.LastIndex(lines[0], "NAME")
+	require.NotEqual(t, -1, headerIdx)
+	// Row 1's "ascii-only" starts where? Use the rune-prefix length.
+	for i, line := range lines[1:] {
+		nameStart := strings.Index(line, []string{"ascii-only", "second-row"}[i])
+		require.NotEqual(t, -1, nameStart, "row %d: name should appear", i)
+		// Convert nameStart from byte index to visual column index via lipgloss.Width of the prefix
+		prefix := line[:nameStart]
+		assert.Equal(t, headerIdx, lipgloss.Width(prefix),
+			"row %d: visual column of name must match header column", i)
+	}
+}
+
+func TestBuildCopyTable_ExtraColumnsFromItemColumns(t *testing.T) {
+	items := []model.Item{
+		{
+			Name:    "thing",
+			Columns: []model.KeyValue{{Key: "Image", Value: "nginx:1.25"}},
+		},
+	}
+	got := BuildCopyTable(items, []string{"Name", "Image"})
+	assert.Contains(t, got, "IMAGE")
+	assert.Contains(t, got, "nginx:1.25")
+}
+
+func TestBuildCopyTable_NoTruncation(t *testing.T) {
+	longName := strings.Repeat("a", 200)
+	items := []model.Item{{Name: longName}}
+	got := BuildCopyTable(items, []string{"Name"})
+	assert.Contains(t, got, longName)
+}
+
+func TestBuildCopyTable_RowCount(t *testing.T) {
+	items := []model.Item{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	got := BuildCopyTable(items, []string{"Name"})
+	// 1 header + 3 data rows, each terminated by \n
+	assert.Equal(t, 4, strings.Count(got, "\n"))
+}
+
+func TestBuildCopyTable_EmptyItemsHeaderOnly(t *testing.T) {
+	got := BuildCopyTable(nil, []string{"Name", "Namespace"})
+	// Header row only, terminated by \n.
+	assert.Equal(t, "NAME  NAMESPACE\n", got)
+}

--- a/internal/app/copy_format_test.go
+++ b/internal/app/copy_format_test.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestAvailableCopyFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		level model.Level
+		want  []CopyFormat
+	}{
+		{"Clusters", model.LevelClusters, []CopyFormat{CopyFormatTable}},
+		{"ResourceTypes", model.LevelResourceTypes, []CopyFormat{CopyFormatTable}},
+		{"Resources", model.LevelResources, []CopyFormat{CopyFormatYAML, CopyFormatJSON, CopyFormatTable}},
+		{"Owned", model.LevelOwned, []CopyFormat{CopyFormatYAML, CopyFormatJSON, CopyFormatTable}},
+		{"Containers", model.LevelContainers, []CopyFormat{CopyFormatYAML, CopyFormatJSON, CopyFormatTable}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := availableCopyFormats(tt.level)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCopyFormatLabelAndKey(t *testing.T) {
+	assert.Equal(t, "YAML", CopyFormatYAML.Label())
+	assert.Equal(t, "y", CopyFormatYAML.ShortcutKey())
+	assert.Equal(t, "JSON", CopyFormatJSON.Label())
+	assert.Equal(t, "", CopyFormatJSON.ShortcutKey(),
+		"JSON returns no shortcut because 'j' is consumed by cursor-down navigation")
+	assert.Equal(t, "Table", CopyFormatTable.Label())
+	assert.Equal(t, "t", CopyFormatTable.ShortcutKey())
+}
+
+func TestCopyFormatStatusKey(t *testing.T) {
+	assert.Equal(t, "yaml", CopyFormatYAML.statusKey())
+	assert.Equal(t, "json", CopyFormatJSON.statusKey())
+	assert.Equal(t, "table", CopyFormatTable.statusKey())
+}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -173,11 +173,14 @@ type monitoringDashboardMsg struct {
 	context string
 }
 
-// yamlClipboardMsg carries YAML content to be copied to clipboard.
-// count is the number of manifests joined into content (1 for single).
+// yamlClipboardMsg carries serialized content to be copied to the clipboard.
+// format is one of "yaml" (default), "json", "table". Empty format is treated
+// as "yaml" for back-compat with existing call sites that haven't been
+// updated. count is the number of items joined into content (1 = single).
 type yamlClipboardMsg struct {
 	content string
 	count   int
+	format  string
 	err     error
 }
 

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -130,6 +130,13 @@ func (m Model) overlayHintBarSelector() string {
 			{Key: "enter/key", Desc: "select"},
 			{Key: "esc", Desc: "close"},
 		})
+	case overlayCopyFormat:
+		return m.renderHints([]ui.HintEntry{
+			{Key: "j/k", Desc: "navigate"},
+			{Key: "y/t", Desc: "shortcut"},
+			{Key: "enter", Desc: "apply"},
+			{Key: "esc", Desc: "cancel"},
+		})
 	case overlayPortForward:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "j/k", Desc: "select port"},

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -519,13 +519,14 @@ const maxBulkYAMLCopy = 50
 
 // supportsBulkYAMLCopy reports whether copyYAMLToClipboard implements a
 // per-selection bulk fetch at the current navigation level. LevelContainers
-// is single-Pod-by-OwnedName (containers don't have separate YAML), so its
-// dispatcher must fall through to the cursor branch even with a selection
-// — otherwise the user sees a "Fetching N..." toast but the clipboard ends
-// up with one Pod's YAML. Keep this in sync with the bulk branches in
-// copyYAMLToClipboard.
+// is included because container rows fan a single Pod-YAML fetch through
+// ExtractContainerBlocksYAML, extracting one spec block per selected
+// container name (see commands_yaml.go). Keep this in sync with the bulk
+// branches in copyYAMLToClipboard.
 func (m Model) supportsBulkYAMLCopy() bool {
-	return m.nav.Level == model.LevelResources || m.nav.Level == model.LevelOwned
+	return m.nav.Level == model.LevelResources ||
+		m.nav.Level == model.LevelOwned ||
+		m.nav.Level == model.LevelContainers
 }
 
 // dispatchYAMLClipboardCopy routes Y / `:export yaml` to either the
@@ -540,7 +541,7 @@ func (m Model) dispatchYAMLClipboardCopy() (tea.Model, tea.Cmd) {
 	if m.hasSelection() && m.supportsBulkYAMLCopy() {
 		n := len(m.selectedItemsList())
 		if n > maxBulkYAMLCopy {
-			m.setStatusMessage(fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), true)
+			m.setStatusMessage(fmt.Sprintf("Max %d exceeded for bulk YAML/JSON copy", maxBulkYAMLCopy), true)
 			return m, scheduleStatusClear()
 		}
 		if n > 0 {
@@ -555,8 +556,17 @@ func (m Model) dispatchYAMLClipboardCopy() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleExplorerActionKeyCopyYAML() (tea.Model, tea.Cmd, bool) {
-	ret, cmd := m.dispatchYAMLClipboardCopy()
-	return ret, cmd, true
+	// Cap check for YAML/JSON bulk copy happens at open time so the
+	// user gets immediate feedback rather than after picking a format.
+	// Table has no cap because it's a local string build, not a fetch.
+	if m.hasSelection() && m.supportsBulkYAMLCopy() {
+		if n := len(m.selectedItemsList()); n > maxBulkYAMLCopy {
+			m.setStatusMessage(fmt.Sprintf("Max %d exceeded for bulk YAML/JSON copy", maxBulkYAMLCopy), true)
+			return m, scheduleStatusClear(), true
+		}
+	}
+	m.openCopyFormatPicker()
+	return m, nil, true
 }
 
 func (m Model) handleExplorerActionKeyNewTab() (tea.Model, tea.Cmd, bool) {

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -792,22 +792,26 @@ func TestCopyNameSelectionFilteredOutFallsBack(t *testing.T) {
 }
 
 // TestCopyYAMLSelectionFilteredOutFallsBack mirrors the above for `Y`.
-// The single-item cursor path dispatches silently — no bulk "Fetching..."
-// or cap "Max ..." status is set before the fetch resolves. Asserting
-// statusMessage is empty pins down the "took the cursor branch silently"
-// intent rather than just "didn't take the bulk branch."
+// With a ghost selection (hasSelection() true but selectedItemsList() empty),
+// the picker still opens — its scope falls through to the cursor row, matching
+// the precedence today's Y already follows. No "Fetching..." or "Max..." status
+// is set at open time; status only updates once the user picks a format and
+// the fetch resolves.
 func TestCopyYAMLSelectionFilteredOutFallsBack(t *testing.T) {
 	m := basePush80Model()
 	m.selectedItems["ghost-ns/ghost-pod"] = true
 	m.setCursor(0)
 
-	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	ret, _, handled := m.handleExplorerActionKeyCopyYAML()
 	require.True(t, handled)
 	rm := ret.(Model)
 
+	assert.True(t, rm.copyFormatPicker.active, "Y opens the picker")
+	assert.Len(t, rm.copyFormatPicker.scope, 1,
+		"scope falls back to cursor row when selection has no visible items")
+	assert.Equal(t, "pod-1", rm.copyFormatPicker.scope[0].Name)
 	assert.Empty(t, rm.statusMessage,
-		"cursor path dispatches silently; status only updates once the fetch resolves")
-	assert.NotNil(t, cmd, "must still dispatch single-item fetch from cursor")
+		"opening the picker does not set a status; that happens after apply")
 }
 
 // TestCopyYAMLBulkErrorWrapsNamespaceName checks that the bulk fetch path
@@ -835,22 +839,32 @@ func TestCopyYAMLBulkErrorWrapsNamespaceName(t *testing.T) {
 // "Fetching N manifests..." hint before dispatching, so the user has
 // feedback during the sequential fetch (client-go's default rate limiter
 // serializes the per-item Gets — see maxBulkYAMLCopy comment).
+//
+// After Task 10, Y opens the picker first; applying the YAML row from the
+// picker is what runs dispatchYAMLClipboardCopy and sets the status — so
+// the test now drives open-then-apply rather than direct dispatch.
 func TestCopyYAMLBulkSetsFetchingStatus(t *testing.T) {
 	m := basePush80Model()
 	m.toggleSelection(m.middleItems[0])
 	m.toggleSelection(m.middleItems[1])
 
-	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	mdl, _, handled := m.handleExplorerActionKeyCopyYAML()
 	require.True(t, handled)
-	rm := ret.(Model)
+	r := mdl.(Model)
+	require.True(t, r.copyFormatPicker.active, "Y must open the picker")
+
+	// Apply the YAML row (cursor=0 at LevelResources → YAML).
+	mdl2, cmd := r.applyCopyFormatPicker()
+	rm := mdl2.(Model)
 
 	assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage)
 	assert.NotNil(t, cmd)
 }
 
 // TestCopyYAMLBulkRejectsOverCap verifies selections larger than
-// maxBulkYAMLCopy bail out with an error toast and no fetch is dispatched
-// — protects the UI from multi-second stalls behind the rate limiter.
+// maxBulkYAMLCopy bail out with an error toast at open time, before the
+// user even picks a format. The picker stays closed so the cap rejection
+// is the only feedback they see — no half-open overlay.
 func TestCopyYAMLBulkRejectsOverCap(t *testing.T) {
 	m := basePush80Model()
 	m.middleItems = make([]model.Item, maxBulkYAMLCopy+1)
@@ -867,14 +881,16 @@ func TestCopyYAMLBulkRejectsOverCap(t *testing.T) {
 	require.True(t, handled)
 	rm := ret.(Model)
 
-	assert.Equal(t, fmt.Sprintf("Max %d exceeded for bulk YAML copy", maxBulkYAMLCopy), rm.statusMessage)
+	assert.Equal(t, fmt.Sprintf("Max %d exceeded for bulk YAML/JSON copy", maxBulkYAMLCopy), rm.statusMessage)
 	assert.True(t, rm.statusMessageErr, "must surface as error toast")
+	assert.False(t, rm.copyFormatPicker.active, "picker must not open when cap is exceeded")
 	// Cmd is the auto-clear timer, not a fetch.
 	assert.NotNil(t, cmd)
 }
 
 // TestCopyYAMLBulkAtCapDispatches confirms the boundary case (exactly N=cap)
-// is allowed through.
+// is allowed through: Y opens the picker, and applying YAML kicks off the
+// bulk fetch with the "Fetching..." status.
 func TestCopyYAMLBulkAtCapDispatches(t *testing.T) {
 	m := basePush80Model()
 	m.middleItems = make([]model.Item, maxBulkYAMLCopy)
@@ -887,9 +903,14 @@ func TestCopyYAMLBulkAtCapDispatches(t *testing.T) {
 		m.toggleSelection(m.middleItems[i])
 	}
 
-	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	mdl, _, handled := m.handleExplorerActionKeyCopyYAML()
 	require.True(t, handled)
-	rm := ret.(Model)
+	r := mdl.(Model)
+	require.True(t, r.copyFormatPicker.active, "exactly N=cap must open the picker")
+
+	// Apply YAML (cursor=0 at LevelResources → YAML).
+	mdl2, cmd := r.applyCopyFormatPicker()
+	rm := mdl2.(Model)
 
 	assert.Contains(t, rm.statusMessage, "Fetching")
 	assert.False(t, rm.statusMessageErr)
@@ -907,7 +928,7 @@ func TestUpdateYamlClipboardCountAwareStatus(t *testing.T) {
 			count:   3,
 		})
 		rm := ret.(Model)
-		assert.Equal(t, "Copied 3 manifests to clipboard", rm.statusMessage)
+		assert.Equal(t, "Copied 3 manifests as YAML", rm.statusMessage)
 		assert.NotNil(t, cmd)
 	})
 	t.Run("single", func(t *testing.T) {
@@ -949,30 +970,35 @@ func TestCopyYAMLBulkLevelOwnedWrapsErrorWithNamespaceName(t *testing.T) {
 
 // TestCopyYAMLBulkLevelOwnedDispatcherShowsFetchingStatus confirms the
 // dispatcher's "Fetching N manifests..." pre-fetch status applies at
-// LevelOwned the same as LevelResources.
+// LevelOwned the same as LevelResources, once the user picks YAML from
+// the picker that Y opens.
 func TestCopyYAMLBulkLevelOwnedDispatcherShowsFetchingStatus(t *testing.T) {
 	m := basePush80Model()
 	m.nav.Level = model.LevelOwned
 	m.toggleSelection(m.middleItems[0])
 	m.toggleSelection(m.middleItems[1])
 
-	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	mdl, _, handled := m.handleExplorerActionKeyCopyYAML()
 	require.True(t, handled)
-	rm := ret.(Model)
+	r := mdl.(Model)
+	require.True(t, r.copyFormatPicker.active, "Y must open the picker at LevelOwned")
+
+	// Apply YAML (cursor=0 → YAML at LevelOwned).
+	mdl2, cmd := r.applyCopyFormatPicker()
+	rm := mdl2.(Model)
 
 	assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage)
 	assert.NotNil(t, cmd)
 }
 
-// TestCopyYAMLLevelContainersIgnoresSelection guards LevelContainers, where
-// the cmd unconditionally fetches the parent Pod's YAML — bulk doesn't
-// apply (containers don't have separate YAML). With selection, the
-// dispatcher must skip the misleading "Fetching N manifests..." status and
-// fall through to the single-pod path silently. Without this gate, a user
-// who multi-selects two containers and presses `Y` sees a "Fetching 2..."
-// toast but the clipboard ends up with the parent Pod's YAML once and the
-// final status flips to "YAML copied" — promising N, delivering 1.
-func TestCopyYAMLLevelContainersIgnoresSelection(t *testing.T) {
+// TestCopyYAMLLevelContainersBulkSelection asserts the new bulk behavior at
+// LevelContainers: when N containers are selected and the user picks YAML
+// from the picker that Y opens, the dispatcher fires the "Fetching N
+// manifests..." status, fetches the parent Pod once, and the command
+// extracts the matching container spec blocks. Without seeded Pod YAML in
+// the fake client the fetch errors, but error wrapping (`ns/name:`)
+// confirms the bulk path was taken rather than the single-pod fallthrough.
+func TestCopyYAMLLevelContainersBulkSelection(t *testing.T) {
 	m := basePush80Model()
 	m.nav.Level = model.LevelContainers
 	m.nav.OwnedName = "pod-1"
@@ -983,15 +1009,77 @@ func TestCopyYAMLLevelContainersIgnoresSelection(t *testing.T) {
 	m.toggleSelection(m.middleItems[0])
 	m.toggleSelection(m.middleItems[1])
 
-	ret, cmd, handled := m.handleExplorerActionKeyCopyYAML()
+	mdl, _, handled := m.handleExplorerActionKeyCopyYAML()
 	require.True(t, handled)
-	rm := ret.(Model)
+	r := mdl.(Model)
+	require.True(t, r.copyFormatPicker.active, "Y must open the picker at LevelContainers")
 
-	assert.Empty(t, rm.statusMessage,
-		"LevelContainers does not support bulk; dispatcher must take the cursor branch silently")
-	require.NotNil(t, cmd, "must still dispatch a single-pod fetch")
+	// Apply YAML (cursor=0 → YAML).
+	mdl2, cmd := r.applyCopyFormatPicker()
+	rm := mdl2.(Model)
+
+	assert.Equal(t, "Fetching 2 manifests...", rm.statusMessage,
+		"LevelContainers now supports bulk; dispatcher must show the fetching toast")
+	require.NotNil(t, cmd, "must still dispatch a bulk fetch")
 
 	ymsg, ok := cmd().(yamlClipboardMsg)
 	require.True(t, ok)
-	assert.Equal(t, 1, ymsg.count, "single-pod fetch must be tagged count=1")
+	require.Error(t, ymsg.err, "fake client has no pod seeded; Pod GET must fail")
+	assert.Contains(t, ymsg.err.Error(), "default/pod-1",
+		"bulk path wraps the Pod fetch error with ns/name")
+	assert.Equal(t, 0, ymsg.count, "early-return on error keeps count at zero")
+}
+
+// TestYKeyOpensPicker_AtResources confirms `Y` at LevelResources opens the
+// copy-as picker instead of dispatching a YAML copy directly. This is the
+// observable contract change for Task 10: Y is no longer a direct YAML
+// dispatcher — it gates on format choice via the picker.
+func TestYKeyOpensPicker_AtResources(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a", Kind: "Pod"}}
+	m.setCursor(0)
+	mdl, _, handled := m.handleExplorerActionKeyCopyYAML()
+	assert.True(t, handled)
+	r := mdl.(Model)
+	assert.True(t, r.copyFormatPicker.active, "Y must open the picker, not copy directly")
+}
+
+// TestYKeyOpensPicker_AtClusters confirms `Y` at LevelClusters opens the
+// picker with the Table-only format set — there is no manifest behind a
+// cluster row, so YAML/JSON are deliberately omitted.
+func TestYKeyOpensPicker_AtClusters(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelClusters
+	m.middleItems = []model.Item{{Name: "kind-1"}}
+	m.setCursor(0)
+	mdl, _, handled := m.handleExplorerActionKeyCopyYAML()
+	assert.True(t, handled)
+	r := mdl.(Model)
+	assert.True(t, r.copyFormatPicker.active)
+	assert.Equal(t, []CopyFormat{CopyFormatTable}, r.copyFormatPicker.formats)
+}
+
+// TestYKeyBulkCapExceeded verifies the cap check fires at open time: with
+// more than maxBulkYAMLCopy items selected at a bulk-capable level, the
+// picker must NOT open and an error toast is shown immediately. This gives
+// the user feedback before they pick a format rather than after.
+func TestYKeyBulkCapExceeded(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	items := make([]model.Item, 51)
+	for i := range items {
+		items[i] = model.Item{Name: fmt.Sprintf("p-%d", i), Kind: "Pod"}
+	}
+	m.middleItems = items
+	m.selectedItems = map[string]bool{}
+	for i := range items {
+		m.selectedItems[selectionKey(items[i])] = true
+	}
+	m.setCursor(0)
+	mdl, _, handled := m.handleExplorerActionKeyCopyYAML()
+	assert.True(t, handled)
+	r := mdl.(Model)
+	assert.False(t, r.copyFormatPicker.active, "picker must NOT open when cap is exceeded")
+	assert.Contains(t, r.statusMessage, "Max 50 exceeded")
 }

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -97,6 +97,8 @@ func (m Model) isOverlayToggleKey(key string) bool {
 		return key == kb.OrphanOverlay
 	case overlayLocalClusters:
 		return key == kb.LocalClusterManager
+	case overlayCopyFormat:
+		return key == kb.CopyYAML
 	}
 	return false
 }
@@ -239,6 +241,9 @@ func (m Model) handleOverlayKeySecondary(msg tea.KeyMsg) (tea.Model, tea.Cmd, bo
 		return mdl, cmd, true
 	case overlayTrafficCapture:
 		mdl, cmd := m.updateOverlayCapture(msg)
+		return mdl, cmd, true
+	case overlayCopyFormat:
+		mdl, cmd := m.handleCopyFormatPickerKey(msg)
 		return mdl, cmd, true
 	}
 	return m, nil, false

--- a/internal/app/update_yaml_msgs.go
+++ b/internal/app/update_yaml_msgs.go
@@ -72,10 +72,26 @@ func (m Model) updateYamlClipboard(msg yamlClipboardMsg) (tea.Model, tea.Cmd) {
 		m.setErrorFromErr("Error: ", msg.err)
 		return m, scheduleStatusClear()
 	}
+	label, unit := copyFormatStatusParts(msg.format)
 	if msg.count > 1 {
-		m.setStatusMessage(fmt.Sprintf("Copied %d manifests to clipboard", msg.count), false)
+		m.setStatusMessage(fmt.Sprintf("Copied %d %s as %s", msg.count, unit, label), false)
 	} else {
-		m.setStatusMessage("YAML copied to clipboard", false)
+		m.setStatusMessage(fmt.Sprintf("%s copied to clipboard", label), false)
 	}
 	return m, tea.Batch(copyToSystemClipboard(msg.content), scheduleStatusClear())
+}
+
+// copyFormatStatusParts returns the (label, plural-unit) pair used in the
+// clipboard status message. label is title-case for the status line ("YAML",
+// "JSON", "Table"); unit is the plural noun for bulk copies. Empty format
+// defaults to YAML so legacy callers stay correct.
+func copyFormatStatusParts(format string) (label, unit string) {
+	switch format {
+	case "json":
+		return "JSON", "manifests"
+	case "table":
+		return "Table", "rows"
+	default:
+		return "YAML", "manifests"
+	}
 }

--- a/internal/app/update_yaml_msgs_test.go
+++ b/internal/app/update_yaml_msgs_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateYamlClipboardStatusByFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      yamlClipboardMsg
+		expected string
+	}{
+		{"single yaml (legacy empty format)", yamlClipboardMsg{content: "x", count: 1}, "YAML copied to clipboard"},
+		{"single yaml (explicit)", yamlClipboardMsg{content: "x", count: 1, format: "yaml"}, "YAML copied to clipboard"},
+		{"single json", yamlClipboardMsg{content: "x", count: 1, format: "json"}, "JSON copied to clipboard"},
+		{"single table", yamlClipboardMsg{content: "x", count: 1, format: "table"}, "Table copied to clipboard"},
+		{"bulk yaml", yamlClipboardMsg{content: "x", count: 4, format: "yaml"}, "Copied 4 manifests as YAML"},
+		{"bulk json", yamlClipboardMsg{content: "x", count: 4, format: "json"}, "Copied 4 manifests as JSON"},
+		{"bulk table", yamlClipboardMsg{content: "x", count: 4, format: "table"}, "Copied 4 rows as Table"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{}
+			ret, _ := m.updateYamlClipboard(tt.msg)
+			rm := ret.(Model)
+			assert.Equal(t, tt.expected, rm.statusMessage)
+		})
+	}
+}

--- a/internal/app/view_overlay_copy_format.go
+++ b/internal/app/view_overlay_copy_format.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// renderOverlayCopyFormat paints the Y-key copy-as picker as a small
+// OverlayList. Each row is a CopyFormat; the single-letter shortcut
+// chip ([y]/[t]) is shown via ShowKey (JSON has no chip — its
+// shortcut would collide with cursor-down). Hints live on the bottom
+// hint bar via overlayHintBarSelector — no in-overlay footer. Returns
+// empty content + zero dims when the picker isn't active so the
+// view-dispatch fallback fires.
+func (m Model) renderOverlayCopyFormat() (string, int, int) {
+	if !m.copyFormatPicker.active {
+		return "", 0, 0
+	}
+	formats := m.copyFormatPicker.formats
+	items := make([]ui.OverlayListItem, len(formats))
+	for i, f := range formats {
+		items[i] = ui.OverlayListItem{
+			Key:  f.ShortcutKey(),
+			Name: f.Label(),
+		}
+	}
+	cfg := ui.OverlayListConfig{
+		Title:        "Copy as",
+		Cursor:       m.copyFormatPicker.cursor,
+		ShowKey:      true,
+		EmptyMessage: "No formats available",
+	}
+	overlayW := ui.OverlayListWidth(items, cfg, max(m.width-10, 1))
+	content := ui.RenderOverlayList(items, cfg, max(overlayW-4, 1))
+	height := max(min(10, m.height-6), 1)
+	return content, overlayW, height
+}

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -270,6 +270,9 @@ func (m Model) renderOverlayContentExtended() (string, int, int, bool) {
 	case overlayTrafficCapture:
 		c, w, h := m.renderOverlayTrafficCapture()
 		return c, w, h, true
+	case overlayCopyFormat:
+		c, w, h := m.renderOverlayCopyFormat()
+		return c, w, h, true
 	}
 	return "", 0, 0, false
 }

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -48,9 +48,9 @@ func headerWithIndicator(label string, colName string, colWidth int) string {
 func plainExtraCell(ec extraColumn, item *model.Item) string {
 	var val string
 	if item == nil {
-		val = columnHeaderLabel(ec.key) + sortIndicatorForColumn(ec.key)
+		val = ColumnHeaderLabel(ec.key) + sortIndicatorForColumn(ec.key)
 	} else {
-		val = getExtraColumnValue(item, ec.key)
+		val = GetExtraColumnValue(item, ec.key)
 	}
 	switch {
 	case strings.HasPrefix(val, "↑ ") || strings.HasPrefix(val, "↓ "):
@@ -66,7 +66,7 @@ func plainExtraCell(ec extraColumn, item *model.Item) string {
 
 // styledExtraCell builds the styled cell for a single extra column.
 func styledExtraCell(ec extraColumn, item *model.Item) string {
-	val := getExtraColumnValue(item, ec.key)
+	val := GetExtraColumnValue(item, ec.key)
 	style := resourceColumnStyle(ec.key, val)
 	switch {
 	case strings.HasPrefix(val, "↑ "):

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -292,8 +292,8 @@ func blockedColumnsForMode() map[string]bool {
 	}
 }
 
-// getExtraColumnValue retrieves the value for a given column key from an item.
-func getExtraColumnValue(item *model.Item, key string) string {
+// GetExtraColumnValue retrieves the value for a given column key from an item.
+func GetExtraColumnValue(item *model.Item, key string) string {
 	if item == nil {
 		return ""
 	}
@@ -324,11 +324,11 @@ var columnHeaderAliases = map[string]string{
 	"Service Account":     "SA",
 }
 
-// columnHeaderLabel returns the uppercase display label for a column key,
+// ColumnHeaderLabel returns the uppercase display label for a column key,
 // applying any alias from columnHeaderAliases. Used by plainExtraCell so
 // internal Column keys can stay descriptive while the rendered table header
 // stays compact.
-func columnHeaderLabel(key string) string {
+func ColumnHeaderLabel(key string) string {
 	if alias, ok := columnHeaderAliases[key]; ok {
 		return strings.ToUpper(alias)
 	}

--- a/internal/ui/explorer_table_columns.go
+++ b/internal/ui/explorer_table_columns.go
@@ -102,7 +102,7 @@ func headerCellForKey(key string, extraCols []extraColumn,
 	}
 	for _, ec := range extraCols {
 		if ec.key == key {
-			return headerWithIndicator(columnHeaderLabel(ec.key), ec.key, ec.width)
+			return headerWithIndicator(ColumnHeaderLabel(ec.key), ec.key, ec.width)
 		}
 	}
 	return ""

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -96,7 +96,7 @@ func helpSections() []helpSection {
 				{kb.ForceDelete, "Force delete (Pod/Job only)"},
 				{kb.SaveResource, "Save resource to file / toggle warnings-only (Events)"},
 				{kb.CopyName, "Copy resource name to clipboard"},
-				{helpKeyDisplay(kb.CopyYAML), "Copy resource YAML to clipboard"},
+				{helpKeyDisplay(kb.CopyYAML), "Open copy-as picker (YAML / JSON / Table)"},
 				{helpKeyDisplay(kb.PasteApply), "Apply resource from clipboard (kubectl apply)"},
 				{"", "Port forwarding: use action menu (" + kb.ActionMenu + ") on Pod/Service/Deployment/StatefulSet/DaemonSet"},
 				{"", "Auto-navigates to Port Forwards list after creation; shows resolved local port"},


### PR DESCRIPTION
## Summary

- Press `Y` to open a small picker overlay instead of copying YAML directly. Pick YAML / JSON / Table.
- Works at every navigation level. Clusters / ResourceTypes offer Table only (no manifest behind those rows). Resources / Owned / Containers offer all three.
- At Containers, YAML / JSON output is just the container spec block extracted from the Pod manifest — not the full Pod. Multi-container selection supported (new bulk path).
- Table format mirrors the explorer's current view: respects hidden columns and the user's column order.
- Lowercase `y` (copy name) is unchanged.

Closes #232.

## Behavior matrix

| Level | `Y` (uppercase) — new | `y` (lowercase) — unchanged |
|---|---|---|
| Clusters | picker: Table only | copy context name |
| ResourceTypes | picker: Table only | copy kind name |
| Resources | picker: YAML / JSON / Table | copy name(s) |
| Owned | picker: YAML / JSON / Table | copy name(s) |
| Containers | picker: YAML / JSON / Table (container spec only) | copy container name |

Inside the picker: `j`/`k` cycle, `Enter` applies, `Esc` cancels, `y`/`t` letter shortcuts apply directly (`j` is consumed by cursor-down so JSON requires Enter).

## Test plan

- [x] `go test ./... -race` passes
- [x] `go vet ./...` clean
- [x] Walk through the 10 manual cases in `TESTS.md > Copy-as picker (Y)` against a live cluster
- [x] Verify `:export yaml` / `:export json` in the command bar still work (unchanged path)
- [x] Verify hiding/reordering columns via `,` (column toggle) reflects in the copied Table

🤖 Generated with [Claude Code](https://claude.com/claude-code)