### PR TITLE
fix: details pane shows children + theme color tracking

### DIFF
--- a/internal/app/owned_preview_coalesce_test.go
+++ b/internal/app/owned_preview_coalesce_test.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	clientfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestDeploymentChildren_NotCoalescedByMainListRefresh exercises the scheduler
+// coalescing path that previously dropped owned-children loads. Both the main
+// resource list ("List Deployments") and the owned-pods preview ("List
+// Deployment children") run with Kind=ResourceList against the same
+// context+namespace+gen, so before the Sig fix they shared a coalesce
+// signature: the watch-tick refresh of the main list would silently drop the
+// queued children load (and vice versa), leaving the right-pane children pane
+// stuck empty.
+//
+// This test verifies the chain at LevelResources hovering a Deployment runs to
+// completion: loadOwned returns an ownedLoadedMsg with the pod, and feeding it
+// back through updateOwnedLoaded populates rightItems so renderRightResources
+// renders the split preview.
+func TestDeploymentChildren_NotCoalescedByMainListRefresh(t *testing.T) {
+	rs := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "ReplicaSet",
+		"metadata": map[string]any{
+			"name":      "argo-workflows-server-abc",
+			"namespace": "argo",
+			"ownerReferences": []any{
+				map[string]any{"kind": "Deployment", "name": "argo-workflows-server"},
+			},
+		},
+	}}
+	pod := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":              "argo-workflows-server-abc-xyz",
+			"namespace":         "argo",
+			"creationTimestamp": "2026-01-01T00:00:00Z",
+			"ownerReferences": []any{
+				map[string]any{"kind": "ReplicaSet", "name": "argo-workflows-server-abc"},
+			},
+		},
+		"spec":   map[string]any{"containers": []any{map[string]any{"name": "main"}}},
+		"status": map[string]any{"phase": "Running"},
+	}}
+
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		{Group: "apps", Version: "v1", Resource: "replicasets"}:          "ReplicaSetList",
+		{Group: "", Version: "v1", Resource: "pods"}:                     "PodList",
+		{Group: "", Version: "v1", Resource: "events"}:                   "EventList",
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}:  "PodMetricsList",
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}: "NodeMetricsList",
+	}
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, rs, pod)
+	cs := clientfake.NewClientset()
+
+	m := baseModelCov()
+	m.client = k8s.NewTestClient(cs, dyn)
+	m.nav.Context = "test-ctx"
+	m.namespace = ""
+	m.allNamespaces = true
+
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind:       "Deployment",
+		Resource:   "deployments",
+		APIGroup:   "apps",
+		APIVersion: "v1",
+		Namespaced: true,
+	}
+	m.middleItems = []model.Item{
+		{Name: "argo-workflows-server", Namespace: "argo", Kind: "Deployment"},
+	}
+	m.setCursor(0)
+	m.scheduler.StartWorkers()
+	t.Cleanup(m.scheduler.StopWorkers)
+
+	require.True(t, m.resourceTypeHasChildren())
+
+	// Run loadOwned and confirm it produces the pod (not nil, not ErrCoalesced).
+	ownedCmd := m.loadOwned(true)
+	require.NotNil(t, ownedCmd)
+
+	msg := ownedCmd()
+	require.NotNil(t, msg, "ownedCmd returned nil — the scheduler coalesced or context-switched this submission")
+
+	owned, ok := msg.(ownedLoadedMsg)
+	require.True(t, ok, "expected ownedLoadedMsg, got %T", msg)
+	require.NoError(t, owned.err)
+	require.Len(t, owned.items, 1)
+	assert.Equal(t, "argo-workflows-server-abc-xyz", owned.items[0].Name)
+
+	newModel, _ := m.updateOwnedLoaded(owned)
+	m2 := newModel.(Model)
+	require.Len(t, m2.rightItems, 1)
+}

--- a/internal/app/scheduler/scheduler.go
+++ b/internal/app/scheduler/scheduler.go
@@ -30,6 +30,7 @@ func (r SubmitReq) Sig() Sig {
 	return Sig{
 		KubeContext: r.KubeContext,
 		Kind:        r.Kind,
+		Name:        r.Name,
 		Target:      r.Target,
 		Gen:         r.Gen,
 	}

--- a/internal/app/scheduler/scheduler_coalesce.go
+++ b/internal/app/scheduler/scheduler_coalesce.go
@@ -3,7 +3,16 @@ package scheduler
 // Sig identifies an in-flight or queued scheduler task for coalescing.
 // Two Submits with identical Sigs are treated as duplicates: the older
 // queued entry is replaced by the newer one (newer wins). Sigs are
-// compared by value; all four fields contribute to identity.
+// compared by value; all five fields contribute to identity.
+//
+// Name is included so two distinct loads with the same Kind/Target/Gen
+// do not collapse into each other — e.g. "List Deployments" (the main
+// resource list at LevelResources) and "List Deployment children" (the
+// owned-pod preview for the hovered Deployment) both run with
+// Kind=ResourceList against the same context/namespace, but represent
+// different requests that must both complete. Without Name in the Sig,
+// each watch-tick refresh would drop whichever of the two was still
+// queued, leaving the right-pane children stuck empty.
 //
 // Gen is the caller's requestGen at submission time so navigation that
 // invalidates cached results also invalidates the coalesce signature
@@ -12,6 +21,7 @@ package scheduler
 type Sig struct {
 	KubeContext string
 	Kind        Kind
+	Name        string
 	Target      string
 	Gen         uint64
 }

--- a/internal/app/scheduler/scheduler_coalesce_test.go
+++ b/internal/app/scheduler/scheduler_coalesce_test.go
@@ -7,21 +7,34 @@ import (
 )
 
 func TestSig_EqualByFields(t *testing.T) {
-	a := Sig{KubeContext: "c1", Kind: KindResourceList, Target: "default", Gen: 7}
-	b := Sig{KubeContext: "c1", Kind: KindResourceList, Target: "default", Gen: 7}
+	a := Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Pods", Target: "default", Gen: 7}
+	b := Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Pods", Target: "default", Gen: 7}
 	assert.Equal(t, a, b)
 }
 
+// TestSig_NameInSignature is a regression test for the bug where
+// "List Deployments" (the main resource list refresh) and "List Deployment
+// children" (the owned-pods preview) had identical Sigs and coalesced each
+// other under watch-tick refresh, leaving the right-pane children pane stuck
+// empty for Deployment / StatefulSet / DaemonSet hovers.
+func TestSig_NameInSignature(t *testing.T) {
+	mainList := Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Deployments", Target: "c1 / argo", Gen: 7}
+	childList := Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Deployment children", Target: "c1 / argo", Gen: 7}
+	assert.NotEqual(t, mainList, childList,
+		"main resource list and owned-children preview must NOT share a coalesce Sig")
+}
+
 func TestSig_DifferByAnyField(t *testing.T) {
-	base := Sig{KubeContext: "c1", Kind: KindResourceList, Target: "default", Gen: 7}
+	base := Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Pods", Target: "default", Gen: 7}
 	cases := []struct {
 		name string
 		s    Sig
 	}{
-		{"different context", Sig{KubeContext: "c2", Kind: KindResourceList, Target: "default", Gen: 7}},
-		{"different kind", Sig{KubeContext: "c1", Kind: KindMetrics, Target: "default", Gen: 7}},
-		{"different target", Sig{KubeContext: "c1", Kind: KindResourceList, Target: "kube-system", Gen: 7}},
-		{"different gen", Sig{KubeContext: "c1", Kind: KindResourceList, Target: "default", Gen: 8}},
+		{"different context", Sig{KubeContext: "c2", Kind: KindResourceList, Name: "List Pods", Target: "default", Gen: 7}},
+		{"different kind", Sig{KubeContext: "c1", Kind: KindMetrics, Name: "List Pods", Target: "default", Gen: 7}},
+		{"different name", Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Pod children", Target: "default", Gen: 7}},
+		{"different target", Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Pods", Target: "kube-system", Gen: 7}},
+		{"different gen", Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Pods", Target: "default", Gen: 8}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/app/scheduler/scheduler_test.go
+++ b/internal/app/scheduler/scheduler_test.go
@@ -16,10 +16,11 @@ func TestSubmitReq_Sig(t *testing.T) {
 	req := SubmitReq{
 		KubeContext: "c1",
 		Kind:        KindResourceList,
+		Name:        "List Pods",
 		Target:      "default",
 		Gen:         5,
 	}
-	assert.Equal(t, Sig{KubeContext: "c1", Kind: KindResourceList, Target: "default", Gen: 5}, req.Sig())
+	assert.Equal(t, Sig{KubeContext: "c1", Kind: KindResourceList, Name: "List Pods", Target: "default", Gen: 5}, req.Sig())
 }
 
 func TestSubmitReq_PriorityZeroValueIsCritical(t *testing.T) {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -45,10 +45,13 @@ func ThemeColor(spec string) lipgloss.TerminalColor {
 }
 
 // Theme color slots used by inline lipgloss.Color(ColorX) calls throughout
-// the codebase. Overwritten by applyNoColorTheme (blanked) and by the
-// color branch of ApplyTheme (restored to defaults). They stay as package
-// variables so code that already references them keeps compiling
-// unchanged.
+// the codebase. ApplyTheme rewrites them from the active theme so inline
+// call sites track theme changes; applyNoColorTheme blanks them so inline
+// foreground calls resolve to NoColor{}. They stay as package variables
+// so code that already references them keeps compiling unchanged.
+//
+// Initial values are the Tokyonight Storm defaults so any early call site
+// that fires before ApplyTheme still emits a valid color.
 var (
 	ColorPrimary    = defaultColorPrimary
 	ColorSecondary  = defaultColorSecondary

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -104,26 +104,32 @@ func ApplyTheme(t Theme) {
 	}
 	// Returning to color mode after no-color was active: restore whatever
 	// profile termenv originally detected (typically TrueColor in a normal
-	// terminal, Ascii when NO_COLOR was set externally) and restore the
-	// Color* theme variables that no-color blanked.
+	// terminal, Ascii when NO_COLOR was set externally) and repopulate the
+	// Color* theme variables from the active theme — inline
+	// lipgloss.Color(ColorX) call sites otherwise stay frozen at the default
+	// Tokyonight palette regardless of which theme is loaded.
+	//
+	// ColorOrange / ColorCyan have no Theme field (they are special-purpose
+	// constants — high-CPU warning amber, freshly-created cyan) and stay at
+	// their compile-time defaults.
 	if originalColorProfileSaved {
 		lipgloss.DefaultRenderer().SetColorProfile(originalColorProfile)
 	}
-	ColorPrimary = defaultColorPrimary
-	ColorSecondary = defaultColorSecondary
-	ColorFile = defaultColorFile
-	ColorSelectedFg = defaultColorSelectedFg
-	ColorSelectedBg = defaultColorSelectedBg
-	ColorBorder = defaultColorBorder
-	ColorDimmed = defaultColorDimmed
-	ColorError = defaultColorError
-	ColorWarning = defaultColorWarning
-	ColorPurple = defaultColorPurple
+	ColorPrimary = t.Primary
+	ColorSecondary = t.Secondary
+	ColorFile = t.Text
+	ColorSelectedFg = t.SelectedFg
+	ColorSelectedBg = t.SelectedBg
+	ColorBorder = t.Border
+	ColorDimmed = t.Dimmed
+	ColorError = t.Error
+	ColorWarning = t.Warning
+	ColorPurple = t.Purple
 	ColorOrange = defaultColorOrange
 	ColorCyan = defaultColorCyan
-	ColorBase = defaultColorBase
-	ColorBarBg = defaultColorBarBg
-	ColorSurface = defaultColorSurface
+	ColorBase = t.Base
+	ColorBarBg = t.BarBg
+	ColorSurface = t.Surface
 	// baseBg is applied to all column/content text styles so the theme
 	// background shows behind text (ANSI resets from inner styled content
 	// would otherwise clear the container background). NoColor when transparent.

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -115,6 +115,54 @@ func TestApplyTheme(t *testing.T) {
 	_ = OverlayStyle.Render("test")
 }
 
+// TestApplyTheme_TracksActiveThemeInColorSlots regression-guards a bug where
+// the package-level Color* slots stayed frozen at the Tokyonight defaults
+// regardless of which theme was loaded — inline lipgloss.Color(ColorPrimary)
+// call sites (e.g. the detail-pane key style in RenderResourceSummary) showed
+// the default blue even after switching themes.
+func TestApplyTheme_TracksActiveThemeInColorSlots(t *testing.T) {
+	origNoColor := ConfigNoColor
+	t.Cleanup(func() {
+		ConfigNoColor = origNoColor
+		ApplyTheme(DefaultTheme())
+	})
+	ConfigNoColor = false
+
+	custom := Theme{
+		Primary:    "#ff00aa",
+		Secondary:  "#00ff11",
+		Text:       "#abcdef",
+		SelectedFg: "#101010",
+		SelectedBg: "#202020",
+		Border:     "#303030",
+		Dimmed:     "#404040",
+		Error:      "#ff1122",
+		Warning:    "#ffaa00",
+		Purple:     "#aa00ff",
+		Base:       "#050505",
+		BarBg:      "#070707",
+		Surface:    "#090909",
+	}
+	ApplyTheme(custom)
+
+	assert.Equal(t, custom.Primary, ColorPrimary)
+	assert.Equal(t, custom.Secondary, ColorSecondary)
+	assert.Equal(t, custom.Text, ColorFile)
+	assert.Equal(t, custom.SelectedFg, ColorSelectedFg)
+	assert.Equal(t, custom.SelectedBg, ColorSelectedBg)
+	assert.Equal(t, custom.Border, ColorBorder)
+	assert.Equal(t, custom.Dimmed, ColorDimmed)
+	assert.Equal(t, custom.Error, ColorError)
+	assert.Equal(t, custom.Warning, ColorWarning)
+	assert.Equal(t, custom.Purple, ColorPurple)
+	assert.Equal(t, custom.Base, ColorBase)
+	assert.Equal(t, custom.BarBg, ColorBarBg)
+	assert.Equal(t, custom.Surface, ColorSurface)
+	// Orange / Cyan are special-purpose constants with no theme slot.
+	assert.Equal(t, defaultColorOrange, ColorOrange)
+	assert.Equal(t, defaultColorCyan, ColorCyan)
+}
+
 func TestColumnsForKind(t *testing.T) {
 	// Save and restore globals after test.
 	origResource := ConfigResourceColumns


### PR DESCRIPTION
## Summary

Two unrelated bugs surfaced while debugging the right-pane details view:

1. **Children pane stuck empty for Deployments / StatefulSets / DaemonSets / etc.** — the scheduler's coalesce signature collided between the main resource list and the owned-children preview, so every watch-tick refresh dropped the queued children load with `ErrCoalesced`.
2. **Details-pane key labels (NAME, NAMESPACE, LABELS, ANNOTATIONS, …) didn't follow the active theme** — `ApplyTheme` reset the package-level `Color*` slots back to the Tokyonight defaults instead of reading from the incoming theme.

Each commit fixes one bug independently and ships its own regression test.

### Commit 1 — fix(scheduler)

`Sig` now includes `Name`. ``List Deployments`` and ``List Deployment children`` no longer share a coalesce signature, so both run to completion under watch-tick refresh. End-to-end test drives the full ``loadOwned → ownedLoadedMsg → updateOwnedLoaded`` chain against a fake Deployment → ReplicaSet → Pod ownership graph and asserts ``rightItems`` is populated.

### Commit 2 — fix(theme)

``ApplyTheme`` now populates the inline ``ColorPrimary`` / ``ColorSecondary`` / ``ColorFile`` / ``ColorSelectedFg`` / ``ColorSelectedBg`` / ``ColorBorder`` / ``ColorDimmed`` / ``ColorError`` / ``ColorWarning`` / ``ColorPurple`` / ``ColorBase`` / ``ColorBarBg`` / ``ColorSurface`` slots from the active theme. ``ColorOrange`` and ``ColorCyan`` keep their defaults — they have no Theme field and represent special-purpose constants. Regression test asserts each slot tracks a custom theme after ``ApplyTheme``.

## Test plan

- [x] ``go test ./...`` (full suite passes)
- [x] ``go test -race ./internal/app/scheduler/ ./internal/app/`` (race-clean)
- [x] ``make lint`` (golangci-lint: 0 issues)
- [x] Manual: drilled into Deployments on a live k3d cluster, confirmed pod table appears in right pane on top of DETAILS
- [x] Manual: confirmed the scheduler-coalesce log no longer fires for "List Deployment children" — every watch tick produces an ``updateOwnedLoaded`` with ``items=1``