### PR TITLE
fix(copy): JSON shortcut chip + partial-success on bulk YAML/JSON copy

### DIFF
--- a/internal/app/commands_yaml.go
+++ b/internal/app/commands_yaml.go
@@ -36,17 +36,16 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 			}
 			return func() tea.Msg {
 				docs := make([]string, 0, len(targets))
+				var failures []string
 				for _, t := range targets {
 					content, err := m.client.GetResourceYAML(context.Background(), kctx, t.ns, rt, t.name)
 					if err != nil {
-						return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+						failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+						continue
 					}
 					docs = append(docs, strings.TrimRight(content, "\n"))
 				}
-				return yamlClipboardMsg{
-					content: strings.Join(docs, "\n---\n") + "\n",
-					count:   len(docs),
-				}
+				return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
 			}
 		}
 		sel := m.selectedMiddleItem()
@@ -91,6 +90,7 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 			}
 			return func() tea.Msg {
 				docs := make([]string, 0, len(targets))
+				var failures []string
 				for _, t := range targets {
 					var (
 						content string
@@ -105,14 +105,12 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 						err = fmt.Errorf("unknown resource type: %s", t.kind)
 					}
 					if err != nil {
-						return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+						failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+						continue
 					}
 					docs = append(docs, strings.TrimRight(content, "\n"))
 				}
-				return yamlClipboardMsg{
-					content: strings.Join(docs, "\n---\n") + "\n",
-					count:   len(docs),
-				}
+				return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
 			}
 		}
 		sel := m.selectedMiddleItem()
@@ -178,6 +176,16 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 // the snapshot captured at picker-open time. Returns nil for an empty
 // scope at any level. LevelContainers extracts each container spec
 // block from the Pod YAML.
+//
+// Bulk paths are resilient to per-item failures: if some of the N
+// requested fetches fail (RBAC, 404 on a row that was just deleted by
+// a controller, transient network blip), the successes are still
+// concatenated and copied. The per-item errors are joined into the
+// returned yamlClipboardMsg.err so updateYamlClipboard can surface
+// them — but only after the successful payload has been recorded so
+// the user gets a partial copy rather than an empty clipboard.
+// Without this every "select N → Y" interaction was all-or-nothing,
+// turning a single broken row into "nothing copied" across the batch.
 func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 	if len(scope) == 0 {
 		return nil
@@ -201,17 +209,16 @@ func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 		}
 		return func() tea.Msg {
 			docs := make([]string, 0, len(targets))
+			var failures []string
 			for _, t := range targets {
 				content, err := m.client.GetResourceYAML(context.Background(), kctx, t.ns, rt, t.name)
 				if err != nil {
-					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+					failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+					continue
 				}
 				docs = append(docs, strings.TrimRight(content, "\n"))
 			}
-			return yamlClipboardMsg{
-				content: strings.Join(docs, "\n---\n") + "\n",
-				count:   len(docs),
-			}
+			return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
 		}
 	case model.LevelOwned:
 		type fetchTarget struct {
@@ -235,6 +242,7 @@ func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 		}
 		return func() tea.Msg {
 			docs := make([]string, 0, len(targets))
+			var failures []string
 			for _, t := range targets {
 				var (
 					content string
@@ -249,14 +257,12 @@ func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 					err = fmt.Errorf("unknown resource type: %s", t.kind)
 				}
 				if err != nil {
-					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", t.ns, t.name, err)}
+					failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+					continue
 				}
 				docs = append(docs, strings.TrimRight(content, "\n"))
 			}
-			return yamlClipboardMsg{
-				content: strings.Join(docs, "\n---\n") + "\n",
-				count:   len(docs),
-			}
+			return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
 		}
 	case model.LevelContainers:
 		podName := m.nav.OwnedName
@@ -277,6 +283,40 @@ func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 		}
 	}
 	return nil
+}
+
+// buildBulkYAMLClipboardMsg assembles a yamlClipboardMsg for a bulk-fetch
+// path with per-item failure tolerance. docs holds the successful YAML
+// payloads (joined with the standard \n---\n multi-doc separator);
+// failures carries the "<ns>/<name>: <err>" lines for each fetch that
+// errored out. total is the original target count.
+//
+// Behavior:
+//   - All N succeeded → success message (count == N, no err).
+//   - All N failed → error-only message (no content, single err with
+//     every failure joined).
+//   - Mixed → partial-success message: content is the successes,
+//     count is len(docs), err is the joined failures so the status
+//     line can render "copied K/N, M failed: ...".
+//
+// Without this, every per-item failure aborts the batch and leaves the
+// clipboard untouched — which made "select N → Y → YAML" look broken
+// whenever a single row (e.g. a 404 from a controller-driven delete
+// racing the fetch, or an RBAC gap on one item) tripped the loop.
+func buildBulkYAMLClipboardMsg(docs, failures []string, total int) yamlClipboardMsg {
+	if len(docs) == 0 {
+		return yamlClipboardMsg{
+			err: fmt.Errorf("all %d fetches failed: %s", total, strings.Join(failures, "; ")),
+		}
+	}
+	msg := yamlClipboardMsg{
+		content: strings.Join(docs, "\n---\n") + "\n",
+		count:   len(docs),
+	}
+	if len(failures) > 0 {
+		msg.err = fmt.Errorf("copied %d/%d, %d failed: %s", len(docs), total, len(failures), strings.Join(failures, "; "))
+	}
+	return msg
 }
 
 // exportResourceToFile saves the selected resource YAML to a file.

--- a/internal/app/commands_yaml_partial_test.go
+++ b/internal/app/commands_yaml_partial_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildBulkYAMLClipboardMsg_AllSucceeded(t *testing.T) {
+	docs := []string{"a: 1", "b: 2", "c: 3"}
+	msg := buildBulkYAMLClipboardMsg(docs, nil, 3)
+	assert.NoError(t, msg.err)
+	assert.Equal(t, 3, msg.count)
+	assert.Equal(t, "a: 1\n---\nb: 2\n---\nc: 3\n", msg.content)
+}
+
+func TestBuildBulkYAMLClipboardMsg_AllFailed(t *testing.T) {
+	failures := []string{"ns/a: forbidden", "ns/b: 404"}
+	msg := buildBulkYAMLClipboardMsg(nil, failures, 2)
+	require.Error(t, msg.err)
+	assert.Empty(t, msg.content)
+	assert.Equal(t, 0, msg.count)
+	assert.Contains(t, msg.err.Error(), "all 2 fetches failed")
+	assert.Contains(t, msg.err.Error(), "ns/a: forbidden")
+	assert.Contains(t, msg.err.Error(), "ns/b: 404")
+}
+
+// TestBuildBulkYAMLClipboardMsg_PartialSuccess is the regression test for the
+// "select N → Y → YAML produces empty clipboard when one row fails" bug. The
+// successful docs must still be packed into content with the proper multi-doc
+// joiner; err carries the per-item failures so updateYamlClipboard can surface
+// them as a warning rather than dropping the clipboard write.
+func TestBuildBulkYAMLClipboardMsg_PartialSuccess(t *testing.T) {
+	docs := []string{"a: 1", "b: 2"}
+	failures := []string{"ns/c: forbidden"}
+	msg := buildBulkYAMLClipboardMsg(docs, failures, 3)
+	require.Error(t, msg.err)
+	assert.Equal(t, "a: 1\n---\nb: 2\n", msg.content,
+		"partial-success content must still contain the docs that succeeded")
+	assert.Equal(t, 2, msg.count, "count reflects successes, not total")
+	assert.Contains(t, msg.err.Error(), "copied 2/3, 1 failed")
+	assert.Contains(t, msg.err.Error(), "ns/c: forbidden")
+}
+
+// TestUpdateYamlClipboard_PartialSuccessStillCopies guards the
+// updateYamlClipboard branch that must NOT short-circuit on err when the
+// payload is non-empty. Prior to the fix, any err returned from the bulk
+// fetch dropped the clipboard write entirely; now a partial-success msg
+// (content + err both set) goes down the copy path with a "Warning:"
+// status so the user gets the rows that succeeded.
+func TestUpdateYamlClipboard_PartialSuccessStillCopies(t *testing.T) {
+	m := baseModelCov()
+	msg := yamlClipboardMsg{
+		content: "a: 1\n---\nb: 2\n",
+		count:   2,
+		err:     assertableErr("copied 2/3, 1 failed: ns/c: forbidden"),
+	}
+	updated, cmd := m.updateYamlClipboard(msg)
+	m2 := updated.(Model)
+	require.NotNil(t, cmd, "partial success must still dispatch the clipboard write cmd")
+	assert.True(t, strings.HasPrefix(m2.statusMessage, "Warning:"),
+		"partial success surfaces as a Warning, not silent success")
+}
+
+// assertableErr is a tiny helper to build a deterministic error for tests
+// without pulling in fmt at every call site.
+type assertableErr string
+
+func (e assertableErr) Error() string { return string(e) }

--- a/internal/app/copy_format.go
+++ b/internal/app/copy_format.go
@@ -30,16 +30,16 @@ func (f CopyFormat) Label() string {
 }
 
 // ShortcutKey returns the single-letter shortcut that selects this
-// format directly from the picker. JSON deliberately returns "" — the
-// natural shortcut would be "j", but the picker key router consumes
-// "j" for cursor-down navigation, so users apply JSON via Enter on
-// its row (or navigate to it and press Enter). Returning "" here is
-// the single source of truth: the picker view shows no [j] chip and
-// the key router skips JSON in its shortcut loop.
+// format directly from the picker. JSON uses uppercase "J" because
+// lowercase "j" is reserved for cursor-down navigation in the picker
+// (and globally); the chip-in-picker behaviour stays consistent with
+// YAML and Table so every row advertises a shortcut.
 func (f CopyFormat) ShortcutKey() string {
 	switch f {
 	case CopyFormatYAML:
 		return "y"
+	case CopyFormatJSON:
+		return "J"
 	case CopyFormatTable:
 		return "t"
 	}

--- a/internal/app/copy_format_picker_keys.go
+++ b/internal/app/copy_format_picker_keys.go
@@ -5,12 +5,11 @@ import (
 )
 
 // handleCopyFormatPickerKey routes key events to the active copy-as
-// picker. j/k/down/up cycle the cursor; enter applies the cursor row;
-// esc/q cancel; lowercase letter shortcuts apply the matching format
-// directly. The letter `j` is reserved for cursor-down navigation
-// (cursor movement wins over the shadow JSON shortcut), so JSON must
-// be applied via Enter or by typing the up arrow / k to navigate up
-// to its row.
+// picker. j/k/down/up cycle the cursor (j/k stays consistent with
+// the global navigation aliases); enter applies the cursor row;
+// esc/q cancel; letter shortcuts apply the matching format directly.
+// JSON's shortcut is uppercase "J" so it doesn't collide with the
+// lowercase "j" cursor-down alias.
 func (m Model) handleCopyFormatPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc", "q":
@@ -26,8 +25,7 @@ func (m Model) handleCopyFormatPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.applyCopyFormatPicker()
 	}
 	// Letter shortcuts: apply the matching format directly. Formats
-	// that return an empty ShortcutKey (today: JSON, which would
-	// otherwise collide with cursor-down) are skipped.
+	// that return an empty ShortcutKey are skipped.
 	pressed := msg.String()
 	for i, f := range m.copyFormatPicker.formats {
 		key := f.ShortcutKey()

--- a/internal/app/copy_format_picker_test.go
+++ b/internal/app/copy_format_picker_test.go
@@ -370,6 +370,23 @@ func TestCopyFormatPicker_YShortcutAppliesYAML(t *testing.T) {
 	require.NotNil(t, cmd, "yaml dispatch returns non-nil cmd")
 }
 
+// TestCopyFormatPicker_JShortcutAppliesJSON guards the uppercase-J shortcut
+// for JSON. Lowercase j stays bound to cursor-down navigation; the user
+// reaches JSON either via uppercase J or by arrow-key + Enter. Regression
+// test: prior to this binding JSON was the only row without a shortcut
+// chip in the overlay, breaking the visual consistency of the picker.
+func TestCopyFormatPicker_JShortcutAppliesJSON(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.middleItems = []model.Item{{Name: "a", Kind: "Pod"}}
+	m.setCursor(0)
+	m.openCopyFormatPicker()
+	mdl, cmd := m.handleCopyFormatPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("J")})
+	r := mdl.(Model)
+	assert.False(t, r.copyFormatPicker.active, "J applies JSON and closes picker")
+	require.NotNil(t, cmd, "json dispatch returns non-nil cmd")
+}
+
 func TestCopyFormatPicker_EnterAppliesCursorRow(t *testing.T) {
 	m := baseExplorerModel()
 	m.nav.Level = model.LevelResources

--- a/internal/app/copy_format_test.go
+++ b/internal/app/copy_format_test.go
@@ -32,8 +32,8 @@ func TestCopyFormatLabelAndKey(t *testing.T) {
 	assert.Equal(t, "YAML", CopyFormatYAML.Label())
 	assert.Equal(t, "y", CopyFormatYAML.ShortcutKey())
 	assert.Equal(t, "JSON", CopyFormatJSON.Label())
-	assert.Equal(t, "", CopyFormatJSON.ShortcutKey(),
-		"JSON returns no shortcut because 'j' is consumed by cursor-down navigation")
+	assert.Equal(t, "J", CopyFormatJSON.ShortcutKey(),
+		"JSON uses uppercase J so it does not collide with lowercase j cursor-down navigation")
 	assert.Equal(t, "Table", CopyFormatTable.Label())
 	assert.Equal(t, "t", CopyFormatTable.ShortcutKey())
 }

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -133,7 +133,7 @@ func (m Model) overlayHintBarSelector() string {
 	case overlayCopyFormat:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "j/k", Desc: "navigate"},
-			{Key: "y/t", Desc: "shortcut"},
+			{Key: "y/J/t", Desc: "shortcut"},
 			{Key: "enter", Desc: "apply"},
 			{Key: "esc", Desc: "cancel"},
 		})

--- a/internal/app/update_yaml_msgs.go
+++ b/internal/app/update_yaml_msgs.go
@@ -68,14 +68,22 @@ func (m Model) updateActionResult(msg actionResultMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateYamlClipboard(msg yamlClipboardMsg) (tea.Model, tea.Cmd) {
-	if msg.err != nil {
+	// Pure-error path (content empty): surface the error and stop.
+	// Partial-success path (content present + err set) falls through to
+	// the copy + status branch so the user gets the partial payload on
+	// the clipboard; buildBulkYAMLClipboardMsg's err already names the
+	// failed items in the "copied K/N, M failed: ..." form.
+	if msg.err != nil && msg.content == "" {
 		m.setErrorFromErr("Error: ", msg.err)
 		return m, scheduleStatusClear()
 	}
 	label, unit := copyFormatStatusParts(msg.format)
-	if msg.count > 1 {
+	switch {
+	case msg.err != nil:
+		m.setErrorFromErr("Warning: ", msg.err)
+	case msg.count > 1:
 		m.setStatusMessage(fmt.Sprintf("Copied %d %s as %s", msg.count, unit, label), false)
-	} else {
+	default:
 		m.setStatusMessage(fmt.Sprintf("%s copied to clipboard", label), false)
 	}
 	return m, tea.Batch(copyToSystemClipboard(msg.content), scheduleStatusClear())


### PR DESCRIPTION
## Summary

Two bugs reported on the Y-key copy-as picker:

1. **JSON had no shortcut chip in the picker.** ``[y] YAML`` / ``JSON`` / ``[t] Table`` — the missing chip on the middle row broke the visual consistency and forced users to either arrow-key + Enter or memorize the gap. The natural mnemonic ``j`` was reserved for cursor-down navigation.
2. **Bulk YAML/JSON copy dropped the whole batch when any single item failed.** ``select N → Y → YAML`` produced an empty clipboard if even one of the N fetches hit a 404, RBAC gap, or transient error. The user saw "Fetching N manifests..." → silence → empty clipboard, with no indication that anything was attempted.

## Commit 1 — JSON shortcut

Bound ``CopyFormatJSON.ShortcutKey()`` to uppercase ``J``. Lowercase ``j`` stays the cursor-down alias (consistent with the global j/k navigation), and ``J`` doesn't collide with anything in the picker. Picker now renders ``[y] YAML`` / ``[J] JSON`` / ``[t] Table``; hint bar updated to ``y/J/t shortcut``.

## Commit 2 — Bulk-copy resilience

Made the LevelResources and LevelOwned bulk fetch loops in ``copyYAMLForScope`` (picker path) and ``copyYAMLToClipboard`` (legacy path) collect per-item failures instead of returning on the first error.

``buildBulkYAMLClipboardMsg`` packs the result:

| Case | content | err | UI status |
|------|---------|-----|-----------|
| All N succeeded | full payload | nil | ``Copied N manifests as YAML`` |
| All N failed | empty | joined errors | ``Error: all N fetches failed: ...`` |
| Mixed (K succeeded, M failed) | payload of K | joined M failures | ``Warning: copied K/N, M failed: ...`` + clipboard write |

``updateYamlClipboard`` no longer short-circuits on err when content is present, so partial-success batches still reach the clipboard write — the user gets the rows that worked plus a Warning naming the ones that didn't.

## Test plan

- [x] ``go test ./...`` (all green; new partial-success + JSON shortcut tests under TestBuildBulkYAML / TestUpdateYamlClipboard_PartialSuccessStillCopies / TestCopyFormatPicker_JShortcutAppliesJSON)
- [x] ``make lint`` (golangci-lint: 0 issues)
- [x] Manual: ``Y → J`` on 24 selected Deployments produces valid JSON in clipboard
- [x] Manual: picker overlay now shows ``[y] YAML`` / ``[J] JSON`` / ``[t] Table``