### PR TITLE
fix(kv-editor): dedicated selection column for the Secret/ConfigMap/Label editors

### DIFF
--- a/internal/ui/configmapview.go
+++ b/internal/ui/configmapview.go
@@ -144,11 +144,8 @@ func renderConfigMapEditorTable(
 	selectedKeys map[string]bool, // keys marked with `s` for batch copy; nil = none
 	width, height int,
 ) string {
-	// +2 budgets for the "✓ " / "  " selection-indicator prefix every
-	// key row carries — without this the key text gets truncated even
-	// when the underlying name fits.
-	keyColW := computeKeyColumnWidth(cm.Keys, width, 3) + 2
-	valColW := max(width-keyColW-5, 8)
+	keyColW := computeKeyColumnWidth(cm.Keys, width, 3)
+	valColW := max(width-kvSelColumnW-keyColW-8, 8)
 
 	bodyHeight := max(height-2, 1)
 	start := scrollWindowStart(selectedIdx, bodyHeight, len(cm.Keys))
@@ -160,26 +157,23 @@ func renderConfigMapEditorTable(
 		v := cm.Data[k]
 		displayV := configMapValueDisplay(v, valColW)
 
-		// Consistent 2-char prefix across all rows (including editing)
-		// so column alignment stays stable. See secretview for the
-		// rationale.
-		prefix := "  "
-		if selectedKeys[k] {
-			prefix = "\u2713 "
-		}
+		// Selection mark lives in its own leading column so the KEY
+		// cell no longer shifts two characters right just to leave
+		// room for a "  " / "\u2713 " prefix on every row.
+		selCell := kvSelectionCell(selectedKeys[k])
 		var keyText, valText string
 		switch {
 		case i == selectedIdx && editing && editColumn == 0:
-			keyText = prefix + overlayCursor(editKey, editKeyCursor, true, keyColW-2)
+			keyText = overlayCursor(editKey, editKeyCursor, true, keyColW)
 			valText = SingleLineCell(editValue, valColW)
 		case i == selectedIdx && editing && editColumn == 1:
-			keyText = prefix + SingleLineCell(editKey, keyColW-2)
+			keyText = SingleLineCell(editKey, keyColW)
 			valText = overlayCursor(editValue, editValueCursor, true, valColW)
 		default:
-			keyText = prefix + SingleLineCell(k, keyColW-2)
+			keyText = SingleLineCell(k, keyColW)
 			valText = displayV
 		}
-		t.Row(keyText, valText)
+		t.Row(selCell, keyText, valText)
 	}
 	rendered := t.Render()
 	if len(cm.Keys) == 0 {

--- a/internal/ui/configmapview.go
+++ b/internal/ui/configmapview.go
@@ -151,7 +151,7 @@ func renderConfigMapEditorTable(
 	start := scrollWindowStart(selectedIdx, bodyHeight, len(cm.Keys))
 	end := min(start+bodyHeight, len(cm.Keys))
 
-	t := newKVEditorTable(keyColW, valColW, selectedIdx-start)
+	t := newKVEditorTable(keyColW, valColW, selectedIdx-start, editing)
 	for i := start; i < end; i++ {
 		k := cm.Keys[i]
 		v := cm.Data[k]

--- a/internal/ui/kv_editor.go
+++ b/internal/ui/kv_editor.go
@@ -474,9 +474,21 @@ func scrollWindowStart(cursor, windowH, total int) int {
 	return start
 }
 
+// kvSelColumnW is the visible width (without padding) of the leading
+// "selection marker" column shared by every K/V editor. Wide enough
+// for the "✓" glyph plus no trailing space; lipgloss/table's per-cell
+// padding (1,1) supplies the gap to the KEY column on either side.
+const kvSelColumnW = 1
+
 // newKVEditorTable builds a lipgloss/table configured for the K/V
-// editor look: vertical column divider only, header underline, theme-
-// aware bg, and per-row styling that highlights the cursor row.
+// editor look: leading selection column, KEY, VALUE — with vertical
+// dividers between cells, header underline, theme-aware bg, and per-
+// row styling that highlights the cursor row.
+//
+// The selection column is the first column so the "✓" lands in a cell
+// of its own instead of being prefixed onto the KEY value (which used
+// to shift every row's key text two columns to the right whether or
+// not the row was actually selected).
 //
 // cursorRow is the body-row index (0-based; lipgloss/table's HeaderRow
 // is the constant -1) of the cursor. Pass -1 when no row is the cursor
@@ -493,16 +505,21 @@ func newKVEditorTable(keyColW, valColW, cursorRow int) *table.Table {
 		BorderStyle(lipgloss.NewStyle().
 			Foreground(lipgloss.Color(ColorBorder)).
 			Background(BaseBg)).
-		Headers("KEY", "VALUE").
+		Headers("", "KEY", "VALUE").
 		StyleFunc(func(row, col int) lipgloss.Style {
 			// Padding eats text space; widen the cell by the padding
 			// budget (1 + 1 = 2) so the row-data Truncate's full
-			// keyColW / valColW characters can land inside without
-			// wrapping into a second visual line.
+			// content can land inside without wrapping into a second
+			// visual line.
 			base := lipgloss.NewStyle().Padding(0, 1).Background(BaseBg)
-			cellW := valColW + 2
-			if col == 0 {
+			var cellW int
+			switch col {
+			case 0:
+				cellW = kvSelColumnW + 2
+			case 1:
 				cellW = keyColW + 2
+			default:
+				cellW = valColW + 2
 			}
 			base = base.Width(cellW)
 			switch {
@@ -517,9 +534,25 @@ func newKVEditorTable(keyColW, valColW, cursorRow int) *table.Table {
 					Background(lipgloss.Color(ColorSelectedBg)).
 					Bold(true)
 			case col == 0:
+				// Selection mark cell: emphasised when set, dimmed
+				// otherwise so the column doesn't read as visual noise
+				// on rows the user hasn't marked.
+				return base.Foreground(lipgloss.Color(ColorSecondary)).Bold(true)
+			case col == 1:
 				return base.Foreground(lipgloss.Color(ColorSecondary)).Bold(true)
 			default:
 				return base.Foreground(lipgloss.Color(ColorDimmed))
 			}
 		})
+}
+
+// kvSelectionCell returns the rendered content for the leading
+// selection-marker column. Returns the checkmark glyph for selected
+// rows and an empty string for unselected ones — lipgloss/table pads
+// the cell to kvSelColumnW so column alignment stays stable either way.
+func kvSelectionCell(selected bool) string {
+	if selected {
+		return "✓"
+	}
+	return ""
 }

--- a/internal/ui/kv_editor.go
+++ b/internal/ui/kv_editor.go
@@ -493,7 +493,18 @@ const kvSelColumnW = 1
 // cursorRow is the body-row index (0-based; lipgloss/table's HeaderRow
 // is the constant -1) of the cursor. Pass -1 when no row is the cursor
 // (e.g. an empty table that's only showing headers + a placeholder).
-func newKVEditorTable(keyColW, valColW, cursorRow int) *table.Table {
+//
+// editing toggles off the SelectedBg highlight on the cursor row when
+// the user is actively editing an inline cell. The cursor character
+// itself renders as reverse-video at the byte offset (see
+// overlayCursor); its embedded \x1b[7m / \x1b[0m SGR pair breaks the
+// continuity of any background the table wraps around the cell, so
+// the row's SelectedBg ends up visible BEFORE the cursor and missing
+// AFTER it — the user-reported "background is different before and
+// after the cursor" symptom. Dropping the row's SelectedBg during
+// edit mode lets the cursor's own reverse-video pair carry the
+// visual indicator without competing with an outer bg.
+func newKVEditorTable(keyColW, valColW, cursorRow int, editing bool) *table.Table {
 	return table.New().
 		Border(lipgloss.NormalBorder()).
 		BorderRow(false).
@@ -528,6 +539,15 @@ func newKVEditorTable(keyColW, valColW, cursorRow int) *table.Table {
 					Foreground(lipgloss.Color(ColorPrimary)).
 					Bold(true).
 					Underline(true)
+			case row == cursorRow && editing:
+				// Editing the cursor row: drop the SelectedBg so the
+				// cursor's reverse-video glyph isn't fighting an outer
+				// background that won't survive its embedded SGR reset.
+				// Bold + Primary keeps the row visually distinct from
+				// idle rows.
+				return base.
+					Foreground(lipgloss.Color(ColorPrimary)).
+					Bold(true)
 			case row == cursorRow:
 				return base.
 					Foreground(lipgloss.Color(ColorSelectedFg)).

--- a/internal/ui/kv_editor_cursor_bg_test.go
+++ b/internal/ui/kv_editor_cursor_bg_test.go
@@ -1,0 +1,126 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestRenderSecretEditor_CursorRowNoSelectedBgWhileEditing pins the
+// fix for the user's "background is different before and after the
+// cursor" report. The cursor renders as reverse-video on the char at
+// the cursor byte offset (overlayCursor); its embedded \x1b[7m
+// ... \x1b[0m pair issues an SGR reset, and the table's outer
+// SelectedBg wrapper does NOT survive that reset — so head text
+// before the cursor showed the row's SelectedBg, while tail text
+// after the cursor reverted to BaseBg, producing the two-tone band.
+//
+// The fix: during edit mode, the cursor row drops its SelectedBg
+// styling (kept Bold + Primary fg so the row stays visually
+// distinct). The reverse-video cursor remains the active-row
+// indicator, and head/tail share a single background.
+//
+// Asserts: the SelectedBg color (defaultColorSelectedBg = "#7aa2f7"
+// in TrueColor SGR = 48;2;122;162;247) does NOT appear in the
+// rendered editor when editing == true. Pinned to TrueColor profile
+// so the assertion is deterministic regardless of the host
+// terminal's detected profile.
+func TestRenderSecretEditor_CursorRowNoSelectedBgWhileEditing(t *testing.T) {
+	original := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(original) })
+
+	origTheme := ActiveTheme
+	origContrast := ConfigMinContrastRatio
+	origNoColor := ConfigNoColor
+	t.Cleanup(func() {
+		ConfigNoColor = origNoColor
+		ConfigMinContrastRatio = origContrast
+		ApplyTheme(origTheme)
+	})
+	ConfigNoColor = false
+	ConfigMinContrastRatio = 0
+	ApplyTheme(DefaultTheme())
+	// ApplyTheme's color branch resets the color profile to whatever
+	// termenv originally detected when a previous test triggered
+	// no-color mode. Force TrueColor AFTER ApplyTheme so the SGR
+	// triples this test inspects are emitted verbatim.
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+
+	secret := &model.SecretData{
+		Keys: []string{"DB_PASSWORD"},
+		Data: map[string]string{"DB_PASSWORD": "hunter2"},
+	}
+
+	// Render with editing=true, cursor parked in the middle of the
+	// value so head+cursor+tail are all non-empty.
+	editing := RenderSecretEditorOverlay(
+		secret, 0, nil, true,
+		true,
+		"DB_PASSWORD", 11,
+		"hunter2", 3,
+		1, "", false,
+		nil, false, 0, 0,
+		120, 30,
+	)
+
+	// TrueColor SGR for #7aa2f7 (defaultColorSelectedBg). lipgloss
+	// quantises the hex through termenv before emitting, which yields
+	// "121;162;247" rather than the literal "122;162;247" — so match
+	// the actually-emitted triple, not the raw hex math.
+	selectedBgSGR := "48;2;121;162;247"
+	assert.NotContains(t, editing, selectedBgSGR,
+		"editing-mode render must not embed the SelectedBg color anywhere — "+
+			"its embedded SGR reset would create a head/tail bg mismatch around the cursor")
+}
+
+// TestRenderSecretEditor_CursorRowKeepsSelectedBgWhenIdle is the
+// negative companion: when NOT editing, the cursor row SHOULD carry
+// the SelectedBg highlight — that's the normal "you're on this row"
+// indicator. Without this guard the previous test would pass even if
+// we accidentally stripped SelectedBg in the idle case too.
+func TestRenderSecretEditor_CursorRowKeepsSelectedBgWhenIdle(t *testing.T) {
+	original := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(original) })
+
+	origTheme := ActiveTheme
+	origContrast := ConfigMinContrastRatio
+	origNoColor := ConfigNoColor
+	t.Cleanup(func() {
+		ConfigNoColor = origNoColor
+		ConfigMinContrastRatio = origContrast
+		ApplyTheme(origTheme)
+	})
+	ConfigNoColor = false
+	ConfigMinContrastRatio = 0
+	ApplyTheme(DefaultTheme())
+	// ApplyTheme's color branch resets the color profile to whatever
+	// termenv originally detected when a previous test triggered
+	// no-color mode. Force TrueColor AFTER ApplyTheme so the SGR
+	// triples this test inspects are emitted verbatim.
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+
+	secret := &model.SecretData{
+		Keys: []string{"DB_PASSWORD"},
+		Data: map[string]string{"DB_PASSWORD": "hunter2"},
+	}
+
+	idle := RenderSecretEditorOverlay(
+		secret, 0, nil, true,
+		false,
+		"", 0,
+		"", 0,
+		0, "", false,
+		nil, false, 0, 0,
+		120, 30,
+	)
+
+	selectedBgSGR := "48;2;121;162;247"
+	assert.True(t, strings.Contains(idle, selectedBgSGR),
+		"idle-mode render must keep SelectedBg on the cursor row — "+
+			"that's the only visual cue without an active text cursor")
+}

--- a/internal/ui/kv_editor_cursor_bg_test.go
+++ b/internal/ui/kv_editor_cursor_bg_test.go
@@ -53,7 +53,7 @@ func TestRenderSecretEditor_CursorRowNoSelectedBgWhileEditing(t *testing.T) {
 
 	secret := &model.SecretData{
 		Keys: []string{"DB_PASSWORD"},
-		Data: map[string]string{"DB_PASSWORD": "hunter2"},
+		Data: map[string]string{"DB_PASSWORD": "<redacted>"},
 	}
 
 	// Render with editing=true, cursor parked in the middle of the
@@ -62,7 +62,7 @@ func TestRenderSecretEditor_CursorRowNoSelectedBgWhileEditing(t *testing.T) {
 		secret, 0, nil, true,
 		true,
 		"DB_PASSWORD", 11,
-		"hunter2", 3,
+		"<redacted>", 3,
 		1, "", false,
 		nil, false, 0, 0,
 		120, 30,
@@ -106,7 +106,7 @@ func TestRenderSecretEditor_CursorRowKeepsSelectedBgWhenIdle(t *testing.T) {
 
 	secret := &model.SecretData{
 		Keys: []string{"DB_PASSWORD"},
-		Data: map[string]string{"DB_PASSWORD": "hunter2"},
+		Data: map[string]string{"DB_PASSWORD": "<redacted>"},
 	}
 
 	idle := RenderSecretEditorOverlay(

--- a/internal/ui/kv_editor_selection_column_test.go
+++ b/internal/ui/kv_editor_selection_column_test.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// visualCol returns the visual column at which `needle` starts inside
+// `line`. Counts grapheme width via lipgloss.Width so multi-byte UTF-8
+// characters (box-drawing glyphs, the ✓ mark) count as one column —
+// strings.Index returns the byte offset, which mis-aligns rows that
+// contain different multi-byte runs above the column under test.
+// Returns -1 when needle isn't found.
+func visualCol(line, needle string) int {
+	prefix, _, found := strings.Cut(line, needle)
+	if !found {
+		return -1
+	}
+	return lipgloss.Width(prefix)
+}
+
+// TestKVEditor_SelectionMarkInDedicatedColumn pins the layout change
+// for the user's "the checkmark shifts the value by a space" report.
+// Before the fix every row carried a 2-char prefix on the KEY cell:
+// "  " when unselected, "✓ " when selected. The result was that the
+// KEY column header sat flush at column 0 while every key value
+// started 2 columns to the right — and unselected rows wasted those
+// 2 columns rendering whitespace whether or not anything was marked.
+//
+// The fix promotes the marker to its own leading column. The header
+// of the marker column is empty; selected rows show "✓" in that cell,
+// unselected rows render an empty cell. Either way the KEY column's
+// content aligns with the KEY header, and the value column doesn't
+// shift when the user toggles selection.
+func TestKVEditor_SelectionMarkInDedicatedColumn(t *testing.T) {
+	secret := &model.SecretData{
+		Keys: []string{"alpha", "bravo"},
+		Data: map[string]string{"alpha": "a-val", "bravo": "b-val"},
+	}
+
+	// Selecting only the first row exercises both branches inside a
+	// single render.
+	selected := map[string]bool{"alpha": true}
+
+	out := RenderSecretEditorOverlay(
+		secret, 0, nil, true,
+		false, "", 0, "", 0, 0, "", false,
+		selected, false, 0, 0,
+		120, 30,
+	)
+	plain := stripANSI(out)
+	lines := strings.Split(plain, "\n")
+
+	// Locate the KEY header line and the two data lines by content.
+	headerIdx, alphaIdx, bravoIdx := -1, -1, -1
+	for i, line := range lines {
+		if strings.Contains(line, "KEY") && strings.Contains(line, "VALUE") {
+			headerIdx = i
+		}
+		if strings.Contains(line, "alpha") && alphaIdx == -1 {
+			alphaIdx = i
+		}
+		if strings.Contains(line, "bravo") && bravoIdx == -1 {
+			bravoIdx = i
+		}
+	}
+	if headerIdx < 0 || alphaIdx < 0 || bravoIdx < 0 {
+		t.Fatalf("could not locate header/alpha/bravo rows in render:\n%s", plain)
+	}
+
+	keyHeaderCol := visualCol(lines[headerIdx], "KEY")
+	alphaCol := visualCol(lines[alphaIdx], "alpha")
+	bravoCol := visualCol(lines[bravoIdx], "bravo")
+
+	// Both data rows must align with the header. Without the fix the
+	// data rows landed 2 columns to the right (the "✓ " / "  " prefix
+	// budget inside the KEY cell).
+	assert.Equal(t, keyHeaderCol, alphaCol,
+		"alpha key must align with KEY header; got header=%d alpha=%d", keyHeaderCol, alphaCol)
+	assert.Equal(t, keyHeaderCol, bravoCol,
+		"bravo key must align with KEY header; got header=%d bravo=%d", keyHeaderCol, bravoCol)
+
+	// The checkmark must appear strictly to the LEFT of the KEY column
+	// header — i.e. in the dedicated selection column, not inside the
+	// KEY cell.
+	checkCol := visualCol(lines[alphaIdx], "✓")
+	if checkCol < 0 {
+		t.Fatalf("alpha row must render the ✓ glyph:\n%s", lines[alphaIdx])
+	}
+	assert.Less(t, checkCol, keyHeaderCol,
+		"selection mark must sit in its own column, before the KEY column; got mark=%d key=%d",
+		checkCol, keyHeaderCol)
+
+	// The bravo row (unselected) must NOT carry the mark.
+	assert.NotContains(t, lines[bravoIdx], "✓",
+		"unselected row must render an empty selection cell, not a checkmark")
+}

--- a/internal/ui/labelview.go
+++ b/internal/ui/labelview.go
@@ -159,7 +159,7 @@ func renderLabelEditorTable(keys []string, data map[string]string, selectedIdx i
 	start := scrollWindowStart(selectedIdx, bodyHeight, len(keys))
 	end := min(start+bodyHeight, len(keys))
 
-	t := newKVEditorTable(keyColW, valColW, selectedIdx-start)
+	t := newKVEditorTable(keyColW, valColW, selectedIdx-start, editing)
 	for i := start; i < end; i++ {
 		k := keys[i]
 		v := data[k]

--- a/internal/ui/labelview.go
+++ b/internal/ui/labelview.go
@@ -152,9 +152,8 @@ func RenderLabelEditorOverlay(
 }
 
 func renderLabelEditorTable(keys []string, data map[string]string, selectedIdx int, editing bool, editKey string, editKeyCursor int, editValue string, editValueCursor int, editColumn int, selectedKeys map[string]bool, width, height int) string {
-	// +2 budgets for the "✓ " / "  " selection-indicator prefix.
-	keyColW := computeKeyColumnWidth(keys, width, 2) + 2
-	valColW := max(width-keyColW-5, 8)
+	keyColW := computeKeyColumnWidth(keys, width, 2)
+	valColW := max(width-kvSelColumnW-keyColW-8, 8)
 
 	bodyHeight := max(height-2, 1)
 	start := scrollWindowStart(selectedIdx, bodyHeight, len(keys))
@@ -165,25 +164,22 @@ func renderLabelEditorTable(keys []string, data map[string]string, selectedIdx i
 		k := keys[i]
 		v := data[k]
 
-		// Consistent 2-char prefix across all rows (including editing)
-		// so column alignment stays stable. See secretview.
-		prefix := "  "
-		if selectedKeys[k] {
-			prefix = "\u2713 "
-		}
+		// Selection mark lives in its own leading column \u2014 see
+		// secretview for the rationale on dropping the in-cell prefix.
+		selCell := kvSelectionCell(selectedKeys[k])
 		var keyText, valText string
 		switch {
 		case i == selectedIdx && editing && editColumn == 0:
-			keyText = prefix + overlayCursor(editKey, editKeyCursor, true, keyColW-2)
+			keyText = overlayCursor(editKey, editKeyCursor, true, keyColW)
 			valText = SingleLineCell(editValue, valColW)
 		case i == selectedIdx && editing && editColumn == 1:
-			keyText = prefix + SingleLineCell(editKey, keyColW-2)
+			keyText = SingleLineCell(editKey, keyColW)
 			valText = overlayCursor(editValue, editValueCursor, true, valColW)
 		default:
-			keyText = prefix + SingleLineCell(k, keyColW-2)
+			keyText = SingleLineCell(k, keyColW)
 			valText = SingleLineCell(v, valColW)
 		}
-		t.Row(keyText, valText)
+		t.Row(selCell, keyText, valText)
 	}
 	rendered := t.Render()
 	if len(keys) == 0 {

--- a/internal/ui/secretview.go
+++ b/internal/ui/secretview.go
@@ -197,7 +197,7 @@ func renderSecretEditorTable(
 	start := scrollWindowStart(selectedIdx, bodyHeight, len(secret.Keys))
 	end := min(start+bodyHeight, len(secret.Keys))
 
-	t := newKVEditorTable(keyColW, valColW, selectedIdx-start)
+	t := newKVEditorTable(keyColW, valColW, selectedIdx-start, editing)
 	for i := start; i < end; i++ {
 		k := secret.Keys[i]
 		v := secret.Data[k]

--- a/internal/ui/secretview.go
+++ b/internal/ui/secretview.go
@@ -187,14 +187,11 @@ func renderSecretEditorTable(
 	selectedKeys map[string]bool, // keys marked with `s` for batch copy; nil = none
 	width, height int,
 ) string {
-	// +2 for the "✓ " / "  " selection-indicator prefix every key
-	// row carries — without this the key text gets truncated even
-	// when the underlying name fits, because the prefix steals two
-	// of the column's visible chars.
-	keyColW := computeKeyColumnWidth(secret.Keys, width, 3) + 2
-	// Width budget left after the key column: subtract column divider
-	// + 2*2 padding cells per column = ~5 chars of table chrome.
-	valColW := max(width-keyColW-5, 8)
+	keyColW := computeKeyColumnWidth(secret.Keys, width, 3)
+	// Width budget left after the selection + key columns: subtract
+	// the two column dividers + 3 * 2 cell-padding pairs (sel, key,
+	// value) = the table chrome the renderer consumes.
+	valColW := max(width-kvSelColumnW-keyColW-8, 8)
 
 	bodyHeight := max(height-2, 1) // -1 header, -1 header underline
 	start := scrollWindowStart(selectedIdx, bodyHeight, len(secret.Keys))
@@ -204,28 +201,25 @@ func renderSecretEditorTable(
 	for i := start; i < end; i++ {
 		k := secret.Keys[i]
 		v := secret.Data[k]
-		// All key cells carry a 2-char prefix slot ("  " unselected,
-		// "✓ " selected) so column alignment stays stable when the
-		// user toggles selection or enters/exits edit mode. Without
-		// this the cursor row's key text would shift left by 2
-		// columns the moment editing started.
-		prefix := "  "
-		if selectedKeys[k] {
-			prefix = "✓ "
-		}
+		// Selection cell lives in its own column now — the leading
+		// "  " / "✓ " prefix that used to ride inside the KEY cell
+		// shifted every key two columns to the right whether or not
+		// the row was actually selected. With a dedicated column the
+		// KEY cell starts flush against its own padding.
+		selCell := kvSelectionCell(selectedKeys[k])
 		var keyText, valText string
 		switch {
 		case i == selectedIdx && editing && editColumn == 0:
-			keyText = prefix + overlayCursor(editKey, editKeyCursor, true, keyColW-2)
+			keyText = overlayCursor(editKey, editKeyCursor, true, keyColW)
 			valText = SingleLineCell(editValue, valColW)
 		case i == selectedIdx && editing && editColumn == 1:
-			keyText = prefix + SingleLineCell(editKey, keyColW-2)
+			keyText = SingleLineCell(editKey, keyColW)
 			valText = overlayCursor(editValue, editValueCursor, true, valColW)
 		default:
-			keyText = prefix + SingleLineCell(k, keyColW-2)
+			keyText = SingleLineCell(k, keyColW)
 			valText = secretValueDisplay(v, revealedKeys[k] || allRevealed, valColW)
 		}
-		t.Row(keyText, valText)
+		t.Row(selCell, keyText, valText)
 	}
 	rendered := t.Render()
 	if len(secret.Keys) == 0 {

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -120,13 +120,23 @@ func TestApplyTheme(t *testing.T) {
 // regardless of which theme was loaded — inline lipgloss.Color(ColorPrimary)
 // call sites (e.g. the detail-pane key style in RenderResourceSummary) showed
 // the default blue even after switching themes.
+//
+// Snapshots ConfigMinContrastRatio + ConfigNoColor + ActiveTheme up front
+// and pins ratio to 0 so ApplyTheme's EnforceMinContrast pass leaves the
+// hand-picked colors untouched — without this guard a sibling test that
+// raised the ratio would silently drift custom.Primary toward the bg and
+// break our exact-equal assertions.
 func TestApplyTheme_TracksActiveThemeInColorSlots(t *testing.T) {
 	origNoColor := ConfigNoColor
+	origContrast := ConfigMinContrastRatio
+	origTheme := ActiveTheme
 	t.Cleanup(func() {
 		ConfigNoColor = origNoColor
-		ApplyTheme(DefaultTheme())
+		ConfigMinContrastRatio = origContrast
+		ApplyTheme(origTheme)
 	})
 	ConfigNoColor = false
+	ConfigMinContrastRatio = 0
 
 	custom := Theme{
 		Primary:    "#ff00aa",


### PR DESCRIPTION
## Summary

The three K/V editor overlays (Secret, ConfigMap, Label / Annotation) rendered the multi-selection checkmark **inside** the KEY cell. Every row carried a 2-char prefix — ``"  "`` for unselected, ``"✓ "`` for selected — so:

- The KEY column header sat flush at column 0, but every key value started 2 columns further right.
- Unselected rows wasted those 2 columns rendering whitespace regardless of whether anything was actually marked.
- Toggling selection on a row didn't shift the row (the budget was always 2 chars), but the overall layout looked off because the header and the cells disagreed on where the KEY column "starts".

User wording: *"there's no dedicated column for the selection (checkmark). Instead we shifted the secret values by one space and it looks ugly."*

## Fix

Promote the marker to its own leading column in ``newKVEditorTable`` (``kv_editor.go``):

- Headers: ``"", "KEY", "VALUE"`` — empty title for the marker column.
- Width: ``kvSelColumnW = 1`` (plus lipgloss/table's padding) so the cell holds a single glyph cleanly.
- Selected rows pass ``"✓"`` via the new ``kvSelectionCell`` helper; unselected rows pass ``""``.
- The lipgloss/table column divider draws between the marker cell and the KEY cell, so the layout reads as three distinct columns.

The three editor renderers (``secretview.go``, ``configmapview.go``, ``labelview.go``) drop the prefix machinery and stop reserving ``+2`` on ``keyColW``.

## Before / after

Before — every key shifted 2 cols right of the KEY header:

```
  KEY          VALUE
✓ chart      │ airflow-1.16.0
  component  │ config
```

After — selection column is its own column; KEY header lines up with each row's key text:

```
    │ KEY        │ VALUE
 ✓  │ chart      │ airflow-1.16.0
    │ component  │ config
```

## Test plan

- [x] ``go test ./...`` — full suite green
- [x] ``make lint`` — golangci-lint clean
- [x] Manual: opened Label / Annotation Editor for an ArgoCD-managed ConfigMap with 5 labels, toggled selection on row 1 — checkmark appears in the dedicated column, the other 4 rows' keys align with the KEY header
- [x] Regression test ``TestKVEditor_SelectionMarkInDedicatedColumn`` asserts both rows align with the KEY header column (visual-width compare, multi-byte ✓ doesn't trip byte indexing)