### PR TITLE
fix(logs): keep cursor at top when older history loads after gg

### DIFF
--- a/internal/app/update_exec_log_msgs.go
+++ b/internal/app/update_exec_log_msgs.go
@@ -186,12 +186,17 @@ func (m Model) updateLogHistory(msg logHistoryMsg) Model {
 		return m
 	}
 
-	// Prepend and adjust scroll to maintain view position.
+	// Prepend and adjust scroll to maintain view position — unless the user
+	// is still anchored at the absolute top (e.g. just pressed `gg` and the
+	// async fetch resolved before they navigated), in which case keep them
+	// at 0 so the newly revealed older lines come into view.
 	prepended := len(newOlderLines)
 	m.logLines = append(newOlderLines, m.logLines...)
-	m.logScroll += prepended
-	if m.logCursor >= 0 {
-		m.logCursor += prepended
+	if m.logCursor > 0 || m.logScroll > 0 {
+		m.logScroll += prepended
+		if m.logCursor >= 0 {
+			m.logCursor += prepended
+		}
 	}
 	m.logTailLines += ui.ConfigLogTailLines
 

--- a/internal/app/update_msg_extra_test.go
+++ b/internal/app/update_msg_extra_test.go
@@ -1900,6 +1900,72 @@ func TestUpdateLogHistoryNotInLogMode(t *testing.T) {
 	assert.Nil(t, cmd) // not in log mode, skip
 }
 
+// When the user has navigated to the absolute top (e.g. pressed `gg`),
+// the cursor and scroll must stay at 0 after older history is prepended
+// so the newly revealed lines come into view. Regression for the
+// "gg jumps back down ~1000 lines a second later" bug.
+func TestUpdateLogHistoryAtTopKeepsCursor(t *testing.T) {
+	m := baseModel()
+	m.mode = modeLogs
+	m.logLoadingHistory = true
+	m.logLines = []string{"existing-1", "existing-2", "existing-3"}
+	m.logCursor = 0
+	m.logScroll = 0
+
+	result, _ := m.Update(logHistoryMsg{
+		lines:     []string{"older1", "older2", "existing-1", "existing-2", "existing-3"},
+		prevTotal: 3,
+	})
+	mdl := result.(Model)
+	assert.False(t, mdl.logLoadingHistory)
+	assert.Equal(t, 0, mdl.logCursor, "cursor must remain at top to reveal older lines")
+	assert.Equal(t, 0, mdl.logScroll, "scroll must remain at top to reveal older lines")
+	assert.Equal(t, 5, len(mdl.logLines))
+	assert.Equal(t, "older1", mdl.logLines[0])
+}
+
+// When the user has scrolled away from the top while the async history
+// fetch was in flight, prepending older lines must shift the cursor and
+// scroll by the prepended count to preserve visual position.
+func TestUpdateLogHistoryMidScrollPreservesPosition(t *testing.T) {
+	m := baseModel()
+	m.mode = modeLogs
+	m.logLoadingHistory = true
+	m.logLines = []string{"existing-1", "existing-2", "existing-3"}
+	m.logCursor = 2
+	m.logScroll = 1
+
+	result, _ := m.Update(logHistoryMsg{
+		lines:     []string{"older1", "older2", "existing-1", "existing-2", "existing-3"},
+		prevTotal: 3,
+	})
+	mdl := result.(Model)
+	assert.Equal(t, 4, mdl.logCursor, "cursor shifted by 2 prepended lines")
+	assert.Equal(t, 3, mdl.logScroll, "scroll shifted by 2 prepended lines")
+}
+
+// Same at-top guard applies on the no-overlap fallback path (logs may
+// have rotated between fetches, in which case all fetched lines are
+// prepended).
+func TestUpdateLogHistoryNoOverlapAtTopKeepsCursor(t *testing.T) {
+	m := baseModel()
+	m.mode = modeLogs
+	m.logLoadingHistory = true
+	m.logLines = []string{"current-1", "current-2", "current-3"}
+	m.logCursor = 0
+	m.logScroll = 0
+
+	result, _ := m.Update(logHistoryMsg{
+		lines:     []string{"rotated-1", "rotated-2"}, // no overlap with current
+		prevTotal: 3,
+	})
+	mdl := result.(Model)
+	assert.Equal(t, 0, mdl.logCursor)
+	assert.Equal(t, 0, mdl.logScroll)
+	assert.Equal(t, 5, len(mdl.logLines))
+	assert.Equal(t, "rotated-1", mdl.logLines[0])
+}
+
 // --- logSaveAllMsg ---
 
 func TestUpdateLogSaveAllSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary

In the pod log viewer, pressing `gg` jumped to the top correctly, then ~1 second later the view jumped back down by roughly 1000 lines. Each subsequent `gg` repeated the same dance.

Root cause: `gg` correctly sets `logCursor=0` and `logFollow=false`, but it also fires `maybeLoadMoreHistory`. The async `kubectl logs` fetch resolves ~1s later in `updateLogHistory`, which unconditionally shifts `logCursor` and `logScroll` by the number of prepended lines to preserve visual position. For a user pinned at the absolute top, "preserve visual position" was the wrong contract — they wanted to see the newly revealed older lines, not stay anchored past them. With the default `--tail=1000` batch, the cursor jumped from 0 to ~1000.

## Type of change

- [x] fix: bug fix

## Related issue

- n/a

## Changes

- `internal/app/update_exec_log_msgs.go`: in `updateLogHistory`, skip the cursor/scroll shift when the user is still at the absolute top (`logCursor == 0 && logScroll == 0`) when the response arrives. Mid-scroll behavior is unchanged.
- `internal/app/update_msg_extra_test.go`: three regression tests — `TestUpdateLogHistoryAtTopKeepsCursor`, `TestUpdateLogHistoryMidScrollPreservesPosition`, `TestUpdateLogHistoryNoOverlapAtTopKeepsCursor` (covers the rotated-logs fallback path).

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->