### PR TITLE
feat: add configurable data directories (LFK_*_DIR overrides)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -741,3 +741,21 @@ The application follows the [XDG Base Directory Specification](https://specifica
 | `~/.local/share/lfk/lfk.log` (default) | Application log file (configurable via `log_path`) |
 
 State files stored at the legacy `~/.config/lfk/` location are automatically migrated to the new XDG state directory on first access.
+
+### Directory overrides
+
+For portable installs such as Scoop's persist directory, lfk honors three environment variables that override the XDG variables and OS defaults:
+
+| Variable | Overrides | Holds |
+|---|---|---|
+| `LFK_CONFIG_DIR` | config directory | `config.yaml` |
+| `LFK_STATE_DIR` | state directory | bookmarks, session, pinned groups, history, cluster colors, captures |
+| `LFK_DATA_DIR` | data directory | `lfk.log` |
+
+Each variable is used verbatim as the lfk directory — unlike `XDG_*_HOME`, no `lfk` component is appended. Resolution precedence per directory:
+
+1. `LFK_<X>_DIR` if set.
+2. `$XDG_<X>_HOME/lfk` if set.
+3. OS default (`~/.config/lfk`, `~/.local/state/lfk`, `~/.local/share/lfk`).
+
+The `--config` flag and the `log_path` config field are full file-path overrides and still win over `LFK_CONFIG_DIR` and `LFK_DATA_DIR` respectively.

--- a/internal/app/bookmarks.go
+++ b/internal/app/bookmarks.go
@@ -8,20 +8,17 @@ import (
 
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 // bookmarksFilePath returns the path to the bookmarks file.
-// Uses $XDG_STATE_HOME/lfk/ (defaults to ~/.local/state/lfk/) per XDG specification.
+// Resolves the lfk state directory via internal/paths.
 func bookmarksFilePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "bookmarks.yaml")
+	return filepath.Join(dir, "bookmarks.yaml")
 }
 
 // loadBookmarks reads bookmarks from the YAML file on disk.

--- a/internal/app/cluster_colors.go
+++ b/internal/app/cluster_colors.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -26,18 +27,13 @@ type clusterColorsState struct {
 }
 
 // clusterColorsFilePath returns the path to the cluster-colors state file.
-// Uses $XDG_STATE_HOME/lfk/ (defaults to ~/.local/state/lfk/) per XDG spec —
-// same convention as bookmarks.yaml and the input histories.
+// Resolves the lfk state directory via internal/paths.
 func clusterColorsFilePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "cluster-colors.yaml")
+	return filepath.Join(dir, "cluster-colors.yaml")
 }
 
 // loadClusterColors reads the cluster-colours map from disk. Returns an

--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 const maxHistoryEntries = 500
 
-// Filenames for the persistent input histories under $XDG_STATE_HOME/lfk/.
+// Filenames for the persistent input histories in the lfk state directory.
 // `/` (search) and `f` (filter) share one file: the query syntax and matched
 // fields are identical between the two, only the action on a match differs
 // (jump vs. narrow), so users want to recall the same query regardless of
@@ -33,27 +34,23 @@ type commandHistory struct {
 	entries  []string
 	cursor   int    // -1 means "not browsing history" (typing new command)
 	draft    string // saves what the user was typing before browsing history
-	filename string // file under $XDG_STATE_HOME/lfk/; empty = command bar (back-compat)
+	filename string // file in the lfk state directory; empty = command bar (back-compat)
 }
 
 // historyFilePath returns the path to the command bar history file.
-// Uses $XDG_STATE_HOME/lfk/history (defaults to ~/.local/state/lfk/history).
+// Uses the "history" file in the lfk state directory (see internal/paths).
 func historyFilePath() string {
 	return historyFilePathFor(historyFileCommand)
 }
 
 // historyFilePathFor returns the path to the named history file. Returns
-// "" when the home directory cannot be resolved.
+// "" when the state directory cannot be resolved.
 func historyFilePathFor(name string) string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", name)
+	return filepath.Join(dir, name)
 }
 
 // loadCommandHistory reads command bar history from disk.

--- a/internal/app/kubetris_game.go
+++ b/internal/app/kubetris_game.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 // tPieceIndex is the index of the T-shaped piece in the tetrominoes table.
@@ -244,15 +245,11 @@ func (g *kubetrisGame) isGhost(x, y, ghostY int) bool {
 }
 
 func highScoreFilePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "kubetris-highscore")
+	return filepath.Join(dir, "kubetris-highscore")
 }
 
 func (g *kubetrisGame) loadHighScore() {

--- a/internal/app/localcluster_state.go
+++ b/internal/app/localcluster_state.go
@@ -1,5 +1,5 @@
 // localcluster_state persists the manager overlay's last-seen view of
-// local clusters to $XDG_STATE_HOME/lfk/local-clusters.yaml. The cache
+// local clusters to the lfk state directory (local-clusters.yaml). The cache
 // drives the cluster picker's status icon (filled vs hollow) so stopped
 // clusters don't disappear from the picker between manager refreshes.
 // Mirrors cluster_colors.go and discovery_cache.go: schema-versioned,
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 const localClusterStateSchemaVersion = 1
@@ -39,15 +40,11 @@ type localClusterStateFile struct {
 }
 
 func localClusterStateFilePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "local-clusters.yaml")
+	return filepath.Join(dir, "local-clusters.yaml")
 }
 
 // loadLocalClusterState reads the cache from disk. Returns an empty
@@ -95,7 +92,7 @@ func loadLocalClusterState() map[string]localClusterCacheEntry {
 func saveLocalClusterState(entries []localClusterCacheEntry) error {
 	path := localClusterStateFilePath()
 	if path == "" {
-		err := errors.New("no state path: HOME and XDG_STATE_HOME both unset")
+		err := errors.New("no state path: cannot resolve lfk state directory")
 		logger.Warn("local cluster state save failed", "error", err)
 		return err
 	}

--- a/internal/app/pinned.go
+++ b/internal/app/pinned.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 // PinnedState stores pinned CRD groups scoped either to a kube context or to
@@ -18,15 +19,11 @@ type PinnedState struct {
 
 // pinnedFilePath returns the path to the pinned groups state file.
 func pinnedFilePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "pinned.yaml")
+	return filepath.Join(dir, "pinned.yaml")
 }
 
 // loadPinnedState reads pinned groups from disk.

--- a/internal/app/portable_dirs_test.go
+++ b/internal/app/portable_dirs_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestPortableStateDir verifies that every app-package state path honors
+// LFK_STATE_DIR, so a portable install (for example Scoop's persist
+// directory) keeps all state files under one redirectable root.
+func TestPortableStateDir(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("LFK_STATE_DIR", stateDir)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"session", sessionFilePath(), filepath.Join(stateDir, "session.yaml")},
+		{"pinned", pinnedFilePath(), filepath.Join(stateDir, "pinned.yaml")},
+		{"bookmarks", bookmarksFilePath(), filepath.Join(stateDir, "bookmarks.yaml")},
+		{"cluster-colors", clusterColorsFilePath(), filepath.Join(stateDir, "cluster-colors.yaml")},
+		{"portforwards", portForwardStatePath(), filepath.Join(stateDir, "portforwards.yaml")},
+		{"local-clusters", localClusterStateFilePath(), filepath.Join(stateDir, "local-clusters.yaml")},
+		{"kubetris", highScoreFilePath(), filepath.Join(stateDir, "kubetris-highscore")},
+		{"history", historyFilePathFor("history"), filepath.Join(stateDir, "history")},
+	}
+	for _, tc := range tests {
+		if tc.got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}

--- a/internal/app/portforward_state.go
+++ b/internal/app/portforward_state.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 // PortForwardState represents a single persisted port forward.
@@ -30,15 +31,11 @@ type PortForwardStates struct {
 
 // portForwardStatePath returns the path to the port forward state file.
 func portForwardStatePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "portforwards.yaml")
+	return filepath.Join(dir, "portforwards.yaml")
 }
 
 // loadPortForwardState reads saved port forwards from disk.

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 // SessionTab represents the persisted navigation state for a single tab.
@@ -36,17 +37,13 @@ type SessionState struct {
 }
 
 // sessionFilePath returns the path to the session state file.
-// Uses $XDG_STATE_HOME/lfk/ (defaults to ~/.local/state/lfk/) per XDG specification.
+// Resolves the lfk state directory via internal/paths.
 func sessionFilePath() string {
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		stateDir = filepath.Join(home, ".local", "state")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(stateDir, "lfk", "session.yaml")
+	return filepath.Join(dir, "session.yaml")
 }
 
 // migrateStateFile checks if a state file exists at the legacy ~/.config/lfk/ location

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 // RegisterShellCompletions attaches dynamic completion functions to the
@@ -194,13 +195,9 @@ func completionConfigPath(configOverride string) (string, bool) {
 	if configOverride != "" {
 		return configOverride, true
 	}
-	configDir := os.Getenv("XDG_CONFIG_HOME")
-	if configDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", false
-		}
-		configDir = filepath.Join(home, ".config")
+	dir, err := paths.ConfigDir()
+	if err != nil {
+		return "", false
 	}
-	return filepath.Join(configDir, "lfk", "config.yaml"), true
+	return filepath.Join(dir, "config.yaml"), true
 }

--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 // CaptureBackend identifies which capture engine the user picked.
@@ -41,7 +43,7 @@ type CaptureRequest struct {
 	Interface string // default "any"
 	SnapLen   int    // default 65535
 	BPFFilter string // optional
-	OutputDir string // default $XDG_STATE_HOME/lfk/captures
+	OutputDir string // default: "captures" in the lfk state directory
 }
 
 // CaptureEntry is one running or completed capture.
@@ -381,12 +383,13 @@ func (m *CaptureManager) StopAll() {
 }
 
 // defaultCaptureDir returns the user-default capture directory.
+// Returns "" when the state directory cannot be resolved.
 func defaultCaptureDir() string {
-	if x := os.Getenv("XDG_STATE_HOME"); x != "" {
-		return filepath.Join(x, "lfk", "captures")
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
 	}
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "state", "lfk", "captures")
+	return filepath.Join(dir, "captures")
 }
 
 // captureLastErrorMaxLen bounds the stderr substring stored in

--- a/internal/k8s/capture_paths_test.go
+++ b/internal/k8s/capture_paths_test.go
@@ -1,0 +1,21 @@
+package k8s
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestDefaultCaptureDirHonorsLFKStateDir verifies the capture directory
+// follows LFK_STATE_DIR so portable installs keep packet captures together
+// with the rest of lfk's state.
+func TestDefaultCaptureDirHonorsLFKStateDir(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("LFK_STATE_DIR", stateDir)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	got := defaultCaptureDir()
+	want := filepath.Join(stateDir, "captures")
+	if got != want {
+		t.Errorf("defaultCaptureDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 var (
@@ -23,15 +25,16 @@ func init() {
 }
 
 // Init opens (or creates) the log file at logPath, sets up a JSON handler,
-// and assigns the package-level Logger. If logPath is empty the default
-// ~/.local/share/lfk/lfk.log is used. Parent directories are created as needed.
+// and assigns the package-level Logger. If logPath is empty the log file
+// defaults to lfk.log inside the resolved data directory (see internal/paths).
+// Parent directories are created as needed.
 func Init(logPath string) error {
 	if logPath == "" {
-		home, err := os.UserHomeDir()
+		dir, err := paths.DataDir()
 		if err != nil {
 			return err
 		}
-		logPath = filepath.Join(home, ".local", "share", "lfk", "lfk.log")
+		logPath = filepath.Join(dir, "lfk.log")
 	}
 
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,50 @@
+// Package paths resolves lfk's config, state, and data directories.
+//
+// Each directory is resolved with the following precedence:
+//
+//  1. $LFK_<X>_DIR         — used verbatim as the lfk directory.
+//  2. $XDG_<X>_HOME/lfk    — XDG base directory with an "lfk" component appended.
+//  3. <home>/<default>/lfk — OS default when neither variable is set.
+//
+// The LFK_* variables let portable installs (for example Scoop's persist
+// directory) redirect lfk's files without disturbing the shared XDG variables.
+package paths
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConfigDir returns the directory that holds config.yaml.
+func ConfigDir() (string, error) {
+	return resolve("LFK_CONFIG_DIR", "XDG_CONFIG_HOME", ".config")
+}
+
+// StateDir returns the directory that holds runtime state: bookmarks, session,
+// pinned groups, input history, cluster colors, port-forward and local-cluster
+// state, and packet captures.
+func StateDir() (string, error) {
+	return resolve("LFK_STATE_DIR", "XDG_STATE_HOME", filepath.Join(".local", "state"))
+}
+
+// DataDir returns the directory that holds the application log file.
+func DataDir() (string, error) {
+	return resolve("LFK_DATA_DIR", "XDG_DATA_HOME", filepath.Join(".local", "share"))
+}
+
+// resolve applies the three-step precedence. defaultSubPath is the
+// home-relative path used when neither environment variable is set.
+func resolve(lfkVar, xdgVar, defaultSubPath string) (string, error) {
+	if dir := os.Getenv(lfkVar); dir != "" {
+		return dir, nil
+	}
+	if xdg := os.Getenv(xdgVar); xdg != "" {
+		return filepath.Join(xdg, "lfk"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, defaultSubPath, "lfk"), nil
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,88 @@
+package paths
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestDirResolution exercises the precedence of each directory accessor:
+// LFK_*_DIR (verbatim) > XDG_*_HOME (with an "lfk" component appended) > OS default.
+func TestDirResolution(t *testing.T) {
+	home := t.TempDir()
+
+	tests := []struct {
+		name   string
+		fn     func() (string, error)
+		lfkVar string
+		xdgVar string
+		lfkVal string
+		xdgVal string
+		want   string
+	}{
+		{
+			name: "config: LFK_CONFIG_DIR wins, used verbatim",
+			fn:   ConfigDir, lfkVar: "LFK_CONFIG_DIR", xdgVar: "XDG_CONFIG_HOME",
+			lfkVal: "/portable/cfg", xdgVal: "/xdg/cfg", want: "/portable/cfg",
+		},
+		{
+			name: "config: XDG_CONFIG_HOME, lfk appended",
+			fn:   ConfigDir, lfkVar: "LFK_CONFIG_DIR", xdgVar: "XDG_CONFIG_HOME",
+			lfkVal: "", xdgVal: "/xdg/cfg", want: filepath.Join("/xdg/cfg", "lfk"),
+		},
+		{
+			name: "config: OS default",
+			fn:   ConfigDir, lfkVar: "LFK_CONFIG_DIR", xdgVar: "XDG_CONFIG_HOME",
+			lfkVal: "", xdgVal: "", want: filepath.Join(home, ".config", "lfk"),
+		},
+		{
+			name: "state: LFK_STATE_DIR wins, used verbatim",
+			fn:   StateDir, lfkVar: "LFK_STATE_DIR", xdgVar: "XDG_STATE_HOME",
+			lfkVal: "/portable/state", xdgVal: "/xdg/state", want: "/portable/state",
+		},
+		{
+			name: "state: XDG_STATE_HOME, lfk appended",
+			fn:   StateDir, lfkVar: "LFK_STATE_DIR", xdgVar: "XDG_STATE_HOME",
+			lfkVal: "", xdgVal: "/xdg/state", want: filepath.Join("/xdg/state", "lfk"),
+		},
+		{
+			name: "state: OS default",
+			fn:   StateDir, lfkVar: "LFK_STATE_DIR", xdgVar: "XDG_STATE_HOME",
+			lfkVal: "", xdgVal: "", want: filepath.Join(home, ".local", "state", "lfk"),
+		},
+		{
+			name: "data: LFK_DATA_DIR wins, used verbatim",
+			fn:   DataDir, lfkVar: "LFK_DATA_DIR", xdgVar: "XDG_DATA_HOME",
+			lfkVal: "/portable/data", xdgVal: "/xdg/data", want: "/portable/data",
+		},
+		{
+			name: "data: XDG_DATA_HOME, lfk appended",
+			fn:   DataDir, lfkVar: "LFK_DATA_DIR", xdgVar: "XDG_DATA_HOME",
+			lfkVal: "", xdgVal: "/xdg/data", want: filepath.Join("/xdg/data", "lfk"),
+		},
+		{
+			name: "data: OS default",
+			fn:   DataDir, lfkVar: "LFK_DATA_DIR", xdgVar: "XDG_DATA_HOME",
+			lfkVal: "", xdgVal: "", want: filepath.Join(home, ".local", "share", "lfk"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set HOME and USERPROFILE so os.UserHomeDir() is deterministic on
+			// both Unix and Windows. Explicit empty values clear any LFK_*/XDG_*
+			// inherited from the developer's environment, keeping the test hermetic.
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv(tc.lfkVar, tc.lfkVal)
+			t.Setenv(tc.xdgVar, tc.xdgVal)
+
+			got, err := tc.fn()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/paths"
 )
 
 type configFile struct {
@@ -353,22 +354,18 @@ func LoadConfig(configOverride string) {
 }
 
 // loadConfigFile reads and parses the YAML config file.
-// When configOverride is non-empty, it is used directly instead of the default
-// XDG-based path.
+// When configOverride is non-empty, it is used directly instead of the
+// resolved config directory (see internal/paths).
 func loadConfigFile(configOverride string) (configFile, bool) {
 	var configPath string
 	if configOverride != "" {
 		configPath = configOverride
 	} else {
-		configDir := os.Getenv("XDG_CONFIG_HOME")
-		if configDir == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return configFile{}, false
-			}
-			configDir = filepath.Join(home, ".config")
+		dir, err := paths.ConfigDir()
+		if err != nil {
+			return configFile{}, false
 		}
-		configPath = filepath.Join(configDir, "lfk", "config.yaml")
+		configPath = filepath.Join(dir, "config.yaml")
 	}
 
 	data, err := os.ReadFile(configPath)

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -526,6 +526,7 @@ func helpSections() []helpSection {
 				{"", "Config: ~/.config/lfk/config.yaml (or $XDG_CONFIG_HOME/lfk/config.yaml)"},
 				{"", "State:  ~/.local/state/lfk/ (bookmarks, session, history, pinned groups)"},
 				{"", "Logs:   ~/.local/share/lfk/lfk.log"},
+				{"", "Override dirs: LFK_CONFIG_DIR, LFK_STATE_DIR, LFK_DATA_DIR"},
 			},
 		},
 	}

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -525,7 +525,7 @@ func helpSections() []helpSection {
 			bindings: []helpEntry{
 				{"", "Config: ~/.config/lfk/config.yaml (or $XDG_CONFIG_HOME/lfk/config.yaml)"},
 				{"", "State:  ~/.local/state/lfk/ (bookmarks, session, history, pinned groups)"},
-				{"", "Logs:   ~/.local/share/lfk/lfk.log"},
+				{"", "Logs:   ~/.local/share/lfk/lfk.log (or $XDG_DATA_HOME/lfk/lfk.log)"},
 				{"", "Override dirs: LFK_CONFIG_DIR, LFK_STATE_DIR, LFK_DATA_DIR"},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 File locations:
   Config: ~/.config/lfk/config.yaml  (or $XDG_CONFIG_HOME/lfk/config.yaml)
   State:  ~/.local/state/lfk/        (bookmarks, session, history)
-  Logs:   ~/.local/share/lfk/lfk.log
+  Logs:   ~/.local/share/lfk/lfk.log  (or $XDG_DATA_HOME/lfk/lfk.log)
   Override dirs for portable installs: LFK_CONFIG_DIR, LFK_STATE_DIR, LFK_DATA_DIR`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runTUI(cliOpts)

--- a/main.go
+++ b/main.go
@@ -35,7 +35,8 @@ func main() {
 File locations:
   Config: ~/.config/lfk/config.yaml  (or $XDG_CONFIG_HOME/lfk/config.yaml)
   State:  ~/.local/state/lfk/        (bookmarks, session, history)
-  Logs:   ~/.local/share/lfk/lfk.log`,
+  Logs:   ~/.local/share/lfk/lfk.log
+  Override dirs for portable installs: LFK_CONFIG_DIR, LFK_STATE_DIR, LFK_DATA_DIR`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runTUI(cliOpts)
 		},


### PR DESCRIPTION
## Summary

Adds three environment variables — `LFK_CONFIG_DIR`, `LFK_STATE_DIR`, `LFK_DATA_DIR` — that redirect lfk's config, state, and data directories. This lets portable installs (e.g. Scoop's `persist` directory) keep user data across upgrades without setting the shared `XDG_*_HOME` variables, which would redirect every other XDG-aware app on the machine.

- New leaf package `internal/paths` centralizes config/state/data directory resolution. Precedence per directory: `LFK_<X>_DIR` (used verbatim) > `$XDG_<X>_HOME/lfk` > OS default.
- The ~12 previously-scattered XDG-resolution call sites — logger, config loader, shell completion, 8 `internal/app` state files, packet captures — now route through `internal/paths`. `internal/logger` previously hardcoded its log path and ignored `XDG_DATA_HOME`; that is now fixed.
- Behavior is unchanged when the variables are unset: XDG variables and OS defaults resolve exactly as before, and the legacy `~/.config/lfk/` state-file migration is untouched. The `--config` flag and `log_path` config field still override.

Part of #222 — the Scoop manifest change that sets these variables is a separate follow-up (GoReleaser's `scoops:` config cannot emit an `env_set` block).

## Notes

- `defaultCaptureDir` previously returned a relative path if `os.UserHomeDir()` failed (a latent bug); it now returns `""` on that unreachable error, consistent with every sibling state-path function.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` — all 11 packages pass
- [x] `internal/paths` unit tests — 9-case precedence matrix (LFK var / XDG var / OS default x config/state/data); coverage 90.9%
- [x] `internal/app` integration test — all 8 state paths resolve under `LFK_STATE_DIR`
- [x] `internal/k8s` test — capture dir honors `LFK_STATE_DIR`
- [x] `golangci-lint run` — 0 issues
- [x] Manual: set `LFK_STATE_DIR` to a temp dir, run lfk, confirm bookmarks/session/log land there