### PR TITLE
chore: move Scoop distribution to the official Extras bucket

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,19 +98,6 @@ brews:
     test: |
       system "#{bin}/lfk", "--version"
 
-scoops:
-  - repository:
-      owner: janosmiko
-      name: scoop-bucket
-      branch: main
-      token: "{{ .Env.RELEASE_TAP_TOKEN }}"
-    directory: bucket
-    name: lfk
-    homepage: "https://github.com/janosmiko/lfk"
-    description: "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters"
-    license: Apache-2.0
-    commit_msg_template: "chore: bump lfk to {{ .Tag }}"
-
 winget:
   - name: lfk
     publisher: janosmiko

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@
 brew install janosmiko/tap/lfk
 
 # Windows: Scoop
-scoop bucket add extras && scoop install lfk
+scoop bucket add extras
+scoop install lfk
 # or: winget install janosmiko.lfk
 # or: choco install lfk
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@
 brew install janosmiko/tap/lfk
 
 # Windows: Scoop
-scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket && scoop install lfk
+scoop bucket add extras && scoop install lfk
 # or: winget install janosmiko.lfk
 # or: choco install lfk
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,7 @@ Download pre-built binaries from the [GitHub Releases](https://github.com/janosm
 ### Scoop
 
 ```powershell
-scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket
+scoop bucket add extras
 scoop install lfk
 ```
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -18,7 +18,7 @@ To cut a release manually (skipping `release-please`): `make release VERSION=X.Y
 | Channel | Account / Repo | Setup |
 |---|---|---|
 | Homebrew | `janosmiko/homebrew-tap` | Existing. PAT in `RELEASE_TAP_TOKEN`. |
-| Scoop | `janosmiko/scoop-bucket` | Empty repo with README + LICENSE. Same PAT. |
+| Scoop | `ScoopInstaller/Extras` | Manifest submitted as a one-time PR; the excavator bot auto-updates it. No owned repo. |
 | Winget | Fork of `microsoft/winget-pkgs` at `janosmiko/winget-pkgs` | PAT in `WINGET_TOKEN` with `contents:write` on the fork. |
 | AUR | aur.archlinux.org account `janosmiko` | SSH public key uploaded; `lfk-bin` reserved. Private key in `AUR_SSH_PRIVATE_KEY` (multi-line PEM). |
 | Chocolatey | chocolatey.org publisher `janosmiko` | API key in `CHOCOLATEY_API_KEY`. `lfk` package id reserved. |
@@ -32,7 +32,7 @@ To cut a release manually (skipping `release-please`): `make release VERSION=X.Y
 | `GITHUB_TOKEN` | release publish | auto, never rotate manually |
 | `RELEASE_PLEASE_TOKEN` | release-please CI | rotate annually |
 | `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` | Docker push | rotate annually |
-| `RELEASE_TAP_TOKEN` | Homebrew + Scoop | rotate annually |
+| `RELEASE_TAP_TOKEN` | Homebrew | rotate annually |
 | `WINGET_TOKEN` | Winget upstream PR | rotate annually |
 | `AUR_SSH_PRIVATE_KEY` | AUR push | rotate when key compromised |
 | `CHOCOLATEY_API_KEY` | choco push | rotate when key compromised |
@@ -50,7 +50,7 @@ goreleaser release --clean --config .goreleaser.yaml --skip=<comma-separated cha
 
 # Example: re-publish only Chocolatey (skip every other publisher; keep build, archive, sign, sbom).
 goreleaser release --clean --config .goreleaser.yaml \
-  --skip=brews,scoops,winget,aurs,nfpms,dockers,snapcrafts
+  --skip=brews,winget,aurs,nfpms,dockers,snapcrafts
 ```
 
 For Cloudsmith specifically, you can manually push:
@@ -65,7 +65,7 @@ cloudsmith push rpm janosmiko/lfk/any-distro/any-version dist/lfk_<version>_<arc
 Run after each release tag completes. Channels with classic Snap or first-time Chocolatey moderation may legitimately be "pending" — that's not a failure.
 
 - [ ] **Homebrew:** `brew update && brew upgrade lfk` on macOS or Linux; `lfk --version` matches.
-- [ ] **Scoop:** on Windows, `scoop update lfk && lfk --version`.
+- [ ] **Scoop:** the `ScoopInstaller/Extras` excavator bot auto-bumps the manifest within ~a day; then `scoop update lfk && lfk --version` on Windows.
 - [ ] **Winget:** check `https://github.com/microsoft/winget-pkgs/pulls?q=author%3Ajanosmiko` for the auto-PR. Once merged: `winget upgrade janosmiko.lfk`.
 - [ ] **AUR:** `https://aur.archlinux.org/packages/lfk-bin` shows the new version; `yay -Syu lfk-bin` on Arch.
 - [ ] **Chocolatey:** `https://chocolatey.org/packages/lfk` shows the new version (may say "Pending" for first submission). `choco upgrade lfk`.


### PR DESCRIPTION
## Summary

Retires the custom `janosmiko/scoop-bucket` in favor of the official `ScoopInstaller/Extras` bucket (issue #222).

- Removes the GoReleaser `scoops:` block — Scoop is no longer published from this repo.
- `docs/installation.md` and `README.md` point users at `scoop bucket add extras`.
- `docs/release-process.md` drops Scoop from the GoReleaser-driven tables.

The Extras manifest (with `env_set` for the `LFK_*_DIR` variables, so Scoop installs persist data across updates) is submitted separately to `ScoopInstaller/Extras`.

**Do not merge until the `ScoopInstaller/Extras` PR is merged** — otherwise `installation.md` documents an install path that does not work yet.

## Test plan

- [x] `goreleaser check` passes (config valid after removing the `scoops:` block)
- [x] CI green
- [ ] Merge only after the Extras manifest PR is live