### PR TITLE
fix(port-forward): reuse local port on restart, fix setup-overlay UX

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -148,7 +148,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 
 Events list also groups duplicate events (same Type/Reason/Message/Object) by default; press `z` to toggle grouping.
 
-Port forwarding is available via the action menu (`x`) on Pod, Service, Deployment, StatefulSet, and DaemonSet resources. After creating a port forward, the view automatically navigates to the Port Forwards list and displays the resolved local port in the status bar. Active port forwards can be managed via the "Port Forwards" virtual resource in the Networking group.
+Port forwarding is available via the action menu (`x`) on Pod, Service, Deployment, StatefulSet, and DaemonSet resources. In the port-forward dialog, select an exposed port with `j`/`k`, or type a `local:remote` mapping (e.g. `8080:80`) to choose a specific local port — an empty local port is assigned randomly. After creating a port forward, the view automatically navigates to the Port Forwards list and displays the resolved local port in the status bar. Active port forwards can be managed via the "Port Forwards" virtual resource in the Networking group; press `D` there to remove the selected forward.
 
 Resource-specific actions (exec, scale, restart, secret editor, etc.) are available through the action menu (`x`).
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -148,7 +148,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 
 Events list also groups duplicate events (same Type/Reason/Message/Object) by default; press `z` to toggle grouping.
 
-Port forwarding is available via the action menu (`x`) on Pod, Service, Deployment, StatefulSet, and DaemonSet resources. In the port-forward dialog, select an exposed port with `j`/`k`, or type a `local:remote` mapping (e.g. `8080:80`) to choose a specific local port — an empty local port is assigned randomly. After creating a port forward, the view automatically navigates to the Port Forwards list and displays the resolved local port in the status bar. Active port forwards can be managed via the "Port Forwards" virtual resource in the Networking group; press `D` there to remove the selected forward.
+Port forwarding is available via the action menu (`x`) on Pod, Service, Deployment, StatefulSet, and DaemonSet resources. In the port-forward dialog, select an exposed port with `j`/`k`, or type a `local:remote` mapping (e.g. `8080:80`) to choose a specific local port — omit the local port (e.g. `:80`) for a random one. After creating a port forward, the view automatically navigates to the Port Forwards list and displays the resolved local port in the status bar. Active port forwards can be managed via the "Port Forwards" virtual resource in the Networking group; press `D` there to remove the selected forward.
 
 Resource-specific actions (exec, scale, restart, secret editor, etc.) are available through the action menu (`x`).
 

--- a/internal/app/commands_portforward.go
+++ b/internal/app/commands_portforward.go
@@ -59,6 +59,17 @@ func (m Model) stopPortForward(id int) tea.Cmd {
 	}
 }
 
+// restartLocalPort returns the local port to reuse when restarting a port
+// forward. The forward's existing local port is kept — including a port
+// kubectl resolved on the first run — so the restart stays on the same
+// localhost:<port>. An empty value falls back to "0" for a fresh assignment.
+func restartLocalPort(localPort string) string {
+	if localPort == "" {
+		return "0"
+	}
+	return localPort
+}
+
 // restartPortForward restarts a stopped/failed port forward by ID.
 // It removes the old entry and starts a new one with the same parameters.
 func (m Model) restartPortForward(id int) tea.Cmd {
@@ -82,8 +93,7 @@ func (m Model) restartPortForward(id int) tea.Cmd {
 	kubeconfigPaths := m.client.KubeconfigPathForContext(kctx)
 	kubectlKctx := m.kubectlContext(kctx)
 	remotePort := entry.RemotePort
-	// Use "0" for local port to get a fresh random port assignment.
-	localPort := "0"
+	localPort := restartLocalPort(entry.LocalPort)
 
 	mgr.Remove(id)
 

--- a/internal/app/commands_portforward_test.go
+++ b/internal/app/commands_portforward_test.go
@@ -46,3 +46,25 @@ func TestCovRestorePortForwards(t *testing.T) {
 	// No port forwards to restore, and kubectl may not be available.
 	_ = cmds
 }
+
+// TestRestartLocalPort verifies that restarting a port forward reuses the
+// local port the forward already had, rather than picking a new random one.
+func TestRestartLocalPort(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"resolved random port is reused", "54321", "54321"},
+		{"user-specified port is reused", "8080", "8080"},
+		{"unresolved zero stays random", "0", "0"},
+		{"empty falls back to random", "", "0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := restartLocalPort(tc.in); got != tc.want {
+				t.Errorf("restartLocalPort(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -140,6 +140,7 @@ func (m Model) overlayHintBarSelector() string {
 	case overlayPortForward:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "j/k", Desc: "select port"},
+			{Key: "0-9", Desc: "local[:remote] port (eg 8080:80)"},
 			{Key: "enter", Desc: "forward"},
 			{Key: "esc", Desc: "cancel"},
 		})

--- a/internal/app/renderoverlay_test.go
+++ b/internal/app/renderoverlay_test.go
@@ -113,6 +113,29 @@ func TestRenderOverlayPortForward(t *testing.T) {
 	assert.NotEmpty(t, result)
 }
 
+// TestRenderOverlayPortForwardColonTogglesManualMode verifies that a ':' in
+// the input hides the Remote-port row (manual local:remote mode) and that
+// clearing it brings the row back.
+func TestRenderOverlayPortForwardColonTogglesManualMode(t *testing.T) {
+	m := baseOverlayModel()
+	m.overlay = overlayPortForward
+	m.pfAvailablePorts = []ui.PortInfo{{Port: "80", Name: "http"}, {Port: "443", Name: "https"}}
+	m.pfPortCursor = 1
+	m.actionCtx = actionContext{name: "my-pod"}
+	bg := strings.Repeat("bg\n", 10)
+
+	// No ':' — a port is selected, so the Remote-port row is shown.
+	m.portForwardInput = TextInput{Value: "8080"}
+	listMode := m.renderOverlay(bg)
+	assert.Contains(t, listMode, "Remote port")
+
+	// ':' in the input — manual mapping mode, Remote-port row hidden.
+	m.portForwardInput = TextInput{Value: "8080:"}
+	manualMode := m.renderOverlay(bg)
+	assert.NotContains(t, manualMode, "Remote port")
+	assert.Contains(t, manualMode, "Port mapping")
+}
+
 func TestRenderOverlayContainerSelect(t *testing.T) {
 	m := baseOverlayModel()
 	m.overlay = overlayContainerSelect

--- a/internal/app/update_actions_helm_misc.go
+++ b/internal/app/update_actions_helm_misc.go
@@ -219,3 +219,24 @@ func (m Model) executeActionRemove() (tea.Model, tea.Cmd) {
 	}
 	return m, nil
 }
+
+// removeSelectedPortForward removes the port forward under the cursor in the
+// __port_forwards__ browser — the path taken by the D / delete key. Mirrors
+// the action-menu "Remove" but sources the entry from the selected row
+// rather than m.actionCtx.
+func (m Model) removeSelectedPortForward() (tea.Model, tea.Cmd) {
+	sel := m.selectedMiddleItem()
+	if sel == nil {
+		return m, nil
+	}
+	pfID := m.getPortForwardID(sel.Columns)
+	if pfID <= 0 {
+		return m, nil
+	}
+	m.portForwardMgr.Remove(pfID)
+	m.setMiddleItems(m.portForwardItems())
+	m.clampCursor()
+	m.saveCurrentPortForwards()
+	m.setStatusMessage("Port forward removed", false)
+	return m, scheduleStatusClear()
+}

--- a/internal/app/update_actions_helm_misc_test.go
+++ b/internal/app/update_actions_helm_misc_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRemoveSelectedPortForward covers the D / delete key path in the
+// __port_forwards__ browser. The action-menu "Remove" shares the same
+// manager call; these cases exercise the guard paths that return early
+// without touching the port-forward manager.
+func TestRemoveSelectedPortForward(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []model.Item
+	}{
+		{
+			name:  "nil selection is a no-op",
+			items: nil,
+		},
+		{
+			name: "row without a valid port-forward ID is a no-op",
+			items: []model.Item{{
+				Name:    "Pod/my-pod  8080:80",
+				Kind:    "__port_forward_entry__",
+				Columns: []model.KeyValue{{Key: "ID", Value: "0"}},
+			}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := baseModelUpdate()
+			m.nav.Level = model.LevelResources
+			m.nav.ResourceType = model.ResourceTypeEntry{Kind: "__port_forwards__"}
+			m.portForwardMgr = k8s.NewPortForwardManager()
+			m.middleItems = tc.items
+
+			ret, cmd := m.removeSelectedPortForward()
+			result := ret.(Model)
+			assert.Equal(t, model.LevelResources, result.nav.Level)
+			assert.Nil(t, cmd)
+		})
+	}
+}

--- a/internal/app/update_actions_helm_misc_test.go
+++ b/internal/app/update_actions_helm_misc_test.go
@@ -10,16 +10,18 @@ import (
 
 // TestRemoveSelectedPortForward covers the D / delete key path in the
 // __port_forwards__ browser. The action-menu "Remove" shares the same
-// manager call; these cases exercise the guard paths that return early
-// without touching the port-forward manager.
+// manager call.
 func TestRemoveSelectedPortForward(t *testing.T) {
 	tests := []struct {
-		name  string
-		items []model.Item
+		name      string
+		items     []model.Item
+		wantCmd   bool // removal path ran (non-nil cmd)
+		wantEmpty bool // middleItems rebuilt from the (empty) manager
 	}{
 		{
-			name:  "nil selection is a no-op",
-			items: nil,
+			name:    "nil selection is a no-op",
+			items:   nil,
+			wantCmd: false,
 		},
 		{
 			name: "row without a valid port-forward ID is a no-op",
@@ -28,6 +30,17 @@ func TestRemoveSelectedPortForward(t *testing.T) {
 				Kind:    "__port_forward_entry__",
 				Columns: []model.KeyValue{{Key: "ID", Value: "0"}},
 			}},
+			wantCmd: false,
+		},
+		{
+			name: "row with a valid ID runs the removal path",
+			items: []model.Item{{
+				Name:    "Pod/my-pod  8080:80",
+				Kind:    "__port_forward_entry__",
+				Columns: []model.KeyValue{{Key: "ID", Value: "1"}},
+			}},
+			wantCmd:   true,
+			wantEmpty: true,
 		},
 	}
 	for _, tc := range tests {
@@ -41,7 +54,10 @@ func TestRemoveSelectedPortForward(t *testing.T) {
 			ret, cmd := m.removeSelectedPortForward()
 			result := ret.(Model)
 			assert.Equal(t, model.LevelResources, result.nav.Level)
-			assert.Nil(t, cmd)
+			assert.Equal(t, tc.wantCmd, cmd != nil)
+			if tc.wantEmpty {
+				assert.Empty(t, result.middleItems)
+			}
 		})
 	}
 }

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -201,6 +201,10 @@ func (m Model) handleExplorerDirectActionKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 		ret, cmd := m.directActionDescribe()
 		return ret, cmd, true
 	case kb.Delete:
+		if m.nav.Level == model.LevelResources && m.nav.ResourceType.Kind == "__port_forwards__" {
+			ret, cmd := m.removeSelectedPortForward()
+			return ret, cmd, true
+		}
 		ret, cmd := m.directActionDelete()
 		return ret, cmd, true
 	case kb.ForceDelete:

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -330,6 +330,13 @@ func (m Model) handlePortForwardOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		case m.portForwardInput.Value != "":
 			// Manual entry: parse as localPort:remotePort or just port.
 			parts := strings.SplitN(m.portForwardInput.Value, ":", 2)
+			if len(parts) == 2 && parts[1] == "" {
+				// "8080:" has no remote port; kubectl would reject it.
+				// An empty local port (":80") is fine — kubectl picks one.
+				m.setStatusMessage("Port mapping needs a remote port (e.g., 8080:80)", true)
+				m.overlay = overlayNone
+				return m, scheduleStatusClear()
+			}
 			localPort = parts[0]
 			if len(parts) == 2 {
 				remotePort = parts[1]

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -313,8 +313,11 @@ func (m Model) handlePortForwardOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	case "enter":
 		var localPort, remotePort string
+		// A ':' in the input means the user is typing a full local:remote
+		// mapping manually — that takes precedence over any list selection.
+		manualMapping := strings.Contains(m.portForwardInput.Value, ":")
 		switch {
-		case m.pfPortCursor >= 0 && m.pfPortCursor < len(m.pfAvailablePorts):
+		case !manualMapping && m.pfPortCursor >= 0 && m.pfPortCursor < len(m.pfAvailablePorts):
 			p := m.pfAvailablePorts[m.pfPortCursor]
 			remotePort = p.Port
 			if m.portForwardInput.Value != "" {
@@ -375,10 +378,6 @@ func (m Model) handlePortForwardOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		key := msg.String()
 		if len(key) == 1 && ((key[0] >= '0' && key[0] <= '9') || key[0] == ':') {
 			m.portForwardInput.Insert(key)
-			// When user types ':', they want manual local:remote mode — deselect from port list.
-			if key[0] == ':' {
-				m.pfPortCursor = -1
-			}
 		}
 		return m, nil
 	}

--- a/internal/app/update_overlays_logs_test.go
+++ b/internal/app/update_overlays_logs_test.go
@@ -673,7 +673,10 @@ func TestCovPortForwardKeyColon(t *testing.T) {
 	m.pfPortCursor = 0
 	result, _ := m.handlePortForwardOverlayKey(keyMsg(":"))
 	rm := result.(Model)
-	assert.Equal(t, -1, rm.pfPortCursor)
+	// ':' enters manual mode via the input content; the list selection
+	// is preserved so deleting the ':' can restore it.
+	assert.Equal(t, 0, rm.pfPortCursor)
+	assert.Contains(t, rm.portForwardInput.Value, ":")
 }
 
 func TestCovPortForwardKeyInvalidChar(t *testing.T) {

--- a/internal/app/update_overlays_logs_test.go
+++ b/internal/app/update_overlays_logs_test.go
@@ -587,6 +587,19 @@ func TestCovPortForwardKeyEnterManualSinglePort(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+func TestCovPortForwardKeyEnterEmptyRemote(t *testing.T) {
+	m := baseModelBoost2()
+	m.overlay = overlayPortForward
+	m.pfPortCursor = -1
+	m.portForwardInput.Insert("8080:")
+	result, cmd := m.handlePortForwardOverlayKey(keyMsg("enter"))
+	rm := result.(Model)
+	// "8080:" has an empty remote port: rejected with a status message.
+	assert.Equal(t, overlayNone, rm.overlay)
+	assert.NotNil(t, cmd)
+	assert.True(t, rm.hasStatusMessage())
+}
+
 func TestCovPortForwardKeyEnterEmpty(t *testing.T) {
 	m := baseModelBoost2()
 	m.overlay = overlayPortForward

--- a/internal/app/update_overlays_test.go
+++ b/internal/app/update_overlays_test.go
@@ -1138,7 +1138,7 @@ func TestPortForwardOverlayTypesDigits(t *testing.T) {
 	assert.Equal(t, "8080", result.portForwardInput.Value)
 }
 
-func TestPortForwardOverlayColonDeselectsPort(t *testing.T) {
+func TestPortForwardOverlayColonKeepsPortSelected(t *testing.T) {
 	m := Model{
 		overlay:          overlayPortForward,
 		portForwardInput: TextInput{Value: "8080", Cursor: 4},
@@ -1147,10 +1147,18 @@ func TestPortForwardOverlayColonDeselectsPort(t *testing.T) {
 		width:            80,
 		height:           40,
 	}
+	// Typing ':' switches to manual local:remote entry but must keep the
+	// list selection, so removing the ':' can restore it.
 	ret, _ := m.handlePortForwardOverlayKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{':'}})
 	result := ret.(Model)
-	assert.Equal(t, -1, result.pfPortCursor)
 	assert.Equal(t, "8080:", result.portForwardInput.Value)
+	assert.Equal(t, 1, result.pfPortCursor)
+
+	// Deleting the ':' returns to list mode with the same port selected.
+	ret2, _ := result.handlePortForwardOverlayKey(specialKey(tea.KeyBackspace))
+	result2 := ret2.(Model)
+	assert.Equal(t, "8080", result2.portForwardInput.Value)
+	assert.Equal(t, 1, result2.pfPortCursor)
 }
 
 func TestPortForwardOverlayEnterWithNoInput(t *testing.T) {

--- a/internal/app/view_overlay_port_forward.go
+++ b/internal/app/view_overlay_port_forward.go
@@ -1,20 +1,31 @@
 package app
 
 import (
+	"strings"
+
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
 // renderPortForwardOverlay maps the PortForward overlay state onto the
-// unified OverlayInput component. The list of available ports becomes
-// the candidate list; whether the cursor sits on a candidate determines
-// the input rows: either two pinned rows (Remote read-only + Local) or
-// a single free-form "Port mapping" row when the cursor is in manual mode.
+// unified OverlayInput component. The list of available ports becomes the
+// candidate list. A ':' in the input puts the overlay in manual local:remote
+// mode (single free-form "Port mapping" row, no candidate highlight);
+// otherwise, with a port selected, it shows two pinned rows (Remote
+// read-only + Local).
 func renderPortForwardOverlay(m Model) string {
+	// A ':' in the input switches to manual local:remote entry. The list
+	// selection is set aside (no highlight, no Remote/Local rows) but kept
+	// in pfPortCursor, so clearing the ':' restores it.
+	manualMapping := strings.Contains(m.portForwardInput.Value, ":")
+	candidateCursor := m.pfPortCursor
+	if manualMapping {
+		candidateCursor = -1
+	}
 	cfg := ui.OverlayInputConfig{
 		Title:           "Port Forward",
 		Subtitle:        m.actionCtx.name,
 		CandidateTitle:  "Available ports:",
-		CandidateCursor: m.pfPortCursor,
+		CandidateCursor: candidateCursor,
 	}
 	if len(m.pfAvailablePorts) > 0 {
 		cfg.Candidates = make([]ui.OverlayListItem, len(m.pfAvailablePorts))
@@ -30,7 +41,7 @@ func renderPortForwardOverlay(m Model) string {
 		}
 	}
 	switch {
-	case m.pfPortCursor >= 0 && m.pfPortCursor < len(m.pfAvailablePorts):
+	case !manualMapping && m.pfPortCursor >= 0 && m.pfPortCursor < len(m.pfAvailablePorts):
 		cfg.Rows = []ui.OverlayInputRow{
 			{Label: "Remote port: ", Input: m.pfAvailablePorts[m.pfPortCursor].Port, ReadOnly: true},
 			{Label: "Local port:  ", Input: m.portForwardInput.Value, Placeholder: "(random)"},


### PR DESCRIPTION
## Summary
- Restart reuses the forward's existing local port instead of requesting a new random one.
- `D` removes the selected forward directly in the Port Forwards browser (was action-menu only).
- Setup overlay: typing `:` enters manual `local:remote` mode and deleting it restores the remote-port row — manual mode is now derived from the input, not stored in `pfPortCursor`.
- Hint bar documents the `local:remote` mapping format (`0-9 local:remote port (eg 8080:80)`).

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/app/... ./internal/ui/...`
- [x] `golangci-lint run ./internal/app/...` — 0 issues
- [x] Tests added/updated: restart-port reuse, D-remove, `:` toggle + restore (handler and view)

Relates to #248.