### PR TITLE
fix(sort): sort numeric/structured columns numerically

### DIFF
--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"net/netip"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -136,6 +138,16 @@ func comparePrimaryColumn(a, b model.Item, colName string) int {
 		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
 	case "Age":
 		return compareAgeCmp(a, b)
+	case "Ports":
+		return comparePortsCmp(getColumnValue(a, "Ports"), getColumnValue(b, "Ports"))
+	case "Progress":
+		// Argo Workflow progress is an "N/M" fraction, identical in shape
+		// to the Ready ratio — reuse the same comparator.
+		return compareReadyCmp(getColumnValue(a, "Progress"), getColumnValue(b, "Progress"))
+	case "Duration":
+		return compareDurationCmp(getColumnValue(a, "Duration"), getColumnValue(b, "Duration"))
+	case "Cluster IP", "Pod IP", "External IPs":
+		return compareIPCmp(getColumnValue(a, colName), getColumnValue(b, colName))
 	case sortColEventLastSeen:
 		return compareLastSeenCmp(a, b)
 	default:
@@ -263,6 +275,85 @@ func compareLastSeenCmp(a, b model.Item) int {
 	default:
 		return 0
 	}
+}
+
+// comparePortsCmp compares Service "Ports" column values numerically by
+// their leading port number, so "99/TCP" sorts before "10000/TCP" instead
+// of lexicographically. Values are comma-joined lists (e.g. "80/TCP, 443/TCP");
+// only the first entry's port drives the comparison. Falls back to a
+// case-insensitive lexicographic comparison when either value lacks a
+// leading number.
+func comparePortsCmp(a, b string) int {
+	na, okA := leadingPortNumber(a)
+	nb, okB := leadingPortNumber(b)
+	if okA && okB {
+		if c := cmpInt(na, nb); c != 0 {
+			return c
+		}
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	}
+	return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+}
+
+// leadingPortNumber extracts the leading run of digits from a port string
+// (e.g. "8080:30000/TCP" → 8080). Returns false when there is no leading digit.
+func leadingPortNumber(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[:i])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// compareDurationCmp compares two Go duration strings (e.g. "5m30s") by
+// their actual length, so "10m" sorts after "5m" instead of before it.
+// Falls back to case-insensitive lexicographic comparison when either
+// value is not a parseable duration.
+func compareDurationCmp(a, b string) int {
+	da, errA := time.ParseDuration(strings.TrimSpace(a))
+	db, errB := time.ParseDuration(strings.TrimSpace(b))
+	if errA == nil && errB == nil {
+		return cmpInt64(int64(da), int64(db))
+	}
+	return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+}
+
+// compareIPCmp compares IP-address column values numerically, so
+// "10.0.0.9" sorts before "10.0.0.10". Values may be comma-joined lists
+// (e.g. External IPs); only the first address drives the comparison.
+// Falls back to case-insensitive lexicographic comparison when either
+// value lacks a parseable leading address (e.g. "None", "<none>").
+func compareIPCmp(a, b string) int {
+	ia, okA := leadingIP(a)
+	ib, okB := leadingIP(b)
+	if okA && okB {
+		if c := ia.Compare(ib); c != 0 {
+			return c
+		}
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+	}
+	return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+}
+
+// leadingIP parses the first comma-separated token of s as an IP address.
+func leadingIP(s string) (netip.Addr, bool) {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, ','); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr, true
 }
 
 // compareColumnValuesCmp compares two column values with automatic detection

--- a/internal/app/tabs_compare_test.go
+++ b/internal/app/tabs_compare_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestComparePortsCmp_Numeric(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"99 before 10000", "99/TCP", "10000/TCP", -1},
+		{"10000 after 99", "10000/TCP", "99/TCP", 1},
+		{"equal leading port", "80/TCP", "80/UDP", -1},
+		{"identical", "443/TCP", "443/TCP", 0},
+		{"nodeport form", "8080:30000/TCP", "9000:30001/TCP", -1},
+		{"non-numeric falls back lexicographic", "abc", "abd", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := comparePortsCmp(tt.a, tt.b)
+			if (got < 0) != (tt.want < 0) || (got > 0) != (tt.want > 0) {
+				t.Errorf("comparePortsCmp(%q, %q) = %d, want sign of %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComparePortsCmp_SortOrder(t *testing.T) {
+	values := []string{"10000/TCP", "99/TCP", "443/TCP", "8080/TCP"}
+	sort.Slice(values, func(i, j int) bool {
+		return comparePortsCmp(values[i], values[j]) < 0
+	})
+	want := []string{"99/TCP", "443/TCP", "8080/TCP", "10000/TCP"}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("sorted = %v, want %v", values, want)
+		}
+	}
+}
+
+func TestCompareDurationCmp(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"5m before 10m", "5m0s", "10m0s", -1},
+		{"10m after 5m", "10m0s", "5m0s", 1},
+		{"equal", "1h2m3s", "1h2m3s", 0},
+		{"seconds vs minutes", "90s", "1m0s", 1},
+		{"non-duration falls back lexicographic", "abc", "abd", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareDurationCmp(tt.a, tt.b)
+			if (got < 0) != (tt.want < 0) || (got > 0) != (tt.want > 0) {
+				t.Errorf("compareDurationCmp(%q, %q) = %d, want sign of %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareIPCmp(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"9 before 10 in last octet", "10.0.0.9", "10.0.0.10", -1},
+		{"10 after 9", "10.0.0.10", "10.0.0.9", 1},
+		{"identical", "172.16.0.1", "172.16.0.1", 0},
+		{"first token of list drives compare", "10.0.0.2, 10.0.0.99", "10.0.0.3, 10.0.0.1", -1},
+		{"non-IP falls back lexicographic", "None", "abc", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareIPCmp(tt.a, tt.b)
+			if (got < 0) != (tt.want < 0) || (got > 0) != (tt.want > 0) {
+				t.Errorf("compareIPCmp(%q, %q) = %d, want sign of %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareIPCmp_SortOrder(t *testing.T) {
+	values := []string{"10.0.0.10", "10.0.0.9", "10.0.0.1", "10.0.0.100"}
+	sort.Slice(values, func(i, j int) bool {
+		return compareIPCmp(values[i], values[j]) < 0
+	})
+	want := []string{"10.0.0.1", "10.0.0.9", "10.0.0.10", "10.0.0.100"}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("sorted = %v, want %v", values, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Several explorer table columns had no dedicated comparator in `comparePrimaryColumn` and fell through to lexicographic string comparison, producing visibly wrong sort order.

| Column | Before | After |
|---|---|---|
| `Ports` | `10000/TCP` above `99/TCP` | numeric by leading port |
| `Progress` (Argo Workflows) | `N/M` fraction sorted as text | numeric by ratio |
| `Duration` (Argo Workflows) | `10m` before `5m` | numeric by actual length |
| `Cluster IP` / `Pod IP` / `External IPs` | `10.0.0.10` before `10.0.0.9` | numeric by address |

## Changes

- `comparePortsCmp` — sorts by the leading port number (handles `8080:30000/TCP` nodeport form).
- `compareDurationCmp` — compares parsed `time.Duration` values.
- `compareIPCmp` — compares `netip.Addr` values; uses the first token of comma-joined lists.
- `Progress` reuses the existing `compareReadyCmp` since its `N/M` shape matches `Ready`.

Each comparator falls back to case-insensitive lexicographic comparison when a value is not parseable (e.g. `None`, `<none>`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/app ./internal/k8s -race`
- [x] `golangci-lint run` — 0 issues
- [x] New table-driven tests in `tabs_compare_test.go` covering numeric ordering, list values, and non-parseable fallback

Closes #250