### PR TITLE
feat: add jump-back navigation history (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `0` / `1` / `2` | Jump to clusters / types / resources level |
 | `J` / `K` | Scroll preview pane down/up |
 | `o` | Jump to owner/controller of selected resource |
+| `Backspace` | Jump back through teleport history (owner / port-forward / orphan / mark jumps) |
 
 ### Views and Modes
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -21,6 +21,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `0` / `1` / `2` | Jump to clusters / types / resources level |
 | `J` / `K` | Scroll preview pane down/up |
 | `o` / `O` | `o` jumps to the owner/controller of the selected resource; `O` opens the cluster-wide orphan overview overlay |
+| `Backspace` | Jump back through teleport history (owner, port-forward, orphan, and mark jumps push history; hierarchical `h`/`l` navigation does not) |
 
 ## Views and Tools
 
@@ -954,6 +955,7 @@ keybindings:
   preview_down: "J"      # Scroll preview down
   preview_up: "K"        # Scroll preview up
   jump_owner: "o"        # Jump to owner
+  jump_back: "backspace"     # Jump back through teleport history
   toggle_rare: "H"       # Toggle rarely used resource types in the sidebar
 
   # Views and Modes

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -725,6 +725,9 @@ type Model struct {
 	sessionRestored     bool               // true once the pending session has been applied
 	pendingPortForwards *PortForwardStates // loaded port forwards waiting to be re-established
 
+	// Jump history: back stack for "teleport" jumps; jump_back pops it. Capped at jumpHistoryCap.
+	jumpBackStack []navSnapshot
+
 	// Stack of LevelOwned parents for nested drill-downs (popped by navigateParent).
 	ownedParentStack []ownedParentState
 	// Overlay to restore when the current closes — set when a nested overlay flow opens (e.g., RBAC → namespace selector → back to RBAC).
@@ -778,10 +781,8 @@ type Model struct {
 	columnToggleCursor       int
 	columnToggleFilter       string
 	columnToggleFilterActive bool
-	// columnToggleSnapshot captures the pre-overlay values of session/
-	// hidden/order maps for the current kind so Esc can revert when the
-	// user explored toggles live and changed their mind. Captured at
-	// openColumnToggle, consumed at handleColumnToggleKeyEsc.
+	// columnToggleSnapshot captures pre-overlay session/hidden/order maps
+	// so Esc can revert live edits (openColumnToggle -> handleColumnToggleKeyEsc).
 	columnToggleSnapshot columnToggleSnapshot
 	sessionColumns       map[string][]string // kind -> ordered visible extra column keys (session-only)
 	hiddenBuiltinColumns map[string][]string // kind -> hidden built-in column keys (session-only)

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -402,11 +402,16 @@ type TabState struct {
 	// a full refreshCurrentLevel instead of the lighter loadPreview.
 	needsLoad bool
 
-	nav                model.NavigationState
-	leftItems          []model.Item
-	middleItems        []model.Item
-	rightItems         []model.Item
-	leftItemsHistory   [][]model.Item
+	nav              model.NavigationState
+	leftItems        []model.Item
+	middleItems      []model.Item
+	rightItems       []model.Item
+	leftItemsHistory [][]model.Item
+	// jumpBackStack holds this tab's teleport history so each tab navigates
+	// its own jumps independently. navSnapshots are never mutated after
+	// captureNavSnapshot deep-copies their slices, so copying the outer
+	// slice on save/restore is enough.
+	jumpBackStack      []navSnapshot
 	cursors            [5]int
 	middleScroll       int // persistent scroll position for middle column (vim-style scrolloff)
 	leftScroll         int // persistent scroll position for left column (vim-style scrolloff)

--- a/internal/app/jump_history.go
+++ b/internal/app/jump_history.go
@@ -101,6 +101,11 @@ func (m *Model) restoreNavSnapshot(snap navSnapshot) tea.Cmd {
 	// picker rather than restoring into a dead context.
 	if snap.nav.Level > model.LevelClusters && snap.nav.Context != "" {
 		if !m.contextStillValid(snap.nav.Context) {
+			// A jump-back is a navigation transition: cancel in-flight work and
+			// bump requestGen so async responses from the pre-fallback view
+			// can't apply after this reset (mirrors navigateParent).
+			m.cancelAndReset()
+			m.requestGen++
 			m.setStatusMessage("Jump target no longer available — returned to clusters", true)
 			m.nav = model.NavigationState{Level: model.LevelClusters}
 			m.leftItemsHistory = nil

--- a/internal/app/jump_history.go
+++ b/internal/app/jump_history.go
@@ -1,0 +1,196 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// jumpHistoryCap bounds the jump-back stack. When a push would exceed it,
+// the oldest entry is dropped.
+const jumpHistoryCap = 50
+
+// navSnapshot captures only the navigation-positioning state needed to restore
+// the explorer to a previous location after a "teleport" jump. It deliberately
+// does NOT snapshot the whole tabState — just enough to repaint the columns and
+// re-issue a data load for the restored level.
+type navSnapshot struct {
+	nav              model.NavigationState
+	leftItems        []model.Item
+	middleItems      []model.Item
+	leftItemsHistory [][]model.Item
+	cursors          [5]int
+	middleScroll     int // ui.ActiveMiddleScroll
+	leftScroll       int // ui.ActiveLeftScroll
+	expandedGroup    string
+	filterText       string
+}
+
+// captureNavSnapshot records the current navigation-positioning state with all
+// slices deep-copied so later mutation of the Model can't corrupt the snapshot.
+func (m *Model) captureNavSnapshot() navSnapshot {
+	snap := navSnapshot{
+		nav:           m.nav,
+		leftItems:     append([]model.Item(nil), m.leftItems...),
+		middleItems:   append([]model.Item(nil), m.middleItems...),
+		cursors:       m.cursors,
+		middleScroll:  ui.ActiveMiddleScroll,
+		leftScroll:    ui.ActiveLeftScroll,
+		expandedGroup: m.expandedGroup,
+		filterText:    m.filterText,
+	}
+	snap.leftItemsHistory = make([][]model.Item, len(m.leftItemsHistory))
+	for i, hist := range m.leftItemsHistory {
+		snap.leftItemsHistory[i] = append([]model.Item(nil), hist...)
+	}
+	// nav is copied by value above, but ResourceTypeEntry embeds slice
+	// headers that would otherwise alias the live Model. Deep-copy them.
+	snap.nav.ResourceType.Verbs = append([]string(nil), m.nav.ResourceType.Verbs...)
+	snap.nav.ResourceType.PrinterColumns = append([]model.PrinterColumn(nil), m.nav.ResourceType.PrinterColumns...)
+	return snap
+}
+
+// clone returns a fully deep-copied navSnapshot. Every inner slice is
+// reallocated so the result shares no backing storage with the original. This
+// makes the "snapshots are never mutated" invariant enforced by construction.
+func (s navSnapshot) clone() navSnapshot {
+	out := s
+	out.leftItems = append([]model.Item(nil), s.leftItems...)
+	out.middleItems = append([]model.Item(nil), s.middleItems...)
+	out.leftItemsHistory = make([][]model.Item, len(s.leftItemsHistory))
+	for i, hist := range s.leftItemsHistory {
+		out.leftItemsHistory[i] = append([]model.Item(nil), hist...)
+	}
+	out.nav.ResourceType.Verbs = append([]string(nil), s.nav.ResourceType.Verbs...)
+	out.nav.ResourceType.PrinterColumns = append([]model.PrinterColumn(nil), s.nav.ResourceType.PrinterColumns...)
+	return out
+}
+
+// cloneNavSnapshots returns a deep copy of a navSnapshot slice, with each
+// element structurally cloned via clone().
+func cloneNavSnapshots(src []navSnapshot) []navSnapshot {
+	if src == nil {
+		return nil
+	}
+	out := make([]navSnapshot, len(src))
+	for i, s := range src {
+		out[i] = s.clone()
+	}
+	return out
+}
+
+// pushJumpHistory records the current navigation state on the back stack. It
+// must be called by every "teleport" site BEFORE it mutates navigation state,
+// so jump_back can restore the user's origin.
+func (m *Model) pushJumpHistory() {
+	m.jumpBackStack = append(m.jumpBackStack, m.captureNavSnapshot())
+	if len(m.jumpBackStack) > jumpHistoryCap {
+		m.jumpBackStack = m.jumpBackStack[len(m.jumpBackStack)-jumpHistoryCap:]
+	}
+}
+
+// restoreNavSnapshot applies a snapshot back onto the Model and returns a
+// command that reloads data for the restored level. Restore is graceful: if the
+// snapshot targets a level deeper than LevelClusters but its context is no
+// longer known, it falls back to the nearest valid level and surfaces a status
+// message instead of crashing.
+func (m *Model) restoreNavSnapshot(snap navSnapshot) tea.Cmd {
+	// Graceful fallback: a snapshot below the cluster picker needs a context
+	// that still exists. If discovery no longer knows it, drop to the cluster
+	// picker rather than restoring into a dead context.
+	if snap.nav.Level > model.LevelClusters && snap.nav.Context != "" {
+		if !m.contextStillValid(snap.nav.Context) {
+			m.setStatusMessage("Jump target no longer available — returned to clusters", true)
+			m.nav = model.NavigationState{Level: model.LevelClusters}
+			m.leftItemsHistory = nil
+			m.expandedGroup = ""
+			m.filterText = ""
+			m.filterInput.Clear()
+			m.filterActive = false
+			ui.ActiveMiddleScroll = 0
+			ui.ActiveLeftScroll = 0
+			m.clearRight()
+			m.clearSelection()
+			contexts, _ := m.client.GetContexts()
+			m.leftItems = nil
+			m.setMiddleItems(contexts)
+			m.cursors = [5]int{}
+			m.clampCursor()
+			return tea.Batch(m.loadPreview(), scheduleStatusClear())
+		}
+	}
+
+	m.cancelAndReset()
+	m.requestGen++
+	m.clearSelection()
+	m.activeFilterPreset = nil
+	m.unfilteredMiddleItems = nil
+
+	m.nav = snap.nav
+	m.leftItems = append([]model.Item(nil), snap.leftItems...)
+	m.leftItemsHistory = make([][]model.Item, len(snap.leftItemsHistory))
+	for i, hist := range snap.leftItemsHistory {
+		m.leftItemsHistory[i] = append([]model.Item(nil), hist...)
+	}
+	m.cursors = snap.cursors
+	m.expandedGroup = snap.expandedGroup
+
+	m.filterText = snap.filterText
+	m.filterInput.Clear()
+	m.filterActive = false
+	m.searchInput.Clear()
+
+	ui.ActiveMiddleScroll = snap.middleScroll
+	ui.ActiveLeftScroll = snap.leftScroll
+
+	// Instant paint from the snapshot; the reload below refreshes it.
+	m.setMiddleItems(append([]model.Item(nil), snap.middleItems...))
+	m.clearRight()
+	m.clampCursor()
+
+	switch m.nav.Level {
+	case model.LevelResources:
+		m.loading = true
+		return m.loadResources(false)
+	case model.LevelOwned:
+		m.loading = true
+		return m.loadOwned(false)
+	case model.LevelContainers:
+		m.loading = true
+		return m.loadContainers(false)
+	default:
+		return m.loadPreview()
+	}
+}
+
+// contextStillValid reports whether the given Kubernetes context is still known
+// to the client, so a restore doesn't land in a context that has gone away.
+func (m *Model) contextStillValid(ctx string) bool {
+	contexts, err := m.client.GetContexts()
+	if err != nil {
+		// Can't tell — assume valid rather than blocking a legitimate restore.
+		return true
+	}
+	for _, c := range contexts {
+		if c.Name == ctx {
+			return true
+		}
+	}
+	return false
+}
+
+// jumpBack restores the navigation state recorded before the last teleport.
+// No-op when the back stack is empty.
+func (m Model) jumpBack() (tea.Model, tea.Cmd) {
+	n := len(m.jumpBackStack)
+	if n == 0 {
+		m.setStatusMessage("No jump history to go back to", false)
+		return m, scheduleStatusClear()
+	}
+	snap := m.jumpBackStack[n-1]
+	m.jumpBackStack = m.jumpBackStack[:n-1]
+	cmd := m.restoreNavSnapshot(snap)
+	m.saveCurrentSession()
+	return m, cmd
+}

--- a/internal/app/jump_history_test.go
+++ b/internal/app/jump_history_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -97,22 +98,11 @@ func TestJumpHistoryStackCap(t *testing.T) {
 	// Push one more than the cap; the oldest entry must be dropped.
 	for i := range jumpHistoryCap + 10 {
 		m.setCursor(i)
-		m.jumpBackStack = append(m.jumpBackStack, m.captureNavSnapshot())
-		if len(m.jumpBackStack) > jumpHistoryCap {
-			m.jumpBackStack = m.jumpBackStack[len(m.jumpBackStack)-jumpHistoryCap:]
-		}
+		m.pushJumpHistory()
 	}
 	assert.Len(t, m.jumpBackStack, jumpHistoryCap)
 	// Oldest surviving entry should be cursor index 10, not 0.
 	assert.Equal(t, 10, m.jumpBackStack[0].cursors[model.LevelResources])
-}
-
-func TestJumpHistoryPushCapViaPushHelper(t *testing.T) {
-	m := jumpHistoryModel()
-	for range jumpHistoryCap + 5 {
-		m.pushJumpHistory()
-	}
-	assert.Len(t, m.jumpBackStack, jumpHistoryCap)
 }
 
 func TestMultiLevelJumpHistory(t *testing.T) {
@@ -242,4 +232,45 @@ func TestJumpHistoryIsIndependentPerTab(t *testing.T) {
 	m.saveCurrentTab()
 	m.loadTab(0)
 	require.Len(t, m.jumpBackStack, 1, "tab A's jump history must survive the round-trip")
+}
+
+// TestJumpBackKeyIgnoredDuringTextEntry verifies that the JumpBack key
+// (Backspace) is left unhandled by handleExplorerJumpKey while a filter or
+// search query is being edited, so the input handlers receive it instead.
+func TestJumpBackKeyIgnoredDuringTextEntry(t *testing.T) {
+	// The non-editing case reaches jumpBack(), which persists session state;
+	// isolate the state dir so it doesn't leak into other tests.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	kb := ui.ActiveKeybindings
+	jumpBackMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(kb.JumpBack)}
+	if kb.JumpBack == "backspace" {
+		jumpBackMsg = tea.KeyMsg{Type: tea.KeyBackspace}
+	}
+
+	t.Run("not handled while filter active", func(t *testing.T) {
+		m := jumpHistoryModel()
+		m.pushJumpHistory()
+		m.filterActive = true
+		_, _, handled := m.handleExplorerJumpKey(jumpBackMsg)
+		assert.False(t, handled,
+			"JumpBack must be left for the filter input handler while editing")
+	})
+
+	t.Run("not handled while search active", func(t *testing.T) {
+		m := jumpHistoryModel()
+		m.pushJumpHistory()
+		m.searchActive = true
+		_, _, handled := m.handleExplorerJumpKey(jumpBackMsg)
+		assert.False(t, handled,
+			"JumpBack must be left for the search input handler while editing")
+	})
+
+	t.Run("handled when not editing", func(t *testing.T) {
+		m := jumpHistoryModel()
+		m.pushJumpHistory()
+		_, _, handled := m.handleExplorerJumpKey(jumpBackMsg)
+		assert.True(t, handled,
+			"JumpBack must trigger jump-back when no text entry is active")
+	})
 }

--- a/internal/app/jump_history_test.go
+++ b/internal/app/jump_history_test.go
@@ -1,0 +1,245 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// jumpHistoryModel returns a Model positioned at LevelResources in the
+// "test-ctx" context, which the test client reports as a valid context so
+// restore takes the happy path rather than the stale-fallback path.
+func jumpHistoryModel() Model {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "test-ctx"
+	m.leftItems = []model.Item{{Name: "Pods", Extra: "/v1/pods"}}
+	m.leftItemsHistory = [][]model.Item{{{Name: "test-ctx"}}}
+	return m
+}
+
+func TestPushJumpHistoryCapturesState(t *testing.T) {
+	m := jumpHistoryModel()
+	m.setCursor(2)
+	m.filterText = "web"
+	m.expandedGroup = "Workloads"
+
+	m.pushJumpHistory()
+
+	require.Len(t, m.jumpBackStack, 1)
+	snap := m.jumpBackStack[0]
+	assert.Equal(t, model.LevelResources, snap.nav.Level)
+	assert.Equal(t, "test-ctx", snap.nav.Context)
+	assert.Equal(t, 2, snap.cursors[model.LevelResources])
+	assert.Equal(t, "web", snap.filterText)
+	assert.Equal(t, "Workloads", snap.expandedGroup)
+	assert.Len(t, snap.middleItems, 3)
+}
+
+func TestJumpBackRestoresState(t *testing.T) {
+	m := jumpHistoryModel()
+	m.setCursor(2)
+	m.filterText = "origin"
+
+	m.pushJumpHistory()
+
+	// Simulate a teleport mutating navigation away from the origin.
+	m.nav.Level = model.LevelResourceTypes
+	m.nav.ResourceName = "elsewhere"
+	m.setCursor(0)
+	m.filterText = ""
+	m.setMiddleItems([]model.Item{{Name: "other"}})
+
+	result, _ := m.jumpBack()
+	rm := result.(Model)
+
+	assert.Equal(t, model.LevelResources, rm.nav.Level)
+	assert.Equal(t, "test-ctx", rm.nav.Context)
+	assert.Equal(t, 2, rm.cursors[model.LevelResources])
+	assert.Equal(t, "origin", rm.filterText)
+	assert.Len(t, rm.middleItems, 3)
+	assert.Empty(t, rm.jumpBackStack)
+}
+
+func TestTeleportThenJumpBackReturnsToOrigin(t *testing.T) {
+	m := jumpHistoryModel()
+	m.setCursor(1)
+	// navigateToOwner calls pushJumpHistory before mutating nav state.
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "Deployment", APIVersion: "apps/v1", Resource: "deployments"},
+	}
+	result, _ := m.navigateToOwner("Deployment", "my-deploy")
+	rm := result.(Model)
+	require.Len(t, rm.jumpBackStack, 1, "navigateToOwner must record the origin")
+
+	back, _ := rm.jumpBack()
+	bm := back.(Model)
+	assert.Equal(t, model.LevelResources, bm.nav.Level)
+	assert.Equal(t, 1, bm.cursors[model.LevelResources])
+}
+
+func TestJumpBackEmptyStackIsNoOp(t *testing.T) {
+	m := jumpHistoryModel()
+	m.nav.Level = model.LevelOwned
+
+	back, _ := m.jumpBack()
+	bm := back.(Model)
+	assert.Equal(t, model.LevelOwned, bm.nav.Level, "jumpBack on empty stack must not navigate")
+	assert.Empty(t, bm.jumpBackStack)
+}
+
+func TestJumpHistoryStackCap(t *testing.T) {
+	m := jumpHistoryModel()
+	// Push one more than the cap; the oldest entry must be dropped.
+	for i := range jumpHistoryCap + 10 {
+		m.setCursor(i)
+		m.jumpBackStack = append(m.jumpBackStack, m.captureNavSnapshot())
+		if len(m.jumpBackStack) > jumpHistoryCap {
+			m.jumpBackStack = m.jumpBackStack[len(m.jumpBackStack)-jumpHistoryCap:]
+		}
+	}
+	assert.Len(t, m.jumpBackStack, jumpHistoryCap)
+	// Oldest surviving entry should be cursor index 10, not 0.
+	assert.Equal(t, 10, m.jumpBackStack[0].cursors[model.LevelResources])
+}
+
+func TestJumpHistoryPushCapViaPushHelper(t *testing.T) {
+	m := jumpHistoryModel()
+	for range jumpHistoryCap + 5 {
+		m.pushJumpHistory()
+	}
+	assert.Len(t, m.jumpBackStack, jumpHistoryCap)
+}
+
+func TestMultiLevelJumpHistory(t *testing.T) {
+	m := jumpHistoryModel()
+	m.setCursor(0)
+
+	// First teleport: origin A -> B.
+	m.pushJumpHistory()
+	m.nav.Level = model.LevelResourceTypes
+	m.setMiddleItems([]model.Item{{Name: "B"}})
+
+	// Second teleport: B -> C.
+	m.pushJumpHistory()
+	m.nav.Level = model.LevelOwned
+	m.setMiddleItems([]model.Item{{Name: "C"}})
+	require.Len(t, m.jumpBackStack, 2)
+
+	// First jumpBack: C -> B.
+	back1, _ := m.jumpBack()
+	m1 := back1.(Model)
+	assert.Equal(t, model.LevelResourceTypes, m1.nav.Level)
+
+	// Second jumpBack: B -> A.
+	back2, _ := m1.jumpBack()
+	m2 := back2.(Model)
+	assert.Equal(t, model.LevelResources, m2.nav.Level)
+	assert.Empty(t, m2.jumpBackStack)
+}
+
+func TestJumpBackStaleTargetGracefulFallback(t *testing.T) {
+	m := jumpHistoryModel()
+	m.setCursor(1)
+	m.pushJumpHistory()
+	// Corrupt the recorded snapshot's context so it no longer exists.
+	m.jumpBackStack[0].nav.Context = "deleted-ctx"
+
+	m.nav.Level = model.LevelResourceTypes
+
+	result, _ := m.jumpBack()
+	rm := result.(Model)
+	assert.Equal(t, model.LevelClusters, rm.nav.Level,
+		"stale snapshot context must fall back to the cluster picker, not crash")
+	assert.Equal(t, "", rm.nav.Context)
+	assert.True(t, rm.hasStatusMessage(), "stale fallback must surface a status message")
+}
+
+func TestCaptureNavSnapshotDeepCopiesSlices(t *testing.T) {
+	m := jumpHistoryModel()
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind:           "Widget",
+		Verbs:          []string{"get", "list"},
+		PrinterColumns: []model.PrinterColumn{{Name: "Status", JSONPath: ".status.phase"}},
+	}
+	snap := m.captureNavSnapshot()
+
+	// Mutating the live model must not corrupt the snapshot.
+	m.middleItems[0].Name = "mutated"
+	m.leftItems[0].Name = "mutated"
+	m.nav.ResourceType.Verbs[0] = "mutated"
+	m.nav.ResourceType.PrinterColumns[0].Name = "mutated"
+
+	assert.NotEqual(t, "mutated", snap.middleItems[0].Name)
+	assert.NotEqual(t, "mutated", snap.leftItems[0].Name)
+	assert.Equal(t, "get", snap.nav.ResourceType.Verbs[0],
+		"snapshot Verbs must not alias the live model")
+	assert.Equal(t, "Status", snap.nav.ResourceType.PrinterColumns[0].Name,
+		"snapshot PrinterColumns must not alias the live model")
+}
+
+func TestJumpHistoryKeybindingsHaveDefaults(t *testing.T) {
+	kb := ui.DefaultKeybindings()
+	assert.Equal(t, "backspace", kb.JumpBack)
+}
+
+// TestSaveLoadTabRoundTripsJumpStack verifies the per-tab jump-back history
+// survives a saveCurrentTab/loadTab cycle and is decoupled from the Model.
+func TestSaveLoadTabRoundTripsJumpStack(t *testing.T) {
+	m := jumpHistoryModel()
+	m.tabs = []TabState{{}}
+	m.activeTab = 0
+	m.setCursor(2)
+	m.filterText = "origin"
+	m.pushJumpHistory()
+	require.Len(t, m.jumpBackStack, 1)
+
+	m.saveCurrentTab()
+	require.Len(t, m.tabs[0].jumpBackStack, 1)
+
+	// Clear the live stack, then restore from the tab.
+	m.jumpBackStack = nil
+	m.loadTab(0)
+	require.Len(t, m.jumpBackStack, 1)
+	assert.Equal(t, "origin", m.jumpBackStack[0].filterText)
+
+	// Mutating the restored stack must not corrupt the saved tab state.
+	m.jumpBackStack = m.jumpBackStack[:0]
+	assert.Len(t, m.tabs[0].jumpBackStack, 1)
+}
+
+// TestJumpHistoryIsIndependentPerTab verifies that a teleport+jumpBack in one
+// tab does not reach into another tab's jump history.
+func TestJumpHistoryIsIndependentPerTab(t *testing.T) {
+	m := jumpHistoryModel()
+	m.tabs = []TabState{{}, {}}
+	m.activeTab = 0
+
+	// Tab A: record a jump.
+	m.setCursor(1)
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "Deployment", APIVersion: "apps/v1", Resource: "deployments"},
+	}
+	resA, _ := m.navigateToOwner("Deployment", "deploy-a")
+	m = resA.(Model)
+	require.Len(t, m.jumpBackStack, 1, "tab A must record its own jump")
+	m.saveCurrentTab()
+
+	// Switch to tab B — it must start with an empty jump history.
+	m.loadTab(1)
+	assert.Empty(t, m.jumpBackStack, "tab B must not see tab A's jump history")
+
+	// A jumpBack in tab B is a no-op and cannot reach tab A's origin.
+	resB, _ := m.jumpBack()
+	m = resB.(Model)
+	assert.Empty(t, m.jumpBackStack)
+
+	// Switch back to tab A — its jump history is intact.
+	m.saveCurrentTab()
+	m.loadTab(0)
+	require.Len(t, m.jumpBackStack, 1, "tab A's jump history must survive the round-trip")
+}

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -310,6 +310,9 @@ func (m *Model) portForwardItems() []model.Item {
 // navigateToPortForwards switches the view to the Port Forwards resource list.
 // If pfLastCreatedID is set, the cursor is placed on the matching entry.
 func (m *Model) navigateToPortForwards() {
+	// Record the origin so jump_back can return here after this teleport.
+	m.pushJumpHistory()
+
 	// Build the correct left column state for LevelResources.
 	contexts, _ := m.client.GetContexts()
 	var resourceTypes []model.Item
@@ -418,6 +421,7 @@ func (m *Model) saveCurrentTab() {
 	for i, hist := range m.leftItemsHistory {
 		t.leftItemsHistory[i] = append([]model.Item(nil), hist...)
 	}
+	t.jumpBackStack = cloneNavSnapshots(m.jumpBackStack)
 	t.cursors = m.cursors
 	t.middleScroll = ui.ActiveMiddleScroll
 	t.leftScroll = ui.ActiveLeftScroll
@@ -527,6 +531,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	for i, hist := range t.leftItemsHistory {
 		m.leftItemsHistory[i] = append([]model.Item(nil), hist...)
 	}
+	m.jumpBackStack = cloneNavSnapshots(t.jumpBackStack)
 	m.cursors = t.cursors
 	ui.ActiveMiddleScroll = t.middleScroll
 	ui.ActiveLeftScroll = t.leftScroll

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -333,8 +333,6 @@ func (m Model) saveBookmark(bm model.Bookmark) (tea.Model, tea.Cmd) {
 func (m Model) jumpToSlot(slot string) (tea.Model, tea.Cmd) {
 	for _, bm := range m.bookmarks {
 		if bm.Slot == slot {
-			// Record the origin so jump_back can return here after this teleport.
-			m.pushJumpHistory()
 			return m.navigateToBookmark(bm)
 		}
 	}
@@ -641,6 +639,11 @@ func (m Model) navigateToBookmark(bm model.Bookmark) (tea.Model, tea.Cmd) {
 		m.setStatusMessage("Resource type not found in current cluster", true)
 		return m, scheduleStatusClear()
 	}
+
+	// Target resolved successfully. Record the origin so jump_back can return
+	// here after this teleport — done before any nav state is mutated, and
+	// only on a confirmed-resolvable jump so failed jumps leave no history.
+	m.pushJumpHistory()
 
 	// Switch target: context bookmarks exit union mode, named union-set
 	// bookmarks activate union mode, and context-free bookmarks preserve the

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -333,6 +333,8 @@ func (m Model) saveBookmark(bm model.Bookmark) (tea.Model, tea.Cmd) {
 func (m Model) jumpToSlot(slot string) (tea.Model, tea.Cmd) {
 	for _, bm := range m.bookmarks {
 		if bm.Slot == slot {
+			// Record the origin so jump_back can return here after this teleport.
+			m.pushJumpHistory()
 			return m.navigateToBookmark(bm)
 		}
 	}

--- a/internal/app/update_bookmarks_test.go
+++ b/internal/app/update_bookmarks_test.go
@@ -2208,3 +2208,41 @@ func TestSaveBookmarkStatusMessageIncludesKind(t *testing.T) {
 			"status message must call out context-free kind")
 	})
 }
+
+// TestNavigateToBookmark_RecordsJumpHistory verifies a successful bookmark
+// jump records the origin on the jump-back stack — covering both the
+// jumpToSlot path and the overlay Enter path, which both route through
+// navigateToBookmark.
+func TestNavigateToBookmark_RecordsJumpHistory(t *testing.T) {
+	m := baseFinalModel()
+	podRT := model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1", Namespaced: true}
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{podRT}
+	bm := model.Bookmark{Slot: "P", ResourceType: podRT.ResourceRef()}
+
+	result, _ := m.navigateToBookmark(bm)
+	rm := result.(Model)
+
+	require.Len(t, rm.jumpBackStack, 1,
+		"a successful bookmark jump must record the origin for jump-back")
+}
+
+// TestNavigateToBookmark_FailedJumpRecordsNoHistory verifies an unresolvable
+// bookmark (resource type genuinely absent from a discovered cluster) does
+// not push a jump-history entry.
+func TestNavigateToBookmark_FailedJumpRecordsNoHistory(t *testing.T) {
+	m := baseFinalModel()
+	// Discovery has run for the context but the bookmarked type is not in it.
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "Pod", Resource: "pods", APIVersion: "v1"},
+	}
+	bm := model.Bookmark{
+		Slot:         "W",
+		ResourceType: "example.com/v1/widgets",
+	}
+
+	result, _ := m.navigateToBookmark(bm)
+	rm := result.(Model)
+
+	assert.Empty(t, rm.jumpBackStack,
+		"a failed bookmark jump must not record a jump-history entry")
+}

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -66,6 +66,10 @@ func (m Model) handleExplorerNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		}
 	}
 
+	if mdl, cmd, handled := m.handleExplorerJumpKey(msg); handled {
+		return mdl, cmd, true
+	}
+
 	switch msg.String() {
 	case "q":
 		m.overlay = overlayQuitConfirm
@@ -98,9 +102,6 @@ func (m Model) handleExplorerNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		return mdl, cmd, true
 	case kb.JumpBottom, "end":
 		mdl, cmd := m.handleExplorerJumpBottom()
-		return mdl, cmd, true
-	case "home":
-		mdl, cmd := m.handleExplorerHome()
 		return mdl, cmd, true
 	case kb.SelectRange:
 		mdl := m.handleKeySelectRange()
@@ -153,6 +154,19 @@ func (m Model) handleExplorerNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		return mdl, cmd, true
 	case kb.PrevMatch:
 		mdl, cmd := m.handleKeyPrevMatch()
+		return mdl, cmd, true
+	}
+	return m, nil, false
+}
+
+func (m Model) handleExplorerJumpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	kb := ui.ActiveKeybindings
+	switch msg.String() {
+	case "home":
+		mdl, cmd := m.handleExplorerHome()
+		return mdl, cmd, true
+	case kb.JumpBack:
+		mdl, cmd := m.jumpBack()
 		return mdl, cmd, true
 	}
 	return m, nil, false

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -166,6 +166,13 @@ func (m Model) handleExplorerJumpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) 
 		mdl, cmd := m.handleExplorerHome()
 		return mdl, cmd, true
 	case kb.JumpBack:
+		// JumpBack defaults to Backspace. While the user is editing a filter
+		// or search query, Backspace must delete a character — leave the key
+		// unhandled so the input handlers receive it. update_keys.go already
+		// routes active text entry away upstream; this guard is defensive.
+		if m.filterActive || m.searchActive {
+			return m, nil, false
+		}
 		mdl, cmd := m.jumpBack()
 		return mdl, cmd, true
 	}

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -250,6 +250,9 @@ func (m Model) navigateToOwner(kind, name string) (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 
+	// Record the origin so jump_back can return here after this teleport.
+	m.pushJumpHistory()
+
 	// Navigate back to resource types level.
 	for m.nav.Level > model.LevelResourceTypes {
 		ret, _ := m.navigateParent()

--- a/internal/app/update_orphans.go
+++ b/internal/app/update_orphans.go
@@ -289,6 +289,9 @@ func (m Model) jumpToOrphan() (Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 
+	// Record the origin so jump_back can return here after this teleport.
+	m.pushJumpHistory()
+
 	m = m.closeOrphansOverlay()
 
 	// Switch namespace before navigating so the resource list loads

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -361,6 +361,13 @@ func (m Model) explorerHintEntries() []ui.HintEntry {
 	hintEntries = append(hintEntries,
 		ui.HintEntry{Key: kb.Filter, Desc: "filter"},
 		ui.HintEntry{Key: kb.SetMark + "/" + kb.OpenMarks, Desc: "marks"},
+	)
+	// Advertise jump-back only when the stack has entries, so the bar never
+	// lies that a no-op key does something.
+	if len(m.jumpBackStack) > 0 {
+		hintEntries = append(hintEntries, ui.HintEntry{Key: kb.JumpBack, Desc: "jump back"})
+	}
+	hintEntries = append(hintEntries,
 		ui.HintEntry{Key: kb.Help, Desc: "help"},
 		ui.HintEntry{Key: "q", Desc: "quit"},
 	)

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -22,6 +22,7 @@ type Keybindings struct {
 	PreviewDown    string `json:"preview_down" yaml:"preview_down"`
 	PreviewUp      string `json:"preview_up" yaml:"preview_up"`
 	JumpOwner      string `json:"jump_owner" yaml:"jump_owner"`
+	JumpBack       string `json:"jump_back" yaml:"jump_back"`
 
 	// Views and Modes
 	Help            string `json:"help" yaml:"help"`
@@ -117,6 +118,7 @@ func DefaultKeybindings() Keybindings {
 		PageForward: "ctrl+f", PageBack: "ctrl+b",
 		LevelCluster: "0", LevelTypes: "1", LevelResources: "2",
 		PreviewDown: "J", PreviewUp: "K", JumpOwner: "o",
+		JumpBack: "backspace",
 
 		// Views
 		Help: "?", Filter: "f", Search: "/",

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -21,6 +21,7 @@ func helpSections() []helpSection {
 				{kb.Enter, "Open YAML view / navigate into"},
 				{kb.LevelCluster + "/" + kb.LevelTypes + "/" + kb.LevelResources, "Jump to clusters/types/resources level"},
 				{kb.JumpOwner, "Jump to owner/controller of selected resource"},
+				{helpKeyDisplay(kb.JumpBack), "Jump back through teleport history (owner/port-forward/orphan/mark jumps)"},
 				{kb.PreviewDown + "/" + kb.PreviewUp, "Scroll preview pane down/up"},
 				{kb.ExpandCollapse, "Toggle expand/collapse all resource groups / toggle event grouping (Events)"},
 				{kb.PinGroup, "Pin/unpin CRD group (at resource types level)"},


### PR DESCRIPTION
## Summary

Resolves #249.

Non-hierarchical "teleport" jumps previously discarded the user's origin, leaving no way back to the resource pane they came from. This adds a per-tab jump-back history.

- **`backspace`** — return to where you teleported from (full nav state, cursor, and filter restored).
- Tracked teleports: jump-to-owner (`o`), open port-forwards, orphans-overlay jump, bookmark jumps.
- Each teleport pushes a navigation snapshot onto a per-tab stack (capped at 50).
- Hierarchical `left`/`h`/`right`/`l` navigation is unchanged.
- Snapshots are fully deep-copied; restoring a stale target (context no longer valid) falls back to the cluster picker with a status message instead of failing.

Forward navigation was intentionally not included — `backspace` alone solves the filed issue, and reliable cross-terminal forward keys proved problematic.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/app/... ./internal/ui/...`
- [x] `golangci-lint run` (0 issues)
- [x] New tests in `jump_history_test.go`: snapshot capture/restore fidelity, teleport+back returns to origin, empty-stack no-op, stack cap at 50, multi-level history, stale-target fallback, deep-copy isolation, per-tab independence
- [ ] Manual: press `o` on a pod, then `backspace` — returns to the pod pane