### PR TITLE
fix(bulk): clear stale bulk-action snapshot on dispatch and cancel

### DIFF
--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -641,17 +641,23 @@ func (m Model) executeBulkAction(actionLabel string) (tea.Model, tea.Cmd) {
 		m.addLogEntry("DBG", fmt.Sprintf("Bulk sync (%d apps, hook strategy)", len(m.bulkItems)))
 		m.loading = true
 		m.clearSelection()
-		return m, m.bulkSyncArgoApps(false)
+		cmd := m.bulkSyncArgoApps(false)
+		m.resetBulkAction()
+		return m, cmd
 	case "Sync (Apply Only)":
 		m.addLogEntry("DBG", fmt.Sprintf("Bulk sync (%d apps, apply strategy)", len(m.bulkItems)))
 		m.loading = true
 		m.clearSelection()
-		return m, m.bulkSyncArgoApps(true)
+		cmd := m.bulkSyncArgoApps(true)
+		m.resetBulkAction()
+		return m, cmd
 	case "Refresh":
 		m.addLogEntry("DBG", fmt.Sprintf("Bulk refresh (%d apps)", len(m.bulkItems)))
 		m.loading = true
 		m.clearSelection()
-		return m, m.bulkRefreshArgoApps()
+		cmd := m.bulkRefreshArgoApps()
+		m.resetBulkAction()
+		return m, cmd
 	}
 
 	return m, nil

--- a/internal/app/update_actions_bulk.go
+++ b/internal/app/update_actions_bulk.go
@@ -6,6 +6,17 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 )
 
+// resetBulkAction clears the bulk-action snapshot (bulkMode and bulkItems).
+// The snapshot is taken when a bulk action is initiated and carried through
+// the confirmation overlay; it must be cleared once the action is dispatched
+// or cancelled. Leaving it set lets executeAction's bulk gate misroute a
+// later single-item action through the stale snapshot — e.g. prompting to
+// delete N resources while the background bulk delete is still running.
+func (m *Model) resetBulkAction() {
+	m.bulkMode = false
+	m.bulkItems = nil
+}
+
 // openBulkSelectionMenu builds and shows the action overlay for multi-selected items.
 // Extracted from openActionMenu to keep that function's cyclomatic complexity under 30.
 func (m Model) openBulkSelectionMenu() Model {

--- a/internal/app/update_actions_confirm_test.go
+++ b/internal/app/update_actions_confirm_test.go
@@ -145,3 +145,197 @@ func TestHandleConfirmOverlayKey_RestartDispatchesBulkRestart(t *testing.T) {
 	// We rely on the fact that bulkRestartResources logs "Bulk restarting"
 	// and bulkDeleteResources logs "Bulk deleting" — covered by Theme 1.
 }
+
+// --- Regression: stale bulk-action snapshot ---
+//
+// Confirming or cancelling a bulk action used to leave bulkMode/bulkItems
+// set until the background operation finished. During that window a
+// single-item action routed through executeAction's bulk gate and acted
+// on the stale snapshot — e.g. pressing delete on one pod prompted
+// "delete N resources" for the N items deleted moments earlier.
+
+func TestHandleConfirmOverlayKey_BulkDeleteClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.pendingAction = "Delete"
+	m.overlay = overlayConfirm
+	m.bulkItems = make([]model.Item, 50)
+	m.actionCtx = actionContext{
+		context:      "test-ctx",
+		kind:         "Pod",
+		resourceType: model.ResourceTypeEntry{Resource: "pods", Namespaced: true},
+	}
+
+	res, cmd := m.handleConfirmOverlayKey(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := res.(Model)
+
+	require.NotNil(t, cmd, "bulk delete must dispatch a command")
+	assert.False(t, rm.bulkMode, "bulkMode must be reset once the bulk delete is dispatched")
+	assert.Empty(t, rm.bulkItems, "bulkItems must be cleared once the bulk delete is dispatched")
+}
+
+func TestHandleConfirmTypeOverlayKey_BulkForceDeleteClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.pendingAction = "Force Delete"
+	m.overlay = overlayConfirmType
+	m.confirmTypeInput = TextInput{Value: "DELETE", Cursor: 6}
+	m.bulkItems = []model.Item{
+		{Name: "pod-1", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-2", Namespace: "default", Kind: "Pod"},
+	}
+	m.actionCtx = actionContext{
+		context:      "test-ctx",
+		kind:         "Pod",
+		resourceType: model.ResourceTypeEntry{Resource: "pods", Namespaced: true},
+	}
+
+	res, cmd := m.handleConfirmTypeOverlayKey(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := res.(Model)
+
+	require.NotNil(t, cmd, "bulk force delete must dispatch a command")
+	assert.False(t, rm.bulkMode, "bulkMode must be reset once the bulk force delete is dispatched")
+	assert.Empty(t, rm.bulkItems, "bulkItems must be cleared once the bulk force delete is dispatched")
+}
+
+func TestHandleScaleOverlayKey_BulkScaleClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.overlay = overlayScaleInput
+	m.scaleInput = TextInput{Value: "3"}
+	m.bulkItems = []model.Item{
+		{Name: "deploy-1", Namespace: "default", Kind: "Deployment"},
+		{Name: "deploy-2", Namespace: "default", Kind: "Deployment"},
+	}
+	m.actionCtx = actionContext{
+		context:      "test-ctx",
+		kind:         "Deployment",
+		resourceType: model.ResourceTypeEntry{Resource: "deployments", Namespaced: true},
+	}
+
+	res, cmd := m.handleScaleOverlayKey(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := res.(Model)
+
+	require.NotNil(t, cmd, "bulk scale must dispatch a command")
+	assert.False(t, rm.bulkMode, "bulkMode must be reset once the bulk scale is dispatched")
+	assert.Empty(t, rm.bulkItems, "bulkItems must be cleared once the bulk scale is dispatched")
+}
+
+func TestHandleConfirmOverlayKey_CancelClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.pendingAction = "Delete"
+	m.overlay = overlayConfirm
+	m.bulkItems = []model.Item{{Name: "pod-1", Namespace: "default", Kind: "Pod"}}
+
+	res, _ := m.handleConfirmOverlayKey(tea.KeyMsg{Type: tea.KeyEsc})
+	rm := res.(Model)
+
+	assert.False(t, rm.bulkMode, "cancelling a bulk delete must reset bulkMode")
+	assert.Empty(t, rm.bulkItems, "cancelling a bulk delete must clear bulkItems")
+}
+
+func TestHandleConfirmTypeOverlayKey_CancelClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.pendingAction = "Force Delete"
+	m.overlay = overlayConfirmType
+	m.confirmTypeInput = TextInput{Value: "DEL"}
+	m.bulkItems = []model.Item{{Name: "pod-1", Namespace: "default", Kind: "Pod"}}
+
+	res, _ := m.handleConfirmTypeOverlayKey(tea.KeyMsg{Type: tea.KeyEsc})
+	rm := res.(Model)
+
+	assert.False(t, rm.bulkMode, "cancelling a bulk force delete must reset bulkMode")
+	assert.Empty(t, rm.bulkItems, "cancelling a bulk force delete must clear bulkItems")
+}
+
+func TestHandleScaleOverlayKey_CancelClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.overlay = overlayScaleInput
+	m.scaleInput = TextInput{Value: "3"}
+	m.bulkItems = []model.Item{{Name: "deploy-1", Namespace: "default", Kind: "Deployment"}}
+
+	res, _ := m.handleScaleOverlayKey(tea.KeyMsg{Type: tea.KeyEsc})
+	rm := res.(Model)
+
+	assert.False(t, rm.bulkMode, "cancelling a bulk scale must reset bulkMode")
+	assert.Empty(t, rm.bulkItems, "cancelling a bulk scale must clear bulkItems")
+}
+
+// A read-only block dismisses the confirm overlay without dispatching. The
+// bulk snapshot must still be cleared, otherwise it leaks exactly as it
+// would after a successful dispatch.
+
+func TestHandleConfirmOverlayKey_ReadOnlyBlockedClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.cliReadOnly = true
+	m.bulkMode = true
+	m.pendingAction = "Delete"
+	m.overlay = overlayConfirm
+	m.bulkItems = []model.Item{{Name: "pod-1", Namespace: "default", Kind: "Pod"}}
+	m.actionCtx = actionContext{context: "test-ctx", kind: "Pod"}
+
+	res, _ := m.handleConfirmOverlayKey(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := res.(Model)
+
+	assert.Equal(t, overlayNone, rm.overlay, "read-only block must close the overlay")
+	assert.False(t, rm.bulkMode, "read-only block must reset bulkMode")
+	assert.Empty(t, rm.bulkItems, "read-only block must clear bulkItems")
+}
+
+func TestHandleConfirmTypeOverlayKey_ReadOnlyBlockedClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.cliReadOnly = true
+	m.bulkMode = true
+	m.pendingAction = "Force Delete"
+	m.overlay = overlayConfirmType
+	m.confirmTypeInput = TextInput{Value: "DELETE", Cursor: 6}
+	m.bulkItems = []model.Item{{Name: "pod-1", Namespace: "default", Kind: "Pod"}}
+	m.actionCtx = actionContext{context: "test-ctx", kind: "Pod"}
+
+	res, _ := m.handleConfirmTypeOverlayKey(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := res.(Model)
+
+	assert.Equal(t, overlayNone, rm.overlay, "read-only block must close the overlay")
+	assert.False(t, rm.bulkMode, "read-only block must reset bulkMode")
+	assert.Empty(t, rm.bulkItems, "read-only block must clear bulkItems")
+}
+
+func TestCloseCurrentOverlay_ClearsBulkSnapshot(t *testing.T) {
+	// ctrl+c on a confirm overlay is intercepted by handleOverlayKey and
+	// routed to closeCurrentOverlay, bypassing the per-overlay cancel
+	// branches — so the snapshot must be cleared here too.
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.overlay = overlayConfirm
+	m.bulkItems = []model.Item{{Name: "pod-1", Namespace: "default", Kind: "Pod"}}
+
+	res, _ := m.closeCurrentOverlay()
+	rm := res.(Model)
+
+	assert.False(t, rm.bulkMode, "closing the overlay must reset bulkMode")
+	assert.Empty(t, rm.bulkItems, "closing the overlay must clear bulkItems")
+}
+
+func TestExecuteBulkAction_SyncClearsBulkSnapshot(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.bulkItems = []model.Item{
+		{Name: "app-1", Namespace: "argocd", Kind: "Application"},
+		{Name: "app-2", Namespace: "argocd", Kind: "Application"},
+	}
+	m.actionCtx = actionContext{
+		context:      "test-ctx",
+		kind:         "Application",
+		resourceType: model.ResourceTypeEntry{Resource: "applications", Namespaced: true},
+	}
+
+	res, cmd := m.executeBulkAction("Sync")
+	rm := res.(Model)
+
+	require.NotNil(t, cmd, "bulk sync must dispatch a command")
+	assert.False(t, rm.bulkMode, "bulkMode must be reset once the bulk sync is dispatched")
+	assert.Empty(t, rm.bulkItems, "bulkItems must be cleared once the bulk sync is dispatched")
+}

--- a/internal/app/update_actions_confirm_test.go
+++ b/internal/app/update_actions_confirm_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 // TestExecuteBulkAction_RestartOpensConfirmInsteadOfFiring ensures that the
@@ -317,6 +318,23 @@ func TestCloseCurrentOverlay_ClearsBulkSnapshot(t *testing.T) {
 
 	assert.False(t, rm.bulkMode, "closing the overlay must reset bulkMode")
 	assert.Empty(t, rm.bulkItems, "closing the overlay must clear bulkItems")
+}
+
+func TestHandleOverlayKey_ToggleCloseClearsBulkSnapshot(t *testing.T) {
+	// The bulk action menu (overlayAction) is opened with bulkMode set.
+	// Pressing its hotkey again toggles it shut via handleOverlayKey's
+	// toggle path, which must also drop the bulk snapshot.
+	m := baseModelWithFakeClient()
+	m.bulkMode = true
+	m.overlay = overlayAction
+	m.bulkItems = []model.Item{{Name: "pod-1", Namespace: "default", Kind: "Pod"}}
+
+	res, _ := m.handleOverlayKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(ui.ActiveKeybindings.ActionMenu)})
+	rm := res.(Model)
+
+	assert.Equal(t, overlayNone, rm.overlay, "toggle key must close the bulk action menu")
+	assert.False(t, rm.bulkMode, "toggling the bulk action menu shut must reset bulkMode")
+	assert.Empty(t, rm.bulkItems, "toggling the bulk action menu shut must clear bulkItems")
 }
 
 func TestExecuteBulkAction_SyncClearsBulkSnapshot(t *testing.T) {

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -62,6 +62,10 @@ func (m Model) closeCurrentOverlay() (tea.Model, tea.Cmd) {
 	m.logPodFilterText = ""
 	m.logContainerFilterText = ""
 	m.columnToggleFilter = ""
+	// Drop any pending bulk-action snapshot — closing the overlay (Ctrl+C
+	// or toggle key) abandons the action, so a later single-item action
+	// must not be misrouted through the stale selection.
+	m.resetBulkAction()
 	if m.previousOverlay != overlayNone {
 		m.overlay = m.previousOverlay
 		m.previousOverlay = overlayNone

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -9,19 +9,11 @@ import (
 
 func (m Model) handleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Toggle: pressing the same hotkey that opened an overlay closes it.
-	// When the current overlay is layered on top of another (e.g. the
-	// namespace selector launched from inside RBAC), restore the parent
-	// instead of dropping all the way to the explorer — and ALWAYS
-	// clear previousOverlay so a stale parent can't reappear next time
-	// the same hotkey opens the overlay again.
+	// Route through closeCurrentOverlay so toggle-close gets the same
+	// cleanup as Esc/Ctrl+C — parent restoration, filter-state reset, and
+	// dropping any pending bulk-action snapshot.
 	if m.isOverlayToggleKey(msg.String()) {
-		if m.previousOverlay != overlayNone {
-			m.overlay = m.previousOverlay
-		} else {
-			m.overlay = overlayNone
-		}
-		m.previousOverlay = overlayNone
-		return m, nil
+		return m.closeCurrentOverlay()
 	}
 	// Universal Ctrl+C: close the current overlay (or restore its
 	// parent) rather than fall through to closeTabOrQuit inside the

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -18,6 +18,7 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			label := m.pendingAction
 			m.pendingAction = ""
 			m.confirmAction = ""
+			m.resetBulkAction()
 			m.setStatusMessage(readOnlyBlockedMessage(label), true)
 			return m, scheduleStatusClear()
 		}
@@ -47,13 +48,17 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			switch action {
 			case "Restart":
 				m.addLogEntry("DBG", fmt.Sprintf("$ kubectl rollout restart %s (%d items)%s --context %s", rt.Resource, len(expanded), nsArg, ctx))
-				return m, m.bulkRestartResources()
+				cmd := m.bulkRestartResources()
+				m.resetBulkAction()
+				return m, cmd
 			default:
 				// Default remains Delete for compatibility with existing
 				// callers that opened overlayConfirm without setting
 				// pendingAction.
 				m.addLogEntry("DBG", fmt.Sprintf("$ kubectl delete %s (%d items)%s --context %s", rt.Resource, len(expanded), nsArg, ctx))
-				return m, m.bulkDeleteResources()
+				cmd := m.bulkDeleteResources()
+				m.resetBulkAction()
+				return m, cmd
 			}
 		}
 
@@ -73,6 +78,7 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.overlay = overlayNone
 		m.confirmAction = ""
 		m.pendingAction = ""
+		m.resetBulkAction()
 		return m, nil
 	case "ctrl+c":
 		return m.closeTabOrQuit()
@@ -89,6 +95,7 @@ func (m Model) handleConfirmTypeOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.confirmQuestion = ""
 		m.pendingAction = ""
 		m.confirmTypeInput.Clear()
+		m.resetBulkAction()
 		return m, nil
 	case "ctrl+c":
 		return m.closeTabOrQuit()
@@ -103,6 +110,7 @@ func (m Model) handleConfirmTypeOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 				m.confirmTitle = ""
 				m.confirmQuestion = ""
 				m.confirmTypeInput.Clear()
+				m.resetBulkAction()
 				m.setStatusMessage(readOnlyBlockedMessage(label), true)
 				return m, scheduleStatusClear()
 			}
@@ -129,7 +137,9 @@ func (m Model) handleConfirmTypeOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 				m.clearSelection()
 				expanded := expandGroupedItems(m.bulkItems)
 				m.addLogEntry("DBG", fmt.Sprintf("$ kubectl delete --force --grace-period=0 %s (%d items)%s --context %s", rt.Resource, len(expanded), nsArg, ctx))
-				return m, m.bulkForceDeleteResources()
+				cmd := m.bulkForceDeleteResources()
+				m.resetBulkAction()
+				return m, cmd
 			}
 
 			switch action {
@@ -175,6 +185,7 @@ func (m Model) handleScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc", "q":
 		m.overlay = overlayNone
 		m.scaleInput.Clear()
+		m.resetBulkAction()
 		return m, nil
 	case "enter":
 		replicas, err := strconv.ParseInt(m.scaleInput.Value, 10, 32)
@@ -182,6 +193,7 @@ func (m Model) handleScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.setStatusMessage("Invalid replica count", true)
 			m.overlay = overlayNone
 			m.scaleInput.Clear()
+			m.resetBulkAction()
 			return m, scheduleStatusClear()
 		}
 		// Belt-and-suspenders read-only gate: the dispatcher already blocks
@@ -190,6 +202,7 @@ func (m Model) handleScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.actionTargetBlockedByReadOnly() {
 			m.overlay = overlayNone
 			m.scaleInput.Clear()
+			m.resetBulkAction()
 			m.setStatusMessage(readOnlyBlockedMessage("Scale"), true)
 			return m, scheduleStatusClear()
 		}
@@ -201,7 +214,9 @@ func (m Model) handleScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.bulkMode && len(m.bulkItems) > 0 {
 			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl scale %s --replicas=%d (%d items) -n %s --context %s", strings.ToLower(m.actionCtx.kind), replicas, len(m.bulkItems), m.actionCtx.namespace, m.actionCtx.context))
 			m.clearSelection()
-			return m, m.bulkScaleResources(int32(replicas))
+			cmd := m.bulkScaleResources(int32(replicas))
+			m.resetBulkAction()
+			return m, cmd
 		}
 
 		m.addLogEntry("DBG", fmt.Sprintf("$ kubectl scale %s %s --replicas=%d -n %s --context %s", strings.ToLower(m.actionCtx.kind), m.actionCtx.name, replicas, m.actionCtx.namespace, m.actionCtx.context))


### PR DESCRIPTION
## Problem

After confirming a bulk delete (or force-delete / scale), the snapshot held in `bulkMode` / `bulkItems` was only cleared when the **background operation completed**. During that in-flight window:

- the visible selection was already cleared (`clearSelection()` ran at confirm time), so **nothing looked selected**;
- but the stale `bulkMode` / `bulkItems` survived.

`executeAction`'s bulk gate (`update_actions.go` — `if m.bulkMode && len(m.bulkItems) > 0`) then **misrouted the next single-item action** through the stale snapshot. Reported symptom: select 50 pods, delete them, navigate to a different pod, press delete — and the prompt asks to *delete 50 resources*.

## Root cause

The confirm/scale overlay handlers called `clearSelection()` but never reset `bulkMode` / `bulkItems`. Those fields were only reset on async completion (`updateBulkActionResult`), leaving a window where a single-item action saw a stale bulk snapshot. The same leak applied to cancel branches, read-only-blocked early returns, `Ctrl+C` dismissal, and the `executeBulkAction` Sync/Refresh cases.

## Fix

Add `resetBulkAction()` (clears `bulkMode` + `bulkItems`) and call it everywhere the snapshot's life ends:

- confirm / force-confirm / scale overlay **dispatch** paths
- their **cancel** branches and **read-only-blocked** early returns
- `closeCurrentOverlay` (`Ctrl+C` / toggle-key dismissal)
- `executeBulkAction` **Sync / Sync (Apply Only) / Refresh** immediate-dispatch cases

The bulk command builders (`bulkDeleteResources`, `bulkForceDeleteResources`, `bulkScaleResources`, `bulkRestartResources`, `bulkSyncArgoApps`, `bulkRefreshArgoApps`) read `m.bulkItems` synchronously when the `tea.Cmd` is constructed, so resetting the snapshot *after* building the command is safe.

## Test plan

- [x] 10 new regression tests in `update_actions_confirm_test.go` (TDD: written failing first, then fixed) covering dispatch, cancel, read-only block, `Ctrl+C` close, and bulk sync — for `handleConfirmOverlayKey`, `handleConfirmTypeOverlayKey`, `handleScaleOverlayKey`, `closeCurrentOverlay`, `executeBulkAction`
- [x] `go test ./...` — full suite passes
- [x] `go test ./internal/app/ -race` — passes
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues