### PR TITLE
fix: stop node metrics column-order flicker (and prevent the whole class)

### DIFF
--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -378,25 +378,29 @@ func clearStalePodMetricsColumns(item *model.Item) {
 // autoDetectColumns drops the metrics columns whenever every visible row
 // lacks them, and the user sees the column set blink in and out as
 // metrics-server health fluctuates.
+//
+// Column order MUST match updateNodeMetricsEnriched and carryOverMetricsColumns
+// (CPU/MEM block first, everything else after) — otherwise every watch tick on
+// a node metrics-server has no data for flips the column order between two
+// layouts, producing a visible ~1Hz layout blink.
 func ensureNodeMetricsColumnsPlaceholder(item *model.Item) {
 	// Strip any prior CPU/CPU%/MEM/MEM% values so a node that has just
 	// dropped out of metrics-server output does not keep showing stale
 	// numbers from the previous tick — autoDetectColumns already keeps
-	// the columns visible thanks to the placeholders we re-append below.
+	// the columns visible thanks to the placeholders we prepend below.
 	removeCols := map[string]bool{"CPU": true, "CPU%": true, "MEM": true, "MEM%": true}
-	filtered := item.Columns[:0]
+	newCols := []model.KeyValue{
+		{Key: "CPU", Value: "n/a"},
+		{Key: "CPU%", Value: "n/a"},
+		{Key: "MEM", Value: "n/a"},
+		{Key: "MEM%", Value: "n/a"},
+	}
 	for _, kv := range item.Columns {
 		if !removeCols[kv.Key] {
-			filtered = append(filtered, kv)
+			newCols = append(newCols, kv)
 		}
 	}
-	filtered = append(filtered,
-		model.KeyValue{Key: "CPU", Value: "n/a"},
-		model.KeyValue{Key: "CPU%", Value: "n/a"},
-		model.KeyValue{Key: "MEM", Value: "n/a"},
-		model.KeyValue{Key: "MEM%", Value: "n/a"},
-	)
-	item.Columns = filtered
+	item.Columns = newCols
 }
 
 // updateRightsizingLoaded handles the rightsizingLoadedMsg. Stale

--- a/internal/app/update_msg_extra_test.go
+++ b/internal/app/update_msg_extra_test.go
@@ -1829,6 +1829,91 @@ func TestPodMetricsColumnOrderIsStableAcrossAllPaths(t *testing.T) {
 	})
 }
 
+// ensureNodeMetricsColumnsPlaceholder used to append the CPU/CPU%/MEM/MEM%
+// columns while the enriched and carry-over paths prepend them, so on every
+// watch tick a metrics-less node's column order flipped between the two
+// layouts and the user saw a ~1 Hz layout blink. Pin the order: CPU/MEM
+// block first, all other columns after, identical across all three paths.
+func TestNodeMetricsColumnOrderIsStableAcrossAllPaths(t *testing.T) {
+	metricsKeys := []string{"CPU", "CPU%", "MEM", "MEM%"}
+	keysOf := func(cols []model.KeyValue) []string {
+		ks := make([]string, len(cols))
+		for i, kv := range cols {
+			ks[i] = kv.Key
+		}
+		return ks
+	}
+	assertCPUMemFirst := func(t *testing.T, label string, cols []model.KeyValue) {
+		t.Helper()
+		require.GreaterOrEqual(t, len(cols), len(metricsKeys), "%s: too few columns", label)
+		for i, want := range metricsKeys {
+			assert.Equal(t, want, cols[i].Key, "%s: column %d must be %q (CPU/MEM block before other columns); full order=%v", label, i, want, keysOf(cols))
+		}
+	}
+
+	// Path 1: ensureNodeMetricsColumnsPlaceholder (no metrics for this node).
+	t.Run("placeholder", func(t *testing.T) {
+		m := baseModel()
+		m.middleItems = []model.Item{{
+			Name: "node-x",
+			Columns: []model.KeyValue{
+				{Key: "INTERNALDNS", Value: "node-x"},
+				{Key: "VERSION", Value: "v1.31"},
+				{Key: "CPU", Value: "500m"}, // stale prior-tick value
+			},
+		}}
+		result, _ := m.Update(nodeMetricsEnrichedMsg{
+			metrics: map[string]model.PodMetrics{"other": {Name: "other"}},
+			gen:     0,
+		})
+		assertCPUMemFirst(t, "placeholder", result.(Model).middleItems[0].Columns)
+	})
+
+	// Path 2: updateNodeMetricsEnriched with real metrics for this node.
+	t.Run("enriched", func(t *testing.T) {
+		m := baseModel()
+		m.middleItems = []model.Item{{
+			Name: "node-x",
+			Columns: []model.KeyValue{
+				{Key: "INTERNALDNS", Value: "node-x"},
+				{Key: "VERSION", Value: "v1.31"},
+			},
+		}}
+		result, _ := m.Update(nodeMetricsEnrichedMsg{
+			metrics: map[string]model.PodMetrics{
+				"node-x": {Name: "node-x", CPU: 50, Memory: 100 * 1024 * 1024},
+			},
+			gen: 0,
+		})
+		assertCPUMemFirst(t, "enriched", result.(Model).middleItems[0].Columns)
+	})
+
+	// Path 3: carryOverMetricsColumns (watch tick replacing items).
+	t.Run("carryOver", func(t *testing.T) {
+		m := baseModel()
+		m.middleItems = []model.Item{{
+			Name: "node-x",
+			Columns: []model.KeyValue{
+				{Key: "CPU", Value: "n/a"},
+				{Key: "CPU%", Value: "n/a"},
+				{Key: "MEM", Value: "n/a"},
+				{Key: "MEM%", Value: "n/a"},
+				{Key: "INTERNALDNS", Value: "node-x"},
+				{Key: "VERSION", Value: "v1.31"},
+			},
+		}}
+		newItems := []model.Item{{
+			Name: "node-x",
+			Columns: []model.KeyValue{
+				{Key: "INTERNALDNS", Value: "node-x"},
+				{Key: "VERSION", Value: "v1.31"},
+			},
+		}}
+		m.carryOverMetricsColumns(newItems)
+		assertCPUMemFirst(t, "carryOver", newItems[0].Columns)
+	})
+}
+
 // --- nodeMetricsEnrichedMsg ---
 
 func TestUpdateNodeMetricsEnrichedStaleGen(t *testing.T) {

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -54,6 +55,36 @@ type colInfo struct {
 	hasArrow bool // true if any value in this column has a trend arrow
 }
 
+// canonicalColumnPriority pins the display position of the volatile metrics
+// columns. Their values are rewritten on every ~2s refresh by several
+// independent paths (placeholder / metrics-enriched / carry-over), and those
+// paths historically disagreed on whether to prepend or append the block —
+// flipping the column order between two layouts each tick (a visible ~1Hz
+// blink). Deriving display order purely from item.Columns insertion order
+// made every such path load-bearing. Sorting the detected order against this
+// list instead makes display order independent of insertion order, so no
+// mutation path can reintroduce the flicker.
+var canonicalColumnPriority = map[string]int{
+	"CPU": 0, "CPU%": 1, "CPU/R": 2, "CPU/L": 3,
+	"MEM": 4, "MEM%": 5, "MEM/R": 6, "MEM/L": 7,
+}
+
+// stabilizeColumnOrder reorders detected column keys in place so the canonical
+// metrics block always occupies a fixed leading position, while every other
+// column keeps its relative discovery order (stable sort).
+func stabilizeColumnOrder(order []string) {
+	sort.SliceStable(order, func(i, j int) bool {
+		ri, iPinned := canonicalColumnPriority[order[i]]
+		rj, jPinned := canonicalColumnPriority[order[j]]
+		if iPinned && jPinned {
+			return ri < rj
+		}
+		// A pinned key sorts before any unpinned one; two unpinned keys
+		// compare equal so the stable sort preserves their discovery order.
+		return iPinned && !jPinned
+	})
+}
+
 func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind string) []extraColumn {
 	// Collect all available column keys and their max value widths.
 	seen := make(map[string]*colInfo)
@@ -80,6 +111,11 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	if len(order) == 0 {
 		return nil
 	}
+
+	// Pin the metrics block to a canonical position before candidate
+	// selection so display order does not depend on the order the refresh
+	// paths happened to write the columns into item.Columns.
+	stabilizeColumnOrder(order)
 
 	candidates := selectColumnCandidates(seen, order, kind, items)
 

--- a/internal/ui/explorer_table_extra_test.go
+++ b/internal/ui/explorer_table_extra_test.go
@@ -773,6 +773,53 @@ func TestCollectExtraColumns(t *testing.T) {
 	})
 }
 
+// TestCollectExtraColumns_MetricsColumnOrderIsInsertionIndependent is the
+// renderer-level regression guard for the node/pod metrics column flicker.
+// Several refresh paths rewrite the CPU/MEM block on every ~2s tick and
+// historically disagreed on whether to prepend or append it, so the column
+// order flipped between two layouts and the user saw a ~1Hz blink. The
+// renderer must pin the metrics block to a canonical position regardless of
+// where the columns happen to sit in item.Columns.
+func TestCollectExtraColumns_MetricsColumnOrderIsInsertionIndependent(t *testing.T) {
+	origFS := ActiveFullscreenMode
+	ActiveFullscreenMode = false
+	defer func() { ActiveFullscreenMode = origFS }()
+
+	keysOf := func(cols []extraColumn) []string {
+		ks := make([]string, len(cols))
+		for i, c := range cols {
+			ks[i] = c.key
+		}
+		return ks
+	}
+	// Tick A: a path appended the metrics block (metrics last).
+	tickA := []model.Item{{Name: "node-x", Columns: []model.KeyValue{
+		{Key: "VERSION", Value: "v1.31"},
+		{Key: "TAINTS", Value: "none"},
+		{Key: "CPU", Value: "n/a"},
+		{Key: "CPU%", Value: "n/a"},
+		{Key: "MEM", Value: "n/a"},
+		{Key: "MEM%", Value: "n/a"},
+	}}}
+	// Tick B: another path prepended the metrics block (metrics first).
+	tickB := []model.Item{{Name: "node-x", Columns: []model.KeyValue{
+		{Key: "CPU", Value: "n/a"},
+		{Key: "CPU%", Value: "n/a"},
+		{Key: "MEM", Value: "n/a"},
+		{Key: "MEM%", Value: "n/a"},
+		{Key: "VERSION", Value: "v1.31"},
+		{Key: "TAINTS", Value: "none"},
+	}}}
+
+	gotA := keysOf(collectExtraColumns(tickA, 400, 20, "Node"))
+	gotB := keysOf(collectExtraColumns(tickB, 400, 20, "Node"))
+
+	assert.Equal(t, gotA, gotB,
+		"column display order must not depend on insertion order in item.Columns")
+	assert.Equal(t, []string{"CPU", "CPU%", "MEM", "MEM%", "VERSION", "TAINTS"}, gotA,
+		"metrics block must be pinned to the canonical leading position, non-metrics keep discovery order")
+}
+
 // TestCollectExtraColumns_NameReservationGrowsWithLongestName is the
 // regression test for issue #53: when item names are long, the Name
 // column gets squeezed to the 20-char floor while extras (HOSTS,


### PR DESCRIPTION
## Problem

Staying on the Nodes list, the table visibly flickers ~1Hz — the `CPU CPU% MEM MEM%` block jumps between two positions on every refresh tick:

```
NODE  STATUS  CPU CPU% MEM MEM%  INTERNALDNS  VERSION  TAINTS  AGE   <- tick A
NODE  STATUS  INTERNALDNS  VERSION  CPU CPU% MEM MEM%  TAINTS  AGE   <- tick B
```

## Root cause

Extra-column **display order is derived purely from the order keys first appear** across every item's `Columns` slice (`collectExtraColumns` → `autoDetectColumns`, encounter order, no canonical sort).

`ensureNodeMetricsColumnsPlaceholder` **appended** the CPU/MEM block (metrics-server returned no data), while `updateNodeMetricsEnriched` and `carryOverMetricsColumns` **prepend** it. Each ~2s tick flips the order. This is the same bug class fixed for Pods in `b1b53cf` — the node placeholder function never got the matching treatment.

## Fix — two layers

**1. `fix(metrics)` — targeted:** `ensureNodeMetricsColumnsPlaceholder` now prepends, so all three node metrics paths agree (mirrors the Pod fix).

**2. `fix(columns)` — structural:** The prepend/append discipline across N functions was load-bearing and enforced only by comments + per-resource tests — fragile, and already broken twice. `collectExtraColumns` now stable-sorts detected column keys against a canonical priority for the volatile metrics block (`stabilizeColumnOrder`). **Display order no longer depends on insertion order**, so no current or future mutation path — for any resource type — can reintroduce this flicker. Behavior-preserving for the already-correct state; the per-path discipline stays as defense-in-depth.

## Audit (other resource types)

| Column family | Status |
|---|---|
| Pod metrics | 3 paths consistent (`b1b53cf`) |
| Node metrics | consistent after this PR |
| Service endpoints | `inject`/`carryOver` both append — consistent |
| `secret:`/`owner:`/`data:`/`condition:`/`step:`/`__` prefixed | excluded from extra-column detection — immune |

After the structural fix the encounter-order fragility is removed entirely, so the table above is defense-in-depth rather than the load-bearing guarantee.

## Test plan

- [x] `TestNodeMetricsColumnOrderIsStableAcrossAllPaths` — placeholder / enriched / carry-over paths (TDD: placeholder RED first)
- [x] `TestCollectExtraColumns_MetricsColumnOrderIsInsertionIndependent` — renderer-level: two opposite insertion orders must yield identical, canonical output (TDD: RED first)
- [x] `go test ./...` — full suite passes
- [x] `go test ./internal/ui/ ./internal/app/ -race` — passes
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues