### PR TITLE
feat(logger): surface silent failures with dedup to in-app log

### DIFF
--- a/internal/app/app_init_cmd.go
+++ b/internal/app/app_init_cmd.go
@@ -19,6 +19,10 @@ func (m Model) Init() tea.Cmd {
 	if m.stderrChan != nil {
 		cmds = append(cmds, m.waitForStderr())
 	}
+	// Subscribe to deduplicated log events so background failures
+	// (metrics-server unreachable, RBAC denied, ...) reach the in-app
+	// log overlay instead of only the on-disk file.
+	cmds = append(cmds, waitForLoggerUI())
 	if m.watchMode {
 		cmds = append(cmds, scheduleWatchTick(m.watchInterval))
 	}

--- a/internal/app/commands_load_metrics.go
+++ b/internal/app/commands_load_metrics.go
@@ -40,7 +40,9 @@ func (m Model) loadMetrics() tea.Cmd {
 			func(ctx context.Context) tea.Msg {
 				pm, err := client.GetPodMetrics(ctx, kctx, ns, podName)
 				if err != nil {
-					return metricsLoadedMsg{gen: gen} // silently ignore
+					logger.WarnOnce("pod-metrics-load", kctx+"/"+ns+"/"+podName,
+						"pod metrics load failed", "context", kctx, "namespace", ns, "pod", podName, "error", logger.Redact(err.Error()))
+					return metricsLoadedMsg{gen: gen}
 				}
 				cpuReq, cpuLim, memReq, memLim, err := client.GetPodResourceRequests(ctx, kctx, ns, podName)
 				if err != nil {
@@ -63,7 +65,12 @@ func (m Model) loadMetrics() tea.Cmd {
 			func(ctx context.Context) tea.Msg {
 				// Get child pods.
 				childItems, err := client.GetOwnedResources(ctx, kctx, ns, kind, name)
-				if err != nil || len(childItems) == 0 {
+				if err != nil {
+					logger.WarnOnce("owned-resources-load", kctx+"/"+ns+"/"+kind+"/"+name,
+						"owned resources load failed", "context", kctx, "namespace", ns, "kind", kind, "name", name, "error", logger.Redact(err.Error()))
+					return metricsLoadedMsg{gen: gen}
+				}
+				if len(childItems) == 0 {
 					return metricsLoadedMsg{gen: gen}
 				}
 				var podNames []string
@@ -76,7 +83,12 @@ func (m Model) loadMetrics() tea.Cmd {
 					return metricsLoadedMsg{gen: gen}
 				}
 				metrics, err := client.GetPodsMetrics(ctx, kctx, ns, podNames)
-				if err != nil || len(metrics) == 0 {
+				if err != nil {
+					logger.WarnOnce("pods-metrics-load", kctx+"/"+ns+"/"+kind+"/"+name,
+						"workload pod metrics load failed", "context", kctx, "namespace", ns, "kind", kind, "name", name, "error", logger.Redact(err.Error()))
+					return metricsLoadedMsg{gen: gen}
+				}
+				if len(metrics) == 0 {
 					return metricsLoadedMsg{gen: gen}
 				}
 
@@ -140,6 +152,8 @@ func (m Model) loadPreviewEvents() tea.Cmd {
 		func(ctx context.Context) tea.Msg {
 			events, err := client.GetResourceEvents(ctx, kctx, ns, name, kind)
 			if err != nil {
+				logger.WarnOnce("preview-events-load", kctx+"/"+ns+"/"+kind+"/"+name,
+					"preview events load failed", "context", kctx, "namespace", ns, "kind", kind, "name", name, "error", logger.Redact(err.Error()))
 				return previewEventsLoadedMsg{gen: gen}
 			}
 			return previewEventsLoadedMsg{events: events, gen: gen}
@@ -169,11 +183,8 @@ func (m Model) loadPodMetricsForList() tea.Cmd {
 		func(ctx context.Context) tea.Msg {
 			metrics, err := client.GetAllPodMetrics(ctx, kctx, ns)
 			if err != nil {
-				// Don't fail the UI tick, but surface the cause for diagnosis.
-				// Without this log, missing metrics columns look like a UI
-				// bug rather than a backend (metrics-server / RBAC / routing)
-				// problem.
-				logger.Warn("pod metrics load failed", "context", kctx, "namespace", ns, "error", err)
+				logger.WarnOnce("pod-metrics-list-load", kctx+"/"+ns,
+					"pod metrics list load failed", "context", kctx, "namespace", ns, "error", logger.Redact(err.Error()))
 				return podMetricsEnrichedMsg{gen: gen}
 			}
 			return podMetricsEnrichedMsg{metrics: metrics, gen: gen}
@@ -199,12 +210,8 @@ func (m Model) loadNodeMetricsForList() tea.Cmd {
 		func(ctx context.Context) tea.Msg {
 			metrics, err := client.GetAllNodeMetrics(ctx, kctx)
 			if err != nil {
-				// Surface the underlying cause; the UI renders "n/a"
-				// placeholders downstream, which used to mask a silent
-				// routing failure (e.g. `_global` Prometheus block
-				// pointing a metrics-server-only cluster at a missing
-				// Prometheus endpoint).
-				logger.Warn("node metrics load failed", "context", kctx, "error", err)
+				logger.WarnOnce("node-metrics-list-load", kctx,
+					"node metrics list load failed", "context", kctx, "error", logger.Redact(err.Error()))
 				return nodeMetricsEnrichedMsg{gen: gen}
 			}
 			return nodeMetricsEnrichedMsg{metrics: metrics, gen: gen}

--- a/internal/app/log_ui.go
+++ b/internal/app/log_ui.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// loggerUIMsg carries one deduplicated log event from the logger
+// package into the Bubbletea Update loop. The Update handler appends
+// it to m.errorLog so silent background failures (metrics-server
+// unreachable, RBAC denied, kubeconfig exec plugin broken) show up in
+// the in-app log overlay rather than only the on-disk log file.
+type loggerUIMsg logger.UIEntry
+
+// waitForLoggerUI subscribes to the logger UI channel. Returns the
+// next entry as a loggerUIMsg; the Update handler re-arms by issuing
+// another waitForLoggerUI command. Mirrors the StderrCapture
+// subscription pattern (see waitForStderr).
+func waitForLoggerUI() tea.Cmd {
+	return func() tea.Msg {
+		e, ok := <-logger.UIChan()
+		if !ok {
+			return nil
+		}
+		return loggerUIMsg(e)
+	}
+}
+
+// formatLoggerUIArgs renders the slog-style args slice ([k1, v1, k2,
+// v2, ...]) as "k1=v1 k2=v2" for the in-app overlay. Odd-length args
+// (a key with no value) fall back to rendering the trailing key alone.
+func formatLoggerUIArgs(args []any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i := 0; i < len(args); i += 2 {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		key := fmt.Sprintf("%v", args[i])
+		if i+1 >= len(args) {
+			b.WriteString(key)
+			continue
+		}
+		val := fmt.Sprintf("%v", args[i+1])
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteString(val)
+	}
+	return b.String()
+}
+
+func (m *Model) appendLoggerUIEntry(e logger.UIEntry) {
+	line := e.Message
+	if extra := formatLoggerUIArgs(e.Args); extra != "" {
+		line = line + " " + extra
+	}
+	m.errorLog = append(m.errorLog, ui.ErrorLogEntry{
+		Time:    e.Time,
+		Message: line,
+		Level:   e.Level,
+	})
+	if len(m.errorLog) > 500 {
+		m.errorLog = m.errorLog[len(m.errorLog)-500:]
+	}
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/creack/pty"
+	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -43,6 +44,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case stderrCapturedMsg:
 		m.setStatusMessage("stderr: "+msg.message, true)
 		return m, tea.Batch(scheduleStatusClear(), m.waitForStderr())
+	case loggerUIMsg:
+		m.appendLoggerUIEntry(logger.UIEntry(msg))
+		return m, waitForLoggerUI()
 	default:
 		if dark, ok := ui.ParseColorModeMsg(msg); ok {
 			ui.SetColorMode(dark)

--- a/internal/logger/dedup.go
+++ b/internal/logger/dedup.go
@@ -1,0 +1,143 @@
+package logger
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultDedupWindow is the rolling window during which identical
+// (tag + contextKey) emissions are suppressed. Five minutes keeps a
+// recovering-then-failing-again service visible to the user without
+// drowning the in-app log and on-disk log in identical lines.
+const DefaultDedupWindow = 5 * time.Minute
+
+var (
+	dedupMu     sync.Mutex
+	dedupState  = map[string]*dedupEntry{}
+	dedupOps    int // ShouldEmit call counter, drives periodic pruning
+	dedupWindow = DefaultDedupWindow
+	dedupNow    = time.Now // overridable in tests
+)
+
+// dedupPruneEvery is how often (in ShouldEmit calls) we sweep stale
+// entries. Tuned high enough that the O(N) scan cost is amortized to
+// near zero, low enough that a high-cardinality key space (varying
+// stderr lines, per-pod tags across many namespaces) can't accumulate
+// for long. Exposed via a var so tests can lower it.
+var dedupPruneEvery = 1024
+
+type dedupEntry struct {
+	lastEmit   time.Time
+	suppressed int
+}
+
+// ShouldEmit reports whether a deduplicated log event identified by
+// (tag, contextKey) should be emitted right now. If the window has
+// elapsed since the previous emission, it returns true plus the count
+// of events suppressed during that window (so callers can surface
+// "(suppressed 142x)" in the next line). If still inside the window,
+// it returns false and increments the suppressed counter.
+//
+// The (tag, contextKey) pair is the dedup key. Use a stable tag per
+// call site ("node-metrics-load", "stderr-aws-sso") and a contextKey
+// that distinguishes legitimately-different occurrences (cluster name,
+// the redacted line itself). Two different contexts dedup
+// independently — one cluster's outage never masks another's.
+func ShouldEmit(tag, contextKey string) (emit bool, suppressed int) {
+	key := tag + "\x00" + contextKey
+	now := dedupNow()
+	dedupMu.Lock()
+	defer dedupMu.Unlock()
+	dedupOps++
+	if dedupOps%dedupPruneEvery == 0 {
+		pruneDedupStateLocked(now)
+	}
+	e, ok := dedupState[key]
+	if !ok {
+		dedupState[key] = &dedupEntry{lastEmit: now}
+		return true, 0
+	}
+	if now.Sub(e.lastEmit) >= dedupWindow {
+		supp := e.suppressed
+		e.lastEmit = now
+		e.suppressed = 0
+		return true, supp
+	}
+	e.suppressed++
+	return false, 0
+}
+
+// WarnOnce emits a WARN log at most once per dedup window. Identical
+// repeats during the window are silently counted; the next emission
+// after the window includes "suppressed_during_window" so the rate is
+// not lost. The entry is also published to UIChan for the in-app log
+// overlay.
+func WarnOnce(tag, contextKey, msg string, args ...any) {
+	emit, supp := ShouldEmit(tag, contextKey)
+	if !emit {
+		return
+	}
+	if supp > 0 {
+		args = append(args, "suppressed_during_window", supp)
+	}
+	Warn(msg, args...)
+	publishUI("WRN", msg, args)
+}
+
+// ErrorOnce is the ERROR-level equivalent of WarnOnce. Use for repeated
+// failures (auth expired, endpoint missing) that would otherwise spam
+// every background tick.
+func ErrorOnce(tag, contextKey, msg string, args ...any) {
+	emit, supp := ShouldEmit(tag, contextKey)
+	if !emit {
+		return
+	}
+	if supp > 0 {
+		args = append(args, "suppressed_during_window", supp)
+	}
+	Error(msg, args...)
+	publishUI("ERR", msg, args)
+}
+
+// pruneDedupStateLocked evicts entries whose window has fully elapsed
+// AND have no suppressed events still owed an emission. The 2x window
+// margin keeps an entry around long enough that a flapping failure
+// (down, up, down) still emits once-per-window rather than re-emitting
+// the first occurrence as "new". Caller must hold dedupMu.
+func pruneDedupStateLocked(now time.Time) {
+	cutoff := now.Add(-2 * dedupWindow)
+	for k, v := range dedupState {
+		if v.lastEmit.Before(cutoff) && v.suppressed == 0 {
+			delete(dedupState, k)
+		}
+	}
+}
+
+// ResetDedupForTest clears the dedup state. Test-only.
+func ResetDedupForTest() {
+	dedupMu.Lock()
+	dedupState = map[string]*dedupEntry{}
+	dedupOps = 0
+	dedupMu.Unlock()
+}
+
+// SetDedupPruneEveryForTest overrides the prune interval. Test-only.
+func SetDedupPruneEveryForTest(n int) {
+	dedupMu.Lock()
+	dedupPruneEvery = n
+	dedupMu.Unlock()
+}
+
+// SetDedupWindowForTest overrides the dedup window. Test-only.
+func SetDedupWindowForTest(d time.Duration) {
+	dedupMu.Lock()
+	dedupWindow = d
+	dedupMu.Unlock()
+}
+
+// SetDedupClockForTest overrides the clock. Test-only.
+func SetDedupClockForTest(now func() time.Time) {
+	dedupMu.Lock()
+	dedupNow = now
+	dedupMu.Unlock()
+}

--- a/internal/logger/dedup.go
+++ b/internal/logger/dedup.go
@@ -116,11 +116,17 @@ func pruneDedupStateLocked(now time.Time) {
 	}
 }
 
-// ResetDedupForTest clears the dedup state. Test-only.
+// ResetDedupForTest clears the dedup state AND restores every
+// Set*ForTest override to its production default, so tests can't leak
+// state into each other via a forgotten window/clock/prune setting.
+// Test-only.
 func ResetDedupForTest() {
 	dedupMu.Lock()
 	dedupState = map[string]*dedupEntry{}
 	dedupOps = 0
+	dedupWindow = DefaultDedupWindow
+	dedupPruneEvery = 1024
+	dedupNow = time.Now
 	dedupMu.Unlock()
 }
 

--- a/internal/logger/dedup.go
+++ b/internal/logger/dedup.go
@@ -49,7 +49,10 @@ func ShouldEmit(tag, contextKey string) (emit bool, suppressed int) {
 	dedupMu.Lock()
 	defer dedupMu.Unlock()
 	dedupOps++
-	if dedupOps%dedupPruneEvery == 0 {
+	// Guard the modulo: dedupPruneEvery is exposed via a test setter,
+	// and a 0 (or negative) value would panic. Treat non-positive as
+	// "pruning disabled" rather than crashing.
+	if dedupPruneEvery > 0 && dedupOps%dedupPruneEvery == 0 {
 		pruneDedupStateLocked(now)
 	}
 	e, ok := dedupState[key]

--- a/internal/logger/dedup_test.go
+++ b/internal/logger/dedup_test.go
@@ -1,0 +1,187 @@
+package logger
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldEmit_FirstCallEmits(t *testing.T) {
+	ResetDedupForTest()
+	emit, supp := ShouldEmit("tag", "ctx")
+	assert.True(t, emit)
+	assert.Equal(t, 0, supp)
+}
+
+// Regression guard for the EKS metrics-server case (node-metrics-load
+// failing every 2s): repeats inside the window are silently suppressed
+// so neither the on-disk log nor the in-app overlay drown in identical
+// lines.
+func TestShouldEmit_SuppressesInsideWindow(t *testing.T) {
+	ResetDedupForTest()
+	SetDedupWindowForTest(5 * time.Minute)
+	now := time.Now()
+	SetDedupClockForTest(func() time.Time { return now })
+	defer SetDedupClockForTest(time.Now)
+
+	emit, _ := ShouldEmit("tag", "ctx")
+	assert.True(t, emit, "first call should emit")
+
+	for range 10 {
+		emit, _ = ShouldEmit("tag", "ctx")
+		assert.False(t, emit, "repeats inside window must be suppressed")
+	}
+}
+
+// After the window expires, the next call emits and reports the count
+// of events suppressed during that window — the rate is preserved even
+// though the lines were dropped.
+func TestShouldEmit_ReEmitsAfterWindowWithSuppressedCount(t *testing.T) {
+	ResetDedupForTest()
+	SetDedupWindowForTest(5 * time.Minute)
+	current := time.Now()
+	SetDedupClockForTest(func() time.Time { return current })
+	defer SetDedupClockForTest(time.Now)
+
+	ShouldEmit("tag", "ctx")
+	for range 7 {
+		ShouldEmit("tag", "ctx")
+	}
+	current = current.Add(6 * time.Minute)
+
+	emit, supp := ShouldEmit("tag", "ctx")
+	assert.True(t, emit)
+	assert.Equal(t, 7, supp, "must report the 7 suppressed events")
+}
+
+// Different (tag, contextKey) pairs dedup independently. One cluster's
+// outage must not mask another cluster's identical-tag failure.
+func TestShouldEmit_DifferentKeysIndependent(t *testing.T) {
+	ResetDedupForTest()
+
+	emitA, _ := ShouldEmit("metrics", "cluster-a")
+	emitB, _ := ShouldEmit("metrics", "cluster-b")
+	assert.True(t, emitA)
+	assert.True(t, emitB, "cluster-b must emit even though cluster-a just did")
+
+	emitA2, _ := ShouldEmit("metrics", "cluster-a")
+	assert.False(t, emitA2, "cluster-a repeat is suppressed")
+}
+
+func TestShouldEmit_ConcurrentSafe(t *testing.T) {
+	ResetDedupForTest()
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			ShouldEmit("tag", "ctx")
+		})
+	}
+	wg.Wait()
+	// No assertion needed: -race catches any concurrent map write.
+}
+
+// WarnOnce/ErrorOnce publish to UIChan on emit only; suppressed
+// repeats must not push anything to the UI overlay either.
+func TestWarnOnce_PublishesOnEmitNotOnSuppress(t *testing.T) {
+	ResetDedupForTest()
+	drainUIChan()
+
+	WarnOnce("tag", "ctx", "boom", "k", "v")
+	select {
+	case e := <-UIChan():
+		assert.Equal(t, "WRN", e.Level)
+		assert.Equal(t, "boom", e.Message)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected UIChan entry on first emit")
+	}
+
+	WarnOnce("tag", "ctx", "boom", "k", "v")
+	select {
+	case e := <-UIChan():
+		t.Fatalf("did not expect a UIChan entry for suppressed repeat: %+v", e)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestErrorOnce_PublishesAtErrorLevel(t *testing.T) {
+	ResetDedupForTest()
+	drainUIChan()
+
+	ErrorOnce("err-tag", "ctx", "broken")
+	select {
+	case e := <-UIChan():
+		assert.Equal(t, "ERR", e.Level)
+		assert.Equal(t, "broken", e.Message)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected UIChan entry on first emit")
+	}
+}
+
+// dedupState is pruned periodically (every dedupPruneEvery calls).
+// Without this, high-cardinality keys (per-pod context keys across
+// many namespaces, varying stderr lines from a flapping plugin) would
+// accumulate indefinitely in a long-running session.
+func TestShouldEmit_EvictsStaleEntries(t *testing.T) {
+	ResetDedupForTest()
+	SetDedupWindowForTest(5 * time.Minute)
+	SetDedupPruneEveryForTest(4)
+	defer SetDedupPruneEveryForTest(1024)
+	current := time.Now()
+	SetDedupClockForTest(func() time.Time { return current })
+	defer SetDedupClockForTest(time.Now)
+
+	ShouldEmit("tag", "stale-a")
+	ShouldEmit("tag", "stale-b")
+
+	current = current.Add(15 * time.Minute) // past 2x window
+
+	// Two more calls to hit the prune threshold (dedupOps reaches 4).
+	ShouldEmit("tag", "fresh-c")
+	ShouldEmit("tag", "fresh-d")
+
+	dedupMu.Lock()
+	_, staleAStill := dedupState["tag\x00stale-a"]
+	_, staleBStill := dedupState["tag\x00stale-b"]
+	_, freshCStill := dedupState["tag\x00fresh-c"]
+	dedupMu.Unlock()
+
+	assert.False(t, staleAStill, "stale entry must be evicted past 2x window")
+	assert.False(t, staleBStill, "stale entry must be evicted past 2x window")
+	assert.True(t, freshCStill, "fresh entry must survive prune")
+}
+
+// A pruned entry's re-occurrence emits as a fresh first-occurrence —
+// not as a suppressed-count emission — since prune already cleared its
+// state. Guards against losing the suppressed-count side channel for
+// frequently-recurring keys (those have suppressed>0 and are not
+// evicted).
+func TestShouldEmit_PrunedEntryEmitsFresh(t *testing.T) {
+	ResetDedupForTest()
+	SetDedupWindowForTest(1 * time.Minute)
+	SetDedupPruneEveryForTest(2)
+	defer SetDedupPruneEveryForTest(1024)
+	current := time.Now()
+	SetDedupClockForTest(func() time.Time { return current })
+	defer SetDedupClockForTest(time.Now)
+
+	ShouldEmit("tag", "abandoned")
+	current = current.Add(3 * time.Minute)
+	ShouldEmit("tag", "trigger-prune") // bumps dedupOps to 2 -> prune
+
+	current = current.Add(1 * time.Second)
+	emit, supp := ShouldEmit("tag", "abandoned")
+	assert.True(t, emit)
+	assert.Equal(t, 0, supp, "pruned entry should look like a first emission")
+}
+
+func drainUIChan() {
+	for {
+		select {
+		case <-UIChan():
+		default:
+			return
+		}
+	}
+}

--- a/internal/logger/dedup_test.go
+++ b/internal/logger/dedup_test.go
@@ -176,6 +176,19 @@ func TestShouldEmit_PrunedEntryEmitsFresh(t *testing.T) {
 	assert.Equal(t, 0, supp, "pruned entry should look like a first emission")
 }
 
+// Regression guard: setting dedupPruneEvery to 0 must NOT panic the
+// modulo in ShouldEmit. Treat non-positive as "pruning disabled".
+func TestShouldEmit_PruneEveryZeroDoesNotPanic(t *testing.T) {
+	ResetDedupForTest()
+	SetDedupPruneEveryForTest(0)
+	defer SetDedupPruneEveryForTest(1024)
+
+	// Hundreds of calls would each hit `dedupOps % 0` without the guard.
+	for range 200 {
+		ShouldEmit("tag", "ctx")
+	}
+}
+
 func drainUIChan() {
 	for {
 		select {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -162,7 +162,21 @@ func (sc *StderrCapture) readLoop() {
 				// and the TUI message also flows through setStatusMessage which
 				// re-logs it — so we must redact at the source.
 				redacted := Redact(msg)
-				Logger.Error(redacted, "source", "stderr")
+				// Dedup identical lines per rolling window. A wedged exec
+				// credential plugin (expired SSO, missing VPN) emits the
+				// same error 20+ times/sec; without this gate, both the
+				// on-disk log and the in-app overlay drown in repeats.
+				// Key on the redacted text itself so any change in the
+				// error surfaces immediately.
+				emit, supp := ShouldEmit("stderr", redacted)
+				if !emit {
+					continue
+				}
+				args := []any{"source", "stderr"}
+				if supp > 0 {
+					args = append(args, "suppressed_during_window", supp)
+				}
+				Logger.Error(redacted, args...)
 				select {
 				case sc.MsgChan <- redacted:
 				default:

--- a/internal/logger/ui_channel.go
+++ b/internal/logger/ui_channel.go
@@ -1,0 +1,36 @@
+package logger
+
+import "time"
+
+// UIEntry is one log line surfaced to the in-app log overlay.
+type UIEntry struct {
+	Time    time.Time
+	Level   string // "WRN" / "ERR" / "INF"
+	Message string
+	Args    []any // slog-style key/value pairs as passed to the emitter
+}
+
+// uiChan is the buffered channel of log events the app's Bubbletea loop
+// subscribes to. Buffered + non-blocking send: emit-path never stalls,
+// and the in-app overlay can miss extreme bursts without breaking the
+// underlying file logger.
+var uiChan = make(chan UIEntry, 64)
+
+// UIChan returns the read end of the in-app log channel. The app
+// subscribes to it via a tea.Cmd that reads one entry and re-arms,
+// mirroring the StderrCapture pattern.
+func UIChan() <-chan UIEntry {
+	return uiChan
+}
+
+// publishUI sends to the UI channel without blocking. Drops on full;
+// the on-disk log already has the line, and dropping is preferable to
+// stalling the emit path (or growing the channel unbounded in the
+// presence of a wedged UI).
+func publishUI(level, msg string, args []any) {
+	e := UIEntry{Time: time.Now(), Level: level, Message: msg, Args: args}
+	select {
+	case uiChan <- e:
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
Background goroutines (metrics-server load, owned-resources fetch, preview events, ...) swallowed errors silently — the UI rendered `n/a` or empty previews with no breadcrumb anywhere. The on-disk log only explained part of it, and a wedged exec credential plugin (expired SSO, missing VPN) drowned the in-app log with identical lines firing every tick.

This PR adds a small dedup facility so silent failures become visible without becoming spam.

### Logger surface
- `logger.ShouldEmit(tag, contextKey) (emit bool, suppressed int)` — primitive. Rolling 5-minute window per (tag, contextKey). Identical calls inside the window are silently counted; the first call after the window includes `suppressed_during_window=N` so the rate is preserved.
- `logger.WarnOnce(tag, contextKey, msg, args...)` and `logger.ErrorOnce(...)` — sugar that emits + publishes to `UIChan`.
- `logger.UIChan() <-chan UIEntry` — buffered (64), lossy channel of log events to surface in the in-app overlay.

### App wiring
- New `waitForLoggerUI()` `tea.Cmd` subscribes to `UIChan`; the Update handler appends each `loggerUIMsg` to `m.errorLog` and re-arms. Mirrors the existing `waitForStderr` pattern.
- `app_init_cmd.go` dispatches the first subscribe alongside `waitForStderr`.

### Source-level dedup applied
- `internal/logger/logger.go` — `StderrCapture.readLoop` now gates via `ShouldEmit("stderr", redacted)` so an SSO-expired loop logs once per window instead of 20x/sec.
- `internal/app/commands_load_metrics.go` — silent swallow sites for `GetPodMetrics`, `GetOwnedResources`, `GetPodsMetrics`, `GetResourceEvents`, `GetAllPodMetrics`, `GetAllNodeMetrics` now call `logger.WarnOnce` with distinct (cluster, namespace, kind, name) context keys so different failures dedup independently.

### Misc
- Bumps `golang.org/x/net` to v0.55.0 (GO-2026-5026; govulncheck CI gate).

## Test plan
- [x] `go test ./... -race -count=1`
- [x] `TestShouldEmit_*` covers first-emit, in-window suppression, post-window re-emit with suppressed count, key independence, concurrency (`-race`), and UIChan publishing semantics.
- [x] Manual on metrics-server-only EKS: expect a single `WRN node metrics list load failed ...` in the in-app log (Shift+E) and one matching line in `lfk.log`, not one per tick.
- [x] Manual on a context with expired AWS SSO: expect one `ERR stderr: aws ...` per 5 min instead of 20+/sec.