### PR TITLE
feat(actions): add "Go to Node" to the Pod action menu (#264)

### DIFF
--- a/internal/app/readonly_test.go
+++ b/internal/app/readonly_test.go
@@ -45,7 +45,7 @@ func TestIsMutatingAction(t *testing.T) {
 
 	readOnly := []string{
 		"Logs", "Tail Logs", "Describe", "Events",
-		"Resize", "Go to Pod", "Open in Browser",
+		"Resize", "Go to Pod", "Go to Node", "Open in Browser",
 		"Startup Analysis", "Crash Investigator", "Alerts", "Visualize", "Vuln Scan",
 		"", "unknown action", "Diff",
 		// Watch is observation-only, not a mutation.

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -454,6 +454,9 @@ func (m Model) executeActionCoreOps(actionLabel string) (tea.Model, tea.Cmd, boo
 	case "Go to Pod":
 		mdl, cmd := m.executeActionGoToPod()
 		return mdl, cmd, true
+	case "Go to Node":
+		mdl, cmd := m.executeActionGoToNode()
+		return mdl, cmd, true
 	case "Debug Mount":
 		mdl, cmd := m.executeActionDebugMount()
 		return mdl, cmd, true

--- a/internal/app/update_actions_helm_misc.go
+++ b/internal/app/update_actions_helm_misc.go
@@ -59,6 +59,28 @@ func (m Model) executeActionGoToPod() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// executeActionGoToNode handles the "Go to Node" action on a Pod —
+// teleports the explorer to the Node hosting the selected pod. The
+// node name is read from the pod's "Node" column (populated by
+// populatePodDetails from spec.nodeName). Unscheduled pods (Pending,
+// no nodeName yet) surface a status message instead of navigating to
+// an empty name that would land the user on the Node list with the
+// wrong cursor.
+func (m Model) executeActionGoToNode() (tea.Model, tea.Cmd) {
+	var nodeName string
+	for _, kv := range m.actionCtx.columns {
+		if kv.Key == "Node" {
+			nodeName = kv.Value
+			break
+		}
+	}
+	if nodeName == "" {
+		m.setStatusMessage("Pod is not scheduled to a node", true)
+		return m, scheduleStatusClear()
+	}
+	return m.navigateToOwner("Node", nodeName)
+}
+
 // executeActionDebugMount handles the "Debug Mount" action.
 func (m Model) executeActionDebugMount() (tea.Model, tea.Cmd) {
 	ns := m.actionCtx.namespace

--- a/internal/app/update_actions_test.go
+++ b/internal/app/update_actions_test.go
@@ -1346,6 +1346,40 @@ func TestCovExecuteActionGoToPodMultiple(t *testing.T) {
 	assert.Equal(t, overlayPodSelect, rm.overlay)
 }
 
+// Pods scheduled to a node populate the "Node" column with the
+// node name; "Go to Node" must teleport the explorer there.
+func TestCovExecuteActionGoToNodeScheduled(t *testing.T) {
+	m := testModelExec()
+	m.actionCtx.columns = []model.KeyValue{{Key: "Node", Value: "ip-10-0-0-1"}}
+	result, _ := m.executeAction("Go to Node")
+	_ = result
+}
+
+// An unscheduled pod (Pending, no spec.nodeName) lacks the "Node"
+// column or has it empty. Navigation must be refused with a status
+// message — landing on the Node list with an empty pendingTarget
+// would silently mis-select the cursor.
+func TestCovExecuteActionGoToNodeUnscheduled(t *testing.T) {
+	m := testModelExec()
+	m.actionCtx.columns = []model.KeyValue{{Key: "Node", Value: ""}}
+	result, cmd := m.executeAction("Go to Node")
+	rm := result.(Model)
+	assert.NotNil(t, cmd, "must schedule status clear")
+	assert.True(t, rm.hasStatusMessage())
+}
+
+// Belt-and-braces: a pod item with no Node column at all (e.g. an
+// older cache entry, a transient state) must take the same refusal
+// path as the empty-value case.
+func TestCovExecuteActionGoToNodeMissingColumn(t *testing.T) {
+	m := testModelExec()
+	m.actionCtx.columns = nil
+	result, cmd := m.executeAction("Go to Node")
+	rm := result.(Model)
+	assert.NotNil(t, cmd)
+	assert.True(t, rm.hasStatusMessage())
+}
+
 func TestCovExecuteActionGoToPodNone(t *testing.T) {
 	m := testModelExec()
 	m.actionCtx.columns = nil

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -89,6 +89,7 @@ func actionsForCoreKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Startup Analysis", Description: "Analyze pod startup timing", Key: "S"},
 			{Label: "Crash Investigator", Description: "Investigate crash loop / failing pod", Key: "I"},
 			{Label: "Capture Traffic", Description: "Capture network packets to pcap", Key: "c"},
+			{Label: "Go to Node", Description: "Navigate to the node hosting this pod", Key: "g"},
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Right-sizing", Description: "Per-container CPU/Mem recommendations", Key: "z"},

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -73,6 +73,7 @@ func TestActionsForKind(t *testing.T) {
 		assert.Contains(t, labels, "Delete")
 		assert.Contains(t, labels, "Port Forward")
 		assert.Contains(t, labels, "Debug")
+		assert.Contains(t, labels, "Go to Node")
 	})
 
 	t.Run("Deployment actions", func(t *testing.T) {


### PR DESCRIPTION
Closes #264.

## Summary
Common troubleshooting step: from a misbehaving pod, jump to the node hosting it (cordon, drain, check capacity, exec a node shell). Until now the only path was reading `spec.nodeName` from describe or walking the resource tree by hand.

- Adds `Go to Node` (key `g`) to the Pod action menu (`x` -> `g`).
- Reads the `Node` column populated from `spec.nodeName` by `populatePodDetails`.
- Routes through `navigateToOwner("Node", nodeName)` — same teleport used by PVC's `Go to Pod`, so jump-back history (`Ctrl-O`) is recorded automatically.
- Unscheduled pods (Pending, no `spec.nodeName`) surface a status message instead of navigating to an empty target.
- Classified read-only; allowed in `--read-only` mode.

## Test plan
- [x] `go test ./... -race -count=1`
- [x] `TestActionsForKind` asserts `Go to Node` in the Pod menu.
- [x] `TestCovExecuteActionGoToNode{Scheduled,Unscheduled,MissingColumn}` covers the navigate path and both refusal paths.
- [x] `readonly_test.go` adds `Go to Node` to the read-only allowlist.
- [ ] Manual: on a Pod row, press `x` -> `g`; explorer jumps to the Node level with the hosting node selected. `Ctrl-O` returns to the Pod.
- [ ] Manual: on a Pending Pod, press `x` -> `g`; status bar shows "Pod is not scheduled to a node" and the explorer does not navigate.