### PR TITLE
feat(events): make the events overlay readable by default (#263)

### DIFF
--- a/internal/app/update_dispatch_msgs.go
+++ b/internal/app/update_dispatch_msgs.go
@@ -181,6 +181,11 @@ func (m Model) updateEventTimeline(msg eventTimelineMsg) (tea.Model, tea.Cmd) {
 	m.eventTimelineSearchQuery = ""
 	m.eventTimelineSearchActive = false
 	m.eventTimelineFullscreen = false
+	// Default to wrap-on so long event messages (multi-line FailedScheduling
+	// reasons, Helm hook output, container error chains) stay visible in
+	// the overlay instead of being right-truncated. The user can press `>`
+	// to flip back to no-wrap if they prefer horizontal scrolling.
+	m.eventTimelineWrap = true
 	m.eventTimelineLines = m.buildEventTimelineLines()
 	m.overlay = overlayEventTimeline
 	return m, nil

--- a/internal/app/update_msg_extra_test.go
+++ b/internal/app/update_msg_extra_test.go
@@ -1060,6 +1060,10 @@ func TestUpdateEventTimelineSuccess(t *testing.T) {
 	assert.Len(t, mdl.eventTimelineData, 1)
 	assert.Equal(t, 0, mdl.eventTimelineScroll)
 	assert.Nil(t, cmd)
+	// Wrap defaults to on so long messages (FailedScheduling reasons,
+	// Helm hook output) don't right-truncate in the default overlay
+	// view. User can press `>` to flip off.
+	assert.True(t, mdl.eventTimelineWrap, "events overlay must open with wrap enabled")
 }
 
 // --- rbacCheckMsg ---

--- a/internal/app/update_overlays_events.go
+++ b/internal/app/update_overlays_events.go
@@ -9,6 +9,14 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// eventTimelineMessageColumn is the column at which the message field
+// starts in lines produced by buildEventTimelineLines (age width 8 +
+// sep 1 + type width 7 + sep 1 + reason width 20 + sep 1 = 38). The
+// event viewer uses this as the hanging indent for wrap mode so
+// continuation lines align under the message column instead of
+// re-flowing flush to the left margin.
+const eventTimelineMessageColumn = 8 + 1 + 7 + 1 + 20 + 1
+
 // buildEventTimelineLines converts event timeline data into flat text lines
 // for cursor navigation. Each event becomes a single line with format:
 // {age}  {type}  {reason}  {message}

--- a/internal/app/view_modes_event_viewer.go
+++ b/internal/app/view_modes_event_viewer.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -143,13 +144,48 @@ func (m Model) renderEventViewerLines(lines []string, scroll, maxLines, lineCont
 }
 
 func (m Model) renderEventViewerLinesWrapped(lines []string, scroll, maxLines, lineContentWidth int) []string {
+	selStart := min(m.eventTimelineVisualStart, m.eventTimelineCursor)
+	selEnd := max(m.eventTimelineVisualStart, m.eventTimelineCursor)
+	colStart := min(m.eventTimelineVisualCol, m.eventTimelineCursorCol)
+	colEnd := max(m.eventTimelineVisualCol, m.eventTimelineCursorCol)
+
 	var visible []string
 	for i := scroll; i < len(lines) && len(visible) < maxLines; i++ {
 		isCursor := i == m.eventTimelineCursor
+		inSel := m.eventTimelineVisualMode != 0 && i >= selStart && i <= selEnd
 		gutter := " "
 		if isCursor {
 			gutter = ui.YamlCursorIndicatorStyle.Render("▎")
 		}
+
+		// Visual selection: V-mode wraps cleanly (full physical-line
+		// highlight on each sub-line); v/B modes need deterministic
+		// columns, so they truncate to a single line as in non-wrap
+		// rendering. Without this branch, entering visual mode in
+		// fullscreen+wrap left both the cursor and the selection
+		// invisible because the rendered line skipped both gutter
+		// styling and selection styling.
+		if inSel {
+			if m.eventTimelineVisualMode == 'V' {
+				physLines := ui.WrapEventLine(lines[i], lineContentWidth, eventTimelineMessageColumn)
+				for _, pl := range physLines {
+					if len(visible) >= maxLines {
+						break
+					}
+					visible = append(visible, gutter+ui.SelectedStyle.Render(ansi.Strip(pl)))
+				}
+			} else {
+				truncLine := lines[i]
+				if len([]rune(truncLine)) > lineContentWidth {
+					truncLine = string([]rune(truncLine)[:lineContentWidth])
+				}
+				rendered := ui.RenderVisualSelection(truncLine, rune(m.eventTimelineVisualMode), i, selStart, selEnd,
+					m.eventTimelineVisualStart, m.eventTimelineVisualCol, m.eventTimelineCursorCol, colStart, colEnd)
+				visible = append(visible, gutter+rendered)
+			}
+			continue
+		}
+
 		// Hanging-indent wrap so continuation lines align under the
 		// message column rather than re-flowing flush-left. Every
 		// physical sub-line gets the gutter prefix so the cursor's

--- a/internal/app/view_modes_event_viewer.go
+++ b/internal/app/view_modes_event_viewer.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/ansi"
 
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -148,6 +147,7 @@ func (m Model) renderEventViewerLinesWrapped(lines []string, scroll, maxLines, l
 	selEnd := max(m.eventTimelineVisualStart, m.eventTimelineCursor)
 	colStart := min(m.eventTimelineVisualCol, m.eventTimelineCursorCol)
 	colEnd := max(m.eventTimelineVisualCol, m.eventTimelineCursorCol)
+	lowerQuery := strings.ToLower(m.eventTimelineSearchQuery)
 
 	var visible []string
 	for i := scroll; i < len(lines) && len(visible) < maxLines; i++ {
@@ -158,45 +158,74 @@ func (m Model) renderEventViewerLinesWrapped(lines []string, scroll, maxLines, l
 			gutter = ui.YamlCursorIndicatorStyle.Render("▎")
 		}
 
-		// Visual selection: V-mode wraps cleanly (full physical-line
-		// highlight on each sub-line); v/B modes need deterministic
-		// columns, so they truncate to a single line as in non-wrap
-		// rendering. Without this branch, entering visual mode in
-		// fullscreen+wrap left both the cursor and the selection
-		// invisible because the rendered line skipped both gutter
-		// styling and selection styling.
-		if inSel {
-			if m.eventTimelineVisualMode == 'V' {
-				physLines := ui.WrapEventLine(lines[i], lineContentWidth, eventTimelineMessageColumn)
-				for _, pl := range physLines {
-					if len(visible) >= maxLines {
-						break
-					}
-					visible = append(visible, gutter+ui.SelectedStyle.Render(ansi.Strip(pl)))
-				}
-			} else {
-				truncLine := lines[i]
-				if len([]rune(truncLine)) > lineContentWidth {
-					truncLine = string([]rune(truncLine)[:lineContentWidth])
-				}
-				rendered := ui.RenderVisualSelection(truncLine, rune(m.eventTimelineVisualMode), i, selStart, selEnd,
-					m.eventTimelineVisualStart, m.eventTimelineVisualCol, m.eventTimelineCursorCol, colStart, colEnd)
-				visible = append(visible, gutter+rendered)
+		// Block-mode (B) selection has no meaningful geometry over
+		// wrapped sub-lines (rectangular column ranges across multiple
+		// physical rows don't represent what the user picked). Fall
+		// back to the single-line truncate path for that case only.
+		if inSel && m.eventTimelineVisualMode == 'B' {
+			truncLine := lines[i]
+			if len([]rune(truncLine)) > lineContentWidth {
+				truncLine = string([]rune(truncLine)[:lineContentWidth])
 			}
+			rendered := ui.RenderVisualSelection(truncLine, rune(m.eventTimelineVisualMode), i, selStart, selEnd,
+				m.eventTimelineVisualStart, m.eventTimelineVisualCol, m.eventTimelineCursorCol, colStart, colEnd)
+			visible = append(visible, gutter+rendered)
 			continue
 		}
 
-		// Hanging-indent wrap so continuation lines align under the
-		// message column rather than re-flowing flush-left. Every
-		// physical sub-line gets the gutter prefix so the cursor's
-		// presence doesn't make continuation lines visually shift.
-		subLines := ui.WrapEventLine(lines[i], lineContentWidth, eventTimelineMessageColumn)
-		for _, sub := range subLines {
+		// Unified wrap rendering: per-sub-line gutter, V-mode full
+		// highlight, v-mode char highlight mapped across sub-lines,
+		// block cursor placed on the sub-line containing CursorCol so
+		// it stays visible while navigating.
+		opts := ui.WrappedEventRowOpts{
+			Line:          lines[i],
+			Gutter:        gutter,
+			ContentW:      lineContentWidth,
+			HangingIndent: eventTimelineMessageColumn,
+			IsCursor:      isCursor,
+			CursorCol:     m.eventTimelineCursorCol,
+		}
+		switch {
+		case inSel && m.eventTimelineVisualMode == 'V':
+			opts.SelectionLine = true
+		case inSel && m.eventTimelineVisualMode == 'v':
+			opts.SelStart, opts.SelEnd = m.charSelectionRangeForLine(lines[i], i, selStart, selEnd)
+		default:
+			opts.LowerSearch = lowerQuery
+		}
+		block := ui.RenderWrappedEventRow(opts)
+		for sub := range strings.SplitSeq(block, "\n") {
 			if len(visible) >= maxLines {
 				break
 			}
-			visible = append(visible, gutter+sub)
+			visible = append(visible, sub)
 		}
 	}
 	return visible
+}
+
+// charSelectionRangeForLine mirrors the per-line logic of
+// ui.renderCharSelection for the wrap renderer: anchor-only line
+// highlights from anchorCol to end; cursor-only line highlights from
+// 0 to cursorCol+1; middle lines highlight everything.
+func (m Model) charSelectionRangeForLine(line string, i, selStart, selEnd int) (int, int) {
+	lineWidth := len([]rune(line))
+	if selStart == selEnd {
+		return min(m.eventTimelineVisualCol, m.eventTimelineCursorCol),
+			max(m.eventTimelineVisualCol, m.eventTimelineCursorCol) + 1
+	}
+	var startCol, endCol int
+	if m.eventTimelineVisualStart <= m.eventTimelineCursor {
+		startCol, endCol = m.eventTimelineVisualCol, m.eventTimelineCursorCol
+	} else {
+		startCol, endCol = m.eventTimelineCursorCol, m.eventTimelineVisualCol
+	}
+	switch i {
+	case selStart:
+		return startCol, lineWidth
+	case selEnd:
+		return 0, endCol + 1
+	default:
+		return 0, lineWidth
+	}
 }

--- a/internal/app/view_modes_event_viewer.go
+++ b/internal/app/view_modes_event_viewer.go
@@ -103,7 +103,7 @@ func (m Model) renderEventViewerLines(lines []string, scroll, maxLines, lineCont
 	lowerQuery := strings.ToLower(m.eventTimelineSearchQuery)
 
 	if m.eventTimelineWrap {
-		return m.renderEventViewerLinesWrapped(lines, scroll, maxLines, lineContentWidth)
+		return m.renderEventViewerLinesWrapped(lines, scroll, maxLines, lineContentWidth, selStart, selEnd, colStart, colEnd)
 	}
 
 	var visible []string
@@ -142,11 +142,7 @@ func (m Model) renderEventViewerLines(lines []string, scroll, maxLines, lineCont
 	return visible
 }
 
-func (m Model) renderEventViewerLinesWrapped(lines []string, scroll, maxLines, lineContentWidth int) []string {
-	selStart := min(m.eventTimelineVisualStart, m.eventTimelineCursor)
-	selEnd := max(m.eventTimelineVisualStart, m.eventTimelineCursor)
-	colStart := min(m.eventTimelineVisualCol, m.eventTimelineCursorCol)
-	colEnd := max(m.eventTimelineVisualCol, m.eventTimelineCursorCol)
+func (m Model) renderEventViewerLinesWrapped(lines []string, scroll, maxLines, lineContentWidth, selStart, selEnd, colStart, colEnd int) []string {
 	lowerQuery := strings.ToLower(m.eventTimelineSearchQuery)
 
 	var visible []string

--- a/internal/app/view_modes_event_viewer.go
+++ b/internal/app/view_modes_event_viewer.go
@@ -180,6 +180,7 @@ func (m Model) renderEventViewerLinesWrapped(lines []string, scroll, maxLines, l
 			HangingIndent: eventTimelineMessageColumn,
 			IsCursor:      isCursor,
 			CursorCol:     m.eventTimelineCursorCol,
+			Fullscreen:    true,
 		}
 		switch {
 		case inSel && m.eventTimelineVisualMode == 'V':

--- a/internal/app/view_modes_event_viewer.go
+++ b/internal/app/view_modes_event_viewer.go
@@ -143,21 +143,23 @@ func (m Model) renderEventViewerLines(lines []string, scroll, maxLines, lineCont
 }
 
 func (m Model) renderEventViewerLinesWrapped(lines []string, scroll, maxLines, lineContentWidth int) []string {
-	wrapStyle := lipgloss.NewStyle().Width(lineContentWidth)
 	var visible []string
 	for i := scroll; i < len(lines) && len(visible) < maxLines; i++ {
 		isCursor := i == m.eventTimelineCursor
-		wrapped := wrapStyle.Render(lines[i])
-		subLines := strings.Split(wrapped, "\n")
-		for si, sub := range subLines {
+		gutter := " "
+		if isCursor {
+			gutter = ui.YamlCursorIndicatorStyle.Render("▎")
+		}
+		// Hanging-indent wrap so continuation lines align under the
+		// message column rather than re-flowing flush-left. Every
+		// physical sub-line gets the gutter prefix so the cursor's
+		// presence doesn't make continuation lines visually shift.
+		subLines := ui.WrapEventLine(lines[i], lineContentWidth, eventTimelineMessageColumn)
+		for _, sub := range subLines {
 			if len(visible) >= maxLines {
 				break
 			}
-			if isCursor && si == 0 {
-				visible = append(visible, ui.YamlCursorIndicatorStyle.Render("▎")+sub)
-			} else {
-				visible = append(visible, " "+sub)
-			}
+			visible = append(visible, gutter+sub)
 		}
 	}
 	return visible

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -367,7 +367,13 @@ func (m Model) renderOverlayQuotaDashboard() (string, int, int) {
 }
 
 func (m Model) renderOverlayEventTimeline() (string, int, int) {
-	w, h := min(100, m.width-6), min(30, m.height-4)
+	// Events frequently carry long messages (image pulls, FailedScheduling
+	// reasons, Helm pre/post-install output) that get truncated in a
+	// narrow overlay even with wrap on. Take a generous slice of the
+	// terminal — leaving only a thin chrome border around it — so the
+	// overlay-mode view is useful without immediately reaching for `f`
+	// (fullscreen) or `>` (wrap).
+	w, h := min(160, m.width-6), min(45, m.height-4)
 	params := ui.EventViewerParams{
 		Lines: m.eventTimelineLines, ResourceName: m.actionCtx.name,
 		Scroll: m.eventTimelineScroll, Cursor: m.eventTimelineCursor, CursorCol: m.eventTimelineCursorCol,

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -380,6 +380,7 @@ func (m Model) renderOverlayEventTimeline() (string, int, int) {
 		Width: w, Height: h, Wrap: m.eventTimelineWrap, Fullscreen: false,
 		VisualMode: m.eventTimelineVisualMode, VisualStart: m.eventTimelineVisualStart, VisualCol: m.eventTimelineVisualCol,
 		SearchQuery: m.eventTimelineSearchQuery, SearchActive: m.eventTimelineSearchActive, SearchInput: m.eventTimelineSearchInput.Value,
+		HangingIndent: eventTimelineMessageColumn,
 	}
 	return ui.RenderEventViewer(params), w, h
 }

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -269,6 +269,12 @@ type WrappedEventRowOpts struct {
 	SelEnd        int  // absolute col on the logical line (exclusive)
 	// Search highlight (applied only when no selection is active):
 	LowerSearch string
+	// Fullscreen suppresses the overlay-mode background style on plain
+	// rows: in fullscreen mode the surrounding FullscreenBorderStyle
+	// owns the body background, and applying OverlayNormalStyle here
+	// would paint a different-colored rectangle behind text rows than
+	// the empty padding rows around them.
+	Fullscreen bool
 }
 
 // RenderWrappedEventRow renders one logical event line as a multi-line
@@ -317,10 +323,14 @@ func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
 			text = highlightEventSearchLine(text, opts.LowerSearch)
 			styled = true
 		}
-		if !styled {
+		if !styled && !opts.Fullscreen {
 			// Apply overlay-normal styling so wrapped rows match the
 			// surrounding (non-wrap) rows' fg/bg pair instead of
 			// punching a transparent rectangle through the overlay.
+			// Skipped in fullscreen: the FullscreenBorderStyle owns
+			// the body background, and an explicit fg/bg here would
+			// paint text rows a different color than empty padding
+			// rows around them.
 			text = OverlayNormalStyle.Render(text)
 		}
 
@@ -432,19 +442,27 @@ func RenderEventViewer(p EventViewerParams) string {
 		colStart:   colStart,
 		colEnd:     colEnd,
 	}
-	for i := scroll; i < end; i++ {
-		b.WriteString(renderEventViewerLine(p, i, evLineCtx))
-		if i < end-1 {
-			b.WriteString("\n")
+	// Pagination is by physical lines, not logical events: in wrap
+	// mode one event expands to multiple sub-lines, and counting by
+	// logical events would emit far more physical rows than
+	// maxVisible — pushing the footer and the overlay's bottom
+	// border off the viewport. Stop emitting as soon as we fill the
+	// reserved height. The logical `end` is still used below by the
+	// footer for the "line N/M" indicator.
+	var physicalLines []string
+	for i := scroll; i < len(p.Lines) && len(physicalLines) < maxVisible; i++ {
+		rendered := renderEventViewerLine(p, i, evLineCtx)
+		for sub := range strings.SplitSeq(rendered, "\n") {
+			if len(physicalLines) >= maxVisible {
+				break
+			}
+			physicalLines = append(physicalLines, sub)
 		}
 	}
-
-	// Pad to fixed height.
-	rendered := end - scroll
-	for rendered < maxVisible {
-		b.WriteString("\n")
-		rendered++
+	for len(physicalLines) < maxVisible {
+		physicalLines = append(physicalLines, "")
 	}
+	b.WriteString(strings.Join(physicalLines, "\n"))
 	b.WriteString("\n")
 
 	// Search input / footer.

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -272,30 +272,21 @@ type WrappedEventRowOpts struct {
 }
 
 // RenderWrappedEventRow renders one logical event line as a multi-line
-// wrapped block. Each physical sub-line is prefixed with the gutter so
-// the leftmost column stays consistent regardless of cursor / selection
-// state; selection highlight and block cursor are placed on the
-// physical sub-line(s) that the logical columns map to, so navigating
-// h/l in wrap mode actually shows where the cursor is.
+// wrapped block. Mirrors the convention used by the YAML and describe
+// viewers: the cursor block and per-line selection highlight sit on
+// the FIRST physical sub-line, continuation sub-lines are plain
+// (gutter + indented text). RenderCursorAtCol's "append a highlighted
+// space when col >= width" branch keeps the cursor visible when
+// CursorCol drifted past the visible chunk after navigating from a
+// long event to a short one — same behaviour YAML relies on.
+//
+// V-mode (line) selection still spans every sub-line because the user
+// explicitly asked for the whole wrapped block to be highlighted; v
+// and B modes stick to the simpler single-line model.
 func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
 	chunks := wrappedEventChunks(opts.Line, opts.ContentW, opts.HangingIndent)
-
-	// Pick which chunk receives the block cursor. The "first chunk
-	// whose origStart..origStart+origLen contains CursorCol" rule
-	// works for in-line positions; past-end (cursor stayed at col 50
-	// after navigating from a long event to a short one) clamps to
-	// the last chunk so the cursor never simply disappears.
-	cursorChunk := -1
-	if opts.IsCursor && len(chunks) > 0 {
-		for ci, ch := range chunks {
-			if opts.CursorCol >= ch.origStart && opts.CursorCol < ch.origStart+ch.origLen {
-				cursorChunk = ci
-				break
-			}
-		}
-		if cursorChunk == -1 {
-			cursorChunk = len(chunks) - 1
-		}
+	if len(chunks) == 0 {
+		return opts.Gutter
 	}
 
 	var sb strings.Builder
@@ -305,50 +296,62 @@ func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
 		}
 		sb.WriteString(opts.Gutter)
 		text := ch.text
-		switch {
-		case opts.SelectionLine:
-			// V-mode: full physical-line highlight. Strip producer ANSI so
-			// the selection style owns the visual presentation.
+
+		styled := false
+		if opts.SelectionLine {
+			// V-mode: full highlight on every sub-line.
 			text = SelectedStyle.Render(ansi.Strip(text))
-		case opts.SelEnd > opts.SelStart:
-			text = applyCharSelectionToChunk(text, ch, opts.SelStart, opts.SelEnd)
-		case opts.LowerSearch != "":
+			styled = true
+		} else if i == 0 {
+			// First sub-line carries selection and search styling.
+			switch {
+			case opts.SelEnd > opts.SelStart:
+				text = applyCharSelectionToFirstSubLine(text, opts.SelStart, opts.SelEnd)
+				styled = true
+			case opts.LowerSearch != "":
+				text = highlightEventSearchLine(text, opts.LowerSearch)
+				styled = true
+			}
+		} else if opts.LowerSearch != "" {
+			// Highlight matches on continuation sub-lines too.
 			text = highlightEventSearchLine(text, opts.LowerSearch)
+			styled = true
 		}
-		if i == cursorChunk {
-			rawCol := max(opts.CursorCol-ch.origStart, 0)
-			physCol := ch.indentCols + rawCol
-			text = RenderCursorAtCol(text, "", physCol)
+		if !styled {
+			// Apply overlay-normal styling so wrapped rows match the
+			// surrounding (non-wrap) rows' fg/bg pair instead of
+			// punching a transparent rectangle through the overlay.
+			text = OverlayNormalStyle.Render(text)
+		}
+
+		if opts.IsCursor && i == 0 {
+			text = RenderCursorAtCol(text, "", opts.CursorCol)
 		}
 		sb.WriteString(text)
 	}
 	return sb.String()
 }
 
-// applyCharSelectionToChunk highlights the slice of a chunk that falls
-// inside the logical-line selection range [selStart, selEnd). Returns
-// the chunk text unchanged if the selection does not overlap.
-func applyCharSelectionToChunk(text string, ch wrappedEventChunk, selStart, selEnd int) string {
-	chunkSelStart := selStart - ch.origStart
-	chunkSelEnd := selEnd - ch.origStart
-	if chunkSelStart < 0 {
-		chunkSelStart = 0
-	}
-	if chunkSelEnd > ch.origLen {
-		chunkSelEnd = ch.origLen
-	}
-	if chunkSelEnd <= chunkSelStart {
-		return text
-	}
-	physStart := ch.indentCols + chunkSelStart
-	physEnd := ch.indentCols + chunkSelEnd
+// applyCharSelectionToFirstSubLine highlights the [selStart, selEnd)
+// column range on the first physical sub-line of a wrapped event. The
+// range is clamped to the sub-line's bounds; the selection that
+// extends past contentW is not shown on continuation lines (matches
+// the YAML viewer's behaviour, where v-mode selection only paints the
+// first sub-line).
+func applyCharSelectionToFirstSubLine(text string, selStart, selEnd int) string {
 	runes := []rune(text)
-	if physStart < 0 || physEnd > len(runes) {
+	if selStart < 0 {
+		selStart = 0
+	}
+	if selEnd > len(runes) {
+		selEnd = len(runes)
+	}
+	if selEnd <= selStart {
 		return text
 	}
-	return string(runes[:physStart]) +
-		SelectedStyle.Render(string(runes[physStart:physEnd])) +
-		string(runes[physEnd:])
+	return string(runes[:selStart]) +
+		SelectedStyle.Render(string(runes[selStart:selEnd])) +
+		string(runes[selEnd:])
 }
 
 // RenderEventViewer renders the event viewer with cursor, visual selection,

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // RenderEventTimelineOverlay renders the event timeline overlay content.
@@ -351,10 +352,21 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 	inSelection := p.VisualMode != 0 && i >= ctx.selStart && i <= ctx.selEnd
 	isCursorLine := i == p.Cursor
 
-	// Visual selection forces a single truncated line — char-based
-	// selection needs deterministic column positions, which a wrapped
-	// multi-line block cannot offer.
+	gutter := " "
+	if isCursorLine {
+		gutter = YamlCursorIndicatorStyle.Render("▎")
+	}
+
+	// Visual selection.
+	//
+	// Line-mode (V) wraps cleanly: every physical sub-line is fully
+	// highlighted, so the selection follows the visible block.
+	// Char-mode (v) and block-mode (B) need deterministic column
+	// positions, so they fall back to single-line truncate.
 	if inSelection {
+		if p.Wrap && p.VisualMode == 'V' {
+			return renderWrappedLineSelection(line, gutter, ctx.contentW, p.HangingIndent)
+		}
 		selLine := line
 		if len([]rune(selLine)) > ctx.contentW {
 			selLine = string([]rune(selLine)[:ctx.contentW])
@@ -365,15 +377,7 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 			p.VisualStart, p.VisualCol, p.CursorCol,
 			ctx.colStart, ctx.colEnd,
 		)
-		if isCursorLine {
-			return YamlCursorIndicatorStyle.Render("▎") + rendered
-		}
-		return " " + rendered
-	}
-
-	gutter := " "
-	if isCursorLine {
-		gutter = YamlCursorIndicatorStyle.Render("▎")
+		return gutter + rendered
 	}
 
 	if p.Wrap {
@@ -389,6 +393,25 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 		return renderEventCursorLine(p, fitLine, ctx, gutter)
 	}
 	return renderEventNormalLine(p, fitLine, ctx, gutter)
+}
+
+// renderWrappedLineSelection returns a hanging-indent-wrapped block
+// with the V-mode selection style applied to every physical sub-line.
+// Producer ANSI (kyverno-style colored levels, dim timestamps) is
+// stripped so the selection style owns the visual without invisible-
+// on-invisible color collisions — same rule as the non-wrap V path
+// in RenderVisualSelection.
+func renderWrappedLineSelection(line, gutter string, contentW, hangingIndent int) string {
+	physLines := WrapEventLine(line, contentW, hangingIndent)
+	var sb strings.Builder
+	for i, pl := range physLines {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(gutter)
+		sb.WriteString(SelectedStyle.Render(ansi.Strip(pl)))
+	}
+	return sb.String()
 }
 
 // renderWrappedEventBlock returns the multi-line wrapped form of one

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -279,6 +279,25 @@ type WrappedEventRowOpts struct {
 // h/l in wrap mode actually shows where the cursor is.
 func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
 	chunks := wrappedEventChunks(opts.Line, opts.ContentW, opts.HangingIndent)
+
+	// Pick which chunk receives the block cursor. The "first chunk
+	// whose origStart..origStart+origLen contains CursorCol" rule
+	// works for in-line positions; past-end (cursor stayed at col 50
+	// after navigating from a long event to a short one) clamps to
+	// the last chunk so the cursor never simply disappears.
+	cursorChunk := -1
+	if opts.IsCursor && len(chunks) > 0 {
+		for ci, ch := range chunks {
+			if opts.CursorCol >= ch.origStart && opts.CursorCol < ch.origStart+ch.origLen {
+				cursorChunk = ci
+				break
+			}
+		}
+		if cursorChunk == -1 {
+			cursorChunk = len(chunks) - 1
+		}
+	}
+
 	var sb strings.Builder
 	for i, ch := range chunks {
 		if i > 0 {
@@ -296,8 +315,9 @@ func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
 		case opts.LowerSearch != "":
 			text = highlightEventSearchLine(text, opts.LowerSearch)
 		}
-		if opts.IsCursor && opts.CursorCol >= ch.origStart && opts.CursorCol < ch.origStart+ch.origLen {
-			physCol := ch.indentCols + (opts.CursorCol - ch.origStart)
+		if i == cursorChunk {
+			rawCol := max(opts.CursorCol-ch.origStart, 0)
+			physCol := ch.indentCols + rawCol
 			text = RenderCursorAtCol(text, "", physCol)
 		}
 		sb.WriteString(text)

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -181,6 +181,44 @@ type EventViewerParams struct {
 	SearchQuery  string
 	SearchActive bool
 	SearchInput  string
+	// HangingIndent is the column at which the message field starts in
+	// Lines. Continuation lines under wrap are indented by this many
+	// spaces so the wrapped message text stays under the original
+	// message column (table-style continuation). Zero means flush-left.
+	HangingIndent int
+}
+
+// WrapEventLine wraps a single event timeline line into physical lines
+// that fit within contentW. The first physical line uses the full
+// width; continuation lines are indented by hangingIndent so wrapped
+// message text aligns under the original message column instead of
+// re-flowing flush to the left margin.
+//
+// Falls back to flush-left wrap if contentW is too narrow to leave
+// any useful room for continuation text after the indent.
+func WrapEventLine(line string, contentW, hangingIndent int) []string {
+	if contentW <= 0 {
+		return []string{line}
+	}
+	runes := []rune(line)
+	if len(runes) <= contentW {
+		return []string{line}
+	}
+	// Clamp the indent: leave at least 8 chars per continuation line.
+	// On very narrow terminals we just flush-left.
+	if hangingIndent < 0 || hangingIndent >= contentW-8 {
+		hangingIndent = 0
+	}
+	out := []string{string(runes[:contentW])}
+	rest := runes[contentW:]
+	pad := strings.Repeat(" ", hangingIndent)
+	chunkSize := contentW - hangingIndent
+	for len(rest) > 0 {
+		n := min(chunkSize, len(rest))
+		out = append(out, pad+string(rest[:n]))
+		rest = rest[n:]
+	}
+	return out
 }
 
 // RenderEventViewer renders the event viewer with cursor, visual selection,
@@ -253,10 +291,7 @@ func RenderEventViewer(p EventViewerParams) string {
 		contentW = 10
 	}
 
-	wrapStyle := lipgloss.NewStyle().Width(contentW)
-
 	evLineCtx := eventLineContext{
-		wrapStyle:  wrapStyle,
 		contentW:   contentW,
 		lowerQuery: lowerQuery,
 		selStart:   selStart,
@@ -302,7 +337,6 @@ func RenderEventViewer(p EventViewerParams) string {
 
 // eventLineContext holds shared state for rendering individual event viewer lines.
 type eventLineContext struct {
-	wrapStyle  lipgloss.Style
 	contentW   int
 	lowerQuery string
 	selStart   int
@@ -317,13 +351,9 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 	inSelection := p.VisualMode != 0 && i >= ctx.selStart && i <= ctx.selEnd
 	isCursorLine := i == p.Cursor
 
-	fitLine := line
-	if p.Wrap {
-		fitLine = ctx.wrapStyle.Render(line)
-	} else if len([]rune(fitLine)) > ctx.contentW {
-		fitLine = string([]rune(fitLine)[:ctx.contentW])
-	}
-
+	// Visual selection forces a single truncated line — char-based
+	// selection needs deterministic column positions, which a wrapped
+	// multi-line block cannot offer.
 	if inSelection {
 		selLine := line
 		if len([]rune(selLine)) > ctx.contentW {
@@ -341,23 +371,51 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 		return " " + rendered
 	}
 
+	gutter := " "
 	if isCursorLine {
-		return renderEventCursorLine(p, line, fitLine, ctx)
+		gutter = YamlCursorIndicatorStyle.Render("▎")
 	}
 
-	return renderEventNormalLine(p, line, fitLine, ctx)
+	if p.Wrap {
+		return renderWrappedEventBlock(p, line, gutter, ctx)
+	}
+
+	// Non-wrap path: truncate to contentW.
+	fitLine := line
+	if len([]rune(fitLine)) > ctx.contentW {
+		fitLine = string([]rune(fitLine)[:ctx.contentW])
+	}
+	if isCursorLine {
+		return renderEventCursorLine(p, fitLine, ctx, gutter)
+	}
+	return renderEventNormalLine(p, fitLine, ctx, gutter)
 }
 
-// renderEventCursorLine renders the cursor line with gutter indicator and block cursor.
-func renderEventCursorLine(p EventViewerParams, line, fitLine string, ctx eventLineContext) string {
-	gutter := YamlCursorIndicatorStyle.Render("▎")
-	if p.Wrap {
-		displayLine := fitLine
-		if p.SearchQuery != "" {
-			displayLine = ctx.wrapStyle.Render(highlightEventSearchLine(line, ctx.lowerQuery))
+// renderWrappedEventBlock returns the multi-line wrapped form of one
+// event line. Every physical sub-line is prefixed with the gutter (or
+// space) so the leftmost column stays consistent — moving the cursor
+// over a wrapped event no longer makes the continuation lines appear
+// to shift left, which used to read as "wrapped a second time".
+func renderWrappedEventBlock(p EventViewerParams, line, gutter string, ctx eventLineContext) string {
+	physLines := WrapEventLine(line, ctx.contentW, p.HangingIndent)
+	var sb strings.Builder
+	for i, pl := range physLines {
+		if i > 0 {
+			sb.WriteByte('\n')
 		}
-		return gutter + displayLine
+		sb.WriteString(gutter)
+		if p.SearchQuery != "" {
+			sb.WriteString(highlightEventSearchLine(pl, ctx.lowerQuery))
+		} else {
+			sb.WriteString(pl)
+		}
 	}
+	return sb.String()
+}
+
+// renderEventCursorLine renders the non-wrap cursor line with gutter
+// indicator and block cursor at the configured column.
+func renderEventCursorLine(p EventViewerParams, fitLine string, ctx eventLineContext, gutter string) string {
 	displayLine := fitLine
 	if p.SearchQuery != "" {
 		displayLine = highlightEventSearchLine(displayLine, ctx.lowerQuery)
@@ -365,22 +423,15 @@ func renderEventCursorLine(p EventViewerParams, line, fitLine string, ctx eventL
 	return gutter + RenderCursorAtCol(displayLine, fitLine, p.CursorCol)
 }
 
-// renderEventNormalLine renders a non-cursor, non-selected line.
-func renderEventNormalLine(p EventViewerParams, line, fitLine string, ctx eventLineContext) string {
-	if p.Wrap {
-		displayLine := fitLine
-		if p.SearchQuery != "" {
-			displayLine = ctx.wrapStyle.Render(highlightEventSearchLine(line, ctx.lowerQuery))
-		}
-		return " " + displayLine
-	}
+// renderEventNormalLine renders a non-wrap, non-cursor, non-selected line.
+func renderEventNormalLine(p EventViewerParams, fitLine string, ctx eventLineContext, gutter string) string {
 	displayLine := fitLine
 	if p.SearchQuery != "" {
 		displayLine = highlightEventSearchLine(displayLine, ctx.lowerQuery)
 	} else {
 		displayLine = OverlayNormalStyle.Render(displayLine)
 	}
-	return " " + displayLine
+	return gutter + displayLine
 }
 
 // highlightEventSearchLine highlights search matches in a single line using

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -189,37 +189,146 @@ type EventViewerParams struct {
 	HangingIndent int
 }
 
+// wrappedEventChunk describes one physical sub-line of a wrapped event
+// row, tracking how it maps back to the original logical line so the
+// renderer can place a block cursor or per-character selection
+// highlight on the correct physical sub-line + column.
+type wrappedEventChunk struct {
+	text       string // full sub-line text including any leading indent
+	indentCols int    // leading pad width within text
+	origStart  int    // index of first original-line char in this chunk
+	origLen    int    // count of original-line chars in this chunk
+}
+
+// wrappedEventChunks splits a logical event line into physical sub-lines
+// with column tracking. The first sub-line uses the full contentW; later
+// sub-lines are indented by hangingIndent so the wrapped message stays
+// under the original message column.
+//
+// Falls back to flush-left wrap if contentW is too narrow to leave any
+// useful room for continuation text after the indent.
+func wrappedEventChunks(line string, contentW, hangingIndent int) []wrappedEventChunk {
+	runes := []rune(line)
+	if contentW <= 0 || len(runes) <= contentW {
+		return []wrappedEventChunk{{text: line, origLen: len(runes)}}
+	}
+	// Clamp the indent: leave at least 8 chars per continuation line.
+	if hangingIndent < 0 || hangingIndent >= contentW-8 {
+		hangingIndent = 0
+	}
+	out := []wrappedEventChunk{{
+		text:      string(runes[:contentW]),
+		origStart: 0,
+		origLen:   contentW,
+	}}
+	pad := strings.Repeat(" ", hangingIndent)
+	chunkSize := contentW - hangingIndent
+	pos := contentW
+	for pos < len(runes) {
+		n := min(chunkSize, len(runes)-pos)
+		out = append(out, wrappedEventChunk{
+			text:       pad + string(runes[pos:pos+n]),
+			indentCols: hangingIndent,
+			origStart:  pos,
+			origLen:    n,
+		})
+		pos += n
+	}
+	return out
+}
+
 // WrapEventLine wraps a single event timeline line into physical lines
 // that fit within contentW. The first physical line uses the full
 // width; continuation lines are indented by hangingIndent so wrapped
 // message text aligns under the original message column instead of
 // re-flowing flush to the left margin.
-//
-// Falls back to flush-left wrap if contentW is too narrow to leave
-// any useful room for continuation text after the indent.
 func WrapEventLine(line string, contentW, hangingIndent int) []string {
-	if contentW <= 0 {
-		return []string{line}
-	}
-	runes := []rune(line)
-	if len(runes) <= contentW {
-		return []string{line}
-	}
-	// Clamp the indent: leave at least 8 chars per continuation line.
-	// On very narrow terminals we just flush-left.
-	if hangingIndent < 0 || hangingIndent >= contentW-8 {
-		hangingIndent = 0
-	}
-	out := []string{string(runes[:contentW])}
-	rest := runes[contentW:]
-	pad := strings.Repeat(" ", hangingIndent)
-	chunkSize := contentW - hangingIndent
-	for len(rest) > 0 {
-		n := min(chunkSize, len(rest))
-		out = append(out, pad+string(rest[:n]))
-		rest = rest[n:]
+	chunks := wrappedEventChunks(line, contentW, hangingIndent)
+	out := make([]string, len(chunks))
+	for i, c := range chunks {
+		out[i] = c.text
 	}
 	return out
+}
+
+// WrappedEventRowOpts bundles inputs for RenderWrappedEventRow. The
+// caller computes which selection range applies (line-mode highlights
+// the whole row; char-mode pre-computes the absolute column range on
+// the logical line). Cursor block rendering is opt-in via IsCursor.
+type WrappedEventRowOpts struct {
+	Line          string
+	Gutter        string // prefix prepended to every physical sub-line
+	ContentW      int
+	HangingIndent int
+	// Cursor block:
+	IsCursor  bool
+	CursorCol int
+	// Selection:
+	SelectionLine bool // full-row highlight (V mode)
+	SelStart      int  // absolute col on the logical line (inclusive)
+	SelEnd        int  // absolute col on the logical line (exclusive)
+	// Search highlight (applied only when no selection is active):
+	LowerSearch string
+}
+
+// RenderWrappedEventRow renders one logical event line as a multi-line
+// wrapped block. Each physical sub-line is prefixed with the gutter so
+// the leftmost column stays consistent regardless of cursor / selection
+// state; selection highlight and block cursor are placed on the
+// physical sub-line(s) that the logical columns map to, so navigating
+// h/l in wrap mode actually shows where the cursor is.
+func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
+	chunks := wrappedEventChunks(opts.Line, opts.ContentW, opts.HangingIndent)
+	var sb strings.Builder
+	for i, ch := range chunks {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(opts.Gutter)
+		text := ch.text
+		switch {
+		case opts.SelectionLine:
+			// V-mode: full physical-line highlight. Strip producer ANSI so
+			// the selection style owns the visual presentation.
+			text = SelectedStyle.Render(ansi.Strip(text))
+		case opts.SelEnd > opts.SelStart:
+			text = applyCharSelectionToChunk(text, ch, opts.SelStart, opts.SelEnd)
+		case opts.LowerSearch != "":
+			text = highlightEventSearchLine(text, opts.LowerSearch)
+		}
+		if opts.IsCursor && opts.CursorCol >= ch.origStart && opts.CursorCol < ch.origStart+ch.origLen {
+			physCol := ch.indentCols + (opts.CursorCol - ch.origStart)
+			text = RenderCursorAtCol(text, "", physCol)
+		}
+		sb.WriteString(text)
+	}
+	return sb.String()
+}
+
+// applyCharSelectionToChunk highlights the slice of a chunk that falls
+// inside the logical-line selection range [selStart, selEnd). Returns
+// the chunk text unchanged if the selection does not overlap.
+func applyCharSelectionToChunk(text string, ch wrappedEventChunk, selStart, selEnd int) string {
+	chunkSelStart := selStart - ch.origStart
+	chunkSelEnd := selEnd - ch.origStart
+	if chunkSelStart < 0 {
+		chunkSelStart = 0
+	}
+	if chunkSelEnd > ch.origLen {
+		chunkSelEnd = ch.origLen
+	}
+	if chunkSelEnd <= chunkSelStart {
+		return text
+	}
+	physStart := ch.indentCols + chunkSelStart
+	physEnd := ch.indentCols + chunkSelEnd
+	runes := []rune(text)
+	if physStart < 0 || physEnd > len(runes) {
+		return text
+	}
+	return string(runes[:physStart]) +
+		SelectedStyle.Render(string(runes[physStart:physEnd])) +
+		string(runes[physEnd:])
 }
 
 // RenderEventViewer renders the event viewer with cursor, visual selection,
@@ -357,16 +466,33 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 		gutter = YamlCursorIndicatorStyle.Render("▎")
 	}
 
-	// Visual selection.
-	//
-	// Line-mode (V) wraps cleanly: every physical sub-line is fully
-	// highlighted, so the selection follows the visible block.
-	// Char-mode (v) and block-mode (B) need deterministic column
-	// positions, so they fall back to single-line truncate.
-	if inSelection {
-		if p.Wrap && p.VisualMode == 'V' {
-			return renderWrappedLineSelection(line, gutter, ctx.contentW, p.HangingIndent)
+	// Wrap-mode rendering is unified via RenderWrappedEventRow: it
+	// handles the gutter, block-cursor placement on the physical
+	// sub-line containing CursorCol, V-mode full-row highlight, and
+	// v-mode char selection across sub-lines. Block-mode (B) keeps the
+	// single-line truncate path below because rectangular column
+	// selection over wrapped sub-lines has no meaningful geometry.
+	if p.Wrap && (!inSelection || p.VisualMode == 'V' || p.VisualMode == 'v') {
+		opts := WrappedEventRowOpts{
+			Line:          line,
+			Gutter:        gutter,
+			ContentW:      ctx.contentW,
+			HangingIndent: p.HangingIndent,
+			IsCursor:      isCursorLine,
+			CursorCol:     p.CursorCol,
 		}
+		switch {
+		case inSelection && p.VisualMode == 'V':
+			opts.SelectionLine = true
+		case inSelection && p.VisualMode == 'v':
+			opts.SelStart, opts.SelEnd = charSelectionRangeForLine(p, ctx, i)
+		default:
+			opts.LowerSearch = ctx.lowerQuery
+		}
+		return RenderWrappedEventRow(opts)
+	}
+
+	if inSelection {
 		selLine := line
 		if len([]rune(selLine)) > ctx.contentW {
 			selLine = string([]rune(selLine)[:ctx.contentW])
@@ -380,11 +506,7 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 		return gutter + rendered
 	}
 
-	if p.Wrap {
-		return renderWrappedEventBlock(p, line, gutter, ctx)
-	}
-
-	// Non-wrap path: truncate to contentW.
+	// Non-wrap, non-selection path.
 	fitLine := line
 	if len([]rune(fitLine)) > ctx.contentW {
 		fitLine = string([]rune(fitLine)[:ctx.contentW])
@@ -395,45 +517,31 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 	return renderEventNormalLine(p, fitLine, ctx, gutter)
 }
 
-// renderWrappedLineSelection returns a hanging-indent-wrapped block
-// with the V-mode selection style applied to every physical sub-line.
-// Producer ANSI (kyverno-style colored levels, dim timestamps) is
-// stripped so the selection style owns the visual without invisible-
-// on-invisible color collisions — same rule as the non-wrap V path
-// in RenderVisualSelection.
-func renderWrappedLineSelection(line, gutter string, contentW, hangingIndent int) string {
-	physLines := WrapEventLine(line, contentW, hangingIndent)
-	var sb strings.Builder
-	for i, pl := range physLines {
-		if i > 0 {
-			sb.WriteByte('\n')
-		}
-		sb.WriteString(gutter)
-		sb.WriteString(SelectedStyle.Render(ansi.Strip(pl)))
+// charSelectionRangeForLine returns the [start, end) column range to
+// highlight on the given logical line under v-mode selection. Mirrors
+// renderCharSelection's per-line logic: anchor-only line highlights
+// from anchorCol to end-of-line; cursor-only line highlights from 0 to
+// cursorCol+1; middle lines highlight everything (caller can detect
+// "everything" via end == len(line)).
+func charSelectionRangeForLine(p EventViewerParams, ctx eventLineContext, i int) (start, end int) {
+	lineWidth := len([]rune(p.Lines[i]))
+	if ctx.selStart == ctx.selEnd {
+		return min(p.VisualCol, p.CursorCol), max(p.VisualCol, p.CursorCol) + 1
 	}
-	return sb.String()
-}
-
-// renderWrappedEventBlock returns the multi-line wrapped form of one
-// event line. Every physical sub-line is prefixed with the gutter (or
-// space) so the leftmost column stays consistent — moving the cursor
-// over a wrapped event no longer makes the continuation lines appear
-// to shift left, which used to read as "wrapped a second time".
-func renderWrappedEventBlock(p EventViewerParams, line, gutter string, ctx eventLineContext) string {
-	physLines := WrapEventLine(line, ctx.contentW, p.HangingIndent)
-	var sb strings.Builder
-	for i, pl := range physLines {
-		if i > 0 {
-			sb.WriteByte('\n')
-		}
-		sb.WriteString(gutter)
-		if p.SearchQuery != "" {
-			sb.WriteString(highlightEventSearchLine(pl, ctx.lowerQuery))
-		} else {
-			sb.WriteString(pl)
-		}
+	var startCol, endCol int
+	if p.VisualStart <= p.Cursor {
+		startCol, endCol = p.VisualCol, p.CursorCol
+	} else {
+		startCol, endCol = p.CursorCol, p.VisualCol
 	}
-	return sb.String()
+	switch i {
+	case ctx.selStart:
+		return startCol, lineWidth
+	case ctx.selEnd:
+		return 0, endCol + 1
+	default:
+		return 0, lineWidth // middle line — highlight everything
+	}
 }
 
 // renderEventCursorLine renders the non-wrap cursor line with gutter

--- a/internal/ui/overlay_event_viewer_test.go
+++ b/internal/ui/overlay_event_viewer_test.go
@@ -166,13 +166,12 @@ func TestRenderEventViewer_BlockCursorVisibleInWrap(t *testing.T) {
 		CursorCol:     38 + 3, // 4th char of the message
 	}
 	out := RenderEventViewer(p)
-	// CursorBlockStyle is reverse-video — emits ESC[7m … ESC[0m around
-	// the cursor character. Assert the styled escape sequence wraps
-	// the expected character rather than just checking the char
-	// appears anywhere.
-	cursorMark := CursorBlockStyle.Render("d")
-	assert.Contains(t, out, cursorMark,
-		"block cursor must be present at CursorCol with reverse-video styling")
+	// Assert the styled cursor token appears AT the expected position,
+	// not just anywhere in the output — a bare Contains("d") would
+	// trivially pass even if the cursor were not applied at CursorCol
+	// (CodeRabbit nitpick).
+	assert.Contains(t, out, prefix+"abc"+CursorBlockStyle.Render("d"),
+		"block cursor must wrap the character at CursorCol")
 }
 
 // Defaults case: opening events places the cursor at line 0, col 0.
@@ -193,8 +192,11 @@ func TestRenderEventViewer_BlockCursorAtZeroColumnInWrap(t *testing.T) {
 		CursorCol:     0,
 	}
 	out := RenderEventViewer(p)
-	cursorMark := CursorBlockStyle.Render("2")
-	assert.Contains(t, out, cursorMark,
+	// Positional assertion: the cursor-styled "2" must be followed by
+	// "m" (the line is "2m       Warning..."), proving the cursor
+	// wraps the character at CursorCol=0 rather than somewhere
+	// arbitrary.
+	assert.Contains(t, out, CursorBlockStyle.Render("2")+"m       Warning",
 		"block cursor must render on the first character at CursorCol=0")
 }
 
@@ -216,9 +218,10 @@ func TestRenderEventViewer_BlockCursorClampsPastLineEndInWrap(t *testing.T) {
 		CursorCol:     500, // far past end
 	}
 	out := RenderEventViewer(p)
-	// RenderCursorAtCol appends a highlighted space when col >= width.
-	pastEndCursor := CursorBlockStyle.Render(" ")
-	assert.Contains(t, out, pastEndCursor,
+	// Positional assertion: the past-end cursor block (a highlighted
+	// space) must appear immediately after the full line text, not
+	// just anywhere in the rendered overlay.
+	assert.Contains(t, out, "short line"+CursorBlockStyle.Render(" "),
 		"block cursor must remain visible when CursorCol is past the line end")
 }
 

--- a/internal/ui/overlay_event_viewer_test.go
+++ b/internal/ui/overlay_event_viewer_test.go
@@ -166,12 +166,60 @@ func TestRenderEventViewer_BlockCursorVisibleInWrap(t *testing.T) {
 		CursorCol:     38 + 3, // 4th char of the message
 	}
 	out := RenderEventViewer(p)
-	// CursorBlockStyle renders a reverse-video block. Just check the
-	// rendered output contains both the expected pre-cursor chars and
-	// the char "d" at that position survives the render (it will be
-	// styled with reverse video — assert presence as a smoke check).
-	assert.Contains(t, out, prefix+"abc")
-	assert.Contains(t, out, "d")
+	// CursorBlockStyle is reverse-video — emits ESC[7m … ESC[0m around
+	// the cursor character. Assert the styled escape sequence wraps
+	// the expected character rather than just checking the char
+	// appears anywhere.
+	cursorMark := CursorBlockStyle.Render("d")
+	assert.Contains(t, out, cursorMark,
+		"block cursor must be present at CursorCol with reverse-video styling")
+}
+
+// Defaults case: opening events places the cursor at line 0, col 0.
+// The block cursor must render on the very first character of the
+// line (right after the gutter). This was the regression report —
+// "cursor not visible (or disappears) in both views" — for the
+// common open-events-and-look path.
+func TestRenderEventViewer_BlockCursorAtZeroColumnInWrap(t *testing.T) {
+	t.Parallel()
+	line := "2m       Warning  FailedScheduling   " + strings.Repeat("a", 200)
+	p := EventViewerParams{
+		Lines:         []string{line},
+		Width:         60,
+		Height:        20,
+		Wrap:          true,
+		HangingIndent: 38,
+		Cursor:        0,
+		CursorCol:     0,
+	}
+	out := RenderEventViewer(p)
+	cursorMark := CursorBlockStyle.Render("2")
+	assert.Contains(t, out, cursorMark,
+		"block cursor must render on the first character at CursorCol=0")
+}
+
+// If CursorCol points past the line's last character (e.g. cursor
+// stayed at col 50 after navigating from a long event to a short
+// one), the cursor would otherwise vanish — no chunk contains it.
+// The block cursor must clamp to the end of the last chunk so the
+// user can always see where the cursor parked.
+func TestRenderEventViewer_BlockCursorClampsPastLineEndInWrap(t *testing.T) {
+	t.Parallel()
+	line := "short line"
+	p := EventViewerParams{
+		Lines:         []string{line},
+		Width:         60,
+		Height:        20,
+		Wrap:          true,
+		HangingIndent: 38,
+		Cursor:        0,
+		CursorCol:     500, // far past end
+	}
+	out := RenderEventViewer(p)
+	// RenderCursorAtCol appends a highlighted space when col >= width.
+	pastEndCursor := CursorBlockStyle.Render(" ")
+	assert.Contains(t, out, pastEndCursor,
+		"block cursor must remain visible when CursorCol is past the line end")
 }
 
 // Regression guard for the two issues raised on #263 in the events

--- a/internal/ui/overlay_event_viewer_test.go
+++ b/internal/ui/overlay_event_viewer_test.go
@@ -1,0 +1,101 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A short line that fits within contentW must come back unchanged —
+// no padding, no extra newlines, no split.
+func TestWrapEventLine_ShortLineUnchanged(t *testing.T) {
+	t.Parallel()
+	got := WrapEventLine("hello", 80, 10)
+	assert.Equal(t, []string{"hello"}, got)
+}
+
+// The first physical line consumes the full contentW; each subsequent
+// line is prefixed with hangingIndent spaces so wrapped message text
+// stays under the message column.
+func TestWrapEventLine_HangingIndent(t *testing.T) {
+	t.Parallel()
+	// Line: 38-col prefix (e.g. "2m       Warning  FailedScheduling    ")
+	// followed by 60 chars of message → total 98. With contentW=50 and
+	// hangingIndent=38, the first sub-line takes 50 chars, leaving 48
+	// of message; each continuation fits (50 - 38) = 12 chars of
+	// message preceded by 38 spaces.
+	prefix := strings.Repeat("x", 38)
+	msg := strings.Repeat("a", 60)
+	line := prefix + msg
+
+	got := WrapEventLine(line, 50, 38)
+	pad := strings.Repeat(" ", 38)
+
+	assert.Equal(t, prefix+strings.Repeat("a", 12), got[0],
+		"first line keeps the full prefix and uses contentW chars")
+	for i := 1; i < len(got); i++ {
+		assert.True(t, strings.HasPrefix(got[i], pad),
+			"continuation %d must start with hangingIndent spaces, got %q", i, got[i])
+		assert.LessOrEqual(t, len([]rune(got[i])), 50,
+			"continuation %d must not exceed contentW", i)
+	}
+	// All message chars must be present in concatenation order.
+	var sb strings.Builder
+	sb.WriteString(got[0])
+	for _, l := range got[1:] {
+		sb.WriteString(strings.TrimPrefix(l, pad))
+	}
+	assert.Equal(t, line, sb.String())
+}
+
+// If the indent is too wide to leave any meaningful continuation room
+// (less than 8 chars), fall back to flush-left wrap to stay readable
+// on narrow terminals.
+func TestWrapEventLine_NarrowTerminalFallsBackFlushLeft(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", 100)
+	got := WrapEventLine(long, 20, 38) // 38 indent in 20-col content → fall back
+
+	for i, l := range got {
+		assert.False(t, strings.HasPrefix(l, "  "),
+			"on narrow terminals continuation %d must NOT be padded, got %q", i, l)
+	}
+}
+
+func TestWrapEventLine_DegenerateInputs(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{""}, WrapEventLine("", 80, 10))
+	assert.Equal(t, []string{"abc"}, WrapEventLine("abc", 0, 10))
+	// Negative indent is treated as 0.
+	got := WrapEventLine(strings.Repeat("a", 50), 20, -5)
+	assert.NotEmpty(t, got)
+}
+
+// Regression guard for the two issues raised on #263 in the events
+// overlay: each physical sub-line is prefixed with the gutter so the
+// continuation lines do not appear to shift left when the cursor
+// lands on the event.
+func TestRenderEventViewer_WrappedContinuationsHaveGutter(t *testing.T) {
+	t.Parallel()
+	prefix := strings.Repeat("x", 38)
+	msg := strings.Repeat("a", 200)
+	p := EventViewerParams{
+		Lines:         []string{prefix + msg},
+		Width:         60, // contentW = 53
+		Height:        20,
+		Wrap:          true,
+		HangingIndent: 38,
+		Cursor:        0,
+	}
+	out := RenderEventViewer(p)
+
+	// Every line of the rendered block that contains message text must
+	// start with the cursor gutter "▎" (or the surrounding chrome).
+	// We can't easily assert the styled escape sequence, but every
+	// physical sub-line should be present in the output.
+	assert.Contains(t, out, prefix)
+	// Continuation chunks (`pad + 12-or-fewer a's`) should appear.
+	pad := strings.Repeat(" ", 38)
+	assert.Contains(t, out, pad+strings.Repeat("a", 12))
+}

--- a/internal/ui/overlay_event_viewer_test.go
+++ b/internal/ui/overlay_event_viewer_test.go
@@ -72,6 +72,58 @@ func TestWrapEventLine_DegenerateInputs(t *testing.T) {
 	assert.NotEmpty(t, got)
 }
 
+// V-line visual selection used to collapse the wrap and render the
+// event as a single truncated line — confusing because exiting visual
+// mode brought wrap back. With this fix the selection follows the
+// wrapped block: every physical sub-line is fully highlighted.
+func TestRenderEventViewer_VisualLineModeKeepsWrap(t *testing.T) {
+	t.Parallel()
+	prefix := strings.Repeat("x", 38)
+	msg := strings.Repeat("a", 200)
+	p := EventViewerParams{
+		Lines:         []string{prefix + msg},
+		Width:         60,
+		Height:        20,
+		Wrap:          true,
+		HangingIndent: 38,
+		Cursor:        0,
+		VisualMode:    'V',
+		VisualStart:   0,
+	}
+	out := RenderEventViewer(p)
+	// Continuation chunk (38-space indent + message piece) must still
+	// appear in the rendered output — proving the wrap survived the
+	// selection rendering rather than collapsing to a single line.
+	pad := strings.Repeat(" ", 38)
+	assert.Contains(t, out, pad+strings.Repeat("a", 12))
+}
+
+// Char-mode (v) selection on a wrapped event keeps the column-based
+// semantics — it deliberately collapses to a single truncated line so
+// the highlight columns map deterministically. Guard against future
+// changes that accidentally enable wrap for char mode.
+func TestRenderEventViewer_CharModeCollapsesToSingleLine(t *testing.T) {
+	t.Parallel()
+	prefix := strings.Repeat("x", 38)
+	msg := strings.Repeat("a", 200)
+	p := EventViewerParams{
+		Lines:         []string{prefix + msg},
+		Width:         60,
+		Height:        20,
+		Wrap:          true,
+		HangingIndent: 38,
+		Cursor:        0,
+		VisualMode:    'v',
+		VisualStart:   0,
+		VisualCol:     0,
+		CursorCol:     5,
+	}
+	out := RenderEventViewer(p)
+	pad := strings.Repeat(" ", 38)
+	assert.NotContains(t, out, pad+strings.Repeat("a", 12),
+		"char-mode selection should not produce indented continuation")
+}
+
 // Regression guard for the two issues raised on #263 in the events
 // overlay: each physical sub-line is prefixed with the gutter so the
 // continuation lines do not appear to shift left when the cursor

--- a/internal/ui/overlay_event_viewer_test.go
+++ b/internal/ui/overlay_event_viewer_test.go
@@ -98,11 +98,11 @@ func TestRenderEventViewer_VisualLineModeKeepsWrap(t *testing.T) {
 	assert.Contains(t, out, pad+strings.Repeat("a", 12))
 }
 
-// Char-mode (v) selection on a wrapped event keeps the column-based
-// semantics — it deliberately collapses to a single truncated line so
-// the highlight columns map deterministically. Guard against future
-// changes that accidentally enable wrap for char mode.
-func TestRenderEventViewer_CharModeCollapsesToSingleLine(t *testing.T) {
+// Char-mode (v) selection on a wrapped event now keeps the wrap and
+// places the highlight on the actual selected character range across
+// physical sub-lines. The wrap survives navigation; only the
+// selection geometry differs from V-mode (range, not full row).
+func TestRenderEventViewer_CharModeKeepsWrap(t *testing.T) {
 	t.Parallel()
 	prefix := strings.Repeat("x", 38)
 	msg := strings.Repeat("a", 200)
@@ -120,8 +120,58 @@ func TestRenderEventViewer_CharModeCollapsesToSingleLine(t *testing.T) {
 	}
 	out := RenderEventViewer(p)
 	pad := strings.Repeat(" ", 38)
+	assert.Contains(t, out, pad+strings.Repeat("a", 12),
+		"char-mode selection must still wrap the event row")
+}
+
+// Block-mode (B) selection has no meaningful geometry over wrapped
+// sub-lines, so it intentionally falls back to single-line truncate.
+func TestRenderEventViewer_BlockModeCollapsesToSingleLine(t *testing.T) {
+	t.Parallel()
+	prefix := strings.Repeat("x", 38)
+	msg := strings.Repeat("a", 200)
+	p := EventViewerParams{
+		Lines:         []string{prefix + msg},
+		Width:         60,
+		Height:        20,
+		Wrap:          true,
+		HangingIndent: 38,
+		Cursor:        0,
+		VisualMode:    'B',
+		VisualStart:   0,
+		VisualCol:     0,
+		CursorCol:     5,
+	}
+	out := RenderEventViewer(p)
+	pad := strings.Repeat(" ", 38)
 	assert.NotContains(t, out, pad+strings.Repeat("a", 12),
-		"char-mode selection should not produce indented continuation")
+		"block-mode selection should not produce indented continuation")
+}
+
+// In wrap mode, the cursor was previously only a gutter character on
+// the first physical sub-line — invisible if the user expected a
+// block cursor at CursorCol. Now the block cursor is placed on the
+// physical sub-line containing CursorCol so navigation is visible.
+func TestRenderEventViewer_BlockCursorVisibleInWrap(t *testing.T) {
+	t.Parallel()
+	prefix := strings.Repeat("x", 38)
+	msg := "abcdefghij" + strings.Repeat("Z", 200)
+	p := EventViewerParams{
+		Lines:         []string{prefix + msg},
+		Width:         60,
+		Height:        20,
+		Wrap:          true,
+		HangingIndent: 38,
+		Cursor:        0,
+		CursorCol:     38 + 3, // 4th char of the message
+	}
+	out := RenderEventViewer(p)
+	// CursorBlockStyle renders a reverse-video block. Just check the
+	// rendered output contains both the expected pre-cursor chars and
+	// the char "d" at that position survives the render (it will be
+	// styled with reverse video — assert presence as a smoke check).
+	assert.Contains(t, out, prefix+"abc")
+	assert.Contains(t, out, "d")
 }
 
 // Regression guard for the two issues raised on #263 in the events


### PR DESCRIPTION
Closes #263.

## Summary
Opening the events overlay used to show very little information: it capped at 100 columns wide and 30 lines tall regardless of terminal size, and wrap was off by default — so on a wide screen (the reporter's 1512px terminal) most rows right-truncated and useful messages (FailedScheduling reasons, image-pull errors, Helm hook output) were unreadable without first pressing \`>\` or \`f\`.

- Bump overlay caps to 160x45. Smaller terminals still clamp to \`(width-6, height-4)\`.
- Default \`eventTimelineWrap=true\` on each open. Long messages wrap to multiple lines instead of being right-clipped. \`>\` still toggles for users who prefer horizontal scrolling.

## Test plan
- [x] \`go test ./... -count=1\`
- [x] \`TestUpdateEventTimelineSuccess\` asserts wrap is on after open.
- [x] Existing \`TestEventTimelineWrapToggle\` still passes (the \`>\` toggle test starts from a manually-constructed model, independent of the dispatch defaults).
- [x] Manual: open events overlay on a wide terminal — long lines wrap and most of the screen is used.
- [x] Manual: press \`>\` to toggle off wrap, press \`f\` for fullscreen — both still work as before.