### PR TITLE
fix(sort): numeric ordering for percent columns (CPU%, MEM%, */R, */L)

### DIFF
--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -115,10 +115,43 @@ func itemTiebreakerLess(a, b model.Item, primaryCol string) bool {
 	return a.Extra < b.Extra
 }
 
+// valueCmpFunc compares two extra-column string values. Used by the
+// columnValueCmp registry below to type extra columns whose semantics
+// can't be inferred from their value alone (e.g. "45%" could be a
+// percent or a label, "80/TCP" could be a port or a path).
+type valueCmpFunc func(a, b string) int
+
+// columnValueCmp registers per-column comparators for extra-column
+// values (those stored in Item.Columns rather than top-level Item fields).
+// Adding a new typed column is a one-line registration here — keeping
+// the format dispatch in one place avoids the bug class where new
+// percent/resource columns silently fell through to lexicographic sort
+// (e.g. "100%" < "9%").
+var columnValueCmp = map[string]valueCmpFunc{
+	"CPU":          func(a, b string) int { return compareResourceValuesCmp(a, b, "CPU") },
+	"MEM":          func(a, b string) int { return compareResourceValuesCmp(a, b, "MEM") },
+	"CPU%":         comparePercentCmp,
+	"MEM%":         comparePercentCmp,
+	"CPU/R":        comparePercentCmp,
+	"CPU/L":        comparePercentCmp,
+	"MEM/R":        comparePercentCmp,
+	"MEM/L":        comparePercentCmp,
+	"Ports":        comparePortsCmp,
+	"Progress":     compareReadyCmp, // "N/M" fraction, same shape as Ready ratio
+	"Duration":     compareDurationCmp,
+	"Cluster IP":   compareIPCmp,
+	"Pod IP":       compareIPCmp,
+	"External IPs": compareIPCmp,
+}
+
 // comparePrimaryColumn returns -1, 0, or +1 for a < b, a == b, a > b
 // according to the selected sort column. Returning 0 lets the caller run
 // a tiebreaker chain instead of relying on sort.SliceStable's input-order
 // preservation.
+//
+// Columns whose comparator needs the whole Item (top-level fields,
+// timestamps, status priority) are handled inline; extra columns go
+// through columnValueCmp, with auto-detection as the final fallback.
 func comparePrimaryColumn(a, b model.Item, colName string) int {
 	switch colName {
 	case "Name":
@@ -138,21 +171,14 @@ func comparePrimaryColumn(a, b model.Item, colName string) int {
 		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
 	case "Age":
 		return compareAgeCmp(a, b)
-	case "Ports":
-		return comparePortsCmp(getColumnValue(a, "Ports"), getColumnValue(b, "Ports"))
-	case "Progress":
-		// Argo Workflow progress is an "N/M" fraction, identical in shape
-		// to the Ready ratio — reuse the same comparator.
-		return compareReadyCmp(getColumnValue(a, "Progress"), getColumnValue(b, "Progress"))
-	case "Duration":
-		return compareDurationCmp(getColumnValue(a, "Duration"), getColumnValue(b, "Duration"))
-	case "Cluster IP", "Pod IP", "External IPs":
-		return compareIPCmp(getColumnValue(a, colName), getColumnValue(b, colName))
 	case sortColEventLastSeen:
 		return compareLastSeenCmp(a, b)
-	default:
-		return compareColumnValuesCmp(getColumnValue(a, colName), getColumnValue(b, colName), colName)
 	}
+	va, vb := getColumnValue(a, colName), getColumnValue(b, colName)
+	if cmp, ok := columnValueCmp[colName]; ok {
+		return cmp(va, vb)
+	}
+	return compareColumnValuesCmp(va, vb)
 }
 
 func cmpInt(a, b int) int {
@@ -226,6 +252,38 @@ func compareResourceValues(a, b, col string) bool {
 func compareResourceValuesCmp(a, b, col string) int {
 	isCPU := strings.HasPrefix(col, "CPU")
 	return cmpInt64(ui.ParseResourceValue(a, isCPU), ui.ParseResourceValue(b, isCPU))
+}
+
+// comparePercentCmp compares two percentage-formatted column values
+// (e.g. "42%", "n/a") numerically by their leading integer percentage.
+// "n/a" (and any other unparseable value) sorts after real values so
+// metrics-less rows land at the bottom in ascending order.
+func comparePercentCmp(a, b string) int {
+	pa, okA := parsePercent(a)
+	pb, okB := parsePercent(b)
+	switch {
+	case okA && okB:
+		return cmpFloat(pa, pb)
+	case okA:
+		return -1
+	case okB:
+		return 1
+	default:
+		return strings.Compare(strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b)))
+	}
+}
+
+func parsePercent(s string) (float64, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "%")
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // compareAgeCmp returns the three-way age comparison with zero-time
@@ -360,11 +418,9 @@ func leadingIP(s string) (netip.Addr, bool) {
 // of resource quantities (10Gi, 500Mi, 100m), plain numbers, and strings.
 // Returns -1, 0, or +1 so sort.SliceStable callers can detect equality
 // and fall through to the row-identity tiebreaker chain.
-func compareColumnValuesCmp(a, b, colName string) int {
-	// Known CPU/MEM columns: use resource value parser directly.
-	if colName == "CPU" || colName == "MEM" || colName == "CPU/R" || colName == "CPU/L" || colName == "MEM/R" || colName == "MEM/L" {
-		return compareResourceValuesCmp(a, b, colName)
-	}
+func compareColumnValuesCmp(a, b string) int {
+	// Auto-detect for unknown columns: typed columns are dispatched via
+	// columnValueCmp before reaching here.
 
 	// Try parsing as resource quantities (Gi, Mi, Ki, B suffixes or millicores).
 	if looksLikeResourceQuantity(a) || looksLikeResourceQuantity(b) {

--- a/internal/app/tabs_compare_test.go
+++ b/internal/app/tabs_compare_test.go
@@ -3,6 +3,8 @@ package app
 import (
 	"sort"
 	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
 
 func TestComparePortsCmp_Numeric(t *testing.T) {
@@ -96,4 +98,64 @@ func TestCompareIPCmp_SortOrder(t *testing.T) {
 			t.Fatalf("sorted = %v, want %v", values, want)
 		}
 	}
+}
+
+func TestComparePercentCmp(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"5% before 50%", "5%", "50%", -1},
+		{"50% before 100%", "50%", "100%", -1},
+		{"9% before 10%", "9%", "10%", -1},
+		{"equal", "42%", "42%", 0},
+		{"n/a sorts after real value", "n/a", "0%", 1},
+		{"real value before n/a", "0%", "n/a", -1},
+		{"n/a equals n/a", "n/a", "n/a", 0},
+		{"whitespace tolerated", " 7% ", "12%", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := comparePercentCmp(tt.a, tt.b)
+			if (got < 0) != (tt.want < 0) || (got > 0) != (tt.want > 0) {
+				t.Errorf("comparePercentCmp(%q, %q) = %d, want sign of %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComparePercentCmp_SortOrder(t *testing.T) {
+	values := []string{"50%", "5%", "100%", "9%", "n/a", "0%"}
+	sort.Slice(values, func(i, j int) bool {
+		return comparePercentCmp(values[i], values[j]) < 0
+	})
+	want := []string{"0%", "5%", "9%", "50%", "100%", "n/a"}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("sorted = %v, want %v", values, want)
+		}
+	}
+}
+
+func TestComparePrimaryColumn_PercentColumns(t *testing.T) {
+	cols := []string{"CPU%", "MEM%", "CPU/R", "CPU/L", "MEM/R", "MEM/L"}
+	for _, col := range cols {
+		t.Run(col, func(t *testing.T) {
+			a := itemWithCol(col, "9%")
+			b := itemWithCol(col, "50%")
+			if got := comparePrimaryColumn(a, b, col); got >= 0 {
+				t.Errorf("comparePrimaryColumn(9%%, 50%%) on %s = %d, want < 0", col, got)
+			}
+			c := itemWithCol(col, "n/a")
+			d := itemWithCol(col, "0%")
+			if got := comparePrimaryColumn(c, d, col); got <= 0 {
+				t.Errorf("comparePrimaryColumn(n/a, 0%%) on %s = %d, want > 0", col, got)
+			}
+		})
+	}
+}
+
+func itemWithCol(key, val string) model.Item {
+	return model.Item{Columns: []model.KeyValue{{Key: key, Value: val}}}
 }


### PR DESCRIPTION
## Summary
- Node `CPU%`/`MEM%` were sorted lexicographically (`"100%" < "9%"`). Pod `CPU/R`, `CPU/L`, `MEM/R`, `MEM/L` went through the resource parser, which returns 0 for `"42%"` and left rows unordered.
- New `comparePercentCmp` parses the leading number and sorts `"n/a"` last.
- Refactor: extra-column comparators now live in a `columnValueCmp` registry — one map entry per typed column, instead of editing two if-chains. `compareColumnValuesCmp` is now purely the auto-detect fallback for unregistered columns.

Fixes #272

## Test plan
- [x] Unit: `TestComparePercentCmp` (8 cases incl. n/a handling, whitespace)
- [x] Unit: `TestComparePercentCmp_SortOrder`
- [x] Unit: `TestComparePrimaryColumn_PercentColumns` covering all six percent columns
- [x] `go test ./internal/app/ ./internal/ui/ -race -count=1`
- [x] `go build ./... && go vet ./...`
- [x] golangci-lint via pre-commit