### PR TITLE
refactor(ui): consolidate builtin column dispatch into a registry

### DIFF
--- a/internal/ui/explorer_column_registry.go
+++ b/internal/ui/explorer_column_registry.go
@@ -1,0 +1,153 @@
+package ui
+
+import "github.com/janosmiko/lfk/internal/model"
+
+// builtinColWidths holds the precomputed widths for the fixed (non-extra)
+// columns, indexed by name. Bundling them keeps the dispatcher signatures
+// tractable as the set of builtin columns grows.
+type builtinColWidths struct {
+	context, ns, ready, restarts, status, age int
+}
+
+// builtinColHeaders holds the precomputed (already padded + sort-indicator
+// decorated) header strings for each fixed column.
+type builtinColHeaders struct {
+	context, ns, ready, restarts, status, age string
+}
+
+// plainCellInputs carries the inputs needed to render a plain-text builtin
+// cell. The preprocessed value strings come from the caller because some
+// (e.g. restarts) have row-specific upstream handling.
+type plainCellInputs struct {
+	item                             *model.Item
+	ns, ready, restarts, status, age string
+	widths                           builtinColWidths
+}
+
+// styledCellInputs carries the inputs needed to render a styled builtin cell.
+type styledCellInputs struct {
+	item             model.Item
+	widths           builtinColWidths
+	anyRecentRestart bool
+}
+
+// builtinColumn is the metadata + render functions for a single fixed
+// (non-extra) column. Holding these in a registry lets the four dispatch
+// switches (width / header / plain / styled) collapse into one map lookup.
+type builtinColumn struct {
+	key    string
+	width  func(builtinColWidths) int
+	header func(builtinColHeaders) string
+	plain  func(plainCellInputs) string
+	styled func(styledCellInputs) string
+}
+
+// builtinColumns is the canonical list of fixed columns. Adding a new builtin
+// column means appending one entry here instead of editing five dispatch
+// switches.
+//
+// Context is intentionally part of this registry but is also treated as a
+// conditional column: when its precomputed width is zero, the row renderer
+// falls through to the extras lookup so a user-requested "Context" extra
+// can still render.
+var builtinColumns = []builtinColumn{
+	{
+		key:    "Context",
+		width:  func(w builtinColWidths) int { return w.context },
+		header: func(h builtinColHeaders) string { return h.context },
+		plain: func(p plainCellInputs) string {
+			name := ""
+			if p.item != nil {
+				name = p.item.ClusterName
+			}
+			return padRight(Truncate(name, p.widths.context-1), p.widths.context)
+		},
+		styled: func(s styledCellInputs) string {
+			return DimStyle.Render(padRight(Truncate(s.item.ClusterName, s.widths.context-1), s.widths.context))
+		},
+	},
+	{
+		key:    "Namespace",
+		width:  func(w builtinColWidths) int { return w.ns },
+		header: func(h builtinColHeaders) string { return h.ns },
+		plain: func(p plainCellInputs) string {
+			return padRight(Truncate(p.ns, p.widths.ns-1), p.widths.ns)
+		},
+		styled: func(s styledCellInputs) string {
+			ns := s.item.Namespace
+			if ns == "" {
+				ns = "-"
+			}
+			return DimStyle.Render(padRight(Truncate(ns, s.widths.ns-1), s.widths.ns))
+		},
+	},
+	{
+		key:    "Ready",
+		width:  func(w builtinColWidths) int { return w.ready },
+		header: func(h builtinColHeaders) string { return h.ready },
+		plain: func(p plainCellInputs) string {
+			return padRight(p.ready, p.widths.ready)
+		},
+		styled: func(s styledCellInputs) string {
+			return DimStyle.Render(padRight(s.item.Ready, s.widths.ready))
+		},
+	},
+	{
+		key:    "Restarts",
+		width:  func(w builtinColWidths) int { return w.restarts },
+		header: func(h builtinColHeaders) string { return h.restarts },
+		plain: func(p plainCellInputs) string {
+			return padRight(p.restarts, p.widths.restarts)
+		},
+		styled: func(s styledCellInputs) string {
+			return styledRestartsCell(s.item, s.widths.restarts, s.anyRecentRestart)
+		},
+	},
+	{
+		key:    "Status",
+		width:  func(w builtinColWidths) int { return w.status },
+		header: func(h builtinColHeaders) string { return h.status },
+		plain: func(p plainCellInputs) string {
+			return padRight(Truncate(AbbreviateStatusForWidth(p.status, p.widths.status-1), p.widths.status-1), p.widths.status)
+		},
+		styled: func(s styledCellInputs) string {
+			val := AbbreviateStatusForWidth(s.item.Status, s.widths.status-1)
+			return StatusStyle(val).Render(padRight(Truncate(val, s.widths.status-1), s.widths.status))
+		},
+	},
+	{
+		key:    "Age",
+		width:  func(w builtinColWidths) int { return w.age },
+		header: func(h builtinColHeaders) string { return h.age },
+		plain: func(p plainCellInputs) string {
+			return padRight(p.age, p.widths.age)
+		},
+		styled: func(s styledCellInputs) string {
+			age := LiveAge(s.item)
+			return AgeStyle(age).Render(padRight(age, s.widths.age))
+		},
+	},
+}
+
+var builtinColumnsByKey = func() map[string]*builtinColumn {
+	m := make(map[string]*builtinColumn, len(builtinColumns))
+	for i := range builtinColumns {
+		m[builtinColumns[i].key] = &builtinColumns[i]
+	}
+	return m
+}()
+
+// renderableBuiltin returns the builtin column entry for key, or nil. Context
+// is only renderable when its precomputed width is positive; other builtins
+// always count as renderable (callers may still get a zero-width cell). This
+// gating lives here so the row renderer doesn't need to special-case Context.
+func renderableBuiltin(key string, widths builtinColWidths) *builtinColumn {
+	col, ok := builtinColumnsByKey[key]
+	if !ok {
+		return nil
+	}
+	if key == "Context" && widths.context <= 0 {
+		return nil
+	}
+	return col
+}

--- a/internal/ui/explorer_column_registry_test.go
+++ b/internal/ui/explorer_column_registry_test.go
@@ -82,11 +82,17 @@ func TestBuiltinColumnsRegistryHasExpectedKeys(t *testing.T) {
 	}
 	got := make(map[string]bool, len(builtinColumns))
 	for _, col := range builtinColumns {
+		// A duplicate key would otherwise overwrite the prior entry in
+		// builtinColumnsByKey (the first would be dead) and silently
+		// leave the set-equality check below intact, since map writes
+		// of the same key don't grow the set.
+		assert.Falsef(t, got[col.key], "duplicate registry key %q", col.key)
 		got[col.key] = true
 		assert.NotNil(t, col.width, "%q missing width fn", col.key)
 		assert.NotNil(t, col.header, "%q missing header fn", col.key)
 		assert.NotNil(t, col.plain, "%q missing plain fn", col.key)
 		assert.NotNil(t, col.styled, "%q missing styled fn", col.key)
 	}
+	assert.Len(t, builtinColumns, len(expected), "registry entry count drifted from expected set")
 	assert.Equal(t, expected, got, "registry keys drifted from expected set")
 }

--- a/internal/ui/explorer_column_registry_test.go
+++ b/internal/ui/explorer_column_registry_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// --- renderableBuiltin ---
+
+func TestRenderableBuiltin(t *testing.T) {
+	allWidths := builtinColWidths{context: 8, ns: 10, ready: 6, restarts: 4, status: 12, age: 5}
+
+	tests := []struct {
+		name        string
+		key         string
+		widths      builtinColWidths
+		wantNonNil  bool
+		wantKeyBack string
+	}{
+		{name: "Namespace with positive width", key: "Namespace", widths: allWidths, wantNonNil: true, wantKeyBack: "Namespace"},
+		{name: "Ready with positive width", key: "Ready", widths: allWidths, wantNonNil: true, wantKeyBack: "Ready"},
+		{name: "Restarts with positive width", key: "Restarts", widths: allWidths, wantNonNil: true, wantKeyBack: "Restarts"},
+		{name: "Status with positive width", key: "Status", widths: allWidths, wantNonNil: true, wantKeyBack: "Status"},
+		{name: "Age with positive width", key: "Age", widths: allWidths, wantNonNil: true, wantKeyBack: "Age"},
+		{name: "Context with positive width", key: "Context", widths: allWidths, wantNonNil: true, wantKeyBack: "Context"},
+
+		// Non-Context builtins remain renderable even at width zero — callers
+		// may still emit a zero-width cell.
+		{name: "Namespace with zero width still renderable", key: "Namespace", widths: builtinColWidths{}, wantNonNil: true, wantKeyBack: "Namespace"},
+		{name: "Status with zero width still renderable", key: "Status", widths: builtinColWidths{}, wantNonNil: true, wantKeyBack: "Status"},
+
+		// Context is gated — zero or negative width falls through to extras.
+		{name: "Context with zero width falls through", key: "Context", widths: builtinColWidths{}, wantNonNil: false},
+		{name: "Context with negative width falls through", key: "Context", widths: builtinColWidths{context: -1}, wantNonNil: false},
+
+		// Unknown keys are never registry entries.
+		{name: "unknown key", key: "CPU", widths: allWidths, wantNonNil: false},
+		{name: "empty key", key: "", widths: allWidths, wantNonNil: false},
+		{name: "Name is not a builtin column", key: "Name", widths: allWidths, wantNonNil: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderableBuiltin(tt.key, tt.widths)
+			if !tt.wantNonNil {
+				assert.Nil(t, got, "expected nil for key=%q", tt.key)
+				return
+			}
+			if assert.NotNil(t, got, "expected non-nil for key=%q", tt.key) {
+				assert.Equal(t, tt.wantKeyBack, got.key)
+			}
+		})
+	}
+}
+
+// --- isBuiltinColumnKey ---
+
+// Pinned so that drifts between the registry and the predicate (Context
+// inclusion in particular) surface as test failures rather than runtime
+// renderer bugs.
+func TestIsBuiltinColumnKey(t *testing.T) {
+	for _, key := range []string{"Namespace", "Ready", "Restarts", "Status", "Age"} {
+		assert.Truef(t, isBuiltinColumnKey(key), "%q should be a strict builtin", key)
+	}
+	assert.False(t, isBuiltinColumnKey("Context"), "Context is intentionally excluded")
+	assert.False(t, isBuiltinColumnKey("Name"), "Name is the leading column, not a strict builtin")
+	assert.False(t, isBuiltinColumnKey("CPU"), "extras like CPU are not strict builtins")
+	assert.False(t, isBuiltinColumnKey(""), "empty key is not a builtin")
+}
+
+// --- builtinColumns registry shape ---
+
+func TestBuiltinColumnsRegistryHasExpectedKeys(t *testing.T) {
+	expected := map[string]bool{
+		"Context":   true,
+		"Namespace": true,
+		"Ready":     true,
+		"Restarts":  true,
+		"Status":    true,
+		"Age":       true,
+	}
+	got := make(map[string]bool, len(builtinColumns))
+	for _, col := range builtinColumns {
+		got[col.key] = true
+		assert.NotNil(t, col.width, "%q missing width fn", col.key)
+		assert.NotNil(t, col.header, "%q missing header fn", col.key)
+		assert.NotNil(t, col.plain, "%q missing plain fn", col.key)
+		assert.NotNil(t, col.styled, "%q missing styled fn", col.key)
+	}
+	assert.Equal(t, expected, got, "registry keys drifted from expected set")
+}

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -82,8 +82,6 @@ func styledExtraCell(ec extraColumn, item *model.Item) string {
 	}
 }
 
-// plainBuiltinCell builds the plain-text cell for a single built-in column.
-// Values are the already-resolved display strings for this row (e.g. ns with
 // statusAbbreviations maps long-form Pod-ish status strings to a compact
 // label used when the STATUS column has been shrunk under width pressure.
 // Entries here are status values that are otherwise too verbose for narrow
@@ -119,53 +117,6 @@ func AbbreviateStatusForWidth(status string, w int) string {
 	return status
 }
 
-// dash fallback, preprocessed restarts with arrow prefix).
-func plainBuiltinCell(key string, ns, ready, restarts, status, age string,
-	nsW, readyW, restartsW, statusW, ageW int,
-) string {
-	switch key {
-	case "Namespace":
-		return padRight(Truncate(ns, nsW-1), nsW)
-	case "Ready":
-		return padRight(ready, readyW)
-	case "Restarts":
-		return padRight(restarts, restartsW)
-	case "Status":
-		return padRight(Truncate(AbbreviateStatusForWidth(status, statusW-1), statusW-1), statusW)
-	case "Age":
-		return padRight(age, ageW)
-	}
-	return ""
-}
-
-// styledBuiltinCell builds the styled cell for a single built-in column.
-// Namespaces are dimmed, Ready is dimmed, Restarts is delegated to
-// styledRestartsCell for its arrow handling, Status and Age use their own
-// status-aware style helpers.
-func styledBuiltinCell(key string, item model.Item,
-	nsW, readyW, restartsW, statusW, ageW int, anyRecentRestart bool,
-) string {
-	switch key {
-	case "Namespace":
-		ns := item.Namespace
-		if ns == "" {
-			ns = "-"
-		}
-		return DimStyle.Render(padRight(Truncate(ns, nsW-1), nsW))
-	case "Ready":
-		return DimStyle.Render(padRight(item.Ready, readyW))
-	case "Restarts":
-		return styledRestartsCell(item, restartsW, anyRecentRestart)
-	case "Status":
-		val := AbbreviateStatusForWidth(item.Status, statusW-1)
-		return StatusStyle(val).Render(padRight(Truncate(val, statusW-1), statusW))
-	case "Age":
-		age := LiveAge(item)
-		return AgeStyle(age).Render(padRight(age, ageW))
-	}
-	return ""
-}
-
 // styledRestartsCell renders the restarts column with recent-restart arrow
 // styling. Rows whose LastRestartAt is within the past hour are tagged with
 // an up-arrow; when any row in the table has a recent restart, rows without
@@ -196,23 +147,15 @@ func formatTableRowOrdered(name, ns, ready, restarts, status, age string,
 	nameW, contextW, nsW, readyW, restartsW, statusW, ageW int,
 	order []string, extraCols []extraColumn, item *model.Item,
 ) string {
+	widths := builtinColWidths{context: contextW, ns: nsW, ready: readyW, restarts: restartsW, status: statusW, age: ageW}
+	inputs := plainCellInputs{item: item, ns: ns, ready: ready, restarts: restarts, status: status, age: age, widths: widths}
 	var row strings.Builder
 	row.WriteString(padRight(Truncate(name, nameW-1), nameW))
 	for _, key := range order {
-		if key == "Context" && contextW > 0 {
-			contextName := ""
-			if item != nil {
-				contextName = item.ClusterName
-			}
-			row.WriteString(padRight(Truncate(contextName, contextW-1), contextW))
+		if col := renderableBuiltin(key, widths); col != nil {
+			row.WriteString(col.plain(inputs))
 			continue
 		}
-		if isBuiltinColumnKey(key) {
-			row.WriteString(plainBuiltinCell(key, ns, ready, restarts, status, age,
-				nsW, readyW, restartsW, statusW, ageW))
-			continue
-		}
-		// Extra column: look up metadata and emit via plainExtraCell.
 		for _, ec := range extraCols {
 			if ec.key == key {
 				row.WriteString(plainExtraCell(ec, item))
@@ -230,15 +173,13 @@ func formatTableRowStyledOrdered(item model.Item,
 	nameW, contextW, nsW, readyW, restartsW, statusW, ageW int,
 	order []string, extraCols []extraColumn, anyRecentRestart bool,
 ) string {
+	widths := builtinColWidths{context: contextW, ns: nsW, ready: readyW, restarts: restartsW, status: statusW, age: ageW}
+	inputs := styledCellInputs{item: item, widths: widths, anyRecentRestart: anyRecentRestart}
 	var base strings.Builder
 	base.WriteString(styledNameCell(item, nameW))
 	for _, key := range order {
-		if key == "Context" && contextW > 0 {
-			base.WriteString(DimStyle.Render(padRight(Truncate(item.ClusterName, contextW-1), contextW)))
-			continue
-		}
-		if isBuiltinColumnKey(key) {
-			base.WriteString(styledBuiltinCell(key, item, nsW, readyW, restartsW, statusW, ageW, anyRecentRestart))
+		if col := renderableBuiltin(key, widths); col != nil {
+			base.WriteString(col.styled(inputs))
 			continue
 		}
 		for _, ec := range extraCols {

--- a/internal/ui/explorer_format_test.go
+++ b/internal/ui/explorer_format_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
 
 // --- formatTableRowOrdered ---
@@ -378,4 +381,91 @@ func TestRenderTabBar(t *testing.T) {
 			}
 		}
 	})
+}
+
+// --- Row builder byte-parity regression ---
+//
+// These tests pin exact output for the row builders so the wantContains-style
+// tests above can't silently let column-cell padding/truncation/styling drift
+// past us. They're the safety net for the builtin-column-registry refactor:
+// if any registry entry diverges from its old switch-arm semantics, the
+// expected byte string here fails immediately.
+
+func TestFormatTableRowOrdered_AllColumnsExactBytes(t *testing.T) {
+	prev := ActiveHighlightQuery
+	ActiveHighlightQuery = ""
+	t.Cleanup(func() { ActiveHighlightQuery = prev })
+
+	item := model.Item{
+		Name:        "pod-1",
+		Namespace:   "default",
+		Status:      "Running",
+		Ready:       "1/1",
+		Restarts:    "0",
+		Age:         "5d",
+		ClusterName: "prod",
+	}
+	order := []string{"Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
+
+	got := formatTableRowOrdered(
+		item.Name, item.Namespace, item.Ready, item.Restarts, item.Status, item.Age,
+		10, 8, 10, 6, 4, 10, 4,
+		order, nil, &item,
+	)
+
+	// name(10) + context(8) + ns(10) + ready(6) + restarts(4) + status(10) + age(4) = 52
+	want := "pod-1     prod    default   1/1   0   Running   5d  "
+	assert.Equal(t, want, got)
+	assert.Equal(t, 52, len(got), "total width must match sum of column widths")
+}
+
+func TestFormatTableRowOrdered_ContextZeroWidthFallsThrough(t *testing.T) {
+	prev := ActiveHighlightQuery
+	ActiveHighlightQuery = ""
+	t.Cleanup(func() { ActiveHighlightQuery = prev })
+
+	item := model.Item{Name: "pod-1", Namespace: "default", ClusterName: "should-not-render"}
+	order := []string{"Context", "Namespace"}
+
+	got := formatTableRowOrdered(
+		"pod-1", "default", "", "", "", "",
+		10, 0, 10, 0, 0, 0, 0,
+		order, nil, &item,
+	)
+
+	want := "pod-1     default   "
+	assert.Equal(t, want, got)
+	assert.NotContains(t, got, "should-not-render", "zero-width Context must not render ClusterName")
+}
+
+func TestFormatTableRowStyledOrdered_VisibleWidthAndContent(t *testing.T) {
+	prev := ActiveHighlightQuery
+	ActiveHighlightQuery = ""
+	t.Cleanup(func() { ActiveHighlightQuery = prev })
+
+	item := model.Item{
+		Name:        "pod-1",
+		Namespace:   "default",
+		Status:      "Running",
+		Ready:       "1/1",
+		Restarts:    "0",
+		Age:         "5d",
+		ClusterName: "prod",
+	}
+	order := []string{"Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
+
+	got := formatTableRowStyledOrdered(item,
+		10, 8, 10, 6, 4, 10, 4,
+		order, nil, false)
+
+	// Visible width pins padding; ANSI-stripped content pins per-cell text.
+	// Together these catch any styling/padding drift in the registry's
+	// styled render functions without overcommitting to lipgloss escape
+	// byte sequences.
+	assert.Equal(t, 52, lipgloss.Width(got),
+		"visible width must equal sum of column widths")
+	assert.Equal(t,
+		"pod-1     prod    default   1/1   0   Running   5d  ",
+		ansi.Strip(got),
+		"ANSI-stripped styled row must match plain row layout")
 }

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -317,12 +317,15 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		headerLabel = "NAME"
 	}
 	nameHeader := headerWithIndicator(headerLabel, "Name", nameW)
-	contextHeader := headerWithIndicator("CONTEXT", "Context", contextW)
-	nsHeader := headerWithIndicator("NAMESPACE", "Namespace", nsW)
-	readyHeader := headerWithIndicator("READY", "Ready", readyW)
-	rsHeader := headerWithIndicator("RS", "Restarts", restartsW)
-	statusHeader := headerWithIndicator("STATUS", "Status", statusW)
-	ageHeader := headerWithIndicator("AGE", "Age", ageW)
+	colWidths := builtinColWidths{context: contextW, ns: nsW, ready: readyW, restarts: restartsW, status: statusW, age: ageW}
+	colHeaders := builtinColHeaders{
+		context:  headerWithIndicator("CONTEXT", "Context", contextW),
+		ns:       headerWithIndicator("NAMESPACE", "Namespace", nsW),
+		ready:    headerWithIndicator("READY", "Ready", readyW),
+		restarts: headerWithIndicator("RS", "Restarts", restartsW),
+		status:   headerWithIndicator("STATUS", "Status", statusW),
+		age:      headerWithIndicator("AGE", "Age", ageW),
+	}
 
 	var hdrParts []string
 	if wantMarker {
@@ -335,7 +338,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 	}
 	hdrParts = append(hdrParts, nameHeader)
 	for _, key := range order {
-		hdrParts = append(hdrParts, headerCellForKey(key, contextW, extraCols, contextHeader, nsHeader, readyHeader, rsHeader, statusHeader, ageHeader))
+		hdrParts = append(hdrParts, headerCellForKey(key, colWidths, colHeaders, extraCols))
 	}
 	hdr := strings.Join(hdrParts, "")
 	b.WriteString(DimStyle.Bold(true).Render(Truncate(hdr, width)))
@@ -353,7 +356,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		ActiveMiddleColumnLayout = append(ActiveMiddleColumnLayout, MiddleColumnRegion{Key: "Name", StartX: x, EndX: x + nameW})
 		x += nameW
 		for _, key := range order {
-			w := widthForColumnKey(key, contextW, nsW, readyW, restartsW, statusW, ageW, extraCols)
+			w := widthForColumnKey(key, colWidths, extraCols)
 			ActiveMiddleColumnLayout = append(ActiveMiddleColumnLayout, MiddleColumnRegion{Key: key, StartX: x, EndX: x + w})
 			x += w
 		}

--- a/internal/ui/explorer_table_columns.go
+++ b/internal/ui/explorer_table_columns.go
@@ -1,13 +1,12 @@
 package ui
 
 // isBuiltinColumnKey reports whether key is one of the fixed built-in item
-// field columns other than the union-only Context column.
+// field columns other than the union-only Context column. Context is excluded
+// because, when it isn't already requested via hasContext, an extras-defined
+// "Context" can still render.
 func isBuiltinColumnKey(key string) bool {
-	switch key {
-	case "Namespace", "Ready", "Restarts", "Status", "Age":
-		return true
-	}
-	return false
+	_, ok := builtinColumnsByKey[key]
+	return ok && key != "Context"
 }
 
 // orderedColumnKeys returns the ordered list of column keys (excluding "Name")
@@ -65,22 +64,10 @@ func orderedColumnKeys(hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasA
 }
 
 // widthForColumnKey returns the precomputed width for a given column key.
-func widthForColumnKey(key string, contextW, nsW, readyW, restartsW, statusW, ageW int, extraCols []extraColumn) int {
-	switch key {
-	case "Context":
-		if contextW > 0 {
-			return contextW
-		}
-	case "Namespace":
-		return nsW
-	case "Ready":
-		return readyW
-	case "Restarts":
-		return restartsW
-	case "Status":
-		return statusW
-	case "Age":
-		return ageW
+// Builtin keys come from the column registry; extras are looked up by key.
+func widthForColumnKey(key string, widths builtinColWidths, extraCols []extraColumn) int {
+	if col := renderableBuiltin(key, widths); col != nil {
+		return col.width(widths)
 	}
 	for _, ec := range extraCols {
 		if ec.key == key {
@@ -91,25 +78,11 @@ func widthForColumnKey(key string, contextW, nsW, readyW, restartsW, statusW, ag
 }
 
 // headerCellForKey returns the pre-styled header cell string for a single
-// column key.
-func headerCellForKey(key string, contextW int, extraCols []extraColumn,
-	contextHeader, nsHeader, readyHeader, rsHeader, statusHeader, ageHeader string,
-) string {
-	switch key {
-	case "Context":
-		if contextW > 0 {
-			return contextHeader
-		}
-	case "Namespace":
-		return nsHeader
-	case "Ready":
-		return readyHeader
-	case "Restarts":
-		return rsHeader
-	case "Status":
-		return statusHeader
-	case "Age":
-		return ageHeader
+// column key. Builtin keys read from the precomputed headers struct; extras
+// build their header on the fly using stored width + label.
+func headerCellForKey(key string, widths builtinColWidths, headers builtinColHeaders, extraCols []extraColumn) string {
+	if col := renderableBuiltin(key, widths); col != nil {
+		return col.header(headers)
 	}
 	for _, ec := range extraCols {
 		if ec.key == key {


### PR DESCRIPTION
## Summary

Collapse four parallel dispatch switches (width / header / plain cell / styled cell) plus two inline Context branches in the explorer row builders into a single builtin-column registry. Adding a builtin column is now one struct literal, not edits across five locations. Pure refactor — no user-visible behavior change.

## Type of change

- [ ] feat: new user-facing feature
- [ ] fix: bug fix
- [x] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

<!-- e.g. Closes #123 -->

## Changes

- New `internal/ui/explorer_column_registry.go` defining `builtinColumn` (width / header / plain / styled fns), the `builtinColumns` slice + lookup map, `builtinColWidths` / `builtinColHeaders` / cell-input structs, and a `renderableBuiltin` helper that gates Context to width > 0.
- `widthForColumnKey`, `headerCellForKey`, `isBuiltinColumnKey` in `explorer_table_columns.go` reduced to a single registry lookup each; the strict-builtin set is now derived from the registry rather than a parallel list.
- `formatTableRowOrdered` / `formatTableRowStyledOrdered` route through the registry; the inline `if key == "Context"` branches are gone, and the now-unused `plainBuiltinCell` / `styledBuiltinCell` helpers are removed.
- Call sites in `explorer_table.go` pass `builtinColWidths` / `builtinColHeaders` structs instead of six positional ints/strings.
- Tests: registry unit tests (`renderableBuiltin` edge cases incl. Context width gating, registry key-set + fn presence, `isBuiltinColumnKey`) and exact-byte regression tests for both row builders + the Context-zero-width fall-through path.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

Pure refactor — behavior preserved byte-for-byte by the new regression tests, so no live-cluster check required.

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->