### PR TITLE
fix(views): apply GVR-keyed view columns and hide unlisted builtins

### DIFF
--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -275,6 +275,46 @@ func (m *Model) middleColumnKind() string {
 	return strings.ToLower(m.nav.ResourceType.Kind)
 }
 
+// middleColumnRef returns the ui.ResourceRef identifying the resource
+// currently rendered in the middle column. Used to resolve view configs
+// keyed by GVR or Kind. At LevelOwned/LevelContainers the parent's GVR
+// does not match the rendered items, so only Kind is populated (matching
+// the kind returned by middleColumnKind); resolution then falls back to
+// Kind-only lookup. At shallower levels the full GVR is returned so views
+// keyed by `<group>/<version>/<resource>` resolve.
+func (m *Model) middleColumnRef() ui.ResourceRef {
+	if m.nav.Level == model.LevelOwned || m.nav.Level == model.LevelContainers {
+		if len(m.middleItems) > 0 && m.middleItems[0].Kind != "" {
+			return ui.ResourceRef{Kind: m.middleItems[0].Kind}
+		}
+		return ui.ResourceRef{Kind: m.nav.ResourceType.Kind}
+	}
+	return ui.ResourceRef{
+		Group:    m.nav.ResourceType.APIGroup,
+		Version:  m.nav.ResourceType.APIVersion,
+		Resource: m.nav.ResourceType.Resource,
+		Kind:     m.nav.ResourceType.Kind,
+	}
+}
+
+// viewRefForKind returns a ResourceRef suitable for resolving view config
+// (HiddenBuiltinsForView / ColumnsForKind / ResolveView) for the given
+// kind. When kind matches nav.ResourceType.Kind, the full GVR is included
+// so views keyed by GVR resolve. Otherwise (LevelOwned/LevelContainers
+// where rendered kind diverges from nav.ResourceType) a Kind-only ref is
+// returned so resolution falls back to Kind lookup.
+func (m *Model) viewRefForKind(kind string) ui.ResourceRef {
+	if kind != "" && strings.EqualFold(kind, m.nav.ResourceType.Kind) {
+		return ui.ResourceRef{
+			Group:    m.nav.ResourceType.APIGroup,
+			Version:  m.nav.ResourceType.APIVersion,
+			Resource: m.nav.ResourceType.Resource,
+			Kind:     m.nav.ResourceType.Kind,
+		}
+	}
+	return ui.ResourceRef{Kind: kind}
+}
+
 // navKey builds a unique key from the current navigation state, used for
 // cursor memory and item caching.
 func (m *Model) navKey() string {

--- a/internal/app/update_column_toggle.go
+++ b/internal/app/update_column_toggle.go
@@ -190,7 +190,7 @@ func (m *Model) collectBuiltinToggleEntries(items []model.Item, kind string) []c
 		for _, k := range sessionHidden {
 			hidden[k] = true
 		}
-	} else if viewHidden := ui.HiddenBuiltinsForView(kind, m.nav.Context); viewHidden != nil {
+	} else if viewHidden := ui.HiddenBuiltinsForView(m.viewRefForKind(kind), m.nav.Context); viewHidden != nil {
 		for k := range viewHidden {
 			hidden[k] = true
 		}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -172,7 +172,7 @@ func (m Model) applySessionColumnsForKind(kind string) {
 			set[k] = true
 		}
 		ui.ActiveHiddenBuiltinColumns = set
-	} else if viewHidden := ui.HiddenBuiltinsForView(kind, m.nav.Context); viewHidden != nil {
+	} else if viewHidden := ui.HiddenBuiltinsForView(m.viewRefForKind(kind), m.nav.Context); viewHidden != nil {
 		ui.ActiveHiddenBuiltinColumns = viewHidden
 	} else {
 		ui.ActiveHiddenBuiltinColumns = nil
@@ -243,6 +243,9 @@ func (m Model) viewExplorer() string {
 	// Set fullscreen mode and context for column visibility.
 	ui.ActiveFullscreenMode = m.fullscreenMiddle
 	ui.ActiveContext = m.nav.Context
+	// Carry the middle column's resource ref so view configs keyed by
+	// GVR (e.g. "apps/v1/deployments") resolve inside collectExtraColumns.
+	ui.ActiveResourceRef = m.middleColumnRef()
 
 	// Set sort state for column header indicators.
 	// Mirror the Event override so the arrow appears on "Last Seen"

--- a/internal/app/views_apply_e2e_test.go
+++ b/internal/app/views_apply_e2e_test.go
@@ -76,7 +76,7 @@ func TestViewsConfigEndToEnd_PodWithLabelColumn(t *testing.T) {
 	})
 
 	t.Run("ColumnsForKind returns the view's column order", func(t *testing.T) {
-		cols := ui.ColumnsForKind("Pod", "")
+		cols := ui.ColumnsForKind(ui.ResourceRef{Kind: "Pod"}, "")
 		assert.Equal(t, []string{"Name", "GitSHA", "Age"}, cols)
 	})
 }

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -269,58 +269,52 @@ type ConfigFilterPreset struct {
 // ConfigFilterPresets maps lowercase Kind names to user-configured filter presets.
 var ConfigFilterPresets map[string][]ConfigFilterPreset
 
-// ColumnsForKind returns the configured column list for the given resource kind
+// ColumnsForKind returns the configured column list for the given resource
 // and cluster context. Resolution order: per-cluster resource_columns,
-// per-cluster views, global resource_columns, global views. Per-cluster wins
-// over global; the legacy resource_columns surface wins over views within a
-// scope so users with both keys configured see the explicit resource_columns
-// override.
-func ColumnsForKind(kind, context string) []string {
-	lk := strings.ToLower(kind)
+// per-cluster views (GVR then Kind), global resource_columns, global views
+// (GVR then Kind). Per-cluster wins over global; the legacy resource_columns
+// surface wins over views within a scope so users with both keys configured
+// see the explicit resource_columns override. GVR keys win over Kind keys
+// within the views surface, matching ResolveView.
+func ColumnsForKind(rt ResourceRef, context string) []string {
+	gvrKey := rt.GVRKey()
+	kindKey := rt.KindKey()
 	if context != "" {
 		if len(ConfigClusterResourceColumns) > 0 {
 			if clusterCols, ok := ConfigClusterResourceColumns[context]; ok {
-				if cols, ok := clusterCols[lk]; ok {
+				if cols, ok := clusterCols[kindKey]; ok {
 					return cols
 				}
 			}
 		}
-		if cols := viewColumnNames(ConfigClusterViews[context], lk); cols != nil {
+		if cols := viewColumnNames(ConfigClusterViews[context], gvrKey, kindKey); cols != nil {
 			return cols
 		}
 	}
-	if len(ConfigResourceColumns) > 0 && kind != "" {
-		if cols, ok := ConfigResourceColumns[lk]; ok {
+	if len(ConfigResourceColumns) > 0 && kindKey != "" {
+		if cols, ok := ConfigResourceColumns[kindKey]; ok {
 			return cols
 		}
 	}
-	if cols := viewColumnNames(ConfigViews, lk); cols != nil {
+	if cols := viewColumnNames(ConfigViews, gvrKey, kindKey); cols != nil {
 		return cols
 	}
 	return nil
 }
 
 // HiddenBuiltinsForView returns the set of built-in column keys that should
-// be hidden when rendering kind under the given cluster context. When a view
+// be hidden when rendering rt under the given cluster context. When a view
 // is configured and its columns list omits a given built-in (Context,
 // Namespace, Ready, Restarts, Age, Status), that built-in is hidden so the
 // table renders only what the user asked for. Returns nil when no view is
-// configured for this kind in this scope. Per-cluster wins over global.
-func HiddenBuiltinsForView(kind, context string) map[string]bool {
-	if kind == "" {
+// configured for this resource in this scope. Resolution follows ResolveView:
+// per-cluster GVR > per-cluster Kind > global GVR > global Kind.
+func HiddenBuiltinsForView(rt ResourceRef, context string) map[string]bool {
+	if rt.Kind == "" && rt.Resource == "" {
 		return nil
 	}
-	lk := strings.ToLower(kind)
-	var v *View
-	if context != "" && len(ConfigClusterViews) > 0 {
-		if cluster, ok := ConfigClusterViews[context]; ok {
-			v = cluster[lk]
-		}
-	}
-	if v == nil {
-		v = ConfigViews[lk]
-	}
-	if v == nil {
+	v, ok := ResolveView(rt, context)
+	if !ok || v == nil {
 		return nil
 	}
 	listed := make(map[string]bool, len(v.Columns))
@@ -340,16 +334,20 @@ func HiddenBuiltinsForView(kind, context string) map[string]bool {
 }
 
 // viewColumnNames returns the ordered list of column Name fields from the
-// view stored under key kind, or nil when no view exists. Columns flagged
-// |W (FlagWideOnly) are omitted unless ActiveFullscreenMode is set, so
-// users can keep wide-only columns in their config without crowding narrow
-// table layouts.
-func viewColumnNames(views map[string]*View, kind string) []string {
-	if len(views) == 0 || kind == "" {
+// view stored under gvrKey (preferred) or kindKey (fallback), or nil when
+// no view exists under either. Matches the GVR-then-Kind resolution order
+// used by ResolveView. Columns flagged |W (FlagWideOnly) are omitted unless
+// ActiveFullscreenMode is set, so users can keep wide-only columns in their
+// config without crowding narrow table layouts.
+func viewColumnNames(views map[string]*View, gvrKey, kindKey string) []string {
+	if len(views) == 0 {
 		return nil
 	}
-	v, ok := views[kind]
-	if !ok || v == nil || len(v.Columns) == 0 {
+	v := views[gvrKey]
+	if v == nil && kindKey != "" {
+		v = views[kindKey]
+	}
+	if v == nil || len(v.Columns) == 0 {
 		return nil
 	}
 	names := make([]string, 0, len(v.Columns))

--- a/internal/ui/config_test.go
+++ b/internal/ui/config_test.go
@@ -74,10 +74,10 @@ func TestColumnsForKind_CaseInsensitive(t *testing.T) {
 		"pod": {"name", "status"},
 	}
 
-	assert.Equal(t, []string{"name", "status"}, ColumnsForKind("Pod", ""))
-	assert.Equal(t, []string{"name", "status"}, ColumnsForKind("pod", ""))
-	assert.Nil(t, ColumnsForKind("Deployment", ""))
-	assert.Nil(t, ColumnsForKind("", ""))
+	assert.Equal(t, []string{"name", "status"}, ColumnsForKind(ResourceRef{Kind: "Pod"}, ""))
+	assert.Equal(t, []string{"name", "status"}, ColumnsForKind(ResourceRef{Kind: "pod"}, ""))
+	assert.Nil(t, ColumnsForKind(ResourceRef{Kind: "Deployment"}, ""))
+	assert.Nil(t, ColumnsForKind(ResourceRef{}, ""))
 }
 
 func TestDetectIconModeFromEnv(t *testing.T) {

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -28,6 +28,14 @@ var ActiveFullscreenMode bool
 // Used by collectExtraColumns for per-cluster column config lookups.
 var ActiveContext string
 
+// ActiveResourceRef is set by the app to the resource currently rendered
+// in the middle column. Used by collectExtraColumns so view configs keyed
+// by GVR (e.g. "apps/v1/deployments") resolve, not only by Kind. Empty
+// fields cause GVR lookup to miss and fall back to Kind, matching legacy
+// behaviour at LevelOwned/LevelContainers where the rendered kind diverges
+// from nav.ResourceType.
+var ActiveResourceRef ResourceRef
+
 // ActiveExtraColumnKeys holds the keys of the extra columns currently displayed
 // in the middle column table. Set during RenderTable for the column toggle overlay.
 var ActiveExtraColumnKeys []string

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -250,7 +250,16 @@ func selectColumnCandidates(seen map[string]*colInfo, order []string, kind strin
 		return candidates
 	}
 
-	configCols := ColumnsForKind(kind, ActiveContext)
+	// Build a ResourceRef so GVR-keyed view configs resolve. When the
+	// rendered kind matches ActiveResourceRef (set by the app for the
+	// middle column) carry through the full GVR; otherwise fall back to
+	// Kind-only — at LevelOwned/LevelContainers the rendered kind diverges
+	// from nav.ResourceType so GVR can't be trusted and Kind lookup applies.
+	rt := ResourceRef{Kind: kind}
+	if kind != "" && strings.EqualFold(kind, ActiveResourceRef.Kind) {
+		rt = ActiveResourceRef
+	}
+	configCols := ColumnsForKind(rt, ActiveContext)
 	if len(configCols) > 0 {
 		if len(configCols) == 1 && configCols[0] == "*" {
 			return order

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -182,45 +182,45 @@ func TestColumnsForKind(t *testing.T) {
 
 	t.Run("returns nil when nothing configured", func(t *testing.T) {
 		ConfigResourceColumns = nil
-		assert.Nil(t, ColumnsForKind("Pod", ""))
-		assert.Nil(t, ColumnsForKind("", ""))
+		assert.Nil(t, ColumnsForKind(ResourceRef{Kind: "Pod"}, ""))
+		assert.Nil(t, ColumnsForKind(ResourceRef{}, ""))
 	})
 
 	t.Run("returns nil for unconfigured kind", func(t *testing.T) {
 		ConfigResourceColumns = map[string][]string{
 			"pod": {"IP", "Node", "Image"},
 		}
-		assert.Nil(t, ColumnsForKind("Deployment", ""))
+		assert.Nil(t, ColumnsForKind(ResourceRef{Kind: "Deployment"}, ""))
 	})
 
 	t.Run("returns columns for configured kind", func(t *testing.T) {
 		ConfigResourceColumns = map[string][]string{
 			"pod": {"IP", "Node", "Image"},
 		}
-		assert.Equal(t, []string{"IP", "Node", "Image"}, ColumnsForKind("Pod", ""))
+		assert.Equal(t, []string{"IP", "Node", "Image"}, ColumnsForKind(ResourceRef{Kind: "Pod"}, ""))
 	})
 
 	t.Run("kind lookup is case-insensitive", func(t *testing.T) {
 		ConfigResourceColumns = map[string][]string{
 			"deployment": {"Replicas", "Available"},
 		}
-		assert.Equal(t, []string{"Replicas", "Available"}, ColumnsForKind("Deployment", ""))
-		assert.Equal(t, []string{"Replicas", "Available"}, ColumnsForKind("deployment", ""))
-		assert.Equal(t, []string{"Replicas", "Available"}, ColumnsForKind("DEPLOYMENT", ""))
+		assert.Equal(t, []string{"Replicas", "Available"}, ColumnsForKind(ResourceRef{Kind: "Deployment"}, ""))
+		assert.Equal(t, []string{"Replicas", "Available"}, ColumnsForKind(ResourceRef{Kind: "deployment"}, ""))
+		assert.Equal(t, []string{"Replicas", "Available"}, ColumnsForKind(ResourceRef{Kind: "DEPLOYMENT"}, ""))
 	})
 
 	t.Run("empty kind returns nil", func(t *testing.T) {
 		ConfigResourceColumns = map[string][]string{
 			"pod": {"IP"},
 		}
-		assert.Nil(t, ColumnsForKind("", ""))
+		assert.Nil(t, ColumnsForKind(ResourceRef{}, ""))
 	})
 
 	t.Run("wildcard works", func(t *testing.T) {
 		ConfigResourceColumns = map[string][]string{
 			"pod": {"*"},
 		}
-		assert.Equal(t, []string{"*"}, ColumnsForKind("Pod", ""))
+		assert.Equal(t, []string{"*"}, ColumnsForKind(ResourceRef{Kind: "Pod"}, ""))
 	})
 }
 

--- a/internal/ui/views_columns_for_kind_test.go
+++ b/internal/ui/views_columns_for_kind_test.go
@@ -20,7 +20,7 @@ func TestColumnsForKind_ReadsFromView(t *testing.T) {
 	ConfigViews = map[string]*View{"pod": v}
 	ConfigResourceColumns = nil
 
-	cols := ColumnsForKind("Pod", "")
+	cols := ColumnsForKind(ResourceRef{Kind: "Pod"}, "")
 	assert.Equal(t, []string{"Name", "GitSHA", "Age"}, cols)
 }
 
@@ -33,7 +33,7 @@ func TestColumnsForKind_ResourceColumnsWinsOverViewInSameScope(t *testing.T) {
 	ConfigViews = map[string]*View{"pod": v}
 	ConfigResourceColumns = map[string][]string{"pod": {"Name", "Status"}}
 
-	cols := ColumnsForKind("Pod", "")
+	cols := ColumnsForKind(ResourceRef{Kind: "Pod"}, "")
 	assert.Equal(t, []string{"Name", "Status"}, cols, "explicit resource_columns wins over views in the same scope")
 }
 
@@ -61,12 +61,12 @@ func TestColumnsForKind_WideOnlyFiltered(t *testing.T) {
 
 	t.Run("narrow mode hides |W column", func(t *testing.T) {
 		ActiveFullscreenMode = false
-		assert.Equal(t, []string{"Name", "Age"}, ColumnsForKind("Pod", ""))
+		assert.Equal(t, []string{"Name", "Age"}, ColumnsForKind(ResourceRef{Kind: "Pod"}, ""))
 	})
 
 	t.Run("fullscreen mode reveals |W column", func(t *testing.T) {
 		ActiveFullscreenMode = true
-		assert.Equal(t, []string{"Name", "GitSHA", "Age"}, ColumnsForKind("Pod", ""))
+		assert.Equal(t, []string{"Name", "GitSHA", "Age"}, ColumnsForKind(ResourceRef{Kind: "Pod"}, ""))
 	})
 }
 
@@ -82,9 +82,45 @@ func TestColumnsForKind_PerClusterViewWinsOverGlobal(t *testing.T) {
 		"prod": {"pod": prodView},
 	}
 
-	cols := ColumnsForKind("Pod", "prod")
+	cols := ColumnsForKind(ResourceRef{Kind: "Pod"}, "prod")
 	assert.Equal(t, []string{"Name", "X", "Y"}, cols)
 
-	cols = ColumnsForKind("Pod", "dev")
+	cols = ColumnsForKind(ResourceRef{Kind: "Pod"}, "dev")
 	assert.Equal(t, []string{"Name", "Age"}, cols, "fallback to global view when per-cluster has none")
+}
+
+// Issue #262 regression: a GVR-keyed view's columns list must be returned
+// when only a GVR key is configured. Previously ColumnsForKind looked up
+// by Kind only, so users got the default columns instead of their config.
+func TestColumnsForKind_GVRKeyedViewReturnsColumns(t *testing.T) {
+	resetViewsGlobals(t)
+	origRC := ConfigResourceColumns
+	t.Cleanup(func() { ConfigResourceColumns = origRC })
+
+	v, _ := BuildView(&ConfigView{Columns: []string{"Name", "Replicas", "Available", "REV:.metadata.resourceVersion", "Age"}})
+	ConfigViews = map[string]*View{"apps/v1/deployments": v}
+	ConfigResourceColumns = nil
+
+	rt := ResourceRef{Group: "apps", Version: "v1", Resource: "deployments", Kind: "Deployment"}
+	cols := ColumnsForKind(rt, "")
+	assert.Equal(t, []string{"Name", "Replicas", "Available", "REV", "Age"}, cols)
+}
+
+// GVR takes precedence over Kind when both are configured.
+func TestColumnsForKind_GVRWinsOverKind(t *testing.T) {
+	resetViewsGlobals(t)
+	origRC := ConfigResourceColumns
+	t.Cleanup(func() { ConfigResourceColumns = origRC })
+
+	gvr, _ := BuildView(&ConfigView{Columns: []string{"Name", "Replicas"}})
+	kind, _ := BuildView(&ConfigView{Columns: []string{"Name", "Available", "Age"}})
+	ConfigViews = map[string]*View{
+		"apps/v1/deployments": gvr,
+		"deployment":          kind,
+	}
+	ConfigResourceColumns = nil
+
+	rt := ResourceRef{Group: "apps", Version: "v1", Resource: "deployments", Kind: "Deployment"}
+	cols := ColumnsForKind(rt, "")
+	assert.Equal(t, []string{"Name", "Replicas"}, cols, "GVR view wins over Kind view")
 }

--- a/internal/ui/views_hidden_builtins_test.go
+++ b/internal/ui/views_hidden_builtins_test.go
@@ -17,7 +17,7 @@ func TestHiddenBuiltinsForView_HidesUnlistedBuiltins(t *testing.T) {
 	}
 	ConfigViews = map[string]*View{"pod": v}
 
-	hidden := HiddenBuiltinsForView("Pod", "")
+	hidden := HiddenBuiltinsForView(ResourceRef{Kind: "Pod"}, "")
 	assert.Equal(t, map[string]bool{
 		"Context":   true,
 		"Namespace": true,
@@ -36,7 +36,7 @@ func TestHiddenBuiltinsForView_ListedBuiltinsKept(t *testing.T) {
 	})
 	ConfigViews = map[string]*View{"pod": v}
 
-	hidden := HiddenBuiltinsForView("Pod", "")
+	hidden := HiddenBuiltinsForView(ResourceRef{Kind: "Pod"}, "")
 	assert.False(t, hidden["Status"])
 	assert.False(t, hidden["Ready"])
 	assert.False(t, hidden["Age"])
@@ -46,7 +46,7 @@ func TestHiddenBuiltinsForView_ListedBuiltinsKept(t *testing.T) {
 
 func TestHiddenBuiltinsForView_NoViewReturnsNil(t *testing.T) {
 	resetViewsGlobals(t)
-	assert.Nil(t, HiddenBuiltinsForView("Pod", ""))
+	assert.Nil(t, HiddenBuiltinsForView(ResourceRef{Kind: "Pod"}, ""))
 }
 
 func TestHiddenBuiltinsForView_PerClusterWins(t *testing.T) {
@@ -57,12 +57,12 @@ func TestHiddenBuiltinsForView_PerClusterWins(t *testing.T) {
 	ConfigViews = map[string]*View{"pod": global}
 	ConfigClusterViews = map[string]map[string]*View{"prod": {"pod": prod}}
 
-	hiddenProd := HiddenBuiltinsForView("Pod", "prod")
+	hiddenProd := HiddenBuiltinsForView(ResourceRef{Kind: "Pod"}, "prod")
 	assert.True(t, hiddenProd["Status"], "prod view doesn't list Status")
 	assert.True(t, hiddenProd["Age"], "prod view doesn't list Age")
 	assert.False(t, hiddenProd["Namespace"], "prod view lists Namespace")
 
-	hiddenDev := HiddenBuiltinsForView("Pod", "dev")
+	hiddenDev := HiddenBuiltinsForView(ResourceRef{Kind: "Pod"}, "dev")
 	assert.True(t, hiddenDev["Namespace"], "global view doesn't list Namespace; dev falls back to global")
 	assert.False(t, hiddenDev["Age"], "global view lists Age")
 }
@@ -73,5 +73,42 @@ func TestHiddenBuiltinsForView_AllBuiltinsListedReturnsNil(t *testing.T) {
 		Columns: []string{"Name", "Context", "Namespace", "Ready", "Restarts", "Status", "Age"},
 	})
 	ConfigViews = map[string]*View{"pod": v}
-	assert.Nil(t, HiddenBuiltinsForView("Pod", ""))
+	assert.Nil(t, HiddenBuiltinsForView(ResourceRef{Kind: "Pod"}, ""))
+}
+
+// Issue #262 regression: a GVR-keyed view must hide unlisted built-ins
+// the same way a Kind-keyed view does. Previously HiddenBuiltinsForView
+// only looked up by Kind, so configs under `apps/v1/deployments` left
+// every built-in column visible.
+func TestHiddenBuiltinsForView_GVRKeyedHidesUnlistedBuiltins(t *testing.T) {
+	resetViewsGlobals(t)
+
+	v, _ := BuildView(&ConfigView{Columns: []string{"Name", "Replicas", "Available", "REV:.metadata.resourceVersion", "Age"}})
+	ConfigViews = map[string]*View{"apps/v1/deployments": v}
+
+	rt := ResourceRef{Group: "apps", Version: "v1", Resource: "deployments", Kind: "Deployment"}
+	hidden := HiddenBuiltinsForView(rt, "")
+
+	assert.True(t, hidden["Namespace"], "Namespace not in view; should be hidden")
+	assert.True(t, hidden["Ready"], "Ready not in view; should be hidden")
+	assert.True(t, hidden["Status"], "Status not in view; should be hidden")
+	assert.False(t, hidden["Age"], "Age listed; should not be hidden")
+}
+
+// GVR takes precedence over Kind when both are configured, matching ResolveView.
+func TestHiddenBuiltinsForView_GVRWinsOverKind(t *testing.T) {
+	resetViewsGlobals(t)
+
+	gvr, _ := BuildView(&ConfigView{Columns: []string{"Name", "Replicas"}})
+	kind, _ := BuildView(&ConfigView{Columns: []string{"Name", "Status", "Ready", "Age"}})
+	ConfigViews = map[string]*View{
+		"apps/v1/deployments": gvr,
+		"deployment":          kind,
+	}
+
+	rt := ResourceRef{Group: "apps", Version: "v1", Resource: "deployments", Kind: "Deployment"}
+	hidden := HiddenBuiltinsForView(rt, "")
+
+	assert.True(t, hidden["Status"], "GVR view doesn't list Status; should be hidden even though Kind view lists it")
+	assert.True(t, hidden["Age"], "GVR view doesn't list Age")
 }


### PR DESCRIPTION
## Summary

Fixes #262 — when a view is configured under a GVR key (e.g. `apps/v1/deployments`) instead of a Kind key (`deployment`), the `columns` list was silently ignored and built-in columns stayed visible. `sort_column` and JSONPath column values already worked because `ResolveView` checks GVR-then-Kind; the column-visibility helpers did not.

- `ColumnsForKind` and `HiddenBuiltinsForView` now take a `ResourceRef` and resolve GVR-then-Kind (matching `ResolveView`).
- `HiddenBuiltinsForView` delegates to `ResolveView` to avoid drifting from its lookup order.
- New `ui.ActiveResourceRef` global carries the rendered resource into `collectExtraColumns`.
- At LevelOwned/LevelContainers (rendered kind diverges from `nav.ResourceType`) callers pass a Kind-only ref, preserving existing behaviour.

## Test plan
- [x] `go test ./... -race`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] New tests cover GVR-keyed lookup and GVR-wins-over-Kind precedence for both helpers
- [ ] Manual: with `views.apps/v1/deployments` configured with custom `columns` + `sort_column`, deployments list renders the configured columns (not defaults + extras) and respects the sort