### PR TITLE
fix(nix): update vendorHash after k8s dependency bump

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-zUfHbY8zyQxKOuruwi0G6J+d5o3ihU96Hg1OqPRtB9g=";
+            vendorHash = "sha256-3kQLUdKc8VYblYHFVh+iPl+mMfdnkHe138dMwPy50WQ=";
 
             subPackages = [ "." ];
 


### PR DESCRIPTION
## Summary

`nix run github:janosmiko/lfk` fails with a hash mismatch because commit `dba14ac` updated Go dependencies in `go.sum` (k8s.io modules 0.36.0→0.36.1, several golang.org/x/* packages) without updating the `vendorHash` in `flake.nix`.

## Reproduction

```sh
nix run github:janosmiko/lfk
```

Output:

```
error: hash mismatch in fixed-output derivation '/nix/store/anxzqbais7b240ma89sam5c38gygalp9-lfk-0.12.6-8749e2f-go-modules.drv':
         specified: sha256-zUfHbY8zyQxKOuruwi0G6J+d5o3ihU96Hg1OqPRtB9g=
            got:    sha256-3kQLUdKc8VYblYHFVh+iPl+mMfdnkHe138dMwPy50WQ=
error: Cannot build '/nix/store/cjdl3ampmxkrqw26x3cq505y7lmsnf1a-lfk-0.12.6-8749e2f.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/6kqldagydwkp2p1fz7pslpylsw1sv7nb-lfk-0.12.6-8749e2f
❌ /nix/store/cjdl3ampmxkrqw26x3cq505y7lmsnf1a-lfk-0.12.6-8749e2f.drv^out
error: Build failed due to failed dependency
```

## Type of change

- [x] fix: bug fix

## Related issue

Closes #284

## Changes

- Update `vendorHash` in `flake.nix` from `sha256-zUfHb...` to `sha256-3kQLUd...` to match current `go.sum`

## Testing

- [x] `go build ./...` succeeds (no Go code changed)
- [ ] `go test ./...` passes (no Go code changed)
- [ ] `golangci-lint run` passes (no Go code changed)
- [ ] Manually verified against a real cluster (N/A — build-time only fix)

## Checklist

- [x] Commits follow conventional commit style (`fix(nix): ...`)
- [x] README / `docs/` not affected
- [x] No keybinding changes
- [x] No secrets, tokens, or personal data
- [x] PR is opened from a feature branch on a fork