### PR TITLE
feat: add negative namespace selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Clusters (kubeconfig contexts)
                     +-- Containers (for Pods)
 ```
 
-Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`. All-namespaces mode is enabled by default (toggle with `A`).
+Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection — shows all except the marked namespaces, each prefixed with `!`), or `A` to reset to all-namespaces mode.
 
 ### Owner Resolution
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -148,6 +148,7 @@ type Model struct {
 
 	// Multi-select namespace state.
 	selectedNamespaces  map[string]bool
+	nsSelectionNegated  bool // when true, selectedNamespaces is an EXCLUDE set
 	nsFilterMode        bool
 	nsSelectionModified bool   // tracks if Space was pressed in current ns overlay session
 	nsFilterEntryItem   string // namespace name selected when filter mode was entered; restored on Esc

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -432,6 +432,7 @@ type TabState struct {
 	namespace          string
 	allNamespaces      bool
 	selectedNamespaces map[string]bool
+	nsSelectionNegated bool
 	sortColumnName     string // column name to sort by (e.g. "Name", "Age", "CPU")
 	sortAscending      bool
 	filterText         string

--- a/internal/app/negative_namespace_test.go
+++ b/internal/app/negative_namespace_test.go
@@ -1,0 +1,491 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// --- effectiveNamespace: negation ---
+
+func TestEffectiveNamespaceNegated(t *testing.T) {
+	tests := []struct {
+		name               string
+		namespace          string
+		allNamespaces      bool
+		selectedNamespaces map[string]bool
+		nsSelectionNegated bool
+		expected           string
+	}{
+		{
+			name:               "negated with one excluded: returns empty (must list all)",
+			namespace:          "default",
+			selectedNamespaces: map[string]bool{"kube-system": true},
+			nsSelectionNegated: true,
+			expected:           "",
+		},
+		{
+			name:               "negated with multiple excluded: returns empty",
+			namespace:          "default",
+			selectedNamespaces: map[string]bool{"kube-system": true, "monitoring": true},
+			nsSelectionNegated: true,
+			expected:           "",
+		},
+		{
+			name:               "negated with empty set: returns empty (equivalent to all)",
+			namespace:          "default",
+			selectedNamespaces: nil,
+			nsSelectionNegated: true,
+			expected:           "",
+		},
+		{
+			name:               "not negated, single selected: unchanged",
+			namespace:          "default",
+			selectedNamespaces: map[string]bool{"production": true},
+			nsSelectionNegated: false,
+			expected:           "production",
+		},
+		{
+			name:               "not negated, allNamespaces: unchanged",
+			namespace:          "default",
+			allNamespaces:      true,
+			nsSelectionNegated: false,
+			expected:           "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{
+				namespace:          tt.namespace,
+				allNamespaces:      tt.allNamespaces,
+				selectedNamespaces: tt.selectedNamespaces,
+				nsSelectionNegated: tt.nsSelectionNegated,
+			}
+			assert.Equal(t, tt.expected, m.effectiveNamespace())
+		})
+	}
+}
+
+// --- filterLoadedItemsBySelectedNamespaces: negation ---
+
+func TestFilterLoadedItemsBySelectedNamespacesNegated(t *testing.T) {
+	items := []model.Item{
+		{Name: "pod-a", Namespace: "default"},
+		{Name: "pod-b", Namespace: "kube-system"},
+		{Name: "pod-c", Namespace: "monitoring"},
+		{Name: "node-1", Namespace: ""}, // cluster-scoped: always kept
+	}
+
+	t.Run("exclude one namespace: keeps others and cluster-scoped", func(t *testing.T) {
+		m := Model{
+			selectedNamespaces: map[string]bool{"kube-system": true},
+			nsSelectionNegated: true,
+		}
+		result := m.filterLoadedItemsBySelectedNamespaces(items)
+		names := negNsItemNames(result)
+		assert.Contains(t, names, "pod-a")
+		assert.NotContains(t, names, "pod-b")
+		assert.Contains(t, names, "pod-c")
+		assert.Contains(t, names, "node-1") // cluster-scoped always kept
+	})
+
+	t.Run("exclude multiple namespaces", func(t *testing.T) {
+		m := Model{
+			selectedNamespaces: map[string]bool{"kube-system": true, "monitoring": true},
+			nsSelectionNegated: true,
+		}
+		result := m.filterLoadedItemsBySelectedNamespaces(items)
+		names := negNsItemNames(result)
+		assert.Contains(t, names, "pod-a")
+		assert.NotContains(t, names, "pod-b")
+		assert.NotContains(t, names, "pod-c")
+		assert.Contains(t, names, "node-1")
+	})
+
+	t.Run("single excluded namespace is NOT short-circuited", func(t *testing.T) {
+		// This is the critical regression: the old early-return
+		// `if len(m.selectedNamespaces) <= 1 { return items }` must NOT fire
+		// when negated with exactly one excluded namespace.
+		m := Model{
+			selectedNamespaces: map[string]bool{"kube-system": true},
+			nsSelectionNegated: true,
+		}
+		result := m.filterLoadedItemsBySelectedNamespaces(items)
+		// kube-system must be excluded
+		for _, item := range result {
+			assert.NotEqual(t, "kube-system", item.Namespace,
+				"kube-system must be excluded when negated")
+		}
+	})
+
+	t.Run("non-negated behavior unchanged with two namespaces", func(t *testing.T) {
+		m := Model{
+			selectedNamespaces: map[string]bool{"default": true, "monitoring": true},
+			nsSelectionNegated: false,
+		}
+		result := m.filterLoadedItemsBySelectedNamespaces(items)
+		names := negNsItemNames(result)
+		assert.Contains(t, names, "pod-a")
+		assert.NotContains(t, names, "pod-b")
+		assert.Contains(t, names, "pod-c")
+		assert.Contains(t, names, "node-1")
+	})
+
+	t.Run("non-negated behavior unchanged with one namespace (early-return)", func(t *testing.T) {
+		m := Model{
+			selectedNamespaces: map[string]bool{"default": true},
+			nsSelectionNegated: false,
+		}
+		result := m.filterLoadedItemsBySelectedNamespaces(items)
+		// Early-return: all items returned unchanged
+		assert.Len(t, result, len(items))
+	})
+}
+
+func negNsItemNames(items []model.Item) []string {
+	names := make([]string, len(items))
+	for i, it := range items {
+		names[i] = it.Name
+	}
+	return names
+}
+
+// --- fetchFingerprint: negation changes fingerprint ---
+
+func TestFetchFingerprintNegationDifferent(t *testing.T) {
+	sel := map[string]bool{"kube-system": true}
+
+	mInclude := Model{
+		namespace:          "default",
+		selectedNamespaces: sel,
+		nsSelectionNegated: false,
+	}
+	mExclude := Model{
+		namespace:          "default",
+		selectedNamespaces: sel,
+		nsSelectionNegated: true,
+	}
+
+	fpInclude := mInclude.fetchFingerprint()
+	fpExclude := mExclude.fetchFingerprint()
+
+	assert.NotEqual(t, fpInclude, fpExclude,
+		"include-scope and exclude-scope over the same set must produce different fingerprints")
+}
+
+func TestFetchFingerprintNegationContainsBang(t *testing.T) {
+	m := Model{
+		namespace:          "default",
+		selectedNamespaces: map[string]bool{"kube-system": true},
+		nsSelectionNegated: true,
+	}
+	fp := m.fetchFingerprint()
+	assert.True(t, strings.Contains(fp, "!"),
+		"negated fingerprint must contain '!' prefix: got %q", fp)
+}
+
+// --- namespace selector "tab" key (toggles exclude mode) ---
+
+func TestNamespaceOverlayTabTogglesNegation(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.nsSelectionNegated = false
+
+	ret, _ := m.handleNamespaceOverlayKey(keyMsg("tab"))
+	result := ret.(Model)
+
+	assert.True(t, result.nsSelectionNegated, "tab must set nsSelectionNegated to true")
+	assert.True(t, result.nsSelectionModified, "tab must set nsSelectionModified")
+}
+
+func TestNamespaceOverlayTabTogglesOff(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.nsSelectionNegated = true
+
+	ret, _ := m.handleNamespaceOverlayKey(keyMsg("tab"))
+	result := ret.(Model)
+
+	assert.False(t, result.nsSelectionNegated, "tab must toggle nsSelectionNegated off")
+	assert.True(t, result.nsSelectionModified, "tab must set nsSelectionModified")
+}
+
+func TestNamespaceOverlayTabWithEmptySetIsHarmless(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.selectedNamespaces = nil
+	m.nsSelectionNegated = false
+
+	ret, _ := m.handleNamespaceOverlayKey(keyMsg("tab"))
+	result := ret.(Model)
+
+	assert.True(t, result.nsSelectionNegated, "tab on empty set must still flip the flag")
+}
+
+func TestNamespaceOverlayAllNamespacesClearsNegation(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.nsSelectionNegated = true
+
+	ret, _ := m.handleNamespaceOverlayKey(keyMsg(ui.ActiveKeybindings.AllNamespaces))
+	result := ret.(Model)
+
+	assert.False(t, result.nsSelectionNegated, "'A' must clear nsSelectionNegated")
+	assert.True(t, result.allNamespaces, "'A' must set allNamespaces")
+}
+
+func TestNamespaceOverlayApplySingleNamespaceClearsNegation(t *testing.T) {
+	items := []model.Item{
+		{Name: "All Namespaces", Status: "all"},
+		{Name: "default"},
+		{Name: "kube-system"},
+	}
+	m := newNamespaceOverlayModel()
+	m.overlayItems = items
+	m.overlayCursor = 1 // cursor on "default"
+	m.nsSelectionNegated = true
+	m.nsSelectionModified = false // no Space pressed
+
+	ret, _ := m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+
+	assert.False(t, result.nsSelectionNegated,
+		"applying single namespace via cursor must clear nsSelectionNegated")
+}
+
+// --- scope label rendering ---
+
+func TestNsLabelNegatedRendersExclPrefix(t *testing.T) {
+	m := Model{
+		width:              80,
+		namespace:          "default",
+		selectedNamespaces: map[string]bool{"kube-system": true},
+		nsSelectionNegated: true,
+	}
+	// Build the label the same way view.go does — exercise the logic
+	// via the actual view function rather than re-implementing it here.
+	label := m.buildNsLabelText()
+	assert.True(t, strings.Contains(label, "!kube-system"),
+		"negated single ns label must contain '!kube-system', got: %q", label)
+}
+
+func TestNsLabelNegatedMultipleNs(t *testing.T) {
+	m := Model{
+		width:     80,
+		namespace: "default",
+		selectedNamespaces: map[string]bool{
+			"kube-system": true,
+			"monitoring":  true,
+		},
+		nsSelectionNegated: true,
+	}
+	label := m.buildNsLabelText()
+	assert.True(t, strings.Contains(label, "!"),
+		"negated multi-ns label must contain '!' prefixes, got: %q", label)
+}
+
+func TestNsLabelNegatedOverflowHasExcludeHint(t *testing.T) {
+	m := Model{
+		width:     80,
+		namespace: "default",
+		selectedNamespaces: map[string]bool{
+			"ns-a": true, "ns-b": true, "ns-c": true, "ns-d": true, "ns-e": true,
+		},
+		nsSelectionNegated: true,
+	}
+	label := m.buildNsLabelText()
+	assert.Contains(t, label, "+2 more excl",
+		"negated overflow label must signal the count refers to excluded namespaces, got: %q", label)
+}
+
+func TestNsLabelNonNegatedOverflowNoExcludeHint(t *testing.T) {
+	m := Model{
+		width:     80,
+		namespace: "default",
+		selectedNamespaces: map[string]bool{
+			"ns-a": true, "ns-b": true, "ns-c": true, "ns-d": true, "ns-e": true,
+		},
+		nsSelectionNegated: false,
+	}
+	label := m.buildNsLabelText()
+	assert.Contains(t, label, "+2 more")
+	assert.NotContains(t, label, "excl")
+}
+
+func TestNsLabelNotNegated(t *testing.T) {
+	m := Model{
+		width:              80,
+		namespace:          "kube-system",
+		selectedNamespaces: map[string]bool{"kube-system": true},
+		nsSelectionNegated: false,
+	}
+	label := m.buildNsLabelText()
+	assert.False(t, strings.Contains(label, "!"),
+		"non-negated label must not contain '!', got: %q", label)
+}
+
+// --- session round-trip ---
+
+func TestSessionRoundTripPreservesNegation(t *testing.T) {
+	st := &SessionTab{
+		Context:            "prod",
+		Namespace:          "default",
+		AllNamespaces:      false,
+		SelectedNamespaces: []string{"kube-system"},
+		NsSelectionNegated: true,
+	}
+	tab := buildSessionTabState(st, nil)
+	assert.True(t, tab.nsSelectionNegated,
+		"buildSessionTabState must preserve NsSelectionNegated")
+}
+
+func TestSessionRoundTripNegationFalseDefault(t *testing.T) {
+	st := &SessionTab{
+		Context:       "prod",
+		Namespace:     "default",
+		AllNamespaces: false,
+	}
+	tab := buildSessionTabState(st, nil)
+	assert.False(t, tab.nsSelectionNegated,
+		"NsSelectionNegated must default to false when not set")
+}
+
+// --- bookmark round-trip ---
+
+func TestBookmarkRoundTripPreservesNegation(t *testing.T) {
+	tests := []struct {
+		name           string
+		bookmark       model.Bookmark
+		initialNegated bool
+		expectNegated  bool
+		expectSelected []string
+		expectAllNs    bool
+	}{
+		{
+			name: "negated single namespace restores flag and set",
+			bookmark: model.Bookmark{
+				Namespace:          "kube-system",
+				Namespaces:         []string{"kube-system"},
+				NsSelectionNegated: true,
+			},
+			initialNegated: false,
+			expectNegated:  true,
+			expectSelected: []string{"kube-system"},
+		},
+		{
+			name: "negated multiple namespaces restores flag and set",
+			bookmark: model.Bookmark{
+				Namespace:          "kube-system",
+				Namespaces:         []string{"kube-system", "monitoring"},
+				NsSelectionNegated: true,
+			},
+			initialNegated: false,
+			expectNegated:  true,
+			expectSelected: []string{"kube-system", "monitoring"},
+		},
+		{
+			name: "non-negated bookmark resets stale true flag to false",
+			bookmark: model.Bookmark{
+				Namespace:          "production",
+				Namespaces:         []string{"production"},
+				NsSelectionNegated: false,
+			},
+			initialNegated: true,
+			expectNegated:  false,
+			expectSelected: []string{"production"},
+		},
+		{
+			name: "all-namespaces bookmark resets stale true flag to false",
+			bookmark: model.Bookmark{
+				Namespace:          "",
+				Namespaces:         nil,
+				NsSelectionNegated: false,
+			},
+			initialNegated: true,
+			expectNegated:  false,
+			expectAllNs:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{
+				nsSelectionNegated:    tt.initialNegated,
+				bookmarkLoadNamespace: true,
+			}
+			target := bookmarkTarget{kind: bookmarkTargetContext, context: "ctx", lookupContext: "ctx"}
+			m.applyBookmarkNamespace(tt.bookmark, target, "ctx")
+
+			assert.Equal(t, tt.expectNegated, m.nsSelectionNegated)
+			if tt.expectAllNs {
+				assert.True(t, m.allNamespaces)
+				assert.Nil(t, m.selectedNamespaces)
+				return
+			}
+			assert.False(t, m.allNamespaces)
+			for _, ns := range tt.expectSelected {
+				assert.True(t, m.selectedNamespaces[ns], "expected %q selected", ns)
+			}
+			assert.Len(t, m.selectedNamespaces, len(tt.expectSelected))
+		})
+	}
+}
+
+// --- Space-deselect-to-empty clears negation ---
+
+func TestNamespaceOverlaySpaceDeselectToEmptyClearsNegation(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.allNamespaces = false
+	m.nsSelectionNegated = true
+	m.overlayCursor = 2 // cursor on "kube-system"
+
+	ret, _ := m.handleNamespaceOverlayKey(keyMsg(" "))
+	result := ret.(Model)
+
+	assert.True(t, result.allNamespaces,
+		"deselecting last namespace must set allNamespaces")
+	assert.False(t, result.nsSelectionNegated,
+		"deselecting to empty must clear nsSelectionNegated")
+}
+
+// --- Enter commits a built exclude set (negation preserved) ---
+
+func TestNamespaceOverlayEnterCommitsExcludeSet(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.overlayCursor = 2 // cursor on "kube-system"
+
+	// Space selects, Tab negates, Enter commits.
+	ret, _ := m.handleNamespaceOverlayKey(keyMsg(" "))
+	m = ret.(Model)
+	ret, _ = m.handleNamespaceOverlayKey(keyMsg("tab"))
+	m = ret.(Model)
+	ret, _ = m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+
+	assert.True(t, result.nsSelectionNegated,
+		"Enter on a built exclude set must preserve negation")
+	assert.True(t, result.selectedNamespaces["kube-system"],
+		"Enter must commit the selected namespace")
+	assert.False(t, result.allNamespaces)
+}
+
+// --- helpers ---
+
+func newNamespaceOverlayModel() Model {
+	return Model{
+		overlay: overlayNamespace,
+		overlayItems: []model.Item{
+			{Name: "All Namespaces", Status: "all"},
+			{Name: "default"},
+			{Name: "kube-system"},
+		},
+		overlayCursor: 0,
+		tabs:          []TabState{{}},
+		width:         80,
+		height:        40,
+	}
+}

--- a/internal/app/negative_namespace_test.go
+++ b/internal/app/negative_namespace_test.go
@@ -473,6 +473,27 @@ func TestNamespaceOverlayEnterCommitsExcludeSet(t *testing.T) {
 	assert.False(t, result.allNamespaces)
 }
 
+// --- filter-accept single-result apply clears a restored exclude scope ---
+
+func TestNamespaceOverlayFilterAcceptSingleResultClearsNegation(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	// Exclude scope restored from a session/bookmark: negation is on, but
+	// the user has not toggled anything in this overlay session yet.
+	m.nsSelectionNegated = true
+	m.nsSelectionModified = false
+	m.nsFilterMode = true
+	m.overlayFilter.Value = "kube-system"
+
+	ret, _ := m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+
+	assert.False(t, result.nsSelectionNegated,
+		"applying a single filtered namespace must clear the restored negation")
+	assert.True(t, result.selectedNamespaces["kube-system"],
+		"the filtered namespace must be committed as an include selection")
+	assert.False(t, result.allNamespaces)
+}
+
 // --- helpers ---
 
 func newNamespaceOverlayModel() Model {

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -119,6 +119,7 @@ func (m Model) overlayHintBarSelector() string {
 	case overlayNamespace:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "space", Desc: "select"},
+			{Key: "tab", Desc: "exclude"},
 			{Key: "A", Desc: "all"},
 			{Key: "enter", Desc: "apply"},
 			{Key: "/", Desc: "filter"},

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -17,6 +17,7 @@ type SessionTab struct {
 	Namespace          string   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	AllNamespaces      bool     `json:"all_namespaces,omitempty" yaml:"all_namespaces,omitempty"`
 	SelectedNamespaces []string `json:"selected_namespaces,omitempty" yaml:"selected_namespaces,omitempty"`
+	NsSelectionNegated bool     `json:"ns_selection_negated,omitempty" yaml:"ns_selection_negated,omitempty"`
 	ResourceType       string   `json:"resource_type,omitempty" yaml:"resource_type,omitempty"`
 	ResourceName       string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
 }
@@ -28,6 +29,7 @@ type SessionState struct {
 	Namespace          string   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	AllNamespaces      bool     `json:"all_namespaces,omitempty" yaml:"all_namespaces,omitempty"`
 	SelectedNamespaces []string `json:"selected_namespaces,omitempty" yaml:"selected_namespaces,omitempty"`
+	NsSelectionNegated bool     `json:"ns_selection_negated,omitempty" yaml:"ns_selection_negated,omitempty"`
 	ResourceType       string   `json:"resource_type,omitempty" yaml:"resource_type,omitempty"` // group/version/resource ref string
 	ResourceName       string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
 
@@ -137,6 +139,7 @@ func (m *Model) saveCurrentSession() {
 				slices.Sort(nsList)
 				st.SelectedNamespaces = nsList
 			}
+			st.NsSelectionNegated = t.nsSelectionNegated
 		}
 		if t.nav.ResourceType.Resource != "" {
 			st.ResourceType = t.nav.ResourceType.ResourceRef()

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -102,7 +102,7 @@ func (m Model) effectiveContext() string {
 }
 
 func (m *Model) effectiveNamespace() string {
-	if m.allNamespaces || len(m.selectedNamespaces) > 1 {
+	if m.allNamespaces || m.nsSelectionNegated || len(m.selectedNamespaces) > 1 {
 		return "" // fetch all, filter client-side
 	}
 	if len(m.selectedNamespaces) == 1 {
@@ -113,13 +113,10 @@ func (m *Model) effectiveNamespace() string {
 	return m.namespace
 }
 
-// fetchFingerprint returns a stable digest of the parameters that
-// determine what a resource list fetch returns: effective namespace, the
-// allNamespaces toggle, and the selectedNamespaces multi-select filter.
-// It is used by the preview-cache shortcut in navigateChildResourceType
-// to decide whether a primed cache entry is still applicable. Context and
-// resource are not included because they are already part of the navKey
-// the fingerprint is paired with.
+// fetchFingerprint returns a stable digest of what a resource list fetch
+// returns: effective namespace, the allNamespaces toggle, and the
+// selectedNamespaces multi-select filter (with its negation flag). Used by
+// the preview-cache shortcut; context/resource live in the paired navKey.
 func (m *Model) fetchFingerprint() string {
 	var b strings.Builder
 	if m.allNamespaces {
@@ -135,8 +132,10 @@ func (m *Model) fetchFingerprint() string {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		b.WriteString("sel=")
-		b.WriteString(strings.Join(keys, ","))
+		if m.nsSelectionNegated {
+			b.WriteString("!")
+		}
+		fmt.Fprintf(&b, "sel=%s", strings.Join(keys, ","))
 	}
 	return b.String()
 }
@@ -442,6 +441,7 @@ func (m *Model) saveCurrentTab() {
 	t.namespace = m.namespace
 	t.allNamespaces = m.allNamespaces
 	t.selectedNamespaces = copyMapStringBool(m.selectedNamespaces)
+	t.nsSelectionNegated = m.nsSelectionNegated
 	t.sortColumnName = m.sortColumnName
 	t.sortAscending = m.sortAscending
 	t.filterText = m.filterText
@@ -552,6 +552,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.namespace = t.namespace
 	m.allNamespaces = t.allNamespaces
 	m.selectedNamespaces = copyMapStringBool(t.selectedNamespaces)
+	m.nsSelectionNegated = t.nsSelectionNegated
 	m.sortColumnName = t.sortColumnName
 	m.sortAscending = t.sortAscending
 	m.filterText = t.filterText
@@ -710,6 +711,7 @@ func (m *Model) cloneCurrentTab() TabState {
 		namespace:              m.namespace,
 		allNamespaces:          m.allNamespaces,
 		selectedNamespaces:     copyMapStringBool(m.selectedNamespaces),
+		nsSelectionNegated:     m.nsSelectionNegated,
 		sortColumnName:         m.sortColumnName,
 		sortAscending:          m.sortAscending,
 		filterText:             m.filterText,

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -608,6 +608,8 @@ func keyMsg(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyEsc}
 	case "enter":
 		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}
 	case "backspace":
 		return tea.KeyMsg{Type: tea.KeyBackspace}
 	case "ctrl+c":

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -280,14 +280,15 @@ func (m Model) bookmarkToSlot(slot string) (tea.Model, tea.Cmd) {
 	}
 
 	bm := model.Bookmark{
-		Name:         name,
-		Context:      bmContext,
-		UnionSet:     bmUnionSet,
-		Namespace:    ns,
-		Namespaces:   nsList,
-		ResourceType: rt.ResourceRef(),
-		ResourceName: m.nav.ResourceName,
-		Slot:         slot,
+		Name:               name,
+		Context:            bmContext,
+		UnionSet:           bmUnionSet,
+		Namespace:          ns,
+		Namespaces:         nsList,
+		NsSelectionNegated: m.nsSelectionNegated,
+		ResourceType:       rt.ResourceRef(),
+		ResourceName:       m.nav.ResourceName,
+		Slot:               slot,
 	}
 
 	// Check if slot is already in use; if so, ask for confirmation.

--- a/internal/app/update_bookmarks_navigate.go
+++ b/internal/app/update_bookmarks_navigate.go
@@ -61,6 +61,7 @@ func (m *Model) applyBookmarkNamespace(bm model.Bookmark, target bookmarkTarget,
 	case bm.Namespace == "" && len(bm.Namespaces) == 0:
 		m.allNamespaces = true
 		m.selectedNamespaces = nil
+		m.nsSelectionNegated = false
 	case len(bm.Namespaces) > 1:
 		m.allNamespaces = false
 		m.namespace = bm.Namespaces[0]
@@ -68,6 +69,7 @@ func (m *Model) applyBookmarkNamespace(bm model.Bookmark, target bookmarkTarget,
 		for _, ns := range bm.Namespaces {
 			m.selectedNamespaces[ns] = true
 		}
+		m.nsSelectionNegated = bm.NsSelectionNegated
 	default:
 		m.allNamespaces = false
 		ns := bm.Namespace
@@ -76,6 +78,7 @@ func (m *Model) applyBookmarkNamespace(bm model.Bookmark, target bookmarkTarget,
 		}
 		m.namespace = ns
 		m.selectedNamespaces = map[string]bool{ns: true}
+		m.nsSelectionNegated = bm.NsSelectionNegated
 	}
 	// Invalidate the old namespace's cache within the new context. When the
 	// context also changed, the entire old context was already wiped by

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -71,7 +71,7 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	m.itemCache[m.navKey()] = m.middleItems
 	m.clearRight()
 
-	applySessionNamespaces(&m, sess.AllNamespaces, sess.Namespace, sess.SelectedNamespaces)
+	applySessionNamespaces(&m, sess.AllNamespaces, sess.Namespace, sess.SelectedNamespaces, sess.NsSelectionNegated)
 
 	var cmds []tea.Cmd
 	needsDiscovery := m.shouldFireDiscoveryFor(discoveryCtx)
@@ -154,6 +154,7 @@ func (m Model) restoreMultiTabSession(sess *SessionState, contexts []model.Item)
 		Namespace:          activeSess.Namespace,
 		AllNamespaces:      activeSess.AllNamespaces,
 		SelectedNamespaces: activeSess.SelectedNamespaces,
+		NsSelectionNegated: activeSess.NsSelectionNegated,
 		ResourceType:       activeSess.ResourceType,
 		ResourceName:       activeSess.ResourceName,
 	}, contexts)
@@ -187,6 +188,7 @@ func buildSessionTabState(st *SessionTab, discovered []model.ResourceTypeEntry) 
 		} else {
 			tab.selectedNamespaces = map[string]bool{st.Namespace: true}
 		}
+		tab.nsSelectionNegated = st.NsSelectionNegated
 	} else {
 		tab.allNamespaces = true
 	}
@@ -227,10 +229,11 @@ func contextInList(ctx string, items []model.Item) bool {
 	return false
 }
 
-func applySessionNamespaces(m *Model, allNS bool, ns string, selectedNS []string) {
+func applySessionNamespaces(m *Model, allNS bool, ns string, selectedNS []string, negated bool) {
 	if allNS {
 		m.allNamespaces = true
 		m.selectedNamespaces = nil
+		m.nsSelectionNegated = false
 	} else if ns != "" {
 		m.namespace = ns
 		m.allNamespaces = false
@@ -242,5 +245,6 @@ func applySessionNamespaces(m *Model, allNS bool, ns string, selectedNS []string
 		} else {
 			m.selectedNamespaces = map[string]bool{ns: true}
 		}
+		m.nsSelectionNegated = negated
 	}
 }

--- a/internal/app/update_bookmarks_test.go
+++ b/internal/app/update_bookmarks_test.go
@@ -98,21 +98,21 @@ func TestContextInList(t *testing.T) {
 func TestApplySessionNamespaces(t *testing.T) {
 	t.Run("all namespaces mode", func(t *testing.T) {
 		m := Model{namespace: "old"}
-		applySessionNamespaces(&m, true, "", nil)
+		applySessionNamespaces(&m, true, "", nil, false)
 		assert.True(t, m.allNamespaces)
 		assert.Nil(t, m.selectedNamespaces)
 	})
 
 	t.Run("single namespace", func(t *testing.T) {
 		m := Model{}
-		applySessionNamespaces(&m, false, "production", nil)
+		applySessionNamespaces(&m, false, "production", nil, false)
 		assert.Equal(t, "production", m.namespace)
 		assert.False(t, m.allNamespaces)
 	})
 
 	t.Run("multiple namespaces", func(t *testing.T) {
 		m := Model{}
-		applySessionNamespaces(&m, false, "ns-1", []string{"ns-1", "ns-2", "ns-3"})
+		applySessionNamespaces(&m, false, "ns-1", []string{"ns-1", "ns-2", "ns-3"}, false)
 		assert.Equal(t, "ns-1", m.namespace)
 		assert.Len(t, m.selectedNamespaces, 3)
 		assert.True(t, m.selectedNamespaces["ns-1"])
@@ -1926,16 +1926,16 @@ func TestFinalContextInListEmpty(t *testing.T) {
 
 func TestFinalApplySessionNamespaces(t *testing.T) {
 	m := baseFinalModel()
-	applySessionNamespaces(&m, true, "", nil)
+	applySessionNamespaces(&m, true, "", nil, false)
 	assert.True(t, m.allNamespaces)
 
 	m2 := baseFinalModel()
-	applySessionNamespaces(&m2, false, "custom-ns", nil)
+	applySessionNamespaces(&m2, false, "custom-ns", nil, false)
 	assert.Equal(t, "custom-ns", m2.namespace)
 	assert.False(t, m2.allNamespaces)
 
 	m3 := baseFinalModel()
-	applySessionNamespaces(&m3, false, "ns1", []string{"ns1", "ns2"})
+	applySessionNamespaces(&m3, false, "ns1", []string{"ns1", "ns2"}, false)
 	assert.Equal(t, "ns1", m3.namespace)
 	assert.True(t, m3.selectedNamespaces["ns1"])
 	assert.True(t, m3.selectedNamespaces["ns2"])

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -332,6 +332,7 @@ func (m Model) handleNamespaceFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			items := m.filteredOverlayItems()
 			if len(items) == 1 {
 				oldNs := m.namespace
+				m.nsSelectionNegated = false
 				if items[0].Status == "all" {
 					m.selectedNamespaces = nil
 					m.allNamespaces = true

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -95,10 +95,12 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.selectedNamespaces = map[string]bool{ns: true}
 			m.namespace = ns
 			m.allNamespaces = false
+			m.nsSelectionNegated = false
 		default:
 			// Cursor on "All Namespaces" or no specific item.
 			m.selectedNamespaces = nil
 			m.allNamespaces = true
+			m.nsSelectionNegated = false
 		}
 		m.invalidateOrphanCacheForNamespace(m.nav.Context, oldNs)
 		m.overlayFilter.Clear()
@@ -157,6 +159,7 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					if len(m.selectedNamespaces) == 0 {
 						m.selectedNamespaces = nil
 						m.allNamespaces = true
+						m.nsSelectionNegated = false
 					}
 				} else {
 					m.selectedNamespaces[selected.Name] = true
@@ -166,6 +169,18 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Advance cursor to the next item after toggling.
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, 1, len(items)-1)
+		return m, nil
+
+	case "tab":
+		if m.pendingUnionSetName != "" {
+			return m.rejectPendingUnionSetNamespaceMultiSelect()
+		}
+		if m.unionMode {
+			m.setStatusMessage("Union mode supports exactly one namespace", true)
+			return m, scheduleStatusClear()
+		}
+		m.nsSelectionNegated = !m.nsSelectionNegated
+		m.nsSelectionModified = true
 		return m, nil
 
 	case ui.ActiveKeybindings.AllNamespaces:
@@ -186,6 +201,7 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.nsSelectionModified = true
 		m.selectedNamespaces = nil
 		m.allNamespaces = true
+		m.nsSelectionNegated = false
 		for i, item := range items {
 			if item.Status == "all" {
 				m.overlayCursor = i

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -525,13 +525,12 @@ func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea
 }
 
 func (m Model) filterLoadedItemsBySelectedNamespaces(items []model.Item) []model.Item {
-	// Filter by selected namespaces when multi-select is active.
-	if len(m.selectedNamespaces) <= 1 {
+	if (!m.nsSelectionNegated && len(m.selectedNamespaces) <= 1) || (m.nsSelectionNegated && len(m.selectedNamespaces) == 0) {
 		return items
 	}
 	filtered := make([]model.Item, 0, len(items))
 	for _, item := range items {
-		if item.Namespace == "" || m.selectedNamespaces[item.Namespace] {
+		if item.Namespace == "" || m.selectedNamespaces[item.Namespace] != m.nsSelectionNegated {
 			filtered = append(filtered, item)
 		}
 	}

--- a/internal/app/update_whocan.go
+++ b/internal/app/update_whocan.go
@@ -391,7 +391,7 @@ func (m Model) renderWhoCanOverlay(background string) string {
 
 	// Match Can-I's scope label format ("ns: all" / "ns: <name>") so
 	// Tab between modes shows the same scope chip in the same shape.
-	nsLabel := ui.CanIScopeLabel(m.canINamespaces)
+	nsLabel := ui.CanIScopeLabel(m.canINamespaces, m.nsSelectionNegated)
 
 	// Filter input renders as the overlay footer — same vertical
 	// position Can-I uses for its search bar so the input lands in the

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -451,27 +451,7 @@ func (m Model) renderTitleBar() string {
 		}
 	}
 
-	nsText := m.namespace
-	switch {
-	case m.allNamespaces:
-		nsText = "all"
-	case len(m.selectedNamespaces) > 1:
-		names := make([]string, 0, len(m.selectedNamespaces))
-		for ns := range m.selectedNamespaces {
-			names = append(names, ns)
-		}
-		sort.Strings(names)
-		if len(names) > 3 {
-			nsText = fmt.Sprintf("%s +%d more", strings.Join(names[:3], ","), len(names)-3)
-		} else {
-			nsText = strings.Join(names, ",")
-		}
-	case len(m.selectedNamespaces) == 1:
-		for ns := range m.selectedNamespaces {
-			nsText = ns
-		}
-	}
-	nsLabel := ui.NamespaceBadgeStyle.Render(" ns: " + nsText + " ")
+	nsLabel := ui.NamespaceBadgeStyle.Render(" ns: " + m.buildNsLabelText() + " ")
 
 	var versionLabel string
 	if m.version != "" {
@@ -764,4 +744,37 @@ func (m Model) viewExplorerThreeCol(middle string, leftW, leftInner, rightW, rig
 	left := ui.InactiveColumnStyle.Width(leftW).Height(contentHeight).MaxHeight(contentHeight + 2).Render(leftCol)
 	right := ui.InactiveColumnStyle.Width(rightW).Height(contentHeight).MaxHeight(contentHeight + 2).Render(rightCol)
 	return lipgloss.JoinHorizontal(lipgloss.Top, left, middle, right)
+}
+
+// buildNsLabelText returns the text portion of the namespace scope chip shown
+// in the title bar. When nsSelectionNegated is true, each selected namespace
+// is prefixed with "!" to indicate it is excluded.
+func (m Model) buildNsLabelText() string {
+	if m.allNamespaces {
+		return "all"
+	}
+	if len(m.selectedNamespaces) == 0 {
+		return m.namespace
+	}
+
+	names := make([]string, 0, len(m.selectedNamespaces))
+	for ns := range m.selectedNamespaces {
+		names = append(names, ns)
+	}
+	sort.Strings(names)
+
+	if m.nsSelectionNegated {
+		for i, ns := range names {
+			names[i] = "!" + ns
+		}
+	}
+
+	if len(names) > 3 {
+		more := "more"
+		if m.nsSelectionNegated {
+			more = "more excl"
+		}
+		return fmt.Sprintf("%s +%d %s", strings.Join(names[:3], ","), len(names)-3, more)
+	}
+	return strings.Join(names, ",")
 }

--- a/internal/app/view_overlay_lists.go
+++ b/internal/app/view_overlay_lists.go
@@ -621,15 +621,19 @@ func renderNamespaceOverlay(m Model, items []model.Item, height int) string {
 	listItems := make([]ui.OverlayListItem, len(items))
 	for i, it := range items {
 		active := false
+		marker := ""
 		switch {
 		case it.Status == "all":
 			active = m.allNamespaces && len(m.selectedNamespaces) == 0
+		case m.nsSelectionNegated && m.selectedNamespaces[it.Name]:
+			active = true
+			marker = "!"
 		case m.selectedNamespaces[it.Name]:
 			active = true
 		case it.Name == m.namespace && !m.allNamespaces && len(m.selectedNamespaces) == 0:
 			active = true
 		}
-		listItems[i] = ui.OverlayListItem{Name: it.Name, Active: active}
+		listItems[i] = ui.OverlayListItem{Name: it.Name, Active: active, ActiveMarker: marker}
 	}
 	return ui.RenderOverlayList(listItems, ui.OverlayListConfig{
 		Title:            "Select Namespace",

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -702,6 +702,7 @@ func (m Model) renderCanIOverlay(background string) string {
 		innerW, innerH,
 		hintBar,
 		m.canIResourceScroll,
+		m.nsSelectionNegated,
 	)
 	// RBAC overlay uses baseBg end-to-end: title (TitleStyle/barBg=baseBg)
 	// + column boxes (Active/InactiveColumnStyle/baseBg) + filler. Mixing

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -290,14 +290,15 @@ type PodMetrics struct {
 
 // Bookmark represents a saved navigation path for quick access.
 type Bookmark struct {
-	Name         string   `json:"name" yaml:"name"`
-	Context      string   `json:"context,omitempty" yaml:"context,omitempty"`
-	UnionSet     string   `json:"union_set,omitempty" yaml:"union_set,omitempty"`
-	Namespace    string   `json:"namespace" yaml:"namespace"`
-	Namespaces   []string `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
-	ResourceType string   `json:"resource_type" yaml:"resource_type"` // resource ref string (group/version/resource)
-	ResourceName string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
-	Slot         string   `json:"slot,omitempty" yaml:"slot,omitempty"` // single char key for vim-style named marks (a-z, A-Z, 0-9)
+	Name               string   `json:"name" yaml:"name"`
+	Context            string   `json:"context,omitempty" yaml:"context,omitempty"`
+	UnionSet           string   `json:"union_set,omitempty" yaml:"union_set,omitempty"`
+	Namespace          string   `json:"namespace" yaml:"namespace"`
+	Namespaces         []string `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
+	NsSelectionNegated bool     `json:"ns_selection_negated,omitempty" yaml:"ns_selection_negated,omitempty"`
+	ResourceType       string   `json:"resource_type" yaml:"resource_type"` // resource ref string (group/version/resource)
+	ResourceName       string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
+	Slot               string   `json:"slot,omitempty" yaml:"slot,omitempty"` // single char key for vim-style named marks (a-z, A-Z, 0-9)
 }
 
 // IsContextAware reports whether this bookmark is anchored to a specific

--- a/internal/ui/caniview.go
+++ b/internal/ui/caniview.go
@@ -24,7 +24,7 @@ var canIVerbs = []struct {
 
 // RenderCanIView renders the can-i browser with a two-column layout.
 // The left column (API groups) is interactive; the right column (resources) is display-only.
-func RenderCanIView(groups []string, resources []model.CanIResource, groupCursor, groupScroll int, subjectName string, namespaces []string, width, height int, hintBar string, resourceScroll int) string {
+func RenderCanIView(groups []string, resources []model.CanIResource, groupCursor, groupScroll int, subjectName string, namespaces []string, width, height int, hintBar string, resourceScroll int, nsNegated bool) string {
 	// Title at the left, scope label flushed to the far right with
 	// baseBg-painted gap fill. Matches the WhoCan header layout so the
 	// title bar reads consistently across both modes.
@@ -33,7 +33,7 @@ func RenderCanIView(groups []string, resources []model.CanIResource, groupCursor
 	// namespaces slice into "ns: all" so the user always sees what
 	// scope is active — earlier behavior rendered "ns: " (no value),
 	// which looked like a render bug.
-	scopeLabel := CanIScopeLabel(namespaces)
+	scopeLabel := CanIScopeLabel(namespaces, nsNegated)
 	// Subject chip mirrors the Who-Can verb chip styling: dim "Subject:"
 	// label + light value, both on baseBg so they sit flush in the title
 	// row's barBg band.
@@ -100,15 +100,23 @@ func joinTitleAndRightLabel(title, rightLabel string, width int) string {
 // Collapses the all-namespaces sentinels ([""] and the empty slice)
 // to a literal "ns: all" so the label never reads as "ns: " — that
 // looked like a render bug to users who picked "All Namespaces" in
-// the namespace selector.
-func CanIScopeLabel(namespaces []string) string {
+// the namespace selector. When negated is true, each namespace is
+// prefixed with "!" to indicate it is excluded.
+func CanIScopeLabel(namespaces []string, negated bool) string {
 	if len(namespaces) == 0 {
 		return "ns: all"
 	}
 	if len(namespaces) == 1 && namespaces[0] == "" {
 		return "ns: all"
 	}
-	return "ns: " + strings.Join(namespaces, ",")
+	if !negated {
+		return "ns: " + strings.Join(namespaces, ",")
+	}
+	prefixed := make([]string, len(namespaces))
+	for i, ns := range namespaces {
+		prefixed[i] = "!" + ns
+	}
+	return "ns: " + strings.Join(prefixed, ",")
 }
 
 // canIVerbColWidth returns the column width for a verb label (label length + 1 space padding).

--- a/internal/ui/caniview_test.go
+++ b/internal/ui/caniview_test.go
@@ -214,7 +214,7 @@ func TestRenderCanIView(t *testing.T) {
 			{Resource: "deployments", Verbs: map[string]bool{"get": true, "list": true}},
 			{Resource: "statefulsets", Verbs: map[string]bool{"get": false}},
 		}
-		result := RenderCanIView(groups, resources, 0, 0, "admin", []string{"default"}, 120, 30, "hint bar text", 0)
+		result := RenderCanIView(groups, resources, 0, 0, "admin", []string{"default"}, 120, 30, "hint bar text", 0, false)
 		assert.Contains(t, result, "RBAC Explorer: Can-I?")
 		assert.Contains(t, result, "admin")
 		assert.Contains(t, result, "API Groups")
@@ -224,7 +224,7 @@ func TestRenderCanIView(t *testing.T) {
 	})
 
 	t.Run("narrow width does not panic", func(t *testing.T) {
-		result := RenderCanIView([]string{"apps"}, nil, 0, 0, "user", []string{"default"}, 40, 10, "", 0)
+		result := RenderCanIView([]string{"apps"}, nil, 0, 0, "user", []string{"default"}, 40, 10, "", 0, false)
 		assert.Contains(t, result, "Can-I?")
 	})
 
@@ -232,7 +232,7 @@ func TestRenderCanIView(t *testing.T) {
 		// At 80-col width the left column is narrow (20% = ~14 cols) and
 		// "No groups found" wraps; assert on the resilient first word
 		// instead of the whole phrase.
-		result := RenderCanIView(nil, nil, 0, 0, "test-user", []string{"ns1"}, 80, 20, "", 0)
+		result := RenderCanIView(nil, nil, 0, 0, "test-user", []string{"ns1"}, 80, 20, "", 0, false)
 		assert.Contains(t, result, "No groups")
 		assert.Contains(t, result, "No resources in this group")
 	})

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -84,7 +84,7 @@ func helpSections() []helpSection {
 		{
 			title: "Actions",
 			bindings: []helpEntry{
-				{kb.NamespaceSelector, "Select namespace"},
+				{kb.NamespaceSelector, "Select namespace (space: include, tab: exclude, A: all-namespaces)"},
 				{kb.AllNamespaces, "Toggle all-namespaces mode"},
 				{kb.ActionMenu, "Action menu: l=tail logs (last 10 lines + follow), L=full logs, exec, debug, debug pod, describe, edit, delete, scale, port-forward, events, startup analysis, crash investigator, traffic capture, RBAC permissions"},
 				{kb.Logs, "View full logs for selected resource"},

--- a/internal/ui/overlay_list.go
+++ b/internal/ui/overlay_list.go
@@ -24,13 +24,14 @@ const overlayListChrome = 4
 // fields render only when the matching feature flag in OverlayListConfig
 // is enabled — callers leave them zero-valued otherwise.
 type OverlayListItem struct {
-	Key         string // shortcut letter; rendered "[k]" when cfg.ShowKey
-	Name        string // primary text
-	Description string // dim secondary suffix; rendered when cfg.ShowDescription
-	Status      string // status badge; rendered "[s]" when cfg.ShowStatus
-	Active      bool   // ✓ marker when cfg.ShowActiveMarker
-	Selected    bool   // checkbox state when cfg.MultiSelect
-	Disabled    bool   // renders dim and (by convention) can't be acted on
+	Key          string // shortcut letter; rendered "[k]" when cfg.ShowKey
+	Name         string // primary text
+	Description  string // dim secondary suffix; rendered when cfg.ShowDescription
+	Status       string // status badge; rendered "[s]" when cfg.ShowStatus
+	Active       bool   // ✓ marker when cfg.ShowActiveMarker
+	ActiveMarker string // overrides the default ✓ glyph when Active and non-empty
+	Selected     bool   // checkbox state when cfg.MultiSelect
+	Disabled     bool   // renders dim and (by convention) can't be acted on
 
 	// Header rows render as group dividers ("── Name ──") in CategoryStyle.
 	// All other field flags are ignored — no marker, no key, no status,
@@ -240,6 +241,15 @@ func RenderOverlayList(items []OverlayListItem, cfg OverlayListConfig, innerW in
 // the highlight background) and for width measurement. `hasActive`
 // controls whether the active-marker column is reserved — see
 // anyActive for the collapse rule.
+// activeMarkerGlyph returns the single-cell marker drawn for an Active row,
+// defaulting to ✓ unless the item overrides it (e.g. "!" for excluded items).
+func activeMarkerGlyph(it OverlayListItem) string {
+	if it.ActiveMarker != "" {
+		return it.ActiveMarker
+	}
+	return "✓"
+}
+
 func itemPlainLine(it OverlayListItem, cfg OverlayListConfig, hasActive bool) string {
 	if it.Header {
 		return "── " + it.Name + " ──"
@@ -254,7 +264,7 @@ func itemPlainLine(it OverlayListItem, cfg OverlayListConfig, hasActive bool) st
 	}
 	if hasActive {
 		if it.Active {
-			p.WriteString("✓ ")
+			p.WriteString(activeMarkerGlyph(it) + " ")
 		} else {
 			p.WriteString("  ")
 		}
@@ -289,7 +299,7 @@ func itemStyledLine(it OverlayListItem, cfg OverlayListConfig, hasActive bool) s
 	}
 	if hasActive {
 		if it.Active {
-			p.WriteString(OverlayFilterStyle.Render("✓ "))
+			p.WriteString(OverlayFilterStyle.Render(activeMarkerGlyph(it) + " "))
 		} else {
 			p.WriteString("  ")
 		}

--- a/internal/ui/overlay_list_test.go
+++ b/internal/ui/overlay_list_test.go
@@ -151,6 +151,16 @@ func TestRenderOverlayList(t *testing.T) {
 		assert.NotContains(t, out, "✓")
 	})
 
+	t.Run("ActiveMarker overrides the default check glyph", func(t *testing.T) {
+		items := []OverlayListItem{
+			{Name: "A", Active: true},
+			{Name: "B", Active: true, ActiveMarker: "!"},
+		}
+		out := RenderOverlayList(items, OverlayListConfig{ShowActiveMarker: true}, w)
+		assert.Contains(t, out, "✓", "default marker still used for items without an override")
+		assert.Contains(t, out, "! B", "overridden item renders its custom marker")
+	})
+
 	t.Run("active-marker column collapses when no item is active", func(t *testing.T) {
 		// When ShowActiveMarker is on but nothing's active, the 2-cell
 		// reserved space disappears so [k]/[s] sit flush against the


### PR DESCRIPTION
## Summary

Adds negative namespace selection to the namespace selector: "show everything **except** these namespaces", alongside the existing all / single / multi-select modes.

- New `Model.nsSelectionNegated` flag reinterprets the existing `selectedNamespaces` set as an **exclude** set (no second map; include and exclude are mutually exclusive).
- `effectiveNamespace` lists all namespaces server-side whenever negated (even when excluding a single namespace); `filterLoadedItemsBySelectedNamespaces` inverts the predicate and always keeps cluster-scoped items.
- `fetchFingerprint` encodes the negation flag so the preview cache never serves include-results for an exclude scope.
- **Selector UX:** `Tab` toggles exclude mode; excluded rows render a `!` marker (via a new `OverlayListItem.ActiveMarker` override); `A` / all-namespaces / single-namespace apply all clear negation; union mode continues to block multi-select.
- **Label:** the title scope chip and `CanIScopeLabel` prefix excluded namespaces with `!` (e.g. `ns: !kube-system, !default`).
- **Persistence:** the flag round-trips through sessions, bookmarks, and tab snapshots.
- Updates in-app help, the selector hint bar, and the README.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/...`
- [x] `go test -race ./internal/app/... ./internal/ui/...`
- [x] `make lint` (0 issues)
- [x] Manual: open selector, `Tab` to enter exclude mode, mark namespaces, confirm list shows everything except them and the chip reads `ns: !ns1, !ns2`
- [x] Manual: save a bookmark/session in exclude mode, reload, confirm negation restored
- [x] Manual: `A` and single-namespace apply reset exclude mode