### PR TITLE
fix: gate explorer hint bar by nav level at context picker

### DIFF
--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -323,6 +323,10 @@ func (m Model) handleKeyPrevMatch() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKeyNamespaceSelector() (tea.Model, tea.Cmd) {
+	if m.nav.Level == model.LevelClusters {
+		m.setStatusMessage("Namespace selection requires a selected context", true)
+		return m, scheduleStatusClear()
+	}
 	return m.openNamespaceSelectorForContext(m.activeContext())
 }
 

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -218,6 +218,10 @@ func (m Model) handleExplorerDirectActionKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 }
 
 func (m Model) handleExplorerActionKeyAllNamespaces() (tea.Model, tea.Cmd, bool) {
+	if m.nav.Level == model.LevelClusters {
+		m.setStatusMessage("Namespace selection requires a selected context", true)
+		return m, scheduleStatusClear(), true
+	}
 	if m.unionMode {
 		m.setStatusMessage("Union mode supports exactly one namespace", true)
 		return m, scheduleStatusClear(), true
@@ -643,6 +647,10 @@ func (m Model) handleExplorerActionKeyPrevTab() (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) handleExplorerActionKeyCreateTemplate() (tea.Model, tea.Cmd, bool) {
+	if m.nav.Level == model.LevelClusters {
+		m.setStatusMessage("Create from template requires a selected context", true)
+		return m, scheduleStatusClear(), true
+	}
 	if m.readOnly {
 		m.setStatusMessage(readOnlyBlockedMessage("Create from template"), true)
 		return m, scheduleStatusClear(), true

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -29,6 +29,19 @@ func TestActionKeyATogglesAllNamespaces(t *testing.T) {
 	assert.False(t, result.allNamespaces)
 }
 
+func TestActionKeyAllNamespacesNoOpAtClusters(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelClusters
+	m.allNamespaces = false
+
+	ret, cmd, handled := m.handleExplorerActionKey(runeKey('A'))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.False(t, result.allNamespaces, "all-namespaces must not toggle without a selected context")
+	assert.NotEmpty(t, result.statusMessage)
+	assert.NotNil(t, cmd)
+}
+
 // --- handleExplorerActionKey: ctrl+d half page down ---
 
 func TestActionKeyCtrlDHalfPageDown(t *testing.T) {
@@ -371,6 +384,19 @@ func TestActionKeyAOpensTemplates(t *testing.T) {
 	assert.True(t, handled)
 	result := ret.(Model)
 	assert.Equal(t, overlayTemplates, result.overlay)
+}
+
+func TestActionKeyANoOpAtClusters(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelClusters
+
+	ret, cmd, handled := m.handleExplorerActionKey(runeKey('a'))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.Equal(t, overlayNone, result.overlay,
+		"template overlay must not open without a selected context")
+	assert.NotEmpty(t, result.statusMessage)
+	assert.NotNil(t, cmd)
 }
 
 func TestActionKeyATemplateMatchesCurrentKind(t *testing.T) {

--- a/internal/app/update_keys_namespace_selector_test.go
+++ b/internal/app/update_keys_namespace_selector_test.go
@@ -26,6 +26,19 @@ func nsSelectorModel() Model {
 // populate synchronously: overlayItems is non-nil before any tea.Cmd
 // runs, m.loading stays false, and ensureNamespaceCacheFresh returns nil
 // so no API call is scheduled.
+func TestHandleKeyNamespaceSelector_NoOpAtClusters(t *testing.T) {
+	m := nsSelectorModel()
+	m.nav.Level = model.LevelClusters
+
+	ret, cmd := m.handleKeyNamespaceSelector()
+	result := ret.(Model)
+
+	assert.NotEqual(t, overlayNamespace, result.overlay,
+		"namespace overlay must not open without a selected context")
+	assert.NotEmpty(t, result.statusMessage)
+	assert.NotNil(t, cmd)
+}
+
 func TestHandleKeyNamespaceSelector_SeedsFromFreshCache(t *testing.T) {
 	m := nsSelectorModel()
 	m.cachedNamespaces[m.activeContext()] = namespaceCacheEntry{

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -330,16 +330,27 @@ func (m Model) explorerHintEntries() []ui.HintEntry {
 		{Key: kb.Left + "/" + kb.Right, Desc: "navigate"},
 		{Key: kb.Down + "/" + kb.Up, Desc: "move"},
 		{Key: kb.Enter, Desc: "view"},
-		{Key: kb.NamespaceSelector, Desc: "namespace"},
-		{Key: kb.AllNamespaces, Desc: "all-ns"},
 	}
-	// At the cluster picker and resource-type browser, both the action
-	// menu and column sort are no-ops: selectedResourceKind() returns
-	// "" so openActionMenu() bails out, and sortMiddleItems() early-
-	// returns so </> doesn't reorder anything. Hide both hints there
-	// to avoid advertising dead keys.
+	// Namespace selection only makes sense once a context is selected. At
+	// the cluster picker no context is active, so these keys would act on
+	// the implicit kubeconfig current-context rather than the hovered row;
+	// their handlers no-op there, so keep the hints hidden too.
+	if m.nav.Level != model.LevelClusters {
+		hintEntries = append(hintEntries,
+			ui.HintEntry{Key: kb.NamespaceSelector, Desc: "namespace"},
+			ui.HintEntry{Key: kb.AllNamespaces, Desc: "all-ns"},
+		)
+	}
+	// Column sort is a no-op at both the cluster picker and the resource-
+	// type browser: sortMiddleItems() early-returns so </> doesn't reorder
+	// anything. Hide the sort hint there to avoid advertising dead keys.
 	hasResourceContext := m.nav.Level != model.LevelClusters && m.nav.Level != model.LevelResourceTypes
-	if hasResourceContext {
+	// The action menu has real entries at the cluster picker (set color,
+	// manage local clusters via openClusterPickerActionMenu) and at the
+	// resource levels. It is a no-op only at the resource-type browser,
+	// where openResourceActionMenu() bails out on an empty kind. Advertise
+	// it everywhere except there.
+	if m.nav.Level != model.LevelResourceTypes {
 		hintEntries = append(hintEntries, ui.HintEntry{Key: kb.ActionMenu, Desc: "actions"})
 	}
 	// Advertise the read-only toggle on every level so users can
@@ -350,9 +361,12 @@ func (m Model) explorerHintEntries() []ui.HintEntry {
 	if m.nav.Level == model.LevelClusters || !m.cliReadOnly {
 		hintEntries = append(hintEntries, ui.HintEntry{Key: kb.ReadOnlyToggle, Desc: "toggle RO"})
 	}
-	// "create" runs `kubectl apply` from a template. Hide it in
-	// read-only mode since it would be blocked anyway.
-	if !m.readOnly {
+	// "create" runs `kubectl apply` from a template against the active
+	// context. At LevelClusters no context is selected yet, so the action
+	// is a no-op there (see handleExplorerActionKeyCreateTemplate) and the
+	// hint must stay hidden. Also hidden in read-only mode since it would
+	// be blocked anyway.
+	if m.nav.Level != model.LevelClusters && !m.readOnly {
 		hintEntries = append(hintEntries, ui.HintEntry{Key: kb.CreateTemplate, Desc: "create"})
 	}
 	if hasResourceContext {

--- a/internal/app/view_status_extra_test.go
+++ b/internal/app/view_status_extra_test.go
@@ -205,9 +205,9 @@ func TestStatusBarDashboardHints(t *testing.T) {
 	assert.Contains(t, stripped, "namespace")
 }
 
-// --- statusBar: cluster-list hints omit "actions" ---
+// --- statusBar: cluster-list hints show "actions", omit "create" ---
 
-func TestStatusBarClusterListOmitsActionsHint(t *testing.T) {
+func TestStatusBarClusterListHints(t *testing.T) {
 	m := Model{
 		nav:           model.NavigationState{Level: model.LevelClusters},
 		middleItems:   []model.Item{{Name: "ctx-a"}},
@@ -217,8 +217,15 @@ func TestStatusBarClusterListOmitsActionsHint(t *testing.T) {
 		selectedItems: make(map[string]bool),
 	}
 	stripped := stripANSI(m.statusBar())
-	assert.NotContains(t, stripped, "actions")
-	assert.Contains(t, stripped, "create")
+	// The cluster picker has real action-menu entries (set color, manage
+	// local clusters), so "actions" must be advertised.
+	assert.Contains(t, stripped, "actions")
+	// No context is selected at LevelClusters, so "create" (kubectl apply
+	// against the active context) is a no-op and must stay hidden.
+	assert.NotContains(t, stripped, "create")
+	// Namespace selection also requires a selected context.
+	assert.NotContains(t, stripped, "namespace")
+	assert.NotContains(t, stripped, "all-ns")
 	assert.Contains(t, stripped, "filter")
 }
 


### PR DESCRIPTION
## Summary

At the cluster/context picker (`LevelClusters`) no context is selected yet, so several hotkeys advertised on the bottom hint bar were no-ops or acted on an implicit target. This aligns the hint bar (and the underlying handlers) with what each key actually does per nav level.

| Key | Action | Before | After |
|---|---|---|---|
| `x` | actions | hidden (stale "no-op" comment) | **shown** — opens Set color / Manage local clusters |
| `a` | create | shown | hidden + handler no-op (kubectl apply needs a context) |
| `\` | namespace | shown | hidden + handler no-op (acted on kubeconfig current-context, not the hovered row) |
| `A` | all-ns | shown | hidden + handler no-op |

Sort (`>/<`) stays hidden at both the cluster picker and resource-type browser (genuinely a no-op there). The `actions` hint remains hidden only at the resource-type browser, where `openResourceActionMenu()` bails out on an empty kind. Navigate/move/view/filter/marks are unchanged (valid at every level).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/app/ ./internal/ui/`
- [x] Added/updated tests: `TestStatusBarClusterListHints`, `TestActionKeyANoOpAtClusters`, `TestActionKeyAllNamespacesNoOpAtClusters`, `TestHandleKeyNamespaceSelector_NoOpAtClusters`