### PR TITLE
fix: persist in-context read-only toggle to per-context override

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -748,7 +748,7 @@ Invalid config values are dropped at startup with a warning in the error log.
 
 | Key | Action |
 |---|---|
-| `Ctrl+R` (inside a context) | Toggle read-only mode for the current tab. Session-scoped — does not write to config and does not leak across context switches. Blocked when `--read-only` is set. |
+| `Ctrl+R` (inside a context) | Toggle read-only mode for the current tab. Recorded as a session override for that context, so it survives re-entry and stays in sync with the picker's `[RO]` marker; does not write to config and never leaks across contexts. Blocked when `--read-only` is set. |
 | `Ctrl+R` (at the cluster picker) | Toggle the `[RO]` marker on the highlighted context row. Stored as a session override that wins over per-context config and is honored on context entry. Blocked when `--read-only` is set (the CLI flag forces every context RO). |
 
 The `[RO]` badge appears in the title bar only when you're inside a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -219,11 +219,14 @@ tab when created and re-evaluate on context switch.
   over per-context and global config when entering that context.
   Persists across back-and-forth navigation to the picker; cleared on
   process exit. Blocked when `--read-only` is set.
-- **Inside a context**: flips read-only for the current tab.
-  Session-scoped — does not write to the config file, and does not leak
-  across context switches. Blocked when `--read-only` is set; the CLI
-  flag is the strongest precedence level and cannot be defeated within
-  the running process.
+- **Inside a context**: flips read-only for the current tab and records
+  the choice as a session override for that context, so it survives
+  navigating back to the picker and re-entering, and keeps the picker's
+  `[RO]` marker in sync. Session-scoped — does not write to the config
+  file. Keyed by context, so unlocking one context never leaks read-write
+  state into another. Blocked when `--read-only` is set; the CLI flag is
+  the strongest precedence level and cannot be defeated within the
+  running process.
 
 ### CLI flag
 

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -284,9 +284,12 @@ func (m *Model) refreshContextReadOnlyMarkers() {
 //   - per-context config (clusters.<ctx>.read_only)
 //   - global config (read_only)
 //
-// The in-context Ctrl+R toggle bypasses this function — it sets m.readOnly
-// directly for the current tab. Switching contexts re-runs recompute and
-// drops the in-context toggle.
+// The in-context Ctrl+R toggle also records its result in
+// contextROOverrides (keyed by the active context), so re-entering that
+// context re-reads the override here and preserves the user's last choice
+// rather than reverting to config. Switching to a *different* context reads
+// that context's own override/config, so an unlock never leaks across
+// contexts.
 func (m *Model) recomputeReadOnly(ctx string) {
 	if m.cliReadOnly {
 		m.readOnly = true
@@ -362,6 +365,18 @@ func (m Model) handleKeyReadOnlyToggle() (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 	m.readOnly = !m.readOnly
+	// Persist the toggle to the per-context override so it survives re-entry
+	// (recomputeReadOnly reads the override on context entry) and keeps the
+	// cluster-picker [RO] marker in sync. Keyed by context, so unlocking one
+	// context never leaks read-write state into another. The union sentinel
+	// is skipped: it is not a real context and each member keeps its own
+	// policy via readOnlyForContext.
+	if !m.isUnionSentinel() && m.nav.Context != "" {
+		if m.contextROOverrides == nil {
+			m.contextROOverrides = make(map[string]bool)
+		}
+		m.contextROOverrides[m.nav.Context] = m.readOnly
+	}
 	state := "OFF"
 	if m.readOnly {
 		state = "ON"

--- a/internal/app/readonly_test.go
+++ b/internal/app/readonly_test.go
@@ -505,7 +505,8 @@ func TestRefreshContextReadOnlyMarkers_NoOpOutsideClusterPicker(t *testing.T) {
 
 func TestHandleKeyReadOnlyToggle_InsideContext(t *testing.T) {
 	// Inside a specific context, the toggle flips the active tab's RO
-	// state directly. The override map is not touched.
+	// state and records the choice in the per-context override so it
+	// survives re-entry and stays in sync with the cluster-picker marker.
 	m := Model{
 		nav:  model.NavigationState{Level: model.LevelResources, Context: "prod"},
 		tabs: []TabState{{}}, width: 80, height: 40,
@@ -513,7 +514,35 @@ func TestHandleKeyReadOnlyToggle_InsideContext(t *testing.T) {
 	ret, _ := m.handleKeyReadOnlyToggle()
 	result := ret.(Model)
 	assert.True(t, result.readOnly)
-	assert.Empty(t, result.contextROOverrides, "in-context toggle must not write to the override map")
+	assert.True(t, result.contextROOverrides["prod"], "in-context toggle must record the override for the active context")
+}
+
+// TestHandleKeyReadOnlyToggle_InsideContext_PersistsAcrossReentry is the
+// regression for the L942 desync bug: turning read-only OFF inside a context
+// must survive navigating back to the picker and re-entering, even when
+// per-context config says the context should be read-only. Before the fix the
+// in-context toggle lived only in m.readOnly, so recomputeReadOnly on re-entry
+// re-read the config and silently re-locked the context.
+func TestHandleKeyReadOnlyToggle_InsideContext_PersistsAcrossReentry(t *testing.T) {
+	prev := ui.ConfigClusterReadOnly
+	t.Cleanup(func() { ui.ConfigClusterReadOnly = prev })
+	ui.ConfigClusterReadOnly = map[string]bool{"prod": true} // config locks prod
+
+	m := Model{
+		nav:  model.NavigationState{Level: model.LevelResources, Context: "prod"},
+		tabs: []TabState{{}}, width: 80, height: 40,
+		readOnly: true, // entered prod read-only via config
+	}
+
+	// User unlocks the context with in-context Ctrl+R.
+	ret, _ := m.handleKeyReadOnlyToggle()
+	result := ret.(Model)
+	require.False(t, result.readOnly)
+	require.False(t, result.contextROOverrides["prod"], "toggle OFF must record an explicit false override")
+
+	// Simulate navigating back to the picker and re-entering prod.
+	result.recomputeReadOnly("prod")
+	assert.False(t, result.readOnly, "in-context unlock must survive re-entry and beat the per-context config")
 }
 
 // newTestModelForNav builds a minimal Model adequate for navigateChildCluster.

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -149,6 +149,11 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 		m.popLeft()
 		m.clearRight()
 		m.restoreCursor()
+		// The restored rows were captured on context entry and carry stale
+		// [RO] markers; an in-context Ctrl+R toggle since then updated the
+		// override but not this snapshot. Re-apply so the picker marker
+		// matches the context's current read-only state.
+		m.refreshContextReadOnlyMarkers()
 		return m, m.loadPreview()
 
 	case model.LevelResources:

--- a/internal/app/update_navigation_test.go
+++ b/internal/app/update_navigation_test.go
@@ -99,6 +99,28 @@ func TestCov80NavigateParentFromResourceTypes(t *testing.T) {
 	_ = cmd
 }
 
+// TestNavigateParentToClusters_RefreshesReadOnlyMarkers guards the L942 sync:
+// navigating back to the cluster picker must re-apply each row's [RO] marker
+// from the (possibly just-toggled) override map rather than show the stale
+// snapshot captured on context entry.
+func TestNavigateParentToClusters_RefreshesReadOnlyMarkers(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.nav.Context = "prod"
+	// Snapshot captured on entry says prod was read-write...
+	m.leftItems = []model.Item{{Name: "prod", ReadOnly: false}}
+	m.leftItemsHistory = [][]model.Item{{{Name: "root"}}}
+	// ...but an in-context toggle since then locked it via the override.
+	m.contextROOverrides = map[string]bool{"prod": true}
+
+	result, _ := m.navigateParent()
+	rm := result.(Model)
+	require.Equal(t, model.LevelClusters, rm.nav.Level)
+	require.Len(t, rm.middleItems, 1)
+	assert.True(t, rm.middleItems[0].ReadOnly,
+		"cluster picker row must reflect the override after navigating back")
+}
+
 func TestCov80NavigateParentFromResources(t *testing.T) {
 	m := basePush80Model()
 	m.nav.Level = model.LevelResources


### PR DESCRIPTION
## Summary

Fixes a read-only mode (`Ctrl+R`) desync where mutating actions (e.g. `a` to create from templates) stayed blocked after the user toggled read-only off.

**Root cause:** two unreconciled stores. The cluster-picker `Ctrl+R` wrote `contextROOverrides[ctx]` (persistent, per-context); the in-context `Ctrl+R` wrote only `m.readOnly` (live, per-tab). On context re-entry, `recomputeReadOnly` re-read the override/config and silently dropped the in-context toggle.

**Fix:** the in-context branch of `handleKeyReadOnlyToggle` now also records the result in `contextROOverrides[m.nav.Context]` (skipping the union sentinel). The two toggles become one coherent per-context state — the toggle survives re-entry and keeps the picker `[RO]` marker in sync. Keyed by context, so unlocking one context never leaks read-write state into another (the cross-context guard in `TestRecomputeReadOnly_Precedence` still holds). Also re-applies the picker markers when navigating back from a context so they aren't visually stale.

This reverses a previously documented-and-tested contract ("in-context toggle does not persist") — but that contract was the reported bug. Tests and docs updated to match.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `make lint`
- [x] Updated `TestHandleKeyReadOnlyToggle_InsideContext` (now asserts the override is written)
- [x] Added `TestHandleKeyReadOnlyToggle_InsideContext_PersistsAcrossReentry` (in-context unlock beats per-context config on re-entry)
- [x] Added `TestNavigateParentToClusters_RefreshesReadOnlyMarkers` (picker marker reflects override after backing out)