### PR TITLE
fix: clear hint-bar message immediately on explorer navigation

### DIFF
--- a/internal/app/status_clear.go
+++ b/internal/app/status_clear.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// clearTransientStatus immediately drops any active status/error message so it
+// does not linger in the hint bar while the user navigates. The startup tip is
+// dismissed separately in handleKey. No-op when nothing is showing.
+func (m *Model) clearTransientStatus() {
+	if m.statusMessage == "" {
+		return
+	}
+	m.statusMessage = ""
+	m.statusMessageErr = false
+	m.statusMessageExp = time.Time{}
+}
+
+// clearStatusOnNavigationKey clears a lingering hint-bar message when msg is an
+// explorer movement key (up/down/left/right plus the top/bottom jumps), so a
+// toast disappears on the next navigation keystroke instead of waiting out its
+// 5s timer. Returns m unchanged for any other key.
+func (m Model) clearStatusOnNavigationKey(msg tea.KeyMsg) Model {
+	kb := ui.ActiveKeybindings
+	switch msg.String() {
+	case kb.Down, "down", kb.Up, "up", kb.Left, "left", kb.Right, "right",
+		kb.JumpTop, kb.JumpBottom, "end":
+		m.clearTransientStatus()
+	}
+	return m
+}

--- a/internal/app/status_clear.go
+++ b/internal/app/status_clear.go
@@ -21,14 +21,26 @@ func (m *Model) clearTransientStatus() {
 }
 
 // clearStatusOnNavigationKey clears a lingering hint-bar message when msg is an
-// explorer movement key (up/down/left/right plus the top/bottom jumps), so a
-// toast disappears on the next navigation keystroke instead of waiting out its
-// 5s timer. Returns m unchanged for any other key.
+// explorer navigation key, so a toast disappears as soon as the user moves on
+// instead of waiting out its 5s timer. Covers cursor movement, page/preview
+// scrolling, level jumps, owner/back jumps, search-match jumps and tab
+// switching — anything that changes what the user is looking at.
+//
+// Called before key dispatch (handleExplorerKey), so a handler that sets a
+// fresh message for the same key (e.g. JumpOwner reporting "no owner", or
+// NewTab rejected in union mode) still overwrites the cleared state and wins.
+// Returns m unchanged for any other key.
 func (m Model) clearStatusOnNavigationKey(msg tea.KeyMsg) Model {
 	kb := ui.ActiveKeybindings
 	switch msg.String() {
 	case kb.Down, "down", kb.Up, "up", kb.Left, "left", kb.Right, "right",
-		kb.JumpTop, kb.JumpBottom, "end":
+		kb.JumpTop, kb.JumpBottom, "end", "home",
+		kb.PageDown, kb.PageUp, kb.PageForward, kb.PageBack, "pgdown", "pgup",
+		kb.PreviewDown, kb.PreviewUp,
+		kb.LevelCluster, kb.LevelTypes, kb.LevelResources,
+		kb.JumpBack, kb.JumpOwner,
+		kb.NextMatch, kb.PrevMatch,
+		kb.NextTab, kb.PrevTab, kb.NewTab:
 		m.clearTransientStatus()
 	}
 	return m

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -41,6 +41,11 @@ func (m Model) handleExplorerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 
+	// Navigating clears any lingering hint-bar toast immediately rather than
+	// letting it wait out its 5s timer. Done before dispatch so a handler that
+	// sets a fresh message (e.g. Left exiting dashboard fullscreen) still wins.
+	m = m.clearStatusOnNavigationKey(msg)
+
 	if mdl, cmd, handled := m.handleExplorerNavKey(msg); handled {
 		return mdl, cmd
 	}

--- a/internal/app/update_keys_test.go
+++ b/internal/app/update_keys_test.go
@@ -67,6 +67,39 @@ func TestHandleKeyDismissesStatusTip(t *testing.T) {
 	assert.False(t, result.statusMessageTip)
 }
 
+// --- navigation clears a lingering status/error message immediately ---
+
+func TestHandleKeyNavigationClearsStatusMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{"down (j)", runeKey('j')},
+		{"up (k)", runeKey('k')},
+		{"left (h)", runeKey('h')},
+		{"right (l)", runeKey('l')},
+		{"down arrow", specialKey(tea.KeyDown)},
+		{"up arrow", specialKey(tea.KeyUp)},
+		{"left arrow", specialKey(tea.KeyLeft)},
+		{"right arrow", specialKey(tea.KeyRight)},
+		{"jump bottom (G)", runeKey('G')},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := baseExplorerModel()
+			m.setCursor(1)
+			m.statusMessage = "Read-only mode: ON"
+			m.statusMessageErr = true
+			m.statusMessageExp = time.Now().Add(5 * time.Second)
+
+			ret, _ := m.handleKey(tc.key)
+			result := ret.(Model)
+			assert.Empty(t, result.statusMessage, "navigation must clear the hint-bar message immediately")
+			assert.False(t, result.statusMessageErr)
+		})
+	}
+}
+
 // --- handleKey: cursor movement j/k ---
 
 func TestHandleKeyJMovesDown(t *testing.T) {

--- a/internal/app/update_keys_test.go
+++ b/internal/app/update_keys_test.go
@@ -82,7 +82,9 @@ func TestHandleKeyNavigationClearsStatusMessage(t *testing.T) {
 		{"up arrow", specialKey(tea.KeyUp)},
 		{"left arrow", specialKey(tea.KeyLeft)},
 		{"right arrow", specialKey(tea.KeyRight)},
+		{"jump top (g)", runeKey('g')},
 		{"jump bottom (G)", runeKey('G')},
+		{"end", specialKey(tea.KeyEnd)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -96,6 +98,76 @@ func TestHandleKeyNavigationClearsStatusMessage(t *testing.T) {
 			result := ret.(Model)
 			assert.Empty(t, result.statusMessage, "navigation must clear the hint-bar message immediately")
 			assert.False(t, result.statusMessageErr)
+		})
+	}
+}
+
+// TestClearStatusOnNavigationKey covers the full navigation/scroll key set the
+// helper clears on. It exercises the helper directly so the assertions aren't
+// coupled to handler side-effects (some nav handlers, e.g. JumpOwner, set their
+// own message after the clear). Defaults assumed; see ui.DefaultKeybindings.
+func TestClearStatusOnNavigationKey(t *testing.T) {
+	clears := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{"down (j)", runeKey('j')},
+		{"up (k)", runeKey('k')},
+		{"left (h)", runeKey('h')},
+		{"right (l)", runeKey('l')},
+		{"jump top (g)", runeKey('g')},
+		{"jump bottom (G)", runeKey('G')},
+		{"home", specialKey(tea.KeyHome)},
+		{"end", specialKey(tea.KeyEnd)},
+		{"half page down (ctrl+d)", specialKey(tea.KeyCtrlD)},
+		{"half page up (ctrl+u)", specialKey(tea.KeyCtrlU)},
+		{"full page down (ctrl+f)", specialKey(tea.KeyCtrlF)},
+		{"full page up (ctrl+b)", specialKey(tea.KeyCtrlB)},
+		{"pgdown", specialKey(tea.KeyPgDown)},
+		{"pgup", specialKey(tea.KeyPgUp)},
+		{"preview down (J)", runeKey('J')},
+		{"preview up (K)", runeKey('K')},
+		{"level clusters (0)", runeKey('0')},
+		{"level types (1)", runeKey('1')},
+		{"level resources (2)", runeKey('2')},
+		{"jump back (backspace)", specialKey(tea.KeyBackspace)},
+		{"jump owner (o)", runeKey('o')},
+		{"next match (n)", runeKey('n')},
+		{"prev match (N)", runeKey('N')},
+		{"next tab (])", runeKey(']')},
+		{"prev tab ([)", runeKey('[')},
+		{"new tab (t)", runeKey('t')},
+	}
+	for _, tc := range clears {
+		t.Run(tc.name, func(t *testing.T) {
+			m := baseExplorerModel()
+			m.statusMessage = "some toast"
+			m.statusMessageErr = true
+			m.statusMessageExp = time.Now().Add(5 * time.Second)
+
+			result := m.clearStatusOnNavigationKey(tc.key)
+			assert.Empty(t, result.statusMessage, "navigation key must clear the message")
+			assert.False(t, result.statusMessageErr)
+		})
+	}
+
+	// Non-navigation keys must leave the message intact.
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{"action menu (x)", runeKey('x')},
+		{"filter (f)", runeKey('f')},
+		{"enter", specialKey(tea.KeyEnter)},
+	} {
+		t.Run("keeps/"+tc.name, func(t *testing.T) {
+			m := baseExplorerModel()
+			m.statusMessage = "some toast"
+			m.statusMessageExp = time.Now().Add(5 * time.Second)
+
+			result := m.clearStatusOnNavigationKey(tc.key)
+			assert.Equal(t, "some toast", result.statusMessage,
+				"non-navigation key must not clear the message")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Status and error toasts in the explorer hint bar lingered for the full 5s `scheduleStatusClear` timer. The startup tip already cleared on any keypress, but regular messages did not — so a `Read-only mode: ON` or error toast stayed on screen while the user navigated away.

Now any explorer **navigation** key clears the message immediately — anything that changes what the user is looking at:

- cursor movement: `h/j/k/l` + arrow keys
- top/bottom/home/end jumps: `g`/`G`/`Home`/`End`
- page scrolling: `ctrl+d`/`ctrl+u` (half), `ctrl+f`/`ctrl+b`/`PgDn`/`PgUp` (full)
- preview-pane scroll: `J`/`K`
- level jumps: `0`/`1`/`2`
- owner/back jumps: `o` / `Backspace`
- search-match jumps: `n`/`N`
- tab switching: `[`/`]`/`t`

`clearStatusOnNavigationKey` (in `internal/app/status_clear.go`) is called from `handleExplorerKey` *before* dispatch, so a handler that sets a fresh message for the same key (e.g. `JumpOwner` reporting "no owner", or `NewTab` rejected in union mode) still overwrites the cleared state and wins. The detection lives in a helper rather than inline in `handleExplorerNavKey` to keep that function under the gocyclo-30 cap.

Action keys that aren't navigation (e.g. `x`, `f`, `Enter`) leave the message intact.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `make lint`
- [x] `TestHandleKeyNavigationClearsStatusMessage` — integration via handleKey (j/k/h/l, arrows, g, G, End)
- [x] `TestClearStatusOnNavigationKey` — unit-tests the helper across the full nav/scroll set, plus negative cases (x/f/Enter keep the message)