### PR TITLE
feat: refresh namespaces in the namespace selector with R

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Clusters (kubeconfig contexts)
                     +-- Containers (for Pods)
 ```
 
-Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection — shows all except the marked namespaces, each prefixed with `!`), or `A` to reset to all-namespaces mode.
+Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection — shows all except the marked namespaces, each prefixed with `!`), `A` to reset to all-namespaces mode, or `R` to refresh the list from the cluster.
 
 ### Owner Resolution
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -136,7 +136,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `L` | View logs for selected resource | `logs` |
 | `e` | Secret/ConfigMap editor (inline key-value editing) | `secret_editor` |
 | `E` | Edit selected resource in $KUBE_EDITOR or $EDITOR | `edit` |
-| `R` | Refresh current view | `refresh` |
+| `R` | Refresh current view (also works inside the namespace selector — re-fetches the namespace list from the cluster) | `refresh` |
 | `v` | Describe selected resource | `describe` |
 | `D` | Delete resource (force delete Pod/Job if already deleting, force finalize others) | `delete` |
 | `X` | Force delete (Pod/Job only) | `force_delete` |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -143,15 +143,14 @@ type Model struct {
 	// Text input for type-to-confirm overlay (e.g., Force Finalize).
 	confirmTypeInput TextInput
 
-	// All-namespaces mode.
-	allNamespaces bool
-
-	// Multi-select namespace state.
+	// Namespace selection state (all-namespaces mode + multi-select).
+	allNamespaces       bool
 	selectedNamespaces  map[string]bool
 	nsSelectionNegated  bool // when true, selectedNamespaces is an EXCLUDE set
 	nsFilterMode        bool
 	nsSelectionModified bool   // tracks if Space was pressed in current ns overlay session
 	nsFilterEntryItem   string // namespace name selected when filter mode was entered; restored on Esc
+	nsOverlayContext    string // context the open namespace overlay lists; used by the in-overlay refresh (R)
 
 	// Fullscreen toggles: middle = hides left and right columns; dashboard
 	// = renders the cluster dashboard full screen.

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -123,6 +123,7 @@ func (m Model) overlayHintBarSelector() string {
 			{Key: "A", Desc: "all"},
 			{Key: "enter", Desc: "apply"},
 			{Key: "/", Desc: "filter"},
+			{Key: "R", Desc: "refresh"},
 			{Key: "esc", Desc: "close"},
 		})
 	case overlayAction:

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -342,6 +342,11 @@ func (m Model) openNamespaceSelectorForContext(contextName string) (tea.Model, t
 	m.overlayFilter.Clear()
 	ui.ResetOverlayNsScroll()
 	m.nsSelectionModified = false
+	// Remember which context this overlay lists so the in-overlay refresh
+	// (R) re-fetches the right namespaces even when activeContext() would
+	// resolve differently (e.g. the union-set namespace picker, which opens
+	// for the first member context before union mode is active).
+	m.nsOverlayContext = contextName
 
 	// Reuse the existing per-context namespace cache (also used by the
 	// command-bar autocompleter). When a cached entry exists we seed the

--- a/internal/app/update_keys_namespace_selector_test.go
+++ b/internal/app/update_keys_namespace_selector_test.go
@@ -181,6 +181,40 @@ func TestHandleKeyNamespaceSelector_StaleCacheSchedulesBackgroundRefresh(t *test
 	assert.NotNil(t, cmd, "stale cache must schedule a silent refresh command")
 }
 
+// TestHandleNamespaceOverlay_RefreshReloads verifies the in-overlay refresh
+// (R / kb.Refresh) re-fetches namespaces and keeps the overlay open.
+func TestHandleNamespaceOverlay_RefreshReloads(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.overlay = overlayNamespace
+	m.nsOverlayContext = m.activeContext()
+	m.overlayItems = []model.Item{
+		{Name: "All Namespaces", Status: "all"},
+		{Name: "default", Status: "Active"},
+	}
+
+	ret, cmd := m.handleNamespaceOverlayKey(runeKey('R'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay, "refresh must keep the overlay open")
+	assert.NotNil(t, cmd, "refresh must schedule a namespace reload")
+	assert.Contains(t, result.statusMessage, "Refresh")
+	assert.False(t, result.statusMessageErr)
+}
+
+// TestHandleNamespaceOverlay_RefreshNoClientNoOp verifies refresh is a safe
+// no-op (no panic, overlay intact) when no client is wired.
+func TestHandleNamespaceOverlay_RefreshNoClientNoOp(t *testing.T) {
+	m := nsSelectorModel() // baseExplorerModel: m.client == nil
+	m.overlay = overlayNamespace
+	m.nsOverlayContext = "test"
+
+	ret, cmd := m.handleNamespaceOverlayKey(runeKey('R'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay)
+	assert.Nil(t, cmd)
+}
+
 // TestUpdateNamespacesLoaded_SilentPreservesOverlayCursor guards the
 // race between the user navigating an open overlay and the silent
 // stale-while-revalidate refresh landing. Without this guard, the

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -265,6 +265,22 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.overlayCursor = 0
 		return m, nil
 
+	case ui.ActiveKeybindings.Refresh:
+		// Re-fetch the namespace list from the API. GetNamespaces always
+		// hits the cluster (no client cache), so the non-silent load gets
+		// fresh data and repopulates the overlay via updateNamespacesLoaded
+		// when it returns. The current list stays visible until then
+		// (stale-while-revalidate), so the overlay never blanks out.
+		kctx := m.nsOverlayContext
+		if kctx == "" {
+			kctx = m.activeContext()
+		}
+		if m.client == nil || kctx == "" {
+			return m, nil
+		}
+		m.setStatusMessage("Refreshing namespaces...", false)
+		return m, tea.Batch(m.loadNamespacesForContext(kctx, false), scheduleStatusClear())
+
 	case "ctrl+c":
 		// Close the overlay rather than the tab — once an overlay is
 		// open Ctrl+C should match Esc semantics. The tab-close only

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -84,7 +84,7 @@ func helpSections() []helpSection {
 		{
 			title: "Actions",
 			bindings: []helpEntry{
-				{kb.NamespaceSelector, "Select namespace (space: include, tab: exclude, A: all-namespaces)"},
+				{kb.NamespaceSelector, "Select namespace (space: include, tab: exclude, A: all-namespaces, R: refresh)"},
 				{kb.AllNamespaces, "Toggle all-namespaces mode"},
 				{kb.ActionMenu, "Action menu: l=tail logs (last 10 lines + follow), L=full logs, exec, debug, debug pod, describe, edit, delete, scale, port-forward, events, startup analysis, crash investigator, traffic capture, RBAC permissions"},
 				{kb.Logs, "View full logs for selected resource"},


### PR DESCRIPTION
## Summary

Pressing `R` (the existing `refresh` keybinding, shift+r) inside the namespace selector now re-fetches the namespace list from the cluster — useful when a namespace was created/deleted outside lfk while the selector is open.

- `GetNamespaces` always hits the API (no client cache), so the non-silent load gets fresh data and `updateNamespacesLoaded` repopulates the overlay.
- The current list stays visible until fresh data arrives (stale-while-revalidate) — no blank flash.
- New `Model.nsOverlayContext` (set in `openNamespaceSelectorForContext`) makes refresh target the context the overlay actually lists. This is correct even in the union-set namespace picker, which opens for the first member context *before* union mode is active and where `activeContext()` would resolve to the wrong context.

Docs/help/hint-bar updated: namespace overlay hint bar, in-app help, `docs/keybindings.md`, `README.md`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `make lint`
- [x] `TestHandleNamespaceOverlay_RefreshReloads` — R reloads, keeps overlay open, sets status
- [x] `TestHandleNamespaceOverlay_RefreshNoClientNoOp` — safe no-op without a client