### PR TITLE
fix: dashboard events preview background tear under non-black themes (#293)

### DIFF
--- a/internal/app/view_extra_test.go
+++ b/internal/app/view_extra_test.go
@@ -132,6 +132,12 @@ func TestViewExplorerDashboardTwoColWrappedEventsFillBackground(t *testing.T) {
 	out := m.View()
 
 	assert.Contains(t, out, "\x1b[", "forced color profile must emit ANSI sequences")
+	// Guard against a vacuous pass: confirm a wrap boundary actually emitted the
+	// parameterless reset. The fix rewrites it to "reset + bgSeq" (keeping the
+	// reset present), so its absence would mean no wrap occurred — making the
+	// NotContains check below meaningless.
+	assert.Contains(t, out, "\x1b[m",
+		"a wrapped event sub-line must emit the parameterless reset for this test to be meaningful")
 	// A parameterless reset immediately followed by a space is un-backgrounded
 	// padding after a wrap boundary — the black tear. FillLinesBg must rewrite
 	// it to "reset + bgSeq".

--- a/internal/app/view_extra_test.go
+++ b/internal/app/view_extra_test.go
@@ -88,6 +88,57 @@ func TestViewExplorerDashboardTwoColFillsThemeBackground(t *testing.T) {
 		"two-col rows must not overflow the content area and wrap (no blank tail line between rows)")
 }
 
+// TestViewExplorerDashboardTwoColWrappedEventsFillBackground guards the issue
+// #293 follow-up: the events column wraps long messages, and lipgloss emits the
+// parameterless reset (ESC[m) at each wrap boundary. FillLinesBg must re-apply
+// the theme background after that reset too, or the per-column padding that
+// follows a wrapped sub-line renders with the terminal default (a black "tear")
+// — the artifact reported in the cluster events preview.
+func TestViewExplorerDashboardTwoColWrappedEventsFillBackground(t *testing.T) {
+	origProfile := lipgloss.DefaultRenderer().ColorProfile()
+	origTheme := ui.ActiveTheme
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	ui.ApplyTheme(ui.DefaultTheme())
+	t.Cleanup(func() {
+		lipgloss.DefaultRenderer().SetColorProfile(origProfile)
+		ui.ApplyTheme(origTheme)
+	})
+
+	// A long, styled message that must wrap across several sub-lines within the
+	// right column — each wrap boundary closes with the parameterless reset.
+	longMsg := ui.DimStyle.Render("Readiness probe failed: Get http://172.18.12.93:8080/healthz: " +
+		"dial tcp 172.18.12.93:8080: connect: connection refused after several retries")
+	m := Model{
+		nav:                 model.NavigationState{Level: model.LevelResourceTypes, Context: "test"},
+		middleItems:         []model.Item{{Name: "Cluster Dashboard", Extra: "__overview__"}},
+		width:               120,
+		height:              40,
+		mode:                modeExplorer,
+		namespace:           "default",
+		fullscreenDashboard: true,
+		dashboardPreview:    "NODES: 3 Ready\nPODS: 42 Running",
+		dashboardEventsPreview: ui.DimStyle.Bold(true).Render("  RECENT EVENTS") + "\n\n" +
+			"  " + ui.StatusProgressing.Render("⚠") + " 2m   " +
+			ui.StatusFailed.Render("Unhealthy:") + " " + ui.NormalStyle.Render("Pod/argocd-server") + "\n" +
+			"       " + longMsg,
+		tabs:               []TabState{{}},
+		selectedItems:      make(map[string]bool),
+		cursorMemory:       make(map[string]int),
+		itemCache:          make(map[string][]model.Item),
+		yamlCollapsed:      make(map[string]bool),
+		selectedNamespaces: make(map[string]bool),
+	}
+
+	out := m.View()
+
+	assert.Contains(t, out, "\x1b[", "forced color profile must emit ANSI sequences")
+	// A parameterless reset immediately followed by a space is un-backgrounded
+	// padding after a wrap boundary — the black tear. FillLinesBg must rewrite
+	// it to "reset + bgSeq".
+	assert.NotContains(t, out, "\x1b[m ",
+		"wrapped event sub-lines must re-apply the theme background after the parameterless reset")
+}
+
 // TestClampPreviewScrollDashboard guards against scrolling the fullscreen
 // dashboard past its last line. clampPreviewScroll previously only knew the
 // right-column preview's content, so in dashboard mode it let previewScroll

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -360,11 +360,18 @@ func FillLinesBg(content string, width int, bg lipgloss.TerminalColor) string {
 
 	fill := lipgloss.NewStyle().Background(bg)
 	reset := "\x1b[0m"
+	// lipgloss/reflow emit the parameterless SGR reset (ESC[m) at word-wrap
+	// boundaries inside a styled span, while a style's own closing reset is the
+	// full ESC[0m. Both clear the background, so both must be followed by bgSeq
+	// — otherwise padding after a wrap-induced reset renders with the terminal
+	// default (black under non-black themes), "tearing" the panel (issue #293).
+	shortReset := "\x1b[m"
 
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
 		// Prepend bg at start of line and after every ANSI reset.
 		line = bgSeq + strings.ReplaceAll(line, reset, reset+bgSeq)
+		line = strings.ReplaceAll(line, shortReset, shortReset+bgSeq)
 		// Pad to full width.
 		w := lipgloss.Width(line)
 		if w < width {

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -2,9 +2,11 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,4 +77,41 @@ func TestAgeStyle(t *testing.T) {
 			assert.Equal(t, tt.expectedFg, got, "age=%q expected %s style", tt.age, tt.desc)
 		})
 	}
+}
+
+// --- FillLinesBg ---
+
+// TestFillLinesBgReestablishesBgAfterShortReset guards issue #293's recurrence
+// in the dashboard events column. lipgloss/reflow emit the parameterless SGR
+// reset (ESC[m) at word-wrap boundaries, not the full ESC[0m. FillLinesBg must
+// re-apply the background after both, or column padding following a
+// wrap-induced reset renders with the terminal default (a black "tear").
+func TestFillLinesBgReestablishesBgAfterShortReset(t *testing.T) {
+	origProfile := lipgloss.DefaultRenderer().ColorProfile()
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(origProfile) })
+
+	// Use an explicit color (not the theme-dependent BaseBg) so the test does
+	// not depend on global theme state another test may have mutated.
+	bg := lipgloss.Color("#1a1a2e")
+
+	// Derive the exact bg sequence FillLinesBg injects, and guard against a
+	// vacuous pass: a downgraded color profile would emit no sequence.
+	sample := lipgloss.NewStyle().Background(bg).Render("X")
+	bgSeq, _, _ := strings.Cut(sample, "X")
+	if bgSeq == "" {
+		t.Fatal("color profile must emit a background sequence for this test to be meaningful")
+	}
+
+	// A styled span closed by the parameterless reset, followed by spaces, and
+	// already at full width so no trailing fill is appended — the wrap boundary
+	// lipgloss produces (interior column padding follows the reset). The old
+	// code left these spaces un-backgrounded.
+	content := "\x1b[38;2;1;2;3mhello\x1b[m     "
+	got := FillLinesBg(content, 10, bg)
+
+	assert.Contains(t, got, "\x1b[m"+bgSeq,
+		"background must be re-established immediately after the parameterless reset")
+	assert.NotContains(t, got, "\x1b[m ",
+		"no un-backgrounded padding may follow a parameterless reset")
 }


### PR DESCRIPTION
## Summary

Follow-up to #293 / #294. The reporter confirmed the cluster details usage bars are fixed, but the same black "tearing" still appeared in the **cluster events preview** — the two-column fullscreen dashboard's `RECENT EVENTS` column — under non-black themes.

**Root cause.** `FillLinesBg` re-established the theme background only after the full SGR reset (`ESC[0m`). When the events column word-wraps a long message, lipgloss/reflow emit the *parameterless* reset (`ESC[m`) at each wrap boundary. The per-column padding following a wrapped sub-line then rendered with the terminal default (black), tearing the panel. The single-column dashboard path truncates messages (no wrap, closes with `ESC[0m`), which is why only the wrapping events column tore.

**Fix.** Handle both reset forms in `FillLinesBg`. Fixing it at this layer is the root-cause fix and covers every caller — relevant since the bug already recurred once in a different view.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test -race ./...`, `make lint` (0 issues)
- [x] `TestFillLinesBgReestablishesBgAfterShortReset` (ui) — guards the parameterless-reset handling; fails on pre-fix code, passes after
- [x] `TestViewExplorerDashboardTwoColWrappedEventsFillBackground` (app) — integration guard through `m.View()` with a long wrapping event message (the reporter's scenario); fails on pre-fix code, passes after

Closes #293