### PR TITLE
fix: apply theme switch to cached previews immediately

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -508,9 +508,11 @@ type Model struct {
 
 	// Metrics content: rendered bar graph for the preview column.
 	metricsContent string
+	metricsData    *metricsInputs // raw numbers behind metricsContent; recomposed on theme/resize, nil when none
 
 	// Preview events content: rendered event timeline for the preview column.
 	previewEventsContent string
+	previewEventsData    []ui.EventTimelineEntry // raw entries behind previewEventsContent; recomposed on theme/resize
 
 	// Baseline metrics for trend detection (updated every ~60s, not every refresh).
 	prevPodMetrics      map[string]model.PodMetrics
@@ -519,10 +521,11 @@ type Model struct {
 	prevNodeMetricsTime time.Time
 
 	// Dashboard state for the cluster overview / monitoring previews.
-	dashboardPreview       string                   // rendered cluster dashboard (right column / fullscreen)
-	dashboardEventsPreview string                   // warning events for the two-column layout
-	dashboardData          map[string]dashboardData // retained per context; recomposed at current width on resize / fullscreen toggle
-	monitoringPreview      string                   // rendered monitoring dashboard
+	dashboardPreview       string                    // rendered cluster dashboard (right column / fullscreen)
+	dashboardEventsPreview string                    // warning events for the two-column layout
+	dashboardData          map[string]dashboardData  // retained per context; recomposed at current width on resize / fullscreen toggle
+	monitoringPreview      string                    // rendered monitoring dashboard
+	monitoringData         map[string]monitoringData // raw alerts retained per context; recomposed on theme change / resize
 
 	// Collapsible tree view state for resource types.
 	expandedGroup     string // currently expanded category (accordion behavior)

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 // viewMode tracks the current view state.
@@ -456,6 +457,10 @@ type TabState struct {
 	// to clear them.
 	metricsContent       string
 	previewEventsContent string
+	// Raw inputs behind the two footers above, retained per-tab so a theme
+	// change / resize can re-render them in place (see recomposeThemedContent).
+	metricsData       *metricsInputs
+	previewEventsData []ui.EventTimelineEntry
 
 	// Toggle to show only Warning events in Event list view.
 	warningEventsOnly bool

--- a/internal/app/commands_dashboard.go
+++ b/internal/app/commands_dashboard.go
@@ -61,6 +61,14 @@ type dashboardData struct {
 	nodeMetricsErr error
 }
 
+// monitoringData retains the raw alert payload behind monitoringPreview so the
+// monitoring dashboard can be re-rendered on a theme change or resize without
+// re-querying Prometheus. Mirrors dashboardData's per-context retention.
+type monitoringData struct {
+	alerts []k8s.AlertInfo
+	errMsg string // non-empty when the monitoring backend was unreachable
+}
+
 // loadDashboard fans out the cluster dashboard fetch into 6 parallel
 // Low-priority scheduler tasks, one per section. Each emits a
 // dashboardPartialMsg as it completes; handleDashboardPartial
@@ -367,18 +375,6 @@ func (m Model) composeDashboard(data dashboardData) (content, events string) {
 	return content, events
 }
 
-// recomposeDashboard re-renders dashboardPreview / dashboardEventsPreview from
-// the retained data at the current width. No-op when no data is loaded for the
-// active context. Called on data load, fullscreen toggle, and window resize so
-// the bars always fit the available space.
-func (m Model) recomposeDashboard() Model {
-	ctx := m.dashboardPreviewTargetContext()
-	if data, ok := m.dashboardData[ctx]; ok {
-		m.dashboardPreview, m.dashboardEventsPreview = m.composeDashboard(data)
-	}
-	return m
-}
-
 // countPodStats tallies pod statuses.
 func countPodStats(podItems []model.Item) podStats {
 	ps := podStats{total: len(podItems)}
@@ -528,34 +524,52 @@ func (m Model) loadMonitoringDashboardFor(kctx string) tea.Cmd {
 		"Monitoring dashboard",
 		bgtaskTarget(kctx, ns),
 		func() tea.Msg {
-			var lines []string
-			lines = append(lines, "")
-			lines = append(lines, ui.DimStyle.Bold(true).Render("  MONITORING OVERVIEW"))
-			lines = append(lines, "")
-
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			alerts, err := client.GetAllActiveAlerts(ctx, kctx, ns)
+			errMsg := ""
 			if err != nil {
-				lines = append(lines, ui.DimStyle.Render("  Prometheus/Alertmanager not reachable"))
-				lines = append(lines, ui.DimStyle.Render("  "+err.Error()))
-				lines = append(lines, "")
-				lines = append(lines, ui.DimStyle.Render("  Searched in well-known namespaces:"))
-				lines = append(lines, ui.DimStyle.Render("  monitoring, prometheus, observability, kube-prometheus-stack"))
-				lines = append(lines, "")
-				return monitoringDashboardMsg{content: strings.Join(lines, "\n"), context: kctx}
+				errMsg = err.Error()
+				alerts = nil
 			}
-
-			lines = monitoringAlertSummary(lines, alerts)
-			lines = append(lines, "")
-			sortAlerts(alerts)
-			lines = monitoringAlertTable(lines, alerts)
-
-			lines = append(lines, "")
-			return monitoringDashboardMsg{content: strings.Join(lines, "\n"), context: kctx}
+			return monitoringDashboardMsg{
+				content: composeMonitoring(alerts, errMsg),
+				alerts:  alerts,
+				errMsg:  errMsg,
+				context: kctx,
+			}
 		},
 	)
+}
+
+// composeMonitoring renders the monitoring dashboard body from raw alert data.
+// It takes no model state so it can run both inside the load goroutine and in
+// recomposeMonitoring, where it re-renders with the current theme on a theme
+// change. errMsg, when non-empty, signals the monitoring backend was
+// unreachable and renders the connectivity hint instead of the alert table.
+func composeMonitoring(alerts []k8s.AlertInfo, errMsg string) string {
+	var lines []string
+	lines = append(lines, "")
+	lines = append(lines, ui.DimStyle.Bold(true).Render("  MONITORING OVERVIEW"))
+	lines = append(lines, "")
+
+	if errMsg != "" {
+		lines = append(lines, ui.DimStyle.Render("  Prometheus/Alertmanager not reachable"))
+		lines = append(lines, ui.DimStyle.Render("  "+errMsg))
+		lines = append(lines, "")
+		lines = append(lines, ui.DimStyle.Render("  Searched in well-known namespaces:"))
+		lines = append(lines, ui.DimStyle.Render("  monitoring, prometheus, observability, kube-prometheus-stack"))
+		lines = append(lines, "")
+		return strings.Join(lines, "\n")
+	}
+
+	lines = monitoringAlertSummary(lines, alerts)
+	lines = append(lines, "")
+	sortAlerts(alerts)
+	lines = monitoringAlertTable(lines, alerts)
+	lines = append(lines, "")
+	return strings.Join(lines, "\n")
 }
 
 // monitoringAlertSummary renders the alert summary header with state/severity counts.

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -167,9 +167,14 @@ type dashboardPartialMsg struct {
 	data    dashboardData
 }
 
-// monitoringDashboardMsg carries the rendered monitoring dashboard content.
+// monitoringDashboardMsg carries the rendered monitoring dashboard content
+// plus the raw alert payload it was built from. The raw payload is retained so
+// the dashboard can be re-rendered on a theme change or resize without
+// re-querying Prometheus (see recomposeMonitoring).
 type monitoringDashboardMsg struct {
-	content string
+	content string          // pre-rendered body for immediate display
+	alerts  []k8s.AlertInfo // raw payload retained for theme/resize recompose
+	errMsg  string          // non-empty when the monitoring backend was unreachable
 	context string
 }
 

--- a/internal/app/recompose.go
+++ b/internal/app/recompose.go
@@ -1,0 +1,72 @@
+package app
+
+import "github.com/janosmiko/lfk/internal/ui"
+
+// recomposeThemedContent re-renders every cached, pre-rendered preview string
+// (dashboard, monitoring, metrics bar, events footer) from its retained raw
+// data. Those strings bake the active theme's color codes into their bytes, so
+// a theme switch otherwise leaves them stale until the next data tick.
+// Recomposing here applies the new theme immediately; because the bars are also
+// width-dependent, it doubles as the resize refresh path.
+func (m Model) recomposeThemedContent() Model {
+	m = m.recomposeDashboard()
+	m = m.recomposeMonitoring()
+	m = m.recomposeMetrics()
+	m = m.recomposePreviewEvents()
+	return m
+}
+
+// recomposeDashboard re-renders dashboardPreview / dashboardEventsPreview from
+// the retained data at the current width. No-op when no data is loaded for the
+// active context. Called on data load, fullscreen toggle, and window resize so
+// the bars always fit the available space.
+func (m Model) recomposeDashboard() Model {
+	ctx := m.dashboardPreviewTargetContext()
+	if data, ok := m.dashboardData[ctx]; ok {
+		m.dashboardPreview, m.dashboardEventsPreview = m.composeDashboard(data)
+	}
+	return m
+}
+
+// recomposeMonitoring re-renders monitoringPreview from the retained alert data
+// for the active context. No-op when no data is loaded for that context.
+func (m Model) recomposeMonitoring() Model {
+	ctx := m.dashboardPreviewTargetContext()
+	if data, ok := m.monitoringData[ctx]; ok {
+		m.monitoringPreview = composeMonitoring(data.alerts, data.errMsg)
+	}
+	return m
+}
+
+// recomposeMetrics re-renders the right-pane resource-usage bar from the
+// retained raw numbers at the current width. No-op when no metrics are loaded.
+func (m Model) recomposeMetrics() Model {
+	if m.metricsData == nil {
+		return m
+	}
+	d := m.metricsData
+	m.metricsContent = ui.RenderResourceUsage(
+		d.cpuUsed, d.cpuReq, d.cpuLim,
+		d.memUsed, d.memReq, d.memLim,
+		m.rightFooterInnerWidth(),
+	)
+	return m
+}
+
+// recomposePreviewEvents re-renders the right-pane events footer from the
+// retained entries at the current width. No-op when no events are loaded.
+func (m Model) recomposePreviewEvents() Model {
+	if len(m.previewEventsData) == 0 {
+		return m
+	}
+	m.previewEventsContent = ui.RenderPreviewEvents(m.previewEventsData, m.rightFooterInnerWidth())
+	return m
+}
+
+// rightFooterInnerWidth returns the content width of the right-column footer
+// region (resource-usage bar / events), matching renderRightColumn's geometry.
+func (m Model) rightFooterInnerWidth() int {
+	usable := m.width - 6
+	rightW := max(10, usable-max(10, usable*12/100)-max(10, usable*51/100))
+	return max(rightW-4, 20)
+}

--- a/internal/app/recompose_theme_test.go
+++ b/internal/app/recompose_theme_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// themeA and themeB differ only in their Base background, which is enough for
+// the recompose assertions: a stale (non-recomposed) string keeps themeA's
+// "48;2;..." background code, a recomposed one carries themeB's.
+func themeA() ui.Theme { t := ui.DefaultTheme(); t.Base = "#101010"; return t }
+func themeB() ui.Theme { t := ui.DefaultTheme(); t.Base = "#fa00fa"; return t }
+
+func withTrueColor(t *testing.T) {
+	origProfile := lipgloss.DefaultRenderer().ColorProfile()
+	origTheme := ui.ActiveTheme
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() {
+		lipgloss.DefaultRenderer().SetColorProfile(origProfile)
+		ui.ApplyTheme(origTheme)
+	})
+}
+
+// TestRecomposeThemedContentRerendersCachedPreviews guards the theme-switch
+// staleness fix: dashboard, monitoring, metrics, and events previews bake the
+// active theme's colors into cached strings, so a theme switch must recompose
+// them from retained raw data rather than wait for the next data tick.
+func TestRecomposeThemedContentRerendersCachedPreviews(t *testing.T) {
+	withTrueColor(t)
+	ui.ApplyTheme(themeA())
+
+	m := Model{
+		width:  120,
+		height: 40,
+		metricsData: &metricsInputs{
+			cpuUsed: 500, cpuReq: 1000, cpuLim: 2000,
+			memUsed: 256, memReq: 512, memLim: 1024,
+		},
+		previewEventsData: []ui.EventTimelineEntry{
+			{Timestamp: time.Time{}, Type: "Warning", Reason: "BackOff", Message: "boom", InvolvedName: "p", InvolvedKind: "Pod"},
+		},
+		monitoringData: map[string]monitoringData{
+			"ctx": {alerts: []k8s.AlertInfo{{Name: "HighCPU", State: "firing", Severity: "critical"}}},
+		},
+		dashboardData: map[string]dashboardData{
+			"ctx": {nodeCount: 3, readyNodes: 3, pods: podStats{total: 10, running: 10}},
+		},
+		nav: model.NavigationState{Context: "ctx"},
+	}
+
+	// Render everything under theme A.
+	m = m.recomposeThemedContent()
+	metricsA, eventsA, monA, dashA := m.metricsContent, m.previewEventsContent, m.monitoringPreview, m.dashboardPreview
+	require.NotEmpty(t, metricsA)
+	require.NotEmpty(t, eventsA)
+	require.NotEmpty(t, monA)
+	require.NotEmpty(t, dashA)
+
+	// Switch theme and recompose.
+	ui.ApplyTheme(themeB())
+	m = m.recomposeThemedContent()
+
+	assert.NotEqual(t, metricsA, m.metricsContent, "metrics bar must re-render under the new theme")
+	assert.NotEqual(t, eventsA, m.previewEventsContent, "events footer must re-render under the new theme")
+	assert.NotEqual(t, monA, m.monitoringPreview, "monitoring dashboard must re-render under the new theme")
+	assert.NotEqual(t, dashA, m.dashboardPreview, "cluster dashboard must re-render under the new theme")
+}
+
+// TestColorschemeCommitRecomposesFooters guards the handler wiring: committing
+// a scheme in the overlay must re-render the cached footers so the new theme
+// applies immediately instead of on the next data tick.
+func TestColorschemeCommitRecomposesFooters(t *testing.T) {
+	withTrueColor(t)
+	ui.ApplyTheme(ui.DefaultTheme())
+
+	m := Model{
+		overlay:            overlayColorscheme,
+		schemeEntries:      []ui.SchemeEntry{{Name: "Dark", IsHeader: true}, {Name: "dracula"}},
+		schemeCursor:       0,
+		schemeOriginalName: "tokyonight",
+		width:              120,
+		height:             40,
+		tabs:               []TabState{{}},
+		metricsData: &metricsInputs{
+			cpuUsed: 500, cpuReq: 1000, cpuLim: 2000,
+			memUsed: 256, memReq: 512, memLim: 1024,
+		},
+		nav: model.NavigationState{Context: "ctx"},
+	}
+	m = m.recomposeMetrics()
+	before := m.metricsContent
+	require.NotEmpty(t, before)
+
+	ret, _ := m.handleColorschemeNormalMode(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNone, result.overlay, "overlay must close on commit")
+	assert.NotEqual(t, before, result.metricsContent,
+		"committing a new scheme must recompose the metrics footer with the new theme")
+}
+
+// TestColorschemeLivePreviewRecomposesFooters guards the live-preview path: the
+// picker keeps the explorer un-dimmed for side-by-side comparison, so moving the
+// cursor (j/k) must recompose the cached previews with the previewed theme, not
+// wait for commit or the next tick.
+func TestColorschemeLivePreviewRecomposesFooters(t *testing.T) {
+	withTrueColor(t)
+	ui.ApplyTheme(ui.DefaultTheme())
+
+	m := Model{
+		overlay: overlayColorscheme,
+		// Cursor starts on the first scheme; "j" moves to the second (dracula),
+		// which differs from the initial tokyonight default.
+		schemeEntries:      []ui.SchemeEntry{{Name: "tokyonight"}, {Name: "dracula"}},
+		schemeCursor:       0,
+		schemeOriginalName: "tokyonight",
+		width:              120,
+		height:             40,
+		tabs:               []TabState{{}},
+		metricsData: &metricsInputs{
+			cpuUsed: 500, cpuReq: 1000, cpuLim: 2000,
+			memUsed: 256, memReq: 512, memLim: 1024,
+		},
+		nav: model.NavigationState{Context: "ctx"},
+	}
+	m = m.recomposeMetrics()
+	before := m.metricsContent
+	require.NotEmpty(t, before)
+
+	ret, _ := m.handleColorschemeNormalMode(runeKey('j'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayColorscheme, result.overlay, "overlay stays open during preview")
+	assert.NotEqual(t, before, result.metricsContent,
+		"moving the cursor must recompose the metrics footer with the previewed theme")
+}
+
+// TestRecomposeIsNoOpWithoutRetainedData ensures recompose leaves the footers
+// empty (no panic, no spurious content) when nothing is loaded.
+func TestRecomposeIsNoOpWithoutRetainedData(t *testing.T) {
+	withTrueColor(t)
+	ui.ApplyTheme(themeA())
+	m := Model{width: 120, height: 40, nav: model.NavigationState{Context: "ctx"}}
+	m = m.recomposeThemedContent()
+	assert.Empty(t, m.metricsContent)
+	assert.Empty(t, m.previewEventsContent)
+	assert.Empty(t, m.monitoringPreview)
+	assert.Empty(t, m.dashboardPreview)
+}

--- a/internal/app/recompose_theme_test.go
+++ b/internal/app/recompose_theme_test.go
@@ -24,10 +24,12 @@ func themeB() ui.Theme { t := ui.DefaultTheme(); t.Base = "#fa00fa"; return t }
 func withTrueColor(t *testing.T) {
 	origProfile := lipgloss.DefaultRenderer().ColorProfile()
 	origTheme := ui.ActiveTheme
+	origSchemeName := ui.ActiveSchemeName
 	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
 	t.Cleanup(func() {
 		lipgloss.DefaultRenderer().SetColorProfile(origProfile)
 		ui.ApplyTheme(origTheme)
+		ui.ActiveSchemeName = origSchemeName
 	})
 }
 

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -32,23 +32,6 @@ func (m *Model) popLeft() {
 	}
 }
 
-// clearRight resets the right column and YAML preview so stale data doesn't linger.
-// Every caller of clearRight is a navigation transition that will dispatch a
-// new preview load, so we arm previewLoading here to keep the right pane's
-// spinner visible during the gap. Without this, navigateParent/navigateChild
-// and other transitions briefly render "No resources found".
-func (m *Model) clearRight() {
-	m.rightItems = nil
-	m.yamlContent = ""
-	m.yamlSections = nil
-	m.previewYAML = ""
-	m.metricsContent = ""
-	m.previewEventsContent = ""
-	m.resourceTree = nil
-	m.mapView = false
-	m.previewLoading = true
-}
-
 // selectedResourceKind returns the Kind of the currently selected resource,
 // which is context-dependent on the navigation level.
 func (m *Model) selectedResourceKind() string {
@@ -457,6 +440,8 @@ func (m *Model) saveCurrentTab() {
 	t.monitoringPreview = m.monitoringPreview
 	t.metricsContent = m.metricsContent
 	t.previewEventsContent = m.previewEventsContent
+	t.metricsData = m.metricsData
+	t.previewEventsData = m.previewEventsData
 	t.warningEventsOnly = m.warningEventsOnly
 	t.eventGrouping = m.eventGrouping
 	t.expandedGroup = m.expandedGroup
@@ -570,6 +555,8 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	// metrics / events instead of leaking the previous tab's values.
 	m.metricsContent = t.metricsContent
 	m.previewEventsContent = t.previewEventsContent
+	m.metricsData = t.metricsData
+	m.previewEventsData = t.previewEventsData
 	m.warningEventsOnly = t.warningEventsOnly
 	m.eventGrouping = t.eventGrouping
 	m.expandedGroup = t.expandedGroup

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -714,6 +714,8 @@ func (m *Model) cloneCurrentTab() TabState {
 		monitoringPreview:      m.monitoringPreview,
 		metricsContent:         m.metricsContent,
 		previewEventsContent:   m.previewEventsContent,
+		metricsData:            m.metricsData,
+		previewEventsData:      append([]ui.EventTimelineEntry(nil), m.previewEventsData...),
 		warningEventsOnly:      m.warningEventsOnly,
 		eventGrouping:          m.eventGrouping,
 		expandedGroup:          m.expandedGroup,

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -436,8 +436,9 @@ func (m Model) updateWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	m.width = msg.Width
 	m.height = msg.Height
 	m.clampAllCursors()
-	// Re-render the dashboard so its bars use the new width.
-	m = m.recomposeDashboard()
+	// Re-render every width-dependent cached preview (dashboard, monitoring,
+	// metrics bar, events footer) so they use the new width.
+	m = m.recomposeThemedContent()
 	// Resize the embedded PTY terminal if active.
 	if m.mode == modeExec && m.execTerm != nil && m.execPTY != nil {
 		cols := m.width

--- a/internal/app/update_dispatch_msgs.go
+++ b/internal/app/update_dispatch_msgs.go
@@ -212,6 +212,12 @@ func (m Model) updateDashboardLoaded(msg dashboardLoadedMsg) Model {
 
 func (m Model) updateMonitoringDashboard(msg monitoringDashboardMsg) Model {
 	if msg.context == m.dashboardPreviewTargetContext() {
+		if m.monitoringData == nil {
+			m.monitoringData = make(map[string]monitoringData)
+		}
+		// Retain the raw alerts so a theme change / resize can re-render the
+		// dashboard in place via recomposeMonitoring without re-querying.
+		m.monitoringData[msg.context] = monitoringData{alerts: msg.alerts, errMsg: msg.errMsg}
 		m.monitoringPreview = msg.content
 	}
 	return m

--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -14,26 +14,30 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// metricsInputs holds the raw resource-usage numbers behind metricsContent,
+// retained so the bar can be re-rendered at the current width / theme without
+// a metrics-server round-trip (see recomposeMetrics).
+type metricsInputs struct {
+	cpuUsed, cpuReq, cpuLim int64
+	memUsed, memReq, memLim int64
+}
+
 func (m Model) updateMetricsLoaded(msg metricsLoadedMsg) Model {
 	if msg.gen != m.requestGen {
 		return m // stale response
 	}
 	if msg.cpuUsed == 0 && msg.memUsed == 0 {
 		m.metricsContent = ""
+		m.metricsData = nil
 		return m
 	}
-	// Calculate available width for the metrics bar.
-	usable := m.width - 6
-	rightW := max(10, usable-max(10, usable*12/100)-max(10, usable*51/100))
-	innerW := max(
-		// column padding + border
-		rightW-4, 20)
-	m.metricsContent = ui.RenderResourceUsage(
-		msg.cpuUsed, msg.cpuReq, msg.cpuLim,
-		msg.memUsed, msg.memReq, msg.memLim,
-		innerW,
-	)
-	return m
+	// Retain the raw numbers so a theme change / resize can re-render the bar
+	// in place via recomposeMetrics, then compose at the current width.
+	m.metricsData = &metricsInputs{
+		cpuUsed: msg.cpuUsed, cpuReq: msg.cpuReq, cpuLim: msg.cpuLim,
+		memUsed: msg.memUsed, memReq: msg.memReq, memLim: msg.memLim,
+	}
+	return m.recomposeMetrics()
 }
 
 func (m Model) updatePreviewEventsLoaded(msg previewEventsLoadedMsg) Model {
@@ -42,12 +46,9 @@ func (m Model) updatePreviewEventsLoaded(msg previewEventsLoadedMsg) Model {
 	}
 	if len(msg.events) == 0 {
 		m.previewEventsContent = ""
+		m.previewEventsData = nil
 		return m
 	}
-	// Calculate available width for the events section.
-	usable := m.width - 6
-	rightW := max(10, usable-max(10, usable*12/100)-max(10, usable*51/100))
-	innerW := max(rightW-4, 20)
 	entries := make([]ui.EventTimelineEntry, len(msg.events))
 	for i, e := range msg.events {
 		entries[i] = ui.EventTimelineEntry{
@@ -61,8 +62,10 @@ func (m Model) updatePreviewEventsLoaded(msg previewEventsLoadedMsg) Model {
 			InvolvedKind: e.InvolvedKind,
 		}
 	}
-	m.previewEventsContent = ui.RenderPreviewEvents(entries, innerW)
-	return m
+	// Retain the entries so a theme change / resize can re-render the footer in
+	// place via recomposePreviewEvents, then compose at the current width.
+	m.previewEventsData = entries
+	return m.recomposePreviewEvents()
 }
 
 // updatePreviewServiceEndpointsLoaded injects the rollup into every

--- a/internal/app/update_overlays_colorscheme.go
+++ b/internal/app/update_overlays_colorscheme.go
@@ -36,6 +36,9 @@ func (m Model) handleColorschemeNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		}
 		m.overlay = overlayNone
 		m.schemeFilter.Clear()
+		// Re-render cached previews so they drop the live-preview theme's baked
+		// colors and paint with the restored theme immediately.
+		m = m.recomposeThemedContent()
 		return m, nil
 
 	case "enter":
@@ -49,6 +52,9 @@ func (m Model) handleColorschemeNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 			}
 			m.overlay = overlayNone
 			m.schemeFilter.Clear()
+			// Re-render cached previews so the new theme applies immediately
+			// instead of waiting for the next data tick.
+			m = m.recomposeThemedContent()
 			return m, scheduleStatusClear()
 		}
 		return m, nil
@@ -146,6 +152,8 @@ func (m Model) handleColorschemeNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		if theme, ok := ui.BuiltinSchemes()[ui.ActiveSchemeName]; ok {
 			ui.ApplyTheme(theme)
 		}
+		// Re-render cached previews so the transparency change applies now.
+		m = m.recomposeThemedContent()
 		if ui.ConfigTransparentBg {
 			m.setStatusMessage("Transparent background: on", false)
 		} else {
@@ -213,6 +221,8 @@ func (m Model) handleColorschemeFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 			}
 			m.overlay = overlayNone
 			m.schemeFilter.Clear()
+			// Re-render cached previews so the new theme applies immediately.
+			m = m.recomposeThemedContent()
 			return m, scheduleStatusClear()
 		}
 		m.previewSchemeAtCursor(filtered)
@@ -229,6 +239,10 @@ func (m Model) handleColorschemeFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 }
 
 // previewSchemeAtCursor applies the scheme under the cursor as a live preview.
+// The colorscheme picker keeps the explorer behind it un-dimmed for side-by-side
+// comparison (see renderOverlay), so the cached preview strings (dashboard,
+// monitoring, metrics bar, events footer) must be recomposed on every preview
+// step — otherwise their baked-in theme colors stay stale until the next tick.
 func (m *Model) previewSchemeAtCursor(filtered []string) {
 	if m.schemeCursor >= 0 && m.schemeCursor < len(filtered) {
 		name := filtered[m.schemeCursor]
@@ -236,6 +250,7 @@ func (m *Model) previewSchemeAtCursor(filtered []string) {
 		if theme, ok := schemes[name]; ok {
 			ui.ApplyTheme(theme)
 			ui.ActiveSchemeName = name
+			*m = m.recomposeThemedContent()
 		}
 	}
 }

--- a/internal/app/update_overlays_misc.go
+++ b/internal/app/update_overlays_misc.go
@@ -151,6 +151,8 @@ func (m Model) applyFilterPreset(preset FilterPreset) (tea.Model, tea.Cmd) {
 		m.resourceTree = nil
 		m.metricsContent = ""
 		m.previewEventsContent = ""
+		m.metricsData = nil
+		m.previewEventsData = nil
 	}
 	m.setStatusMessage(fmt.Sprintf("Filter: %s (%d matches)", preset.Name, len(filtered)), false)
 	return m, tea.Batch(scheduleStatusClear(), m.loadPreview())

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -17,6 +17,7 @@ func (m *Model) clearRight() {
 	m.yamlContent = ""
 	m.yamlSections = nil
 	m.previewYAML = ""
+	m.previewScroll = 0
 	m.metricsContent = ""
 	m.previewEventsContent = ""
 	m.metricsData = nil

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -7,6 +7,25 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// clearRight resets the right column and YAML preview so stale data doesn't linger.
+// Every caller of clearRight is a navigation transition that will dispatch a
+// new preview load, so we arm previewLoading here to keep the right pane's
+// spinner visible during the gap. Without this, navigateParent/navigateChild
+// and other transitions briefly render "No resources found".
+func (m *Model) clearRight() {
+	m.rightItems = nil
+	m.yamlContent = ""
+	m.yamlSections = nil
+	m.previewYAML = ""
+	m.metricsContent = ""
+	m.previewEventsContent = ""
+	m.metricsData = nil
+	m.previewEventsData = nil
+	m.resourceTree = nil
+	m.mapView = false
+	m.previewLoading = true
+}
+
 // clampPreviewScroll prevents scrolling past the preview content.
 // Only details+events scroll; pinned header (children) and footer (resource usage) are excluded.
 func (m *Model) clampPreviewScroll() {


### PR DESCRIPTION
## Summary

Switching color scheme (Shift+T) — or toggling transparent background — left several pre-rendered previews showing the **old theme's colors until the next data tick**: the cluster dashboard, the monitoring dashboard, the right-pane resource-usage bar, and the events footer. Their section titles, separators, pod counts, and event text all lagged.

**Root cause.** These regions are rendered once into ANSI strings cached on the model, with the active theme's color codes baked into the bytes. `ApplyTheme` only swaps the live style globals used by fresh `View()`-time renders, so the cached strings stay stale until the next tick recomputes them.

**Fix.** Retain the raw inputs behind each cached string and recompose from that data whenever the theme changes:

- `recompose.go` — `recomposeThemedContent()` plus per-target helpers (`recomposeDashboard` / `recomposeMonitoring` / `recomposeMetrics` / `recomposePreviewEvents`) and `rightFooterInnerWidth`.
- **Monitoring** load split into fetch + `composeMonitoring(alerts, errMsg)` so it can re-render without re-querying Prometheus; raw alerts retained per-context (`monitoringData`), mirroring `dashboardData`.
- **Metrics / events** raw inputs retained per-tab (`metricsData`, `previewEventsData`), cleared on navigation so a footer can't show a stale resource's data.
- Wired into every theme-apply path: the colorscheme picker's **live preview** (it keeps the explorer un-dimmed for side-by-side comparison, so each cursor move must recompose), commit (enter / filter-accept), esc-cancel restore, and the `t` transparency toggle.
- The same recompose runs on **resize**, fixing latent width staleness in the bars.

Files were kept under the 800-line cap by extracting `recompose.go` and relocating `clearRight` into `view_right.go`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test -race ./...`, `make lint` (0 issues)
- [x] `TestRecomposeThemedContentRerendersCachedPreviews` — all four previews re-render under a new theme
- [x] `TestColorschemeCommitRecomposesFooters` — committing a scheme recomposes
- [x] `TestColorschemeLivePreviewRecomposesFooters` — scrolling the picker recomposes live
- [x] `TestRecomposeIsNoOpWithoutRetainedData` — no-op / no panic when nothing is loaded
