### PR TITLE
feat: derive CRD display names from Kind to preserve camel case

### DIFF
--- a/internal/model/sidebar.go
+++ b/internal/model/sidebar.go
@@ -90,7 +90,7 @@ func partitionDiscovered(discovered []ResourceTypeEntry) (categorized, crdGroups
 			// BuiltInMetadata yet — surface it in the mapped category with
 			// the generic CRD glyph so it's visible instead of hidden.
 			categorized = append(categorized, Item{
-				Name:       titleCaseFirst(rt.Resource),
+				Name:       displayNameFromKind(rt.Kind, rt.Resource),
 				Kind:       rt.Kind,
 				Extra:      rt.ResourceRef(),
 				Category:   cat,
@@ -105,7 +105,7 @@ func partitionDiscovered(discovered []ResourceTypeEntry) (categorized, crdGroups
 			}
 			// Surface uncategorized core K8s resources under "Advanced".
 			categorized = append(categorized, Item{
-				Name:       titleCaseFirst(rt.Resource),
+				Name:       displayNameFromKind(rt.Kind, rt.Resource),
 				Kind:       rt.Kind,
 				Extra:      rt.ResourceRef(),
 				Category:   AdvancedCategory,
@@ -116,7 +116,7 @@ func partitionDiscovered(discovered []ResourceTypeEntry) (categorized, crdGroups
 		}
 		// Unknown resource in a CRD group — show with generic icon.
 		crdGroups = append(crdGroups, Item{
-			Name:       titleCaseFirst(rt.Resource),
+			Name:       displayNameFromKind(rt.Kind, rt.Resource),
 			Kind:       rt.Kind,
 			Extra:      rt.ResourceRef(),
 			Category:   rt.APIGroup,
@@ -149,6 +149,31 @@ func titleCaseFirst(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// displayNameFromKind derives a sidebar display name for a discovered
+// resource, preferring the resource's Kind so multi-word casing is preserved.
+// Kubernetes forces resource plurals to lowercase, which loses the casing of
+// kinds like "ApplicationSet" (plural "applicationsets"). When the plural is a
+// regular suffixing of the lowercased kind ("+s", "+es", or "y"->"ies"), the
+// kind reconstructs the intended camel case. Irregular plurals (and an empty
+// kind) fall back to capitalizing the plural's first letter.
+//
+// Kubernetes kinds are ASCII identifiers, so byte length is rune length here
+// and the byte-index slicing below is safe.
+func displayNameFromKind(kind, plural string) string {
+	if kind != "" {
+		lower := strings.ToLower(kind)
+		switch plural {
+		case lower + "s", lower + "es":
+			// Reuse the plural's actual suffix so casing comes from the kind.
+			return kind + plural[len(lower):]
+		}
+		if strings.HasSuffix(lower, "y") && plural == lower[:len(lower)-1]+"ies" {
+			return kind[:len(kind)-1] + "ies"
+		}
+	}
+	return titleCaseFirst(plural)
 }
 
 // sortSidebarItems orders sidebar items: core categories in fixed order,

--- a/internal/model/sidebar_test.go
+++ b/internal/model/sidebar_test.go
@@ -7,6 +7,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDisplayNameFromKind(t *testing.T) {
+	tests := []struct {
+		name   string
+		kind   string
+		plural string
+		want   string
+	}{
+		{"camel-case kind plus s", "ApplicationSet", "applicationsets", "ApplicationSets"},
+		{"simple kind plus s", "Widget", "widgets", "Widgets"},
+		{"kind plus es", "Ingress", "ingresses", "Ingresses"},
+		{"camel kind plus es", "StorageClass", "storageclasses", "StorageClasses"},
+		{"y to ies", "NetworkPolicy", "networkpolicies", "NetworkPolicies"},
+		{"regular y plural keeps kind", "Gateway", "gateways", "Gateways"},
+		{"irregular plural falls back to plural", "Endpoints", "endpoints", "Endpoints"},
+		{"mismatched plural falls back", "Foo", "bars", "Bars"},
+		{"empty kind falls back to plural", "", "widgets", "Widgets"},
+		{"empty plural", "Widget", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, displayNameFromKind(tt.kind, tt.plural))
+		})
+	}
+}
+
+func TestBuildSidebarItems_CamelCasesCRDFromKind(t *testing.T) {
+	discovered := []ResourceTypeEntry{
+		// Custom CRD whose plural is the lowercased kind + "s". The display
+		// name should recover the kind's camel case instead of "Applicationsets".
+		{Kind: "ApplicationSet", APIGroup: "example.com", APIVersion: "v1", Resource: "applicationsets", Namespaced: true},
+	}
+
+	items := BuildSidebarItems(discovered)
+
+	var got *Item
+	for i := range items {
+		if items[i].Kind == "ApplicationSet" {
+			got = &items[i]
+			break
+		}
+	}
+	require.NotNil(t, got)
+	assert.Equal(t, "ApplicationSets", got.Name)
+}
+
 func TestBuildSidebarItems_CategorizesBuiltIns(t *testing.T) {
 	discovered := []ResourceTypeEntry{
 		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true},
@@ -148,7 +193,7 @@ func TestBuildSidebarItems_RareResourcesHiddenByDefault(t *testing.T) {
 	defaultNames := collectByDisplay(defaultItems)
 	assert.Contains(t, defaultNames, "Pods", "Pod must always appear")
 	assert.NotContains(t, defaultNames, "CSIDrivers", "rare curated entry must be hidden by default")
-	assert.NotContains(t, defaultNames, "Tokenreviews", "uncategorized core resource must be hidden by default")
+	assert.NotContains(t, defaultNames, "TokenReviews", "uncategorized core resource must be hidden by default")
 
 	// With toggle ON: rare curated surfaces in its category, uncategorized
 	// core resources surface under "Advanced".
@@ -158,9 +203,9 @@ func TestBuildSidebarItems_RareResourcesHiddenByDefault(t *testing.T) {
 	require.Contains(t, toggleNames, "CSIDrivers")
 	assert.Equal(t, "Storage", toggleNames["CSIDrivers"].Category)
 
-	require.Contains(t, toggleNames, "Tokenreviews")
-	assert.Equal(t, AdvancedCategory, toggleNames["Tokenreviews"].Category)
-	assert.Equal(t, "TokenReview", toggleNames["Tokenreviews"].Kind)
+	require.Contains(t, toggleNames, "TokenReviews")
+	assert.Equal(t, AdvancedCategory, toggleNames["TokenReviews"].Category)
+	assert.Equal(t, "TokenReview", toggleNames["TokenReviews"].Kind)
 }
 
 // TestBuildSidebarItems_CuratedOrderWithinCategory verifies that items in
@@ -215,15 +260,15 @@ func TestBuildSidebarItems_GroupFallbackCategorizesUnknownNetworking(t *testing.
 	items := BuildSidebarItems(discovered)
 	byName := collectByDisplay(items)
 
-	require.Contains(t, byName, "Futurenetresources",
+	require.Contains(t, byName, "FutureNetResources",
 		"unknown networking.k8s.io resource must appear via group fallback")
-	assert.Equal(t, "Networking", byName["Futurenetresources"].Category)
-	assert.Equal(t, "⧫", byName["Futurenetresources"].Icon.Unicode,
+	assert.Equal(t, "Networking", byName["FutureNetResources"].Category)
+	assert.Equal(t, "⧫", byName["FutureNetResources"].Icon.Unicode,
 		"fallback items use the generic CRD glyph")
 
-	require.Contains(t, byName, "Futuregatewayresources",
+	require.Contains(t, byName, "FutureGatewayResources",
 		"unknown gateway.networking.k8s.io resource must appear via group fallback")
-	assert.Equal(t, "Networking", byName["Futuregatewayresources"].Category)
+	assert.Equal(t, "Networking", byName["FutureGatewayResources"].Category)
 }
 
 // TestBuildSidebarItems_GroupFallbackOrderedBeforePortForwards verifies
@@ -254,11 +299,11 @@ func TestBuildSidebarItems_GroupFallbackOrderedBeforePortForwards(t *testing.T) 
 	// The unknown resource must slot after them, before Port Forwards.
 	idxGateway := indexOf(networking, "Gateways")
 	idxHTTPRoute := indexOf(networking, "HTTPRoutes")
-	idxFallback := indexOf(networking, "Futuregatewayresources")
+	idxFallback := indexOf(networking, "FutureGatewayResources")
 	idxPortFwd := indexOf(networking, "Port Forwards")
 	require.GreaterOrEqual(t, idxGateway, 0, "Gateways must appear")
 	require.GreaterOrEqual(t, idxHTTPRoute, 0, "HTTPRoutes must appear")
-	require.GreaterOrEqual(t, idxFallback, 0, "Futuregatewayresources must appear via fallback")
+	require.GreaterOrEqual(t, idxFallback, 0, "FutureGatewayResources must appear via fallback")
 	require.GreaterOrEqual(t, idxPortFwd, 0, "Port Forwards must appear")
 
 	assert.Less(t, idxGateway, idxFallback,
@@ -309,7 +354,7 @@ func TestBuildSidebarItems_SkipsNonListableResources(t *testing.T) {
 
 	assert.Contains(t, names, "Pods", "listable resource must appear")
 	assert.Contains(t, names, "Releases", "pseudo-resource with empty Verbs must appear")
-	assert.NotContains(t, names, "Tokenreviews", "non-listable review API must be hidden")
+	assert.NotContains(t, names, "TokenReviews", "non-listable review API must be hidden")
 	assert.NotContains(t, names, "Subjectaccessreviews", "non-listable review API must be hidden")
 	assert.NotContains(t, names, "Selfsubjectreviews", "non-listable review API must be hidden")
 	assert.NotContains(t, names, "Selfsubjectaccessreviews", "non-listable review API must be hidden")


### PR DESCRIPTION
Closes #301

## Problem

Uncurated CRDs render in the sidebar with awkward casing. Display names are derived by upper-casing the first letter of the lowercase Kubernetes plural, so a CRD with plural `applicationsets` shows as **Applicationsets**. Kubernetes forces CRD plurals to lowercase, so the intended camel case is only recoverable from the resource `Kind`.

Today, nice casing only exists for CRDs hand-curated in `BuiltInMetadata`.

## Solution

New `displayNameFromKind(kind, plural)` helper reconstructs casing from the `Kind` (which preserves camel case) when the plural is a regular suffixing of `lower(kind)`:

| Kind | plural | display |
|---|---|---|
| `ApplicationSet` | `applicationsets` | **ApplicationSets** |
| `Ingress` | `ingresses` | **Ingresses** |
| `StorageClass` | `storageclasses` | **StorageClasses** |
| `NetworkPolicy` | `networkpolicies` | **NetworkPolicies** |

Irregular plurals (and an empty kind) fall back to the previous `titleCaseFirst(plural)` behavior — no regression. The `y`->`ies` rule was added beyond the issue's literal `s`/`es` ask since it covers another common k8s plural pattern.

Wired into all three CRD/fallback branches in `partitionDiscovered`. Curated `BuiltInMetadata` entries are still matched first, so only uncurated CRDs and auto-categorized resources are affected.

## Test plan

- [x] `TestDisplayNameFromKind` — table-driven, 10 cases incl. `+s`/`+es`/`ies`/irregular/empty fallbacks
- [x] `TestBuildSidebarItems_CamelCasesCRDFromKind` — integration through `BuildSidebarItems`
- [x] Updated 3 pre-existing assertions to the improved camelCase output
- [x] `go test -race ./internal/model/` green; full `go build`/`go test ./...` green
- [x] `gofmt`, `go vet`, `golangci-lint` — 0 issues