### PR TITLE
fix: show manually-triggered jobs in CronJob > Jobs subview

### DIFF
--- a/internal/k8s/client_data.go
+++ b/internal/k8s/client_data.go
@@ -311,6 +311,14 @@ func (c *Client) TriggerCronJob(ctx context.Context, contextName, namespace, cro
 			Annotations: map[string]string{
 				"cronjob.kubernetes.io/instantiate": "manual",
 			},
+			// Tie the manual Job to its CronJob the same way the
+			// kube-controller-manager does for scheduled runs. Without this
+			// owner reference the Job is absent from the CronJob's Jobs
+			// subview (which filters by ownerRef) and is not garbage-collected
+			// when the CronJob is deleted.
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(cronJob, batchv1.SchemeGroupVersion.WithKind("CronJob")),
+			},
 		},
 		Spec: cronJob.Spec.JobTemplate.Spec,
 	}

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -230,7 +230,7 @@ func TestGetPodResourceRequests_NotFound(t *testing.T) {
 
 func TestTriggerCronJob(t *testing.T) {
 	cronJob := &batchv1.CronJob{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-cron", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cron", Namespace: "default", UID: "cj-uid"},
 		Spec: batchv1.CronJobSpec{
 			Schedule: "*/5 * * * *",
 			JobTemplate: batchv1.JobTemplateSpec{
@@ -257,6 +257,14 @@ func TestTriggerCronJob(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, jobs.Items, 1)
 	assert.Equal(t, "busybox", jobs.Items[0].Spec.Template.Spec.Containers[0].Image)
+
+	// The manual Job must carry a controller ownerReference back to the
+	// CronJob, otherwise it is missing from the CronJob's Jobs subview.
+	owner := metav1.GetControllerOf(&jobs.Items[0])
+	require.NotNil(t, owner)
+	assert.Equal(t, "CronJob", owner.Kind)
+	assert.Equal(t, "my-cron", owner.Name)
+	assert.Equal(t, k8stypes.UID("cj-uid"), owner.UID)
 }
 
 func TestTriggerCronJob_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #304 — a manually-triggered job (via `x-t`) was missing from the CronJob's Jobs subview, even though it appeared in the flat Jobs resource list.

**Root cause:** `TriggerCronJob` created the Job with only the `cronjob.kubernetes.io/instantiate: manual` annotation but no `ownerReference` to the CronJob. The subview (`getJobsByOwner`), resource tree (`buildCronJobTree`), and rightsizing walk (`podsForCronJob`) all filter Jobs by `ownerReference` pointing at the CronJob, so the manual Job was filtered out everywhere.

**Fix:** Set a controller `ownerReference` on the manual Job, mirroring what kube-controller-manager does for scheduled runs. The Job now appears in the subview/tree/rightsizing and is garbage-collected when the CronJob is deleted.

## Behavioral note

Because the Job now carries a controller ownerRef, the CronJob controller counts it as an active child, so it participates in `concurrencyPolicy`/history-limit handling like a scheduled run. This is the correct semantics for a manual trigger.

## Test plan

- [x] Extended `TestTriggerCronJob` to assert the controller ownerReference (Kind/Name/UID)
- [x] `go build ./...`
- [x] `go vet ./internal/k8s/`, gofumpt clean
- [x] `go test ./internal/k8s/ ./internal/app/` pass