### PR TITLE
fix: honor CRD additionalPrinterColumns priority and keep them visible

### DIFF
--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -149,7 +149,21 @@ func (m Model) applySessionColumnsForKind(kind string) {
 		ui.ActiveSessionColumns = nil
 		ui.ActiveHiddenBuiltinColumns = nil
 		ui.ActiveColumnOrder = nil
+		ui.ActivePrinterColumns = nil
 		return
+	}
+	// CRD additionalPrinterColumns for the navigated resource type drive
+	// priority-aware, first-class printer-column rendering. Only applies when
+	// the rendered kind matches nav.ResourceType (the middle column at
+	// LevelResources); owned children/containers have their own kinds.
+	if rt := m.nav.ResourceType; len(rt.PrinterColumns) > 0 && rt.Kind != "" && strings.EqualFold(rt.Kind, kind) {
+		pcs := make(map[string]int, len(rt.PrinterColumns))
+		for _, pc := range rt.PrinterColumns {
+			pcs[pc.Name] = pc.Priority
+		}
+		ui.ActivePrinterColumns = pcs
+	} else {
+		ui.ActivePrinterColumns = nil
 	}
 	// Session extras: nil vs non-nil-empty distinguishes "auto-detect" from
 	// "user explicitly configured no extras".
@@ -195,11 +209,13 @@ func (m Model) withSessionColumnsForKind(kind string, fn func() string) string {
 	prevSession := ui.ActiveSessionColumns
 	prevHidden := ui.ActiveHiddenBuiltinColumns
 	prevOrder := ui.ActiveColumnOrder
+	prevPrinter := ui.ActivePrinterColumns
 	m.applySessionColumnsForKind(kind)
 	defer func() {
 		ui.ActiveSessionColumns = prevSession
 		ui.ActiveHiddenBuiltinColumns = prevHidden
 		ui.ActiveColumnOrder = prevOrder
+		ui.ActivePrinterColumns = prevPrinter
 	}()
 	return fn()
 }

--- a/internal/k8s/client_crd.go
+++ b/internal/k8s/client_crd.go
@@ -95,12 +95,29 @@ func extractCRDPrinterColumns(spec map[string]any, preferredVersion string) []mo
 				Name:     colName,
 				Type:     colType,
 				JSONPath: jsonPath,
+				Priority: printerColumnPriority(cm["priority"]),
 			})
 		}
 		return result
 	}
 
 	return nil
+}
+
+// printerColumnPriority coerces an additionalPrinterColumns "priority" value to
+// an int. Unstructured JSON decodes numbers to float64; YAML-sourced specs may
+// carry int64. A missing or non-numeric priority defaults to 0 (shown).
+func printerColumnPriority(v any) int {
+	switch p := v.(type) {
+	case int64:
+		return int(p)
+	case int:
+		return p
+	case float64:
+		return int(p)
+	default:
+		return 0
+	}
 }
 
 // buildContainerItem creates a model.Item for a container with enriched details.

--- a/internal/k8s/client_crd_test.go
+++ b/internal/k8s/client_crd_test.go
@@ -12,6 +12,34 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 )
 
+// --- extractCRDPrinterColumns ---
+
+func TestExtractCRDPrinterColumns_CapturesPriority(t *testing.T) {
+	spec := map[string]any{
+		"versions": []any{
+			map[string]any{
+				"name": "v1alpha1",
+				"additionalPrinterColumns": []any{
+					// priority omitted -> 0 (shown by default, like kubectl)
+					map[string]any{"name": "Phase", "type": "string", "jsonPath": ".status.phase"},
+					// JSON numbers decode to float64.
+					map[string]any{"name": "Parent", "type": "string", "jsonPath": ".spec.parent", "priority": float64(1)},
+					// YAML/int64 path is also accepted.
+					map[string]any{"name": "Created At", "type": "string", "jsonPath": ".status.createdAt", "priority": int64(0)},
+				},
+			},
+		},
+	}
+
+	cols := extractCRDPrinterColumns(spec, "v1alpha1")
+
+	assert.Equal(t, []model.PrinterColumn{
+		{Name: "Phase", Type: "string", JSONPath: ".status.phase", Priority: 0},
+		{Name: "Parent", Type: "string", JSONPath: ".spec.parent", Priority: 1},
+		{Name: "Created At", Type: "string", JSONPath: ".status.createdAt", Priority: 0},
+	}, cols)
+}
+
 // --- preferredCRDVersion ---
 
 func TestPreferredCRDVersion(t *testing.T) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -59,6 +59,10 @@ type PrinterColumn struct {
 	Name     string
 	Type     string // string, integer, number, boolean, date
 	JSONPath string // e.g. ".status.phase", ".spec.source.repoURL"
+	// Priority mirrors the column's additionalPrinterColumns priority.
+	// kubectl shows priority 0 columns in standard output and hides
+	// priority > 0 columns unless `-o wide`; LFK applies the same default.
+	Priority int
 }
 
 // CanIVerbState is the display state for one RBAC verb in the Can-I view.

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -178,17 +178,17 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	// paths happened to write the columns into item.Columns.
 	stabilizeColumnOrder(order)
 
-	candidates := selectColumnCandidates(seen, order, kind, items)
+	candidates, fromAutoDetect := selectColumnCandidates(seen, order, kind, items)
 
 	if len(candidates) == 0 {
 		return nil
 	}
 
 	// Mandatory CRD printer-column protection applies only on the default
-	// auto-detect path; an explicit session override (column-toggle overlay)
-	// is authoritative and left untouched. When active, move mandatory columns
-	// to the front so the width budget serves them before optional extras.
-	mandatoryActive := ActivePrinterColumns != nil && ActiveSessionColumns == nil
+	// auto-detect path; an explicit session or configured (views.<kind>.columns)
+	// order is authoritative and left untouched. When active, move mandatory
+	// columns to the front so the width budget serves them before optional extras.
+	mandatoryActive := fromAutoDetect && ActivePrinterColumns != nil
 	if mandatoryActive {
 		candidates = prioritizeMandatoryColumns(candidates)
 	}
@@ -321,21 +321,24 @@ func fitExtraColumns(candidates []string, seen map[string]*colInfo, available, m
 }
 
 // selectColumnCandidates determines which extra columns to display based on
-// session overrides, per-kind config, or auto-detection.
+// session overrides, per-kind config, or auto-detection. The second return
+// value reports whether the auto-detect path produced the result; only then
+// may mandatory CRD printer-column protection reorder/force columns (an
+// explicit session or config order is authoritative and left untouched).
 //
 // ActiveSessionColumns is the authoritative signal when non-nil: an empty
 // slice means the user explicitly configured this kind with no extras and
 // must not fall through to auto-detect. Only a nil slice means "no session
 // override" and lets the config / auto-detect paths run.
-func selectColumnCandidates(seen map[string]*colInfo, order []string, kind string, items []model.Item) []string {
+func selectColumnCandidates(seen map[string]*colInfo, order []string, kind string, items []model.Item) (candidates []string, fromAutoDetect bool) {
 	if ActiveSessionColumns != nil {
-		candidates := make([]string, 0, len(ActiveSessionColumns))
+		out := make([]string, 0, len(ActiveSessionColumns))
 		for _, key := range ActiveSessionColumns {
 			if _, ok := seen[key]; ok {
-				candidates = append(candidates, key)
+				out = append(out, key)
 			}
 		}
-		return candidates
+		return out, false
 	}
 
 	// Build a ResourceRef so GVR-keyed view configs resolve. When the
@@ -350,18 +353,18 @@ func selectColumnCandidates(seen map[string]*colInfo, order []string, kind strin
 	configCols := ColumnsForKind(rt, ActiveContext)
 	if len(configCols) > 0 {
 		if len(configCols) == 1 && configCols[0] == "*" {
-			return order
+			return order, false
 		}
-		var candidates []string
+		var out []string
 		for _, cfgKey := range configCols {
 			if _, ok := seen[cfgKey]; ok {
-				candidates = append(candidates, cfgKey)
+				out = append(out, cfgKey)
 			}
 		}
-		return candidates
+		return out, false
 	}
 
-	return autoDetectColumns(seen, order, items)
+	return autoDetectColumns(seen, order, items), true
 }
 
 // autoDetectColumns selects columns based on heuristic thresholds and blocked lists.

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
@@ -37,6 +38,24 @@ func CollectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 // ActiveSessionColumns holds the session-only column override for the current
 // resource type. Set by the app before rendering. Nil means no override.
 var ActiveSessionColumns []string
+
+// ActivePrinterColumns maps CRD additionalPrinterColumns names to their
+// declared priority for the resource type currently rendered in the middle
+// column. Set by the app before rendering; nil for non-CRD resources or CRDs
+// without printer columns. Priority 0 columns are treated as mandatory (always
+// shown, never dropped by the width budget); priority > 0 columns are hidden by
+// default, matching kubectl's standard vs. `-o wide` behaviour.
+var ActivePrinterColumns map[string]int
+
+// isMandatoryColumn reports whether key is a CRD printer column that must
+// always be shown (priority 0).
+func isMandatoryColumn(key string) bool {
+	if ActivePrinterColumns == nil {
+		return false
+	}
+	prio, ok := ActivePrinterColumns[key]
+	return ok && prio == 0
+}
 
 // ActiveHiddenBuiltinColumns holds the set of built-in column keys that should
 // be suppressed in the current middle-column render. Valid keys: "Context",
@@ -85,6 +104,48 @@ func stabilizeColumnOrder(order []string) {
 	})
 }
 
+// extraColWidth computes the capped display width (including 1 spacing column)
+// and the pre-cap natural width for an extra column, given its collected info.
+func extraColWidth(info *colInfo, key string, maxColW int) (colW, natural int) {
+	colW = len(key)
+	maxVal := info.maxValW
+	// When some values have arrows, non-arrow values need a placeholder space.
+	// The arrow values already include the arrow in their visual width, so
+	// ensure non-arrow values get +1 to match.
+	if info.hasArrow {
+		maxVal++
+	}
+	if maxVal > colW {
+		colW = maxVal
+	}
+	natural = colW + 1 // pre-cap natural width (with spacing)
+	if colW > maxColW {
+		colW = maxColW
+	}
+	colW++ // spacing
+	return colW, natural
+}
+
+// prioritizeMandatoryColumns returns candidates with mandatory CRD printer
+// columns (priority 0) moved to the front, preserving relative order within
+// each group. Returns the input unchanged when there are no mandatory columns.
+// fitExtraColumns relies on the resulting contiguous mandatory prefix.
+func prioritizeMandatoryColumns(candidates []string) []string {
+	if !slices.ContainsFunc(candidates, isMandatoryColumn) {
+		return candidates
+	}
+	mandatory := make([]string, 0, len(candidates))
+	rest := make([]string, 0, len(candidates))
+	for _, k := range candidates {
+		if isMandatoryColumn(k) {
+			mandatory = append(mandatory, k)
+		} else {
+			rest = append(rest, k)
+		}
+	}
+	return append(mandatory, rest...)
+}
+
 func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind string) []extraColumn {
 	// Collect all available column keys and their max value widths.
 	seen := make(map[string]*colInfo)
@@ -123,6 +184,15 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 		return nil
 	}
 
+	// Mandatory CRD printer-column protection applies only on the default
+	// auto-detect path; an explicit session override (column-toggle overlay)
+	// is authoritative and left untouched. When active, move mandatory columns
+	// to the front so the width budget serves them before optional extras.
+	mandatoryActive := ActivePrinterColumns != nil && ActiveSessionColumns == nil
+	if mandatoryActive {
+		candidates = prioritizeMandatoryColumns(candidates)
+	}
+
 	// Reserve budget for the Name column based on the longest item name
 	// so resource names with long identifiers (Ingress hostnames, Node
 	// FQDNs, helm releases, generated suffixes) don't get squeezed to a
@@ -148,56 +218,74 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	// minExtrasBudget = capped column (maxColW + spacing). Tracks the
 	// same maxColW used below so the budget scales with fullscreen mode.
 	const nameFloor = 20
-	maxColWForBudget := 20
+	maxColW := 20
 	if ActiveFullscreenMode {
-		maxColWForBudget = 40
+		maxColW = 40
 	}
-	minExtrasBudget := maxColWForBudget + 1
+	minExtrasBudget := maxColW + 1
 	longestName := 0
 	for _, item := range items {
 		if w := lipgloss.Width(item.Name); w > longestName {
 			longestName = w
 		}
 	}
+
+	// Sum the width mandatory CRD printer columns need so the name reservation
+	// below can be capped to leave room for them. Without this, long generated
+	// resource names (issue #305) consume the budget and trailing user-declared
+	// columns get silently dropped.
+	mandatoryBudget := 0
+	if mandatoryActive {
+		for _, key := range candidates {
+			if isMandatoryColumn(key) {
+				w, _ := extraColWidth(seen[key], key, maxColW)
+				mandatoryBudget += w
+			}
+		}
+	}
+
 	nameReserve := longestName + 1 // +1 for column spacing
 	if nameReserve+usedWidth > totalWidth {
 		// Can't fit the full name even after dropping every extra. Cap
 		// the reservation so at least one extra gets a fair budget.
 		nameReserve = max(totalWidth-usedWidth-minExtrasBudget, nameFloor)
 	}
+	if mandatoryBudget > 0 {
+		// Never let the name reservation crowd out mandatory columns; NAME
+		// shrinks toward its floor and overflow is clipped by the caller.
+		nameReserve = min(nameReserve, max(totalWidth-usedWidth-mandatoryBudget, nameFloor))
+	}
 	nameReserve = max(nameReserve, nameFloor)
+	// available may be negative when mandatory columns alone exceed the row;
+	// fitExtraColumns still emits them and the caller clips the overflow.
 	available := totalWidth - usedWidth - nameReserve
-	if available < 8 {
+	if available < 8 && mandatoryBudget == 0 {
 		return nil
 	}
 
+	return fitExtraColumns(candidates, seen, available, maxColW, mandatoryActive)
+}
+
+// fitExtraColumns selects columns from candidates that fit within available
+// width and computes their display widths. Columns are added in order until the
+// budget is exhausted (optional columns then stop); mandatory CRD printer
+// columns are always emitted even past the budget, leaving the row to be
+// clipped. Leftover budget is redistributed round-robin to capped columns.
+//
+// When mandatoryActive, callers must pass candidates with the mandatory
+// (priority-0) columns as a contiguous prefix (see prioritizeMandatoryColumns):
+// the budget break below ends the optional tail, so a mandatory column after an
+// over-budget optional one would otherwise be lost.
+func fitExtraColumns(candidates []string, seen map[string]*colInfo, available, maxColW int, mandatoryActive bool) []extraColumn {
 	result := make([]extraColumn, 0, len(candidates))
 	naturalW := make([]int, 0, len(candidates)) // pre-cap desired width including spacing
 	remainingW := available
-	maxColW := 20
-	if ActiveFullscreenMode {
-		maxColW = 40
-	}
 	for _, key := range candidates {
 		info := seen[key]
-		// Column width: max of header length and value length, capped, plus 1 for spacing.
-		colW := len(key)
-		maxVal := info.maxValW
-		// When some values have arrows, non-arrow values need a placeholder space.
-		// The arrow values already include the arrow in their visual width,
-		// so ensure non-arrow values get +1 to match.
-		if info.hasArrow {
-			maxVal++ // reserve space for placeholder on non-arrow rows
-		}
-		if maxVal > colW {
-			colW = maxVal
-		}
-		natural := colW + 1 // pre-cap natural width (with spacing)
-		if colW > maxColW {
-			colW = maxColW
-		}
-		colW++ // spacing
-		if colW > remainingW {
+		colW, natural := extraColWidth(info, key, maxColW)
+		// Mandatory printer columns are always emitted; remainingW may go
+		// negative, which is fine — NAME floors and the row is clipped.
+		if colW > remainingW && (!mandatoryActive || !isMandatoryColumn(key)) {
 			break
 		}
 		result = append(result, extraColumn{key: key, width: colW, hasArrow: info.hasArrow})
@@ -288,6 +376,16 @@ func autoDetectColumns(seen map[string]*colInfo, order []string, items []model.I
 	alwaysShow := map[string]bool{"Condition": true}
 	var candidates []string
 	for _, key := range order {
+		// CRD additionalPrinterColumns get kubectl semantics: priority 0 is
+		// always shown (bypassing the threshold and blocked list), priority > 0
+		// is hidden by default. A user can still reveal priority > 0 columns via
+		// the column-toggle overlay (which routes through ActiveSessionColumns).
+		if prio, ok := ActivePrinterColumns[key]; ok {
+			if prio == 0 {
+				candidates = append(candidates, key)
+			}
+			continue
+		}
 		if blocked[key] || isHiddenColumnPrefix(key) {
 			continue
 		}

--- a/internal/ui/explorer_format_columns_test.go
+++ b/internal/ui/explorer_format_columns_test.go
@@ -72,6 +72,78 @@ func TestCollectExtraColumns_MandatoryPrinterColumnsSurvive(t *testing.T) {
 	}
 }
 
+// TestCollectExtraColumns_ConfiguredOrderNotReshuffled verifies that an
+// explicit views.<kind>.columns configuration is authoritative: mandatory
+// printer-column protection does not reorder it or hide its priority>0 columns
+// (regression for the auto-detect-path-only contract).
+func TestCollectExtraColumns_ConfiguredOrderNotReshuffled(t *testing.T) {
+	defer func(orig map[string]int) { ActivePrinterColumns = orig }(ActivePrinterColumns)
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	defer func(orig map[string][]string) { ConfigResourceColumns = orig }(ConfigResourceColumns)
+	defer func(orig ResourceRef) { ActiveResourceRef = orig }(ActiveResourceRef)
+	defer func(orig string) { ActiveContext = orig }(ActiveContext)
+	ActiveSessionColumns = nil
+	ActiveResourceRef = ResourceRef{}
+	ActiveContext = ""
+
+	ActivePrinterColumns = map[string]int{"Duration": 0, "Parent": 1, "Created At": 0}
+	// Explicit config order: non-mandatory-first, and includes the priority>0
+	// "Parent" the user chose to surface.
+	ConfigResourceColumns = map[string][]string{
+		"choretask": {"Duration", "Parent", "Created At"},
+	}
+
+	items := []model.Item{
+		{Name: "ct-a", Columns: []model.KeyValue{
+			{Key: "Duration", Value: "1.0"}, {Key: "Parent", Value: "p"}, {Key: "Created At", Value: "2026-05-31T00:00:00Z"},
+		}},
+		{Name: "ct-b", Columns: []model.KeyValue{
+			{Key: "Duration", Value: "2.0"}, {Key: "Parent", Value: "q"}, {Key: "Created At", Value: "2026-05-31T00:01:00Z"},
+		}},
+	}
+
+	cols := collectExtraColumns(items, 200, 20, "ChoreTask")
+
+	if got := keysOf(cols); len(got) != 3 || got[0] != "Duration" || got[1] != "Parent" || got[2] != "Created At" {
+		t.Errorf("configured column order must be preserved verbatim, got %v", got)
+	}
+}
+
+// TestSelectColumnCandidates_AutoDetectFlag verifies the fromAutoDetect signal
+// is true only on the auto-detect path, not for session or config overrides.
+func TestSelectColumnCandidates_AutoDetectFlag(t *testing.T) {
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	defer func(orig map[string][]string) { ConfigResourceColumns = orig }(ConfigResourceColumns)
+	defer func(orig ResourceRef) { ActiveResourceRef = orig }(ActiveResourceRef)
+	defer func(orig string) { ActiveContext = orig }(ActiveContext)
+	ActiveResourceRef = ResourceRef{}
+	ActiveContext = ""
+
+	seen := map[string]*colInfo{"Duration": {key: "Duration", count: 2}, "Task": {key: "Task", count: 2}}
+	order := []string{"Duration", "Task"}
+	items := []model.Item{{}, {}}
+
+	// Session override -> not auto-detect.
+	ActiveSessionColumns = []string{"Duration"}
+	ConfigResourceColumns = nil
+	if _, auto := selectColumnCandidates(seen, order, "Foo", items); auto {
+		t.Error("session override must report fromAutoDetect=false")
+	}
+
+	// Config override -> not auto-detect.
+	ActiveSessionColumns = nil
+	ConfigResourceColumns = map[string][]string{"foo": {"Duration"}}
+	if _, auto := selectColumnCandidates(seen, order, "Foo", items); auto {
+		t.Error("config override must report fromAutoDetect=false")
+	}
+
+	// No overrides -> auto-detect.
+	ConfigResourceColumns = nil
+	if _, auto := selectColumnCandidates(seen, order, "Foo", items); !auto {
+		t.Error("default path must report fromAutoDetect=true")
+	}
+}
+
 // TestCollectExtraColumns_NonCRDUnaffected verifies that with no printer-column
 // metadata the heuristic pipeline behaves exactly as before (no regression).
 func TestCollectExtraColumns_NonCRDUnaffected(t *testing.T) {

--- a/internal/ui/explorer_format_columns_test.go
+++ b/internal/ui/explorer_format_columns_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// keysOf extracts the ordered column keys from a collectExtraColumns result.
+func keysOf(cols []extraColumn) []string {
+	out := make([]string, len(cols))
+	for i, c := range cols {
+		out[i] = c.key
+	}
+	return out
+}
+
+func containsKey(cols []extraColumn, key string) bool {
+	for _, c := range cols {
+		if c.key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCollectExtraColumns_MandatoryPrinterColumnsSurvive verifies that CRD
+// additionalPrinterColumns with priority 0 are treated as mandatory: they are
+// not dropped by the width budget even when long resource names would
+// otherwise starve trailing columns, and priority > 0 columns are hidden by
+// default (matching kubectl).
+func TestCollectExtraColumns_MandatoryPrinterColumnsSurvive(t *testing.T) {
+	defer func(orig map[string]int) { ActivePrinterColumns = orig }(ActivePrinterColumns)
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	defer func(orig bool) { ActiveFullscreenMode = orig }(ActiveFullscreenMode)
+	ActiveSessionColumns = nil
+	ActiveFullscreenMode = false
+
+	// Long generated names, like the ChoreTask CRD in issue #305, eat the
+	// width budget under the old name-reservation rule.
+	const longName = "build-squanderlings-the-bardic-continuum-server-77c9339f39816d8af2-a449f710"
+	mkItem := func(suffix string) model.Item {
+		return model.Item{
+			Name:   longName + suffix,
+			Status: "Succeeded",
+			Columns: []model.KeyValue{
+				{Key: "Duration", Value: "77.091"},
+				{Key: "Task", Value: "clone-and-build"},
+				{Key: "Catalog", Value: "buildah"},
+				{Key: "Error Code", Value: "0"},
+				{Key: "Created At", Value: "2026-05-31T00:58:01Z"},
+				{Key: "Parent", Value: "top-level"},
+			},
+		}
+	}
+	items := []model.Item{mkItem("-a"), mkItem("-b"), mkItem("-c")}
+
+	ActivePrinterColumns = map[string]int{
+		"Duration": 0, "Task": 0, "Catalog": 0,
+		"Error Code": 0, "Created At": 0,
+		"Parent": 1, // priority > 0 -> hidden by default
+	}
+
+	// A realistically narrow middle column.
+	cols := collectExtraColumns(items, 120, 20, "ChoreTask")
+
+	if containsKey(cols, "Parent") {
+		t.Errorf("priority>0 column Parent must be hidden by default, got %v", keysOf(cols))
+	}
+	if !containsKey(cols, "Created At") {
+		t.Errorf("mandatory last-declared column Created At must survive width budget, got %v", keysOf(cols))
+	}
+}
+
+// TestCollectExtraColumns_NonCRDUnaffected verifies that with no printer-column
+// metadata the heuristic pipeline behaves exactly as before (no regression).
+func TestCollectExtraColumns_NonCRDUnaffected(t *testing.T) {
+	defer func(orig map[string]int) { ActivePrinterColumns = orig }(ActivePrinterColumns)
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	ActivePrinterColumns = nil
+	ActiveSessionColumns = nil
+
+	// Keys not in blockedColumnsForMode so the default auto-detect surfaces them.
+	items := []model.Item{
+		{Name: "svc-a", Columns: []model.KeyValue{{Key: "Ports", Value: "80/TCP"}, {Key: "Replicas", Value: "3"}}},
+		{Name: "svc-b", Columns: []model.KeyValue{{Key: "Ports", Value: "443/TCP"}, {Key: "Replicas", Value: "2"}}},
+	}
+	cols := collectExtraColumns(items, 120, 20, "Service")
+	if !containsKey(cols, "Ports") || !containsKey(cols, "Replicas") {
+		t.Errorf("expected Ports and Replicas columns, got %v", keysOf(cols))
+	}
+}


### PR DESCRIPTION
Closes #305

## Problem

CRD `additionalPrinterColumns` were extracted but then flattened into LFK's generic "extra columns" pipeline and treated as *optional*. Two consequences:

1. **Trailing columns silently dropped.** The width budget reserves space for the longest resource name first; with long generated names (the reporter's ChoreTask names are ~100 chars) the budget is exhausted and the last-declared columns — like the all-important **Created At** — never render.
2. **`priority` was never read.** kubectl hides `priority > 0` columns unless `-o wide`; LFK ignored the field, so any agreement on hiding columns was coincidental.

## Fix — treat printer columns as first-class (kubectl semantics)

| Priority | Behavior |
|---|---|
| `0` | **Mandatory**: always shown — bypasses the auto-detect count threshold and blocked-list, ordered first, never dropped by the width budget (the row clips instead). The NAME reservation is capped to leave room. |
| `> 0` | **Hidden by default** (like `kubectl get` vs `-o wide`); still reachable via the column-toggle overlay. |

For the reporter's CRD: Phase, Duration, Task, Catalog, Error Code, **Created At** all show; **Parent** (`priority: 1`) is hidden by default. Created At being visible also makes it sortable, addressing the sort-by-timestamp need.

### Changes
- `model.PrinterColumn.Priority` + capture in `extractCRDPrinterColumns` (`printerColumnPriority` coerces float64/int64/int).
- `ui.ActivePrinterColumns` (name→priority), set per-render from `nav.ResourceType` in `applySessionColumnsForKind`, saved/restored in `withSessionColumnsForKind`.
- `autoDetectColumns` priority filtering; `collectExtraColumns` mandatory ordering + name-reservation cap; extracted `extraColWidth`/`prioritizeMandatoryColumns`/`fitExtraColumns` helpers.

Protection applies only on the default auto-detect path; an explicit session/column-overlay override stays authoritative.

## Test plan
- [x] `TestExtractCRDPrinterColumns_CapturesPriority` — priority parsing incl. omitted/float64/int64
- [x] `TestCollectExtraColumns_MandatoryPrinterColumnsSurvive` — last-declared mandatory column survives long names; `priority>0` hidden
- [x] `TestCollectExtraColumns_NonCRDUnaffected` — no regression on the non-CRD path
- [x] `go test -race ./internal/ui/ ./internal/k8s/ ./internal/model/ ./internal/app/` green; full `go test ./...` green
- [x] `gofmt` clean; `golangci-lint` 0 issues