### PR TITLE
feat: graceful shutdown notice with 10s force-quit timeout

### DIFF
--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -123,6 +123,7 @@ category, and every entry maps to a constant in `app_types.go`.
 | `overlayConfirm`     | delete / drain                   | y/n confirmation for reversible actions.                      |
 | `overlayConfirmType` | force delete / force finalize    | Requires typing `DELETE` for destructive ops.                 |
 | `overlayQuitConfirm` | `q`                              | Confirm before exiting lfk.                                   |
+| `overlayShuttingDown`| after confirming quit            | Notice shown while background processes drain; force quits after 10s if it hangs. |
 | `overlayPasteConfirm`| paste into search / filter       | Confirm multi-line paste.                                     |
 
 ### Information panels

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -699,8 +699,8 @@ type Model struct {
 	commandBarNameLoading string // cache key currently being fetched ("" if idle)
 
 	// Stderr capture channel for exec credential plugin errors.
-	stderrChan <-chan string
-
+	stderrChan    <-chan string
+	shutdownState // graceful-shutdown flags (m.shuttingDown, m.shutdownNotifier)
 	// Resource map view: shows relationship tree in the right column.
 	mapView      bool
 	resourceTree *model.ResourceNode

--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -135,29 +135,6 @@ func (m *Model) cancelInFlightRequests() {
 	}
 }
 
-// performQuitCleanup runs every shutdown side effect that must happen
-// before tea.Quit is dispatched: stop port-forwards, cancel log
-// streams, cancel in-flight API requests, and persist session state.
-// Centralising this here keeps the three quit entry points
-// (handleQuitConfirmOverlayKey, closeTabOrQuit's last-tab branch, and
-// the :quit command) in lockstep so adding a fourth path — or a new
-// cleanup step — does not require remembering the full sequence at
-// every call site.
-func (m *Model) performQuitCleanup() {
-	if m.portForwardMgr != nil {
-		m.portForwardMgr.StopAll()
-	}
-	if m.captureMgr != nil {
-		m.captureMgr.StopAll()
-	}
-	m.cancelAllTabLogStreams()
-	m.cancelInFlightRequests()
-	if m.scheduler != nil {
-		m.scheduler.StopWorkers()
-	}
-	m.saveCurrentSession()
-}
-
 // applyPinnedTypes recomputes model.PinnedTypes from config-level pins plus the
 // pins scoped to the active context (or named union set). Legacy whole-group
 // pins (a bare group name with no "/", from older pinned.yaml files or the

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -81,6 +81,7 @@ const (
 	overlayLocalClusters  // local-cluster manager (Ctrl+N at LevelClusters)
 	overlayTrafficCapture // per-pod live packet capture (action menu key c)
 	overlayCopyFormat     // Y-key copy-as picker (YAML / JSON / Table)
+	overlayShuttingDown   // non-interactive "graceful shutdown in progress" notice
 )
 
 // whoCanState groups the reverse-RBAC ("Who-Can") fields so they live

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -202,8 +202,7 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 		// kubectl log streams started from any tab don't outlive the
 		// process. Without this, `:q` / `:q!` / `:quit` leaks the
 		// kubectl subprocess and its reader goroutine — issue #48.
-		m.performQuitCleanup()
-		return m, tea.Quit
+		return m.beginShutdown()
 
 	case "namespace":
 		return m.executeNamespaceCommand(tokens[1:])

--- a/internal/app/commands_capture.go
+++ b/internal/app/commands_capture.go
@@ -118,7 +118,7 @@ func (m Model) waitForCaptureUpdate() tea.Cmd {
 // Uses context.Background() rather than m.reqCtx because the capture is meant
 // to outlive the current navigation — the user explicitly stops it via the
 // overlay's `s` key (mgr.Stop) or via __captures__ row actions, and on app
-// shutdown via captureMgr.StopAll() in performQuitCleanup. m.reqCtx would
+// shutdown via captureMgr.StopAll() in signalShutdown. m.reqCtx would
 // kill the capture every time the user navigates to a different view.
 func (m Model) startCapture(req k8s.CaptureRequest, liveBuf *captureRing) tea.Cmd {
 	mgr := m.captureMgr

--- a/internal/app/filter_input_test.go
+++ b/internal/app/filter_input_test.go
@@ -693,8 +693,8 @@ func TestCovQuitConfirmKeyY(t *testing.T) {
 	m.overlay = overlayQuitConfirm
 	result, cmd := m.handleQuitConfirmOverlayKey(keyMsg("y"))
 	rm := result.(Model)
-	assert.Equal(t, overlayNone, rm.overlay)
-	assert.NotNil(t, cmd) // tea.Quit
+	assert.Equal(t, overlayShuttingDown, rm.overlay)
+	assert.NotNil(t, cmd) // shutdown drain
 }
 
 func TestCovQuitConfirmKeyBigY(t *testing.T) {
@@ -702,8 +702,8 @@ func TestCovQuitConfirmKeyBigY(t *testing.T) {
 	m.overlay = overlayQuitConfirm
 	result, cmd := m.handleQuitConfirmOverlayKey(keyMsg("Y"))
 	rm := result.(Model)
-	assert.Equal(t, overlayNone, rm.overlay)
-	assert.NotNil(t, cmd) // tea.Quit
+	assert.Equal(t, overlayShuttingDown, rm.overlay)
+	assert.NotNil(t, cmd) // shutdown drain
 }
 
 func TestCovQuitConfirmKeyN(t *testing.T) {

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -16,6 +16,11 @@ type stderrCapturedMsg struct {
 	message string
 }
 
+// shutdownCompleteMsg signals that the asynchronous quit drain (worker
+// pools, informer caches, session save) has finished, so the program can
+// dispatch tea.Quit and exit cleanly.
+type shutdownCompleteMsg struct{}
+
 type contextsLoadedMsg struct {
 	items []model.Item
 	err   error

--- a/internal/app/shutdown.go
+++ b/internal/app/shutdown.go
@@ -41,17 +41,22 @@ func (m *Model) SetShutdownNotifier(fn func()) {
 // goroutine. The drain reports completion via shutdownCompleteMsg, at
 // which point Update dispatches tea.Quit.
 func (m Model) beginShutdown() (tea.Model, tea.Cmd) {
-	m.signalShutdown()
-	// Persist the session synchronously on the UI goroutine: it is a fast
-	// local-disk write that can't hang on an unreachable cluster, and
-	// keeping it here avoids racing with a late Update-driven save once the
-	// drain goroutine is running.
-	m.saveCurrentSession()
-	m.overlay = overlayShuttingDown
-	m.shuttingDown = true
+	if m.shuttingDown {
+		return m, nil
+	}
+	// Arm the force-quit watchdog first so the grace period bounds every
+	// step below, including the synchronous session save — a local-disk
+	// write that is normally fast but could stall on a slow or networked
+	// home directory.
 	if m.shutdownNotifier != nil {
 		m.shutdownNotifier()
 	}
+	m.signalShutdown()
+	// Persist the session synchronously on the UI goroutine: keeping it off
+	// the drain goroutine avoids racing with a late Update-driven save.
+	m.saveCurrentSession()
+	m.overlay = overlayShuttingDown
+	m.shuttingDown = true
 	return m, m.shutdownDrainCmd()
 }
 

--- a/internal/app/shutdown.go
+++ b/internal/app/shutdown.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ForceQuitGracePeriod bounds how long the graceful drain may run before
+// the force-quit watchdog (armed via SetShutdownNotifier) kills the
+// program. Exported so main can wire the watchdog to the same value the
+// shutdown notice advertises.
+const ForceQuitGracePeriod = 10 * time.Second
+
+// shutdownState groups the graceful-quit fields so they live together
+// without pushing the main Model struct over the file-length cap (the
+// same pattern whoCanState uses). It is embedded in Model, so the quit
+// handlers reference its fields directly (m.shuttingDown, m.shutdownNotifier).
+type shutdownState struct {
+	// shuttingDown is set once the user commits to quitting. It blocks
+	// further input and switches the view to the graceful-shutdown notice
+	// while background workers drain.
+	shuttingDown bool
+	// shutdownNotifier, when set, is invoked the moment graceful shutdown
+	// begins. main wires it to a watchdog that force-exits the process if
+	// the drain hangs past ForceQuitGracePeriod.
+	shutdownNotifier func()
+}
+
+// SetShutdownNotifier registers a callback invoked once when graceful
+// shutdown begins. main uses it to arm a force-exit watchdog so a hung
+// background drain cannot wedge the terminal indefinitely.
+func (m *Model) SetShutdownNotifier(fn func()) {
+	m.shutdownNotifier = fn
+}
+
+// beginShutdown starts a graceful quit: it fires the instant cancellations
+// synchronously (so in-flight API requests abort before they ride out TCP
+// timeouts), shows the shutdown notice, notifies the force-exit watchdog,
+// and hands the blocking drain off to a command that runs on its own
+// goroutine. The drain reports completion via shutdownCompleteMsg, at
+// which point Update dispatches tea.Quit.
+func (m Model) beginShutdown() (tea.Model, tea.Cmd) {
+	m.signalShutdown()
+	// Persist the session synchronously on the UI goroutine: it is a fast
+	// local-disk write that can't hang on an unreachable cluster, and
+	// keeping it here avoids racing with a late Update-driven save once the
+	// drain goroutine is running.
+	m.saveCurrentSession()
+	m.overlay = overlayShuttingDown
+	m.shuttingDown = true
+	if m.shutdownNotifier != nil {
+		m.shutdownNotifier()
+	}
+	return m, m.shutdownDrainCmd()
+}
+
+// signalShutdown issues every non-blocking cancellation so background
+// goroutines (port-forwards, captures, log streams, in-flight API
+// requests) begin winding down immediately. Every call here only signals
+// — nothing waits — so it is safe to run on the UI goroutine without
+// freezing the render loop. Centralising it keeps the quit entry points
+// (handleQuitConfirmOverlayKey, closeTabOrQuit's last-tab branch, and the
+// :quit command) in lockstep.
+func (m *Model) signalShutdown() {
+	if m.portForwardMgr != nil {
+		m.portForwardMgr.StopAll()
+	}
+	if m.captureMgr != nil {
+		m.captureMgr.StopAll()
+	}
+	m.cancelAllTabLogStreams()
+	m.cancelInFlightRequests()
+}
+
+// shutdownDrainCmd runs drainShutdown on a background goroutine and emits
+// shutdownCompleteMsg when it returns. It closes over a snapshot of the
+// model; that is safe because input is blocked once shuttingDown is set,
+// so no concurrent Update mutates the state drainShutdown reads.
+func (m Model) shutdownDrainCmd() tea.Cmd {
+	return func() tea.Msg {
+		m.drainShutdown()
+		return shutdownCompleteMsg{}
+	}
+}
+
+// drainShutdown blocks until the worker pools and informer caches have
+// fully stopped. Each wait here can take seconds when a cluster is
+// unreachable, so it runs off the UI goroutine (see shutdownDrainCmd)
+// behind the graceful-shutdown notice. signalShutdown must have run first
+// so the goroutines this waits on are already cancelled and exit promptly.
+func (m *Model) drainShutdown() {
+	if m.scheduler != nil {
+		m.scheduler.StopWorkers()
+	}
+	if m.client != nil {
+		m.client.Shutdown()
+	}
+}

--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// beginShutdown must give the user immediate visible feedback (the
+// shutdown notice overlay + shuttingDown flag) and hand the blocking
+// drain off to a command rather than running it inline, so the render
+// loop is never frozen while workers wind down.
+func TestBeginShutdown_ShowsNoticeAndReturnsDrainCmd(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}}
+
+	ret, cmd := m.beginShutdown()
+	result := ret.(Model)
+
+	assert.True(t, result.shuttingDown, "shutdown must mark the model")
+	assert.Equal(t, overlayShuttingDown, result.overlay,
+		"shutdown must switch to the graceful-shutdown notice")
+	require.NotNil(t, cmd, "shutdown must return the drain command")
+}
+
+// The instant cancellations (in-flight API requests) run synchronously in
+// beginShutdown so they abort before they ride out TCP timeouts — the
+// blocking drain is deferred, but cancellation is not.
+func TestBeginShutdown_CancelsInFlightRequestsSynchronously(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}}
+	reqCtx := armReqCtx(&m)
+	require.NoError(t, reqCtx.Err())
+
+	_, _ = m.beginShutdown()
+
+	assert.ErrorIs(t, reqCtx.Err(), context.Canceled,
+		"beginShutdown must cancel reqCtx before deferring the drain")
+}
+
+// The drain command, once executed, reports completion so Update can
+// dispatch tea.Quit.
+func TestShutdownDrainCmd_EmitsCompleteMsg(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}}
+
+	cmd := m.shutdownDrainCmd()
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	assert.IsType(t, shutdownCompleteMsg{}, msg)
+}
+
+// While shutting down, Update freezes the model: every message except the
+// drain's completion is swallowed so nothing mutates state under the drain
+// goroutine.
+func TestUpdate_FreezesModelWhileShuttingDown(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}}
+	m.shuttingDown = true
+	m.overlay = overlayShuttingDown
+
+	// A keypress must be ignored.
+	ret, cmd := m.Update(keyMsg("q"))
+	result := ret.(Model)
+	assert.Nil(t, cmd, "no command should be issued during shutdown")
+	assert.True(t, result.shuttingDown, "shutdown state must persist")
+	assert.Equal(t, overlayShuttingDown, result.overlay)
+
+	// The drain's completion still drives the quit.
+	_, cmd = m.Update(shutdownCompleteMsg{})
+	require.NotNil(t, cmd, "completion must dispatch quit")
+	assert.Equal(t, tea.Quit(), cmd())
+}
+
+// beginShutdown invokes the registered notifier exactly once so main can
+// arm its force-quit watchdog.
+func TestBeginShutdown_FiresNotifier(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.tabs = []TabState{{}}
+	calls := 0
+	m.SetShutdownNotifier(func() { calls++ })
+
+	_, _ = m.beginShutdown()
+
+	assert.Equal(t, 1, calls, "shutdown notifier must fire once")
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -32,6 +32,17 @@ func isContextCanceled(err error) bool {
 
 // Update handles messages.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Once graceful shutdown has begun, the drain goroutine owns the shared
+	// managers; freeze the model so no concurrent Update path mutates state
+	// underneath it. The only message that still matters is the drain's
+	// completion, which triggers the actual quit.
+	if m.shuttingDown {
+		if _, ok := msg.(shutdownCompleteMsg); ok {
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		return m.updateWindowSize(msg)

--- a/internal/app/update_actions_misc.go
+++ b/internal/app/update_actions_misc.go
@@ -132,8 +132,7 @@ func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 		m.overlay = overlayQuitConfirm
 		return m, nil
 	}
-	m.performQuitCleanup()
-	return m, tea.Quit
+	return m.beginShutdown()
 }
 
 func (m Model) executeActionScale() Model {

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -437,9 +437,7 @@ func (m Model) handleContainerSelectOverlayKey(msg tea.KeyMsg) (tea.Model, tea.C
 func (m Model) handleQuitConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "enter", "y", "Y":
-		m.overlay = overlayNone
-		m.performQuitCleanup()
-		return m, tea.Quit
+		return m.beginShutdown()
 	case "n", "N", "esc", "q":
 		m.overlay = overlayNone
 		return m, nil

--- a/internal/app/update_overlays_test.go
+++ b/internal/app/update_overlays_test.go
@@ -1308,8 +1308,12 @@ func TestQuitConfirmOverlayConfirms(t *testing.T) {
 			}
 			ret, cmd := m.handleQuitConfirmOverlayKey(tt.key)
 			result := ret.(Model)
-			assert.Equal(t, overlayNone, result.overlay)
-			assert.NotNil(t, cmd, "should issue tea.Quit")
+			// Confirming now starts a graceful shutdown: the view switches
+			// to the shutdown notice and a drain command runs before the
+			// program exits via shutdownCompleteMsg.
+			assert.Equal(t, overlayShuttingDown, result.overlay)
+			assert.True(t, result.shuttingDown)
+			assert.NotNil(t, cmd, "should start the shutdown drain")
 		})
 	}
 }

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -134,6 +134,19 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 			InnerWidth:  qw - 6,
 			InnerHeight: qh - 2,
 		}), qw, qh, true
+	case overlayShuttingDown:
+		// Mirror the Quit overlay: a single line centered on both axes in a
+		// fixed-size box. See the overlayQuitConfirm case for the height
+		// arithmetic (visible outer height is sh+2; the inner slice is
+		// sh-2 rows so Align centers the title on the middle row).
+		sw := max(min(32, m.width-10), 10)
+		sh := max(min(3, m.height-6), 3)
+		return ui.RenderOverlayConfirm(ui.OverlayConfirmConfig{
+			Title:       "Shutting down...",
+			Centered:    true,
+			InnerWidth:  sw - 6,
+			InnerHeight: sh - 2,
+		}), sw, sh, true
 	case overlayConfirm:
 		return ui.RenderOverlayConfirm(ui.OverlayConfirmConfig{
 			Title:   "Confirm Delete",

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	_ "net/http/pprof" // registers /debug/pprof/* under DefaultServeMux when LFK_PPROF_ADDR is set
 	"os"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -194,14 +196,49 @@ func runTUI(opts app.StartupOptions) error {
 	if ui.ColorModeEnabled() {
 		defer ui.DisableColorModeNotifications()
 	}
-	p := tea.NewProgram(m, progOpts...)
 
-	if _, err := p.Run(); err != nil {
+	// Force-quit watchdog: when the user confirms quit, the model fires
+	// this notifier. If the graceful drain (worker pools, informer caches)
+	// has not let the process exit within the grace period, kill the
+	// program — which restores the terminal — and exit, so a drain wedged
+	// on an unreachable cluster cannot leave the user stuck on a frozen
+	// alt-screen. p is assigned just below; the closure captures the
+	// variable, so it is set by the time the notifier ever runs.
+	var p *tea.Program
+	m.SetShutdownNotifier(armForceQuit(app.ForceQuitGracePeriod,
+		func() { p.Kill(); p.Wait() },
+		func() { os.Exit(0) },
+	))
+	p = tea.NewProgram(m, progOpts...)
+
+	// ErrProgramKilled is expected when the watchdog force-quits; treat it
+	// as a clean exit rather than surfacing it as a startup failure.
+	if _, err := p.Run(); err != nil && !errors.Is(err, tea.ErrProgramKilled) {
 		os.Stderr = origStderr
 		return fmt.Errorf("running application: %w", err)
 	}
 
 	return nil
+}
+
+// armForceQuit returns a notifier that, once invoked, force-terminates the
+// process if it has not exited within grace. It kills the Bubble Tea
+// program first (restoring the terminal) and then exits. kill and exit are
+// injected so the timing logic is testable without a real program or a
+// real os.Exit.
+//
+// The timer goroutine is intentionally not cancellable: on a clean exit
+// the process returns from main well before grace elapses and the runtime
+// reaps the sleeping goroutine, so it never fires. It only acts when the
+// drain genuinely overruns grace — which is exactly the force-quit case.
+func armForceQuit(grace time.Duration, kill, exit func()) func() {
+	return func() {
+		go func() {
+			time.Sleep(grace)
+			kill()
+			exit()
+		}()
+	}
 }
 
 // validatePprofAddr ensures LFK_PPROF_ADDR points at a loopback host so

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// armForceQuit must, after the grace period, kill the program first (to
+// restore the terminal) and only then exit — and it must not act before
+// the grace elapses.
+func TestArmForceQuit_KillsThenExitsAfterGrace(t *testing.T) {
+	order := make(chan string, 2)
+	notify := armForceQuit(20*time.Millisecond,
+		func() { order <- "kill" },
+		func() { order <- "exit" },
+	)
+
+	notify()
+
+	// Nothing should fire before the grace period.
+	select {
+	case got := <-order:
+		t.Fatalf("watchdog fired %q before grace elapsed", got)
+	case <-time.After(5 * time.Millisecond):
+	}
+
+	got := make([]string, 0, 2)
+	for range 2 {
+		select {
+		case s := <-order:
+			got = append(got, s)
+		case <-time.After(time.Second):
+			t.Fatalf("watchdog did not fire within timeout, got %v", got)
+		}
+	}
+
+	if got[0] != "kill" || got[1] != "exit" {
+		t.Fatalf("expected kill then exit, got %v", got)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -10,18 +10,20 @@ import (
 // the grace elapses.
 func TestArmForceQuit_KillsThenExitsAfterGrace(t *testing.T) {
 	order := make(chan string, 2)
-	notify := armForceQuit(20*time.Millisecond,
+	notify := armForceQuit(100*time.Millisecond,
 		func() { order <- "kill" },
 		func() { order <- "exit" },
 	)
 
 	notify()
 
-	// Nothing should fire before the grace period.
+	// Nothing should fire before the grace period. The pre-check window is
+	// kept a clear fraction below the grace so a descheduled goroutine on a
+	// busy CI runner does not flake this assertion.
 	select {
 	case got := <-order:
 		t.Fatalf("watchdog fired %q before grace elapsed", got)
-	case <-time.After(5 * time.Millisecond):
+	case <-time.After(20 * time.Millisecond):
 	}
 
 	got := make([]string, 0, 2)


### PR DESCRIPTION
## Summary

Closing the app could appear to hang while background processes (informer caches, worker pools, port-forwards) drained — with no feedback and no upper bound on the wait. This adds a visible graceful-shutdown notice and a hard 10s force-quit guarantee.

When the user confirms quit (Enter/`y` on the quit overlay, last-tab `Ctrl+C`, or `:quit`):

- A centered **"Shutting down..."** overlay is shown (matches the Quit overlay style).
- Instant cancellations (port-forwards, captures, log streams, in-flight API requests) and the session save run **synchronously**; the blocking waits (scheduler workers + informer caches — the usual hang sources) run on a **goroutine** behind the notice so the UI never freezes.
- A **force-quit watchdog** (`main.go`, armed when shutdown begins) kills the Bubble Tea program — restoring the terminal — and `os.Exit`s after the grace period. This is the only thing that can guarantee the process exits when an informer wait hangs on an unreachable cluster.

`Update` freezes the model once `shuttingDown` is set, so no concurrent message path mutates state under the drain goroutine; only the drain-completion message drives the final `tea.Quit`.

## Design notes

- All three quit entry points route through `beginShutdown`, keeping cleanup in lockstep.
- The double `client.Shutdown()` (drain + deferred in `main`) is safe: `informerCache.Stop()` is idempotent and mutex-guarded; calls are sequential in the graceful path and `os.Exit` covers the force path.
- New fields live in an embedded `shutdownState` struct (the codebase's existing `whoCanState` pattern) to respect the 800-line file cap on `app.go`.
- `ErrProgramKilled` from the watchdog is treated as a clean exit.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/app/ .`
- [x] `golangci-lint run ./...` (0 issues)
- New tests: `internal/app/shutdown_test.go` (begin/drain/freeze behavior, notifier), `main_test.go` (watchdog kill-then-exit ordering); updated existing quit overlay tests.
- [x] Manual: confirm quit on a reachable cluster shows the notice and exits promptly; confirm on an unreachable/hung cluster force-quits within 10s with the terminal restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)