### PR TITLE
fix(scheduler): reclaim superseded background work so the focused view wins

### DIFF
--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -199,8 +199,14 @@ func (m Model) loadResources(forPreview bool) tea.Cmd {
 		}
 		unionCtxs := m.unionContexts
 		client := m.client
+		// Main list is Critical, preview hovers stay High — see the
+		// non-union path below for the rationale.
+		unionListPriority := scheduler.PriorityHigh
+		if !forPreview {
+			unionListPriority = scheduler.PriorityCritical
+		}
 		return m.scheduleK8sCall(
-			scheduler.PriorityHigh,
+			unionListPriority,
 			scheduler.KindResourceList,
 			"List "+model.DisplayNameFor(rt)+" (union)",
 			strings.Join(unionCtxs, ", "),
@@ -230,8 +236,17 @@ func (m Model) loadResources(forPreview bool) tea.Cmd {
 		}
 	}
 	client := m.client
+	// The main resource list (drill-in / watch refresh) is the view the user
+	// is actively waiting on, so it runs at Critical: it gets the reserved
+	// worker and is never queued behind background dashboard/metrics/preview
+	// work. Preview hovers stay High — they are speculative and must remain
+	// preemptible so rapid sidebar cursoring can drop superseded fetches.
+	listPriority := scheduler.PriorityHigh
+	if !forPreview {
+		listPriority = scheduler.PriorityCritical
+	}
 	return m.scheduleK8sCall(
-		scheduler.PriorityHigh,
+		listPriority,
 		scheduler.KindResourceList,
 		"List "+model.DisplayNameFor(rt),
 		bgtaskTarget(kctx, ns),
@@ -773,7 +788,13 @@ func (m Model) scheduleK8sCall(prio scheduler.Priority, kind scheduler.Kind, nam
 	})
 	return func() tea.Msg {
 		res := <-future
-		if errors.Is(res.Err, scheduler.ErrCoalesced) || errors.Is(res.Err, scheduler.ErrContextSwitched) {
+		// All three sentinels mean "this submission was intentionally
+		// abandoned" — coalesced by a newer one, context dropped, or
+		// superseded by a newer requestGen via CancelStaleByGen. Return nil
+		// so the UI ignores it; the surviving submission carries the result.
+		if errors.Is(res.Err, scheduler.ErrCoalesced) ||
+			errors.Is(res.Err, scheduler.ErrContextSwitched) ||
+			errors.Is(res.Err, scheduler.ErrSuperseded) {
 			return nil
 		}
 		// Today the inner Fn wrapper above always passes nil as the

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -2,40 +2,15 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
-	"github.com/janosmiko/lfk/internal/ui"
 )
-
-// helmHistoryTimeout caps how long the helm history subprocess may run before
-// being killed. Prevents the loader goroutine from leaking when helm hangs on
-// an unresponsive API server.
-const helmHistoryTimeout = 30 * time.Second
-
-// helmErrOutputCap bounds how much of helm's stderr/stdout we propagate into
-// error messages and logs. Helm can emit multi-kilobyte NOTES.txt content and
-// values snippets that would otherwise bloat logs and the UI error overlay.
-const helmErrOutputCap = 512
-
-// truncateHelmOutput trims helm subprocess output to helmErrOutputCap bytes so
-// logs and UI error messages stay bounded.
-func truncateHelmOutput(out []byte) string {
-	s := strings.TrimSpace(string(out))
-	if len(s) > helmErrOutputCap {
-		return s[:helmErrOutputCap] + "...(truncated)"
-	}
-	return s
-}
 
 // --- Commands ---
 
@@ -613,104 +588,6 @@ func (m Model) loadRevisions() tea.Cmd {
 	return func() tea.Msg {
 		revs, err := client.GetDeploymentRevisions(reqCtx, kctx, ns, name)
 		return revisionListMsg{revisions: revs, err: err}
-	}
-}
-
-// fetchHelmHistory shells out to `helm history` and returns the parsed
-// revisions (newest first). It is shared between the rollback and read-only
-// history overlays so both views use the same data source. The subprocess is
-// bounded by helmHistoryTimeout and its error output is truncated before
-// being logged or propagated to the UI.
-func fetchHelmHistory(helmPath, name, ns, kubeCtx, kubeconfigPaths string) ([]ui.HelmRevision, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), helmHistoryTimeout)
-	defer cancel()
-
-	args := []string{"history", name, "-n", ns, "--kube-context", kubeCtx, "-o", "json", "--max", "50"}
-	cmd := exec.CommandContext(ctx, helmPath, args...)
-	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
-	logExecCmd("Running helm command", cmd)
-	output, cmdErr := cmd.CombinedOutput()
-	if cmdErr != nil {
-		truncated := truncateHelmOutput(output)
-		logger.Error("helm history failed", "cmd", cmd.String(), "error", cmdErr, "output", truncated)
-		return nil, fmt.Errorf("%w: %s", cmdErr, truncated)
-	}
-
-	var entries []struct {
-		Revision    int    `json:"revision"`
-		Status      string `json:"status"`
-		Chart       string `json:"chart"`
-		AppVersion  string `json:"app_version"`
-		Description string `json:"description"`
-		Updated     string `json:"updated"`
-	}
-	if jsonErr := json.Unmarshal(output, &entries); jsonErr != nil {
-		return nil, fmt.Errorf("failed to parse helm history: %w", jsonErr)
-	}
-
-	revisions := make([]ui.HelmRevision, len(entries))
-	for i, e := range entries {
-		revisions[i] = ui.HelmRevision{
-			Revision:    e.Revision,
-			Status:      e.Status,
-			Chart:       e.Chart,
-			AppVersion:  e.AppVersion,
-			Description: e.Description,
-			Updated:     e.Updated,
-		}
-	}
-	// Reverse so newest revision is first.
-	for i, j := 0, len(revisions)-1; i < j; i, j = i+1, j-1 {
-		revisions[i], revisions[j] = revisions[j], revisions[i]
-	}
-	return revisions, nil
-}
-
-// loadHelmRevisions fetches the revision history for a Helm release.
-func (m Model) loadHelmRevisions() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
-	if err != nil {
-		return func() tea.Msg {
-			return helmRevisionListMsg{err: fmt.Errorf("helm not found: %w", err)}
-		}
-	}
-
-	ns := m.actionCtx.namespace
-	name := m.actionCtx.name
-	ctx := m.actionCtx.context
-	kubeconfigPaths := m.client.KubeconfigPathForContext(ctx)
-
-	return func() tea.Msg {
-		revisions, err := fetchHelmHistory(helmPath, name, ns, m.kubectlContext(ctx), kubeconfigPaths)
-		if err != nil {
-			return helmRevisionListMsg{err: err}
-		}
-		return helmRevisionListMsg{revisions: revisions}
-	}
-}
-
-// loadHelmHistory fetches revision history for the read-only history overlay.
-// It reuses fetchHelmHistory but routes the result to helmHistoryListMsg so
-// the update path opens overlayHelmHistory instead of overlayHelmRollback.
-func (m Model) loadHelmHistory() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
-	if err != nil {
-		return func() tea.Msg {
-			return helmHistoryListMsg{err: fmt.Errorf("helm not found: %w", err)}
-		}
-	}
-
-	ns := m.actionCtx.namespace
-	name := m.actionCtx.name
-	ctx := m.actionCtx.context
-	kubeconfigPaths := m.client.KubeconfigPathForContext(ctx)
-
-	return func() tea.Msg {
-		revisions, err := fetchHelmHistory(helmPath, name, ns, m.kubectlContext(ctx), kubeconfigPaths)
-		if err != nil {
-			return helmHistoryListMsg{err: err}
-		}
-		return helmHistoryListMsg{revisions: revisions}
 	}
 }
 

--- a/internal/app/commands_load_helm_history.go
+++ b/internal/app/commands_load_helm_history.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -48,9 +49,22 @@ func fetchHelmHistory(helmPath, name, ns, kubeCtx, kubeconfigPaths string) ([]ui
 	cmd := exec.CommandContext(ctx, helmPath, args...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 	logExecCmd("Running helm command", cmd)
-	output, cmdErr := cmd.CombinedOutput()
+	// Capture stdout and stderr separately: helm writes the JSON document to
+	// stdout but may also print warnings (kubeconfig perms, deprecations) to
+	// stderr on an otherwise-successful run. Merging them (CombinedOutput)
+	// would interleave that text into the JSON and break Unmarshal even
+	// though helm exited 0.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, cmdErr := cmd.Output()
 	if cmdErr != nil {
-		truncated := truncateHelmOutput(output)
+		// Prefer stderr for the error detail; fall back to stdout when helm
+		// wrote the failure there instead.
+		detail := stderr.Bytes()
+		if len(bytes.TrimSpace(detail)) == 0 {
+			detail = output
+		}
+		truncated := truncateHelmOutput(detail)
 		logger.Error("helm history failed", "cmd", cmd.String(), "error", cmdErr, "output", truncated)
 		return nil, fmt.Errorf("%w: %s", cmdErr, truncated)
 	}

--- a/internal/app/commands_load_helm_history.go
+++ b/internal/app/commands_load_helm_history.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// helmHistoryTimeout caps how long the helm history subprocess may run before
+// being killed. Prevents the loader goroutine from leaking when helm hangs on
+// an unresponsive API server.
+const helmHistoryTimeout = 30 * time.Second
+
+// helmErrOutputCap bounds how much of helm's stderr/stdout we propagate into
+// error messages and logs. Helm can emit multi-kilobyte NOTES.txt content and
+// values snippets that would otherwise bloat logs and the UI error overlay.
+const helmErrOutputCap = 512
+
+// truncateHelmOutput trims helm subprocess output to helmErrOutputCap bytes so
+// logs and UI error messages stay bounded.
+func truncateHelmOutput(out []byte) string {
+	s := strings.TrimSpace(string(out))
+	if len(s) > helmErrOutputCap {
+		return s[:helmErrOutputCap] + "...(truncated)"
+	}
+	return s
+}
+
+// fetchHelmHistory shells out to `helm history` and returns the parsed
+// revisions (newest first). It is shared between the rollback and read-only
+// history overlays so both views use the same data source. The subprocess is
+// bounded by helmHistoryTimeout and its error output is truncated before
+// being logged or propagated to the UI.
+func fetchHelmHistory(helmPath, name, ns, kubeCtx, kubeconfigPaths string) ([]ui.HelmRevision, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), helmHistoryTimeout)
+	defer cancel()
+
+	args := []string{"history", name, "-n", ns, "--kube-context", kubeCtx, "-o", "json", "--max", "50"}
+	cmd := exec.CommandContext(ctx, helmPath, args...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
+	logExecCmd("Running helm command", cmd)
+	output, cmdErr := cmd.CombinedOutput()
+	if cmdErr != nil {
+		truncated := truncateHelmOutput(output)
+		logger.Error("helm history failed", "cmd", cmd.String(), "error", cmdErr, "output", truncated)
+		return nil, fmt.Errorf("%w: %s", cmdErr, truncated)
+	}
+
+	var entries []struct {
+		Revision    int    `json:"revision"`
+		Status      string `json:"status"`
+		Chart       string `json:"chart"`
+		AppVersion  string `json:"app_version"`
+		Description string `json:"description"`
+		Updated     string `json:"updated"`
+	}
+	if jsonErr := json.Unmarshal(output, &entries); jsonErr != nil {
+		return nil, fmt.Errorf("failed to parse helm history: %w", jsonErr)
+	}
+
+	revisions := make([]ui.HelmRevision, len(entries))
+	for i, e := range entries {
+		revisions[i] = ui.HelmRevision{
+			Revision:    e.Revision,
+			Status:      e.Status,
+			Chart:       e.Chart,
+			AppVersion:  e.AppVersion,
+			Description: e.Description,
+			Updated:     e.Updated,
+		}
+	}
+	// Reverse so newest revision is first.
+	for i, j := 0, len(revisions)-1; i < j; i, j = i+1, j-1 {
+		revisions[i], revisions[j] = revisions[j], revisions[i]
+	}
+	return revisions, nil
+}
+
+// loadHelmRevisions fetches the revision history for a Helm release.
+func (m Model) loadHelmRevisions() tea.Cmd {
+	helmPath, err := exec.LookPath("helm")
+	if err != nil {
+		return func() tea.Msg {
+			return helmRevisionListMsg{err: fmt.Errorf("helm not found: %w", err)}
+		}
+	}
+
+	ns := m.actionCtx.namespace
+	name := m.actionCtx.name
+	ctx := m.actionCtx.context
+	kubeconfigPaths := m.client.KubeconfigPathForContext(ctx)
+
+	return func() tea.Msg {
+		revisions, err := fetchHelmHistory(helmPath, name, ns, m.kubectlContext(ctx), kubeconfigPaths)
+		if err != nil {
+			return helmRevisionListMsg{err: err}
+		}
+		return helmRevisionListMsg{revisions: revisions}
+	}
+}
+
+// loadHelmHistory fetches revision history for the read-only history overlay.
+// It reuses fetchHelmHistory but routes the result to helmHistoryListMsg so
+// the update path opens overlayHelmHistory instead of overlayHelmRollback.
+func (m Model) loadHelmHistory() tea.Cmd {
+	helmPath, err := exec.LookPath("helm")
+	if err != nil {
+		return func() tea.Msg {
+			return helmHistoryListMsg{err: fmt.Errorf("helm not found: %w", err)}
+		}
+	}
+
+	ns := m.actionCtx.namespace
+	name := m.actionCtx.name
+	ctx := m.actionCtx.context
+	kubeconfigPaths := m.client.KubeconfigPathForContext(ctx)
+
+	return func() tea.Msg {
+		revisions, err := fetchHelmHistory(helmPath, name, ns, m.kubectlContext(ctx), kubeconfigPaths)
+		if err != nil {
+			return helmHistoryListMsg{err: err}
+		}
+		return helmHistoryListMsg{revisions: revisions}
+	}
+}

--- a/internal/app/commands_load_scheduler_helpers_test.go
+++ b/internal/app/commands_load_scheduler_helpers_test.go
@@ -169,7 +169,7 @@ func TestLoadCanISAList_SubmitsAtCriticalPriority(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "loadCanISAList must Submit at Critical priority")
 }
 
-func TestLoadResources_SubmitsAtHighPriority(t *testing.T) {
+func TestLoadResources_MainListSubmitsAtCriticalPriority(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m.nav.Context = "test-ctx"
 	m.nav.ResourceType = model.ResourceTypeEntry{
@@ -181,13 +181,43 @@ func TestLoadResources_SubmitsAtHighPriority(t *testing.T) {
 	}
 	m.scheduler.StopWorkers()
 
+	// The main list (forPreview=false) is the view the user is waiting on,
+	// so it runs Critical to claim the reserved worker and never queue
+	// behind background work.
 	cmd := m.loadResources(false)
 	require.NotNil(t, cmd)
 	go cmd()
 
 	require.Eventually(t, func() bool {
+		return m.scheduler.QueueLenByPriority("test-ctx", scheduler.PriorityCritical) >= 1
+	}, time.Second, 10*time.Millisecond, "main resource list must Submit at Critical priority")
+}
+
+func TestLoadResources_PreviewSubmitsAtHighPriority(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.nav.Context = "test-ctx"
+	m.nav.Level = model.LevelResourceTypes
+	podsRT := model.ResourceTypeEntry{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true}
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{podsRT}
+	m.middleItems = model.BuildSidebarItems([]model.ResourceTypeEntry{podsRT})
+	m.allGroupsExpanded = true
+	visible := m.visibleMiddleItems()
+	for i, item := range visible {
+		if item.Extra == podsRT.ResourceRef() {
+			m.setCursor(i)
+			break
+		}
+	}
+	m.scheduler.StopWorkers()
+
+	// Preview hovers stay High — speculative and preemptible.
+	cmd := m.loadResources(true)
+	require.NotNil(t, cmd)
+	go cmd()
+
+	require.Eventually(t, func() bool {
 		return m.scheduler.QueueLenByPriority("test-ctx", scheduler.PriorityHigh) >= 1
-	}, time.Second, 10*time.Millisecond, "loadResources must Submit at High priority")
+	}, time.Second, 10*time.Millisecond, "preview resource list must Submit at High priority")
 }
 
 func TestLoadOwned_SubmitsAtHighPriority(t *testing.T) {

--- a/internal/app/reclaim_stale_bg_test.go
+++ b/internal/app/reclaim_stale_bg_test.go
@@ -56,6 +56,10 @@ func TestInvalidatePreviewForCursorChange_ReclaimsStaleDashboard(t *testing.T) {
 func TestInvalidatePreviewForCursorChange_KeepsHighPriorityView(t *testing.T) {
 	m := newTestModelWithScheduler()
 	m.nav.Context = "test-ctx"
+	// Carry a non-zero Gen like a real navigation load, so the task's
+	// survival is attributable to the High-priority exemption, not the
+	// Gen==0 "never stale" special-case.
+	m.requestGen = 1
 
 	cmd := m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindResourceList,
 		"List Events", "test-ctx",

--- a/internal/app/reclaim_stale_bg_test.go
+++ b/internal/app/reclaim_stale_bg_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvalidatePreviewForCursorChange_ReclaimsStaleDashboard reproduces the
+// reported bug: a cursor move off the cluster-dashboard overview must drop the
+// queued Low-priority dashboard sections from the now-stale generation so they
+// stop blocking fresh work in the shared Low lane.
+func TestInvalidatePreviewForCursorChange_ReclaimsStaleDashboard(t *testing.T) {
+	m := newTestModelWithScheduler()
+	m.nav.Context = "test-ctx"
+	// Navigation always bumps requestGen before any load, so real dashboard
+	// tasks carry a non-zero Gen. Mirror that here — Gen == 0 is the
+	// intentional "non-navigational, never stale" exemption in staleByGen.
+	m.requestGen = 1
+	// No StartWorkers: keep tasks queued so we can observe the reclaim.
+
+	// A Low dashboard section submitted at the current generation.
+	cmd := m.scheduleK8sCall(scheduler.PriorityLow, scheduler.KindDashboard,
+		"Dashboard: pods", "test-ctx#pods",
+		func(context.Context) tea.Msg { return stubMsg{value: "stale"} })
+	require.NotNil(t, cmd)
+	require.Equal(t, 1, m.scheduler.QueueLen("test-ctx"))
+
+	// Cursor move bumps requestGen and reclaims stale Low work.
+	m.invalidatePreviewForCursorChange()
+
+	assert.Equal(t, 0, m.scheduler.QueueLen("test-ctx"),
+		"stale Low dashboard task must be reclaimed on cursor change")
+
+	// The original cmd resolves to a nil msg (ErrSuperseded maps to nil).
+	// Guard with a timeout so a regression that leaves the task queued fails
+	// fast here instead of blocking on the future until the suite timeout.
+	got := make(chan tea.Msg, 1)
+	go func() { got <- cmd() }()
+	select {
+	case msg := <-got:
+		assert.Nil(t, msg, "superseded task's cmd must return nil, not a stale message")
+	case <-time.After(2 * time.Second):
+		t.Fatal("cmd() blocked: superseded task's future was never resolved")
+	}
+}
+
+// TestInvalidatePreviewForCursorChange_KeepsHighPriorityView guards the scope:
+// a High-priority fetch (the resource list the user is waiting for) must
+// survive the gen bump a cursor move triggers.
+func TestInvalidatePreviewForCursorChange_KeepsHighPriorityView(t *testing.T) {
+	m := newTestModelWithScheduler()
+	m.nav.Context = "test-ctx"
+
+	cmd := m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindResourceList,
+		"List Events", "test-ctx",
+		func(context.Context) tea.Msg { return stubMsg{value: "list"} })
+	require.NotNil(t, cmd)
+
+	m.invalidatePreviewForCursorChange()
+
+	assert.Equal(t, 1, m.scheduler.QueueLen("test-ctx"),
+		"High-priority view fetch must not be reclaimed by a cursor move")
+}

--- a/internal/app/refresh_discovery_watch_test.go
+++ b/internal/app/refresh_discovery_watch_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRefreshCurrentLevel_WatchTickDoesNotRediscover is the fix for
+// "Discover API Resources constantly running" on the resource-type list: a
+// watch-tick refresh (suppressBgtasks) must not invalidate the discovery
+// cache and re-fire discovery every interval. Discovery is session-cached by
+// design and only an explicit refresh re-runs it.
+func TestRefreshCurrentLevel_WatchTickDoesNotRediscover(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.nav.Level = model.LevelResourceTypes
+	// Pretend discovery already completed this session.
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{{Kind: "Pod", Resource: "pods"}}
+
+	m.suppressBgtasks = true // watch-tick refresh
+	_ = m.refreshCurrentLevel()
+
+	assert.Empty(t, m.discoveringContexts,
+		"watch-tick refresh must not start an API-resource discovery")
+}
+
+// TestRefreshCurrentLevel_ManualRefreshRediscovers verifies the explicit
+// shift+r path still re-runs discovery so newly-installed CRDs surface.
+func TestRefreshCurrentLevel_ManualRefreshRediscovers(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.nav.Level = model.LevelResourceTypes
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{{Kind: "Pod", Resource: "pods"}}
+
+	m.suppressBgtasks = false // explicit user refresh
+	_ = m.refreshCurrentLevel()
+
+	assert.True(t, m.discoveringContexts["test-ctx"],
+		"manual refresh must re-run discovery to pick up new CRDs")
+}

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -607,6 +607,49 @@ func (r *Registry) CancelContext(kctx string) {
 	}
 }
 
+// CancelStaleByGen reclaims background work on kctx that a newer
+// requestGen has made irrelevant: it drops queued Low-priority tasks and
+// cancels in-flight Low-priority tasks whose Gen predates keepGen,
+// delivering ErrSuperseded to their Futures.
+//
+// Scoped to Low priority on purpose. Cursor moves bump requestGen only to
+// invalidate the preview pane, so the user's current view (High-priority
+// resource list, YAML, containers) and foundational/mutation work
+// (Critical) must survive a gen bump — only the decorative Low lane
+// (dashboard sections, metrics, preview events) is safe to reclaim and
+// cheap to re-issue. Called from navigation paths right after the bump so
+// superseded dashboard/preview fetches stop blocking fresh work in the
+// shared Low lane instead of running to completion only to be discarded.
+func (r *Registry) CancelStaleByGen(kctx string, keepGen uint64) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	q := r.ctxQueues[kctx]
+	running := append([]*runningTask(nil), r.runningTasks[kctx]...)
+	r.mu.Unlock()
+
+	if q != nil {
+		q.dropStaleByGen(keepGen)
+	}
+
+	for _, rt := range running {
+		// Snapshot taken under r.mu above; we act outside the lock (mirrors
+		// CancelContext). The window is safe: rt.cancel() is idempotent, and
+		// the Future is only ever sent-to/closed by runTask — never here. If
+		// a concurrent CancelContext already set contextSwitched, this guard
+		// skips the task and runTask delivers ErrContextSwitched; otherwise
+		// runTask sees superseded and delivers ErrSuperseded. No double-send.
+		if rt.superseded.Load() || rt.preempted.Load() || rt.contextSwitched.Load() {
+			continue
+		}
+		if staleByGen(rt.task.req, keepGen) {
+			rt.superseded.Store(true)
+			rt.cancel()
+		}
+	}
+}
+
 // Close releases all per-context resources. Idempotent. Pending Futures
 // receive Result{Err: ErrContextSwitched}. Safe on a nil receiver.
 func (r *Registry) Close() {

--- a/internal/app/scheduler/scheduler.go
+++ b/internal/app/scheduler/scheduler.go
@@ -59,6 +59,12 @@ var (
 	// task's context before it could run. Caller's tea.Cmd should return
 	// nil (no UI update needed; the cluster context is gone).
 	ErrContextSwitched = errors.New("scheduler: context switched")
+
+	// ErrSuperseded is delivered when CancelStaleByGen drops or cancels a
+	// Low-priority task whose Gen predates the caller's current requestGen.
+	// The result would be discarded by the caller's gen check anyway, so
+	// the tea.Cmd should return nil and free the worker for fresh work.
+	ErrSuperseded = errors.New("scheduler: superseded by newer generation")
 )
 
 // queuedTask wraps a SubmitReq with its Future channel for delivery.
@@ -98,8 +104,42 @@ func (q *ctxQueue) coalesceBySigLocked(sig Sig) {
 		}
 		kept := lane[:0]
 		for _, t := range lane {
-			if t.req.Sig() == sig {
+			if sig.CoalescesWith(t.req.Sig()) {
 				t.future <- Result{Err: ErrCoalesced}
+				close(t.future)
+				continue
+			}
+			kept = append(kept, t)
+		}
+		q.lanes[prio] = kept
+	}
+}
+
+// staleByGen reports whether a queued/running req should be reclaimed by
+// CancelStaleByGen(keepGen): a Low-priority read whose Gen predates keepGen.
+// Gen == 0 (work submitted without a requestGen) and any non-Low priority
+// (the user's current view, mutations) are never stale.
+func staleByGen(req SubmitReq, keepGen uint64) bool {
+	return req.Priority == PriorityLow &&
+		req.Kind != KindMutation &&
+		req.Gen != 0 &&
+		req.Gen < keepGen
+}
+
+// dropStaleByGen removes queued tasks made stale by keepGen and delivers
+// ErrSuperseded to their Futures. Acquires q.mu itself.
+func (q *ctxQueue) dropStaleByGen(keepGen uint64) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for prio := range q.lanes {
+		lane := q.lanes[prio]
+		if len(lane) == 0 {
+			continue
+		}
+		kept := lane[:0]
+		for _, t := range lane {
+			if staleByGen(t.req, keepGen) {
+				t.future <- Result{Err: ErrSuperseded}
 				close(t.future)
 				continue
 			}

--- a/internal/app/scheduler/scheduler_coalesce.go
+++ b/internal/app/scheduler/scheduler_coalesce.go
@@ -34,3 +34,31 @@ type Sig struct {
 func (s Sig) NeverCoalesce() bool {
 	return s.Kind == KindMutation
 }
+
+// coalesceIgnoresGen reports whether two submissions of this Kind should
+// coalesce even when their Gen differs. Dashboard sections re-fire on a
+// fixed per-context target (e.g. "c1#metrics") every refresh; keeping Gen
+// in their coalesce identity let a watch-tick or cursor-move resubmission
+// stack a second full six-task batch behind the first instead of replacing
+// it, so stale batches accumulated in the Low lane. Other Kinds keep Gen in
+// their identity (see Sig's Gen doc) so a stale-cancelled fetch and a fresh
+// fetch never collapse into one.
+func (k Kind) coalesceIgnoresGen() bool {
+	return k == KindDashboard
+}
+
+// CoalescesWith reports whether a queued task's Sig should be displaced by a
+// newer submission with Sig s. Identity is Kind+Context+Name+Target; Gen is
+// included only for Kinds that do not opt out via coalesceIgnoresGen.
+func (s Sig) CoalescesWith(other Sig) bool {
+	if s.Kind != other.Kind ||
+		s.KubeContext != other.KubeContext ||
+		s.Name != other.Name ||
+		s.Target != other.Target {
+		return false
+	}
+	if s.Kind.coalesceIgnoresGen() {
+		return true
+	}
+	return s.Gen == other.Gen
+}

--- a/internal/app/scheduler/scheduler_stale_test.go
+++ b/internal/app/scheduler/scheduler_stale_test.go
@@ -1,0 +1,151 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dashReq builds a Dashboard-section submission with an explicit Name and Gen
+// so the gen-agnostic coalesce path can be exercised directly.
+func dashReq(kctx, name, target string, gen uint64) SubmitReq {
+	return SubmitReq{
+		KubeContext: kctx,
+		Kind:        KindDashboard,
+		Priority:    PriorityLow,
+		Name:        name,
+		Target:      target,
+		Gen:         gen,
+		Fn:          noopFn,
+		Timeout:     time.Second,
+	}
+}
+
+// TestSubmit_DashboardCoalescesAcrossGen is the fix for the stale-dashboard
+// pile-up: a fresh dashboard batch (newer Gen) must displace the queued
+// same-section task from an older Gen instead of stacking a second copy
+// behind it. Without this, every cursor move / watch tick that bumps
+// requestGen left another full 6-task batch in the Low lane.
+func TestSubmit_DashboardCoalescesAcrossGen(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+
+	old := r.Submit(dashReq("c1", "Dashboard: metrics", "c1#metrics", 1))
+	fresh := r.Submit(dashReq("c1", "Dashboard: metrics", "c1#metrics", 2))
+
+	select {
+	case res := <-old:
+		assert.ErrorIs(t, res.Err, ErrCoalesced, "older-gen dashboard section must coalesce into the newer one")
+	case <-time.After(time.Second):
+		t.Fatal("older dashboard future should have been coalesced")
+	}
+	_ = fresh
+	assert.Equal(t, 1, r.QueueLen("c1"), "only the freshest dashboard section should remain queued")
+}
+
+// TestSubmit_DashboardDifferentSectionDoesNotCoalesce guards against the
+// gen-agnostic rule collapsing distinct sections into one — the six sections
+// share Kind/Target/Gen but differ by Name and must all survive.
+func TestSubmit_DashboardDifferentSectionDoesNotCoalesce(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+
+	r.Submit(dashReq("c1", "Dashboard: pods", "c1#pods", 1))
+	r.Submit(dashReq("c1", "Dashboard: nodes", "c1#nodes", 1))
+
+	assert.Equal(t, 2, r.QueueLen("c1"), "distinct dashboard sections must not coalesce")
+}
+
+// TestCancelStaleByGen_DropsQueuedLowOlderGen verifies the reclaim path:
+// queued Low-priority tasks from an older generation are dropped (future gets
+// ErrSuperseded), while the current generation and any High-priority work the
+// user is actively waiting for are left untouched.
+func TestCancelStaleByGen_DropsQueuedLowOlderGen(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+
+	keep := r.Submit(dashReq("c1", "Dashboard: pods", "c1#pods", 2))  // current gen
+	stale := r.Submit(dashReq("c1", "Dashboard: metrics", "c1#m", 1)) // older gen, Low
+	high := r.Submit(SubmitReq{KubeContext: "c1", Kind: KindResourceList, Priority: PriorityHigh, Name: "List Events", Target: "c1", Gen: 1, Fn: noopFn})
+
+	r.CancelStaleByGen("c1", 2)
+
+	select {
+	case res := <-stale:
+		assert.ErrorIs(t, res.Err, ErrSuperseded, "older-gen Low task must be superseded")
+	case <-time.After(time.Second):
+		t.Fatal("stale future should have been delivered ErrSuperseded")
+	}
+
+	// keep (current gen) and high (older gen but High) both survive.
+	select {
+	case <-keep:
+		t.Fatal("current-gen task must not be cancelled")
+	case <-high:
+		t.Fatal("High-priority task must never be cancelled by gen reclaim")
+	default:
+	}
+	assert.Equal(t, 2, r.QueueLen("c1"))
+}
+
+// TestCancelStaleByGen_KeepsGenZero ensures tasks submitted without a
+// requestGen (Gen == 0, e.g. non-navigational background work) are never
+// treated as stale.
+func TestCancelStaleByGen_KeepsGenZero(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+
+	r.Submit(dashReq("c1", "Dashboard: pods", "c1#pods", 0))
+	r.CancelStaleByGen("c1", 5)
+	assert.Equal(t, 1, r.QueueLen("c1"), "Gen==0 tasks are not subject to gen reclaim")
+}
+
+// TestCancelStaleByGen_CancelsInflightLow verifies a running Low task from an
+// older gen is cancelled via its context and its Future delivers ErrSuperseded
+// rather than being requeued (the preempt path) or delivering a stale value.
+func TestCancelStaleByGen_CancelsInflightLow(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.StartWorkers()
+	defer r.StopWorkers()
+	r.SetWorkersForTest(1, 0)
+
+	started := make(chan struct{})
+	fut := r.Submit(SubmitReq{
+		KubeContext: "c1", Kind: KindDashboard, Priority: PriorityLow,
+		Name: "Dashboard: pods", Target: "c1#pods", Gen: 1,
+		Fn: func(ctx context.Context) (any, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("task never started")
+	}
+
+	r.CancelStaleByGen("c1", 2)
+
+	select {
+	case res := <-fut:
+		require.ErrorIs(t, res.Err, ErrSuperseded, "in-flight stale Low task must resolve as superseded")
+	case <-time.After(2 * time.Second):
+		t.Fatal("superseded in-flight future never delivered")
+	}
+}
+
+// TestCancelStaleByGen_NilAndUnknown is a no-op safety check.
+func TestCancelStaleByGen_NilAndUnknown(t *testing.T) {
+	var nilReg *Registry
+	require.NotPanics(t, func() { nilReg.CancelStaleByGen("c1", 1) })
+
+	r := New(0)
+	defer r.Close()
+	require.NotPanics(t, func() { r.CancelStaleByGen("missing", 1) })
+}

--- a/internal/app/scheduler/scheduler_stale_test.go
+++ b/internal/app/scheduler/scheduler_stale_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// dashReq builds a Dashboard-section submission with an explicit Name and Gen
-// so the gen-agnostic coalesce path can be exercised directly.
-func dashReq(kctx, name, target string, gen uint64) SubmitReq {
+// dashReq builds a Dashboard-section submission on context "c1" with an
+// explicit Name and Gen so the gen-agnostic coalesce path can be exercised
+// directly.
+func dashReq(name, target string, gen uint64) SubmitReq {
 	return SubmitReq{
-		KubeContext: kctx,
+		KubeContext: "c1",
 		Kind:        KindDashboard,
 		Priority:    PriorityLow,
 		Name:        name,
@@ -33,8 +34,8 @@ func TestSubmit_DashboardCoalescesAcrossGen(t *testing.T) {
 	r := New(0)
 	defer r.Close()
 
-	old := r.Submit(dashReq("c1", "Dashboard: metrics", "c1#metrics", 1))
-	fresh := r.Submit(dashReq("c1", "Dashboard: metrics", "c1#metrics", 2))
+	old := r.Submit(dashReq("Dashboard: metrics", "c1#metrics", 1))
+	fresh := r.Submit(dashReq("Dashboard: metrics", "c1#metrics", 2))
 
 	select {
 	case res := <-old:
@@ -53,8 +54,8 @@ func TestSubmit_DashboardDifferentSectionDoesNotCoalesce(t *testing.T) {
 	r := New(0)
 	defer r.Close()
 
-	r.Submit(dashReq("c1", "Dashboard: pods", "c1#pods", 1))
-	r.Submit(dashReq("c1", "Dashboard: nodes", "c1#nodes", 1))
+	r.Submit(dashReq("Dashboard: pods", "c1#pods", 1))
+	r.Submit(dashReq("Dashboard: nodes", "c1#nodes", 1))
 
 	assert.Equal(t, 2, r.QueueLen("c1"), "distinct dashboard sections must not coalesce")
 }
@@ -67,8 +68,8 @@ func TestCancelStaleByGen_DropsQueuedLowOlderGen(t *testing.T) {
 	r := New(0)
 	defer r.Close()
 
-	keep := r.Submit(dashReq("c1", "Dashboard: pods", "c1#pods", 2))  // current gen
-	stale := r.Submit(dashReq("c1", "Dashboard: metrics", "c1#m", 1)) // older gen, Low
+	keep := r.Submit(dashReq("Dashboard: pods", "c1#pods", 2))  // current gen
+	stale := r.Submit(dashReq("Dashboard: metrics", "c1#m", 1)) // older gen, Low
 	high := r.Submit(SubmitReq{KubeContext: "c1", Kind: KindResourceList, Priority: PriorityHigh, Name: "List Events", Target: "c1", Gen: 1, Fn: noopFn})
 
 	r.CancelStaleByGen("c1", 2)
@@ -98,7 +99,7 @@ func TestCancelStaleByGen_KeepsGenZero(t *testing.T) {
 	r := New(0)
 	defer r.Close()
 
-	r.Submit(dashReq("c1", "Dashboard: pods", "c1#pods", 0))
+	r.Submit(dashReq("Dashboard: pods", "c1#pods", 0))
 	r.CancelStaleByGen("c1", 5)
 	assert.Equal(t, 1, r.QueueLen("c1"), "Gen==0 tasks are not subject to gen reclaim")
 }

--- a/internal/app/scheduler/scheduler_workers.go
+++ b/internal/app/scheduler/scheduler_workers.go
@@ -188,6 +188,7 @@ type runningTask struct {
 	cancel          context.CancelFunc
 	preempted       atomic.Bool
 	contextSwitched atomic.Bool
+	superseded      atomic.Bool
 }
 
 func (r *Registry) registerRunning(kctx string, rt *runningTask) {
@@ -227,7 +228,10 @@ func (r *Registry) pokePreempt(kctx string, newPrio Priority) bool {
 	var victim *runningTask
 	worstPrio := newPrio
 	for _, rt := range list {
-		if rt.preempted.Load() {
+		// Skip tasks already being torn down (preempted, or superseded by
+		// CancelStaleByGen): preempting one wastes this submission's single
+		// preemption on a worker slot that is already being reclaimed.
+		if rt.preempted.Load() || rt.superseded.Load() {
 			continue
 		}
 		if rt.task.req.Priority > worstPrio {
@@ -271,6 +275,16 @@ func (r *Registry) runTask(task *queuedTask) {
 	if rt.contextSwitched.Load() {
 		r.Finish(visID)
 		task.future <- Result{Err: ErrContextSwitched}
+		close(task.future)
+		return
+	}
+
+	// Superseded is checked before preempted: a stale-cancelled task must
+	// resolve as ErrSuperseded and NOT be requeued (the preempt path would
+	// re-run it), since a newer generation already owns the result.
+	if rt.superseded.Load() {
+		r.Finish(visID)
+		task.future <- Result{Err: ErrSuperseded}
 		close(task.future)
 		return
 	}

--- a/internal/app/update_actions_misc.go
+++ b/internal/app/update_actions_misc.go
@@ -29,7 +29,15 @@ func (m Model) refreshCurrentLevel() tea.Cmd {
 		// "__union__" string, which restConfigForContext immediately rejects.
 		discoveryCtx := m.effectiveContext()
 		var cmds []tea.Cmd
-		if !m.discoveringContexts[discoveryCtx] {
+		// Only force a discovery round-trip on an explicit user refresh
+		// (shift+r), never on the watch tick. The watch tick reaches
+		// refreshCurrentLevel every interval with suppressBgtasks set;
+		// re-invalidating the cache and re-firing discovery there ran a full
+		// API-resource discovery every few seconds while the user simply sat
+		// on the resource-type list (visible as "Discover API Resources"
+		// constantly running). The resource set is session-cached by design —
+		// new CRDs surface on the next manual refresh, not via polling.
+		if !m.suppressBgtasks && !m.discoveringContexts[discoveryCtx] {
 			if m.discoveringContexts != nil {
 				m.discoveringContexts[discoveryCtx] = true
 			}

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -57,6 +57,18 @@ func (m Model) moveCursor(delta int) (tea.Model, tea.Cmd) {
 	return m, schedulePreviewDebounce(m.previewDebounceGen)
 }
 
+// reclaimStaleBgWork drops queued and cancels in-flight Low-priority
+// scheduler tasks on the active context whose requestGen predates the
+// current one. Call right after bumping m.requestGen on navigation: a
+// cursor move or drill reclaims worker slots from dashboard/preview
+// fetches whose results the gen check would discard anyway, instead of
+// letting them block fresh work in the shared Low lane. High/Critical work
+// (the user's current view, mutations) is left untouched — see
+// scheduler.Registry.CancelStaleByGen.
+func (m *Model) reclaimStaleBgWork() {
+	m.scheduler.CancelStaleByGen(m.effectiveContext(), m.requestGen)
+}
+
 // invalidatePreviewForCursorChange resets the right-column state and bumps
 // requestGen so any in-flight preview load triggered by the previous cursor
 // position is discarded by its message handler instead of being applied to
@@ -67,6 +79,7 @@ func (m Model) moveCursor(delta int) (tea.Model, tea.Cmd) {
 // msg channel with context.Canceled deliveries that crowd out KeyMsgs.
 func (m *Model) invalidatePreviewForCursorChange() {
 	m.requestGen++
+	m.reclaimStaleBgWork()
 	m.previewDebounceGen++
 	m.rightItems = nil
 	m.previewYAML = ""
@@ -106,6 +119,7 @@ func (m *Model) invalidatePreviewFingerprintForCurrentSelection() {
 func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 	m.cancelAndReset()
 	m.requestGen++
+	m.reclaimStaleBgWork()
 	m.clearSelection()
 	m.activeFilterPreset = nil
 	m.unfilteredMiddleItems = nil
@@ -299,6 +313,7 @@ func (m Model) navigateChild() (tea.Model, tea.Cmd) {
 
 	m.cancelAndReset()
 	m.requestGen++
+	m.reclaimStaleBgWork()
 	m.clearSelection()
 
 	// Reset scroll positions when navigating to a new level.


### PR DESCRIPTION
## Summary

Makes the resource the user is actually looking at win over background work in the scheduler, and stops two sources of constant background churn. Addresses four reported symptoms:

1. **Dashboard tasks running while on a different resource type** — stale low-priority background tasks (cluster dashboard sections, metrics, preview events) were neither coalesced across request generations nor cancelled on navigation, so they piled up in the shared Low lane.
2. **"Discover API Resources" constantly running** — the watch tick re-invalidated the discovery cache and re-fired a full API discovery every interval while sitting on the resource-type list.
3. **The focused resource list queued behind preview fetches** — the main list ran at the same priority as the hovered item's preview fetches, so it couldn't jump ahead.
4. **Spurious scheduler warnings / wasted preemptions** (found in review).

## Changes

**Scheduler core**
- `CancelStaleByGen(kctx, keepGen)` drops queued + cancels in-flight **Low** tasks whose `Gen` predates the current `requestGen`; wired into cursor moves and drill in/out. High/Critical work and mutations are never reclaimed.
- `KindDashboard` now coalesces across `Gen` (`CoalescesWith`), so a fresh dashboard batch displaces the queued stale one instead of stacking a second copy.
- New `ErrSuperseded` sentinel + `runningTask.superseded` flag, handled in `runTask` before the preempt/requeue branch.
- `pokePreempt` skips already-superseded tasks so a High submit doesn't waste its single preemption on a slot already being reclaimed.

**App**
- Main resource list (`forPreview=false`, union + non-union) runs at **Critical** so it claims the reserved worker and is never queued behind preview fetches; preview hovers stay High (speculative, preemptible).
- `scheduleK8sCall` treats `ErrSuperseded` like `ErrCoalesced`/`ErrContextSwitched` (return nil, no spurious warning).
- `refreshCurrentLevel` at `LevelResourceTypes` only re-runs API discovery on an explicit refresh (`!suppressBgtasks`), not on the watch tick. The resource set stays session-cached; new CRDs surface on the next manual refresh.

## Test plan

- [x] `go build ./...`, `go vet ./internal/app/...`
- [x] `go test ./internal/app/ ./internal/app/scheduler/`
- [x] `go test -race ./internal/app/scheduler/`
- [x] New unit tests: cross-gen dashboard coalesce, `CancelStaleByGen` (queued/in-flight/Gen==0/nil), reclaim-on-cursor-move, watch-tick-vs-manual discovery gating, list Critical vs preview High priority
- [x] Manual verification on a live cluster: pod list dispatches immediately (no longer queued behind previews); "Discover API Resources" no longer reappears every few seconds

## Follow-up (not in this PR)

A two-epoch refactor (`navEpoch` vs `previewEpoch`) would let the main list revert to High and remove the Low-only cancellation heuristic — cancellation keyed on view scope instead of priority. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)