### PR TITLE
fix: attribute cluster credential failures + Prometheus pod metrics + log viewer cursor

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -117,7 +117,7 @@ Each monitoring entry accepts the following top-level fields:
 |---|---|---|---|
 | `prometheus` | object | *(auto-discovery)* | Prometheus endpoint configuration. See endpoint fields below. |
 | `alertmanager` | object | *(auto-discovery)* | Alertmanager endpoint configuration. See endpoint fields below. |
-| `node_metrics` | string | *(auto-detect)* | Node metrics source: `"prometheus"` (use Prometheus queries), `"metrics-api"` (use metrics.k8s.io API). When empty, uses Prometheus if a prometheus endpoint is configured, otherwise falls back to metrics-api. |
+| `node_metrics` | string | *(auto-detect)* | Metrics source for node **and pod** usage: `"prometheus"` (use Prometheus queries), `"metrics-api"` (use metrics.k8s.io API). When empty, uses Prometheus if a prometheus endpoint is configured, otherwise metrics-api. Either way the other source is tried as a fallback, so pod metrics resolve on clusters served only by Prometheus. |
 
 ### Monitoring Endpoint Fields
 

--- a/internal/app/commands_load_metrics.go
+++ b/internal/app/commands_load_metrics.go
@@ -184,7 +184,7 @@ func (m Model) loadPodMetricsForList() tea.Cmd {
 			metrics, err := client.GetAllPodMetrics(ctx, kctx, ns)
 			if err != nil {
 				logger.WarnOnce("pod-metrics-list-load", kctx+"/"+ns,
-					"pod metrics list load failed", "context", kctx, "namespace", ns, "error", logger.Redact(err.Error()))
+					"pod metrics unavailable: no metrics-server or Prometheus source", "context", kctx, "namespace", ns, "error", logger.Redact(err.Error()))
 				return podMetricsEnrichedMsg{gen: gen}
 			}
 			return podMetricsEnrichedMsg{metrics: metrics, gen: gen}

--- a/internal/app/update_overlays_errorlog.go
+++ b/internal/app/update_overlays_errorlog.go
@@ -362,10 +362,64 @@ func (m Model) handleErrorLogOverlayKeyD() (tea.Model, tea.Cmd) {
 		// Don't toggle debug in visual mode — 'd' is ambiguous.
 		return m, nil
 	}
+
+	// Anchor on the currently selected entry so the cursor stays on the same
+	// log line across the filter change instead of jumping back to the top.
+	// When hiding debug, the selected line may itself be a DBG entry that is
+	// about to disappear — fall back to the nearest surviving entry.
+	before := ui.FilteredErrorLogEntries(m.errorLog, m.showDebugLogs)
 	m.showDebugLogs = !m.showDebugLogs
-	m.errorLogScroll = 0
+	anchor, ok := nearestSurvivingErrorLogEntry(before, m.errorLogCursorLine, m.showDebugLogs)
+
+	after := ui.FilteredErrorLogEntries(m.errorLog, m.showDebugLogs)
+	if ok {
+		if idx := indexOfErrorLogEntry(after, anchor); idx >= 0 {
+			_, maxVisible, maxScroll := m.errorLogVisibleCount()
+			m.errorLogCursorLine = idx
+			m.errorLogScroll = m.errorLogEnsureCursorVisible(maxVisible, maxScroll)
+			return m, nil
+		}
+	}
+
+	// Nothing to anchor to (empty log, or the entry vanished): reset to top.
 	m.errorLogCursorLine = 0
+	m.errorLogScroll = 0
 	return m, nil
+}
+
+// nearestSurvivingErrorLogEntry returns the entry at cursor if it survives the
+// post-toggle debug filter, otherwise the closest entry that does. The list is
+// newest-first, so the outward scan tries the higher index (older entry) before
+// the lower index (newer entry). Returns ok=false when no entry survives or the
+// cursor is out of range.
+func nearestSurvivingErrorLogEntry(entries []ui.ErrorLogEntry, cursor int, showDebugAfter bool) (ui.ErrorLogEntry, bool) {
+	survives := func(e ui.ErrorLogEntry) bool { return showDebugAfter || e.Level != "DBG" }
+	if cursor < 0 || cursor >= len(entries) {
+		return ui.ErrorLogEntry{}, false
+	}
+	if survives(entries[cursor]) {
+		return entries[cursor], true
+	}
+	for off := 1; off < len(entries); off++ {
+		if i := cursor + off; i < len(entries) && survives(entries[i]) {
+			return entries[i], true
+		}
+		if i := cursor - off; i >= 0 && survives(entries[i]) {
+			return entries[i], true
+		}
+	}
+	return ui.ErrorLogEntry{}, false
+}
+
+// indexOfErrorLogEntry finds the index of an entry by its identity
+// (timestamp + level + message). Returns -1 when absent.
+func indexOfErrorLogEntry(entries []ui.ErrorLogEntry, target ui.ErrorLogEntry) int {
+	for i, e := range entries {
+		if e.Time.Equal(target.Time) && e.Level == target.Level && e.Message == target.Message {
+			return i
+		}
+	}
+	return -1
 }
 
 func (m Model) handleErrorLogOverlayKeyG() (tea.Model, tea.Cmd) {

--- a/internal/app/update_overlays_errorlog_cursor_test.go
+++ b/internal/app/update_overlays_errorlog_cursor_test.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/ui"
+	"github.com/stretchr/testify/assert"
+)
+
+// Pressing 'd' toggles the debug filter, which changes the visible entry set
+// and therefore the index of the selected entry. The cursor must follow the
+// entry it was on rather than jumping back to the top.
+func TestErrorLogDebugTogglePreservesCursor(t *testing.T) {
+	// Chronological order; FilteredErrorLogEntries reverses to newest-first.
+	entries := []ui.ErrorLogEntry{
+		{Level: "ERR", Message: "error 1"},
+		{Level: "INF", Message: "info 1"},
+		{Level: "ERR", Message: "error 2"},
+		{Level: "DBG", Message: "debug 1"},
+		{Level: "ERR", Message: "error 3"},
+	}
+	// Reversed, debug hidden: [error 3, error 2, info 1, error 1]
+	// Reversed, debug shown:  [error 3, debug 1, error 2, info 1, error 1]
+
+	t.Run("toggle on keeps selected non-debug entry", func(t *testing.T) {
+		m := Model{
+			overlayErrorLog:    true,
+			errorLog:           entries,
+			showDebugLogs:      false,
+			errorLogCursorLine: 1, // "error 2"
+			tabs:               []TabState{{}},
+			width:              80,
+			height:             40,
+		}
+		ret, _ := m.handleErrorLogOverlayKey(runeKey('d'))
+		result := ret.(Model)
+		assert.True(t, result.showDebugLogs)
+		assert.Equal(t, 2, result.errorLogCursorLine, "cursor should follow 'error 2' to its new index")
+	})
+
+	t.Run("toggle off keeps selected non-debug entry", func(t *testing.T) {
+		m := Model{
+			overlayErrorLog:    true,
+			errorLog:           entries,
+			showDebugLogs:      true,
+			errorLogCursorLine: 2, // "error 2"
+			tabs:               []TabState{{}},
+			width:              80,
+			height:             40,
+		}
+		ret, _ := m.handleErrorLogOverlayKey(runeKey('d'))
+		result := ret.(Model)
+		assert.False(t, result.showDebugLogs)
+		assert.Equal(t, 1, result.errorLogCursorLine, "cursor should follow 'error 2' to its new index")
+	})
+
+	t.Run("toggle off from a debug line lands on nearest surviving entry", func(t *testing.T) {
+		m := Model{
+			overlayErrorLog:    true,
+			errorLog:           entries,
+			showDebugLogs:      true,
+			errorLogCursorLine: 1, // "debug 1" (will disappear)
+			tabs:               []TabState{{}},
+			width:              80,
+			height:             40,
+		}
+		ret, _ := m.handleErrorLogOverlayKey(runeKey('d'))
+		result := ret.(Model)
+		assert.False(t, result.showDebugLogs)
+		// "debug 1" is gone; the nearest surviving entry is "error 2" at new index 1.
+		assert.Equal(t, 1, result.errorLogCursorLine)
+	})
+
+	t.Run("empty log resets to top without panic", func(t *testing.T) {
+		m := Model{
+			overlayErrorLog:    true,
+			errorLog:           nil,
+			showDebugLogs:      false,
+			errorLogCursorLine: 0,
+			tabs:               []TabState{{}},
+			width:              80,
+			height:             40,
+		}
+		ret, _ := m.handleErrorLogOverlayKey(runeKey('d'))
+		result := ret.(Model)
+		assert.Equal(t, 0, result.errorLogCursorLine)
+		assert.Equal(t, 0, result.errorLogScroll)
+	})
+}

--- a/internal/k8s/auth_tagging.go
+++ b/internal/k8s/auth_tagging.go
@@ -1,0 +1,143 @@
+package k8s
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// taggedHTTPClient builds the HTTP client for a context's rest.Config and, when
+// the config uses an exec credential plugin, wraps its transport so credential
+// acquisition failures are attributed to the cluster context (see
+// credTaggingRoundTripper). Mirrors what kubernetes.NewForConfig does
+// internally — rest.HTTPClientFor already installs the exec auth round tripper —
+// so the wrapper lands outermost and observes the failing RoundTrip.
+func taggedHTTPClient(cfg *rest.Config, contextName string) (*http.Client, error) {
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("building http client: %w", err)
+	}
+	if cfg.ExecProvider != nil {
+		// rest.HTTPClientFor can return a client with a nil Transport (the
+		// http.DefaultClient case when no special transport is needed). Fall
+		// back to http.DefaultTransport so RoundTrip never dereferences nil.
+		inner := httpClient.Transport
+		if inner == nil {
+			inner = http.DefaultTransport
+		}
+		httpClient.Transport = &credTaggingRoundTripper{
+			inner:   inner,
+			context: contextName,
+			command: cfg.ExecProvider.Command,
+			profile: awsProfileFromExec(cfg.ExecProvider),
+		}
+	}
+	return httpClient, nil
+}
+
+// awsProfileFromExec extracts the AWS profile a kubeconfig exec credential
+// plugin runs under: the `--profile <name>` / `--profile=<name>` argument,
+// falling back to the AWS_PROFILE env entry. Returns "" when no profile is
+// configured (or the plugin is not AWS).
+func awsProfileFromExec(exec *clientcmdapi.ExecConfig) string {
+	if exec == nil {
+		return ""
+	}
+	for i, a := range exec.Args {
+		if a == "--profile" {
+			if i+1 < len(exec.Args) {
+				return exec.Args[i+1]
+			}
+			return ""
+		}
+		if v, ok := strings.CutPrefix(a, "--profile="); ok {
+			return v
+		}
+	}
+	for _, e := range exec.Env {
+		if e.Name == "AWS_PROFILE" {
+			return e.Value
+		}
+	}
+	return ""
+}
+
+// isExecCredentialError reports whether err is a failure to acquire credentials
+// from a kubeconfig exec plugin (expired AWS SSO, missing VPN, gke auth plugin
+// not logged in, etc). client-go surfaces these as
+// "getting credentials: exec: executable <cmd> failed with exit code N" — the
+// underlying plugin's own message (e.g. the AWS SSO-expired text) only reaches
+// os.Stderr, never this error, so the cluster context here is the reliable
+// signal.
+func isExecCredentialError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "getting credentials"):
+		return true
+	case strings.Contains(s, "exec plugin"):
+		return true
+	case strings.Contains(s, "exec:") && strings.Contains(s, "executable") && strings.Contains(s, "exit code"):
+		return true
+	default:
+		return false
+	}
+}
+
+// isAWSCommand reports whether the exec plugin command is the AWS CLI.
+func isAWSCommand(command string) bool {
+	return filepath.Base(command) == "aws"
+}
+
+// credTaggingRoundTripper wraps a context's REST transport so a credential
+// acquisition failure — which client-go otherwise only reports as a contextless
+// line on os.Stderr from the exec plugin — is logged once with the cluster
+// context and AWS profile that triggered it, plus an actionable hint. It is
+// installed outermost (around the exec auth round tripper) so the failing
+// RoundTrip is observed on the goroutine that knows the context, making the
+// attribution reliable under concurrent multi-cluster loads.
+type credTaggingRoundTripper struct {
+	inner   http.RoundTripper
+	context string // lfk cluster display name
+	command string // exec plugin command (e.g. "aws"), "" if unknown
+	profile string // AWS profile, "" if unknown / non-AWS
+}
+
+func (rt *credTaggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.inner.RoundTrip(req)
+	if isExecCredentialError(err) {
+		rt.logCredentialFailure(err)
+	}
+	return resp, err
+}
+
+func (rt *credTaggingRoundTripper) logCredentialFailure(err error) {
+	msg := "cluster authentication failed: credential plugin error"
+	args := []any{"context", rt.context, "error", logger.Redact(err.Error())}
+	if rt.command != "" {
+		args = append(args, "plugin", rt.command)
+	}
+	if isAWSCommand(rt.command) {
+		msg = "cluster authentication failed: AWS credentials/SSO unavailable"
+		// The profile comes from the kubeconfig; strip control characters so a
+		// crafted/odd profile name can't corrupt the log line or in-app overlay.
+		profile := stripControlChars(rt.profile)
+		if profile != "" {
+			args = append(args, "profile", profile, "hint", "aws sso login --profile "+profile)
+		} else {
+			args = append(args, "hint", "aws sso login")
+		}
+	}
+	// Dedup per (plugin, context): a cluster that keeps failing every
+	// background tick surfaces once per window, and one cluster's outage
+	// never masks another's.
+	logger.ErrorOnce("cluster-auth-"+rt.command, rt.context, msg, args...)
+}

--- a/internal/k8s/auth_tagging_test.go
+++ b/internal/k8s/auth_tagging_test.go
@@ -1,0 +1,143 @@
+package k8s
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+func TestAWSProfileFromExec(t *testing.T) {
+	tests := []struct {
+		name string
+		exec *clientcmdapi.ExecConfig
+		want string
+	}{
+		{"nil", nil, ""},
+		{"profile flag separate arg", &clientcmdapi.ExecConfig{Args: []string{"eks", "get-token", "--profile", "prod"}}, "prod"},
+		{"profile flag equals form", &clientcmdapi.ExecConfig{Args: []string{"eks", "get-token", "--profile=staging"}}, "staging"},
+		{"profile from env", &clientcmdapi.ExecConfig{Env: []clientcmdapi.ExecEnvVar{{Name: "AWS_PROFILE", Value: "dev"}}}, "dev"},
+		{"flag wins over env", &clientcmdapi.ExecConfig{Args: []string{"--profile", "flagprof"}, Env: []clientcmdapi.ExecEnvVar{{Name: "AWS_PROFILE", Value: "envprof"}}}, "flagprof"},
+		{"no profile", &clientcmdapi.ExecConfig{Args: []string{"eks", "get-token"}}, ""},
+		{"trailing profile flag without value", &clientcmdapi.ExecConfig{Args: []string{"eks", "--profile"}}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, awsProfileFromExec(tc.exec))
+		})
+	}
+}
+
+func TestIsExecCredentialError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"aws sso exit", errors.New("getting credentials: exec: executable aws failed with exit code 255"), true},
+		{"generic exec exit", errors.New("exec: executable gke-gcloud-auth-plugin failed with exit code 1"), true},
+		{"exec plugin generic", errors.New("exec plugin: invalid apiVersion"), true},
+		{"unrelated api error", errors.New("pods \"foo\" not found"), false},
+		{"timeout", errors.New("context deadline exceeded"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isExecCredentialError(tc.err))
+		})
+	}
+}
+
+type fakeRoundTripper struct {
+	resp   *http.Response
+	err    error
+	called bool
+}
+
+func (f *fakeRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	f.called = true
+	return f.resp, f.err
+}
+
+func readUI(t *testing.T) (logger.UIEntry, bool) {
+	t.Helper()
+	select {
+	case e := <-logger.UIChan():
+		return e, true
+	case <-time.After(100 * time.Millisecond):
+		return logger.UIEntry{}, false
+	}
+}
+
+func argsToMap(args []any) map[string]string {
+	m := map[string]string{}
+	for i := 0; i+1 < len(args); i += 2 {
+		k, _ := args[i].(string)
+		v, _ := args[i+1].(string)
+		m[k] = v
+	}
+	return m
+}
+
+func TestCredTaggingRoundTripper(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/api", nil)
+
+	t.Run("aws credential error emits contextual line with profile and hint", func(t *testing.T) {
+		logger.ResetDedupForTest()
+		inner := &fakeRoundTripper{err: errors.New("getting credentials: exec: executable aws failed with exit code 255")}
+		rt := &credTaggingRoundTripper{inner: inner, context: "dev-envs", command: "aws", profile: "myprofile"}
+
+		resp, err := rt.RoundTrip(req)
+		closeResp(resp)
+		assert.Error(t, err)
+		assert.True(t, inner.called)
+
+		e, ok := readUI(t)
+		assert.True(t, ok, "expected a UI overlay entry for the credential failure")
+		assert.Equal(t, "ERR", e.Level)
+		m := argsToMap(e.Args)
+		assert.Equal(t, "dev-envs", m["context"])
+		assert.Equal(t, "myprofile", m["profile"])
+		assert.Contains(t, m["hint"], "aws sso login --profile myprofile")
+	})
+
+	t.Run("non-credential error passes through without emitting", func(t *testing.T) {
+		logger.ResetDedupForTest()
+		inner := &fakeRoundTripper{err: errors.New("pods \"foo\" not found")}
+		rt := &credTaggingRoundTripper{inner: inner, context: "dev-envs", command: "aws", profile: "myprofile"}
+
+		resp, err := rt.RoundTrip(req)
+		closeResp(resp)
+		assert.Error(t, err)
+		_, ok := readUI(t)
+		assert.False(t, ok, "should not surface an overlay entry for a normal API error")
+	})
+
+	t.Run("success passes response through", func(t *testing.T) {
+		logger.ResetDedupForTest()
+		want := &http.Response{StatusCode: 200}
+		inner := &fakeRoundTripper{resp: want}
+		rt := &credTaggingRoundTripper{inner: inner, context: "dev-envs", command: "aws", profile: "p"}
+
+		got, err := rt.RoundTrip(req)
+		assert.NoError(t, err)
+		assert.Same(t, want, got)
+		closeResp(got)
+		_, ok := readUI(t)
+		assert.False(t, ok)
+	})
+}
+
+// closeResp closes a response body when present, satisfying the bodyclose
+// linter for the fake round tripper (whose responses carry no real body).
+func closeResp(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+}

--- a/internal/k8s/auth_tagging_test.go
+++ b/internal/k8s/auth_tagging_test.go
@@ -42,6 +42,7 @@ func TestIsExecCredentialError(t *testing.T) {
 	}{
 		{"nil", nil, false},
 		{"aws sso exit", errors.New("getting credentials: exec: executable aws failed with exit code 255"), true},
+		{"executable not found", errors.New("getting credentials: exec: executable aws not found"), true},
 		{"generic exec exit", errors.New("exec: executable gke-gcloud-auth-plugin failed with exit code 1"), true},
 		{"exec plugin generic", errors.New("exec plugin: invalid apiVersion"), true},
 		{"unrelated api error", errors.New("pods \"foo\" not found"), false},

--- a/internal/k8s/client_operations.go
+++ b/internal/k8s/client_operations.go
@@ -371,7 +371,11 @@ func (c *Client) clientsetForContext(contextName string) (kubernetes.Interface, 
 	if err != nil {
 		return nil, err
 	}
-	cs, err := kubernetes.NewForConfig(cfg)
+	httpClient, err := taggedHTTPClient(cfg, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("creating http client: %w", err)
+	}
+	cs, err := kubernetes.NewForConfigAndClient(cfg, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("creating clientset: %w", err)
 	}
@@ -389,7 +393,11 @@ func (c *Client) dynamicForContext(contextName string) (dynamic.Interface, error
 	if err != nil {
 		return nil, err
 	}
-	dynClient, err := dynamic.NewForConfig(cfg)
+	httpClient, err := taggedHTTPClient(cfg, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("creating http client: %w", err)
+	}
+	dynClient, err := dynamic.NewForConfigAndClient(cfg, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("creating dynamic client: %w", err)
 	}
@@ -459,7 +467,11 @@ func (c *Client) metadataForContext(contextName string) (metadata.Interface, err
 	if err != nil {
 		return nil, err
 	}
-	mc, err := metadata.NewForConfig(cfg)
+	httpClient, err := taggedHTTPClient(cfg, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("creating http client: %w", err)
+	}
+	mc, err := metadata.NewForConfigAndClient(cfg, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("creating metadata client: %w", err)
 	}

--- a/internal/k8s/client_rbac.go
+++ b/internal/k8s/client_rbac.go
@@ -87,7 +87,11 @@ func (c *Client) GetSelfRulesAs(ctx context.Context, contextName, namespace, asU
 		}
 	}
 
-	clientset, err := kubernetes.NewForConfig(cfg)
+	httpClient, err := taggedHTTPClient(cfg, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("creating http client: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfigAndClient(cfg, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("creating clientset: %w", err)
 	}

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -2,10 +2,8 @@ package k8s
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -209,31 +207,8 @@ func (c *Client) runPrometheusQuery(ctx context.Context, contextName, query stri
 // "POD" pause container is filtered out by the query, but defensive
 // code here keeps a malformed metric from polluting the map).
 func parsePrometheusContainerResponse(data []byte) (map[string]float64, error) {
-	var resp prometheusQueryResponse
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, fmt.Errorf("parsing prometheus response: %w", err)
-	}
-	if resp.Status != "success" {
-		return nil, fmt.Errorf("prometheus query returned status: %s", resp.Status)
-	}
-	out := make(map[string]float64, len(resp.Data.Result))
-	for _, r := range resp.Data.Result {
-		container := r.Metric["container"]
-		if container == "" {
-			continue
-		}
-		if len(r.Value) < 2 {
-			continue
-		}
-		var s string
-		if err := json.Unmarshal(r.Value[1], &s); err != nil {
-			continue
-		}
-		v, err := strconv.ParseFloat(s, 64)
-		if err != nil {
-			continue
-		}
-		out[container] = v
-	}
-	return out, nil
+	return parsePrometheusVector(data, func(labels map[string]string) (string, bool) {
+		container := labels["container"]
+		return container, container != ""
+	})
 }

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -174,13 +174,16 @@ func (c *Client) runPrometheusQuery(ctx context.Context, contextName, query stri
 		result := cs.CoreV1().Services(ns).ProxyGet("http", svc, promPort, "/api/v1/query", params)
 		return result.DoRaw(rctx)
 	}
-	if cached, ok := promSvcCache.Load(cs); ok {
+	// Keyed by contextName (not the clientset): clientsetForContext builds a
+	// fresh clientset per call, so a clientset key would never hit and re-run
+	// service discovery on every query.
+	if cached, ok := promSvcCache.Load(contextName); ok {
 		entry := cached.(promSvcEntry)
 		data, err := doQuery(entry.namespace, entry.service)
 		if err == nil {
 			return data, nil
 		}
-		promSvcCache.Delete(cs)
+		promSvcCache.Delete(contextName)
 	}
 	var lastErr error
 	for _, ns := range promNs {
@@ -190,7 +193,7 @@ func (c *Client) runPrometheusQuery(ctx context.Context, contextName, query stri
 				lastErr = err
 				continue
 			}
-			promSvcCache.Store(cs, promSvcEntry{namespace: ns, service: svc})
+			promSvcCache.Store(contextName, promSvcEntry{namespace: ns, service: svc})
 			return data, nil
 		}
 	}

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -34,8 +34,26 @@ func (c *Client) metricsGVR(resource string) []schema.GroupVersionResource {
 	}
 }
 
-// GetPodMetrics fetches CPU and memory usage for a single pod using the metrics API.
+// GetPodMetrics fetches CPU and memory usage for a single pod, trying the
+// configured routes (Prometheus / metrics-server) in order.
 func (c *Client) GetPodMetrics(ctx context.Context, contextName, namespace, podName string) (*model.PodMetrics, error) {
+	return runPodMetricsRoutes(contextName,
+		func() (*model.PodMetrics, error) {
+			all, err := c.getAllPodMetricsFromPrometheus(ctx, contextName, namespace)
+			if err != nil {
+				return nil, err
+			}
+			if pm, ok := all[namespace+"/"+podName]; ok {
+				return &pm, nil
+			}
+			return nil, fmt.Errorf("pod metrics for %s/%s not present in prometheus", namespace, podName)
+		},
+		func() (*model.PodMetrics, error) { return c.getPodMetricsFromAPI(ctx, contextName, namespace, podName) },
+	)
+}
+
+// getPodMetricsFromAPI fetches a single pod's metrics from the metrics.k8s.io API.
+func (c *Client) getPodMetricsFromAPI(ctx context.Context, contextName, namespace, podName string) (*model.PodMetrics, error) {
 	dynClient, err := c.dynamicForContext(contextName)
 	if err != nil {
 		return nil, err
@@ -51,8 +69,31 @@ func (c *Client) GetPodMetrics(ctx context.Context, contextName, namespace, podN
 	return nil, fmt.Errorf("fetching pod metrics: metrics API unavailable")
 }
 
-// GetPodsMetrics fetches metrics for multiple pods.
+// GetPodsMetrics fetches metrics for multiple pods, trying the configured
+// routes (Prometheus / metrics-server) in order.
 func (c *Client) GetPodsMetrics(ctx context.Context, contextName, namespace string, podNames []string) ([]model.PodMetrics, error) {
+	return runPodMetricsRoutes(contextName,
+		func() ([]model.PodMetrics, error) {
+			all, err := c.getAllPodMetricsFromPrometheus(ctx, contextName, namespace)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]model.PodMetrics, 0, len(podNames))
+			for _, n := range podNames {
+				if pm, ok := all[namespace+"/"+n]; ok {
+					out = append(out, pm)
+				}
+			}
+			return out, nil
+		},
+		func() ([]model.PodMetrics, error) {
+			return c.getPodsMetricsFromAPI(ctx, contextName, namespace, podNames)
+		},
+	)
+}
+
+// getPodsMetricsFromAPI fetches metrics for multiple pods from the metrics.k8s.io API.
+func (c *Client) getPodsMetricsFromAPI(ctx context.Context, contextName, namespace string, podNames []string) ([]model.PodMetrics, error) {
 	dynClient, err := c.dynamicForContext(contextName)
 	if err != nil {
 		return nil, err
@@ -86,8 +127,23 @@ func (c *Client) GetPodsMetrics(ctx context.Context, contextName, namespace stri
 	return nil, fmt.Errorf("listing pod metrics: metrics API unavailable")
 }
 
-// GetAllPodMetrics fetches metrics for all pods in a namespace and returns a map of pod name -> PodMetrics.
+// GetAllPodMetrics fetches metrics for all pods in a namespace (or the whole
+// cluster when namespace is empty) and returns a map keyed by "namespace/name".
+// It tries the configured routes (Prometheus / metrics-server) in order, so a
+// cluster served only by Prometheus no longer reports "metrics API unavailable".
 func (c *Client) GetAllPodMetrics(ctx context.Context, contextName, namespace string) (map[string]model.PodMetrics, error) {
+	return runPodMetricsRoutes(contextName,
+		func() (map[string]model.PodMetrics, error) {
+			return c.getAllPodMetricsFromPrometheus(ctx, contextName, namespace)
+		},
+		func() (map[string]model.PodMetrics, error) {
+			return c.getAllPodMetricsFromAPI(ctx, contextName, namespace)
+		},
+	)
+}
+
+// getAllPodMetricsFromAPI fetches all pod metrics from the metrics.k8s.io API.
+func (c *Client) getAllPodMetricsFromAPI(ctx context.Context, contextName, namespace string) (map[string]model.PodMetrics, error) {
 	dynClient, err := c.dynamicForContext(contextName)
 	if err != nil {
 		return nil, err
@@ -384,13 +440,13 @@ func (c *Client) getNodeMetricsFromPrometheus(contextName string) (map[string]mo
 	defer cancel()
 
 	cpuQuery := `sum by (node) (rate(container_cpu_usage_seconds_total{container!=""}[3m])) * 1000`
-	cpuMap, cpuErr := c.queryPrometheusNodeMetric(ctx, clientset, promNs, promSvc, promPort, cpuQuery)
+	cpuMap, cpuErr := c.queryPrometheusNodeMetric(ctx, contextName, clientset, promNs, promSvc, promPort, cpuQuery)
 	if cpuErr != nil {
 		logger.Debug("Prometheus node CPU query failed", "error", cpuErr)
 	}
 
 	memQuery := `sum by (node) (container_memory_working_set_bytes{container!=""})`
-	memMap, memErr := c.queryPrometheusNodeMetric(ctx, clientset, promNs, promSvc, promPort, memQuery)
+	memMap, memErr := c.queryPrometheusNodeMetric(ctx, contextName, clientset, promNs, promSvc, promPort, memQuery)
 	if memErr != nil {
 		logger.Debug("Prometheus node memory query failed", "error", memErr)
 	}
@@ -422,11 +478,14 @@ func (c *Client) getNodeMetricsFromPrometheus(contextName string) (map[string]mo
 
 // queryPrometheusNodeMetric runs a PromQL instant query via Kubernetes service proxy
 // and returns a map of node name -> float64 value.
-func (c *Client) queryPrometheusNodeMetric(ctx context.Context, cs kubernetes.Interface, namespaces, services []string, port, query string) (map[string]float64, error) {
+func (c *Client) queryPrometheusNodeMetric(ctx context.Context, contextName string, cs kubernetes.Interface, namespaces, services []string, port, query string) (map[string]float64, error) {
 	params := map[string]string{"query": query}
 
-	// Check cache for a known working namespace+service.
-	if cached, ok := promSvcCache.Load(cs); ok {
+	// Check cache for a known working namespace+service. Keyed by contextName
+	// (not the clientset): clientsetForContext builds a fresh clientset per
+	// call, so a clientset key would never hit and re-run service discovery
+	// on every poll.
+	if cached, ok := promSvcCache.Load(contextName); ok {
 		entry := cached.(promSvcEntry)
 		result := cs.CoreV1().Services(entry.namespace).ProxyGet("http", entry.service, port, "/api/v1/query", params)
 		data, err := result.DoRaw(ctx)
@@ -437,7 +496,7 @@ func (c *Client) queryPrometheusNodeMetric(ctx context.Context, cs kubernetes.In
 			}
 		}
 		// Cache entry stale, remove and fall through to discovery.
-		promSvcCache.Delete(cs)
+		promSvcCache.Delete(contextName)
 	}
 
 	var lastErr error
@@ -455,7 +514,7 @@ func (c *Client) queryPrometheusNodeMetric(ctx context.Context, cs kubernetes.In
 				lastErr = err
 				continue
 			}
-			promSvcCache.Store(cs, promSvcEntry{namespace: ns, service: svc})
+			promSvcCache.Store(contextName, promSvcEntry{namespace: ns, service: svc})
 			return nodeMap, nil
 		}
 	}

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -525,30 +525,24 @@ func (c *Client) queryPrometheusNodeMetric(ctx context.Context, contextName stri
 	return nil, fmt.Errorf("no prometheus service found")
 }
 
-// parsePrometheusNodeResponse parses a Prometheus /api/v1/query JSON response
-// and extracts a map of node name -> float64 value.
-func parsePrometheusNodeResponse(data []byte) (map[string]float64, error) {
+// parsePrometheusVector parses a Prometheus /api/v1/query instant-vector
+// response into a map keyed by keyFunc(metricLabels). Samples for which keyFunc
+// returns ok=false, or whose scalar value can't be parsed, are skipped. Shared
+// by the node, pod, and container readers, which differ only in how the result
+// key is derived from the metric's labels.
+func parsePrometheusVector(data []byte, keyFunc func(labels map[string]string) (string, bool)) (map[string]float64, error) {
 	var resp prometheusQueryResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, fmt.Errorf("parsing prometheus response: %w", err)
 	}
-
 	if resp.Status != "success" {
 		return nil, fmt.Errorf("prometheus query returned status: %s", resp.Status)
 	}
 
 	result := make(map[string]float64, len(resp.Data.Result))
 	for _, r := range resp.Data.Result {
-		node := r.Metric["node"]
-		if node == "" {
-			for _, alt := range []string{"instance", "kubernetes_node", "nodename", "host"} {
-				if v := r.Metric[alt]; v != "" {
-					node = v
-					break
-				}
-			}
-		}
-		if node == "" {
+		key, ok := keyFunc(r.Metric)
+		if !ok {
 			continue
 		}
 		if len(r.Value) < 2 {
@@ -562,8 +556,25 @@ func parsePrometheusNodeResponse(data []byte) (map[string]float64, error) {
 		if err != nil {
 			continue
 		}
-		result[node] = val
+		result[key] = val
 	}
-
 	return result, nil
+}
+
+// parsePrometheusNodeResponse extracts a node name -> value map. The node name
+// comes from the "node" label, falling back to common alternates emitted by
+// different exporters.
+func parsePrometheusNodeResponse(data []byte) (map[string]float64, error) {
+	return parsePrometheusVector(data, func(labels map[string]string) (string, bool) {
+		node := labels["node"]
+		if node == "" {
+			for _, alt := range []string{"instance", "kubernetes_node", "nodename", "host"} {
+				if v := labels[alt]; v != "" {
+					node = v
+					break
+				}
+			}
+		}
+		return node, node != ""
+	})
 }

--- a/internal/k8s/metrics_prometheus_pods.go
+++ b/internal/k8s/metrics_prometheus_pods.go
@@ -1,0 +1,159 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// buildPromPodQuery returns the instant PromQL query for per-pod CPU or memory
+// usage, aggregated by (namespace, pod) so a single query covers a namespace
+// (or, when namespace is empty, the whole cluster). CPU is converted from cores
+// to millicores to match the metrics.k8s.io API path (model.PodMetrics.CPU is
+// millicores); memory is bytes.
+func buildPromPodQuery(namespace, resourceKind string) string {
+	labels := `container!="POD",container!=""`
+	if namespace != "" {
+		// Defense-in-depth: k8s namespaces are DNS-1123 labels (the API server
+		// rejects anything else), but never interpolate a value carrying PromQL
+		// label-selector metacharacters that could break out of the quotes.
+		if strings.ContainsAny(namespace, "\"\\\n") {
+			return ""
+		}
+		labels = `namespace="` + namespace + `",` + labels
+	}
+	switch resourceKind {
+	case "cpu":
+		return fmt.Sprintf(`sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{%s}[3m])) * 1000`, labels)
+	case "memory":
+		return fmt.Sprintf(`sum by (namespace, pod) (container_memory_working_set_bytes{%s})`, labels)
+	default:
+		return ""
+	}
+}
+
+// parsePrometheusPodResponse extracts the per-pod value vector from a PromQL
+// instant query response, keyed by "namespace/pod" to match the lookup keys
+// the metrics-API path and the app-side enrichment build. Samples missing
+// either label are skipped.
+func parsePrometheusPodResponse(data []byte) (map[string]float64, error) {
+	var resp prometheusQueryResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parsing prometheus response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("prometheus query returned status: %s", resp.Status)
+	}
+	out := make(map[string]float64, len(resp.Data.Result))
+	for _, r := range resp.Data.Result {
+		ns, pod := r.Metric["namespace"], r.Metric["pod"]
+		if ns == "" || pod == "" {
+			continue
+		}
+		if len(r.Value) < 2 {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(r.Value[1], &s); err != nil {
+			continue
+		}
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			continue
+		}
+		out[ns+"/"+pod] = v
+	}
+	return out, nil
+}
+
+// getAllPodMetricsFromPrometheus fetches per-pod CPU and memory usage from the
+// configured Prometheus endpoint. namespace == "" queries all namespaces. The
+// result is keyed by "namespace/pod" (matching getAllPodMetricsFromAPI). It
+// errors only when both the CPU and memory queries fail, so a partial outage
+// still surfaces whatever data is available.
+func (c *Client) getAllPodMetricsFromPrometheus(ctx context.Context, contextName, namespace string) (map[string]model.PodMetrics, error) {
+	cpuMap, cpuErr := c.queryPromPodMetric(ctx, contextName, buildPromPodQuery(namespace, "cpu"))
+	if cpuErr != nil {
+		logger.Debug("Prometheus pod CPU query failed", "context", contextName, "namespace", namespace, "error", cpuErr)
+	}
+	memMap, memErr := c.queryPromPodMetric(ctx, contextName, buildPromPodQuery(namespace, "memory"))
+	if memErr != nil {
+		logger.Debug("Prometheus pod memory query failed", "context", contextName, "namespace", namespace, "error", memErr)
+	}
+	if cpuErr != nil && memErr != nil {
+		return nil, fmt.Errorf("prometheus pod queries failed: cpu: %w, mem: %w", cpuErr, memErr)
+	}
+
+	keys := make(map[string]struct{}, len(cpuMap)+len(memMap))
+	for k := range cpuMap {
+		keys[k] = struct{}{}
+	}
+	for k := range memMap {
+		keys[k] = struct{}{}
+	}
+
+	result := make(map[string]model.PodMetrics, len(keys))
+	for key := range keys {
+		ns, pod, ok := strings.Cut(key, "/")
+		if !ok {
+			continue
+		}
+		result[key] = model.PodMetrics{
+			Name:      pod,
+			Namespace: ns,
+			CPU:       int64(math.Round(cpuMap[key])),
+			Memory:    int64(math.Round(memMap[key])),
+		}
+	}
+	return result, nil
+}
+
+// queryPromPodMetric runs an instant PromQL query and parses it into a
+// "namespace/pod" -> value map via the shared Prometheus proxy pipeline.
+func (c *Client) queryPromPodMetric(ctx context.Context, contextName, query string) (map[string]float64, error) {
+	body, err := c.runPrometheusQuery(ctx, contextName, query)
+	if err != nil {
+		return nil, err
+	}
+	return parsePrometheusPodResponse(body)
+}
+
+// runPodMetricsRoutes tries the configured pod-metrics routes (Prometheus /
+// metrics API) in order, returning the first success. It mirrors
+// GetAllNodeMetrics' fallback behavior so a cluster with only one working
+// source still resolves. The error returned when every route fails names both
+// sources, so the single caller-side warning is actionable.
+func runPodMetricsRoutes[T any](contextName string, fromProm, fromAPI func() (T, error)) (T, error) {
+	nodeMetrics, hasPrometheus := resolveNodeMetricsConfig(contextName)
+	routes := selectNodeMetricsRoutes(nodeMetrics, hasPrometheus)
+
+	var zero T
+	var lastErr error
+	for i, route := range routes {
+		var (
+			res T
+			err error
+		)
+		if route == nodeMetricsRoutePrometheus {
+			res, err = fromProm()
+		} else {
+			res, err = fromAPI()
+		}
+		if err == nil {
+			return res, nil
+		}
+		lastErr = err
+		if i+1 < len(routes) {
+			logger.Debug("pod metrics route failed, trying fallback",
+				"context", contextName, "failed_route", route.String(),
+				"fallback_route", routes[i+1].String(), "error", err)
+		}
+	}
+	return zero, fmt.Errorf("no pod metrics source available (metrics-server API or Prometheus): %w", lastErr)
+}

--- a/internal/k8s/metrics_prometheus_pods.go
+++ b/internal/k8s/metrics_prometheus_pods.go
@@ -2,10 +2,8 @@ package k8s
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/janosmiko/lfk/internal/logger"
@@ -43,33 +41,13 @@ func buildPromPodQuery(namespace, resourceKind string) string {
 // the metrics-API path and the app-side enrichment build. Samples missing
 // either label are skipped.
 func parsePrometheusPodResponse(data []byte) (map[string]float64, error) {
-	var resp prometheusQueryResponse
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return nil, fmt.Errorf("parsing prometheus response: %w", err)
-	}
-	if resp.Status != "success" {
-		return nil, fmt.Errorf("prometheus query returned status: %s", resp.Status)
-	}
-	out := make(map[string]float64, len(resp.Data.Result))
-	for _, r := range resp.Data.Result {
-		ns, pod := r.Metric["namespace"], r.Metric["pod"]
+	return parsePrometheusVector(data, func(labels map[string]string) (string, bool) {
+		ns, pod := labels["namespace"], labels["pod"]
 		if ns == "" || pod == "" {
-			continue
+			return "", false
 		}
-		if len(r.Value) < 2 {
-			continue
-		}
-		var s string
-		if err := json.Unmarshal(r.Value[1], &s); err != nil {
-			continue
-		}
-		v, err := strconv.ParseFloat(s, 64)
-		if err != nil {
-			continue
-		}
-		out[ns+"/"+pod] = v
-	}
-	return out, nil
+		return ns + "/" + pod, true
+	})
 }
 
 // getAllPodMetricsFromPrometheus fetches per-pod CPU and memory usage from the

--- a/internal/k8s/metrics_prometheus_pods_test.go
+++ b/internal/k8s/metrics_prometheus_pods_test.go
@@ -1,0 +1,97 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestBuildPromPodQuery(t *testing.T) {
+	cpuNS := buildPromPodQuery("dev", "cpu")
+	assert.Contains(t, cpuNS, "container_cpu_usage_seconds_total")
+	assert.Contains(t, cpuNS, "sum by (namespace, pod)")
+	assert.Contains(t, cpuNS, `namespace="dev"`)
+	assert.Contains(t, cpuNS, "* 1000", "CPU converted cores->millicores")
+
+	memNS := buildPromPodQuery("dev", "memory")
+	assert.Contains(t, memNS, "container_memory_working_set_bytes")
+	assert.NotContains(t, memNS, "rate(", "memory is a gauge")
+
+	allNS := buildPromPodQuery("", "cpu")
+	assert.NotContains(t, allNS, "namespace=", "no namespace filter for all-namespaces query")
+
+	assert.Empty(t, buildPromPodQuery("dev", "bogus"))
+	assert.Empty(t, buildPromPodQuery(`evil"} or up{`, "cpu"), "namespace with PromQL metacharacters is rejected")
+}
+
+func TestParsePrometheusPodResponse(t *testing.T) {
+	data := `{"status":"success","data":{"resultType":"vector","result":[
+		{"metric":{"namespace":"dev","pod":"web-1"},"value":[1700000000,"125.5"]},
+		{"metric":{"namespace":"dev","pod":"web-2"},"value":[1700000000,"40"]},
+		{"metric":{"pod":"no-ns"},"value":[1700000000,"10"]},
+		{"metric":{"namespace":"dev"},"value":[1700000000,"10"]}
+	]}}`
+	got, err := parsePrometheusPodResponse([]byte(data))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]float64{"dev/web-1": 125.5, "dev/web-2": 40}, got)
+
+	_, err = parsePrometheusPodResponse([]byte(`{not json`))
+	assert.Error(t, err)
+
+	_, err = parsePrometheusPodResponse([]byte(`{"status":"error","data":{}}`))
+	assert.Error(t, err)
+}
+
+func TestGetAllPodMetricsFromPrometheus(t *testing.T) {
+	c := &Client{}
+	c.testPromQuery = func(_ context.Context, _ string, query string) ([]byte, error) {
+		if strings.Contains(query, "container_cpu_usage_seconds_total") {
+			return []byte(`{"status":"success","data":{"resultType":"vector","result":[
+				{"metric":{"namespace":"dev","pod":"web-1"},"value":[1700000000,"250"]}]}}`), nil
+		}
+		return []byte(`{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"namespace":"dev","pod":"web-1"},"value":[1700000000,"209715200"]}]}}`), nil
+	}
+
+	got, err := c.getAllPodMetricsFromPrometheus(context.Background(), "ctx", "dev")
+	require.NoError(t, err)
+	require.Contains(t, got, "dev/web-1")
+	pm := got["dev/web-1"]
+	assert.Equal(t, "web-1", pm.Name)
+	assert.Equal(t, "dev", pm.Namespace)
+	assert.Equal(t, int64(250), pm.CPU)
+	assert.Equal(t, int64(209715200), pm.Memory)
+}
+
+// GetAllPodMetrics must prefer Prometheus when it is the configured/implicit
+// route, so a metrics-server-less cluster with Prometheus still shows pod usage
+// instead of erroring with "metrics API unavailable".
+func TestGetAllPodMetrics_PrefersPrometheusWhenConfigured(t *testing.T) {
+	c := &Client{}
+	c.testPromQuery = func(_ context.Context, _ string, query string) ([]byte, error) {
+		val := "100"
+		if !strings.Contains(query, "container_cpu_usage_seconds_total") {
+			val = "1048576"
+		}
+		return []byte(`{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"namespace":"dev","pod":"web-1"},"value":[1700000000,"` + val + `"]}]}}`), nil
+	}
+
+	prev := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = prev })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"ctx": {Prometheus: &model.MonitoringEndpoint{
+			Namespaces: []string{"monitoring"}, Services: []string{"prometheus"}, Port: "9090",
+		}},
+	}
+
+	got, err := c.GetAllPodMetrics(context.Background(), "ctx", "dev")
+	require.NoError(t, err)
+	require.Contains(t, got, "dev/web-1")
+	assert.Equal(t, int64(100), got["dev/web-1"].CPU)
+}

--- a/internal/logger/auth_stderr.go
+++ b/internal/logger/auth_stderr.go
@@ -1,0 +1,33 @@
+package logger
+
+import "strings"
+
+// execCredentialStderrMarkers are case-insensitive substrings that identify a
+// kubeconfig exec credential plugin (AWS SSO, gke-gcloud-auth-plugin, generic
+// AWS credential providers) reporting a credential failure on os.Stderr. These
+// lines carry no cluster context; the failing API call is attributed to its
+// context separately (see internal/k8s credTaggingRoundTripper), so the raw
+// line is demoted out of the in-app overlay to avoid a contextless duplicate.
+var execCredentialStderrMarkers = []string{
+	"sso session",
+	"aws sso login",
+	"loading sso token",
+	"expiredtoken",
+	"the security token included",
+	"unable to locate credentials",
+	"gke-gcloud-auth-plugin",
+}
+
+// looksLikeExecCredentialStderr reports whether a captured stderr line is a
+// credential-plugin failure that should be demoted (logged at Debug, kept out
+// of the in-app overlay) in favor of the context-tagged log emitted at the
+// failing API call.
+func looksLikeExecCredentialStderr(line string) bool {
+	l := strings.ToLower(line)
+	for _, marker := range execCredentialStderrMarkers {
+		if strings.Contains(l, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/logger/auth_stderr_test.go
+++ b/internal/logger/auth_stderr_test.go
@@ -1,0 +1,65 @@
+package logger
+
+import (
+	"testing"
+	"time"
+)
+
+// A credential-plugin stderr line must be demoted: kept out of MsgChan (so it
+// never reaches the in-app overlay) since the context-tagged log carries the
+// actionable signal. A normal stderr line still flows to MsgChan.
+func TestStderrCaptureDemotesCredentialLines(t *testing.T) {
+	ResetDedupForTest()
+	sc := NewStderrCapture()
+	defer sc.Close()
+	w := sc.Writer()
+
+	if _, err := w.Write([]byte("aws: [ERROR]: The SSO session associated with this profile has expired")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case msg := <-sc.MsgChan:
+		t.Fatalf("credential stderr line should not reach MsgChan, got %q", msg)
+	case <-time.After(200 * time.Millisecond):
+		// expected: demoted, no overlay message
+	}
+
+	if _, err := w.Write([]byte("regular stderr diagnostic")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case msg := <-sc.MsgChan:
+		if msg != "regular stderr diagnostic" {
+			t.Fatalf("unexpected msg: %q", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("non-credential stderr line should reach MsgChan")
+	}
+}
+
+func TestLooksLikeExecCredentialStderr(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			"aws sso expired",
+			"aws: [ERROR]: The SSO session associated with this profile has expired or is otherwise invalid. To refresh this SSO session run aws sso login with the corresponding profile.",
+			true,
+		},
+		{"aws sso login hint", "Error loading SSO Token: run aws sso login", true},
+		{"expired token", "ExpiredToken: The security token included in the request is expired", true},
+		{"unable to locate credentials", "Unable to locate credentials. You can configure credentials by running...", true},
+		{"gke auth plugin", "gke-gcloud-auth-plugin: error getting credentials", true},
+		{"unrelated noise", "some unrelated library warning about deprecation", false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeExecCredentialStderr(tc.line); got != tc.want {
+				t.Errorf("looksLikeExecCredentialStderr(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -176,6 +176,16 @@ func (sc *StderrCapture) readLoop() {
 				if supp > 0 {
 					args = append(args, "suppressed_during_window", supp)
 				}
+				// A kubeconfig exec credential plugin (AWS SSO, gke auth) writes
+				// its credential error here with no cluster context. The failing
+				// in-process API call is tagged with the context separately (see
+				// internal/k8s credTaggingRoundTripper), so demote this contextless
+				// duplicate to Debug and keep it out of the in-app overlay rather
+				// than surfacing an unactionable "which cluster?" line.
+				if looksLikeExecCredentialStderr(redacted) {
+					Logger.Debug(redacted, args...)
+					continue
+				}
 				Logger.Error(redacted, args...)
 				select {
 				case sc.MsgChan <- redacted:


### PR DESCRIPTION
Three related fixes surfaced while triaging confusing log output on a multi-cluster setup.

## 1. Attribute credential/SSO failures to their cluster (`fix(logs)`)
**Problem:** `20:55 [ERR] stderr: aws: [ERROR]: The SSO session ... has expired` — no way to tell *which* cluster's SSO expired.

client-go runs kubeconfig exec credential plugins with stderr hardwired to `os.Stderr` and caches authenticators globally, so the raw line carries no context and the text never names the AWS profile.

- Wrap each context's REST transport (built via `rest.HTTPClientFor` + `NewForConfigAndClient`, so the wrapper is outermost — around client-go's exec auth). On a credential failure it emits one deduped, actionable line: cluster context + AWS profile + `aws sso login --profile X` hint, to both the file log and the in-app overlay.
- Demote the now-redundant contextless exec-plugin stderr line to Debug and keep it out of the overlay. Safe: kubectl subprocesses capture their own stderr, so the global capture only sees in-process exec plugins.

## 2. Prometheus fallback for pod metrics (`feat(metrics)`)
**Problem:** `pod metrics list load failed ... metrics API unavailable` on a cluster where pod metrics *are* available via Prometheus.

Pod metrics only ever queried `metrics.k8s.io` (node metrics already had a Prometheus path). Added a per-pod Prometheus query and routed `GetPodMetrics`/`GetPodsMetrics`/`GetAllPodMetrics` through the same Prometheus↔metrics-API fallback. The warning now fires only when **every** source fails and reads `pod metrics unavailable: no metrics-server or Prometheus source`.

Also keyed `promSvcCache` by context name instead of the clientset value — `clientsetForContext` builds a fresh clientset per call, so the old key never hit and re-ran Prometheus service discovery on every poll.

## 3. Preserve log viewer cursor on debug toggle (`fix(logviewer)`)
Pressing `d` reset scroll+cursor to the top. Now anchors on the selected entry's identity across the filter change; if the selected line is a DBG entry being hidden, falls back to the nearest surviving entry.

## Test plan
- [x] TDD: new unit tests for credential tagging, stderr demotion, cursor anchoring, Prometheus pod queries/routing
- [x] `go build ./...`, full `go test ./...`, `-race` on touched packages
- [x] `golangci-lint` clean
- [x] security-reviewer + go-reviewer on the auth diff; HIGH (nil-transport) and defensive findings applied
- [x] docs/config-reference.md updated (`node_metrics` now governs pod metrics too)