### PR TITLE
perf: fix background-work starvation, cache clients, configurable rate limits

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -209,13 +209,32 @@ resource_columns:
 # Service: ["*"]  # show all for Services
 # StatefulSet: ["Replicas"]
 
+# ─── Scheduler & API Client Rate Limits ────────────────────────────────────────
+# Client-side QPS/burst for API calls. Default 50/100 (client-go's stock 5/10 is
+# too low for a multi-resource TUI). Override globally here, or per cluster below.
+# Background-work scheduling keeps metrics / events / security scans / dashboards
+# progressing under continuous foreground load on slow clusters:
+#   workers_per_context  - concurrent workers per cluster (default 8, max 16)
+#   low_reserved_slots   - workers that prefer background work (default 2)
+#   aging_threshold      - promote a starved background task after N higher-prio
+#                          dispatches (default 8; 0 = strict priority)
+# scheduler:
+#   k8s_client_qps: 50
+#   k8s_client_burst: 100
+#   workers_per_context: 8
+#   low_reserved_slots: 2
+#   aging_threshold: 8
+
 # ─── Per-Cluster Overrides ─────────────────────────────────────────────────────
 # Override settings per kubeconfig context name.
-# Supports per-cluster views, resource_columns (deprecated), read_only, and security.
+# Supports per-cluster views, resource_columns (deprecated), read_only, security,
+# and k8s_client_qps / k8s_client_burst.
 # Per-cluster overrides take precedence over the matching global setting.
 clusters:
 # my-prod-cluster:
 #   read_only: true                       # lock production against mutations
+#   k8s_client_qps: 200                   # raise the rate ceiling on a big cluster
+#   k8s_client_burst: 400
 #   security:
 #     enabled: false                      # turn the security dashboard off here
 #   views:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -148,6 +148,8 @@ Currently supported per-cluster overrides:
 | `resource_columns` | map[string]list | Per-resource-type column overrides for this cluster. **Deprecated** — use `views` instead. |
 | `read_only` | bool | Per-context read-only override. Same semantics as the top-level `read_only`. |
 | `security` | object | Per-context security override (`enabled` and/or `sources`). Same semantics as the top-level `security`; wins over it for this context. |
+| `k8s_client_qps` | int | Per-context foreground API client QPS override. Wins over the global `scheduler.k8s_client_qps`. See [API client rate limits](#api-client-rate-limits). |
+| `k8s_client_burst` | int | Per-context foreground API client burst override. Wins over the global `scheduler.k8s_client_burst`. |
 
 Per-cluster `views` take precedence over the global `views` setting.
 
@@ -192,6 +194,79 @@ clusters:
 
 Precedence: `clusters.<ctx>.security.*` overrides the global `security.*`. See
 [Security Dashboard](security.md) for the source catalog and behavior.
+
+## API client rate limits
+
+lfk caps how fast it calls each cluster's API server (client-side QPS/burst).
+The stock client-go default (QPS 5 / burst 10) is low for a multi-resource TUI
+and lets a background scan stall foreground lists, so lfk defaults to **QPS 50 /
+burst 100**. Tune globally under `scheduler`, or per cluster under
+`clusters.<name>`.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `scheduler.k8s_client_qps` | int | `50` | Sustained foreground requests/sec to the API server. |
+| `scheduler.k8s_client_burst` | int | `100` | Burst capacity above QPS for short spikes. |
+| `clusters.<name>.k8s_client_qps` | int | _(global)_ | Per-context QPS override. Wins over the global value. |
+| `clusters.<name>.k8s_client_burst` | int | _(global)_ | Per-context burst override. |
+
+```yaml
+scheduler:
+  k8s_client_qps: 50
+  k8s_client_burst: 100
+
+clusters:
+  big-prod-cluster:
+    k8s_client_qps: 200      # raise the ceiling on a large, dedicated cluster
+    k8s_client_burst: 400
+  shared-cluster:
+    k8s_client_qps: 20       # be gentle on a shared/throttled API server
+    k8s_client_burst: 40
+```
+
+Precedence: `clusters.<ctx>.k8s_client_*` overrides `scheduler.k8s_client_*`,
+which overrides the built-in default. Security source scans run on a separate,
+deliberately lower budget (QPS 10 / burst 20) so background finding scans never
+starve foreground lists — see [Security Dashboard](security.md).
+
+### Background task scheduling
+
+lfk runs API work in a per-context worker pool, classified into priority
+lanes: Critical (API discovery, RBAC, namespaces, mutations), High (the view
+you are looking at — resource lists, drill-in, preview), and Low (background
+work — security scans, metrics, events, dashboards). Three knobs keep
+background work flowing without slowing the foreground, which matters most on
+slow-responding clusters where calls hold a worker for seconds:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `scheduler.workers_per_context` | int | `8` | Concurrent workers per cluster context (clamped 1–16). More slots drain the metrics/events backlog faster on slow clusters. |
+| `scheduler.critical_reserved_slots` | int | `1` | Workers that prefer Critical work (clamped to ≤ half the pool). |
+| `scheduler.low_reserved_slots` | int | `2` | Workers that prefer Low (background) work so metrics/events/dashboards always have a slot even while the foreground floods the pool. Clamped to leave ≥1 general worker. |
+| `scheduler.aging_threshold` | int | `8` | Max higher-priority dispatches a background task waits behind before it is promoted for one task. `0` disables aging (strict priority). |
+
+Reserved workers are not idle: a reserved worker prefers its lane but falls
+back to any other queued work when its lane is empty, so reservations bias
+capacity without wasting it. Critical is never aged. The low-reserved floor
+and aging are complementary: the floor guarantees throughput for background
+work under a saturated pool, while aging bounds queue-ordering latency when
+High and Low are both backed up.
+
+To keep API load bounded on slow clusters, the scheduler avoids redundant work:
+an identical fetch that is already in flight (same kind, target, and navigation
+generation) absorbs new submissions instead of running twice. This gives
+watch-mode its effective cadence under load — a tick that fires while the
+previous identical refresh is still running is coalesced away rather than
+stacking a duplicate fetch, so metrics/list refreshes never pile up faster than
+the cluster can serve them. Automatic and not configurable.
+
+```yaml
+scheduler:
+  workers_per_context: 8
+  critical_reserved_slots: 1
+  low_reserved_slots: 2   # always keep slots for metrics/events/dashboards
+  aging_threshold: 8      # 0 = strict priority; higher = background waits longer
+```
 
 ## Theme
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -64,6 +64,7 @@ Your chosen sort is remembered per resource kind for the running session, so lea
 | `Ctrl+R` | Toggle read-only mode (cluster picker: highlighted row's [RO] marker; inside a context: current tab) |
 | `T` | Switch color scheme (live preview, not persisted) |
 | `Ctrl+T` | Cycle terminal mode (pty / exec / mux — mux skipped without tmux/zellij) |
+| `B` | Show/hide the per-resource SEC severity badge on explorer rows |
 
 ## Orphan filter presets
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -70,9 +70,25 @@ clusters:
   category in a context, not at cluster open. A cluster you never inspect for
   security makes no security API calls — which on EKS avoids invoking the
   kubeconfig `aws` credential plugin (and its "SSO session expired" stderr).
-- **SEC badge**: resource rows (e.g. Pods, Deployments) show a SEC badge with a
-  severity breakdown once findings are loaded. The badge is hidden when no
-  source is available or the dashboard is disabled.
+- **SEC badge**: resource rows (e.g. Pods, Deployments) show a SEC badge once
+  findings are loaded. The glyph and color reflect the **highest** severity
+  present (`●` critical, `◐` high, `○` medium/low), and the number is the count
+  of findings at that severity only — e.g. `●3` means 3 criticals. Lower-severity
+  findings are surfaced in the dashboard, not on the badge. Toggle the badge on/off
+  with `B` (`security_badge_toggle`). The badge is hidden when no source is
+  available or the dashboard is disabled.
+- **Background scan**: once a cluster's sources have been detected (on your first
+  visit to the Security category), their availability is cached to disk. On every
+  later visit to that cluster the findings scan runs automatically in the
+  background, so SEC badges populate without navigating to Security. A cluster you
+  have never inspected stays fully lazy — no security API calls until you open its
+  Security category — so the badge auto-scan never triggers the EKS `aws`
+  credential plugin for clusters you don't look at.
+- **Low priority**: security scans run as a low-priority background task and on a
+  dedicated, throttled API client (QPS 10 / burst 20, separate from the
+  foreground budget), so a multi-source scan never starves foreground resource
+  lists. The foreground client rate is configurable; see
+  [API client rate limits](config-reference.md#api-client-rate-limits).
 - **Drill-down**: open the Security category, pick a source to list finding
   groups (one per check/CVE), then drill into a group to see affected
   resources. `Enter` on an affected resource jumps to the real object;

--- a/docs/security.md
+++ b/docs/security.md
@@ -84,6 +84,13 @@ clusters:
   have never inspected stays fully lazy — no security API calls until you open its
   Security category — so the badge auto-scan never triggers the EKS `aws`
   credential plugin for clusters you don't look at.
+- **Cached findings (stale-while-revalidate)**: a clean scan's findings are
+  persisted per cluster + namespace (next to the availability cache, under the
+  kubectl cache dir). On reopen, SEC badges paint instantly from the last scan
+  while a fresh scan revalidates in the background and replaces them. Findings
+  older than one hour are not painted (the live scan still runs). Partial scans
+  (any source errored) are not cached, so a transient failure never persists an
+  undercount.
 - **Low priority**: security scans run as a low-priority background task and on a
   dedicated, throttled API client (QPS 10 / burst 20, separate from the
   foreground budget), so a multi-source scan never starves foreground resource

--- a/internal/app/atomic_write.go
+++ b/internal/app/atomic_write.go
@@ -1,0 +1,73 @@
+// Package app — atomic_write.go
+// Durable atomic file write shared by the per-host caches (security
+// availability, security findings). Writes to a unique temp file, fsyncs the
+// file and its parent directory, then renames — so a crash mid-write can never
+// leave a half-written file the loaders would have to defend against, and two
+// concurrent writers can never collide on the temp path.
+package app
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeFileDurable atomically writes data to path with the given file mode:
+// write a unique temp file, fsync, chmod, rename, fsync parent dir. The caller
+// is responsible for creating the parent directory. The temp file is removed
+// on any failure before the rename.
+//
+// A unique temp name (os.CreateTemp, not a fixed "path.tmp" sibling) is
+// required because these caches live in the shared kubectl cache dir: two lfk
+// instances saving the same host file would otherwise truncate each other's
+// in-flight temp write and promote a torn file via rename (see the same fix in
+// cluster_colors.go).
+func writeFileDurable(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	cleanup := func() { _ = os.Remove(tmp) }
+	// CreateTemp makes the file 0600; widen/narrow to the requested mode so
+	// callers control the final permissions (e.g. 0600 for sensitive findings).
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	// Explicit Sync before rename: os.WriteFile closes without fsync, leaving a
+	// window where the rename survives a crash but the contents do not.
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		cleanup()
+		return err
+	}
+	// Fsync the parent dir so the rename itself is durable on crash. A failure
+	// here means the data is written but the dir entry may not survive a crash
+	// on non-journaling filesystems — the file is still usable, so this is a
+	// durability gap, not data loss.
+	dirFd, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	syncErr := dirFd.Sync()
+	closeErr := dirFd.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -211,17 +211,17 @@ func (m Model) loadResources(forPreview bool) tea.Cmd {
 		}
 	}
 	client := m.client
-	// The main resource list (drill-in / watch refresh) is the view the user
-	// is actively waiting on, so it runs at Critical: it gets the reserved
-	// worker and is never queued behind background dashboard/metrics/preview
-	// work. Preview hovers stay High — they are speculative and must remain
-	// preemptible so rapid sidebar cursoring can drop superseded fetches.
-	listPriority := scheduler.PriorityHigh
-	if !forPreview {
-		listPriority = scheduler.PriorityCritical
-	}
+	// The main resource list (drill-in / watch refresh) runs at High — the
+	// same lane as preview hovers. It must NOT be Critical: Critical is the
+	// reserved lane for foundational, one-shot gating work (API discovery,
+	// RBAC, namespaces). Submitting the user-driven list there let rapid
+	// navigation flood the single reserved slot with non-coalescing
+	// (per-generation) list loads, and — because general workers drain
+	// Critical first — starve the High preview work that renders pod details.
+	// High keeps the list ahead of Low background (dashboard/metrics/events)
+	// while sharing the general pool fairly with previews.
 	return m.scheduleK8sCall(
-		listPriority,
+		scheduler.PriorityHigh,
 		scheduler.KindResourceList,
 		"List "+model.DisplayNameFor(rt),
 		bgtaskTarget(kctx, ns),

--- a/internal/app/commands_load_scheduler_helpers_test.go
+++ b/internal/app/commands_load_scheduler_helpers_test.go
@@ -169,7 +169,7 @@ func TestLoadCanISAList_SubmitsAtCriticalPriority(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "loadCanISAList must Submit at Critical priority")
 }
 
-func TestLoadResources_MainListSubmitsAtCriticalPriority(t *testing.T) {
+func TestLoadResources_MainListSubmitsAtHighPriority(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m.nav.Context = "test-ctx"
 	m.nav.ResourceType = model.ResourceTypeEntry{
@@ -181,16 +181,19 @@ func TestLoadResources_MainListSubmitsAtCriticalPriority(t *testing.T) {
 	}
 	m.scheduler.StopWorkers()
 
-	// The main list (forPreview=false) is the view the user is waiting on,
-	// so it runs Critical to claim the reserved worker and never queue
-	// behind background work.
+	// The main list (forPreview=false) runs High, not Critical: Critical is
+	// reserved for foundational gating work (discovery/RBAC/namespaces).
+	// Submitting the user-driven list there let rapid navigation flood the
+	// single reserved slot and starve High preview work (pod details).
 	cmd := m.loadResources(false)
 	require.NotNil(t, cmd)
 	go cmd()
 
 	require.Eventually(t, func() bool {
-		return m.scheduler.QueueLenByPriority("test-ctx", scheduler.PriorityCritical) >= 1
-	}, time.Second, 10*time.Millisecond, "main resource list must Submit at Critical priority")
+		return m.scheduler.QueueLenByPriority("test-ctx", scheduler.PriorityHigh) >= 1
+	}, time.Second, 10*time.Millisecond, "main resource list must Submit at High priority")
+	assert.Equal(t, 0, m.scheduler.QueueLenByPriority("test-ctx", scheduler.PriorityCritical),
+		"main list must NOT occupy the reserved Critical lane")
 }
 
 func TestLoadResources_PreviewSubmitsAtHighPriority(t *testing.T) {

--- a/internal/app/commands_security.go
+++ b/internal/app/commands_security.go
@@ -210,11 +210,18 @@ func (m Model) loadSecurityFindings() tea.Cmd {
 		"Loading security findings",
 		bgtaskTarget(kctx, ns),
 		func() tea.Msg {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			// Match the caller deadline to the manager's own per-scan ceiling.
+			// A shorter caller timeout (was a hardcoded 30s vs the manager's
+			// 60s scan) orphaned a slow-but-succeeding scan: this load timed
+			// out and returned nil while the detached scan finished later, so
+			// the findings only appeared on a subsequent navigation. Adding a
+			// small grace margin lets the scan's own timeout fire first and
+			// deliver a partial result rather than the caller pre-empting it.
+			ctx, cancel := context.WithTimeout(context.Background(), mgr.ScanTimeout()+2*time.Second)
 			defer cancel()
 			res, err := mgr.FetchAll(ctx, kctx, ns)
 			if err != nil {
-				// Caller ctx cancelled / preempted / 30s budget elapsed. The
+				// Caller ctx cancelled / preempted / budget elapsed. The
 				// detached scan keeps running and caches its result, so a later
 				// call rebuilds the index. Emit nothing rather than forwarding
 				// an empty result that would wipe the existing badge index.
@@ -248,12 +255,25 @@ func (m Model) updateSecurityFindingsLoaded(msg securityFindingsLoadedMsg) Model
 	if msg.namespace != m.effectiveNamespace() {
 		return m
 	}
+	anyErr := false
 	for source, err := range msg.errors {
 		if err != nil {
+			anyErr = true
 			logger.Info("Security source fetch failed", "source", source, "context", msg.context, "error", err)
 		}
 	}
 	m.securityIndex = security.BuildFindingIndex(msg.findings)
+	// Persist to disk for stale-while-revalidate on the next session — but
+	// only a clean scan: a partial result (some source errored) would cache an
+	// undercount that the badges would show until the TTL expires. A fully
+	// clean scan with zero findings is still cached (it is a valid "nothing
+	// found" answer). Best-effort; a write failure never affects the session.
+	if !anyErr {
+		if err := updateSecurityFindingsCacheForContext(m.client, msg.context, msg.namespace, msg.findings); err != nil {
+			logger.Warn("Failed to persist security findings cache",
+				"context", msg.context, "namespace", msg.namespace, "error", err)
+		}
+	}
 	return m
 }
 

--- a/internal/app/commands_security.go
+++ b/internal/app/commands_security.go
@@ -56,6 +56,31 @@ func (m *Model) maybeProbeSecurityOnFocus() tea.Cmd {
 	return m.loadSecurityAvailability()
 }
 
+// eagerSecurityScanEnabled gates the cluster-open background findings scan.
+// Enabled now that the scheduler lost-wakeup jam is fixed: at cluster open the
+// SEC badges populate from a background, throttled, low-priority scan without
+// the user navigating to the Security category. Set to false to fall back to
+// the lazy-on-focus behavior (scan only when Security is opened). A var (not
+// const) so tests can exercise both paths.
+var eagerSecurityScanEnabled = true
+
+// maybeEagerSecurityScan kicks off a background findings fetch at cluster open
+// so the SEC badges populate without the user navigating to the Security
+// category. It runs only when source availability is already known from the
+// on-disk cache (seeded into securityAvailabilityByName by
+// refreshSecuritySources, which also sets the manager's availability hint), so
+// it performs NO IsAvailable probe: a previously-inspected cluster pays just
+// the Fetch cost, and an as-yet-uninspected one (empty cache) no-ops here and
+// stays fully lazy — preserving the EKS aws-credential-plugin behavior the
+// lazy probe protects. loadSecurityFindings already returns nil when no source
+// is available, so this is a thin, intent-revealing wrapper.
+func (m Model) maybeEagerSecurityScan() tea.Cmd {
+	if !eagerSecurityScanEnabled {
+		return nil
+	}
+	return m.loadSecurityFindings()
+}
+
 // loadSecurityAvailability probes IsAvailable on every registered source
 // for the active cluster and returns a securityAvailabilityLoadedMsg with
 // the per-source result. Each source's probe runs in its own goroutine
@@ -74,7 +99,7 @@ func (m Model) loadSecurityAvailability() tea.Cmd {
 		kctx = m.client.CurrentContext()
 	}
 	return m.trackBgTask(
-		scheduler.KindResourceList,
+		scheduler.KindSecurityScan,
 		"Probing security sources",
 		bgtaskTarget(kctx, ""),
 		func() tea.Msg {
@@ -162,17 +187,7 @@ func (m Model) updateSecurityAvailabilityLoaded(msg securityAvailabilityLoadedMs
 // so subsequent calls within refreshTTL return immediately. Returns nil
 // when no manager is wired or no source is available.
 func (m Model) loadSecurityFindings() tea.Cmd {
-	if m.securityManager == nil {
-		return nil
-	}
-	anyAvailable := false
-	for _, ok := range m.securityAvailabilityByName {
-		if ok {
-			anyAvailable = true
-			break
-		}
-	}
-	if !anyAvailable {
+	if m.securityManager == nil || !m.anySecurityAvailable() {
 		return nil
 	}
 	mgr := m.securityManager
@@ -186,14 +201,25 @@ func (m Model) loadSecurityFindings() tea.Cmd {
 	// instead of keying the manager cache differently and forcing a
 	// redundant full scan for the badge index.
 	ns := m.effectiveNamespace()
+	// KindSecurityScan keeps this background badge scan at PriorityLow so it
+	// yields to the user's foreground resource lists, and gives it its own
+	// dedupe namespace in the registry (distinct from real KindResourceList
+	// loads). The new scheduler aging guarantees Low still makes progress.
 	return m.trackBgTask(
-		scheduler.KindResourceList,
+		scheduler.KindSecurityScan,
 		"Loading security findings",
 		bgtaskTarget(kctx, ns),
 		func() tea.Msg {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			res, _ := mgr.FetchAll(ctx, kctx, ns)
+			res, err := mgr.FetchAll(ctx, kctx, ns)
+			if err != nil {
+				// Caller ctx cancelled / preempted / 30s budget elapsed. The
+				// detached scan keeps running and caches its result, so a later
+				// call rebuilds the index. Emit nothing rather than forwarding
+				// an empty result that would wipe the existing badge index.
+				return nil
+			}
 			return securityFindingsLoadedMsg{
 				context:   kctx,
 				namespace: ns,

--- a/internal/app/scheduler/config.go
+++ b/internal/app/scheduler/config.go
@@ -8,11 +8,30 @@ import (
 // Default clamps and timeouts. Exported as constants so callers can
 // inspect the clamp range and tests can reference the fallback.
 const (
-	MinWorkersPerContext     = 1
-	MaxWorkersPerContext     = 16
-	DefaultWorkersPerContext = 4
+	MinWorkersPerContext = 1
+	MaxWorkersPerContext = 16
+	// DefaultWorkersPerContext is the per-context worker pool size. 8 (up from
+	// 4) gives a slow-responding cluster enough concurrent slots that the
+	// foreground resource lists, previews, and the background metrics/events
+	// fan-out are not all contending for the same handful of workers — the
+	// "Low tasks queued but never run" symptom on a slow API server.
+	DefaultWorkersPerContext = 8
 	DefaultCriticalReserved  = 1
-	DefaultRequestTimeout    = 30 * time.Second
+	// DefaultLowReserved is how many workers prefer Low (background) work so
+	// metrics, events, and dashboard scans always have a slot even while the
+	// foreground floods the general pool. Mirrors CriticalReserved at the
+	// other end of the priority range. Clamped to leave >=1 general worker.
+	DefaultLowReserved    = 2
+	DefaultRequestTimeout = 30 * time.Second
+
+	// DefaultAgingThreshold is how many times a lower-priority lane may be
+	// passed over by higher-priority dequeues before it is force-promoted for
+	// one task. It bounds worst-case starvation latency under sustained
+	// higher-priority load (the user's "Low tasks never run while High keeps
+	// arriving" case). Critical is exempt — it is never aged. 0 disables aging
+	// (strict priority). 8 gives background work roughly one dispatch in nine
+	// under continuous High pressure.
+	DefaultAgingThreshold = 8
 )
 
 // Package-level config globals populated from internal/ui/config_apply.go.
@@ -21,9 +40,11 @@ const (
 var (
 	ConfigWorkersPerContext     = DefaultWorkersPerContext
 	ConfigCriticalReserved      = DefaultCriticalReserved
+	ConfigLowReserved           = DefaultLowReserved
 	ConfigDefaultTimeout        = DefaultRequestTimeout
 	ConfigTimeoutsByKind        = map[Kind]time.Duration{} // empty by default
 	ConfigShowPriorityInOverlay = true
+	ConfigAgingThreshold        = DefaultAgingThreshold
 )
 
 // Config bundles the runtime knobs a Registry uses for scheduling. A nil
@@ -32,8 +53,10 @@ var (
 type Config struct {
 	WorkersPerContext int
 	CriticalReserved  int
+	LowReserved       int
 	Default           time.Duration
 	ByKind            map[Kind]time.Duration
+	AgingThreshold    int
 }
 
 // FromGlobals snapshots the current package-globals into a Config. Called
@@ -44,11 +67,14 @@ func FromGlobals() *Config {
 	byKind := make(map[Kind]time.Duration, len(ConfigTimeoutsByKind))
 	maps.Copy(byKind, ConfigTimeoutsByKind)
 	workers := ClampWorkers(ConfigWorkersPerContext)
+	crit := ClampCriticalReserved(ConfigCriticalReserved, workers)
 	return &Config{
 		WorkersPerContext: workers,
-		CriticalReserved:  ClampCriticalReserved(ConfigCriticalReserved, workers),
+		CriticalReserved:  crit,
+		LowReserved:       ClampLowReserved(ConfigLowReserved, workers, crit),
 		Default:           ConfigDefaultTimeout,
 		ByKind:            byKind,
+		AgingThreshold:    ClampAgingThreshold(ConfigAgingThreshold),
 	}
 }
 
@@ -71,6 +97,31 @@ func ClampCriticalReserved(reserved, workers int) int {
 		return 0
 	}
 	maxReserved := workers / 2
+	if reserved > maxReserved {
+		return maxReserved
+	}
+	return reserved
+}
+
+// ClampAgingThreshold floors the value at 0 (aging disabled = strict
+// priority). There is no upper bound: a large threshold simply means
+// background work waits longer behind sustained higher-priority load.
+func ClampAgingThreshold(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// ClampLowReserved enforces 0 <= reserved <= workers - critical - 1 so at
+// least one general worker always remains for High work (a low-reserved
+// worker prefers Low but falls back, so the floor is about guaranteeing High
+// is never left without a dedicated slot). Negative values clamp to 0.
+func ClampLowReserved(reserved, workers, critical int) int {
+	if reserved < 0 {
+		return 0
+	}
+	maxReserved := max(workers-critical-1, 0)
 	if reserved > maxReserved {
 		return maxReserved
 	}

--- a/internal/app/scheduler/priority.go
+++ b/internal/app/scheduler/priority.go
@@ -41,7 +41,7 @@ func DefaultPriorityFor(k Kind) Priority {
 		return PriorityCritical
 	case KindResourceList, KindContainers, KindYAMLFetch:
 		return PriorityHigh
-	case KindMetrics, KindResourceTree, KindDashboard:
+	case KindMetrics, KindResourceTree, KindDashboard, KindSecurityScan:
 		return PriorityLow
 	default:
 		return PriorityLow

--- a/internal/app/scheduler/priority_test.go
+++ b/internal/app/scheduler/priority_test.go
@@ -33,6 +33,7 @@ func TestDefaultPriorityFor_KnownKinds(t *testing.T) {
 		{KindMetrics, PriorityLow},
 		{KindResourceTree, PriorityLow},
 		{KindDashboard, PriorityLow},
+		{KindSecurityScan, PriorityLow},
 	}
 	for _, tc := range cases {
 		t.Run(tc.kind.String(), func(t *testing.T) {

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -53,6 +53,7 @@ const (
 	KindAPIDiscovery              // discover API resource types for a context (foundational)
 	KindNamespaceList             // list namespaces for a context (foundational)
 	KindRBACCheck                 // RBAC SelfSubjectAccessReview / Can-I checks (foundational)
+	KindSecurityScan              // background security source availability + finding scans
 )
 
 // String returns the human-readable label for a Kind.
@@ -80,6 +81,8 @@ func (k Kind) String() string {
 		return "NamespaceList"
 	case KindRBACCheck:
 		return "RBACCheck"
+	case KindSecurityScan:
+		return "SecurityScan"
 	default:
 		return "Unknown"
 	}

--- a/internal/app/scheduler/scheduler.go
+++ b/internal/app/scheduler/scheduler.go
@@ -75,18 +75,27 @@ type queuedTask struct {
 
 // ctxQueue holds the three priority lanes for one cluster context plus
 // a wake signal channel.
+//
+// skips and agingThreshold implement anti-starvation aging: skips[p] counts
+// how many times lane p has been passed over while non-empty; once it reaches
+// agingThreshold the lane is promoted ahead of higher-priority lanes for one
+// dequeue. Critical (lane 0) is never aged. agingThreshold == 0 disables aging
+// (strict priority). See dequeueByPriorityLocked.
 type ctxQueue struct {
-	mu          sync.Mutex
-	lanes       [3][]*queuedTask // indexed by Priority value
-	wake        chan struct{}    // size 1, non-blocking signal
-	stop        chan struct{}    // closes on context drop or Registry close
-	poolStarted bool
+	mu             sync.Mutex
+	lanes          [3][]*queuedTask // indexed by Priority value
+	skips          [3]int           // per-lane consecutive passed-over count
+	agingThreshold int              // 0 = aging disabled (strict priority)
+	wake           chan struct{}    // size 1, non-blocking signal
+	stop           chan struct{}    // closes on context drop or Registry close
+	poolStarted    bool
 }
 
-func newCtxQueue() *ctxQueue {
+func newCtxQueue(agingThreshold int) *ctxQueue {
 	return &ctxQueue{
-		wake: make(chan struct{}, 1),
-		stop: make(chan struct{}),
+		agingThreshold: agingThreshold,
+		wake:           make(chan struct{}, 1),
+		stop:           make(chan struct{}),
 	}
 }
 
@@ -181,19 +190,58 @@ func (q *ctxQueue) drain(err error) {
 	}
 }
 
-// dequeueByPriorityLocked removes and returns the head of the highest-
-// priority non-empty lane. Returns (nil, false) if all lanes are empty.
-// Caller must hold q.mu.
+// dequeueByPriorityLocked removes and returns the next task to run, honoring
+// priority with anti-starvation aging. Returns (nil, false) if all lanes are
+// empty. Caller must hold q.mu.
+//
+// Critical is absolute: foundational gating work (API discovery, RBAC,
+// namespaces) and destructive mutations must never be delayed, so it is served
+// outright and is never aged. Among the non-Critical lanes the highest-priority
+// non-empty lane wins by default, but a lower lane passed over more than
+// agingThreshold times preempts it for a single dequeue. Without this, sustained
+// High submissions on a slow cluster keep the High lane non-empty forever and
+// Low work (security scans, dashboard, metrics) never runs (priority
+// starvation); aging bounds that wait to ~agingThreshold higher-priority
+// dispatches. agingThreshold == 0 restores strict priority.
 func (q *ctxQueue) dequeueByPriorityLocked() (*queuedTask, bool) {
-	for prio := PriorityCritical; prio <= PriorityLow; prio++ {
-		lane := q.lanes[int(prio)]
-		if len(lane) > 0 {
-			t := lane[0]
-			q.lanes[int(prio)] = lane[1:]
-			return t, true
+	if lane := q.lanes[int(PriorityCritical)]; len(lane) > 0 {
+		q.lanes[int(PriorityCritical)] = lane[1:]
+		return lane[0], true
+	}
+
+	chosen := -1
+	for prio := int(PriorityHigh); prio <= int(PriorityLow); prio++ {
+		if len(q.lanes[prio]) == 0 {
+			continue
+		}
+		if chosen == -1 {
+			chosen = prio // strict-priority default: first non-empty lane
+		}
+		if q.agingThreshold > 0 && q.skips[prio] >= q.agingThreshold {
+			chosen = prio // starved lane overrides the default for one pick
+			break
 		}
 	}
-	return nil, false
+	if chosen == -1 {
+		return nil, false
+	}
+
+	if q.agingThreshold > 0 {
+		// Reset the served lane and age every other non-empty non-Critical
+		// lane that lost this round.
+		for prio := int(PriorityHigh); prio <= int(PriorityLow); prio++ {
+			switch {
+			case prio == chosen:
+				q.skips[prio] = 0
+			case len(q.lanes[prio]) > 0:
+				q.skips[prio]++
+			}
+		}
+	}
+
+	t := q.lanes[chosen][0]
+	q.lanes[chosen] = q.lanes[chosen][1:]
+	return t, true
 }
 
 // hasPendingWork reports whether any priority lane is non-empty. Used by
@@ -238,13 +286,33 @@ func (r *Registry) Submit(req SubmitReq) Future {
 	}
 	q, ok := r.ctxQueues[req.KubeContext]
 	if !ok {
-		q = newCtxQueue()
+		threshold := DefaultAgingThreshold
+		if r.cfg != nil {
+			threshold = r.cfg.AgingThreshold
+		}
+		q = newCtxQueue(threshold)
 		r.ctxQueues[req.KubeContext] = q
 	}
 	r.mu.Unlock()
 
 	t := &queuedTask{req: req, future: fut}
 	sig := req.Sig()
+
+	// Coalesce against work already IN FLIGHT, not just queued. Without this,
+	// a slow fetch (e.g. Pod metrics on a sluggish cluster) that is still
+	// running cannot absorb an identical resubmission — the duplicate queues
+	// behind it and runs a redundant API call when the worker frees up. The
+	// queue-only coalesce below never sees the running task because it lives
+	// in runningTasks, not q.lanes. Checked before enqueue so the caller's
+	// Future resolves immediately with ErrCoalesced (its tea.Cmd returns nil;
+	// the in-flight task's result is the one that matters). Mutations opt out
+	// via NeverCoalesce — a second write must always run.
+	if !sig.NeverCoalesce() && r.coalescesWithRunning(req.KubeContext, sig) {
+		fut <- Result{Err: ErrCoalesced}
+		close(fut)
+		return fut
+	}
+
 	q.mu.Lock()
 	// Re-check after taking q.mu: Close() / CancelContext() can drain
 	// the queue in the window between r.mu.Unlock above and this lock.
@@ -271,6 +339,24 @@ func (r *Registry) Submit(req SubmitReq) Future {
 	r.pokePreempt(req.KubeContext, req.Priority)
 
 	return fut
+}
+
+// coalescesWithRunning reports whether an in-flight task on kctx has a Sig that
+// the incoming sig coalesces with. A task already being torn down (preempted,
+// superseded, or context-switched) is skipped: it is about to free its slot
+// and deliver a sentinel, so coalescing onto it would drop the fresh request.
+func (r *Registry) coalescesWithRunning(kctx string, sig Sig) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, rt := range r.runningTasks[kctx] {
+		if rt.preempted.Load() || rt.superseded.Load() || rt.contextSwitched.Load() {
+			continue
+		}
+		if sig.CoalescesWith(rt.task.req.Sig()) {
+			return true
+		}
+	}
+	return false
 }
 
 // QueueLen returns the number of queued (not in-flight) tasks for kctx.

--- a/internal/app/scheduler/scheduler_aging_test.go
+++ b/internal/app/scheduler/scheduler_aging_test.go
@@ -1,0 +1,144 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// qtask builds a bare queued task carrying only a priority, for white-box
+// dequeue tests that append directly to lanes (bypassing enqueueLocked's
+// wake signal).
+func qtask(p Priority) *queuedTask {
+	return &queuedTask{req: SubmitReq{Priority: p}, future: make(chan Result, 1)}
+}
+
+// TestDequeueByPriority_AgingPromotesStarvedLane verifies the anti-starvation
+// aging: a Low lane passed over more than agingThreshold times is promoted
+// ahead of a still-non-empty High lane for a single dequeue, then strict
+// priority resumes.
+func TestDequeueByPriority_AgingPromotesStarvedLane(t *testing.T) {
+	q := newCtxQueue(3)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for range 10 {
+		q.lanes[int(PriorityHigh)] = append(q.lanes[int(PriorityHigh)], qtask(PriorityHigh))
+	}
+	q.lanes[int(PriorityLow)] = append(q.lanes[int(PriorityLow)], qtask(PriorityLow))
+
+	got := make([]Priority, 0, 4)
+	for range 4 {
+		tk, ok := q.dequeueByPriorityLocked()
+		require.True(t, ok)
+		got = append(got, tk.req.Priority)
+	}
+	// threshold=3: three High picks age Low to 3, the fourth dequeue promotes Low.
+	assert.Equal(t,
+		[]Priority{PriorityHigh, PriorityHigh, PriorityHigh, PriorityLow},
+		got,
+		"Low must be promoted after agingThreshold High picks")
+}
+
+// TestDequeueByPriority_CriticalNeverAged verifies Critical is absolute: it is
+// served outright even when a lower lane has been starved far past the
+// threshold, so foundational/mutation work is never delayed by aging.
+func TestDequeueByPriority_CriticalNeverAged(t *testing.T) {
+	q := newCtxQueue(2)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.skips[int(PriorityLow)] = 100 // Low starved "forever"
+	q.lanes[int(PriorityCritical)] = append(q.lanes[int(PriorityCritical)], qtask(PriorityCritical))
+	q.lanes[int(PriorityLow)] = append(q.lanes[int(PriorityLow)], qtask(PriorityLow))
+
+	tk, ok := q.dequeueByPriorityLocked()
+	require.True(t, ok)
+	assert.Equal(t, PriorityCritical, tk.req.Priority, "Critical must win even when Low is starved")
+}
+
+// TestDequeueByPriority_AgingDisabledIsStrict verifies a non-positive threshold
+// disables aging entirely (strict priority) — the kill switch.
+func TestDequeueByPriority_AgingDisabledIsStrict(t *testing.T) {
+	q := newCtxQueue(0)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for range 5 {
+		q.lanes[int(PriorityHigh)] = append(q.lanes[int(PriorityHigh)], qtask(PriorityHigh))
+	}
+	q.lanes[int(PriorityLow)] = append(q.lanes[int(PriorityLow)], qtask(PriorityLow))
+
+	for i := range 5 {
+		tk, ok := q.dequeueByPriorityLocked()
+		require.True(t, ok)
+		assert.Equal(t, PriorityHigh, tk.req.Priority, "strict priority: High before Low at dequeue %d", i)
+	}
+	tk, ok := q.dequeueByPriorityLocked()
+	require.True(t, ok)
+	assert.Equal(t, PriorityLow, tk.req.Priority)
+}
+
+// TestWorkerDispatch_AgingPreventsLowStarvation is the end-to-end repro of the
+// reported bug: under a continuous backlog of High work on a slow cluster, a
+// Low task must still run rather than being starved to the very end. A single
+// worker serializes dispatch so the order is deterministic; each task blocks
+// until the test releases it, mirroring a slow API server.
+func TestWorkerDispatch_AgingPreventsLowStarvation(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(1, 0)     // single worker => fully serial dispatch
+	r.SetAgingThresholdForTest(3) // promote a starved lane after 3 skips
+
+	executed := make(chan Priority, 64)
+	release := make(chan struct{})
+	mk := func(p Priority) func(context.Context) (any, error) {
+		return func(ctx context.Context) (any, error) {
+			executed <- p
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return nil, nil
+		}
+	}
+
+	// One Low task, then a backlog of distinct High tasks (distinct targets so
+	// they do not coalesce). Submitted before StartWorkers so all are queued.
+	r.Submit(SubmitReq{
+		KubeContext: "c1", Kind: KindSecurityScan, Priority: PriorityLow,
+		Target: "low", Fn: mk(PriorityLow), Timeout: 10 * time.Second,
+	})
+	const highN = 12
+	for i := range highN {
+		r.Submit(SubmitReq{
+			KubeContext: "c1", Kind: KindResourceList, Priority: PriorityHigh,
+			Target: fmt.Sprintf("h%d", i), Fn: mk(PriorityHigh), Timeout: 10 * time.Second,
+		})
+	}
+
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	lowAt := -1
+	for i := 1; i <= highN+1; i++ {
+		var p Priority
+		select {
+		case p = <-executed:
+		case <-time.After(2 * time.Second):
+			close(release)
+			t.Fatalf("dispatch stalled at #%d", i)
+		}
+		if p == PriorityLow {
+			lowAt = i
+			close(release) // let this and remaining tasks finish
+			break
+		}
+		release <- struct{}{} // let this High finish so the worker picks the next
+	}
+	require.NotEqual(t, -1, lowAt, "Low task never ran (starved to the end)")
+	// Strict priority would put Low at highN+1 (=13). Aging must surface it no
+	// later than threshold+1 dispatches.
+	assert.LessOrEqual(t, lowAt, 4, "Low must be promoted after ~threshold High picks, not starved")
+}

--- a/internal/app/scheduler/scheduler_busy_loop_test.go
+++ b/internal/app/scheduler/scheduler_busy_loop_test.go
@@ -34,7 +34,7 @@ func TestWorkerLoop_DoesNotBusyLoopOnStaleWake(t *testing.T) {
 	// when r.started, so we need the queue to exist before
 	// StartWorkers.
 	r.mu.Lock()
-	q := newCtxQueue()
+	q := newCtxQueue(DefaultAgingThreshold)
 	r.ctxQueues["c1"] = q
 	r.mu.Unlock()
 	r.StartWorkers()

--- a/internal/app/scheduler/scheduler_fanout_started_test.go
+++ b/internal/app/scheduler/scheduler_fanout_started_test.go
@@ -1,0 +1,65 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestWorkerDispatch_FanOutWhileBusy mirrors the real jam: the pool is already
+// running, one worker is busy on a long task, and a burst of further work is
+// submitted. Every remaining worker must engage — not leave the burst queued
+// behind the one busy worker.
+func TestWorkerDispatch_FanOutWhileBusy(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(4, 1) // production shape: 4 workers, 1 Critical-reserved
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	var running atomic.Int32
+	reached := make(chan struct{}, 8)
+	release := make(chan struct{})
+	blockingFn := func(ctx context.Context) (any, error) {
+		running.Add(1)
+		reached <- struct{}{}
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		running.Add(-1)
+		return nil, nil
+	}
+
+	// One long-running Critical task occupies the reserved worker.
+	r.Submit(SubmitReq{
+		KubeContext: "c1", Kind: KindResourceList, Priority: PriorityCritical,
+		Target: "crit", Fn: blockingFn, Timeout: 10 * time.Second,
+	})
+	// Wait until it is actually running before submitting the burst, so the
+	// burst lands while a worker is busy (the real scenario).
+	<-reached
+
+	// Burst of High work that must run on the 3 general workers.
+	const high = 3
+	for i := range high {
+		r.Submit(SubmitReq{
+			KubeContext: "c1", Kind: KindContainers, Priority: PriorityHigh,
+			Target: fmt.Sprintf("h%d", i), Fn: blockingFn, Timeout: 10 * time.Second,
+		})
+	}
+
+	// Expect 1 (critical) + 3 (high) = 4 concurrent.
+	timeout := time.After(2 * time.Second)
+	for got := 1; got < 1+high; got++ {
+		select {
+		case <-reached:
+		case <-timeout:
+			close(release)
+			t.Fatalf("only %d of %d tasks running; general workers did not engage", got, 1+high)
+		}
+	}
+	close(release)
+}

--- a/internal/app/scheduler/scheduler_fanout_test.go
+++ b/internal/app/scheduler/scheduler_fanout_test.go
@@ -1,0 +1,67 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWorkerDispatch_BurstFansOutAcrossWorkers reproduces the lost-wakeup jam:
+// a burst of submits whose wake signals collapse into the size-1 wake buffer
+// must still engage every worker, not leave one worker draining serially while
+// the others stay parked. Submitting before StartWorkers makes the collapse
+// deterministic — all N enqueues leave exactly one buffered wake — so without
+// a wake-the-sibling step only one worker ever runs.
+func TestWorkerDispatch_BurstFansOutAcrossWorkers(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(4, 0) // 4 general workers, no Critical reservation
+
+	const n = 4
+	var running atomic.Int32
+	reached := make(chan struct{}, n)
+	release := make(chan struct{})
+
+	fn := func(ctx context.Context) (any, error) {
+		running.Add(1)
+		reached <- struct{}{}
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		running.Add(-1)
+		return nil, nil
+	}
+
+	// Distinct targets => distinct Sig => no coalescing. Long timeout so a
+	// blocked task does not auto-return and mask the lack of concurrency.
+	for i := range n {
+		r.Submit(SubmitReq{
+			KubeContext: "c1",
+			Kind:        KindResourceList,
+			Priority:    PriorityHigh,
+			Target:      fmt.Sprintf("t%d", i),
+			Fn:          fn,
+			Timeout:     10 * time.Second,
+		})
+	}
+
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	timeout := time.After(2 * time.Second)
+	for got := range n {
+		select {
+		case <-reached:
+		case <-timeout:
+			close(release)
+			t.Fatalf("only %d of %d tasks started concurrently; workers did not fan out (lost wakeup)", got, n)
+		}
+	}
+	assert.Equal(t, int32(n), running.Load(), "all workers must run the burst concurrently")
+	close(release)
+}

--- a/internal/app/scheduler/scheduler_inflight_coalesce_test.go
+++ b/internal/app/scheduler/scheduler_inflight_coalesce_test.go
@@ -1,0 +1,114 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockUntil returns a Fn that signals it has started, then blocks until
+// release is closed (or ctx is cancelled). Used to hold a task "in flight"
+// while a second identical submission races against it.
+func blockUntil(started chan<- struct{}, release <-chan struct{}) func(context.Context) (any, error) {
+	return func(ctx context.Context) (any, error) {
+		started <- struct{}{}
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return nil, nil
+	}
+}
+
+// TestSubmit_CoalescesAgainstRunningTask is the core fix for the metrics
+// pile-up: a submission identical (same Sig) to a task already in flight must
+// be dropped with ErrCoalesced rather than queued behind it.
+func TestSubmit_CoalescesAgainstRunningTask(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(1, 0)
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	defer close(release)
+
+	req := SubmitReq{
+		KubeContext: "c1", Kind: KindMetrics, Priority: PriorityLow,
+		Name: "Metrics: Pod/x", Target: "c1 / ns", Gen: 1,
+		Fn: blockUntil(started, release), Timeout: 10 * time.Second,
+	}
+	r.Submit(req)
+	<-started // first task is now running
+
+	// Identical second submission while the first is in flight.
+	fut := r.Submit(req)
+	select {
+	case res := <-fut:
+		assert.ErrorIs(t, res.Err, ErrCoalesced, "identical in-flight submission must be coalesced")
+	case <-time.After(2 * time.Second):
+		t.Fatal("second submission neither ran nor coalesced")
+	}
+	assert.Equal(t, 0, r.QueueLen("c1"), "coalesced submission must not be enqueued behind the running one")
+}
+
+// TestSubmit_DoesNotCoalesceAcrossGen verifies a submission with a different
+// Gen (i.e. the user navigated) is NOT coalesced against the running task — it
+// represents a fresh logical request and must run.
+func TestSubmit_DoesNotCoalesceAcrossGen(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(1, 0)
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	defer close(release)
+
+	base := SubmitReq{
+		KubeContext: "c1", Kind: KindMetrics, Priority: PriorityLow,
+		Name: "Metrics: Pod/x", Target: "c1 / ns", Gen: 1,
+		Fn: blockUntil(started, release), Timeout: 10 * time.Second,
+	}
+	r.Submit(base)
+	<-started
+
+	newer := base
+	newer.Gen = 2
+	newer.Fn = func(context.Context) (any, error) { return nil, nil }
+	r.Submit(newer)
+	// Different gen => enqueued behind the running task, not coalesced.
+	assert.Equal(t, 1, r.QueueLen("c1"), "different-gen submission must enqueue, not coalesce")
+}
+
+// TestSubmit_MutationNeverCoalescesAgainstRunning verifies write operations are
+// never coalesced (NeverCoalesce), even against an identical in-flight one.
+func TestSubmit_MutationNeverCoalescesAgainstRunning(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(1, 0)
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	defer close(release)
+
+	req := SubmitReq{
+		KubeContext: "c1", Kind: KindMutation, Priority: PriorityCritical,
+		Name: "Delete Pod/x", Target: "c1 / ns", Gen: 1,
+		Fn: blockUntil(started, release), Timeout: 10 * time.Second,
+	}
+	r.Submit(req)
+	<-started
+
+	dup := req
+	dup.Fn = func(context.Context) (any, error) { return nil, nil }
+	r.Submit(dup)
+	require.Equal(t, 1, r.QueueLen("c1"), "a second mutation must always enqueue (never coalesce)")
+}

--- a/internal/app/scheduler/scheduler_lowreserve_test.go
+++ b/internal/app/scheduler/scheduler_lowreserve_test.go
@@ -1,0 +1,125 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClampLowReserved verifies the low-reserved clamp always leaves at least
+// one general worker (so High work is never fully without a dedicated slot)
+// and floors at zero.
+func TestClampLowReserved(t *testing.T) {
+	assert.Equal(t, 0, ClampLowReserved(-1, 8, 1))
+	assert.Equal(t, 0, ClampLowReserved(0, 8, 1))
+	assert.Equal(t, 1, ClampLowReserved(1, 8, 1))
+	assert.Equal(t, 6, ClampLowReserved(6, 8, 1))  // 8 - 1 critical - 1 general
+	assert.Equal(t, 6, ClampLowReserved(99, 8, 1)) // capped
+	assert.Equal(t, 0, ClampLowReserved(1, 1, 0))  // single worker: no floor
+	assert.Equal(t, 1, ClampLowReserved(5, 2, 0))  // 2 - 0 - 1 general = 1
+}
+
+// TestPickTask_LowReservedPrefersLowLane verifies a low-reserved worker takes
+// queued Low work ahead of High, while a general worker keeps strict priority
+// (High first). This is the core of the background-work floor.
+func TestPickTask_LowReservedPrefersLowLane(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	q := newCtxQueue(DefaultAgingThreshold)
+	q.lanes[int(PriorityHigh)] = append(q.lanes[int(PriorityHigh)], qtask(PriorityHigh))
+	q.lanes[int(PriorityLow)] = append(q.lanes[int(PriorityLow)], qtask(PriorityLow))
+
+	// Low-reserved worker pulls the Low task first.
+	got, ok := r.pickTask(q, workerClassLow)
+	require.True(t, ok)
+	assert.Equal(t, PriorityLow, got.req.Priority, "low-reserved worker must prefer the Low lane")
+
+	// A general worker, faced with only High remaining, takes High.
+	got, ok = r.pickTask(q, workerClassGeneral)
+	require.True(t, ok)
+	assert.Equal(t, PriorityHigh, got.req.Priority)
+}
+
+// TestPickTask_LowReservedFallsBackWhenNoLow verifies a low-reserved worker
+// does not idle when no Low work is queued — it falls back to the highest
+// available priority, so the reserved slot is never wasted under High load.
+func TestPickTask_LowReservedFallsBackWhenNoLow(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	q := newCtxQueue(DefaultAgingThreshold)
+	q.lanes[int(PriorityHigh)] = append(q.lanes[int(PriorityHigh)], qtask(PriorityHigh))
+
+	got, ok := r.pickTask(q, workerClassLow)
+	require.True(t, ok)
+	assert.Equal(t, PriorityHigh, got.req.Priority, "no Low queued: low-reserved worker falls back to High")
+}
+
+// TestWorkerDispatch_LowReservedFloorRunsBackgroundUnderHighLoad is the
+// end-to-end repro of the reported bug: with a backlog of High work, the
+// reserved background worker still runs a Low task in the first dispatch wave
+// instead of leaving it queued behind the whole High backlog.
+//
+// Pool: 1 general + 1 low-reserved (workers=2, critical=0, low=1). Submitted
+// before StartWorkers so the lanes are fully populated when workers wake.
+func TestWorkerDispatch_LowReservedFloorRunsBackgroundUnderHighLoad(t *testing.T) {
+	r := New(0)
+	defer r.Close()
+	r.SetWorkersForTest(2, 0)
+	r.SetLowReservedForTest(1)
+
+	executed := make(chan Priority, 16)
+	release := make(chan struct{})
+	mk := func(p Priority) func(context.Context) (any, error) {
+		return func(ctx context.Context) (any, error) {
+			executed <- p
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return nil, nil
+		}
+	}
+
+	// A flood of High work plus a single Low task queued behind it.
+	const highN = 6
+	for i := range highN {
+		r.Submit(SubmitReq{
+			KubeContext: "c1", Kind: KindResourceList, Priority: PriorityHigh,
+			Target: fmt.Sprintf("h%d", i), Fn: mk(PriorityHigh), Timeout: 10 * time.Second,
+		})
+	}
+	r.Submit(SubmitReq{
+		KubeContext: "c1", Kind: KindMetrics, Priority: PriorityLow,
+		Target: "low", Fn: mk(PriorityLow), Timeout: 10 * time.Second,
+	})
+
+	r.StartWorkers()
+	defer r.StopWorkers()
+
+	// Collect the first wave (2 workers => 2 concurrent dispatches before any
+	// release). The low-reserved worker must have taken the Low task.
+	first := make([]Priority, 0, 2)
+	for range 2 {
+		select {
+		case p := <-executed:
+			first = append(first, p)
+		case <-time.After(2 * time.Second):
+			close(release)
+			t.Fatalf("only %d task(s) started; pool did not engage", len(first))
+		}
+	}
+	close(release)
+
+	sawLow := false
+	for _, p := range first {
+		if p == PriorityLow {
+			sawLow = true
+		}
+	}
+	assert.True(t, sawLow,
+		"low-reserved worker must run the Low task in the first wave, not starve it behind the High backlog; got %v", first)
+}

--- a/internal/app/scheduler/scheduler_workers.go
+++ b/internal/app/scheduler/scheduler_workers.go
@@ -6,6 +6,18 @@ import (
 	"sync/atomic"
 )
 
+// workerClass selects which priority lane a worker prefers when picking the
+// next task. General workers honor strict priority (with aging); the reserved
+// classes bias toward one end of the range but always fall back so a reserved
+// slot is never wasted when its preferred lane is empty.
+type workerClass int
+
+const (
+	workerClassGeneral  workerClass = iota // strict priority + aging
+	workerClassCritical                    // prefer Critical, else fall back
+	workerClassLow                         // prefer Low, else fall back
+)
+
 // StartWorkers enables worker dispatch. Idempotent. Workers are spawned
 // per cluster context on first Submit AND retroactively for any
 // queues that already exist when StartWorkers is called — this lets
@@ -75,6 +87,37 @@ func (r *Registry) SetWorkersForTest(workers, criticalReserved int) {
 	defer r.mu.Unlock()
 	r.cfg.WorkersPerContext = ClampWorkers(workers)
 	r.cfg.CriticalReserved = ClampCriticalReserved(criticalReserved, r.cfg.WorkersPerContext)
+	// Re-clamp the existing low reservation against the new totals so an
+	// earlier SetLowReservedForTest stays valid (and the default doesn't
+	// exceed a small test pool). Tests that want a specific value call
+	// SetLowReservedForTest after this.
+	r.cfg.LowReserved = ClampLowReserved(r.cfg.LowReserved, r.cfg.WorkersPerContext, r.cfg.CriticalReserved)
+}
+
+// SetLowReservedForTest overrides the low-reserved worker count before any
+// pool is spawned. Clamped against the current worker/critical totals.
+// Production code MUST NOT call this; use the ConfigLowReserved global.
+func (r *Registry) SetLowReservedForTest(n int) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cfg.LowReserved = ClampLowReserved(n, r.cfg.WorkersPerContext, r.cfg.CriticalReserved)
+}
+
+// SetAgingThresholdForTest overrides the anti-starvation aging threshold on a
+// Registry before any per-context queue is created (queues capture it lazily on
+// first Submit). The value is used verbatim — including 0 to disable aging — so
+// tests can exercise both small thresholds and the strict-priority kill switch.
+// Production code MUST NOT call this; use the ConfigAgingThreshold global.
+func (r *Registry) SetAgingThresholdForTest(n int) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cfg.AgingThreshold = n
 }
 
 // ensurePoolFor spawns the per-context worker pool the first time a
@@ -88,16 +131,31 @@ func (r *Registry) ensurePoolFor(_ string, q *ctxQueue) {
 	}
 	q.poolStarted = true
 	for i := range r.cfg.WorkersPerContext {
-		isCritical := i < r.cfg.CriticalReserved
 		r.workersWG.Add(1)
-		go r.workerLoop(q, isCritical)
+		go r.workerLoop(q, workerClassFor(i, r.cfg.CriticalReserved, r.cfg.LowReserved))
 	}
 }
 
-// workerLoop is one worker goroutine: pulls tasks from q honoring
-// priority, runs Fn with timeout, delivers Result. If isCritical is
-// true, this worker only picks up Critical tasks.
-func (r *Registry) workerLoop(q *ctxQueue, isCritical bool) {
+// workerClassFor assigns worker index i a class: the first CriticalReserved
+// workers prefer Critical, the last LowReserved workers prefer Low, and the
+// rest are general. The ranges never overlap because ClampLowReserved keeps
+// critical + low <= workers - 1.
+func workerClassFor(i, criticalReserved, lowReserved int) workerClass {
+	switch {
+	case i < criticalReserved:
+		return workerClassCritical
+	case i >= criticalReserved && i < criticalReserved+lowReserved:
+		return workerClassLow
+	default:
+		return workerClassGeneral
+	}
+}
+
+// workerLoop is one worker goroutine: pulls tasks from q honoring priority
+// and its worker class, runs Fn with timeout, delivers Result. The class
+// biases which lane it prefers (see pickTask); all classes fall back so no
+// worker idles while work is queued.
+func (r *Registry) workerLoop(q *ctxQueue, class workerClass) {
 	defer r.workersWG.Done()
 	for {
 		select {
@@ -112,15 +170,16 @@ func (r *Registry) workerLoop(q *ctxQueue, isCritical bool) {
 			if shutdownPending(r.stopAll, q.stop) {
 				return
 			}
-			// Try to pick a task for this worker class. If none is found
-			// (e.g. a Critical-only worker woke up but only non-Critical
-			// tasks are queued), re-signal so the appropriate worker picks
-			// it up — but ONLY if the queue actually has pending work.
-			// A stale wake left over from the inner drain loop below
-			// would otherwise feed itself: this worker re-signals, the
-			// same goroutine wins the receive race, fails pickTask
-			// again, re-signals, ad infinitum (issue #206).
-			task, ok := r.pickTask(q, isCritical)
+			// Try to pick a task for this worker class. pickTask returns
+			// (nil, false) only when the queue is genuinely empty (a race
+			// between the wake signal and a concurrent pick) — a reserved
+			// worker no longer idles on a non-empty queue since it falls
+			// back to non-Critical work. Re-signal so a sibling retries, but
+			// ONLY when work is actually pending: a stale wake left over from
+			// the inner drain loop below would otherwise feed itself (this
+			// worker re-signals, wins the receive race, fails pickTask again,
+			// re-signals, ad infinitum — issue #206).
+			task, ok := r.pickTask(q, class)
 			if !ok {
 				if q.hasPendingWork() {
 					select {
@@ -130,6 +189,15 @@ func (r *Registry) workerLoop(q *ctxQueue, isCritical bool) {
 				}
 				continue
 			}
+			// Wake a sibling before running: runTask blocks for the whole
+			// duration of the (potentially slow) Fn, so without this a burst
+			// of submits whose wake signals collapsed into the size-1 buffer
+			// would be drained by THIS worker serially while siblings stay
+			// parked — the lost-wakeup jam (one task runs, the rest queue
+			// behind a single blocked worker). Re-signalling on every
+			// successful pick cascades the wake across the pool so queued
+			// work runs in parallel up to WorkersPerContext.
+			r.wakeSibling(q)
 			r.runTask(task)
 			// Drain remaining work for this worker class after running
 			// one — but bail at every iteration if shutdown has been
@@ -139,12 +207,28 @@ func (r *Registry) workerLoop(q *ctxQueue, isCritical bool) {
 				if shutdownPending(r.stopAll, q.stop) {
 					return
 				}
-				task, ok = r.pickTask(q, isCritical)
+				task, ok = r.pickTask(q, class)
 				if !ok {
 					break
 				}
+				r.wakeSibling(q)
 				r.runTask(task)
 			}
+		}
+	}
+}
+
+// wakeSibling re-signals q.wake when work is still queued, so another parked
+// worker engages instead of leaving the current (about-to-block) worker to
+// drain the burst serially. Guarded by hasPendingWork so it never spins on an
+// empty queue (issue #206): the non-blocking send + size-1 buffer cap the
+// signal at one outstanding wake, and a spurious wake just parks the receiver
+// again after a failed pick.
+func (r *Registry) wakeSibling(q *ctxQueue) {
+	if q.hasPendingWork() {
+		select {
+		case q.wake <- struct{}{}:
+		default:
 		}
 	}
 }
@@ -163,21 +247,45 @@ func shutdownPending(stopAll, stop chan struct{}) bool {
 	}
 }
 
-// pickTask dequeues honoring isCritical (Critical-reserved workers only
-// take Critical tasks; non-Critical workers take any priority).
-func (r *Registry) pickTask(q *ctxQueue, isCritical bool) (*queuedTask, bool) {
+// pickTask dequeues the next task for this worker, biased by its class.
+//
+// A Critical-class worker takes Critical first; a Low-class worker takes Low
+// first. When the preferred lane is empty, BOTH fall through to
+// dequeueByPriorityLocked (priority + aging) rather than idling while other
+// work waits — the reservation guarantees a slot is biased toward that lane,
+// not that the worker sits idle. This is what gives background (Low) work a
+// guaranteed floor: under a flood of High submissions the Low-class workers
+// still drain the Low lane, so metrics/events/dashboards keep running instead
+// of queueing behind the foreground backlog. A General worker always honors
+// strict priority (with aging). The Critical preempt poker still makes a
+// Critical slot by bumping a running lower-priority task.
+func (r *Registry) pickTask(q *ctxQueue, class workerClass) (*queuedTask, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if isCritical {
-		lane := q.lanes[int(PriorityCritical)]
-		if len(lane) == 0 {
-			return nil, false
+	switch class {
+	case workerClassCritical:
+		if t, ok := dequeueLaneLocked(q, PriorityCritical); ok {
+			return t, true
 		}
-		t := lane[0]
-		q.lanes[int(PriorityCritical)] = lane[1:]
-		return t, true
+	case workerClassLow:
+		if t, ok := dequeueLaneLocked(q, PriorityLow); ok {
+			return t, true
+		}
+	case workerClassGeneral:
+		// strict priority + aging below
 	}
 	return q.dequeueByPriorityLocked()
+}
+
+// dequeueLaneLocked pops the head of a single priority lane. Caller holds q.mu.
+func dequeueLaneLocked(q *ctxQueue, prio Priority) (*queuedTask, bool) {
+	lane := q.lanes[int(prio)]
+	if len(lane) == 0 {
+		return nil, false
+	}
+	t := lane[0]
+	q.lanes[int(prio)] = lane[1:]
+	return t, true
 }
 
 // runningTask tracks a task currently executing in a worker. The

--- a/internal/app/security_availability_cache.go
+++ b/internal/app/security_availability_cache.go
@@ -90,7 +90,12 @@ func saveSecurityAvailabilityCacheForHost(host string, availability map[string]b
 	if path == "" {
 		return nil
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// 0700 dir to match the findings cache that shares this per-host
+	// directory: whichever cache creates it first sets the mode, so both use
+	// 0700 to keep the dir non-traversable on multi-user hosts. The
+	// availability file itself holds only booleans (which sources exist), so
+	// 0644 on the file is fine.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	// Copy to insulate the on-disk snapshot from later mutations.
@@ -105,42 +110,7 @@ func saveSecurityAvailabilityCacheForHost(host string, availability map[string]b
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	// Open/write/fsync/close explicitly so the file contents are durable
-	// before the rename — os.WriteFile closes without an fsync, leaving a
-	// crash window where the rename survives but the contents do not.
-	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		_ = f.Close()
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		return err
-	}
-	// Fsync parent dir so the rename itself is durable on crash.
-	dirFd, err := os.Open(filepath.Dir(path))
-	if err != nil {
-		return err
-	}
-	syncErr := dirFd.Sync()
-	closeErr := dirFd.Close()
-	if syncErr != nil {
-		return syncErr
-	}
-	return closeErr
+	return writeFileDurable(path, data, 0o644)
 }
 
 // loadSecurityAvailabilityCacheForContext is the convenience accessor used

--- a/internal/app/security_eager_scan_test.go
+++ b/internal/app/security_eager_scan_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+// TestMaybeEagerSecurityScan covers the cluster-open background scan: it fires
+// only when source availability is already known (seeded from the disk cache),
+// so a previously-inspected cluster populates SEC badges without navigating to
+// Security, while a first-ever visit (empty cache) stays fully lazy.
+func TestMaybeEagerSecurityScan(t *testing.T) {
+	// The eager-scan gate is enabled in production; this flips it on explicitly
+	// so the test is independent of the package default. The disabled path is
+	// covered separately by TestMaybeEagerSecurityScanGatedOff.
+	withEagerScanEnabled(t)
+
+	newModel := func() Model {
+		m := baseModelBoost2()
+		m.securityManager = security.NewManager()
+		m.nav.Context = "test-ctx"
+		return m
+	}
+
+	t.Run("scans when cached availability has an available source", func(t *testing.T) {
+		m := newModel()
+		m.securityAvailabilityByName = map[string]bool{"kubescape": true}
+		assert.NotNil(t, m.maybeEagerSecurityScan(),
+			"a known-available source must trigger the eager findings scan")
+	})
+
+	t.Run("no scan when every cached source is unavailable", func(t *testing.T) {
+		m := newModel()
+		m.securityAvailabilityByName = map[string]bool{"kubescape": false}
+		assert.Nil(t, m.maybeEagerSecurityScan())
+	})
+
+	t.Run("no scan with empty cache (first-ever visit stays lazy)", func(t *testing.T) {
+		m := newModel()
+		m.securityAvailabilityByName = map[string]bool{}
+		assert.Nil(t, m.maybeEagerSecurityScan())
+	})
+
+	t.Run("no scan when no manager is wired", func(t *testing.T) {
+		m := baseModelBoost2()
+		m.securityManager = nil
+		m.securityAvailabilityByName = map[string]bool{"kubescape": true}
+		assert.Nil(t, m.maybeEagerSecurityScan())
+	})
+}
+
+// TestMaybeEagerSecurityScanGatedOff verifies the feature gate: with eager scan
+// disabled (the non-default off path), it never fires even when a source is
+// available.
+func TestMaybeEagerSecurityScanGatedOff(t *testing.T) {
+	orig := eagerSecurityScanEnabled
+	eagerSecurityScanEnabled = false
+	t.Cleanup(func() { eagerSecurityScanEnabled = orig })
+
+	m := baseModelBoost2()
+	m.securityManager = security.NewManager()
+	m.nav.Context = "test-ctx"
+	m.securityAvailabilityByName = map[string]bool{"kubescape": true}
+	assert.Nil(t, m.maybeEagerSecurityScan(),
+		"gated off: eager scan must not fire even with an available source")
+}
+
+// withEagerScanEnabled flips the eager-scan gate on for the duration of a test.
+func withEagerScanEnabled(t *testing.T) {
+	t.Helper()
+	orig := eagerSecurityScanEnabled
+	eagerSecurityScanEnabled = true
+	t.Cleanup(func() { eagerSecurityScanEnabled = orig })
+}
+
+// TestSecurityBadgeToggleHandler verifies the badge-visibility hotkey flips the
+// view flag without touching the manager, cache, or index.
+func TestSecurityBadgeToggleHandler(t *testing.T) {
+	m := baseModelBoost2()
+	assert.False(t, m.hideSecurityBadges, "badges visible by default")
+
+	res, _, handled := m.handleExplorerActionKeySecurityBadgeToggle()
+	assert.True(t, handled, "toggle key must be consumed")
+	assert.True(t, res.(Model).hideSecurityBadges, "first press hides badges")
+
+	res2, _, _ := res.(Model).handleExplorerActionKeySecurityBadgeToggle()
+	assert.False(t, res2.(Model).hideSecurityBadges, "second press shows badges again")
+}

--- a/internal/app/security_findings_cache.go
+++ b/internal/app/security_findings_cache.go
@@ -1,0 +1,186 @@
+// Package app — security_findings_cache.go
+// Persists scanned security findings per (host, namespace) so a fresh session
+// paints SEC badges instantly from disk, then revalidates in the background
+// (stale-while-revalidate). Distinct from security_availability_cache.go,
+// which only records WHICH sources exist; this stores the findings themselves.
+// Same per-host cache dir as the discovery/availability caches, so kubectl/k9s
+// cache invalidation also wipes it.
+package app
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+// securityFindingsCacheSchemaVersion bumps when the on-disk shape changes.
+// A mismatch is treated as a miss so an older binary never decodes a
+// forward-incompatible file into garbage findings.
+const securityFindingsCacheSchemaVersion = 1
+
+// securityFindingsCacheFilename is the per-host basename. Distinct from the
+// availability cache so both can live in the same per-host directory.
+const securityFindingsCacheFilename = "lfk-security-findings.yaml"
+
+// securityFindingsCacheTTL bounds how stale a disk-seeded badge paint may be.
+// Findings older than this are not painted at startup (a miss), so a cluster
+// left unopened for a long time doesn't show badges that may be far out of
+// date before the background rescan replaces them. The live scan always runs
+// regardless; this only gates the instant pre-scan paint.
+const securityFindingsCacheTTL = time.Hour
+
+// securityFindingsCacheState is the on-disk shape: one file per cluster API
+// host, holding findings keyed by namespace ("" = all-namespaces). Each entry
+// carries its own scannedAt so per-namespace TTL is independent.
+type securityFindingsCacheState struct {
+	SchemaVersion int                              `json:"schema_version"`
+	Namespaces    map[string]securityFindingsEntry `json:"namespaces"`
+}
+
+type securityFindingsEntry struct {
+	ScannedAt time.Time          `json:"scanned_at"`
+	Findings  []security.Finding `json:"findings"`
+}
+
+// securityFindingsCacheFilePathForHost returns the per-host cache file path,
+// or "" when the host or cache base dir can't be resolved (treated as "skip").
+func securityFindingsCacheFilePathForHost(host string) string {
+	if host == "" {
+		return ""
+	}
+	base := k8s.DiscoveryCacheBaseDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "discovery", k8s.CacheHostDir(host), securityFindingsCacheFilename)
+}
+
+// readFindingsCacheFile loads and validates the whole per-host state. Returns
+// nil on any failure (missing, corrupt, schema mismatch) so callers fall
+// through to a live scan.
+func readFindingsCacheFile(host string) *securityFindingsCacheState {
+	path := securityFindingsCacheFilePathForHost(host)
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			logger.Warn("Security findings cache read failed", "host", k8s.CacheHostDir(host), "error", err)
+		}
+		return nil
+	}
+	var s securityFindingsCacheState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		logger.Warn("Security findings cache is corrupt; ignoring", "host", k8s.CacheHostDir(host), "error", err)
+		return nil
+	}
+	if s.SchemaVersion != securityFindingsCacheSchemaVersion {
+		logger.Info("Security findings cache schema mismatch; ignoring",
+			"host", k8s.CacheHostDir(host), "got", s.SchemaVersion, "want", securityFindingsCacheSchemaVersion)
+		return nil
+	}
+	return &s
+}
+
+// loadSecurityFindingsCacheForHost returns the cached findings for (host,
+// namespace) when present and newer than ttl, else nil (a miss). A nil return
+// is the signal to fall through to a live scan.
+func loadSecurityFindingsCacheForHost(host, namespace string, ttl time.Duration) []security.Finding {
+	s := readFindingsCacheFile(host)
+	if s == nil {
+		return nil
+	}
+	entry, ok := s.Namespaces[namespace]
+	if !ok {
+		return nil
+	}
+	if ttl > 0 && time.Since(entry.ScannedAt) > ttl {
+		return nil
+	}
+	return entry.Findings
+}
+
+// saveSecurityFindingsCacheForHost writes findings for (host, namespace),
+// merging into the existing per-host file so other namespaces' entries
+// survive. scannedAt stamps the entry's freshness. Atomic (tmp + rename +
+// fsync), matching the availability cache's durability. No-op for an empty
+// host.
+func saveSecurityFindingsCacheForHost(host, namespace string, findings []security.Finding, scannedAt time.Time) error {
+	path := securityFindingsCacheFilePathForHost(host)
+	if path == "" {
+		return nil
+	}
+	// Normalize nil to an empty slice so a clean scan with zero findings
+	// round-trips as `findings: []` (a real cached "nothing found") rather
+	// than `findings: null`, which would unmarshal to nil and be
+	// indistinguishable from a cache miss on the next load.
+	if findings == nil {
+		findings = []security.Finding{}
+	}
+	// Merge into any existing state so a save for one namespace doesn't wipe
+	// the others. A corrupt/missing file just starts fresh. NOTE: the
+	// read-modify-write is only atomic within one process (saves run on the
+	// Bubble Tea Update loop). Two lfk instances saving different namespaces
+	// of the same host concurrently can lose one entry (last rename wins) —
+	// acceptable for a best-effort, TTL-bounded cache; the lost entry is
+	// re-derived by the next scan.
+	state := readFindingsCacheFile(host)
+	if state == nil {
+		state = &securityFindingsCacheState{SchemaVersion: securityFindingsCacheSchemaVersion}
+	}
+	if state.Namespaces == nil {
+		state.Namespaces = make(map[string]securityFindingsEntry)
+	}
+	state.Namespaces[namespace] = securityFindingsEntry{
+		ScannedAt: scannedAt.UTC(),
+		Findings:  findings,
+	}
+
+	data, err := yaml.Marshal(state)
+	if err != nil {
+		return err
+	}
+	// 0700 dir / 0600 file: findings carry CVE IDs, resource and container
+	// names, policy text, and labels — more sensitive than the availability
+	// cache's booleans, so they are not world-readable even when lfk is the
+	// first to create the per-host cache directory on a multi-user host.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return writeFileDurable(path, data, 0o600)
+}
+
+// updateSecurityFindingsCacheForContext resolves the context to its host and
+// persists the findings. No-op when the host can't be resolved.
+func updateSecurityFindingsCacheForContext(client *k8s.Client, contextName, namespace string, findings []security.Finding) error {
+	if client == nil || contextName == "" {
+		return nil
+	}
+	host := client.HostForContext(contextName)
+	if host == "" {
+		return nil
+	}
+	return saveSecurityFindingsCacheForHost(host, namespace, findings, time.Now().UTC())
+}
+
+// loadSecurityFindingsCacheForContext resolves the context's host and returns
+// the cached findings within ttl, or nil on a miss.
+func loadSecurityFindingsCacheForContext(client *k8s.Client, contextName, namespace string, ttl time.Duration) []security.Finding {
+	if client == nil || contextName == "" {
+		return nil
+	}
+	host := client.HostForContext(contextName)
+	if host == "" {
+		return nil
+	}
+	return loadSecurityFindingsCacheForHost(host, namespace, ttl)
+}

--- a/internal/app/security_findings_cache_test.go
+++ b/internal/app/security_findings_cache_test.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clientfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+func sampleFindings() []security.Finding {
+	return []security.Finding{
+		{
+			ID:       "CVE-2024-1",
+			Source:   "trivy-operator",
+			Category: "vulnerability",
+			Severity: security.SeverityCritical,
+			Title:    "critical CVE",
+			Resource: security.ResourceRef{Namespace: "default", Kind: "Pod", Name: "web-1"},
+			Summary:  "bad",
+			Labels:   map[string]string{"cve": "CVE-2024-1"},
+		},
+		{
+			ID:       "policy-2",
+			Source:   "kyverno",
+			Category: "policy",
+			Severity: security.SeverityMedium,
+			Title:    "policy violation",
+			Resource: security.ResourceRef{Namespace: "default", Kind: "Deployment", Name: "api"},
+		},
+	}
+}
+
+// TestSecurityFindingsCacheRoundTrip verifies findings persist and load back
+// intact for a given (host, namespace), preserving all fields used by the
+// badge index.
+func TestSecurityFindingsCacheRoundTrip(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+	ns := "default"
+
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, ns, sampleFindings(), time.Now().UTC()))
+
+	got := loadSecurityFindingsCacheForHost(host, ns, time.Hour)
+	require.Len(t, got, 2)
+	assert.Equal(t, "CVE-2024-1", got[0].ID)
+	assert.Equal(t, security.SeverityCritical, got[0].Severity)
+	assert.Equal(t, "web-1", got[0].Resource.Name)
+	assert.Equal(t, security.SeverityMedium, got[1].Severity)
+}
+
+// TestSecurityFindingsCacheNamespaceKeyed verifies findings are stored per
+// namespace within the host file — loading a different namespace must miss.
+func TestSecurityFindingsCacheNamespaceKeyed(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "ns-a", sampleFindings(), time.Now().UTC()))
+
+	assert.Len(t, loadSecurityFindingsCacheForHost(host, "ns-a", time.Hour), 2, "stored namespace must load")
+	assert.Nil(t, loadSecurityFindingsCacheForHost(host, "ns-b", time.Hour), "other namespace must miss")
+
+	// The all-namespaces key ("") is distinct from a named namespace.
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "", sampleFindings(), time.Now().UTC()))
+	assert.Len(t, loadSecurityFindingsCacheForHost(host, "", time.Hour), 2, "all-namespaces key must load independently")
+}
+
+// TestSecurityFindingsCacheTTLExpiry verifies an entry older than the TTL is
+// treated as a miss (stale-while-revalidate still paints it, but the loader
+// here enforces the freshness window the caller passes).
+func TestSecurityFindingsCacheTTLExpiry(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+	ns := "default"
+
+	stale := time.Now().UTC().Add(-2 * time.Hour)
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, ns, sampleFindings(), stale))
+
+	assert.Nil(t, loadSecurityFindingsCacheForHost(host, ns, time.Hour), "entry older than TTL must be a miss")
+	assert.Len(t, loadSecurityFindingsCacheForHost(host, ns, 3*time.Hour), 2, "within a larger TTL it loads")
+}
+
+// TestSecurityFindingsCacheMissReturnsNil covers the no-file and empty-host
+// paths — both must be nil (fall through to a live scan), never panic.
+func TestSecurityFindingsCacheMissReturnsNil(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	assert.Nil(t, loadSecurityFindingsCacheForHost("https://never-written:6443", "default", time.Hour))
+	assert.Nil(t, loadSecurityFindingsCacheForHost("", "default", time.Hour), "empty host must be a no-op miss")
+	assert.NoError(t, saveSecurityFindingsCacheForHost("", "default", sampleFindings(), time.Now().UTC()), "empty host save is a no-op")
+}
+
+// TestSecurityFindingsCacheZeroFindingsRoundTrip verifies a clean scan with
+// zero findings is a real cached result (non-nil), not indistinguishable from
+// a miss — nil must normalize to an empty slice on save so it survives the
+// YAML null round-trip.
+func TestSecurityFindingsCacheZeroFindingsRoundTrip(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "default", nil, time.Now().UTC()))
+	got := loadSecurityFindingsCacheForHost(host, "default", time.Hour)
+	require.NotNil(t, got, "a cached zero-findings scan must be a hit (non-nil), not a miss")
+	assert.Empty(t, got)
+
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "other", []security.Finding{}, time.Now().UTC()))
+	got = loadSecurityFindingsCacheForHost(host, "other", time.Hour)
+	require.NotNil(t, got, "explicit empty slice must also round-trip as a hit")
+	assert.Empty(t, got)
+}
+
+// TestSecurityFindingsCacheFilePerms verifies the findings file is written
+// 0600 (not world-readable) since it carries CVE/policy/resource detail.
+func TestSecurityFindingsCacheFilePerms(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "default", sampleFindings(), time.Now().UTC()))
+
+	path := securityFindingsCacheFilePathForHost(host)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "findings file must not be world-readable")
+}
+
+// findingsCacheTestModel builds a Model whose client resolves a host for
+// "ctx" so the persistence path actually writes a file.
+func findingsCacheTestModel(t *testing.T) Model {
+	t.Helper()
+	c := k8s.NewTestClient(clientfake.NewClientset(), nil)
+	c.SetTestHostForContext("ctx", "https://api.persist.test:6443")
+	m := Model{}
+	m.client = c
+	m.nav = model.NavigationState{Context: "ctx"}
+	m.namespace = "default"
+	return m
+}
+
+// TestUpdateSecurityFindingsLoaded_PersistsCleanScan verifies a fully clean
+// scan (no per-source errors) is written to the disk cache so the next session
+// can paint it.
+func TestUpdateSecurityFindingsLoaded_PersistsCleanScan(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	m := findingsCacheTestModel(t)
+
+	m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+		context:   "ctx",
+		namespace: "default",
+		findings:  sampleFindings(),
+		errors:    map[string]error{"trivy-operator": nil},
+	})
+
+	got := loadSecurityFindingsCacheForHost("https://api.persist.test:6443", "default", time.Hour)
+	require.Len(t, got, 2, "a clean scan must be persisted to disk")
+}
+
+// TestUpdateSecurityFindingsLoaded_SkipsPartialScan verifies a scan where any
+// source errored is NOT persisted — caching an undercount would show stale-low
+// badges until the TTL expires.
+func TestUpdateSecurityFindingsLoaded_SkipsPartialScan(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	m := findingsCacheTestModel(t)
+
+	m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+		context:   "ctx",
+		namespace: "default",
+		findings:  sampleFindings()[:1], // undercount: one source failed
+		errors:    map[string]error{"kyverno": errors.New("timeout")},
+	})
+
+	assert.Nil(t, loadSecurityFindingsCacheForHost("https://api.persist.test:6443", "default", time.Hour),
+		"a partial (errored) scan must not be persisted")
+}

--- a/internal/app/security_refresh.go
+++ b/internal/app/security_refresh.go
@@ -50,8 +50,11 @@ func (m *Model) refreshSecuritySources() {
 	}
 	mgr := security.NewManager()
 	if m.client != nil {
-		kc := m.client.RawClientsetForContext(resolvedCtx)
-		dc := m.client.RawDynamicForContext(resolvedCtx)
+		// Security sources get throttled clients (dedicated lower QPS/Burst)
+		// so background finding scans run at a low rate and never drain the
+		// foreground's API budget.
+		kc := m.client.RawClientsetForContextThrottled(resolvedCtx)
+		dc := m.client.RawDynamicForContextThrottled(resolvedCtx)
 		// register adds src only when its per-source toggle is enabled for
 		// this context (per-cluster override > global > enabled by default).
 		register := func(name string, src security.SecuritySource) {
@@ -81,6 +84,14 @@ func (m *Model) refreshSecuritySources() {
 	// result triggers the loader entry until the live probe completes.
 	if cached := loadSecurityAvailabilityCacheForContext(m.client, resolvedCtx); len(cached) > 0 {
 		m.securityAvailabilityByName = cached
+		// Publish the cached availability as the manager's hint so an eager
+		// findings fetch (maybeEagerSecurityScan, fired at cluster open)
+		// skips the per-source IsAvailable probe — that probe is the exact
+		// EKS aws-credential-plugin call the lazy design avoids. With the
+		// hint set, a previously-inspected cluster scans straight from Fetch
+		// with no new probe; an as-yet-uninspected cluster has no cache and
+		// stays fully lazy.
+		mgr.SetAvailability(resolvedCtx, cached)
 	} else {
 		m.securityAvailabilityByName = make(map[string]bool)
 	}

--- a/internal/app/security_refresh.go
+++ b/internal/app/security_refresh.go
@@ -92,6 +92,18 @@ func (m *Model) refreshSecuritySources() {
 		// with no new probe; an as-yet-uninspected cluster has no cache and
 		// stays fully lazy.
 		mgr.SetAvailability(resolvedCtx, cached)
+		// Stale-while-revalidate: paint SEC badges instantly from the
+		// last session's findings while the eager scan revalidates in the
+		// background (maybeEagerSecurityScan, fired at cluster open, replaces
+		// the index when fresh results land). Keyed by the effective
+		// namespace so the seed matches what the scan will fetch. A miss
+		// (no cache / expired) just leaves the index nil until the scan
+		// completes — the pre-cache behavior.
+		if cachedFindings := loadSecurityFindingsCacheForContext(
+			m.client, resolvedCtx, m.effectiveNamespace(), securityFindingsCacheTTL,
+		); cachedFindings != nil {
+			m.securityIndex = security.BuildFindingIndex(cachedFindings)
+		}
 	} else {
 		m.securityAvailabilityByName = make(map[string]bool)
 	}

--- a/internal/app/security_state.go
+++ b/internal/app/security_state.go
@@ -28,6 +28,12 @@ type securityModelState struct {
 	// showSecurityIgnored toggles whether ignored findings surface in the
 	// explorer. Off by default; flipped with kb.SecurityIgnoreToggle.
 	showSecurityIgnored bool
+	// hideSecurityBadges suppresses the per-resource SEC row badge when set.
+	// Off by default (badges shown); flipped with kb.SecurityBadgeToggle. A
+	// global session preference, not per-tab and not persisted, mirroring
+	// showRareResources — it hides only the row badge, leaving the Security
+	// dashboard and source probing untouched.
+	hideSecurityBadges bool
 	// securityProbedContext is the cluster context whose security sources
 	// have already been probed this activation. Availability probing is
 	// lazy — it runs only when the user focuses the Security category, not

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -96,7 +96,12 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	// Security availability is probed lazily on first focus of the Security
 	// category (maybeProbeSecurityOnFocus), not eagerly on session restore.
 	// refreshSecuritySources above reseeds the sidebar from the on-disk cache
-	// and clears the per-context probe guard for sess.Context.
+	// and clears the per-context probe guard for sess.Context. When that cache
+	// already knows the sources, kick off a no-probe findings scan so the SEC
+	// badges populate on the restored cluster without a trip to Security.
+	if cmd := m.maybeEagerSecurityScan(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 
 	if sess.ResourceType != "" {
 		rt, ok := resolveSessionResourceType(sess.ResourceType, m.discoveredResources[discoveryCtx])

--- a/internal/app/update_dispatch_msgs.go
+++ b/internal/app/update_dispatch_msgs.go
@@ -121,6 +121,16 @@ func (m Model) updateWatchTick(msg watchTickMsg) (tea.Model, tea.Cmd) {
 	if !m.watchMode {
 		return m, nil
 	}
+	// No explicit backpressure gate here: the scheduler's in-flight coalescing
+	// (Registry.Submit dedups against an identical RUNNING task, not just the
+	// queue) already gives this loop fixed-DELAY semantics under load — a tick
+	// that fires while the previous identical refresh is still running is
+	// coalesced away rather than stacking a redundant fetch. An earlier gate on
+	// total queue depth was removed: it conflated the user's foreground list
+	// refresh (High) with background metrics/events (Low) and suppressed a live
+	// list refresh whenever slow background work was still draining (a deleted
+	// pod lingered in the list — see TestWatchTickRemovesDeletedPodFromList).
+	//
 	// Mark this dispatch as a watch-tick refresh so the instrumented
 	// loaders called below (through refreshCurrentLevel) use
 	// Registry.StartUntracked and don't flash the title-bar indicator

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -124,6 +124,8 @@ func (m Model) handleExplorerToolKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 		return m.handleExplorerActionKeyToggleRare()
 	case kb.SecurityIgnoreToggle:
 		return m.handleExplorerActionKeySecurityIgnoreToggle()
+	case kb.SecurityBadgeToggle:
+		return m.handleExplorerActionKeySecurityBadgeToggle()
 	}
 	return m, nil, false
 }

--- a/internal/app/update_keys_actions_security.go
+++ b/internal/app/update_keys_actions_security.go
@@ -28,3 +28,17 @@ func (m Model) handleExplorerActionKeySecurityIgnoreToggle() (tea.Model, tea.Cmd
 	}
 	return m, tea.Batch(m.refreshCurrentLevel(), scheduleStatusClear()), true
 }
+
+// handleExplorerActionKeySecurityBadgeToggle shows/hides the per-resource SEC
+// row badge. It is a pure view toggle — no fetch, no cache bust — so the
+// Security dashboard and source probing are unaffected. The view layer reads
+// hideSecurityBadges into ui.ActiveSecurityBadgesHidden on the next render.
+func (m Model) handleExplorerActionKeySecurityBadgeToggle() (tea.Model, tea.Cmd, bool) {
+	m.hideSecurityBadges = !m.hideSecurityBadges
+	if m.hideSecurityBadges {
+		m.setStatusMessage("Hiding security badges", false)
+	} else {
+		m.setStatusMessage("Showing security badges", false)
+	}
+	return m, scheduleStatusClear(), true
+}

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -369,12 +369,12 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	m.dashboardEventsPreview = ""
 	m.monitoringPreview = ""
 	m.applyPinnedTypes()
-	// Rebuild the security manager against the new cluster's clientsets so
-	// findings, availability, and the SEC badge index reflect the active
-	// cluster instead of lingering on the prior one.
-	m.refreshSecuritySources()
+	// Clear the prior cluster's badge index BEFORE refreshSecuritySources:
+	// that rebuild seeds m.securityIndex from the new cluster's disk-cached
+	// findings (stale-while-revalidate), so nil-ing after would discard it.
 	m.securityIndex = nil
 	m.securityActiveGroup = ""
+	m.refreshSecuritySources()
 	m.nav.Level = model.LevelResourceTypes
 	// Capture whatever the right-pane preview was already displaying for
 	// this context (real discovery hit or seed fallback). We use this

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -415,6 +415,14 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	// switching clusters never triggers the aws credential plugin for a user
 	// who isn't looking at security. refreshSecuritySources above cleared the
 	// per-context probe guard.
+	//
+	// Eager findings scan: when this cluster was inspected before,
+	// refreshSecuritySources seeded availability (and the manager hint) from
+	// the disk cache, so we can populate the SEC badge index now without any
+	// probe. No cache (first-ever visit) -> this no-ops and badges stay lazy.
+	if cmd := m.maybeEagerSecurityScan(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	// Fire discovery once per session per context. The disk cache may have
 	// prefilled m.discoveredResources, but stale-while-revalidate still
 	// wants a live refresh on the user's first interaction with the

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -26,6 +26,7 @@ func (m Model) View() string {
 	// cluster. The renderer reads these globals during table layout.
 	ui.ActiveSecurityIndex = m.securityIndex
 	ui.ActiveSecurityAvailable = m.anySecurityAvailable()
+	ui.ActiveSecurityBadgesHidden = m.hideSecurityBadges
 
 	// Render fullscreen modes (YAML, Logs, Describe, Diff, Exec, Explain) with title bar and tab bar.
 	// Each view renders its own hint bar, so the main status bar is not shown.

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -118,6 +118,18 @@ type Client struct {
 	discoveryMu      sync.Mutex
 	discoveryClients map[string]*disk.CachedDiscoveryClient
 
+	// clientMu guards clientCache. Typed/dynamic/metadata clients are
+	// expensive to build (kubeconfig parse + TLS transport + ~1.8k allocs,
+	// plus an exec-credential plugin invocation for EKS/kubelogin contexts)
+	// and were previously rebuilt on every call, discarding connection
+	// pooling and resetting the client-side QPS limiter each time. clientCache
+	// memoizes them per cache key (see clientCacheKey: context, plus a
+	// "throttled" variant for the lower-rate security clients). Invalidated on
+	// ReloadKubeconfig (the only mid-session config mutation) and per-context
+	// via invalidateClientsForContext.
+	clientMu    sync.Mutex
+	clientCache map[string]*ctxClients
+
 	// informerMu guards informerMode + informers. Writes happen at most
 	// once (SetInformerCacheMode at startup); reads happen on every
 	// GetResources. RWMutex is overkill for the call rate but documents
@@ -338,6 +350,12 @@ func (c *Client) ReloadKubeconfig() error {
 	c.contextOrder = order
 	c.currentContext = current
 	c.configMu.Unlock()
+	// Drop cached clients: they were built from the previous kubeconfig
+	// snapshot (endpoint, credentials, exec plugin). A reload can change any
+	// of those, so the next builder call must reconstruct. Done outside
+	// configMu — invalidateClientCache takes its own clientMu — to keep the
+	// two locks independent and avoid a lock-ordering constraint.
+	c.invalidateClientCache()
 	return nil
 }
 

--- a/internal/k8s/client_build_bench_test.go
+++ b/internal/k8s/client_build_bench_test.go
@@ -1,0 +1,143 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// benchKubeconfig is a minimal two-context kubeconfig: "plain" uses a static
+// token; "exec" uses an exec credential provider (the EKS aws / kubelogin
+// shape) so we can measure the extra cost client-go's exec plugin machinery
+// adds to client construction. The exec command is "true" so it never blocks
+// — we are measuring lfk's build path, not the plugin's runtime.
+const benchKubeconfigPlain = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: plain
+  context:
+    cluster: c
+    user: u
+current-context: plain
+users:
+- name: u
+  user:
+    token: deadbeef
+`
+
+const benchKubeconfigExec = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: exec
+  context:
+    cluster: c
+    user: u
+current-context: exec
+users:
+- name: u
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: "true"
+      args: []
+`
+
+// newBenchClient writes the given kubeconfig to a temp file and builds a real
+// Client against it (no fakes), so the *ForContext builders exercise the full
+// rest.Config + transport + clientset construction path.
+func newBenchClient(b *testing.B, kubeconfig string) *Client {
+	b.Helper()
+	dir := b.TempDir()
+	path := filepath.Join(dir, "config")
+	if err := os.WriteFile(path, []byte(kubeconfig), 0o600); err != nil {
+		b.Fatalf("write kubeconfig: %v", err)
+	}
+	c, err := NewClient(path, nil)
+	if err != nil {
+		b.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// BenchmarkClientsetForContext_Plain measures a full per-call clientset build
+// for a static-token context (the current per-call behavior — no cache).
+func BenchmarkClientsetForContext_Plain(b *testing.B) {
+	c := newBenchClient(b, benchKubeconfigPlain)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		cs, err := c.clientsetForContext("plain")
+		if err != nil || cs == nil {
+			b.Fatalf("clientsetForContext: %v", err)
+		}
+	}
+}
+
+// BenchmarkClientsetForContext_Exec measures the same for an exec-credential
+// (EKS aws / kubelogin) context, where client-go wires up the exec plugin
+// transport on every build.
+func BenchmarkClientsetForContext_Exec(b *testing.B) {
+	c := newBenchClient(b, benchKubeconfigExec)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		cs, err := c.clientsetForContext("exec")
+		if err != nil || cs == nil {
+			b.Fatalf("clientsetForContext: %v", err)
+		}
+	}
+}
+
+// BenchmarkRestConfigForContext isolates just the kubeconfig parse + rest.Config
+// build (the part a config-only cache would eliminate), excluding transport and
+// clientset construction.
+func BenchmarkRestConfigForContext(b *testing.B) {
+	c := newBenchClient(b, benchKubeconfigPlain)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		cfg, err := c.restConfigForContext("plain")
+		if err != nil || cfg == nil {
+			b.Fatalf("restConfigForContext: %v", err)
+		}
+	}
+}
+
+// BenchmarkDynamicForContext_Plain measures the dynamic-client build path.
+func BenchmarkDynamicForContext_Plain(b *testing.B) {
+	c := newBenchClient(b, benchKubeconfigPlain)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		dc, err := c.dynamicForContext("plain")
+		if err != nil || dc == nil {
+			b.Fatalf("dynamicForContext: %v", err)
+		}
+	}
+}
+
+// BenchmarkCachedClientsetReuse is the lower bound: build once, then reuse the
+// same clientset N times. The delta between this and BenchmarkClientsetForContext_*
+// is exactly what a per-context client cache would save per call.
+func BenchmarkCachedClientsetReuse(b *testing.B) {
+	c := newBenchClient(b, benchKubeconfigPlain)
+	cs, err := c.clientsetForContext("plain")
+	if err != nil || cs == nil {
+		b.Fatalf("warmup clientsetForContext: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = cs.Discovery()
+	}
+}

--- a/internal/k8s/client_cache.go
+++ b/internal/k8s/client_cache.go
@@ -1,0 +1,180 @@
+// Package k8s — client_cache.go
+// Per-context memoization of the typed, dynamic, and metadata clients. Building
+// these is expensive (kubeconfig parse + TLS transport + ~1.8k allocs, and an
+// exec-credential plugin invocation for EKS/kubelogin contexts) and was
+// previously done on every call — which also reset the client-side QPS limiter
+// and discarded HTTP connection pooling between calls. Caching restores both
+// and makes the QPS/Burst knobs a real cross-call rate cap. Mirrors the
+// existing per-context discovery-client cache (discovery_cache.go).
+package k8s
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/rest"
+)
+
+// ctxClients holds the cached clients for one cache key. Fields are built
+// lazily — a key may have only the clients that have been requested so far.
+type ctxClients struct {
+	clientset kubernetes.Interface
+	dynamic   dynamic.Interface
+	metadata  metadata.Interface
+}
+
+// clientCacheKey derives the cache key for a context. The throttled
+// (security) clients carry a different rate limit, so they must not share an
+// instance with the foreground clients — they get a distinct key.
+func clientCacheKey(contextName string, throttled bool) string {
+	if throttled {
+		return contextName + "\x00throttled"
+	}
+	return contextName
+}
+
+// cachedClientsLocked returns the ctxClients for key, creating an empty entry
+// if absent. Caller must hold c.clientMu.
+func (c *Client) cachedClientsLocked(key string) *ctxClients {
+	if c.clientCache == nil {
+		c.clientCache = make(map[string]*ctxClients)
+	}
+	entry, ok := c.clientCache[key]
+	if !ok {
+		entry = &ctxClients{}
+		c.clientCache[key] = entry
+	}
+	return entry
+}
+
+// buildClientset constructs a typed clientset from cfg with the
+// context-tagging HTTP client attached (so exec-credential failures are
+// attributed to the cluster in logs). Shared by the foreground and throttled
+// paths so neither skips the tagging wrapper.
+func (c *Client) buildClientset(contextName string, cfg *rest.Config) (kubernetes.Interface, error) {
+	httpClient, err := taggedHTTPClient(cfg, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("creating http client: %w", err)
+	}
+	cs, err := kubernetes.NewForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("creating clientset: %w", err)
+	}
+	return cs, nil
+}
+
+// buildDynamic constructs a dynamic client from cfg with the context-tagging
+// HTTP client attached. See buildClientset.
+func (c *Client) buildDynamic(contextName string, cfg *rest.Config) (dynamic.Interface, error) {
+	httpClient, err := taggedHTTPClient(cfg, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("creating http client: %w", err)
+	}
+	dc, err := dynamic.NewForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("creating dynamic client: %w", err)
+	}
+	return dc, nil
+}
+
+// buildMetadata constructs a metadata-only client from cfg with the
+// context-tagging HTTP client attached.
+func (c *Client) buildMetadata(contextName string, cfg *rest.Config) (metadata.Interface, error) {
+	httpClient, err := taggedHTTPClient(cfg, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("creating http client: %w", err)
+	}
+	mc, err := metadata.NewForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("creating metadata client: %w", err)
+	}
+	return mc, nil
+}
+
+// cachedClientset returns the memoized typed clientset for (contextName,
+// throttled), building and caching it on first use. restConfig supplies the
+// rate-appropriate rest.Config (foreground or throttled) and is only invoked
+// on a cache miss.
+func (c *Client) cachedClientset(contextName string, throttled bool, restConfig func() (*rest.Config, error)) (kubernetes.Interface, error) {
+	key := clientCacheKey(contextName, throttled)
+	c.clientMu.Lock()
+	defer c.clientMu.Unlock()
+	entry := c.cachedClientsLocked(key)
+	if entry.clientset != nil {
+		return entry.clientset, nil
+	}
+	cfg, err := restConfig()
+	if err != nil {
+		return nil, err
+	}
+	cs, err := c.buildClientset(contextName, cfg)
+	if err != nil {
+		return nil, err
+	}
+	entry.clientset = cs
+	return cs, nil
+}
+
+// cachedDynamic returns the memoized dynamic client for (contextName,
+// throttled). See cachedClientset.
+func (c *Client) cachedDynamic(contextName string, throttled bool, restConfig func() (*rest.Config, error)) (dynamic.Interface, error) {
+	key := clientCacheKey(contextName, throttled)
+	c.clientMu.Lock()
+	defer c.clientMu.Unlock()
+	entry := c.cachedClientsLocked(key)
+	if entry.dynamic != nil {
+		return entry.dynamic, nil
+	}
+	cfg, err := restConfig()
+	if err != nil {
+		return nil, err
+	}
+	dc, err := c.buildDynamic(contextName, cfg)
+	if err != nil {
+		return nil, err
+	}
+	entry.dynamic = dc
+	return dc, nil
+}
+
+// cachedMetadata returns the memoized metadata-only client for contextName
+// (foreground rate only; no throttled metadata variant is used).
+func (c *Client) cachedMetadata(contextName string, restConfig func() (*rest.Config, error)) (metadata.Interface, error) {
+	key := clientCacheKey(contextName, false)
+	c.clientMu.Lock()
+	defer c.clientMu.Unlock()
+	entry := c.cachedClientsLocked(key)
+	if entry.metadata != nil {
+		return entry.metadata, nil
+	}
+	cfg, err := restConfig()
+	if err != nil {
+		return nil, err
+	}
+	mc, err := c.buildMetadata(contextName, cfg)
+	if err != nil {
+		return nil, err
+	}
+	entry.metadata = mc
+	return mc, nil
+}
+
+// invalidateClientCache drops every cached client. Called from ReloadKubeconfig
+// after the kubeconfig snapshot is swapped, so the next call to any builder
+// reconstructs against the fresh config (new endpoint/credentials).
+func (c *Client) invalidateClientCache() {
+	c.clientMu.Lock()
+	defer c.clientMu.Unlock()
+	c.clientCache = nil
+}
+
+// invalidateClientsForContext drops the cached clients for a single context
+// (both the foreground and throttled variants), leaving other contexts intact.
+func (c *Client) invalidateClientsForContext(contextName string) {
+	c.clientMu.Lock()
+	defer c.clientMu.Unlock()
+	delete(c.clientCache, clientCacheKey(contextName, false))
+	delete(c.clientCache, clientCacheKey(contextName, true))
+}

--- a/internal/k8s/client_cache_test.go
+++ b/internal/k8s/client_cache_test.go
@@ -1,0 +1,114 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCacheTestClient builds a real Client against a temp kubeconfig so the
+// *ForContext builders run their full construction path (no fakes).
+func newCacheTestClient(t *testing.T) *Client {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(path, []byte(benchKubeconfigPlain), 0o600))
+	c, err := NewClient(path, nil)
+	require.NoError(t, err)
+	return c
+}
+
+// TestClientsetForContext_CachedSameInstance verifies repeated calls return the
+// same clientset instance (cache hit) rather than rebuilding each time.
+func TestClientsetForContext_CachedSameInstance(t *testing.T) {
+	c := newCacheTestClient(t)
+	cs1, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+	cs2, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+	assert.Same(t, cs1, cs2, "clientsetForContext must return the cached instance on the second call")
+}
+
+// TestDynamicForContext_CachedSameInstance verifies dynamic-client caching.
+func TestDynamicForContext_CachedSameInstance(t *testing.T) {
+	c := newCacheTestClient(t)
+	dc1, err := c.dynamicForContext("plain")
+	require.NoError(t, err)
+	dc2, err := c.dynamicForContext("plain")
+	require.NoError(t, err)
+	assert.Same(t, dc1, dc2, "dynamicForContext must return the cached instance")
+}
+
+// TestThrottledClientCachedSeparately verifies the throttled (security) client
+// is cached under a distinct key from the foreground client — they carry
+// different QPS/Burst, so they must be distinct instances.
+func TestThrottledClientCachedSeparately(t *testing.T) {
+	c := newCacheTestClient(t)
+	RateLimitOverridesEnabled = true
+	t.Cleanup(func() { RateLimitOverridesEnabled = false })
+
+	fg, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+	thr := c.RawClientsetForContextThrottled("plain")
+	require.NotNil(t, thr)
+	assert.NotSame(t, fg, thr, "throttled client must be a distinct instance from the foreground client")
+
+	thr2 := c.RawClientsetForContextThrottled("plain")
+	assert.Same(t, thr, thr2, "throttled client must itself be cached")
+}
+
+// TestReloadKubeconfigInvalidatesClientCache verifies a kubeconfig reload drops
+// cached clients so the next call rebuilds against fresh config.
+func TestReloadKubeconfigInvalidatesClientCache(t *testing.T) {
+	c := newCacheTestClient(t)
+	cs1, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+
+	require.NoError(t, c.ReloadKubeconfig())
+
+	cs2, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+	assert.NotSame(t, cs1, cs2, "ReloadKubeconfig must invalidate the client cache so the next call rebuilds")
+}
+
+// TestClientCacheConcurrentAccess exercises the cache under concurrent
+// builders + invalidation so `go test -race` can flag any unsynchronized map
+// access. Mirrors the real call pattern: many tea.Cmd goroutines building
+// clients for the same and different contexts while a reload invalidates.
+func TestClientCacheConcurrentAccess(t *testing.T) {
+	c := newCacheTestClient(t)
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%4 == 0 {
+				c.invalidateClientsForContext("plain")
+				return
+			}
+			_, _ = c.clientsetForContext("plain")
+			_, _ = c.dynamicForContext("plain")
+			_, _ = c.metadataForContext("plain")
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestInvalidateClientsForContext verifies the targeted single-context cache
+// drop (used when one context's credentials/endpoint may have changed without
+// a full kubeconfig reload).
+func TestInvalidateClientsForContext(t *testing.T) {
+	c := newCacheTestClient(t)
+	cs1, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+
+	c.invalidateClientsForContext("plain")
+
+	cs2, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+	assert.NotSame(t, cs1, cs2, "invalidateClientsForContext must drop the context's cached clients")
+}

--- a/internal/k8s/client_operations.go
+++ b/internal/k8s/client_operations.go
@@ -357,51 +357,62 @@ func (c *Client) restConfigForContext(displayName string) (*rest.Config, error) 
 	if err != nil {
 		return nil, fmt.Errorf("building rest config for context %q: %w", displayName, err)
 	}
+	if RateLimitOverridesEnabled {
+		qps, burst := foregroundRate(displayName)
+		applyRateLimit(cfg, qps, burst)
+	}
+	return cfg, nil
+}
+
+// applyRateLimit sets the client-side QPS/Burst on cfg when both are positive.
+// A zero/negative value leaves client-go's own default in place.
+func applyRateLimit(cfg *rest.Config, qps float32, burst int) {
+	if qps > 0 {
+		cfg.QPS = qps
+	}
+	if burst > 0 {
+		cfg.Burst = burst
+	}
+}
+
+// restConfigForContextThrottled builds a rest config for the given context
+// carrying the dedicated, smaller security-client rate limit so background
+// finding scans yield to the foreground rather than draining its shared
+// token bucket.
+func (c *Client) restConfigForContextThrottled(displayName string) (*rest.Config, error) {
+	cfg, err := c.restConfigForContext(displayName)
+	if err != nil {
+		return nil, err
+	}
+	if RateLimitOverridesEnabled {
+		applyRateLimit(cfg, SecurityClientQPS, SecurityClientBurst)
+	}
 	return cfg, nil
 }
 
 func (c *Client) clientsetForContext(contextName string) (kubernetes.Interface, error) {
-	// Allow tests to inject a fake clientset.
+	// Allow tests to inject a fake clientset (before the cache so fakes are
+	// never memoized and every test sees its injected client).
 	if c.testClientset != nil {
 		if cs, ok := c.testClientset.(kubernetes.Interface); ok {
 			return cs, nil
 		}
 	}
-	cfg, err := c.restConfigForContext(contextName)
-	if err != nil {
-		return nil, err
-	}
-	httpClient, err := taggedHTTPClient(cfg, contextName)
-	if err != nil {
-		return nil, fmt.Errorf("creating http client: %w", err)
-	}
-	cs, err := kubernetes.NewForConfigAndClient(cfg, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("creating clientset: %w", err)
-	}
-	return cs, nil
+	return c.cachedClientset(contextName, false, func() (*rest.Config, error) {
+		return c.restConfigForContext(contextName)
+	})
 }
 
 func (c *Client) dynamicForContext(contextName string) (dynamic.Interface, error) {
-	// Allow tests to inject a fake dynamic client.
+	// Allow tests to inject a fake dynamic client (before the cache).
 	if c.testDynClient != nil {
 		if dc, ok := c.testDynClient.(dynamic.Interface); ok {
 			return dc, nil
 		}
 	}
-	cfg, err := c.restConfigForContext(contextName)
-	if err != nil {
-		return nil, err
-	}
-	httpClient, err := taggedHTTPClient(cfg, contextName)
-	if err != nil {
-		return nil, fmt.Errorf("creating http client: %w", err)
-	}
-	dynClient, err := dynamic.NewForConfigAndClient(cfg, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("creating dynamic client: %w", err)
-	}
-	return dynClient, nil
+	return c.cachedDynamic(contextName, false, func() (*rest.Config, error) {
+		return c.restConfigForContext(contextName)
+	})
 }
 
 // RawClientset returns the kubernetes clientset for the currently selected
@@ -454,26 +465,59 @@ func (c *Client) RawDynamicForContext(contextName string) dynamic.Interface {
 	return dc
 }
 
+// RawClientsetForContextThrottled is like RawClientsetForContext but the
+// returned clientset carries the dedicated, smaller security-client rate
+// limit (SecurityClientQPS/Burst). Used to build security source clients so
+// background finding scans yield to the foreground. Honors the injected test
+// clientset so tests bypass real config construction.
+func (c *Client) RawClientsetForContextThrottled(contextName string) kubernetes.Interface {
+	if contextName == "" {
+		return nil
+	}
+	if c.testClientset != nil {
+		if cs, ok := c.testClientset.(kubernetes.Interface); ok {
+			return cs
+		}
+	}
+	cs, err := c.cachedClientset(contextName, true, func() (*rest.Config, error) {
+		return c.restConfigForContextThrottled(contextName)
+	})
+	if err != nil {
+		return nil
+	}
+	return cs
+}
+
+// RawDynamicForContextThrottled is like RawDynamicForContext but the returned
+// dynamic client carries the dedicated, smaller security-client rate limit.
+func (c *Client) RawDynamicForContextThrottled(contextName string) dynamic.Interface {
+	if contextName == "" {
+		return nil
+	}
+	if c.testDynClient != nil {
+		if dc, ok := c.testDynClient.(dynamic.Interface); ok {
+			return dc
+		}
+	}
+	dc, err := c.cachedDynamic(contextName, true, func() (*rest.Config, error) {
+		return c.restConfigForContextThrottled(contextName)
+	})
+	if err != nil {
+		return nil
+	}
+	return dc
+}
+
 // metadataForContext returns a metadata-only client for the given context.
 // When testMetaClient is set (tests), it is returned directly.
 func (c *Client) metadataForContext(contextName string) (metadata.Interface, error) {
-	// Allow tests to inject a fake metadata client.
+	// Allow tests to inject a fake metadata client (before the cache).
 	if c.testMetaClient != nil {
 		if mc, ok := c.testMetaClient.(metadata.Interface); ok {
 			return mc, nil
 		}
 	}
-	cfg, err := c.restConfigForContext(contextName)
-	if err != nil {
-		return nil, err
-	}
-	httpClient, err := taggedHTTPClient(cfg, contextName)
-	if err != nil {
-		return nil, fmt.Errorf("creating http client: %w", err)
-	}
-	mc, err := metadata.NewForConfigAndClient(cfg, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("creating metadata client: %w", err)
-	}
-	return mc, nil
+	return c.cachedMetadata(contextName, func() (*rest.Config, error) {
+		return c.restConfigForContext(contextName)
+	})
 }

--- a/internal/k8s/ratelimit.go
+++ b/internal/k8s/ratelimit.go
@@ -1,0 +1,55 @@
+// Package k8s — ratelimit.go
+// Client-side REST rate-limit knobs. client-go's built-in default (QPS=5,
+// Burst=10) throttles foreground list calls whenever background work runs
+// concurrently — a multi-source security scan or metrics enrichment drains the
+// 10-token bucket and the next pod list queues behind it. These defaults give
+// an interactive multi-resource TUI enough headroom; the config layer can
+// override them globally and per-cluster via RateLimitForContext.
+package k8s
+
+const (
+	// DefaultClientQPS / DefaultClientBurst are the foreground rest.Config
+	// rate limits used when the config layer supplies no override.
+	DefaultClientQPS   float32 = 50
+	DefaultClientBurst int     = 100
+
+	// SecurityClientQPS / SecurityClientBurst are the dedicated, smaller
+	// budget for security-source clients. Giving background finding scans
+	// their own low rate is the practical "low priority" lever — the
+	// bg-task wrapper's scheduler priority is advisory only, so a separate
+	// token bucket is what actually keeps scans from starving the
+	// foreground's shared budget.
+	SecurityClientQPS   float32 = 10
+	SecurityClientBurst int     = 20
+)
+
+// RateLimitForContext, when set by the config layer, returns the effective
+// foreground QPS/Burst for a kube context (per-cluster override > global >
+// default). A nil hook, or a non-positive return, falls back to the
+// Default* constants. Modeled as a function hook so the k8s package keeps no
+// dependency on the ui/config package.
+//
+// Concurrency contract: written exactly once, from ui/config's init() at
+// package load, before any worker goroutine or REST client is created;
+// read-only thereafter. That single-write-before-use ordering is why no
+// mutex guards it. Tests that reassign it run sequentially (no t.Parallel).
+var RateLimitForContext func(context string) (qps float32, burst int)
+
+// RateLimitOverridesEnabled gates whether lfk applies ANY client-side
+// QPS/Burst override (the raised foreground default and the lower security
+// budget). When false, every client uses client-go's stock default (QPS 5 /
+// Burst 10) — the pre-feature baseline. Enabled now that the scheduler
+// lost-wakeup jam is fixed; set to false to fall back to stock client-go
+// limits while diagnosing any throttling regression.
+var RateLimitOverridesEnabled = true
+
+// foregroundRate resolves the foreground rate limit for a context, applying
+// the config hook when present and falling back to the compiled defaults.
+func foregroundRate(context string) (float32, int) {
+	if RateLimitForContext != nil {
+		if qps, burst := RateLimitForContext(context); qps > 0 && burst > 0 {
+			return qps, burst
+		}
+	}
+	return DefaultClientQPS, DefaultClientBurst
+}

--- a/internal/k8s/ratelimit_test.go
+++ b/internal/k8s/ratelimit_test.go
@@ -1,0 +1,55 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+func TestForegroundRate(t *testing.T) {
+	orig := RateLimitForContext
+	t.Cleanup(func() { RateLimitForContext = orig })
+
+	t.Run("nil hook falls back to defaults", func(t *testing.T) {
+		RateLimitForContext = nil
+		qps, burst := foregroundRate("any")
+		assert.Equal(t, DefaultClientQPS, qps)
+		assert.Equal(t, DefaultClientBurst, burst)
+	})
+
+	t.Run("hook value is used", func(t *testing.T) {
+		RateLimitForContext = func(ctx string) (float32, int) {
+			if ctx == "prod" {
+				return 200, 400
+			}
+			return DefaultClientQPS, DefaultClientBurst
+		}
+		qps, burst := foregroundRate("prod")
+		assert.Equal(t, float32(200), qps)
+		assert.Equal(t, 400, burst)
+	})
+
+	t.Run("non-positive hook return falls back to defaults", func(t *testing.T) {
+		RateLimitForContext = func(string) (float32, int) { return 0, 0 }
+		qps, burst := foregroundRate("any")
+		assert.Equal(t, DefaultClientQPS, qps)
+		assert.Equal(t, DefaultClientBurst, burst)
+	})
+}
+
+func TestApplyRateLimit(t *testing.T) {
+	t.Run("positive values set fields", func(t *testing.T) {
+		cfg := &rest.Config{}
+		applyRateLimit(cfg, 50, 100)
+		assert.Equal(t, float32(50), cfg.QPS)
+		assert.Equal(t, 100, cfg.Burst)
+	})
+
+	t.Run("non-positive values leave fields untouched", func(t *testing.T) {
+		cfg := &rest.Config{QPS: 7, Burst: 9}
+		applyRateLimit(cfg, 0, 0)
+		assert.Equal(t, float32(7), cfg.QPS, "zero QPS must not clobber existing")
+		assert.Equal(t, 9, cfg.Burst, "zero Burst must not clobber existing")
+	})
+}

--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -487,6 +487,25 @@ func (c SeverityCounts) Highest() Severity {
 	}
 }
 
+// HighestCount returns the number of findings in the highest-severity bucket
+// that has any, or 0 when empty. Pairs with Highest: the badge colors by
+// Highest and labels with HighestCount so a red badge means "this many
+// criticals", never the all-severity total.
+func (c SeverityCounts) HighestCount() int {
+	switch {
+	case c.Critical > 0:
+		return c.Critical
+	case c.High > 0:
+		return c.High
+	case c.Medium > 0:
+		return c.Medium
+	case c.Low > 0:
+		return c.Low
+	default:
+		return 0
+	}
+}
+
 // FindingIndex aggregates findings by resource for O(1) per-row lookup.
 type FindingIndex struct {
 	counts   map[string]SeverityCounts

--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -127,6 +127,27 @@ func (m *Manager) SetMaxFetchConcurrency(n int) {
 	m.maxFetchConcurrency = n
 }
 
+// ScanTimeout returns the hard ceiling on a single coalesced FetchAll scan.
+// Callers align their own context deadline to this so a slow-but-succeeding
+// scan delivers its result to the triggering load instead of orphaning at a
+// shorter caller timeout while the detached scan runs on.
+func (m *Manager) ScanTimeout() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.scanTimeout
+}
+
+// SetScanTimeout overrides the per-scan hard ceiling. Clamped to a positive
+// value; non-positive is ignored so a misconfig can't disable the timeout.
+func (m *Manager) SetScanTimeout(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.scanTimeout = d
+}
+
 // SetAvailabilityTTL overrides the AnyAvailable cache TTL.
 func (m *Manager) SetAvailabilityTTL(d time.Duration) {
 	m.mu.Lock()
@@ -281,11 +302,16 @@ func (m *Manager) FetchAll(ctx context.Context, kubeCtx, namespace string) (Fetc
 	// started it navigates away. Tying the scan to one caller's ctx would
 	// let a preempted caller abort the shared scan and hand every waiter a
 	// premature empty result.
+	// Capture scanTimeout under the lock before the closure: the DoChan
+	// goroutine reads it on a separate goroutine, and SetScanTimeout writes it
+	// under m.mu — reading m.scanTimeout directly inside the closure would be
+	// an unsynchronized read racing that write.
+	scanTimeout := m.ScanTimeout()
 	ch := m.fetchGroup.DoChan(cacheKey, func() (any, error) {
 		if cached, ok := m.cachedFetch(cacheKey); ok {
 			return cached, nil
 		}
-		scanCtx, cancel := context.WithTimeout(context.Background(), m.scanTimeout)
+		scanCtx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 		defer cancel()
 		return m.fetchAllScan(scanCtx, kubeCtx, namespace, cacheKey), nil
 	})

--- a/internal/security/manager_test.go
+++ b/internal/security/manager_test.go
@@ -640,3 +640,18 @@ func TestManagerIgnoredNamespacesFilterDoesNotAliasCachedSlice(t *testing.T) {
 	require.Len(t, cached.Findings, 1, "cache must be insulated from caller mutation")
 	assert.NotEqual(t, "tamper", cached.Findings[0].ID)
 }
+
+// TestScanTimeoutGetterSetter covers the default, override, and no-op clamp
+// for the per-scan timeout knob used by callers to align their own deadline.
+func TestScanTimeoutGetterSetter(t *testing.T) {
+	m := NewManager()
+	assert.Equal(t, 60*time.Second, m.ScanTimeout(), "default scan timeout")
+
+	m.SetScanTimeout(15 * time.Second)
+	assert.Equal(t, 15*time.Second, m.ScanTimeout(), "override takes effect")
+
+	m.SetScanTimeout(0)
+	assert.Equal(t, 15*time.Second, m.ScanTimeout(), "zero is a no-op")
+	m.SetScanTimeout(-1 * time.Second)
+	assert.Equal(t, 15*time.Second, m.ScanTimeout(), "negative is a no-op")
+}

--- a/internal/security/manager_test.go
+++ b/internal/security/manager_test.go
@@ -355,6 +355,25 @@ func TestFindingIndexDedupeKeepsHighestSeverity(t *testing.T) {
 	}
 }
 
+func TestSeverityCountsHighestCount(t *testing.T) {
+	cases := []struct {
+		name   string
+		counts SeverityCounts
+		want   int
+	}{
+		{"empty", SeverityCounts{}, 0},
+		{"critical wins over lower buckets", SeverityCounts{Critical: 3, High: 6, Low: 110}, 3},
+		{"high when no critical", SeverityCounts{High: 5, Medium: 2}, 5},
+		{"medium when only medium and low", SeverityCounts{Medium: 4, Low: 9}, 4},
+		{"low only", SeverityCounts{Low: 7}, 7},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.counts.HighestCount())
+		})
+	}
+}
+
 func TestManagerInvalidateClearsCache(t *testing.T) {
 	m := NewManager()
 	m.SetRefreshTTL(1 * time.Hour)

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 )
 
@@ -604,6 +605,45 @@ func ResolveReadOnly(context string, cliFlag bool) bool {
 		return v
 	}
 	return ConfigReadOnly
+}
+
+// ConfigK8sClientQPS / ConfigK8sClientBurst are the global foreground REST
+// client rate limits. Defaults mirror k8s.DefaultClientQPS/Burst; raising the
+// stock client-go 5/10 keeps foreground lists responsive while background
+// scans run. Per-cluster overrides take precedence.
+var (
+	ConfigK8sClientQPS   = 50
+	ConfigK8sClientBurst = 100
+)
+
+// ConfigClusterK8sClientQPS / ConfigClusterK8sClientBurst map context names to
+// per-cluster overrides of the foreground client rate. A value here wins over
+// the global default for that context.
+var (
+	ConfigClusterK8sClientQPS   = map[string]int{}
+	ConfigClusterK8sClientBurst = map[string]int{}
+)
+
+// init wires the foreground rate resolver into the k8s package so every REST
+// client picks up the configured (or default) QPS/Burst. Set unconditionally
+// at package load; resolution is lazy, so config applied later is honored.
+func init() {
+	k8s.RateLimitForContext = ResolveK8sClientRate
+}
+
+// ResolveK8sClientRate returns the effective foreground QPS/Burst for a
+// context. Precedence: per-cluster override > global > compiled default.
+// Returned as (float32, int) to match rest.Config fields; this is the resolver
+// wired into k8s.RateLimitForContext.
+func ResolveK8sClientRate(context string) (qps float32, burst int) {
+	q, b := ConfigK8sClientQPS, ConfigK8sClientBurst
+	if v, ok := ConfigClusterK8sClientQPS[context]; ok && v > 0 {
+		q = v
+	}
+	if v, ok := ConfigClusterK8sClientBurst[context]; ok && v > 0 {
+		b = v
+	}
+	return float32(q), b
 }
 
 // ConfigSecurityEnabled is the global default for the security dashboard.

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -283,6 +283,8 @@ func applyConfigMaps(cfg configFile, abbr map[string]string) {
 		ConfigClusterReadOnly = make(map[string]bool, len(cfg.Clusters))
 		ConfigClusterSecurityEnabled = make(map[string]bool, len(cfg.Clusters))
 		ConfigClusterSecuritySources = make(map[string]map[string]bool, len(cfg.Clusters))
+		ConfigClusterK8sClientQPS = make(map[string]int, len(cfg.Clusters))
+		ConfigClusterK8sClientBurst = make(map[string]int, len(cfg.Clusters))
 		for ctx, cc := range cfg.Clusters {
 			if len(cc.ResourceColumns) > 0 {
 				cols := make(map[string][]string, len(cc.ResourceColumns))
@@ -293,6 +295,12 @@ func applyConfigMaps(cfg configFile, abbr map[string]string) {
 			}
 			if cc.ReadOnly != nil {
 				ConfigClusterReadOnly[ctx] = *cc.ReadOnly
+			}
+			if cc.K8sClientQPS != nil && *cc.K8sClientQPS > 0 {
+				ConfigClusterK8sClientQPS[ctx] = *cc.K8sClientQPS
+			}
+			if cc.K8sClientBurst != nil && *cc.K8sClientBurst > 0 {
+				ConfigClusterK8sClientBurst[ctx] = *cc.K8sClientBurst
 			}
 			if cc.Security != nil {
 				if cc.Security.Enabled != nil {
@@ -468,14 +476,21 @@ func rightsizingStrategyLiterals() []string {
 // scheduler package-globals consumed by FromGlobals at request time.
 // A nil section is a no-op; zero/negative values are ignored so
 // omitted fields don't clobber the compiled defaults.
-// K8sClientQPS and K8sClientBurst are persisted in the schema but
-// not yet wired to the K8s client; that lands in a follow-up commit.
+// K8sClientQPS and K8sClientBurst set the global foreground REST client rate
+// (per-cluster overrides are applied from the clusters section). The k8s
+// package reads the resolved value through the RateLimitForContext hook wired
+// in this package's init().
 func applySchedulerConfig(s *SchedulerConfig) {
 	if s.WorkersPerContext > 0 {
 		scheduler.ConfigWorkersPerContext = scheduler.ClampWorkers(s.WorkersPerContext)
 	}
 	if s.CriticalReserved > 0 {
 		scheduler.ConfigCriticalReserved = scheduler.ClampCriticalReserved(s.CriticalReserved, scheduler.ClampWorkers(scheduler.ConfigWorkersPerContext))
+	}
+	if s.LowReserved != nil {
+		workers := scheduler.ClampWorkers(scheduler.ConfigWorkersPerContext)
+		crit := scheduler.ClampCriticalReserved(scheduler.ConfigCriticalReserved, workers)
+		scheduler.ConfigLowReserved = scheduler.ClampLowReserved(*s.LowReserved, workers, crit)
 	}
 	if d, err := time.ParseDuration(s.DefaultTimeout); err == nil && d > 0 {
 		scheduler.ConfigDefaultTimeout = d
@@ -500,8 +515,17 @@ func applySchedulerConfig(s *SchedulerConfig) {
 		}
 		scheduler.ConfigTimeoutsByKind = out
 	}
+	if s.K8sClientQPS > 0 {
+		ConfigK8sClientQPS = s.K8sClientQPS
+	}
+	if s.K8sClientBurst > 0 {
+		ConfigK8sClientBurst = s.K8sClientBurst
+	}
 	if s.ShowPriority != nil {
 		scheduler.ConfigShowPriorityInOverlay = *s.ShowPriority
+	}
+	if s.AgingThreshold != nil {
+		scheduler.ConfigAgingThreshold = scheduler.ClampAgingThreshold(*s.AgingThreshold)
 	}
 }
 
@@ -532,6 +556,8 @@ func schedulerKindByName(name string) (scheduler.Kind, bool) {
 		return scheduler.KindNamespaceList, true
 	case "RBACCheck":
 		return scheduler.KindRBACCheck, true
+	case "SecurityScan":
+		return scheduler.KindSecurityScan, true
 	default:
 		return 0, false
 	}

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -110,6 +110,10 @@ type Keybindings struct {
 	// SecurityIgnoreToggle flips the show/hide-ignored-findings state on
 	// the active security view and triggers a refresh.
 	SecurityIgnoreToggle string `json:"security_ignore_toggle" yaml:"security_ignore_toggle"`
+
+	// SecurityBadgeToggle shows/hides the per-resource SEC severity badge on
+	// explorer rows without affecting the Security dashboard or source probing.
+	SecurityBadgeToggle string `json:"security_badge_toggle" yaml:"security_badge_toggle"`
 }
 
 // DefaultKeybindings returns the default keybinding configuration.
@@ -163,6 +167,7 @@ func DefaultKeybindings() Keybindings {
 		ReadOnlyToggle: "ctrl+r",
 
 		SecurityIgnoreToggle: "ctrl+i",
+		SecurityBadgeToggle:  "B",
 
 		// Cluster color picker. Bound to Shift+L because the picker only
 		// exists at Level=Clusters and "L" is otherwise the Logs action

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -244,11 +244,17 @@ func (sets *UnionSetsConfig) UnmarshalJSON(data []byte) error {
 type SchedulerConfig struct {
 	WorkersPerContext int               `json:"workers_per_context" yaml:"workers_per_context"`
 	CriticalReserved  int               `json:"critical_reserved_slots" yaml:"critical_reserved_slots"`
+	LowReserved       *int              `json:"low_reserved_slots" yaml:"low_reserved_slots"`
 	DefaultTimeout    string            `json:"default_timeout" yaml:"default_timeout"`
 	TimeoutsByKind    map[string]string `json:"timeouts_by_kind" yaml:"timeouts_by_kind"`
 	K8sClientQPS      int               `json:"k8s_client_qps" yaml:"k8s_client_qps"`
 	K8sClientBurst    int               `json:"k8s_client_burst" yaml:"k8s_client_burst"`
 	ShowPriority      *bool             `json:"show_priority_in_tasks_overlay" yaml:"show_priority_in_tasks_overlay"`
+	// AgingThreshold bounds priority starvation: a background (Low) task runs
+	// after at most this many higher-priority dispatches. 0 disables aging
+	// (strict priority). Pointer so an explicit 0 is distinguishable from
+	// "omitted". Omitted keeps the compiled default.
+	AgingThreshold *int `json:"aging_threshold" yaml:"aging_threshold"`
 }
 
 // KubesharkConfig is the on-disk schema for the kubeshark section.
@@ -332,6 +338,11 @@ type clusterConfig struct {
 	// kubeconfig credential plugin is noisy, or enabling only specific
 	// sources per cluster.
 	Security *securityConfig `json:"security" yaml:"security"`
+	// K8sClientQPS / K8sClientBurst override the foreground REST client rate
+	// for this context only — e.g. a higher ceiling on a big cluster, or a
+	// lower one on a shared/throttled API server. Omitted = use the global.
+	K8sClientQPS   *int `json:"k8s_client_qps" yaml:"k8s_client_qps"`
+	K8sClientBurst *int `json:"k8s_client_burst" yaml:"k8s_client_burst"`
 }
 
 // securityConfig is the on-disk schema for the global `security` section and

--- a/internal/ui/config_ratelimit_test.go
+++ b/internal/ui/config_ratelimit_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// saveRateGlobals snapshots and restores the package-level rate-limit config so
+// tests don't leak state into each other.
+func saveRateGlobals(t *testing.T) {
+	t.Helper()
+	origQPS, origBurst := ConfigK8sClientQPS, ConfigK8sClientBurst
+	origCQPS, origCBurst := ConfigClusterK8sClientQPS, ConfigClusterK8sClientBurst
+	t.Cleanup(func() {
+		ConfigK8sClientQPS, ConfigK8sClientBurst = origQPS, origBurst
+		ConfigClusterK8sClientQPS, ConfigClusterK8sClientBurst = origCQPS, origCBurst
+	})
+	ConfigK8sClientQPS, ConfigK8sClientBurst = 50, 100
+	ConfigClusterK8sClientQPS = map[string]int{}
+	ConfigClusterK8sClientBurst = map[string]int{}
+}
+
+func TestResolveK8sClientRate(t *testing.T) {
+	t.Run("default global", func(t *testing.T) {
+		saveRateGlobals(t)
+		qps, burst := ResolveK8sClientRate("any")
+		assert.Equal(t, float32(50), qps)
+		assert.Equal(t, 100, burst)
+	})
+
+	t.Run("global override", func(t *testing.T) {
+		saveRateGlobals(t)
+		ConfigK8sClientQPS, ConfigK8sClientBurst = 80, 160
+		qps, burst := ResolveK8sClientRate("any")
+		assert.Equal(t, float32(80), qps)
+		assert.Equal(t, 160, burst)
+	})
+
+	t.Run("per-cluster overrides global", func(t *testing.T) {
+		saveRateGlobals(t)
+		ConfigK8sClientQPS, ConfigK8sClientBurst = 50, 100
+		ConfigClusterK8sClientQPS = map[string]int{"prod": 200}
+		ConfigClusterK8sClientBurst = map[string]int{"prod": 400}
+
+		qps, burst := ResolveK8sClientRate("prod")
+		assert.Equal(t, float32(200), qps, "per-cluster QPS wins over global")
+		assert.Equal(t, 400, burst, "per-cluster Burst wins over global")
+
+		qps, burst = ResolveK8sClientRate("dev")
+		assert.Equal(t, float32(50), qps, "other contexts fall back to global")
+		assert.Equal(t, 100, burst)
+	})
+
+	t.Run("partial per-cluster override keeps global for the other field", func(t *testing.T) {
+		saveRateGlobals(t)
+		ConfigK8sClientQPS, ConfigK8sClientBurst = 50, 100
+		ConfigClusterK8sClientQPS = map[string]int{"prod": 200} // only QPS overridden
+
+		qps, burst := ResolveK8sClientRate("prod")
+		assert.Equal(t, float32(200), qps)
+		assert.Equal(t, 100, burst, "Burst falls back to global when not overridden")
+	})
+}

--- a/internal/ui/explorer_sec_column.go
+++ b/internal/ui/explorer_sec_column.go
@@ -22,6 +22,12 @@ var ActiveSecurityIndex *security.FindingIndex
 // must not be rendered even if an index happens to be populated.
 var ActiveSecurityAvailable bool
 
+// ActiveSecurityBadgesHidden suppresses the SEC row badge when the user has
+// toggled it off (kb.SecurityBadgeToggle). Set from Model.hideSecurityBadges
+// by the app layer each render. Independent of ActiveSecurityAvailable so the
+// Security dashboard and source probing keep working while badges are hidden.
+var ActiveSecurityBadgesHidden bool
+
 // Severity badge symbols (monochrome width = 1 each).
 const (
 	securityBadgeCritical = "\u25cf" // ● filled circle
@@ -31,36 +37,46 @@ const (
 
 // securityBadgeFor returns a styled severity badge for the given resource,
 // or an empty string when idx is nil or the resource has zero findings.
-// The badge format is "<symbol><total>" (e.g. "●3"), with color driven by
-// the highest severity in the bucket.
+// The badge format is "<symbol><worst-count>" (e.g. "●3": 3 criticals), with
+// both glyph and color driven by the highest severity present. Only the
+// worst-severity count is shown — lower-severity findings are surfaced in the
+// Security dashboard, not on the glance-level row badge.
 func securityBadgeFor(idx *security.FindingIndex, ref security.ResourceRef) string {
 	if idx == nil {
 		return ""
 	}
-	counts := idx.For(ref)
-	if counts.Total() == 0 {
-		return ""
-	}
-	sym, style := securityBadgeSymbolStyle(counts.Highest())
-	if sym == "" {
-		return ""
-	}
-	return style.Render(sym + strconv.Itoa(counts.Total()))
+	return securityBadgeStyled(idx.For(ref))
 }
 
-// securityBadgePlain returns the plain (ANSI-free) text that
-// securityBadgeFor would produce for the given counts. Exported only to the
-// package for width math and test assertions.
+// securityBadgeStyled renders the styled badge for the given counts, or an
+// empty string when there are no findings. It is the single styling path
+// shared by the resource-ref and model.Item entry points.
+func securityBadgeStyled(counts security.SeverityCounts) string {
+	plain := securityBadgePlain(counts)
+	if plain == "" {
+		return ""
+	}
+	_, style := securityBadgeSymbolStyle(counts.Highest())
+	return style.Render(plain)
+}
+
+// securityBadgePlain returns the plain (ANSI-free) badge text for the given
+// counts. It is the single source of truth for the badge string used by both
+// the styled renderers and the name-column width math.
+//
+// The badge shows only the worst-severity count (e.g. "●3" = 3 criticals), so
+// a red "●" badge can never be misread as a total across all severities. The
+// full per-tier breakdown lives in the Security dashboard.
 func securityBadgePlain(counts security.SeverityCounts) string {
-	total := counts.Total()
-	if total == 0 {
+	worst := counts.HighestCount()
+	if worst == 0 {
 		return ""
 	}
 	sym, _ := securityBadgeSymbolStyle(counts.Highest())
 	if sym == "" {
 		return ""
 	}
-	return sym + strconv.Itoa(total)
+	return sym + strconv.Itoa(worst)
 }
 
 // securityBadgeSymbolStyle maps a severity to a (symbol, style) pair. The
@@ -102,25 +118,17 @@ func itemSecurityRef(item *model.Item) security.ResourceRef {
 // (which reference the Deployment, not individual Pods) surface on
 // Pod rows too.
 func securityBadgeForItem(item *model.Item) string {
-	if !ActiveSecurityAvailable || ActiveSecurityIndex == nil || item == nil {
+	if ActiveSecurityBadgesHidden || !ActiveSecurityAvailable || ActiveSecurityIndex == nil || item == nil {
 		return ""
 	}
-	counts := itemSecurityCounts(item)
-	if counts.Total() == 0 {
-		return ""
-	}
-	sym, style := securityBadgeSymbolStyle(counts.Highest())
-	if sym == "" {
-		return ""
-	}
-	return style.Render(sym + strconv.Itoa(counts.Total()))
+	return securityBadgeStyled(itemSecurityCounts(item))
 }
 
 // securityBadgePlainForItem returns the plain text badge for an item, used
 // when computing the width budget for the name column so the styled badge
 // slots in alongside the resource name without clipping.
 func securityBadgePlainForItem(item *model.Item) string {
-	if !ActiveSecurityAvailable || ActiveSecurityIndex == nil || item == nil {
+	if ActiveSecurityBadgesHidden || !ActiveSecurityAvailable || ActiveSecurityIndex == nil || item == nil {
 		return ""
 	}
 	counts := itemSecurityCounts(item)

--- a/internal/ui/explorer_sec_column_test.go
+++ b/internal/ui/explorer_sec_column_test.go
@@ -17,12 +17,14 @@ func withIsolatedActiveState(t *testing.T, idx *security.FindingIndex, available
 	t.Helper()
 	origIdx := ActiveSecurityIndex
 	origAvail := ActiveSecurityAvailable
+	origHidden := ActiveSecurityBadgesHidden
 	origQuery := ActiveHighlightQuery
 	origMS := ActiveMiddleScroll
 	origSel := ActiveSelectedItems
 
 	ActiveSecurityIndex = idx
 	ActiveSecurityAvailable = available
+	ActiveSecurityBadgesHidden = false
 	ActiveHighlightQuery = ""
 	ActiveMiddleScroll = -1
 	ActiveSelectedItems = nil
@@ -30,6 +32,7 @@ func withIsolatedActiveState(t *testing.T, idx *security.FindingIndex, available
 	t.Cleanup(func() {
 		ActiveSecurityIndex = origIdx
 		ActiveSecurityAvailable = origAvail
+		ActiveSecurityBadgesHidden = origHidden
 		ActiveHighlightQuery = origQuery
 		ActiveMiddleScroll = origMS
 		ActiveSelectedItems = origSel
@@ -65,11 +68,38 @@ func TestSecurityBadgeForWithFindings(t *testing.T) {
 	got := securityBadgeFor(idx, security.ResourceRef{Namespace: "default", Kind: "Pod", Name: "api"})
 	plain := ansi.Strip(got)
 
+	// 1 Critical (plus 1 High, 1 Low) -> the badge shows only the worst-severity
+	// count so a red badge can never be misread as a multi-severity total.
 	assert.NotEmpty(t, got, "badge must not be empty when findings exist")
 	assert.Contains(t, plain, "\u25cf", "critical badge must use the filled circle symbol")
-	assert.Contains(t, plain, "3", "badge must include the total finding count")
-	assert.Equal(t, StatusFailed.Render("\u25cf3"), got,
-		"critical badge must use StatusFailed style for the red accent")
+	assert.Equal(t, StatusFailed.Render("\u25cf1"), got,
+		"critical badge must show only the critical count in StatusFailed style")
+}
+
+// TestSecurityBadgeForShowsOnlyWorstCount locks the user-facing rule for the
+// case that triggered this change: a resource with a few criticals among many
+// lower-severity findings must badge "\u25cf3" (3 criticals), never "\u25cf119".
+func TestSecurityBadgeForShowsOnlyWorstCount(t *testing.T) {
+	findings := []security.Finding{}
+	ref := security.ResourceRef{Namespace: "argo-cd", Kind: "Pod", Name: "redis"}
+	add := func(sev security.Severity, n int, prefix string) {
+		for i := range n {
+			findings = append(findings, security.Finding{
+				Title:    prefix + string(rune('a'+i)),
+				Severity: sev,
+				Resource: ref,
+			})
+		}
+	}
+	add(security.SeverityCritical, 3, "crit-")
+	add(security.SeverityHigh, 6, "high-")
+	add(security.SeverityLow, 110, "low-")
+
+	idx := buildIndex(t, findings...)
+	plain := ansi.Strip(securityBadgeFor(idx, ref))
+
+	assert.Equal(t, "\u25cf3", plain,
+		"badge must show 3 criticals only, not the 119 all-severity total")
 }
 
 func TestSecurityBadgeForHighUsesOrange(t *testing.T) {
@@ -90,9 +120,8 @@ func TestSecurityBadgeForHighUsesOrange(t *testing.T) {
 	plain := ansi.Strip(got)
 
 	assert.Contains(t, plain, "\u25d0", "high badge must use the half circle symbol")
-	assert.Contains(t, plain, "2", "badge must include the total finding count")
-	assert.Equal(t, DeprecationStyle.Render("\u25d02"), got,
-		"high badge must use DeprecationStyle for the orange accent")
+	assert.Equal(t, DeprecationStyle.Render("\u25d01"), got,
+		"high badge must show only the high count in DeprecationStyle")
 }
 
 func TestSecurityBadgeForMediumUsesProgressing(t *testing.T) {
@@ -195,6 +224,28 @@ func TestRenderTableShowsSecurityBadgeWhenAvailable(t *testing.T) {
 	assert.True(t,
 		strings.Contains(plain, "\u25cf1"),
 		"expected critical badge with count=1 in rendered table, got:\n%s", plain)
+}
+
+func TestRenderTableHidesSecurityBadgeWhenToggledOff(t *testing.T) {
+	idx := buildIndex(t,
+		security.Finding{
+			Severity: security.SeverityCritical,
+			Resource: security.ResourceRef{Namespace: "default", Kind: "Pod", Name: "nginx"},
+		},
+	)
+	// Source available and findings indexed, but the user toggled badges off.
+	withIsolatedActiveState(t, idx, true)
+	ActiveSecurityBadgesHidden = true
+
+	items := []model.Item{
+		{Name: "nginx", Namespace: "default", Kind: "Pod", Status: "Running"},
+	}
+	result := RenderTable("NAME", items, 0, 80, 20, false, "", "")
+	plain := ansi.Strip(result)
+
+	assert.NotContains(t, plain, "●", "badge must be hidden when toggled off")
+	assert.NotContains(t, plain, "◐")
+	assert.NotContains(t, plain, "○")
 }
 
 func TestRenderTableShowsNoBadgeForResourceWithoutFindings(t *testing.T) {

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -112,6 +112,7 @@ func helpSections() []helpSection {
 				{helpKeyDisplay(kb.ClusterColorPicker), "Cluster color picker (cluster picker only): tint title bar + add row swatch; persisted across restarts"},
 				{kb.ThemeSelector, "Switch color scheme (" + kb.NewTab + ": toggle transparent bg)"},
 				{helpKeyDisplay(kb.TerminalToggle), "Cycle terminal mode (pty / exec / mux — mux skipped if no tmux/zellij detected)"},
+				{kb.SecurityBadgeToggle, "Show/hide the per-resource SEC severity badge on explorer rows"},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

A performance-focused PR addressing background-work starvation, redundant API load, and slow security-badge population on slow-responding clusters. Motivated by observing (via the `:scheduler` overlay) that low-priority work piled up and never executed, and that security findings re-scanned from scratch every session.

Five areas:

- **Scheduler — anti-starvation.** Low-reserved worker floor (`scheduler.low_reserved_slots`, default 2) guarantees background work a slot under a saturated pool. Pool size 4 → 8 (`scheduler.workers_per_context`). Anti-starvation aging (`scheduler.aging_threshold`, default 8; Critical never aged; 0 = strict). In-flight coalescing dedups a submission against an identical task already *running*, eliminating duplicate metrics/list fetches and giving watch mode fixed-delay semantics under load.
- **k8s — per-context client cache.** Clients were rebuilt every call (~100µs, ~1844 allocs; benchmarked), discarding connection pooling, resetting the QPS limiter, and re-invoking the exec-credential plugin on EKS. Now memoized per context (foreground + throttled variant), invalidated on `ReloadKubeconfig`, race-tested.
- **Config — client QPS/burst.** Foreground default 50/100 (from 5/10), configurable globally and per-cluster; security clients get a separate 10/20 budget. A real cross-call cap now that clients are cached.
- **Security — background scans.** Finding scans run as low-priority background work (`KindSecurityScan`); SEC badges populate at cluster open without opening the Security category, while first-ever (EKS) clusters stay lazy. `B` toggles the badge; `shift+r` refreshes.
- **Security — findings disk cache (stale-while-revalidate).** A clean scan's findings are persisted per (host, namespace) and seeded into the badge index at cluster open, so reopening paints badges instantly while a fresh scan revalidates. Findings file is `0600`. Caller deadline aligned to the manager's scan timeout (was a hardcoded 30s vs the 60s scan, which orphaned slow-but-succeeding scans).

## Notes for reviewers

- A watch-backpressure gate on total queue depth was tried and **reverted** — it conflated foreground (High) with background (Low) work and suppressed a live refresh while slow Low work drained (a deleted pod lingered; caught by `TestWatchTickRemovesDeletedPodFromList` under `-race`). In-flight coalescing is the correct per-task mechanism.
- The resource-list submission moves Critical → High so it shares the general pool fairly with previews.
- An adversarial review of the findings-cache commit surfaced and fixed: a cross-process temp-file collision (now `os.CreateTemp`, matching `cluster_colors.go`), a `scanTimeout` data race, world-readable findings (`0600`/`0700`), and a stale-while-revalidate seed that was discarded on context-switch-by-click. The cross-process merge lost-update is documented as accepted (best-effort, TTL-bounded).
- **Caveat:** `k8s_client_qps`/`burst` are intra-call until the client cache lands (it does, in this PR). Typed/dynamic clients now cached; impersonation and host lookup still build fresh configs, so the cache leaks no per-call mutation.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...` (19 packages, 0 failures)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New tests: scheduler aging / low-reserve floor / in-flight coalescing (incl. end-to-end starvation repro), per-context client cache (incl. `-race` concurrency), client-build benchmark, security eager-scan + badge toggle, findings disk-cache (round-trip, namespace-keyed, TTL, zero-findings, file perms, persist-clean / skip-partial), ScanTimeout getter/setter
- [ ] **Manual on a real slow / EKS cluster** (not reproducible in CI): low-priority tasks drain rather than pile up; SEC badges populate at cluster open and **persist instantly across restart**; no aws-credential-plugin invocation for clusters never opened in Security