### PR TITLE
fix(app): make filter/search inert in dashboard fullscreen

### DIFF
--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -330,9 +330,17 @@ func (m Model) handleExplorerUIKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		mdl := m.handleKeyHelp()
 		return mdl, nil, true
 	case kb.Filter:
+		// Filter narrows the visible item list; the fullscreen dashboard has no
+		// list to narrow (it scrolls a rendered preview), so swallow the key.
+		if m.fullscreenDashboard {
+			return m, nil, true
+		}
 		mdl := m.handleKeyFilter()
 		return mdl, nil, true
 	case kb.Search:
+		if m.fullscreenDashboard {
+			return m, nil, true
+		}
 		mdl := m.handleKeySearch()
 		return mdl, nil, true
 	case kb.CommandBar:

--- a/internal/app/update_keys_test.go
+++ b/internal/app/update_keys_test.go
@@ -988,6 +988,38 @@ func TestPush4HandleKeyUpFullscreenDashboard(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
+// Filter and Search narrow the visible item list. The fullscreen dashboard has
+// no list to narrow (it scrolls a rendered preview), so these keys must be
+// inert there — matching the hint bar, which already hides them.
+func TestPush4HandleKeyFilterFullscreenDashboardNoOp(t *testing.T) {
+	m := basePush4Model()
+	m.fullscreenDashboard = true
+	kb := ui.ActiveKeybindings
+	result, _ := m.handleKey(keyMsg(kb.Filter))
+	rm := result.(Model)
+	assert.False(t, rm.filterActive, "filter must not activate in fullscreen dashboard")
+	assert.True(t, rm.fullscreenDashboard, "fullscreen dashboard stays on")
+}
+
+func TestPush4HandleKeySearchFullscreenDashboardNoOp(t *testing.T) {
+	m := basePush4Model()
+	m.fullscreenDashboard = true
+	kb := ui.ActiveKeybindings
+	result, _ := m.handleKey(keyMsg(kb.Search))
+	rm := result.(Model)
+	assert.False(t, rm.searchActive, "search must not activate in fullscreen dashboard")
+	assert.True(t, rm.fullscreenDashboard, "fullscreen dashboard stays on")
+}
+
+// Outside the fullscreen dashboard the same keys keep working as before.
+func TestPush4HandleKeyFilterExplorerActivates(t *testing.T) {
+	m := basePush4Model()
+	kb := ui.ActiveKeybindings
+	result, _ := m.handleKey(keyMsg(kb.Filter))
+	rm := result.(Model)
+	assert.True(t, rm.filterActive, "filter activates in the explorer list")
+}
+
 func TestPush4HandleKeyGGFullscreenDashboard(t *testing.T) {
 	m := basePush4Model()
 	m.fullscreenDashboard = true


### PR DESCRIPTION
## Summary

- In the **cluster dashboard fullscreen** view, pressing `f` (filter) and `/` (search) still opened a text-input prompt, even though that view scrolls a rendered preview and has no item list to narrow.
- The hint bar already hid these keys there (the `isDashboard` reduced hint set), but the key handlers in `handleExplorerUIKey` had no `fullscreenDashboard` guard — unlike the navigation keys, which repurpose to scrolling.
- Both keys are now swallowed as a no-op when `fullscreenDashboard` is active, matching the hint bar and the other dashboard-incompatible keys.

The guard keys off `kb.Filter` / `kb.Search` (not the literal `f` / `/`), so it honors custom keybindings.

## Test plan

- [x] New: `TestPush4HandleKeyFilterFullscreenDashboardNoOp` — filter stays inert in fullscreen dashboard
- [x] New: `TestPush4HandleKeySearchFullscreenDashboardNoOp` — search stays inert in fullscreen dashboard
- [x] New: `TestPush4HandleKeyFilterExplorerActivates` — filter still activates normally in the explorer list (regression guard)
- [x] `go build ./...`, `go vet ./internal/app/`, and the full `internal/app` test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)