### PR TITLE
feat(app): wrap application log lines and add events-style cursor navigation

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -730,9 +730,10 @@ Invalid config values are dropped at startup with a warning in the error log.
 | `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `V` | Line visual selection |
-| `v` | Character visual selection |
-| `h` / `l` | Move cursor column left/right (in character visual mode) |
-| `0` / `$` | Move cursor to line start/end (in character visual mode) |
+| `v` | Character visual selection (from cursor column) |
+| `h` / `l` / `Left` / `Right` | Move cursor column left/right |
+| `0` / `$` / `^` | Move cursor to line start / end / first non-whitespace |
+| `w` / `b` / `e` / `W` / `B` / `E` | Word / WORD motions |
 | `y` | Copy selected lines (visual mode) or all entries (normal mode) |
 | `f` | Toggle fullscreen / overlay mode |
 | `d` | Toggle debug log visibility |
@@ -740,6 +741,8 @@ Invalid config values are dropped at startup with a warning in the error log.
 | `q` | Close overlay |
 
 > **Fullscreen mode**: Press `f` to expand the error log to full terminal size. This removes the overlay border, so mouse text selection works cleanly without picking up background characters. Press `f` again to return to overlay mode.
+
+> **Line wrapping**: Long entries wrap onto continuation lines indented under the message column, so the full text stays readable instead of being truncated.
 
 ## Tabs
 

--- a/internal/app/update_overlays_errorlog.go
+++ b/internal/app/update_overlays_errorlog.go
@@ -297,6 +297,9 @@ func (m Model) handleErrorLogOverlayKeyV2() (tea.Model, tea.Cmd) {
 	if m.errorLogVisualMode == 'v' {
 		m.errorLogVisualMode = 0
 	} else {
+		// Clamp first so the selection anchor isn't left past end-of-line by a
+		// prior vertical move onto a shorter line.
+		m.errorLogCursorCol = m.errorLogClampedCursorCol()
 		m.errorLogVisualMode = 'v'
 		m.errorLogVisualStart = m.errorLogCursorLine
 		m.errorLogVisualStartCol = m.errorLogCursorCol
@@ -309,6 +312,10 @@ func (m Model) handleErrorLogOverlayKeyV2() (tea.Model, tea.Cmd) {
 // main key switch can run. Works in both normal and char-visual modes. These
 // motions never emit a command, so only the updated Model is returned.
 func (m Model) errorLogColumnMotion(key string) (Model, bool) {
+	// Clamp a column left over from a vertical move onto a shorter line before
+	// applying the motion. The clamp only sticks when a column key is handled;
+	// for other keys the returned Model is discarded by the caller.
+	m.errorLogCursorCol = m.errorLogClampedCursorCol()
 	switch key {
 	case "h", "left":
 		return m.handleErrorLogOverlayKeyH(), true
@@ -338,6 +345,14 @@ func (m Model) errorLogCurrentLine() string {
 // text, used to clamp horizontal cursor movement.
 func (m Model) errorLogCurrentLineLen() int {
 	return len([]rune(m.errorLogCurrentLine()))
+}
+
+// errorLogClampedCursorCol returns errorLogCursorCol clamped to the current
+// line. A vertical move (j/k) onto a shorter line leaves the column past that
+// line's end; clamping on read keeps horizontal motions and selection anchors
+// valid while preserving the column when moving back onto a longer line.
+func (m Model) errorLogClampedCursorCol() int {
+	return min(m.errorLogCursorCol, max(m.errorLogCurrentLineLen()-1, 0))
 }
 
 // handleErrorLogOverlayWordMotion applies a vim word/WORD motion (w/e/b/W/E/B)

--- a/internal/app/update_overlays_errorlog.go
+++ b/internal/app/update_overlays_errorlog.go
@@ -76,6 +76,12 @@ func (m Model) handleErrorLogOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Cursor-column movement (h/l/0/$/^ and word motions) — extracted to keep
+	// this function under the gocyclo cap.
+	if mdl, handled := m.errorLogColumnMotion(key); handled {
+		return mdl, nil
+	}
+
 	switch key {
 	case "esc", "q":
 		return m.handleErrorLogOverlayKeyEsc()
@@ -88,18 +94,6 @@ func (m Model) handleErrorLogOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "v":
 		return m.handleErrorLogOverlayKeyV2()
-
-	case "h", "left":
-		return m.handleErrorLogOverlayKeyH()
-
-	case "l", "right":
-		return m.handleErrorLogOverlayKeyL()
-
-	case "0":
-		return m.handleErrorLogOverlayKeyZero()
-
-	case "$":
-		return m.handleErrorLogOverlayKeyDollar()
 
 	case "y":
 		m.errorLogLineInput = ""
@@ -310,50 +304,110 @@ func (m Model) handleErrorLogOverlayKeyV2() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handleErrorLogOverlayKeyH() (tea.Model, tea.Cmd) {
+// errorLogColumnMotion dispatches the cursor-column movement keys (h/l/0/$/^
+// and the vim word motions). Returns handled=false for any other key so the
+// main key switch can run. Works in both normal and char-visual modes. These
+// motions never emit a command, so only the updated Model is returned.
+func (m Model) errorLogColumnMotion(key string) (Model, bool) {
+	switch key {
+	case "h", "left":
+		return m.handleErrorLogOverlayKeyH(), true
+	case "l", "right":
+		return m.handleErrorLogOverlayKeyL(), true
+	case "0":
+		return m.handleErrorLogOverlayKeyZero(), true
+	case "$":
+		return m.handleErrorLogOverlayKeyDollar(), true
+	case "w", "e", "b", "W", "E", "B", "^":
+		return m.handleErrorLogOverlayWordMotion(key), true
+	}
+	return m, false
+}
+
+// errorLogCurrentLine returns the cursor entry's plain text (the basis for
+// horizontal cursor movement and word motions), or "" when out of range.
+func (m Model) errorLogCurrentLine() string {
+	reversed := ui.FilteredErrorLogEntries(m.errorLog, m.showDebugLogs)
+	if m.errorLogCursorLine < 0 || m.errorLogCursorLine >= len(reversed) {
+		return ""
+	}
+	return ui.ErrorLogEntryPlainText(reversed[m.errorLogCursorLine])
+}
+
+// errorLogCurrentLineLen returns the rune length of the cursor entry's plain
+// text, used to clamp horizontal cursor movement.
+func (m Model) errorLogCurrentLineLen() int {
+	return len([]rune(m.errorLogCurrentLine()))
+}
+
+// handleErrorLogOverlayWordMotion applies a vim word/WORD motion (w/e/b/W/E/B)
+// or ^ to the cursor column, reusing the shared motion helpers (update_vim.go).
+// Works in both normal and char-visual modes — char-visual additionally
+// extends the selection to the new column. Results are clamped to the line so
+// the cursor stays on a real character (matching the clamped h/l behaviour).
+func (m Model) handleErrorLogOverlayWordMotion(key string) Model {
 	m.errorLogLineInput = ""
-	if m.errorLogVisualMode == 'v' && m.errorLogCursorCol > 0 {
+	line := m.errorLogCurrentLine()
+	if line == "" {
+		return m
+	}
+	maxCol := len([]rune(line)) - 1
+	switch key {
+	case "^":
+		m.errorLogCursorCol = firstNonWhitespace(line)
+	case "w":
+		m.errorLogCursorCol = min(nextWordStart(line, m.errorLogCursorCol), maxCol)
+	case "W":
+		m.errorLogCursorCol = min(nextWORDStart(line, m.errorLogCursorCol), maxCol)
+	case "e":
+		m.errorLogCursorCol = min(wordEnd(line, m.errorLogCursorCol), maxCol)
+	case "E":
+		m.errorLogCursorCol = min(WORDEnd(line, m.errorLogCursorCol), maxCol)
+	case "b":
+		if nc := prevWordStart(line, m.errorLogCursorCol); nc >= 0 {
+			m.errorLogCursorCol = nc
+		}
+	case "B":
+		if nc := prevWORDStart(line, m.errorLogCursorCol); nc >= 0 {
+			m.errorLogCursorCol = nc
+		}
+	}
+	return m
+}
+
+// h/l/0/$ move the cursor column in both normal and char-visual modes (the
+// cursor line carries a block cursor in normal mode, matching the event
+// viewer); char-visual additionally extends the selection to that column.
+// These never emit a command, so they return the updated Model directly.
+func (m Model) handleErrorLogOverlayKeyH() Model {
+	m.errorLogLineInput = ""
+	if m.errorLogCursorCol > 0 {
 		m.errorLogCursorCol--
 	}
-	return m, nil
+	return m
 }
 
-func (m Model) handleErrorLogOverlayKeyL() (tea.Model, tea.Cmd) {
+func (m Model) handleErrorLogOverlayKeyL() Model {
 	m.errorLogLineInput = ""
-	if m.errorLogVisualMode == 'v' {
-		// Clamp to line length.
-		reversed := ui.FilteredErrorLogEntries(m.errorLog, m.showDebugLogs)
-		if m.errorLogCursorLine < len(reversed) {
-			lineLen := len([]rune(ui.ErrorLogEntryPlainText(reversed[m.errorLogCursorLine])))
-			if m.errorLogCursorCol < lineLen-1 {
-				m.errorLogCursorCol++
-			}
-		}
+	if m.errorLogCursorCol < m.errorLogCurrentLineLen()-1 {
+		m.errorLogCursorCol++
 	}
-	return m, nil
+	return m
 }
 
-func (m Model) handleErrorLogOverlayKeyZero() (tea.Model, tea.Cmd) {
+func (m Model) handleErrorLogOverlayKeyZero() Model {
 	if m.errorLogLineInput != "" {
 		m.errorLogLineInput += "0"
-		return m, nil
+		return m
 	}
-	if m.errorLogVisualMode == 'v' {
-		m.errorLogCursorCol = 0
-	}
-	return m, nil
+	m.errorLogCursorCol = 0
+	return m
 }
 
-func (m Model) handleErrorLogOverlayKeyDollar() (tea.Model, tea.Cmd) {
+func (m Model) handleErrorLogOverlayKeyDollar() Model {
 	m.errorLogLineInput = ""
-	if m.errorLogVisualMode == 'v' {
-		reversed := ui.FilteredErrorLogEntries(m.errorLog, m.showDebugLogs)
-		if m.errorLogCursorLine < len(reversed) {
-			lineLen := len([]rune(ui.ErrorLogEntryPlainText(reversed[m.errorLogCursorLine])))
-			m.errorLogCursorCol = max(lineLen-1, 0)
-		}
-	}
-	return m, nil
+	m.errorLogCursorCol = max(m.errorLogCurrentLineLen()-1, 0)
+	return m
 }
 
 func (m Model) handleErrorLogOverlayKeyD() (tea.Model, tea.Cmd) {

--- a/internal/app/update_overlays_errorlog_cursor_test.go
+++ b/internal/app/update_overlays_errorlog_cursor_test.go
@@ -185,3 +185,39 @@ func TestErrorLogWordMotionInNormalMode(t *testing.T) {
 		assert.Equal(t, 3, col(res))
 	})
 }
+
+// A vertical move (j/k) onto a shorter line leaves errorLogCursorCol past that
+// line's end; column motions and visual-entry must clamp it on read so the
+// cursor stays on a real character (CodeRabbit #325 follow-up).
+func TestErrorLogCursorColClampedOnShorterLine(t *testing.T) {
+	entries := []ui.ErrorLogEntry{{Level: "ERR", Message: "hi"}}  // short line
+	lineLen := len([]rune(ui.ErrorLogEntryPlainText(entries[0]))) // "00:00:00 ERR hi"
+	overflow := lineLen + 50
+
+	t.Run("h clamps before moving", func(t *testing.T) {
+		m := Model{overlayErrorLog: true, errorLog: entries, errorLogCursorCol: overflow}
+		mdl, handled := m.errorLogColumnMotion("h")
+		assert.True(t, handled)
+		assert.Equal(t, lineLen-2, mdl.errorLogCursorCol) // clamped to lineLen-1, then h
+	})
+
+	t.Run("l clamps and stays at end", func(t *testing.T) {
+		m := Model{overlayErrorLog: true, errorLog: entries, errorLogCursorCol: overflow}
+		mdl, _ := m.errorLogColumnMotion("l")
+		assert.Equal(t, lineLen-1, mdl.errorLogCursorCol)
+	})
+
+	t.Run("w clamps before motion", func(t *testing.T) {
+		m := Model{overlayErrorLog: true, errorLog: entries, errorLogCursorCol: overflow}
+		mdl, _ := m.errorLogColumnMotion("w")
+		assert.LessOrEqual(t, mdl.errorLogCursorCol, lineLen-1)
+	})
+
+	t.Run("entering char-visual clamps the anchor", func(t *testing.T) {
+		m := Model{overlayErrorLog: true, errorLog: entries, errorLogCursorCol: overflow}
+		res, _ := m.handleErrorLogOverlayKeyV2()
+		rm := res.(Model)
+		assert.Equal(t, lineLen-1, rm.errorLogVisualStartCol)
+		assert.Equal(t, lineLen-1, rm.errorLogCursorCol)
+	})
+}

--- a/internal/app/update_overlays_errorlog_cursor_test.go
+++ b/internal/app/update_overlays_errorlog_cursor_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/janosmiko/lfk/internal/ui"
 	"github.com/stretchr/testify/assert"
 )
@@ -85,5 +86,102 @@ func TestErrorLogDebugTogglePreservesCursor(t *testing.T) {
 		result := ret.(Model)
 		assert.Equal(t, 0, result.errorLogCursorLine)
 		assert.Equal(t, 0, result.errorLogScroll)
+	})
+}
+
+// The cursor column must be movable in NORMAL mode (not only char-visual),
+// matching the event viewer — the block cursor on the cursor line moves with
+// h/l/0/$ without first pressing v.
+func TestErrorLogHorizontalCursorInNormalMode(t *testing.T) {
+	entries := []ui.ErrorLogEntry{
+		{Level: "ERR", Message: "hello world"},
+	}
+	lineLen := len([]rune(ui.ErrorLogEntryPlainText(entries[0]))) // "HH:MM:SS ERR hello world"
+	base := func() Model {
+		return Model{overlayErrorLog: true, errorLog: entries}
+	}
+
+	t.Run("l moves right in normal mode", func(t *testing.T) {
+		m := base()
+		assert.Equal(t, 1, m.handleErrorLogOverlayKeyL().errorLogCursorCol)
+	})
+
+	t.Run("h moves left in normal mode", func(t *testing.T) {
+		m := base()
+		m.errorLogCursorCol = 3
+		assert.Equal(t, 2, m.handleErrorLogOverlayKeyH().errorLogCursorCol)
+	})
+
+	t.Run("h clamps at column 0", func(t *testing.T) {
+		m := base()
+		assert.Equal(t, 0, m.handleErrorLogOverlayKeyH().errorLogCursorCol)
+	})
+
+	t.Run("l clamps at line end", func(t *testing.T) {
+		m := base()
+		m.errorLogCursorCol = lineLen - 1
+		assert.Equal(t, lineLen-1, m.handleErrorLogOverlayKeyL().errorLogCursorCol)
+	})
+
+	t.Run("0 jumps to start in normal mode", func(t *testing.T) {
+		m := base()
+		m.errorLogCursorCol = 5
+		assert.Equal(t, 0, m.handleErrorLogOverlayKeyZero().errorLogCursorCol)
+	})
+
+	t.Run("dollar jumps to end in normal mode", func(t *testing.T) {
+		m := base()
+		assert.Equal(t, lineLen-1, m.handleErrorLogOverlayKeyDollar().errorLogCursorCol)
+	})
+
+	t.Run("0 with pending line input appends digit instead of moving", func(t *testing.T) {
+		m := base()
+		m.errorLogLineInput = "1"
+		res := m.handleErrorLogOverlayKeyZero()
+		assert.Equal(t, "10", res.errorLogLineInput)
+		assert.Equal(t, 0, res.errorLogCursorCol)
+	})
+}
+
+// Word/WORD motions (w/e/b/W/E/B/^) must move the cursor column in normal mode,
+// matching the event viewer. Plain text for a zero-time ERR entry is
+// "00:00:00 ERR the quick brown".
+func TestErrorLogWordMotionInNormalMode(t *testing.T) {
+	entries := []ui.ErrorLogEntry{{Level: "ERR", Message: "the quick brown"}}
+	at := func(col int) Model {
+		return Model{overlayErrorLog: true, errorLog: entries, errorLogCursorCol: col}
+	}
+	col := func(m tea.Model) int { return m.(Model).errorLogCursorCol }
+
+	tests := []struct {
+		name    string
+		key     string
+		startAt int
+		want    int
+	}{
+		{"w advances to next word start", "w", 0, 3},
+		{"W advances to next WORD start (whitespace-delimited)", "W", 0, 9},
+		{"e moves to word end", "e", 0, 1},
+		{"E moves to WORD end", "E", 0, 7},
+		{"b moves to previous word start", "b", 13, 9},
+		{"B moves to previous WORD start", "B", 13, 9},
+		{"^ moves to first non-whitespace", "^", 13, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := at(tc.startAt)
+			assert.Equal(t, tc.want, col(m.handleErrorLogOverlayWordMotion(tc.key)))
+		})
+	}
+
+	t.Run("motion clamps within the line", func(t *testing.T) {
+		m := at(25) // near "brown"
+		assert.LessOrEqual(t, col(m.handleErrorLogOverlayWordMotion("w")), len([]rune(ui.ErrorLogEntryPlainText(entries[0])))-1)
+	})
+
+	t.Run("word motion routes through the overlay key dispatch", func(t *testing.T) {
+		m := at(0)
+		res, _ := m.handleErrorLogOverlayKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("w")})
+		assert.Equal(t, 3, col(res))
 	})
 }

--- a/internal/app/view_dashboard.go
+++ b/internal/app/view_dashboard.go
@@ -117,7 +117,7 @@ func (m Model) viewErrorLogFullscreen(contentHeight int) string {
 	}
 	fullW := m.width - 2
 	innerW := max(fullW-2, 1) // minus column padding
-	content := ui.RenderErrorLogOverlay(m.errorLog, m.errorLogScroll, contentHeight, m.showDebugLogs, vp)
+	content := ui.RenderErrorLogOverlay(m.errorLog, m.errorLogScroll, innerW, contentHeight, m.showDebugLogs, vp)
 	content = clampErrorLogLines(content, innerW, contentHeight)
 	content = ui.PadToHeight(content, contentHeight)
 	content = ui.FillLinesBg(content, innerW, ui.BaseBg)

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -771,7 +771,7 @@ func (m Model) renderErrorLogOverlay(background string) string {
 	if innerH < 1 {
 		innerH = 1
 	}
-	content := ui.RenderErrorLogOverlay(m.errorLog, m.errorLogScroll, innerH, m.showDebugLogs, vp)
+	content := ui.RenderErrorLogOverlay(m.errorLog, m.errorLogScroll, innerW, innerH, m.showDebugLogs, vp)
 	content = clampErrorLogLines(content, innerW, innerH)
 	content = ui.FillLinesBg(content, innerW, ui.SurfaceBg)
 	overlay := ui.OverlayStyle.Width(overlayW).Height(overlayH).Render(content)
@@ -779,11 +779,12 @@ func (m Model) renderErrorLogOverlay(background string) string {
 	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
 }
 
-// clampErrorLogLines truncates each line of content to maxW visual columns
-// and caps the total line count at maxH. Lines that exceed maxW are cut with
-// a trailing "~" marker via ui.Truncate; extra lines beyond maxH are dropped.
-// This prevents long error messages from wrapping and pushing the overlay
-// past its allocated height.
+// clampErrorLogLines is a defensive safety net that caps the total line count
+// at maxH and each line at maxW visual columns (cutting overflow with a
+// trailing "~" via ui.Truncate). RenderErrorLogOverlay already wraps messages
+// to width and paginates by physical line to fit its viewport, so with
+// wrapping enabled this is ordinarily a no-op — it only fires for edge cases
+// such as wide (CJK) runes whose visual width exceeds their rune count.
 func clampErrorLogLines(content string, maxW, maxH int) string {
 	lines := strings.Split(content, "\n")
 	if len(lines) > maxH {

--- a/internal/ui/overlay_monitoring.go
+++ b/internal/ui/overlay_monitoring.go
@@ -65,9 +65,13 @@ func FilteredErrorLogEntries(entries []ErrorLogEntry, showDebug bool) []ErrorLog
 	return reversed
 }
 
-// ErrorLogEntryPlainText returns a plain text representation of a log entry for clipboard.
+// ErrorLogEntryPlainText returns a plain text representation of a log entry,
+// used for clipboard yank, char-selection column math, and visual-mode
+// rendering. The layout (no brackets around the level) matches the styled
+// non-visual row so selecting a log does not shift the text or wrap the
+// severity in brackets — what is shown selected is what gets copied.
 func ErrorLogEntryPlainText(e ErrorLogEntry) string {
-	return fmt.Sprintf("%s [%s] %s", e.Time.Format("15:04:05"), e.Level, e.Message)
+	return fmt.Sprintf("%s %s %s", e.Time.Format("15:04:05"), e.Level, e.Message)
 }
 
 // errorLogLevelPalette returns the (foreground hex, bold) pair for a given
@@ -85,46 +89,160 @@ func errorLogLevelPalette(level string) (color, label string, bold bool) {
 	}
 }
 
-// renderErrorLogLine formats a single error-log row: indicator + timestamp +
-// styled level + message. When cursorBg is true, every segment inherits the
-// cursor-line background so the level fg color stays visible while the row
-// is highlighted. Non-cursor segments deliberately omit a background so the
-// caller's FillLinesBg pass paints whichever bg fits the surrounding box
-// (SurfaceBg in overlay mode, BaseBg in fullscreen).
-func renderErrorLogLine(entry ErrorLogEntry, cursorBg bool) string {
-	color, label, bold := errorLogLevelPalette(entry.Level)
+// errorLogGutterWidth is the width of the leading line marker prepended to
+// every row: a "▎" bar on the cursor line, a space otherwise.
+const errorLogGutterWidth = 1
 
-	if cursorBg {
-		base := lipgloss.NewStyle().Background(BaseBg).Bold(true)
-		lvlStyle := lipgloss.NewStyle().Inherit(base).Foreground(ThemeColor(color))
-		if bold {
-			lvlStyle = lvlStyle.Bold(true)
-		}
-		ts := base.Render(entry.Time.Format("15:04:05"))
-		lvl := lvlStyle.Render(label)
-		msg := base.Render(entry.Message)
-		sep := base.Render(" ")
-		return base.Render(">") + sep + ts + sep + lvl + sep + msg
+// errorLogMsgColumn is the column where the message starts WITHIN a row's
+// content (after the gutter): "15:04:05" (8) + " " + "LVL" (3) + " " = 13.
+// Continuation lines produced by wrapping are indented this far so wrapped
+// text stays under the message column. The on-screen message column is
+// errorLogGutterWidth + errorLogMsgColumn (the gutter sits to its left).
+const errorLogMsgColumn = 13
+
+// errorLogGutter returns the 1-column line marker prepended to every physical
+// sub-line: a primary-colored "▎" on the cursor line (matching the event
+// viewer's YamlCursorIndicatorStyle gutter), a plain space otherwise. The
+// marker is independent of selection state, so it stays visible in visual mode.
+func errorLogGutter(isCursor bool) string {
+	if isCursor {
+		return YamlCursorIndicatorStyle.Render("▎")
 	}
+	return " "
+}
 
-	// Strip the surfaceBg the theme bakes into OverlayDimStyle and
-	// OverlayNormalStyle so FillLinesBg can paint whichever bg fits
-	// the surrounding box (SurfaceBg in the overlay form, BaseBg in
-	// the fullscreen form). Otherwise the inner segments keep
-	// SurfaceBg and clash with a BaseBg-filled fullscreen frame.
+// errorLogIndent returns an indent string of col spaces, clamped so it never
+// consumes the whole content width (leaving at least one column for text at
+// pathologically narrow widths). Mirrors wrappedEventChunks' indent clamp.
+func errorLogIndent(col, contentW int) string {
+	if col > contentW-1 {
+		col = max(contentW-1, 0)
+	}
+	return strings.Repeat(" ", col)
+}
+
+// renderErrorLogContent builds the colored content sub-lines for an entry —
+// timestamp + styled level + wrapped message — WITHOUT the leading gutter or
+// any cursor decoration. The caller prepends the gutter (and a block cursor on
+// the cursor line). contentW is the width available after the gutter;
+// continuation lines are indented to errorLogMsgColumn so wrapped text stays
+// under the message column. Reuses WrapEventLine (the "other overlay" wrap
+// primitive) with a zero hanging indent.
+//
+// The inner segment styles drop their baked-in background so the caller's
+// FillLinesBg pass paints whichever bg fits the surrounding box (SurfaceBg in
+// the overlay form, BaseBg in fullscreen).
+func renderErrorLogContent(entry ErrorLogEntry, contentW int) []string {
+	color, label, bold := errorLogLevelPalette(entry.Level)
+	chunks := WrapEventLine(entry.Message, max(contentW-errorLogMsgColumn, 1), 0)
+	indent := errorLogIndent(errorLogMsgColumn, contentW)
+
 	ts := OverlayDimStyle.UnsetBackground().Render(entry.Time.Format("15:04:05"))
 	lvlStyle := lipgloss.NewStyle().Foreground(ThemeColor(color))
 	if bold {
 		lvlStyle = lvlStyle.Bold(true)
 	}
 	lvl := lvlStyle.Render(label)
-	return fmt.Sprintf("  %s %s %s", ts, lvl, OverlayNormalStyle.UnsetBackground().Render(entry.Message))
+	msgStyle := OverlayNormalStyle.UnsetBackground()
+
+	lines := make([]string, 0, len(chunks))
+	lines = append(lines, fmt.Sprintf("%s %s %s", ts, lvl, msgStyle.Render(chunks[0])))
+	for _, c := range chunks[1:] {
+		lines = append(lines, indent+msgStyle.Render(c))
+	}
+	return lines
+}
+
+// errorLogVisualWrap splits the plain text used for visual-mode rendering into
+// the first physical sub-line and message continuation chunks aligned under the
+// message column. contentW is the width available after the gutter. Returns
+// (plainText, nil) when the entry fits on a single line, so short entries
+// render identically to the non-wrap behaviour.
+func errorLogVisualWrap(plainText string, contentW int) (first string, cont []string) {
+	firstWidth := max(contentW, 1)
+	runes := []rune(plainText)
+	if len(runes) <= firstWidth {
+		return plainText, nil
+	}
+	first = string(runes[:firstWidth])
+	contWidth := max(contentW-errorLogMsgColumn, 1)
+	for start := firstWidth; start < len(runes); start += contWidth {
+		end := min(start+contWidth, len(runes))
+		cont = append(cont, string(runes[start:end]))
+	}
+	return first, cont
+}
+
+// renderErrorLogSelectionContent builds the selection-highlighted content
+// sub-lines for an entry (no gutter). Line ('V') mode highlights every
+// sub-line; char ('v') mode applies the column-range highlight to the first
+// sub-line only and renders continuation sub-lines as plain wrapped text —
+// matching the event viewer convention (RenderWrappedEventRow), where char
+// selection does not span wrapped lines.
+func renderErrorLogSelectionContent(plainText string, contentW int, vp ErrorLogVisualParams, lineIdx, selStart, selEnd, colStart, colEnd int) []string {
+	first, cont := errorLogVisualWrap(plainText, contentW)
+	indent := errorLogIndent(errorLogMsgColumn, contentW)
+
+	lines := make([]string, 0, 1+len(cont))
+	lines = append(lines, RenderVisualSelection(
+		first, rune(vp.VisualMode),
+		lineIdx, selStart, selEnd,
+		vp.VisualStart, vp.VisualStartCol, vp.CursorCol,
+		colStart, colEnd,
+	))
+	for _, c := range cont {
+		if vp.VisualMode == 'V' {
+			lines = append(lines, indent+SelectedStyle.Render(c))
+		} else {
+			lines = append(lines, indent+OverlayNormalStyle.UnsetBackground().Render(c))
+		}
+	}
+	return lines
+}
+
+// errorLogEntryLines returns the number of physical sub-lines an entry renders
+// to, where contentW is the width available after the gutter. Used to
+// reconcile the key handler's logical-entry scroll with the renderer's
+// physical-line pagination.
+func errorLogEntryLines(entry ErrorLogEntry, contentW int, inSelection bool) int {
+	if inSelection {
+		_, cont := errorLogVisualWrap(ErrorLogEntryPlainText(entry), contentW)
+		return 1 + len(cont)
+	}
+	return len(WrapEventLine(entry.Message, max(contentW-errorLogMsgColumn, 1), 0))
+}
+
+// errorLogStartForCursor returns the scroll (start entry index) that keeps the
+// cursor entry's first sub-line within maxVisible physical lines. The incoming
+// scroll is honoured when it already shows the cursor; otherwise it is clamped
+// into the visible range. This reconciles the key handler's logical-entry
+// scroll model with the renderer's physical-line pagination, so the cursor is
+// never drawn off-screen whether or not entries wrap.
+func errorLogStartForCursor(reversed []ErrorLogEntry, scroll, cursor, maxVisible, contentW int, vp ErrorLogVisualParams, selStart, selEnd int) int {
+	inSel := func(i int) bool { return vp.VisualMode != 0 && i >= selStart && i <= selEnd }
+	// Walk back from the cursor accumulating physical lines until the next
+	// entry above would no longer fit; minStart is the earliest start that
+	// still keeps the cursor's first sub-line on screen.
+	minStart := cursor
+	used := 1 // the cursor entry's first sub-line
+	for s := cursor - 1; s >= 0; s-- {
+		used += errorLogEntryLines(reversed[s], contentW, inSel(s))
+		if used > maxVisible {
+			break
+		}
+		minStart = s
+	}
+	return max(min(scroll, cursor), minStart)
 }
 
 // RenderErrorLogOverlay renders the application log overlay showing timestamped
-// log entries with level indicators. The scroll parameter controls which portion is visible.
-// When showDebug is false, DBG entries are filtered out.
-func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll int, height int, showDebug bool, vp ErrorLogVisualParams) string {
+// log entries with level indicators. Long messages are wrapped to width so they
+// stay readable instead of being truncated. The scroll parameter (in logical
+// entry units, matching the key handler) is honoured when it keeps the cursor
+// visible; pagination is by physical line and the start index is adjusted so a
+// wrapped entry never pushes the cursor (or the footer) off the viewport. When
+// showDebug is false, DBG entries are filtered out.
+func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll, width, height int, showDebug bool, vp ErrorLogVisualParams) string {
 	// Use bg-stripped variants of the overlay styles so the caller's
 	// FillLinesBg pass paints whichever bg fits the surrounding box —
 	// SurfaceBg for the bordered overlay form, BaseBg when this same
@@ -149,12 +267,8 @@ func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll int, height int, show
 
 	// Reserve lines for the title (1), blank line before footer (1), footer (1), and border padding.
 	maxVisible := max(height-4, 1)
-
-	// Clamp scroll.
-	maxScroll := max(len(reversed)-maxVisible, 0)
-	scroll = max(min(scroll, maxScroll), 0)
-
-	end := min(scroll+maxVisible, len(reversed))
+	// Content width is the line width minus the 1-column gutter (line marker).
+	contentW := max(width-errorLogGutterWidth, 1)
 
 	// Visual selection range.
 	selStart := min(vp.VisualStart, vp.CursorLine)
@@ -162,47 +276,39 @@ func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll int, height int, show
 	colStart := min(vp.VisualStartCol, vp.CursorCol)
 	colEnd := max(vp.VisualStartCol, vp.CursorCol)
 
-	for i := scroll; i < end; i++ {
-		entry := reversed[i]
-		plainText := ErrorLogEntryPlainText(entry)
+	// Resolve the start index so the cursor entry is always visible. The key
+	// handler tracks scroll in logical-entry units and is wrap-unaware; here
+	// we paginate by physical line, so a literal entry-based scroll could
+	// leave the cursor (and the footer) off-screen when entries wrap.
+	cursor := max(min(vp.CursorLine, len(reversed)-1), 0)
+	scroll = errorLogStartForCursor(reversed, max(scroll, 0), cursor, maxVisible, contentW, vp, selStart, selEnd)
 
-		// Check if this line is in visual selection.
-		inSelection := vp.VisualMode != 0 && i >= selStart && i <= selEnd
-		isCursorLine := i == vp.CursorLine
-
-		if inSelection {
-			// Render with visual selection highlighting.
-			rendered := RenderVisualSelection(
-				plainText, rune(vp.VisualMode),
-				i, selStart, selEnd,
-				vp.VisualStart, vp.VisualStartCol, vp.CursorCol,
-				colStart, colEnd,
-			)
-			b.WriteString("  " + rendered)
-		} else if isCursorLine && vp.VisualMode == 0 {
-			// Cursor line indicator (outside visual mode). Preserve the
-			// level fg color by composing per-segment styles that inherit
-			// the cursor-line bg, so red/orange ERR/WRN markers stay
-			// visible when the user navigates through the overlay.
-			b.WriteString(renderErrorLogLine(entry, true))
-		} else {
-			b.WriteString(renderErrorLogLine(entry, false))
+	// Paginate by physical line: a wrapped entry expands to several sub-lines,
+	// so counting logical entries would emit more rows than maxVisible and
+	// push the footer (and the overlay border) out of view.
+	physical := make([]string, 0, maxVisible)
+	end := scroll
+	for i := scroll; i < len(reversed) && len(physical) < maxVisible; i++ {
+		for sub := range strings.SplitSeq(renderErrorLogEntry(reversed[i], contentW, vp, i, selStart, selEnd, colStart, colEnd), "\n") {
+			if len(physical) >= maxVisible {
+				break
+			}
+			physical = append(physical, sub)
 		}
-		if i < end-1 {
-			b.WriteString("\n")
-		}
+		end = i + 1
 	}
+	b.WriteString(strings.Join(physical, "\n"))
 
 	b.WriteString("\n\n")
 
-	// Filter count for footer.
+	// Filter count + cursor position for footer.
 	visibleCount := len(reversed)
 	scrollInfo := fmt.Sprintf("%d entries", visibleCount)
 	if visibleCount != len(entries) {
 		scrollInfo += fmt.Sprintf(" (%d hidden)", len(entries)-visibleCount)
 	}
-	if maxScroll > 0 {
-		scrollInfo += fmt.Sprintf(" | scroll %d/%d", scroll+1, maxScroll+1)
+	if scroll > 0 || end < visibleCount {
+		scrollInfo += fmt.Sprintf(" | line %d/%d", cursor+1, visibleCount)
 	}
 	if vp.VisualMode != 0 {
 		modeLabel := "VISUAL LINE"
@@ -213,6 +319,37 @@ func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll int, height int, show
 	}
 	b.WriteString(dimStyle.Render(scrollInfo))
 
+	return b.String()
+}
+
+// renderErrorLogEntry renders one entry into its (possibly multi-line) block.
+// Every physical sub-line is prefixed with the gutter (line marker) so the
+// cursor line is flagged consistently in all modes — matching the event
+// viewer. The cursor line also carries a reverse-video block cursor on its
+// first sub-line when not selecting; during selection the highlight stands in
+// for it. contentW is the width available after the gutter.
+func renderErrorLogEntry(entry ErrorLogEntry, contentW int, vp ErrorLogVisualParams, i, selStart, selEnd, colStart, colEnd int) string {
+	isCursor := i == vp.CursorLine
+	inSelection := vp.VisualMode != 0 && i >= selStart && i <= selEnd
+
+	var lines []string
+	if inSelection {
+		lines = renderErrorLogSelectionContent(ErrorLogEntryPlainText(entry), contentW, vp, i, selStart, selEnd, colStart, colEnd)
+	} else {
+		lines = renderErrorLogContent(entry, contentW)
+		if isCursor && len(lines) > 0 {
+			lines[0] = RenderCursorAtCol(lines[0], "", vp.CursorCol)
+		}
+	}
+
+	gutter := errorLogGutter(isCursor)
+	var b strings.Builder
+	for k, ln := range lines {
+		if k > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(gutter + ln)
+	}
 	return b.String()
 }
 

--- a/internal/ui/overlay_monitoring.go
+++ b/internal/ui/overlay_monitoring.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // overlaySchemeScroll is the persistent scroll position for the colorscheme overlay.
@@ -338,7 +339,11 @@ func renderErrorLogEntry(entry ErrorLogEntry, contentW int, vp ErrorLogVisualPar
 	} else {
 		lines = renderErrorLogContent(entry, contentW)
 		if isCursor && len(lines) > 0 {
-			lines[0] = RenderCursorAtCol(lines[0], "", vp.CursorCol)
+			// Clamp the block cursor to the last real character so a column
+			// left over from a vertical move onto a shorter line lands on the
+			// text rather than parking in the padding past end-of-line.
+			col := min(vp.CursorCol, max(ansi.StringWidth(lines[0])-1, 0))
+			lines[0] = RenderCursorAtCol(lines[0], "", col)
 		}
 	}
 

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -191,6 +191,13 @@ func TestRenderErrorLogOverlay_BlockCursorTracksColumnInNormalMode(t *testing.T)
 	assert.Contains(t, at0, "\x1b[7m", "normal-mode cursor line should carry a reverse-video block cursor")
 	// ...and it moves with the cursor column without entering visual mode.
 	assert.NotEqual(t, at0, at5, "block cursor position should change with CursorCol")
+
+	// A column left over from a vertical move onto a shorter line is clamped to
+	// the last character, so the block cursor never parks past end-of-line.
+	msgW := len([]rune("10:00:00 ERR abcdefgh")) // content (after gutter) width
+	atEnd := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{CursorLine: 0, CursorCol: msgW - 1})
+	atOver := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{CursorLine: 0, CursorCol: 1000})
+	assert.Equal(t, atEnd, atOver, "an out-of-range cursor column should clamp to the last character")
 }
 
 // uniqueLongMessage returns a 120-character message whose every substring is

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +16,7 @@ import (
 
 func TestRenderErrorLogOverlay(t *testing.T) {
 	t.Run("empty entries", func(t *testing.T) {
-		result := RenderErrorLogOverlay(nil, 0, 20, false, ErrorLogVisualParams{})
+		result := RenderErrorLogOverlay(nil, 0, 80, 20, false, ErrorLogVisualParams{})
 		assert.Contains(t, result, "No log entries")
 	})
 
@@ -23,7 +26,7 @@ func TestRenderErrorLogOverlay(t *testing.T) {
 			{Time: time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC), Message: "second warning", Level: "WRN"},
 			{Time: time.Date(2024, 1, 1, 10, 2, 0, 0, time.UTC), Message: "info message", Level: "INF"},
 		}
-		result := RenderErrorLogOverlay(entries, 0, 20, false, ErrorLogVisualParams{})
+		result := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{})
 		assert.Contains(t, result, "Application Log")
 		assert.Contains(t, result, "first error")
 		assert.Contains(t, result, "second warning")
@@ -37,7 +40,7 @@ func TestRenderErrorLogOverlay(t *testing.T) {
 			{Time: time.Now(), Message: "wrn", Level: "WRN"},
 			{Time: time.Now(), Message: "inf", Level: "INF"},
 		}
-		result := RenderErrorLogOverlay(entries, 0, 20, false, ErrorLogVisualParams{})
+		result := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{})
 		assert.Contains(t, result, "ERR")
 		assert.Contains(t, result, "WRN")
 		assert.Contains(t, result, "INF")
@@ -48,7 +51,7 @@ func TestRenderErrorLogOverlay(t *testing.T) {
 			{Time: time.Now(), Message: "debug msg", Level: "DBG"},
 			{Time: time.Now(), Message: "info msg", Level: "INF"},
 		}
-		result := RenderErrorLogOverlay(entries, 0, 20, false, ErrorLogVisualParams{})
+		result := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{})
 		assert.NotContains(t, result, "debug msg")
 		assert.Contains(t, result, "info msg")
 		assert.Contains(t, result, "1 hidden")
@@ -59,7 +62,7 @@ func TestRenderErrorLogOverlay(t *testing.T) {
 			{Time: time.Now(), Message: "debug msg", Level: "DBG"},
 			{Time: time.Now(), Message: "info msg", Level: "INF"},
 		}
-		result := RenderErrorLogOverlay(entries, 0, 20, true, ErrorLogVisualParams{})
+		result := RenderErrorLogOverlay(entries, 0, 80, 20, true, ErrorLogVisualParams{})
 		assert.Contains(t, result, "debug msg")
 		assert.Contains(t, result, "DBG")
 		assert.Contains(t, result, "info msg")
@@ -96,7 +99,7 @@ func TestErrorLogEntryPlainText(t *testing.T) {
 		Message: "something failed",
 	}
 	result := ErrorLogEntryPlainText(e)
-	assert.Equal(t, "10:30:15 [ERR] something failed", result)
+	assert.Equal(t, "10:30:15 ERR something failed", result)
 }
 
 func TestRenderErrorLogOverlayVisualMode(t *testing.T) {
@@ -108,21 +111,265 @@ func TestRenderErrorLogOverlayVisualMode(t *testing.T) {
 
 	t.Run("visual mode shows VISUAL LINE indicator", func(t *testing.T) {
 		vp := ErrorLogVisualParams{VisualMode: 'V', VisualStart: 0, CursorLine: 1}
-		result := RenderErrorLogOverlay(entries, 0, 20, false, vp)
+		result := RenderErrorLogOverlay(entries, 0, 80, 20, false, vp)
 		assert.Contains(t, result, "VISUAL LINE")
 	})
 
 	t.Run("char visual mode shows VISUAL indicator", func(t *testing.T) {
 		vp := ErrorLogVisualParams{VisualMode: 'v', VisualStart: 0, CursorLine: 0}
-		result := RenderErrorLogOverlay(entries, 0, 20, false, vp)
+		result := RenderErrorLogOverlay(entries, 0, 80, 20, false, vp)
 		assert.Contains(t, result, "VISUAL")
 		assert.NotContains(t, result, "VISUAL LINE")
 	})
 
 	t.Run("no visual mode has no indicator", func(t *testing.T) {
-		result := RenderErrorLogOverlay(entries, 0, 20, false, ErrorLogVisualParams{})
+		result := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{})
 		assert.NotContains(t, result, "VISUAL")
 	})
+}
+
+func TestRenderErrorLogOverlay_SelectionHasNoBracketsOrShift(t *testing.T) {
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "ERR", Message: "boom"},
+	}
+	// Visual column of "boom" (ansi.StringWidth handles the multi-byte "▎").
+	col := func(rendered string) int {
+		for ln := range strings.SplitSeq(ansi.Strip(rendered), "\n") {
+			if before, _, found := strings.Cut(ln, "boom"); found {
+				return ansi.StringWidth(before)
+			}
+		}
+		return -1
+	}
+	normal := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{})
+	visual := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{VisualMode: 'V', VisualStart: 0, CursorLine: 0})
+
+	// Selecting a log must not wrap the severity in brackets or shift the text.
+	assert.NotContains(t, ansi.Strip(visual), "[ERR]", "selection must not add brackets around the level")
+	assert.Equal(t, col(normal), col(visual), "message column must not shift when selecting")
+	assert.Equal(t, errorLogDisplayMsgColumn, col(visual))
+}
+
+func TestRenderErrorLogOverlay_CursorMarkerMatchesEventsAndPersistsInVisual(t *testing.T) {
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "ERR", Message: "first"},
+		{Time: time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC), Level: "INF", Message: "second"},
+	}
+	// The cursor line is flagged with the "▎" gutter (matching the event
+	// viewer), not the legacy ">" indicator — and the marker stays visible
+	// when entering line- or char-visual selection.
+	for _, tc := range []struct {
+		name string
+		vp   ErrorLogVisualParams
+	}{
+		{"normal", ErrorLogVisualParams{CursorLine: 0}},
+		{"line-visual", ErrorLogVisualParams{VisualMode: 'V', VisualStart: 0, CursorLine: 0}},
+		{"char-visual", ErrorLogVisualParams{VisualMode: 'v', VisualStart: 0, CursorLine: 0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plain := ansi.Strip(RenderErrorLogOverlay(entries, 0, 80, 20, false, tc.vp))
+			assert.Contains(t, plain, "▎", "cursor line marker must be visible")
+			assert.NotContains(t, plain, ">", "legacy '>' cursor indicator must be gone")
+		})
+	}
+}
+
+func TestRenderErrorLogOverlay_BlockCursorTracksColumnInNormalMode(t *testing.T) {
+	// Force a real color profile so the reverse-video block cursor is emitted
+	// (the default test renderer strips styling).
+	originalProfile := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(originalProfile) })
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "ERR", Message: "abcdefgh"},
+	}
+	at0 := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{CursorLine: 0, CursorCol: 0})
+	at5 := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{CursorLine: 0, CursorCol: 5})
+
+	// A reverse-video block cursor is rendered in normal mode (no selection)...
+	assert.Contains(t, at0, "\x1b[7m", "normal-mode cursor line should carry a reverse-video block cursor")
+	// ...and it moves with the cursor column without entering visual mode.
+	assert.NotEqual(t, at0, at5, "block cursor position should change with CursorCol")
+}
+
+// uniqueLongMessage returns a 120-character message whose every substring is
+// position-identifiable (no repeating window), so wrap reconstruction tests
+// can prove text appears in the right order without false matches.
+func uniqueLongMessage() string {
+	const n = 120
+	var b strings.Builder
+	for i := 0; b.Len() < n; i++ {
+		fmt.Fprintf(&b, "%03d|", i)
+	}
+	return string([]rune(b.String())[:n])
+}
+
+// errorLogDisplayMsgColumn is the on-screen column where the message starts:
+// the 1-column gutter plus the in-content message column.
+const errorLogDisplayMsgColumn = errorLogGutterWidth + errorLogMsgColumn
+
+// reconstructErrorLogMessage rebuilds the message text from a rendered overlay
+// by stripping ANSI and slicing each message-bearing line at the display
+// message column. Title ("Application Log") and footer ("N entries") lines are
+// skipped by name.
+func reconstructErrorLogMessage(rendered string) string {
+	var b strings.Builder
+	for ln := range strings.SplitSeq(ansi.Strip(rendered), "\n") {
+		if !errorLogMessageLine(ln) {
+			continue
+		}
+		b.WriteString(string([]rune(ln)[errorLogDisplayMsgColumn:]))
+	}
+	return b.String()
+}
+
+// countErrorLogMessageLines counts the message-bearing physical lines in a
+// rendered overlay (excluding the title, its bottom-padding blank, and the
+// footer), used to assert wrapping.
+func countErrorLogMessageLines(rendered string) int {
+	n := 0
+	for ln := range strings.SplitSeq(ansi.Strip(rendered), "\n") {
+		if errorLogMessageLine(ln) {
+			n++
+		}
+	}
+	return n
+}
+
+// errorLogMessageLine reports whether a stripped rendered line carries message
+// content (not the title, the title's bottom-padding blank, or the footer).
+func errorLogMessageLine(ln string) bool {
+	if strings.TrimSpace(ln) == "" {
+		return false // blank line (e.g. title bottom padding)
+	}
+	if strings.Contains(ln, "Application Log") || strings.Contains(ln, "entries") {
+		return false // title / footer
+	}
+	return len([]rune(ln)) > errorLogDisplayMsgColumn
+}
+
+func TestRenderErrorLogOverlay_WrapsLongMessage(t *testing.T) {
+	const width = 50
+	longMsg := uniqueLongMessage()
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "ERR", Message: longMsg},
+	}
+	result := RenderErrorLogOverlay(entries, 0, width, 30, false, ErrorLogVisualParams{})
+
+	// No truncation marker — the message is wrapped, not cut.
+	assert.NotContains(t, ansi.Strip(result), "~")
+
+	// Message fully preserved across wrapped continuation lines.
+	assert.Equal(t, longMsg, reconstructErrorLogMessage(result))
+
+	// The message spans more than one line.
+	assert.Greater(t, countErrorLogMessageLines(result), 1, "long message should wrap onto multiple lines")
+
+	// Every rendered line fits within the available width.
+	for ln := range strings.SplitSeq(result, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(ln), width, "line exceeds width: %q", ansi.Strip(ln))
+	}
+}
+
+func TestRenderErrorLogOverlay_WrapsLongCursorMessage(t *testing.T) {
+	const width = 50
+	longMsg := uniqueLongMessage()
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "ERR", Message: longMsg},
+	}
+	vp := ErrorLogVisualParams{CursorLine: 0}
+	result := RenderErrorLogOverlay(entries, 0, width, 30, false, vp)
+
+	plain := ansi.Strip(result)
+	// Cursor line marker present.
+	assert.Contains(t, plain, "▎")
+	// Message preserved across wrapped cursor sub-lines.
+	assert.Equal(t, longMsg, reconstructErrorLogMessage(result))
+	for ln := range strings.SplitSeq(result, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(ln), width, "cursor line exceeds width: %q", ansi.Strip(ln))
+	}
+}
+
+func TestRenderErrorLogOverlay_WrapsLongSelectedMessage(t *testing.T) {
+	const width = 50
+	longMsg := uniqueLongMessage()
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "ERR", Message: longMsg},
+	}
+	// Line-visual mode selecting the single entry.
+	vp := ErrorLogVisualParams{VisualMode: 'V', VisualStart: 0, CursorLine: 0}
+	result := RenderErrorLogOverlay(entries, 0, width, 30, false, vp)
+
+	// Visual rendering carries no brackets, so the message column matches the
+	// non-visual row.
+	assert.Equal(t, longMsg, reconstructErrorLogMessage(result))
+	for ln := range strings.SplitSeq(result, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(ln), width, "selected line exceeds width: %q", ansi.Strip(ln))
+	}
+}
+
+func TestRenderErrorLogOverlay_CharVisualWrapsLongMessage(t *testing.T) {
+	const width = 50
+	longMsg := uniqueLongMessage()
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "ERR", Message: longMsg},
+	}
+	// Char-visual mode selecting a column range on the single entry. The
+	// highlight lands on the first sub-line; continuations render as plain
+	// wrapped text, so the message must still reconstruct fully.
+	vp := ErrorLogVisualParams{VisualMode: 'v', VisualStart: 0, VisualStartCol: 0, CursorLine: 0, CursorCol: 5}
+	result := RenderErrorLogOverlay(entries, 0, width, 30, false, vp)
+
+	assert.Equal(t, longMsg, reconstructErrorLogMessage(result))
+	assert.Greater(t, countErrorLogMessageLines(result), 1, "char-visual long message should wrap")
+	for ln := range strings.SplitSeq(result, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(ln), width, "char-visual line exceeds width: %q", ansi.Strip(ln))
+	}
+}
+
+func TestRenderErrorLogOverlay_CursorVisibleAtBottomWithWrap(t *testing.T) {
+	// Regression for the physical-line pagination vs logical-entry scroll
+	// mismatch: with many wrapping entries and the cursor on the last one,
+	// the cursor entry (and its indicator) must still be rendered even though
+	// the entries above it would consume the physical-line budget.
+	const width = 50
+	base := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	entries := make([]ErrorLogEntry, 12)
+	for i := range entries {
+		entries[i] = ErrorLogEntry{Time: base, Level: "ERR", Message: fmt.Sprintf("entry%02d ", i) + strings.Repeat("x", 90)}
+	}
+	reversed := FilteredErrorLogEntries(entries, false)
+	cursor := len(reversed) - 1              // bottom of the list (newest-first reversed)
+	wantTail := reversed[cursor].Message[:7] // unique "entryNN" prefix of the cursor entry
+
+	// Incoming scroll 0 with a short viewport: the naive entry-based start
+	// would clip the cursor; the renderer must adjust so it is visible.
+	result := RenderErrorLogOverlay(entries, 0, width, 18, false, ErrorLogVisualParams{CursorLine: cursor})
+	plain := ansi.Strip(result)
+
+	assert.Contains(t, plain, "▎", "cursor line marker must be visible")
+	assert.Contains(t, plain, wantTail, "cursor entry must be rendered despite earlier entries wrapping")
+	for ln := range strings.SplitSeq(result, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(ln), width, "line exceeds width: %q", ansi.Strip(ln))
+	}
+}
+
+func TestRenderErrorLogOverlay_ShortMessageUnchangedShape(t *testing.T) {
+	// A short message must still render as exactly one content line, so the
+	// wrapping change does not alter the common single-line case.
+	entries := []ErrorLogEntry{
+		{Time: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), Level: "INF", Message: "short message"},
+	}
+	result := RenderErrorLogOverlay(entries, 0, 80, 20, false, ErrorLogVisualParams{})
+	plain := ansi.Strip(result)
+	msgLines := 0
+	for ln := range strings.SplitSeq(plain, "\n") {
+		if strings.Contains(ln, "short message") {
+			msgLines++
+		}
+	}
+	assert.Equal(t, 1, msgLines, "short message should occupy a single line")
 }
 
 // --- RenderPodStartupOverlay ---


### PR DESCRIPTION
## Summary

The Application Log overlay (`!`) now wraps long entries and navigates like the event viewer.

- **Wrapping:** long messages wrap onto continuation lines indented under the message column instead of being truncated with `~`. Pagination is by physical line and the cursor entry is always kept on screen (this also fixes a pre-existing cursor-clip on logs taller than the viewport).
- **Cursor marker:** matches the event viewer — a `▎` gutter on the cursor line (which now persists in visual mode) plus a reverse-video block cursor, replacing the old `>` indicator and full-line background highlight.
- **No bracket/shift on select:** the level is no longer wrapped in `[...]` in the selection/yank text, so selecting a log no longer shifts the message two columns; copied text matches what is shown.
- **Cursor navigation in normal mode:** horizontal movement (`h`/`l`/`0`/`$`/`^`) and vim word motions (`w`/`e`/`b`/`W`/`E`/`B`) now work without first entering visual mode, reusing the shared motion helpers.
- **Footer:** shows `line X/N` (cursor position) instead of a misleading entry-based scroll counter.

Docs updated in `docs/keybindings.md`.

## Test plan

- [x] `go build ./...` / `go vet ./...`
- [x] `go test -race ./...` — all pass
- [x] `make lint` — 0 issues
- [x] New tests: wrapping (long / cursor / V-selected / char-visual), cursor-visible-at-bottom regression, no-bracket-shift, cursor marker present + persists in `v`/`V`, block cursor tracks column, horizontal cursor + word motions
- [x] Manual: open `!` — long lines wrap (no `~`), `▎` on cursor line, `v`/`V` keep the marker, `h`/`l`/`w`/`e`/`b` move the cursor
