### PR TITLE
fix(ui): refresh all rows immediately on SEC badge toggle

### DIFF
--- a/internal/ui/explorer_table_renderer.go
+++ b/internal/ui/explorer_table_renderer.go
@@ -45,6 +45,16 @@ type tableFingerprint struct {
 	contextLabel string
 	iconMode     string
 	noColor      bool
+	// Security badge render inputs. The cached non-cursor row strings embed
+	// the SEC badge, whose output is decided by these three globals (see
+	// securityBadgeForItem). Without them the badge toggle (kb.SecurityBadgeToggle)
+	// only refreshed the always-rerendered cursor row, leaving cached rows
+	// stale until an unrelated input (data tick, age-bucket roll) changed the
+	// fingerprint. secIndexPtr also catches a findings refresh swapping the
+	// index for a fresh pointer.
+	secBadgesHidden bool
+	secAvailable    bool
+	secIndexPtr     uintptr
 }
 
 func NewTableRenderer() *TableRenderer {
@@ -53,21 +63,24 @@ func NewTableRenderer() *TableRenderer {
 
 func (r *TableRenderer) Render(headerLabel string, items []model.Item, cursor int, width, height int, loading bool, spinnerView string, errMsg string, middleRev, selRev uint64) string {
 	fp := tableFingerprint{
-		itemsPtr:     itemsHeaderPtr(items),
-		itemsLen:     len(items),
-		middleRev:    middleRev,
-		selRev:       selRev,
-		themeRev:     ThemeRev.Load(),
-		ageBucket:    time.Now().Unix() / ageBucketSeconds,
-		width:        width,
-		height:       height,
-		highlight:    ActiveHighlightQuery,
-		hiddenCols:   serializeBoolSet(ActiveHiddenBuiltinColumns),
-		columnOrder:  strings.Join(ActiveColumnOrder, "|"),
-		sessionCols:  strings.Join(ActiveSessionColumns, "|"),
-		contextLabel: ActiveContext,
-		iconMode:     IconMode,
-		noColor:      ConfigNoColor,
+		itemsPtr:        itemsHeaderPtr(items),
+		itemsLen:        len(items),
+		middleRev:       middleRev,
+		selRev:          selRev,
+		themeRev:        ThemeRev.Load(),
+		ageBucket:       time.Now().Unix() / ageBucketSeconds,
+		width:           width,
+		height:          height,
+		highlight:       ActiveHighlightQuery,
+		hiddenCols:      serializeBoolSet(ActiveHiddenBuiltinColumns),
+		columnOrder:     strings.Join(ActiveColumnOrder, "|"),
+		sessionCols:     strings.Join(ActiveSessionColumns, "|"),
+		contextLabel:    ActiveContext,
+		iconMode:        IconMode,
+		noColor:         ConfigNoColor,
+		secBadgesHidden: ActiveSecurityBadgesHidden,
+		secAvailable:    ActiveSecurityAvailable,
+		secIndexPtr:     uintptr(unsafe.Pointer(ActiveSecurityIndex)),
 	}
 	if r.fp != fp {
 		r.fp = fp

--- a/internal/ui/explorer_table_renderer_test.go
+++ b/internal/ui/explorer_table_renderer_test.go
@@ -153,6 +153,54 @@ func TestTableRendererInvalidatesOnApplyTheme(t *testing.T) {
 			"in the fingerprint changed")
 }
 
+// Reproduces the "SEC badge hides/appears in two stages" report. Pressing
+// kb.SecurityBadgeToggle flips ui.ActiveSecurityBadgesHidden, but that flag
+// was not part of the table-renderer fingerprint. Cursor rows re-render every
+// frame (so the badge under the cursor toggled instantly), while non-cursor
+// rows came from the cache and kept their stale badge until an unrelated input
+// (data tick, age-bucket roll) changed the fingerprint ~1s later.
+//
+// Same sentinel technique as TestTableRendererInvalidatesOnApplyTheme: the
+// sentinel can only survive if Render reuses r.rows. Toggling the badge flag
+// between renders must invalidate the cache and clear it.
+//
+// The items slice is pinned to the heap (secToggleHeapSink) so its backing
+// array address — and thus the fingerprint's itemsPtr — stays stable across
+// both Render calls. A stack-allocated slice can move on stack growth, which
+// would change itemsPtr and clear the cache for the wrong reason, masking the
+// toggle behavior under test. In production the equivalent slice
+// (m.middleItems via visibleMiddleItems) is likewise heap-stable between
+// keystrokes.
+var secToggleHeapSink []model.Item
+
+func TestTableRendererInvalidatesOnSecurityBadgeToggle(t *testing.T) {
+	prevHidden := ActiveSecurityBadgesHidden
+	t.Cleanup(func() {
+		ActiveSecurityBadgesHidden = prevHidden
+		secToggleHeapSink = nil
+	})
+
+	r := NewTableRenderer()
+	items := tableRendererTestItems()
+	secToggleHeapSink = items // force the backing array to escape to the heap
+
+	ActiveSecurityBadgesHidden = false
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+	require.NotEmpty(t, r.rows, "first render must populate the cache")
+
+	const sentinelKey = -1
+	r.rows[sentinelKey] = "sentinel"
+
+	ActiveSecurityBadgesHidden = true
+	_ = r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+
+	_, present := r.rows[sentinelKey]
+	assert.False(t, present,
+		"toggling ActiveSecurityBadgesHidden between renders must invalidate the "+
+			"row cache; sentinel survived, so non-cursor rows would keep their stale "+
+			"SEC badge until something else in the fingerprint changed")
+}
+
 func TestTableRendererRestoresGlobalsAfterRender(t *testing.T) {
 	sentinelCache := map[int]string{99: "sentinel"}
 	sentinelLayout := &TableLayoutCache{Computed: true}


### PR DESCRIPTION
## Summary

Pressing `B` (kb.SecurityBadgeToggle) hid/showed the SEC badge in two visible stages: the badge under the cursor flipped instantly, then ~1s later the rest of the rows followed.

**Root cause:** the middle-column table renderer (`internal/ui/explorer_table_renderer.go`) caches non-cursor row strings keyed by a `tableFingerprint` and always re-renders the cursor row fresh. The fingerprint captures every render input that changes a row (width, theme, highlight, icon mode, data revision, …) but **omitted the three globals `securityBadgeForItem` actually reads**: `ActiveSecurityBadgesHidden`, `ActiveSecurityAvailable`, `ActiveSecurityIndex`. So a toggle only repainted the always-rerendered cursor row; cached rows stayed stale until the next data tick bumped `middleItemsRev` (~1s).

This is the same bug class as the earlier theme-delay fix (`TestTableRendererInvalidatesOnApplyTheme`).

## Changes

- Add `secBadgesHidden`, `secAvailable`, `secIndexPtr` to `tableFingerprint` and populate them each render. `secIndexPtr` also fixes the analogous (unreported) lag where a findings refresh swapping the index pointer wouldn't repaint cached rows until the next tick.
- New regression test `TestTableRendererInvalidatesOnSecurityBadgeToggle` (sentinel-survival pattern). The test slice is heap-pinned so `itemsPtr` stays stable across renders, otherwise a stack-moved slice changes the fingerprint incidentally and masks the behavior under test.

## Test plan

- [x] `TestTableRendererInvalidatesOnSecurityBadgeToggle` fails before the fix, passes after (RED→GREEN)
- [x] `go build ./...`
- [x] `go vet ./internal/ui ./internal/app`
- [x] `go test -race ./internal/ui ./internal/app`
- [x] `go test ./...`
- [x] `make lint` (0 issues)
- [x] Manual: press `B` in a cluster with security findings — all row badges hide/appear in the same frame