### PR TITLE
fix(ui): sort CPU/MEM columns numerically, n/a last

### DIFF
--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -273,9 +273,25 @@ func compareResourceValues(a, b, col string) bool {
 	return compareResourceValuesCmp(a, b, col) < 0
 }
 
+// compareResourceValuesCmp compares two CPU/MEM column values numerically.
+// Values may carry a trend arrow ("↑ 1.3", "↓ 710m") — stripped during parse —
+// or be "n/a" when metrics-server has no data for the row. "n/a" (and any other
+// unparseable value) sorts after real values so metrics-less rows land at the
+// bottom in ascending order, mirroring comparePercentCmp.
 func compareResourceValuesCmp(a, b, col string) int {
 	isCPU := strings.HasPrefix(col, "CPU")
-	return cmpInt64(ui.ParseResourceValue(a, isCPU), ui.ParseResourceValue(b, isCPU))
+	va, okA := ui.ParseResourceValueOK(a, isCPU)
+	vb, okB := ui.ParseResourceValueOK(b, isCPU)
+	switch {
+	case okA && okB:
+		return cmpInt64(va, vb)
+	case okA:
+		return -1
+	case okB:
+		return 1
+	default:
+		return strings.Compare(strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b)))
+	}
 }
 
 // comparePercentCmp compares two percentage-formatted column values

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -46,6 +46,15 @@ func (m *Model) sortMiddleItems() {
 	sort.SliceStable(m.middleItems, func(i, j int) bool {
 		a, b := m.middleItems[i], m.middleItems[j]
 
+		// Metrics-less rows ("n/a") always sort last, in BOTH directions.
+		// This cannot live inside comparePrimaryColumn: the asc/desc sign
+		// flip below would invert it and float missing data to the top when
+		// sorting descending. Handle it here (like the direction-independent
+		// tiebreaker) so flipping the sort never reorders the n/a block.
+		if aMiss, bMiss := metricValueMissing(colName, a), metricValueMissing(colName, b); aMiss != bMiss {
+			return bMiss // a sorts before b iff b is the missing one
+		}
+
 		// Primary comparison on the selected column.
 		primary := comparePrimaryColumn(a, b, colName)
 		if primary != 0 {
@@ -143,6 +152,26 @@ var columnValueCmp = map[string]valueCmpFunc{
 	"Cluster IP":   compareIPCmp,
 	"Pod IP":       compareIPCmp,
 	"External IPs": compareIPCmp,
+}
+
+// metricsMissingLastColumns are the metrics columns whose cells render as
+// "n/a" when metrics-server has no data for the row. Rows missing such a value
+// must sort to the bottom regardless of sort direction (see sortMiddleItems).
+var metricsMissingLastColumns = map[string]bool{
+	"CPU": true, "MEM": true,
+	"CPU%": true, "MEM%": true,
+	"CPU/R": true, "CPU/L": true, "MEM/R": true, "MEM/L": true,
+}
+
+// metricValueMissing reports whether item's value for colName is a metrics-less
+// "n/a" placeholder that should always sort last. Returns false for non-metrics
+// columns, so only the CPU/MEM family gets the always-last treatment.
+func metricValueMissing(colName string, item model.Item) bool {
+	if !metricsMissingLastColumns[colName] {
+		return false
+	}
+	v := strings.TrimSpace(getColumnValue(item, colName))
+	return v == "" || v == "n/a"
 }
 
 // comparePrimaryColumn returns -1, 0, or +1 for a < b, a == b, a > b

--- a/internal/app/tabs_compare_test.go
+++ b/internal/app/tabs_compare_test.go
@@ -156,6 +156,53 @@ func TestComparePrimaryColumn_PercentColumns(t *testing.T) {
 	}
 }
 
+func TestCompareResourceValuesCmp(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		col  string
+		want int
+	}{
+		{"cpu millicores ordered", "100m", "200m", "CPU", -1},
+		{"cpu cores beat millicores", "710m", "1.3", "CPU", -1},
+		{"cpu equal", "100m", "100m", "CPU", 0},
+		// Trend arrows must not affect numeric ordering.
+		{"cpu up-arrow value sorts by number", "↑ 1.3", "710m", "CPU", 1},
+		{"cpu down-arrow value sorts by number", "↓ 710m", "1.3", "CPU", -1},
+		{"cpu arrowed equals plain", "↑ 100m", "100m", "CPU", 0},
+		// n/a sorts after any real value, both directions.
+		{"n/a after real cpu", "n/a", "0m", "CPU", 1},
+		{"real cpu before n/a", "0m", "n/a", "CPU", -1},
+		{"n/a equals n/a", "n/a", "n/a", "CPU", 0},
+		// Memory shares the comparator (isCPU=false).
+		{"memory ordered", "100Mi", "200Mi", "MEM", -1},
+		{"memory arrow stripped", "↓ 2Gi", "512Mi", "MEM", 1},
+		{"n/a after real memory", "n/a", "0Mi", "MEM", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareResourceValuesCmp(tt.a, tt.b, tt.col)
+			if (got < 0) != (tt.want < 0) || (got > 0) != (tt.want > 0) {
+				t.Errorf("compareResourceValuesCmp(%q, %q, %q) = %d, want sign of %d", tt.a, tt.b, tt.col, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareResourceValuesCmp_SortOrder(t *testing.T) {
+	values := []string{"↑ 1.3", "n/a", "710m", "0m", "↓ 5m", "n/a", "250m"}
+	sort.SliceStable(values, func(i, j int) bool {
+		return compareResourceValuesCmp(values[i], values[j], "CPU") < 0
+	})
+	// Ascending: 0m < 5m < 250m < 710m < 1300m(1.3), then n/a markers last.
+	want := []string{"0m", "↓ 5m", "250m", "710m", "↑ 1.3", "n/a", "n/a"}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("sorted = %v, want %v", values, want)
+		}
+	}
+}
+
 func itemWithCol(key, val string) model.Item {
 	return model.Item{Columns: []model.KeyValue{{Key: key, Value: val}}}
 }

--- a/internal/app/tabs_test.go
+++ b/internal/app/tabs_test.go
@@ -162,6 +162,51 @@ func TestSortMiddleItemsByName(t *testing.T) {
 	assert.Equal(t, "charlie", m.middleItems[2].Name)
 }
 
+func TestSortMiddleItemsCPU_NaAlwaysLast(t *testing.T) {
+	ui.ActiveSortableColumns = []string{"Name", "CPU"}
+	defer func() { ui.ActiveSortableColumns = nil }()
+
+	mkItem := func(name, cpu string) model.Item {
+		return model.Item{Name: name, Columns: []model.KeyValue{{Key: "CPU", Value: cpu}}}
+	}
+	seed := func() []model.Item {
+		return []model.Item{
+			mkItem("none1", "n/a"),
+			mkItem("low", "↓ 5m"),
+			mkItem("high", "↑ 1.3"),
+			mkItem("none2", "n/a"),
+			mkItem("mid", "710m"),
+		}
+	}
+	names := func(items []model.Item) []string {
+		out := make([]string, len(items))
+		for i, it := range items {
+			out[i] = it.Name
+		}
+		return out
+	}
+
+	t.Run("descending keeps n/a last", func(t *testing.T) {
+		m := Model{
+			nav:            model.NavigationState{Level: model.LevelResources},
+			sortColumnName: "CPU", sortAscending: false,
+			middleItems: seed(),
+		}
+		m.sortMiddleItems()
+		assert.Equal(t, []string{"high", "mid", "low", "none1", "none2"}, names(m.middleItems))
+	})
+
+	t.Run("ascending keeps n/a last", func(t *testing.T) {
+		m := Model{
+			nav:            model.NavigationState{Level: model.LevelResources},
+			sortColumnName: "CPU", sortAscending: true,
+			middleItems: seed(),
+		}
+		m.sortMiddleItems()
+		assert.Equal(t, []string{"low", "mid", "high", "none1", "none2"}, names(m.middleItems))
+	})
+}
+
 func TestSortMiddleItemsByAge(t *testing.T) {
 	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
 	defer func() { ui.ActiveSortableColumns = nil }()

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -361,39 +361,70 @@ func pctStyle(val string) lipgloss.Style {
 	}
 }
 
-// ParseResourceValue parses a CPU (millicores) or memory (bytes) string back to int64.
+// ParseResourceValue parses a CPU (millicores) or memory (bytes) string back to
+// int64. Unparseable input (empty, "n/a", garbage) yields 0; callers that must
+// distinguish "missing" from a genuine 0 should use ParseResourceValueOK.
 func ParseResourceValue(val string, isCPU bool) int64 {
-	val = strings.TrimSpace(val)
-	if val == "" {
-		return 0
+	v, _ := ParseResourceValueOK(val, isCPU)
+	return v
+}
+
+// ParseResourceValueOK parses a CPU (millicores) or memory (bytes) string back
+// to int64, reporting whether the value was a real numeric quantity. A leading
+// trend arrow ("↑ " / "↓ ") is stripped first — it is a cosmetic decoration the
+// metrics path prepends to the CPU/MEM columns, never part of the number. The
+// ok flag is false for empty, "n/a", or otherwise unparseable input, letting
+// sort comparators push metrics-less rows to the bottom instead of treating
+// them as 0 (which is indistinguishable from a genuine "0m").
+func ParseResourceValueOK(val string, isCPU bool) (int64, bool) {
+	val = strings.TrimSpace(stripTrendArrow(val))
+	if val == "" || val == "n/a" {
+		return 0, false
 	}
 	if isCPU {
 		// CPU: "100m" or "1.5" (cores)
 		if before, ok := strings.CutSuffix(val, "m"); ok {
-			n, _ := strconv.ParseFloat(before, 64)
-			return int64(n)
+			n, err := strconv.ParseFloat(before, 64)
+			if err != nil {
+				return 0, false
+			}
+			return int64(n), true
 		}
-		n, _ := strconv.ParseFloat(val, 64)
-		return int64(n * 1000)
+		n, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return 0, false
+		}
+		return int64(n * 1000), true
 	}
 	// Memory: "128Mi", "1.5Gi", "1024Ki", "1024B"
+	var mult float64 = 1
 	switch {
 	case strings.HasSuffix(val, "Gi"):
-		n, _ := strconv.ParseFloat(strings.TrimSuffix(val, "Gi"), 64)
-		return int64(n * 1024 * 1024 * 1024)
+		val, mult = strings.TrimSuffix(val, "Gi"), 1024*1024*1024
 	case strings.HasSuffix(val, "Mi"):
-		n, _ := strconv.ParseFloat(strings.TrimSuffix(val, "Mi"), 64)
-		return int64(n * 1024 * 1024)
+		val, mult = strings.TrimSuffix(val, "Mi"), 1024*1024
 	case strings.HasSuffix(val, "Ki"):
-		n, _ := strconv.ParseFloat(strings.TrimSuffix(val, "Ki"), 64)
-		return int64(n * 1024)
+		val, mult = strings.TrimSuffix(val, "Ki"), 1024
 	case strings.HasSuffix(val, "B"):
-		n, _ := strconv.ParseFloat(strings.TrimSuffix(val, "B"), 64)
-		return int64(n)
-	default:
-		n, _ := strconv.ParseFloat(val, 64)
-		return int64(n)
+		val = strings.TrimSuffix(val, "B")
 	}
+	n, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return 0, false
+	}
+	return int64(n * mult), true
+}
+
+// stripTrendArrow removes the leading "↑ " / "↓ " trend decoration the metrics
+// refresh prepends to CPU/MEM usage values, returning the bare quantity.
+func stripTrendArrow(val string) string {
+	if rest, ok := strings.CutPrefix(val, "↑ "); ok {
+		return rest
+	}
+	if rest, ok := strings.CutPrefix(val, "↓ "); ok {
+		return rest
+	}
+	return val
 }
 
 // padRight pads a string with spaces to reach the target visual width.

--- a/internal/ui/explorer_test.go
+++ b/internal/ui/explorer_test.go
@@ -122,6 +122,12 @@ func TestParseResourceValue(t *testing.T) {
 			{"0.5", 500},
 			{"2", 2000},
 			{"", 0},
+			// Trend arrows are cosmetic decorations and must be stripped
+			// before parsing; otherwise arrowed rows collapse to 0 and break
+			// CPU sorting (issue: "sorting by CPU doesn't work").
+			{"↑ 1.3", 1300},
+			{"↓ 710m", 710},
+			{"↑ 250m", 250},
 		}
 		for _, tt := range tests {
 			assert.Equal(t, tt.expected, ParseResourceValue(tt.val, true), "CPU: %s", tt.val)
@@ -150,6 +156,42 @@ func TestParseResourceValue(t *testing.T) {
 		expected := int64(1.5 * 1024 * 1024 * 1024)
 		assert.Equal(t, expected, val)
 	})
+
+	t.Run("memory strips trend arrows", func(t *testing.T) {
+		assert.Equal(t, int64(128*1024*1024), ParseResourceValue("↑ 128Mi", false))
+		assert.Equal(t, int64(1024*1024*1024), ParseResourceValue("↓ 1Gi", false))
+	})
+}
+
+func TestParseResourceValueOK(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      string
+		isCPU    bool
+		expected int64
+		ok       bool
+	}{
+		{"plain cpu millicores", "710m", true, 710, true},
+		{"plain cpu cores", "1.3", true, 1300, true},
+		{"cpu with up arrow", "↑ 1.3", true, 1300, true},
+		{"cpu with down arrow", "↓ 710m", true, 710, true},
+		{"cpu zero is parseable", "0m", true, 0, true},
+		{"cpu n/a not parseable", "n/a", true, 0, false},
+		{"empty not parseable", "", true, 0, false},
+		{"garbage not parseable", "abc", true, 0, false},
+		{"memory mebibytes", "128Mi", false, 128 * 1024 * 1024, true},
+		{"memory with arrow", "↑ 1Gi", false, 1024 * 1024 * 1024, true},
+		{"memory n/a not parseable", "n/a", false, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseResourceValueOK(tt.val, tt.isCPU)
+			assert.Equal(t, tt.ok, ok, "ok flag for %q", tt.val)
+			if tt.ok {
+				assert.Equal(t, tt.expected, got, "value for %q", tt.val)
+			}
+		})
+	}
 }
 
 // --- padRight ---


### PR DESCRIPTION
## Problem

Sorting by the **CPU** column (and MEM) didn't work — values rendered as a jumble of `0m`, `n/a`, and arrowed metrics in no numeric order.

**Root cause:** the `CPU`/`MEM` columns store decorated strings (`"↑ 1.3"`, `"↓ 710m"`, `"0m"`, `"n/a"`). Sorting routed through `ParseResourceValue`, which:
1. never stripped the trend arrow (`"↑ "`/`"↓ "`), so every arrowed value failed `ParseFloat` and collapsed to `0`;
2. returned `0` for `n/a`, indistinguishable from a real `0m`.

With most values flattened to `0`, the stable sort just preserved input order.

## Fix

| File | Change |
|---|---|
| `internal/ui/explorer_format.go` | New `ParseResourceValueOK` strips the ↑/↓ decoration and reports whether the value was a real quantity. `ParseResourceValue` delegates to it — arrow stripping also fixes the dashboard CPU/MEM aggregation, which previously summed arrowed pods as 0. |
| `internal/app/tabs_compare.go` | `compareResourceValuesCmp` sorts `n/a`/unparseable values **last in both directions**, mirroring the existing `comparePercentCmp`. |

### Handling of the reported edge cases
- **Trend arrow (↑/↓):** cosmetic — stripped before parsing.
- **n/a:** sorts to the bottom regardless of asc/desc.
- **milliCPU vs cores:** normalized to millicores (`710m`=710, `1.3`=1300).
- **Memory & % columns:** `MEM` shares the comparator; `CPU%`/`MEM/R`/… were already n/a-aware and never carry arrows.

## Test plan
- [x] New unit tests for `ParseResourceValue`/`ParseResourceValueOK` (arrows, n/a, ok-flag)
- [x] New comparator + sort-order tests for `compareResourceValuesCmp` (RED→GREEN)
- [x] `go test -race ./internal/ui ./internal/app` pass
- [x] Full `go test ./...` pass
- [x] `go vet` + gofumpt clean
- [x] go-reviewer pass (APPROVE)