### PR TITLE
fix: GUI freeze while loading background jobs

### DIFF
--- a/internal/app/commands_security.go
+++ b/internal/app/commands_security.go
@@ -244,16 +244,16 @@ func (m Model) loadSecurityFindings() tea.Cmd {
 // namespace selection. Per-source errors are logged but do not block
 // index rebuild — partial success is the common case (e.g., Trivy
 // installed but Falco missing).
-func (m Model) updateSecurityFindingsLoaded(msg securityFindingsLoadedMsg) Model {
+func (m Model) updateSecurityFindingsLoaded(msg securityFindingsLoadedMsg) (Model, tea.Cmd) {
 	if m.nav.Context != "" && msg.context != m.nav.Context {
-		return m
+		return m, nil
 	}
 	// Compare against effectiveNamespace — the value loadSecurityFindings
 	// now fetches with — so the guard discards stale messages by the same
 	// key the fetch used (matters in all-namespaces / multi-select mode,
 	// where effectiveNamespace is "" but m.namespace is not).
 	if msg.namespace != m.effectiveNamespace() {
-		return m
+		return m, nil
 	}
 	anyErr := false
 	for source, err := range msg.errors {
@@ -263,18 +263,29 @@ func (m Model) updateSecurityFindingsLoaded(msg securityFindingsLoadedMsg) Model
 		}
 	}
 	m.securityIndex = security.BuildFindingIndex(msg.findings)
-	// Persist to disk for stale-while-revalidate on the next session — but
-	// only a clean scan: a partial result (some source errored) would cache an
-	// undercount that the badges would show until the TTL expires. A fully
-	// clean scan with zero findings is still cached (it is a valid "nothing
-	// found" answer). Best-effort; a write failure never affects the session.
-	if !anyErr {
-		if err := updateSecurityFindingsCacheForContext(m.client, msg.context, msg.namespace, msg.findings); err != nil {
-			logger.Warn("Failed to persist security findings cache",
-				"context", msg.context, "namespace", msg.namespace, "error", err)
-		}
+	if anyErr {
+		// Partial result: don't cache an undercount that the badges would show
+		// until the TTL expires. No persistence.
+		return m, nil
 	}
-	return m
+	// Persist to disk for stale-while-revalidate on the next session — but OFF
+	// the Bubble Tea Update goroutine. Marshaling the full findings set to YAML
+	// and the durable write take multiple seconds on clusters with many
+	// findings; running them inline here froze the UI until the write finished
+	// (the findings message lands on the Update loop exactly when a background
+	// scan completes). A fully clean scan with zero findings is still cached (a
+	// valid "nothing found"). Best-effort; a write failure never affects the
+	// session. saveSecurityFindingsCacheForHost serializes concurrent writes.
+	client := m.client
+	ctx, ns, findings := msg.context, msg.namespace, msg.findings
+	persist := func() tea.Msg {
+		if err := updateSecurityFindingsCacheForContext(client, ctx, ns, findings); err != nil {
+			logger.Warn("Failed to persist security findings cache",
+				"context", ctx, "namespace", ns, "error", err)
+		}
+		return nil
+	}
+	return m, persist
 }
 
 // loadSecurityAffectedResources fetches the resources affected by a

--- a/internal/app/commands_security_test.go
+++ b/internal/app/commands_security_test.go
@@ -292,7 +292,7 @@ func TestSecurityFindingsLoadedBuildsIndex(t *testing.T) {
 		{ID: "F1", Title: "crit", Severity: security.SeverityCritical, Resource: ref},
 		{ID: "F2", Title: "med", Severity: security.SeverityMedium, Resource: ref},
 	}
-	updated := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+	updated, _ := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
 		context:  "kctx",
 		findings: findings,
 	})
@@ -310,7 +310,7 @@ func TestSecurityFindingsLoadedStaleContextDiscarded(t *testing.T) {
 	priorIdx := security.BuildFindingIndex(nil)
 	m.securityIndex = priorIdx
 
-	updated := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+	updated, _ := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
 		context:  "stale",
 		findings: []security.Finding{{ID: "ignored"}},
 	})
@@ -325,7 +325,7 @@ func TestSecurityFindingsLoadedStaleContextDiscarded(t *testing.T) {
 // that their cluster's Trivy/Falco/etc. is broken.
 func TestSecurityFindingsLoadedPropagatesErrors(t *testing.T) {
 	m := newTestModelWithSecurity(t, security.NewManager(), "kctx")
-	updated := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+	updated, _ := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
 		context:  "kctx",
 		findings: nil,
 		errors:   map[string]error{"trivy-operator": assert.AnError},

--- a/internal/app/security_findings_cache.go
+++ b/internal/app/security_findings_cache.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"sigs.k8s.io/yaml"
@@ -20,6 +21,15 @@ import (
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/security"
 )
+
+// securityFindingsCacheMu serializes the findings-cache read-modify-write.
+// Persistence runs on background goroutines (off the Bubble Tea Update loop,
+// where the YAML marshal of a large findings set would freeze the UI), so two
+// scan completions for different namespaces of the same host could otherwise
+// interleave their read/merge/rename and drop an entry. Process-wide is fine —
+// writes are infrequent (scan completions), and the cross-process race is
+// already accepted (see saveSecurityFindingsCacheForHost).
+var securityFindingsCacheMu sync.Mutex
 
 // securityFindingsCacheSchemaVersion bumps when the on-disk shape changes.
 // A mismatch is treated as a miss so an older binary never decodes a
@@ -127,12 +137,14 @@ func saveSecurityFindingsCacheForHost(host, namespace string, findings []securit
 		findings = []security.Finding{}
 	}
 	// Merge into any existing state so a save for one namespace doesn't wipe
-	// the others. A corrupt/missing file just starts fresh. NOTE: the
-	// read-modify-write is only atomic within one process (saves run on the
-	// Bubble Tea Update loop). Two lfk instances saving different namespaces
-	// of the same host concurrently can lose one entry (last rename wins) —
-	// acceptable for a best-effort, TTL-bounded cache; the lost entry is
-	// re-derived by the next scan.
+	// the others. A corrupt/missing file just starts fresh. The read-modify-
+	// write is serialized within this process by securityFindingsCacheMu (saves
+	// run on background goroutines, no longer the Update loop). Two lfk
+	// instances saving different namespaces of the same host concurrently can
+	// still lose one entry (last rename wins) — acceptable for a best-effort,
+	// TTL-bounded cache; the lost entry is re-derived by the next scan.
+	securityFindingsCacheMu.Lock()
+	defer securityFindingsCacheMu.Unlock()
 	state := readFindingsCacheFile(host)
 	if state == nil {
 		state = &securityFindingsCacheState{SchemaVersion: securityFindingsCacheSchemaVersion}

--- a/internal/app/security_findings_cache_test.go
+++ b/internal/app/security_findings_cache_test.go
@@ -149,15 +149,42 @@ func TestUpdateSecurityFindingsLoaded_PersistsCleanScan(t *testing.T) {
 	t.Setenv("KUBECACHEDIR", t.TempDir())
 	m := findingsCacheTestModel(t)
 
-	m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+	_, cmd := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
 		context:   "ctx",
 		namespace: "default",
 		findings:  sampleFindings(),
 		errors:    map[string]error{"trivy-operator": nil},
 	})
+	require.NotNil(t, cmd, "a clean scan must defer persistence to a command")
+	cmd() // run the background persistence (off the Update goroutine)
 
 	got := loadSecurityFindingsCacheForHost("https://api.persist.test:6443", "default", time.Hour)
 	require.Len(t, got, 2, "a clean scan must be persisted to disk")
+}
+
+// TestUpdateSecurityFindingsLoaded_PersistenceIsDeferred verifies the disk
+// write does NOT run inline on the Update goroutine — marshaling the full
+// findings set to YAML there froze the UI until the write finished. The
+// handler must return a command and leave the file unwritten until it runs.
+func TestUpdateSecurityFindingsLoaded_PersistenceIsDeferred(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	m := findingsCacheTestModel(t)
+
+	_, cmd := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+		context:   "ctx",
+		namespace: "default",
+		findings:  sampleFindings(),
+		errors:    map[string]error{"trivy-operator": nil},
+	})
+	require.NotNil(t, cmd, "clean scan must return a persistence command")
+
+	// The write must NOT have happened inline on the Update goroutine.
+	assert.Nil(t, loadSecurityFindingsCacheForHost("https://api.persist.test:6443", "default", time.Hour),
+		"persistence must be deferred, not run inline on the Update goroutine")
+
+	cmd() // only now, off the Update goroutine, does the write happen
+	got := loadSecurityFindingsCacheForHost("https://api.persist.test:6443", "default", time.Hour)
+	require.Len(t, got, 2, "running the deferred command writes the cache")
 }
 
 // TestUpdateSecurityFindingsLoaded_SkipsPartialScan verifies a scan where any
@@ -167,12 +194,13 @@ func TestUpdateSecurityFindingsLoaded_SkipsPartialScan(t *testing.T) {
 	t.Setenv("KUBECACHEDIR", t.TempDir())
 	m := findingsCacheTestModel(t)
 
-	m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
+	_, cmd := m.updateSecurityFindingsLoaded(securityFindingsLoadedMsg{
 		context:   "ctx",
 		namespace: "default",
 		findings:  sampleFindings()[:1], // undercount: one source failed
 		errors:    map[string]error{"kyverno": errors.New("timeout")},
 	})
+	assert.Nil(t, cmd, "a partial (errored) scan must not persist")
 
 	assert.Nil(t, loadSecurityFindingsCacheForHost("https://api.persist.test:6443", "default", time.Hour),
 		"a partial (errored) scan must not be persisted")

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -107,8 +107,8 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 		mdl, cmd := m.updateSecurityAvailabilityLoaded(msg)
 		return mdl, cmd, true
 	case securityFindingsLoadedMsg:
-		mdl := m.updateSecurityFindingsLoaded(msg)
-		return mdl, nil, true
+		mdl, cmd := m.updateSecurityFindingsLoaded(msg)
+		return mdl, cmd, true
 	case securityIgnoresSaveErrMsg:
 		mdl, cmd := m.updateSecurityIgnoresSaveErr(msg)
 		return mdl, cmd, true

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"golang.org/x/sync/singleflight"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/tools/clientcmd"
@@ -118,17 +119,34 @@ type Client struct {
 	discoveryMu      sync.Mutex
 	discoveryClients map[string]*disk.CachedDiscoveryClient
 
-	// clientMu guards clientCache. Typed/dynamic/metadata clients are
-	// expensive to build (kubeconfig parse + TLS transport + ~1.8k allocs,
-	// plus an exec-credential plugin invocation for EKS/kubelogin contexts)
-	// and were previously rebuilt on every call, discarding connection
-	// pooling and resetting the client-side QPS limiter each time. clientCache
-	// memoizes them per cache key (see clientCacheKey: context, plus a
-	// "throttled" variant for the lower-rate security clients). Invalidated on
-	// ReloadKubeconfig (the only mid-session config mutation) and per-context
-	// via invalidateClientsForContext.
+	// clientMu guards clientCache and clientCacheGen. Typed/dynamic/metadata
+	// clients are expensive to build (kubeconfig parse + TLS transport +
+	// ~1.8k allocs) and were previously rebuilt on every call, discarding
+	// connection pooling and resetting the client-side QPS limiter each time.
+	// (The exec-credential plugin for EKS/kubelogin runs lazily on the first
+	// HTTP request, NOT during build, so it is never part of this critical
+	// section.) clientCache memoizes clients per cache key (see clientCacheKey:
+	// context, plus a "throttled" variant for the lower-rate security clients).
+	// Invalidated on ReloadKubeconfig (the only mid-session config mutation)
+	// and per-context via invalidateClientsForContext.
+	//
+	// The actual construction runs OUTSIDE clientMu via clientGroup (see
+	// buildCachedClient): a slow build must never block other callers — in
+	// particular the Bubble Tea Update goroutine, which builds the throttled
+	// security clients synchronously in refreshSecuritySources. clientMu is
+	// only ever held for microsecond map reads/writes around the build.
 	clientMu    sync.Mutex
 	clientCache map[string]*ctxClients
+	// clientGroup coalesces concurrent builds for the same cache key+kind so a
+	// burst of cold-cache callers runs ONE construction, not N. clientCacheGen
+	// is bumped (under clientMu) on every cache invalidation; a build that
+	// races an invalidate compares the generation it captured before building
+	// and skips caching its now-stale result, so an invalidated client is
+	// never served as a cache hit. (The old lock-across-build made invalidate
+	// and build mutually exclusive; building outside the lock reintroduces the
+	// race that the generation guard closes.)
+	clientGroup    singleflight.Group
+	clientCacheGen uint64
 
 	// informerMu guards informerMode + informers. Writes happen at most
 	// once (SetInformerCacheMode at startup); reads happen on every

--- a/internal/k8s/client_cache.go
+++ b/internal/k8s/client_cache.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	"fmt"
+	"strconv"
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -114,8 +115,9 @@ func buildCachedClient[T comparable](
 ) (T, error) {
 	var zero T
 
-	// Fast path: hit returns without entering the singleflight group or the
-	// build, holding clientMu only for the map read.
+	// Fast path: a hit returns without entering the singleflight group or the
+	// build, holding clientMu only for the map read. The generation is
+	// snapshotted under the same lock so it is consistent with the miss.
 	c.clientMu.Lock()
 	if entry, ok := c.clientCache[key]; ok {
 		if v := get(entry); v != zero {
@@ -123,13 +125,19 @@ func buildCachedClient[T comparable](
 			return v, nil
 		}
 	}
+	gen := c.clientCacheGen
 	c.clientMu.Unlock()
 
-	// The singleflight key includes kind, but clientCache stays keyed by key
-	// alone (one ctxClients per context, with get/set selecting the field).
-	// Do NOT collapse this to key: a clientset and a dynamic build for the same
-	// context must be independent flights, or one caller gets the wrong type.
-	res, err, _ := c.clientGroup.Do(key+"\x00"+kind, func() (any, error) {
+	// The singleflight key includes BOTH kind and gen; clientCache itself stays
+	// keyed by key alone (one ctxClients per context, get/set select the field):
+	//   - kind: a clientset and a dynamic build for the same context must be
+	//     independent flights, or one caller gets the wrong type.
+	//   - gen: a caller that arrives after an invalidate (newer gen) must NOT
+	//     join a flight that is still building against the now-stale config —
+	//     singleflight would hand it that pre-invalidate client. A newer gen
+	//     means a different key, hence a fresh flight built against fresh config.
+	sfKey := key + "\x00" + kind + "\x00" + strconv.FormatUint(gen, 10)
+	res, err, _ := c.clientGroup.Do(sfKey, func() (any, error) {
 		// Re-check under the lock: another caller may have finished the build
 		// between our fast-path miss and entering the group.
 		c.clientMu.Lock()
@@ -139,9 +147,6 @@ func buildCachedClient[T comparable](
 				return v, nil
 			}
 		}
-		// Snapshot the cache generation before the (lock-free) build so a
-		// concurrent invalidate is detectable on store.
-		gen := c.clientCacheGen
 		c.clientMu.Unlock()
 
 		built, berr := build()
@@ -152,10 +157,10 @@ func buildCachedClient[T comparable](
 		c.clientMu.Lock()
 		// If an invalidate (ReloadKubeconfig / invalidateClientsForContext)
 		// bumped the generation while we built, our client is against stale
-		// config: hand it to every caller coalesced into this flight (Do
-		// returns the same value to all of them) but do NOT cache it, so the
-		// next caller rebuilds against the fresh config instead of getting a
-		// stale hit.
+		// config: hand it to this flight's callers (all of whom snapshotted the
+		// same pre-invalidate gen, so their request predates the change) but do
+		// NOT cache it — the next caller snapshots the newer gen, takes a fresh
+		// flight, and rebuilds against the fresh config.
 		if c.clientCacheGen == gen {
 			set(c.cachedClientsLocked(key), built)
 		}

--- a/internal/k8s/client_cache.go
+++ b/internal/k8s/client_cache.go
@@ -93,88 +93,153 @@ func (c *Client) buildMetadata(contextName string, cfg *rest.Config) (metadata.I
 	return mc, nil
 }
 
+// buildCachedClient returns the memoized client of type T for (key, kind),
+// constructing it on a miss. The expensive build runs OUTSIDE clientMu: the
+// lock is held only for the microsecond map read on entry and the map write on
+// store, so a slow construction (kubeconfig parse + TLS transport assembly)
+// never blocks another caller — including the Bubble Tea Update goroutine,
+// which builds the throttled security clients synchronously. Concurrent builds
+// for the same (key, kind) are coalesced by clientGroup so a cold-cache burst
+// runs one construction, not N.
+//
+// get/set read and write the kind-specific ctxClients field; build performs the
+// actual construction. kind disambiguates the singleflight key so a clientset
+// and a dynamic build for the same cache key never collapse into each other.
+func buildCachedClient[T comparable](
+	c *Client,
+	key, kind string,
+	get func(*ctxClients) T,
+	set func(*ctxClients, T),
+	build func() (T, error),
+) (T, error) {
+	var zero T
+
+	// Fast path: hit returns without entering the singleflight group or the
+	// build, holding clientMu only for the map read.
+	c.clientMu.Lock()
+	if entry, ok := c.clientCache[key]; ok {
+		if v := get(entry); v != zero {
+			c.clientMu.Unlock()
+			return v, nil
+		}
+	}
+	c.clientMu.Unlock()
+
+	// The singleflight key includes kind, but clientCache stays keyed by key
+	// alone (one ctxClients per context, with get/set selecting the field).
+	// Do NOT collapse this to key: a clientset and a dynamic build for the same
+	// context must be independent flights, or one caller gets the wrong type.
+	res, err, _ := c.clientGroup.Do(key+"\x00"+kind, func() (any, error) {
+		// Re-check under the lock: another caller may have finished the build
+		// between our fast-path miss and entering the group.
+		c.clientMu.Lock()
+		if entry, ok := c.clientCache[key]; ok {
+			if v := get(entry); v != zero {
+				c.clientMu.Unlock()
+				return v, nil
+			}
+		}
+		// Snapshot the cache generation before the (lock-free) build so a
+		// concurrent invalidate is detectable on store.
+		gen := c.clientCacheGen
+		c.clientMu.Unlock()
+
+		built, berr := build()
+		if berr != nil {
+			return zero, berr
+		}
+
+		c.clientMu.Lock()
+		// If an invalidate (ReloadKubeconfig / invalidateClientsForContext)
+		// bumped the generation while we built, our client is against stale
+		// config: hand it to every caller coalesced into this flight (Do
+		// returns the same value to all of them) but do NOT cache it, so the
+		// next caller rebuilds against the fresh config instead of getting a
+		// stale hit.
+		if c.clientCacheGen == gen {
+			set(c.cachedClientsLocked(key), built)
+		}
+		c.clientMu.Unlock()
+		return built, nil
+	})
+	if err != nil {
+		return zero, err
+	}
+	return res.(T), nil
+}
+
 // cachedClientset returns the memoized typed clientset for (contextName,
 // throttled), building and caching it on first use. restConfig supplies the
 // rate-appropriate rest.Config (foreground or throttled) and is only invoked
 // on a cache miss.
 func (c *Client) cachedClientset(contextName string, throttled bool, restConfig func() (*rest.Config, error)) (kubernetes.Interface, error) {
-	key := clientCacheKey(contextName, throttled)
-	c.clientMu.Lock()
-	defer c.clientMu.Unlock()
-	entry := c.cachedClientsLocked(key)
-	if entry.clientset != nil {
-		return entry.clientset, nil
-	}
-	cfg, err := restConfig()
-	if err != nil {
-		return nil, err
-	}
-	cs, err := c.buildClientset(contextName, cfg)
-	if err != nil {
-		return nil, err
-	}
-	entry.clientset = cs
-	return cs, nil
+	return buildCachedClient(c, clientCacheKey(contextName, throttled), "clientset",
+		func(e *ctxClients) kubernetes.Interface { return e.clientset },
+		func(e *ctxClients, v kubernetes.Interface) { e.clientset = v },
+		func() (kubernetes.Interface, error) {
+			cfg, err := restConfig()
+			if err != nil {
+				return nil, err
+			}
+			return c.buildClientset(contextName, cfg)
+		},
+	)
 }
 
 // cachedDynamic returns the memoized dynamic client for (contextName,
 // throttled). See cachedClientset.
 func (c *Client) cachedDynamic(contextName string, throttled bool, restConfig func() (*rest.Config, error)) (dynamic.Interface, error) {
-	key := clientCacheKey(contextName, throttled)
-	c.clientMu.Lock()
-	defer c.clientMu.Unlock()
-	entry := c.cachedClientsLocked(key)
-	if entry.dynamic != nil {
-		return entry.dynamic, nil
-	}
-	cfg, err := restConfig()
-	if err != nil {
-		return nil, err
-	}
-	dc, err := c.buildDynamic(contextName, cfg)
-	if err != nil {
-		return nil, err
-	}
-	entry.dynamic = dc
-	return dc, nil
+	return buildCachedClient(c, clientCacheKey(contextName, throttled), "dynamic",
+		func(e *ctxClients) dynamic.Interface { return e.dynamic },
+		func(e *ctxClients, v dynamic.Interface) { e.dynamic = v },
+		func() (dynamic.Interface, error) {
+			cfg, err := restConfig()
+			if err != nil {
+				return nil, err
+			}
+			return c.buildDynamic(contextName, cfg)
+		},
+	)
 }
 
 // cachedMetadata returns the memoized metadata-only client for contextName
 // (foreground rate only; no throttled metadata variant is used).
 func (c *Client) cachedMetadata(contextName string, restConfig func() (*rest.Config, error)) (metadata.Interface, error) {
-	key := clientCacheKey(contextName, false)
-	c.clientMu.Lock()
-	defer c.clientMu.Unlock()
-	entry := c.cachedClientsLocked(key)
-	if entry.metadata != nil {
-		return entry.metadata, nil
-	}
-	cfg, err := restConfig()
-	if err != nil {
-		return nil, err
-	}
-	mc, err := c.buildMetadata(contextName, cfg)
-	if err != nil {
-		return nil, err
-	}
-	entry.metadata = mc
-	return mc, nil
+	return buildCachedClient(c, clientCacheKey(contextName, false), "metadata",
+		func(e *ctxClients) metadata.Interface { return e.metadata },
+		func(e *ctxClients, v metadata.Interface) { e.metadata = v },
+		func() (metadata.Interface, error) {
+			cfg, err := restConfig()
+			if err != nil {
+				return nil, err
+			}
+			return c.buildMetadata(contextName, cfg)
+		},
+	)
 }
 
 // invalidateClientCache drops every cached client. Called from ReloadKubeconfig
 // after the kubeconfig snapshot is swapped, so the next call to any builder
-// reconstructs against the fresh config (new endpoint/credentials).
+// reconstructs against the fresh config (new endpoint/credentials). Bumping
+// clientCacheGen makes any build currently in flight (now against stale config)
+// skip caching its result — see buildCachedClient's generation guard.
 func (c *Client) invalidateClientCache() {
 	c.clientMu.Lock()
 	defer c.clientMu.Unlock()
 	c.clientCache = nil
+	c.clientCacheGen++
 }
 
 // invalidateClientsForContext drops the cached clients for a single context
 // (both the foreground and throttled variants), leaving other contexts intact.
+// The generation bump applies process-wide (not per-context) — a coarse but
+// safe choice: at worst an unrelated context's racing build rebuilds once.
+//
+//nolint:unparam // per-context invalidation API; contextName is constant only because current callers are tests
 func (c *Client) invalidateClientsForContext(contextName string) {
 	c.clientMu.Lock()
 	defer c.clientMu.Unlock()
 	delete(c.clientCache, clientCacheKey(contextName, false))
 	delete(c.clientCache, clientCacheKey(contextName, true))
+	c.clientCacheGen++
 }

--- a/internal/k8s/client_cache_singleflight_test.go
+++ b/internal/k8s/client_cache_singleflight_test.go
@@ -181,3 +181,55 @@ func TestCachedClient_CoalescedWaitersRacingInvalidate(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotSame(t, results[0], fresh, "the stale coalesced result must not have been cached as a hit")
 }
+
+// TestCachedClient_PostInvalidateCallerStartsFreshFlight verifies a caller that
+// arrives AFTER an invalidation does not join an in-flight build started under
+// the previous generation (singleflight would otherwise hand it that
+// pre-invalidate, now-stale client). The generation is part of the singleflight
+// key, so the later caller starts its own flight and builds against fresh config.
+func TestCachedClient_PostInvalidateCallerStartsFreshFlight(t *testing.T) {
+	c := newCacheTestClient(t)
+	cfg, err := c.restConfigForContext("plain")
+	require.NoError(t, err)
+
+	release := make(chan struct{})
+	aStarted := make(chan struct{})
+	aDone := make(chan kubernetes.Interface, 1)
+	// Caller A: build under the current generation, parked mid-build.
+	go func() {
+		cs, _ := c.cachedClientset("plain", false, func() (*rest.Config, error) {
+			close(aStarted)
+			<-release
+			return cfg, nil
+		})
+		aDone <- cs
+	}()
+	<-aStarted
+
+	// Invalidate (new generation) while A's build is still in flight.
+	c.invalidateClientsForContext("plain")
+
+	// Caller B arrives after the invalidate. It must run its OWN build (its
+	// generation differs from A's flight key), not block on A's parked flight.
+	bBuilt := make(chan struct{})
+	bDone := make(chan kubernetes.Interface, 1)
+	go func() {
+		cs, _ := c.cachedClientset("plain", false, func() (*rest.Config, error) {
+			close(bBuilt)
+			return cfg, nil
+		})
+		bDone <- cs
+	}()
+
+	select {
+	case <-bBuilt:
+		// good: B ran its own build instead of joining A's pre-invalidate flight
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("post-invalidate caller joined the stale in-flight build instead of starting fresh")
+	}
+	b := <-bDone
+	close(release)
+	a := <-aDone
+	assert.NotSame(t, a, b, "post-invalidate caller must build fresh, not receive the pre-invalidate in-flight client")
+}

--- a/internal/k8s/client_cache_singleflight_test.go
+++ b/internal/k8s/client_cache_singleflight_test.go
@@ -1,0 +1,183 @@
+package k8s
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// TestCachedClient_BuildRunsOutsideLock proves a slow build for one cache key
+// does not block a concurrent build for a different key. Before the
+// build-outside-lock fix, clientMu was held across the whole construction, so a
+// build for the throttled key queued behind a slow foreground build — the
+// regression that stalled the Bubble Tea Update goroutine when
+// refreshSecuritySources built the throttled security clients synchronously.
+func TestCachedClient_BuildRunsOutsideLock(t *testing.T) {
+	c := newCacheTestClient(t)
+	cfg, err := c.restConfigForContext("plain")
+	require.NoError(t, err)
+
+	releaseSlow := make(chan struct{})
+	slowStarted := make(chan struct{})
+	go func() {
+		_, _ = c.cachedClientset("plain", false, func() (*rest.Config, error) {
+			close(slowStarted)
+			<-releaseSlow // hold the foreground build open
+			return cfg, nil
+		})
+	}()
+
+	select {
+	case <-slowStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow foreground build never started")
+	}
+
+	fastDone := make(chan struct{})
+	go func() {
+		// Distinct cache key (throttled): must not wait on the foreground build.
+		_, _ = c.cachedClientset("plain", true, func() (*rest.Config, error) {
+			return cfg, nil
+		})
+		close(fastDone)
+	}()
+
+	select {
+	case <-fastDone:
+		// pass: the different-key build completed while the slow one is parked
+	case <-time.After(2 * time.Second):
+		close(releaseSlow)
+		t.Fatal("a build for a different cache key blocked behind a slow build holding clientMu")
+	}
+	close(releaseSlow)
+}
+
+// TestCachedClient_SameKeyCoalesces verifies concurrent builders for the same
+// (key, kind) collapse into a single construction and all receive the same
+// instance — singleflight must not let a cold-cache burst stampede N builds.
+func TestCachedClient_SameKeyCoalesces(t *testing.T) {
+	c := newCacheTestClient(t)
+	cfg, err := c.restConfigForContext("plain")
+	require.NoError(t, err)
+
+	var builds atomic.Int32
+	release := make(chan struct{})
+	var once sync.Once
+	firstStarted := make(chan struct{})
+	//nolint:unparam // signature is dictated by cachedClientset; this test never errors
+	restConfig := func() (*rest.Config, error) {
+		builds.Add(1)
+		once.Do(func() { close(firstStarted) })
+		<-release
+		return cfg, nil
+	}
+
+	const n = 8
+	results := make([]kubernetes.Interface, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cs, _ := c.cachedClientset("plain", false, restConfig)
+			results[i] = cs
+		}(i)
+	}
+
+	<-firstStarted
+	time.Sleep(50 * time.Millisecond) // let the rest pile into the singleflight group
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), builds.Load(), "concurrent same-key builds must coalesce to a single construction")
+	for i := 1; i < n; i++ {
+		assert.Same(t, results[0], results[i], "all coalesced callers must receive the same client instance")
+	}
+}
+
+// TestCachedClient_BuildRacingInvalidate_NotCachedAsStale verifies the
+// generation guard: a build that completes AFTER an invalidate (e.g.
+// ReloadKubeconfig landed mid-build) must not be stored, so the next caller
+// rebuilds against the fresh config instead of getting a stale cache hit. The
+// old lock-across-build made invalidate and build mutually exclusive; building
+// outside the lock reintroduces this race, which the guard closes.
+func TestCachedClient_BuildRacingInvalidate_NotCachedAsStale(t *testing.T) {
+	c := newCacheTestClient(t)
+	cfg, err := c.restConfigForContext("plain")
+	require.NoError(t, err)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	done := make(chan kubernetes.Interface, 1)
+	go func() {
+		cs, _ := c.cachedClientset("plain", false, func() (*rest.Config, error) {
+			close(started)
+			<-release
+			return cfg, nil
+		})
+		done <- cs
+	}()
+
+	<-started
+	// Invalidate while the build is parked — bumps clientCacheGen so the
+	// in-flight build (against now-stale config) skips caching its result.
+	c.invalidateClientsForContext("plain")
+	close(release)
+	racing := <-done
+	require.NotNil(t, racing)
+
+	fresh, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+	assert.NotSame(t, racing, fresh, "a build that raced an invalidate must not be served as a cache hit")
+}
+
+// TestCachedClient_CoalescedWaitersRacingInvalidate covers the hardest
+// interleaving: N callers coalesced into one in-flight build while an
+// invalidate fires mid-flight. All N must receive the same (uncached) client,
+// and the next caller after they return must rebuild a fresh, cacheable client
+// — none of the N may have left the stale client behind as a hit.
+func TestCachedClient_CoalescedWaitersRacingInvalidate(t *testing.T) {
+	c := newCacheTestClient(t)
+	cfg, err := c.restConfigForContext("plain")
+	require.NoError(t, err)
+
+	release := make(chan struct{})
+	var once sync.Once
+	firstStarted := make(chan struct{})
+	//nolint:unparam // signature is dictated by cachedClientset; this test never errors
+	restConfig := func() (*rest.Config, error) {
+		once.Do(func() { close(firstStarted) })
+		<-release
+		return cfg, nil
+	}
+
+	const n = 8
+	results := make([]kubernetes.Interface, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], _ = c.cachedClientset("plain", false, restConfig)
+		}(i)
+	}
+
+	<-firstStarted
+	time.Sleep(50 * time.Millisecond) // let all n coalesce into the single flight
+	c.invalidateClientsForContext("plain")
+	close(release)
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		assert.Same(t, results[0], results[i], "all coalesced callers share the one flight's result")
+	}
+	fresh, err := c.clientsetForContext("plain")
+	require.NoError(t, err)
+	assert.NotSame(t, results[0], fresh, "the stale coalesced result must not have been cached as a hit")
+}


### PR DESCRIPTION
## Summary

Fixes the reported BLOCKER — the TUI freezes for several seconds while loading background jobs — plus a related UI-thread stall found along the way. Two independent fixes, one commit each.

### 1. `fix(app)`: persist security findings off the Update goroutine — the freeze (BLOCKER)

Root cause confirmed by a goroutine dump captured during a live freeze: the Bubble Tea Update goroutine was **`[runnable]`, burning a CPU core inside the yaml.v2 encoder**, marshaling the entire security-findings set to the disk cache **inline on the Update loop**:

```
Model.Update → updateSecurityFindingsLoaded → updateSecurityFindingsCacheForContext
             → saveSecurityFindingsCacheForHost → yaml.Marshal(...)
```

On clusters with many findings this takes several seconds and freezes the whole UI. It matches every symptom: multi-second, single-core (no fan spike), fires exactly when a background scan's findings arrive, and only on clean scans (`!anyErr`) with enough findings.

**Fix:** defer the marshal + durable write into a background `tea.Cmd`. The in-memory `securityIndex` (read by the SEC badges) is still built synchronously, so in-session behavior is unchanged — only the next-session disk seed moves off the UI thread. `securityFindingsCacheMu` serializes the read-modify-write now that it can run from concurrent commands.

### 2. `perf(k8s)`: build cached clients outside `clientMu` via singleflight

A separate UI-thread stall (not the freeze above): the per-context client cache held `clientMu` across the whole client build, so a cold-cache build blocked every other caller on the shared mutex — including the Update goroutine's synchronous `refreshSecuritySources`. The build now runs outside the lock via `singleflight` (coalescing concurrent same-key builds), with a `clientCacheGen` guard so a build racing a cache invalidation isn't stored as stale.

## Test plan

- [x] `go test ./...` green (19 packages)
- [x] `go test -race ./internal/app/ ./internal/k8s/` green
- [x] `golangci-lint run` clean
- [x] New test asserts findings persistence is deferred (file unwritten until the command runs)
- [x] New client-cache tests: build-outside-lock (RED-verified against the old code), same-key coalescing, generation guard on the invalidate race
- [x] Manual: confirmed the freeze no longer reproduces on a real cluster while loading findings
