### PR TITLE
feat(help): word-wrap long keybinding descriptions (#319 a)

### DIFF
--- a/internal/app/update_help.go
+++ b/internal/app/update_help.go
@@ -197,7 +197,7 @@ func (m *Model) helpRecomputeMatches() {
 		m.helpMatchIdx = 0
 		return
 	}
-	lines := ui.BuildHelpLines(m.helpFilter.Value, m.helpContextMode)
+	lines := ui.BuildHelpLines(m.helpFilter.Value, m.helpContextMode, m.width)
 	for i, line := range lines {
 		if ui.MatchLine(line, m.helpSearchQuery) {
 			m.helpMatchLines = append(m.helpMatchLines, i)
@@ -268,7 +268,7 @@ func (m *Model) helpVisibleLines() int {
 // range, so subsequent ctrl+u presses spend dozens of keystrokes
 // undoing phantom scroll before the viewport visibly moves.
 func (m *Model) clampHelpScroll() {
-	totalLines := len(ui.BuildHelpLines(m.helpFilter.Value, m.helpContextMode))
+	totalLines := len(ui.BuildHelpLines(m.helpFilter.Value, m.helpContextMode, m.width))
 	maxScroll := max(totalLines-m.helpVisibleLines(), 0)
 	if m.helpScroll > maxScroll {
 		m.helpScroll = maxScroll

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -178,8 +178,13 @@ func buildHelpSpecs(filter, contextMode string, innerW int) []helpLineSpec {
 		// the wrapped text stays aligned under the original description.
 		// rowOverhead is the fixed prefix helpSpecPlain prepends to an entry
 		// row: 4 leading spaces + keyWidth + 2 spaces between key and desc.
+		// descBudget is the exact room left for the description; flooring at
+		// 1 (rather than a larger value) keeps the wrapped row within innerW
+		// so the renderer's Truncate never lops a character with a "~" — the
+		// only residual overflow is when a section's key column alone is
+		// wider than the panel, which no description width could fix.
 		rowOverhead := 4 + keyWidth + 2
-		descBudget := max(innerW-rowOverhead, 8)
+		descBudget := max(innerW-rowOverhead, 1)
 		blankKey := strings.Repeat(" ", keyWidth)
 		entries := make([]helpLineSpec, 0, len(matched))
 		for _, b := range matched {
@@ -214,31 +219,99 @@ func buildHelpSpecs(filter, contextMode string, innerW int) []helpLineSpec {
 	return specs
 }
 
-// wrapHelpText word-wraps desc to width, then hard-breaks any single
-// token still wider than width (e.g. a slash-joined "owner/port-forward/
-// orphan" enumeration with no spaces). Without the hard break such a
-// token would overrun the column and force RenderHelpScreen to truncate
-// it with a "~", which is exactly what wrapping is meant to avoid.
+// wrapHelpText word-wraps desc to width on word boundaries. A space-free
+// token wider than width (e.g. a slash-joined "owner/port-forward/orphan/
+// finding/mark" enumeration) is broken after its "/" separators so it
+// wraps at readable boundaries rather than mid-word; a segment between
+// slashes that is itself wider than width falls back to a hard character
+// break. The output never exceeds width, so RenderHelpScreen's final
+// Truncate never adds a "~".
 func wrapHelpText(desc string, width int) []string {
 	if width < 1 {
 		width = 1
 	}
-	words := wrapText(desc, width)
-	if len(words) == 0 {
+	if strings.TrimSpace(desc) == "" {
 		return nil
 	}
-	out := make([]string, 0, len(words))
-	for _, w := range words {
-		if lipgloss.Width(w) <= width {
-			out = append(out, w)
+
+	// Tokenize into pieces no wider than width. spaceBefore marks pieces
+	// that follow a real space (a word boundary); slash continuations and
+	// hard-break fragments glue to the previous piece with no space.
+	type piece struct {
+		text        string
+		spaceBefore bool
+	}
+	var pieces []piece
+	for word := range strings.FieldsSeq(desc) {
+		first := true
+		for _, seg := range splitAfterSlash(word) {
+			for _, chunk := range hardChunks(seg, width) {
+				pieces = append(pieces, piece{text: chunk, spaceBefore: first})
+				first = false
+			}
+		}
+	}
+
+	// Greedy pack: keep adding pieces to the current line while they fit.
+	var lines []string
+	cur := ""
+	for _, p := range pieces {
+		if cur == "" {
+			cur = p.text
 			continue
 		}
-		runes := []rune(w)
-		for len(runes) > 0 {
-			n := min(width, len(runes))
-			out = append(out, string(runes[:n]))
-			runes = runes[n:]
+		sep := ""
+		if p.spaceBefore {
+			sep = " "
 		}
+		if lipgloss.Width(cur)+lipgloss.Width(sep)+lipgloss.Width(p.text) <= width {
+			cur += sep + p.text
+			continue
+		}
+		lines = append(lines, cur)
+		cur = p.text
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	return lines
+}
+
+// splitAfterSlash splits s into segments that each end just after a "/"
+// (the slash stays on the left segment), so "owner/port-forward/orphan"
+// becomes ["owner/", "port-forward/", "orphan"]. Used to give long
+// slash-joined tokens readable break points.
+func splitAfterSlash(s string) []string {
+	if !strings.Contains(s, "/") {
+		return []string{s}
+	}
+	runes := []rune(s)
+	var out []string
+	start := 0
+	for i, r := range runes {
+		if r == '/' {
+			out = append(out, string(runes[start:i+1]))
+			start = i + 1
+		}
+	}
+	if start < len(runes) {
+		out = append(out, string(runes[start:]))
+	}
+	return out
+}
+
+// hardChunks splits s into pieces no wider than width by raw rune count,
+// used only as the last resort for a segment with no break opportunity.
+func hardChunks(s string, width int) []string {
+	if lipgloss.Width(s) <= width {
+		return []string{s}
+	}
+	runes := []rune(s)
+	var out []string
+	for len(runes) > 0 {
+		n := min(width, len(runes))
+		out = append(out, string(runes[:n]))
+		runes = runes[n:]
 	}
 	return out
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -51,13 +51,24 @@ func helpKeyDisplay(key string) string {
 // digit query match bytes that live inside an SGR escape (e.g. the
 // "1" in "\x1b[33;1m"), inflating match counts and pointing n/N at
 // rows with no visible match.
-func BuildHelpLines(filter, contextMode string) []string {
-	specs := buildHelpSpecs(filter, contextMode)
+func BuildHelpLines(filter, contextMode string, screenWidth int) []string {
+	specs := buildHelpSpecs(filter, contextMode, helpInnerWidth(screenWidth))
 	out := make([]string, len(specs))
 	for i, s := range specs {
 		out[i] = helpSpecPlain(s)
 	}
 	return out
+}
+
+// helpInnerWidth returns the content width (in cells) available for a
+// single help row at the given screen width. Mirrors the boxW / contentW
+// arithmetic in RenderHelpScreen so buildHelpSpecs wraps descriptions to
+// the exact width the renderer will display — keeping the wrapped row set
+// (and therefore the search-match indices) identical on both paths.
+func helpInnerWidth(screenWidth int) int {
+	boxW := max(screenWidth*70/100, 50)
+	contentW := boxW - 6 // border + padding
+	return max(contentW-2, 10)
 }
 
 // HelpVisibleLines returns the number of help-content rows that fit
@@ -112,7 +123,7 @@ const helpKeyColumnMinWidth = 14
 // BuildHelpLines and RenderHelpScreen so the plain match indices
 // computed by the app layer line up 1:1 with the styled rows on
 // screen.
-func buildHelpSpecs(filter, contextMode string) []helpLineSpec {
+func buildHelpSpecs(filter, contextMode string, innerW int) []helpLineSpec {
 	sections := helpSections()
 	specs := make([]helpLineSpec, 0, 64)
 	for _, section := range sections {
@@ -159,13 +170,34 @@ func buildHelpSpecs(filter, contextMode string) []helpLineSpec {
 			}
 		}
 
+		// Word-wrap each description to the width left after the key column
+		// so long entries read in full instead of being truncated with a
+		// "~". Each wrapped chunk becomes its own entry spec, preserving the
+		// one-spec-per-rendered-row invariant the search/scroll machinery
+		// relies on: continuation rows carry a blank (but same-width) key so
+		// the wrapped text stays aligned under the original description.
+		// rowOverhead is the fixed prefix helpSpecPlain prepends to an entry
+		// row: 4 leading spaces + keyWidth + 2 spaces between key and desc.
+		rowOverhead := 4 + keyWidth + 2
+		descBudget := max(innerW-rowOverhead, 8)
+		blankKey := strings.Repeat(" ", keyWidth)
 		entries := make([]helpLineSpec, 0, len(matched))
 		for _, b := range matched {
-			entries = append(entries, helpLineSpec{
-				kind: helpLineEntry,
-				key:  fmt.Sprintf("%-*s", keyWidth, b.key),
-				desc: b.desc,
-			})
+			chunks := wrapHelpText(b.desc, descBudget)
+			if len(chunks) == 0 {
+				chunks = []string{""}
+			}
+			for ci, chunk := range chunks {
+				key := blankKey
+				if ci == 0 {
+					key = fmt.Sprintf("%-*s", keyWidth, b.key)
+				}
+				entries = append(entries, helpLineSpec{
+					kind: helpLineEntry,
+					key:  key,
+					desc: chunk,
+				})
+			}
 		}
 
 		if len(specs) > 0 {
@@ -180,6 +212,35 @@ func buildHelpSpecs(filter, contextMode string) []helpLineSpec {
 	}
 
 	return specs
+}
+
+// wrapHelpText word-wraps desc to width, then hard-breaks any single
+// token still wider than width (e.g. a slash-joined "owner/port-forward/
+// orphan" enumeration with no spaces). Without the hard break such a
+// token would overrun the column and force RenderHelpScreen to truncate
+// it with a "~", which is exactly what wrapping is meant to avoid.
+func wrapHelpText(desc string, width int) []string {
+	if width < 1 {
+		width = 1
+	}
+	words := wrapText(desc, width)
+	if len(words) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(words))
+	for _, w := range words {
+		if lipgloss.Width(w) <= width {
+			out = append(out, w)
+			continue
+		}
+		runes := []rune(w)
+		for len(runes) > 0 {
+			n := min(width, len(runes))
+			out = append(out, string(runes[:n]))
+			runes = runes[n:]
+		}
+	}
+	return out
 }
 
 // helpSpecPlain returns the un-styled visible form of a help-line
@@ -261,14 +322,12 @@ func RenderHelpScreen(screenWidth, screenHeight, scroll int, filter, search, con
 	// "highlight on already-styled, already-truncated line" path could
 	// match a digit query inside an SGR like \x1b[33;1m, which broke
 	// the sequence and printed "[33;" / ";1m" as visible text.
-	specs := buildHelpSpecs(filter, contextMode)
-	// Truncate each line to the inner-panel content width so one entry
-	// in `lines` always renders as exactly one row. Lipgloss's
-	// auto-wrap behavior would otherwise silently expand long
-	// descriptions to two rows, the rendered row count would diverge
-	// from len(lines), and the outer box height would drift — making
-	// a filter that narrows results visibly shrink the window.
-	innerW := max(contentW-2, 10)
+	innerW := helpInnerWidth(screenWidth)
+	specs := buildHelpSpecs(filter, contextMode, innerW)
+	// buildHelpSpecs already word-wrapped descriptions to innerW, so each
+	// spec is one rendered row. Truncate stays as a safety net for the
+	// rare row whose key column alone overruns innerW (extremely narrow
+	// terminals); it never trims wrapped descriptions in normal layouts.
 	lines := make([]string, len(specs))
 	for i, s := range specs {
 		lines[i] = Truncate(helpSpecStyled(s, search, i == currentMatchLine), innerW)

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -98,7 +98,7 @@ func TestRenderHelpScreen_CurrentMatchStyledDifferently(t *testing.T) {
 	// Find a line index where flipping currentMatchLine actually changes
 	// the render — i.e. the line contains a "filter" match. The exact
 	// index depends on help content ordering; we just need any one.
-	totalLines := len(BuildHelpLines("", ""))
+	totalLines := len(BuildHelpLines("", "", 120))
 	for i := range totalLines {
 		withCurrent := RenderHelpScreen(120, 200, 0, "", "filter", "", i)
 		if withoutCurrent != withCurrent {
@@ -178,7 +178,7 @@ func TestRenderHelpScreen_DigitSearchDoesNotLeakEscapeFragments(t *testing.T) {
 // longer than that (e.g. "Ctrl+F / Ctrl+B / PgDn / PgUp") overflowed
 // and pushed its description right of the rest, breaking alignment.
 func TestBuildHelpSpecs_KeysAlignWithinSection(t *testing.T) {
-	specs := buildHelpSpecs("", "")
+	specs := buildHelpSpecs("", "", helpInnerWidth(120))
 
 	var currentSection string
 	widths := make([]int, 0, 16)
@@ -210,6 +210,51 @@ func TestBuildHelpSpecs_KeysAlignWithinSection(t *testing.T) {
 	check()
 }
 
+// Word-wrap (issue #319 a): long descriptions must wrap onto continuation
+// rows so they read in full instead of being truncated with a "~". Every
+// entry row's plain width must fit innerW so RenderHelpScreen's final
+// Truncate never trims it.
+func TestBuildHelpSpecs_WrappedEntriesFitWidth(t *testing.T) {
+	innerW := 70
+	specs := buildHelpSpecs("", "", innerW)
+	for _, s := range specs {
+		if s.kind != helpLineEntry {
+			continue
+		}
+		w := lipgloss.Width(helpSpecPlain(s))
+		assert.LessOrEqualf(t, w, innerW,
+			"entry row must fit innerW (no truncation): %q (width %d)", helpSpecPlain(s), w)
+	}
+}
+
+// A narrower help width wraps long descriptions onto more rows than a wide
+// one — proving wrapping actually happens (not just truncation).
+func TestBuildHelpSpecs_NarrowWidthWrapsToMoreRows(t *testing.T) {
+	wide := buildHelpSpecs("", "", 200)
+	narrow := buildHelpSpecs("", "", 60)
+	assert.Greater(t, len(narrow), len(wide),
+		"narrow width must wrap long descriptions onto additional rows")
+}
+
+// Continuation rows carry a blank key column (the key shows only on the
+// first row of a wrapped entry) but keep the section's key-column width so
+// the wrapped description stays aligned under the original.
+func TestBuildHelpSpecs_ContinuationRowsHaveBlankAlignedKey(t *testing.T) {
+	specs := buildHelpSpecs("", "", 50) // narrow -> forces wrapping
+	foundContinuation := false
+	for _, s := range specs {
+		if s.kind != helpLineEntry {
+			continue
+		}
+		if strings.TrimSpace(s.key) == "" && s.desc != "" {
+			foundContinuation = true
+			break
+		}
+	}
+	assert.True(t, foundContinuation,
+		"narrow width must produce at least one continuation row with a blank key")
+}
+
 func TestBuildHelpLines_ReturnsPlainText(t *testing.T) {
 	original := lipgloss.DefaultRenderer().ColorProfile()
 	originalNoColor := ConfigNoColor
@@ -223,7 +268,7 @@ func TestBuildHelpLines_ReturnsPlainText(t *testing.T) {
 	ApplyTheme(DefaultTheme())
 	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
 
-	lines := BuildHelpLines("", "")
+	lines := BuildHelpLines("", "", 120)
 	for i, line := range lines {
 		assert.NotContains(t, line, "\x1b",
 			"BuildHelpLines must return plain text (no ANSI escapes) — line %d: %q", i, line)

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -255,6 +255,33 @@ func TestBuildHelpSpecs_ContinuationRowsHaveBlankAlignedKey(t *testing.T) {
 		"narrow width must produce at least one continuation row with a blank key")
 }
 
+// A long slash-joined token must wrap at "/" boundaries rather than being
+// hard-broken mid-word (issue #319 a follow-up: "...findi" / "ng/mark...").
+func TestWrapHelpText_BreaksLongSlashTokenAtSlashes(t *testing.T) {
+	desc := "Jump back through teleport history (owner/port-forward/orphan/finding/mark jumps)"
+	for _, width := range []int{20, 30, 41, 60} {
+		lines := wrapHelpText(desc, width)
+
+		for _, ln := range lines {
+			assert.LessOrEqualf(t, lipgloss.Width(ln), width,
+				"width %d: row %q exceeds the budget", width, ln)
+		}
+
+		// No data loss: ignoring whitespace, the wrapped text reproduces the
+		// original exactly (slash continuations glue with no space).
+		norm := func(s string) string { return strings.ReplaceAll(s, " ", "") }
+		assert.Equalf(t, norm(desc), norm(strings.Join(lines, "")),
+			"width %d: wrapping dropped or duplicated characters", width)
+
+		// At widths that comfortably fit a slash segment, segments stay whole.
+		if width >= 30 {
+			joined := strings.Join(lines, "\n")
+			assert.Containsf(t, joined, "finding/",
+				"width %d: slash segment 'finding/' must not be broken mid-word", width)
+		}
+	}
+}
+
 func TestBuildHelpLines_ReturnsPlainText(t *testing.T) {
 	original := lipgloss.DefaultRenderer().ColorProfile()
 	originalNoColor := ConfigNoColor


### PR DESCRIPTION
Part **a** of #319.

## Problem
Long keybinding descriptions in the help overlay were truncated with a `~` and could not be read in full.

## Change
`buildHelpSpecs` now word-wraps each description to the panel width, emitting continuation rows whose key column is blank but the same width, so wrapped text stays aligned under the original description.

Wrapping happens at spec-build time, so every physical row remains exactly one `helpLineSpec` — preserving the one-spec-per-row invariant the help search, scroll, and `n`/`N` match navigation depend on. `BuildHelpLines`/`buildHelpSpecs` gain a width parameter; new `helpInnerWidth` mirrors the renderer's box arithmetic so both paths wrap to the same budget.

The per-section type-search the issue also asked for (`/` highlight + `f` filter) already exists.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/ui/ ./internal/app/`
- [x] `golangci-lint run`
- [x] New tests: wrapped rows fit width (no truncation), narrow width wraps to more rows, continuation rows carry a blank aligned key

🤖 Generated with [Claude Code](https://claude.com/claude-code)