### PR TITLE
feat(security): finding-ignore visibility — fix dead toggle, namespace scope, config globs

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -87,6 +87,17 @@ icons: auto
 #   sources:
 #     falco: false           # disable a single source; omitted = enabled
 #     trivy: false
+#   # Declarative, glob-based ignore rules (applied at load). Each field is a
+#   # glob (* and ?); an empty field matches anything; a finding is hidden when
+#   # every non-empty field matches. Read-only — the `i` toggle still reveals
+#   # them. Interactive per-finding ignores (action menu `x`) are stored
+#   # separately in ~/.local/state/lfk/security_ignores.yaml.
+#   ignore_patterns:
+#     - source: trivy-operator   # source id; "" = any
+#       group: "CVE-2024-*"      # CVE id / check label / rule name; "" = any
+#       namespace: kube-system   # "" or "*" = any namespace (hides whole group)
+#       cluster: "prod-*"        # kube-context glob; "" = any cluster
+#       comment: accepted in system namespaces
 
 # ─── Log Path ──────────────────────────────────────────────────────────────────
 # Application log file location. Default: ~/.local/share/lfk/lfk.log
@@ -282,6 +293,8 @@ keybindings:
   scale: "S" # Scale resource (default: S)
   mouse_toggle: "alt+ctrl+y" # Suspend/resume mouse capture for native text selection (Ctrl+Option+Y; default: alt+ctrl+y)
   cluster_color_picker: "L" # Open cluster-color picker (default: Shift+L; reuses the Logs key, since Logs has no resource to act on at the cluster picker — at deeper levels "L" still opens Logs)
+  security_ignore_toggle: "i" # Show/hide ignored security findings (default: i; security view only — shadows the Label Editor there)
+  security_badge_toggle: "B" # Show/hide the per-resource SEC severity badge (default: B)
 
 # ─── Search Abbreviations ─────────────────────────────────────────────────────
 # Short names for resource types used in search/filter.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -36,6 +36,7 @@ The configuration file is located at `~/.config/lfk/config.yaml`. All fields are
 | `clusters.<name>.read_only` | bool | _(unset)_ | Per-context read-only override. Wins over the global `read_only` so you can mark specific clusters (e.g. `prod`) read-only while leaving others mutable. |
 | `security.enabled` | bool | `true` | Enable the built-in security findings dashboard (Security category + SEC badge). `false` turns the dashboard and all source probing off. Per-context overrides under `clusters.<name>.security` take precedence. See [Security Dashboard](security.md). |
 | `security.sources.<name>` | bool | `true` | Enable/disable individual sources (`heuristic`, `trivy`, `kyverno`, `kubescape`, `falco`, `gatekeeper`). A source omitted from the map stays enabled. |
+| `security.ignore_patterns` | list | _(empty)_ | Declarative glob-based ignore rules applied at load. Each entry has `cluster`, `source`, `group`, `namespace` (globs; empty = any) and an optional `comment`. A finding is hidden when every non-empty field matches. An all-empty entry is dropped. Read-only (not un-ignorable from the UI); the `i` toggle still reveals them. |
 | `clusters.<name>.security` | object | _(unset)_ | Per-context security override (`enabled` and/or `sources`). Wins over the global `security` settings for that context. |
 | `secret_lazy_loading` | bool | `false` | When `true`, Secret listing fetches metadata only and decoded values load on hover. Much faster in clusters with many Helm release secrets (each release is a multi-hundred-KB Secret) or large TLS payloads, at the cost of an extra GET per hovered Secret. When `false` (default), Secrets list like every other resource type — full objects are pulled and `data` is eagerly decoded, so the Type column and decoded values are visible immediately. See [Secret lazy loading](#secret-lazy-loading) for trade-offs. |
 | `informer_cache` | bool or string | `auto` | Selects the list strategy. Accepts `off` (round-trip every list — matches kubectl), `auto` (default; promote a resource type to a shared informer once a list crosses 1000 items, demote when sustained below 500), and `always` (open a watch eagerly on first use). Legacy bool form is still accepted: `true` → `always`, `false` → `off`. See [Informer cache](#informer-cache) for trade-offs. |
@@ -182,6 +183,13 @@ security:
   sources:
     falco: false           # disable Falco everywhere
 
+  ignore_patterns:        # declarative, glob-based ignore rules (applied at load)
+    - source: trivy-operator
+      group: "CVE-2024-*"  # CVE id / check label / rule name
+      namespace: kube-system  # "" or "*" = any namespace (hides the whole group)
+      cluster: "prod-*"    # kube-context glob; "" = any cluster
+      comment: accepted in system namespaces
+
 clusters:
   prod:
     security:
@@ -192,8 +200,11 @@ clusters:
         trivy: false       # keep the dashboard, drop Trivy on staging only
 ```
 
-Precedence: `clusters.<ctx>.security.*` overrides the global `security.*`. See
-[Security Dashboard](security.md) for the source catalog and behavior.
+Precedence: `clusters.<ctx>.security.*` overrides the global `security.*`. The
+interactive per-cluster ignore-list (action menu) and `ignore_patterns` are
+applied together; config patterns are read-only. See
+[Security Dashboard](security.md) for the source catalog, ignore scopes, and
+behavior.
 
 ## API client rate limits
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -65,6 +65,7 @@ Your chosen sort is remembered per resource kind for the running session, so lea
 | `T` | Switch color scheme (live preview, not persisted) |
 | `Ctrl+T` | Cycle terminal mode (pty / exec / mux — mux skipped without tmux/zellij) |
 | `B` | Show/hide the per-resource SEC severity badge on explorer rows |
+| `i` | Show/hide ignored security findings (security view only — shadows the Label Editor there, which is a no-op on synthetic finding rows) |
 
 ## Orphan filter presets
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -103,10 +103,48 @@ clusters:
 
 ## Ignoring findings
 
-Each cluster has an ignore-list so known/accepted findings can be hidden.
+Known/accepted findings can be hidden so the dashboard surfaces only what still
+needs attention. Two mechanisms exist, applied together: an **interactive
+per-cluster ignore-list** and **declarative config-file patterns**.
+
+### Interactive (action menu)
+
+On a finding group or an affected resource, press `x` to open the action menu.
+The available scopes depend on the row:
+
+| Action | Scope |
+|---|---|
+| Ignore (Group) | Hide the finding across the whole cluster |
+| Ignore (Namespace) | Hide the finding for every resource in the selected row's namespace |
+| Ignore (This Resource) | Hide the finding for one specific resource |
+| Un-ignore | Remove the most specific matching rule (resource → namespace → group) |
 
 | Key | Action |
 |---|---|
-| `Ctrl+I` | Toggle show/hide ignored findings on the active security view |
+| `i` | Toggle show/hide ignored findings (only on a security view) |
+| `x` | Open the action menu to ignore/un-ignore the selected finding |
 
-The ignore-list is stored per cluster and persists across sessions.
+The interactive ignore-list is stored per cluster in
+`$XDG_STATE_HOME/lfk/security_ignores.yaml` (default `~/.local/state/lfk/`) and
+persists across sessions.
+
+### Declarative (config file)
+
+`security.ignore_patterns` in the config file defines glob-based rules applied
+at startup — useful for org-wide accepted findings. Each field is a glob (`*`,
+`?`); an empty field matches anything. A finding is ignored when every non-empty
+field matches it.
+
+```yaml
+security:
+  ignore_patterns:
+    - source: trivy-operator    # source id; "" = any
+      group: "CVE-2024-*"       # CVE id / check label / rule name; "" = any
+      namespace: kube-system    # "" or "*" = any namespace (hides the whole group)
+      cluster: "prod-*"         # kube-context glob; "" = any cluster
+      comment: accepted in system namespaces
+```
+
+Config patterns are read-only — they cannot be un-ignored from the action menu —
+but the `i` toggle still reveals findings they hide. A pattern with every field
+empty is ignored (it would otherwise hide everything).

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -210,6 +210,20 @@ func (m Model) loadResources(forPreview bool) tea.Cmd {
 			}
 		}
 	}
+	// Security findings share one coalesced, cached cluster scan. When that
+	// scan is already warm, render the source's findings synchronously off the
+	// scheduler — instant even when the scheduler is congested, and without a
+	// tracked task (so the explorer stops showing a per-source "scan" entry
+	// that is really a cache-hit filter over the shared scan). A cold cache
+	// falls through to the scan task below, which warms it.
+	if rt.APIGroup == model.SecurityVirtualAPIGroup && m.client != nil {
+		if items, ok, err := m.client.GetSecurityFindingsCached(kctx, ns, rt); ok {
+			rtCopy := rt
+			return func() tea.Msg {
+				return resourcesLoadedMsg{items: items, err: err, forPreview: forPreview, gen: gen, silent: silent, rt: rtCopy}
+			}
+		}
+	}
 	client := m.client
 	// The main resource list (drill-in / watch refresh) runs at High — the
 	// same lane as preview hovers. It must NOT be Critical: Critical is the
@@ -220,10 +234,17 @@ func (m Model) loadResources(forPreview bool) tea.Cmd {
 	// Critical first — starve the High preview work that renders pod details.
 	// High keeps the list ahead of Low background (dashboard/metrics/events)
 	// while sharing the general pool fairly with previews.
+	// Security findings reaching here have a cold cache; name the task so it
+	// reads as the shared security scan (it triggers/awaits the one coalesced
+	// FetchAll that covers every source), not a per-source object listing.
+	listName := "List " + model.DisplayNameFor(rt)
+	if rt.APIGroup == model.SecurityVirtualAPIGroup {
+		listName = "Security findings: " + model.DisplayNameFor(rt)
+	}
 	return m.scheduleK8sCall(
 		scheduler.PriorityHigh,
 		scheduler.KindResourceList,
-		"List "+model.DisplayNameFor(rt),
+		listName,
 		bgtaskTarget(kctx, ns),
 		func(ctx context.Context) tea.Msg {
 			items, err := client.GetResources(ctx, kctx, ns, rt)

--- a/internal/app/commands_security.go
+++ b/internal/app/commands_security.go
@@ -319,6 +319,16 @@ func (m Model) loadSecurityAffectedResources(forPreview bool) tea.Cmd {
 	gen := m.requestGen
 	silent := m.suppressBgtasks
 	reqCtx := m.reqCtx
+	// Warm-cache fast path: the affected-resource view filters the same shared
+	// scan, so serve it synchronously off the scheduler when cached (see
+	// loadResources). Cold cache falls through to the scan task.
+	if m.client != nil {
+		if items, ok, err := m.client.GetSecurityAffectedResourcesCached(kctx, ns, rt, groupKey); ok {
+			return func() tea.Msg {
+				return ownedLoadedMsg{items: items, err: err, forPreview: forPreview, gen: gen, silent: silent}
+			}
+		}
+	}
 	return m.trackBgTask(
 		scheduler.KindResourceList,
 		"List affected resources",

--- a/internal/app/security_ignore_patterns.go
+++ b/internal/app/security_ignore_patterns.go
@@ -90,7 +90,11 @@ func patternIgnoresGroup(patterns []ui.SecurityIgnorePattern, ctx, source, group
 		if patternIsEmpty(p) {
 			continue
 		}
-		if p.Namespace != "" && p.Namespace != "*" {
+		// An all-"*" namespace glob ("", "*", "**", …) means "any namespace" —
+		// the same any-sentinel globMatch uses — so it hides the whole group. A
+		// specific glob (e.g. "kube-*") is namespace-scoped and excluded here,
+		// matching patternIgnoresResource's per-resource behavior.
+		if p.Namespace != "" && strings.Trim(p.Namespace, "*") != "" {
 			continue
 		}
 		if globMatch(p.Cluster, ctx) &&

--- a/internal/app/security_ignore_patterns.go
+++ b/internal/app/security_ignore_patterns.go
@@ -1,0 +1,103 @@
+// Package app — security_ignore_patterns.go
+// Matching for the declarative, glob-based security ignore rules defined in
+// the config file (ui.SecurityIgnorePattern). These complement the
+// interactive per-cluster ignore-list in security_ignores.go: config patterns
+// are read-only (cannot be un-ignored from the UI), but the show-ignored
+// toggle still reveals findings they hide. The interactive action menu reads
+// the YAML state directly, so it never offers a misleading "Un-ignore" for a
+// config-only ignore; only modelIgnoreChecker (used by the grouping/filter
+// engine) consults both layers.
+package app
+
+import (
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// globMatch reports whether s matches a glob pattern supporting `*`
+// (zero-or-more of any character) and `?` (exactly one character). The match
+// is anchored to the whole string and is slash-agnostic (unlike path.Match,
+// `*` spans `/`). An empty pattern or any all-`*` pattern matches anything —
+// the "any" sentinel used by ignore patterns (consecutive stars are
+// equivalent to one). Matching is case-sensitive and runs in linear time via
+// the classic two-pointer backtracking algorithm.
+func globMatch(pattern, s string) bool {
+	if pattern == "" || strings.Trim(pattern, "*") == "" {
+		return true
+	}
+	pr := []rune(pattern)
+	sr := []rune(s)
+	var px, sx int
+	starPx, starSx := -1, 0
+	for sx < len(sr) {
+		switch {
+		case px < len(pr) && (pr[px] == '?' || pr[px] == sr[sx]):
+			px++
+			sx++
+		case px < len(pr) && pr[px] == '*':
+			starPx = px // remember the star and the input position it began at
+			starSx = sx
+			px++
+		case starPx >= 0:
+			px = starPx + 1 // backtrack: let the last star absorb one more char
+			starSx++
+			sx = starSx
+		default:
+			return false
+		}
+	}
+	for px < len(pr) && pr[px] == '*' {
+		px++
+	}
+	return px == len(pr)
+}
+
+// patternIsEmpty reports whether a pattern has no constraints at all. Such a
+// pattern would match every finding, so callers skip it defensively (the
+// config loader also drops these at apply time). Delegates to the single
+// authoritative definition on the config type.
+func patternIsEmpty(p ui.SecurityIgnorePattern) bool {
+	return p.IsEmpty()
+}
+
+// patternIgnoresResource reports whether any config pattern hides the finding
+// identified by (ctx, source, groupKey, namespace). Every non-empty field of
+// a pattern must match. namespace is the finding's namespace (empty for
+// cluster-scoped findings).
+func patternIgnoresResource(patterns []ui.SecurityIgnorePattern, ctx, source, groupKey, namespace string) bool {
+	for _, p := range patterns {
+		if patternIsEmpty(p) {
+			continue
+		}
+		if globMatch(p.Cluster, ctx) &&
+			globMatch(p.Source, source) &&
+			globMatch(p.Group, groupKey) &&
+			globMatch(p.Namespace, namespace) {
+			return true
+		}
+	}
+	return false
+}
+
+// patternIgnoresGroup reports whether any config pattern hides the entire
+// group (ctx, source, groupKey) regardless of namespace. Only patterns whose
+// namespace field is "any" (empty or `*`) qualify; namespace-scoped patterns
+// hide individual resources, not the whole group, so they are excluded here
+// (mirroring how a namespace-scoped interactive rule leaves the group visible).
+func patternIgnoresGroup(patterns []ui.SecurityIgnorePattern, ctx, source, groupKey string) bool {
+	for _, p := range patterns {
+		if patternIsEmpty(p) {
+			continue
+		}
+		if p.Namespace != "" && p.Namespace != "*" {
+			continue
+		}
+		if globMatch(p.Cluster, ctx) &&
+			globMatch(p.Source, source) &&
+			globMatch(p.Group, groupKey) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/security_ignore_patterns_test.go
+++ b/internal/app/security_ignore_patterns_test.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func TestGlobMatch(t *testing.T) {
+	cases := []struct {
+		pattern, s string
+		want       bool
+	}{
+		{"", "anything", true},    // empty = any
+		{"*", "anything", true},   // bare star = any
+		{"", "", true},            // empty matches empty
+		{"exact", "exact", true},  // exact match
+		{"exact", "other", false}, // exact mismatch
+		{"CVE-2024-*", "CVE-2024-1234", true},
+		{"CVE-2024-*", "CVE-2023-1234", false},
+		{"*-system", "kube-system", true},
+		{"*-system", "kube-public", false},
+		{"kube-*", "kube-system", true},
+		{"kube-?", "kube-1", true},
+		{"kube-?", "kube-12", false},   // ? = exactly one
+		{"a*b*c", "axxbyyc", true},     // multiple stars
+		{"a*b*c", "axxbyy", false},     // missing trailing c
+		{"ns/*/*", "ns/Pod/web", true}, // slash-agnostic (unlike path.Match)
+		{"prod-*", "staging-1", false},
+		{"*", "", true},
+		{"?", "", false}, // ? needs one char
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, globMatch(c.pattern, c.s),
+			"globMatch(%q, %q)", c.pattern, c.s)
+	}
+}
+
+func TestPatternIsEmpty(t *testing.T) {
+	assert.True(t, patternIsEmpty(ui.SecurityIgnorePattern{}))
+	assert.True(t, patternIsEmpty(ui.SecurityIgnorePattern{Comment: "note only"}))
+	assert.False(t, patternIsEmpty(ui.SecurityIgnorePattern{Source: "trivy-operator"}))
+	assert.False(t, patternIsEmpty(ui.SecurityIgnorePattern{Namespace: "kube-system"}))
+}
+
+func TestPatternIgnoresResource(t *testing.T) {
+	patterns := []ui.SecurityIgnorePattern{
+		{Source: "trivy-operator", Group: "CVE-2024-*", Namespace: "kube-system"},
+		{Cluster: "prod-*", Source: "heuristic", Group: "no-resource-limits"},
+		{}, // empty -> must be skipped, never matches
+	}
+
+	// All non-empty fields match.
+	assert.True(t, patternIgnoresResource(patterns, "any-ctx", "trivy-operator", "CVE-2024-9", "kube-system"))
+	// Namespace differs -> no match.
+	assert.False(t, patternIgnoresResource(patterns, "any-ctx", "trivy-operator", "CVE-2024-9", "default"))
+	// Group glob differs -> no match.
+	assert.False(t, patternIgnoresResource(patterns, "any-ctx", "trivy-operator", "CVE-2023-9", "kube-system"))
+	// Cluster glob gates the second pattern (empty namespace = any).
+	assert.True(t, patternIgnoresResource(patterns, "prod-eu", "heuristic", "no-resource-limits", "whatever"))
+	assert.False(t, patternIgnoresResource(patterns, "staging", "heuristic", "no-resource-limits", "whatever"))
+	// Empty pattern must never match.
+	assert.False(t, patternIgnoresResource([]ui.SecurityIgnorePattern{{}}, "c", "s", "g", "n"))
+}
+
+// Cluster-scoped findings (ClusterRole, etc.) reach patternIgnoresResource with
+// an empty namespace (namespaceFromResourceKey("/ClusterRole/admin") == ""). An
+// any-namespace pattern must match them; a namespace-specific pattern must not.
+func TestPatternIgnoresResourceClusterScoped(t *testing.T) {
+	anyNS := []ui.SecurityIgnorePattern{{Source: "heuristic", Group: "check-x"}}
+	assert.True(t, patternIgnoresResource(anyNS, "ctx", "heuristic", "check-x", ""),
+		"empty-namespace pattern matches a cluster-scoped finding")
+
+	specificNS := []ui.SecurityIgnorePattern{{Source: "heuristic", Group: "check-x", Namespace: "kube-system"}}
+	assert.False(t, patternIgnoresResource(specificNS, "ctx", "heuristic", "check-x", ""),
+		"namespace-specific pattern must NOT match a cluster-scoped finding")
+}
+
+func TestPatternIgnoresGroup(t *testing.T) {
+	patterns := []ui.SecurityIgnorePattern{
+		{Source: "heuristic", Group: "no-resource-limits"},   // any namespace -> whole group
+		{Source: "trivy-operator", Namespace: "kube-system"}, // namespace-scoped -> NOT whole group
+		{Source: "falco", Group: "*", Namespace: "*"},        // explicit any-namespace
+	}
+
+	// Any-namespace pattern hides the whole group.
+	assert.True(t, patternIgnoresGroup(patterns, "ctx", "heuristic", "no-resource-limits"))
+	// Explicit "*" namespace also counts as whole-group.
+	assert.True(t, patternIgnoresGroup(patterns, "ctx", "falco", "any-rule"))
+	// Namespace-scoped pattern does NOT hide the whole group.
+	assert.False(t, patternIgnoresGroup(patterns, "ctx", "trivy-operator", "CVE-1"))
+	// Non-matching source.
+	assert.False(t, patternIgnoresGroup(patterns, "ctx", "policy-report", "x"))
+}

--- a/internal/app/security_ignore_patterns_test.go
+++ b/internal/app/security_ignore_patterns_test.go
@@ -94,3 +94,18 @@ func TestPatternIgnoresGroup(t *testing.T) {
 	// Non-matching source.
 	assert.False(t, patternIgnoresGroup(patterns, "ctx", "policy-report", "x"))
 }
+
+// An all-"*" namespace glob ("**", "***") means "any namespace" — same as
+// globMatch's any-sentinel — so it must hide the whole group, consistent with
+// patternIgnoresResource (regression for the "*"-only check).
+func TestPatternIgnoresGroup_AllStarNamespaceIsWholeGroup(t *testing.T) {
+	patterns := []ui.SecurityIgnorePattern{{Source: "falco", Group: "rule", Namespace: "**"}}
+	assert.True(t, patternIgnoresGroup(patterns, "ctx", "falco", "rule"),
+		"'**' namespace must count as whole-group")
+	assert.True(t, patternIgnoresResource(patterns, "ctx", "falco", "rule", "any-ns"),
+		"and still match a specific resource (already consistent)")
+
+	// A specific namespace glob stays namespace-scoped (not whole-group).
+	scoped := []ui.SecurityIgnorePattern{{Source: "falco", Group: "rule", Namespace: "kube-*"}}
+	assert.False(t, patternIgnoresGroup(scoped, "ctx", "falco", "rule"))
+}

--- a/internal/app/security_ignore_toggle_key_test.go
+++ b/internal/app/security_ignore_toggle_key_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// TestSecurityIgnoreToggleKeyOnSecurityView drives the REAL explorer key
+// dispatch (not the handler directly) to prove the configured
+// SecurityIgnoreToggle key actually reaches the show-ignored toggle on a
+// security view. This is the regression guard for the original bug: the
+// default was "ctrl+i", which a terminal delivers as "tab" (byte 0x09), so
+// the binding never fired — yet the handler-level unit tests passed because
+// they bypassed the key string entirely.
+func TestSecurityIgnoreToggleKeyOnSecurityView(t *testing.T) {
+	m := Model{}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "__security_heuristic__"}
+	require.False(t, m.showSecurityIgnored)
+
+	res, _, handled := m.handleExplorerActionKey(keyMsg(ui.ActiveKeybindings.SecurityIgnoreToggle))
+
+	require.True(t, handled, "ignore toggle key must be handled on a security view")
+	assert.True(t, res.(Model).showSecurityIgnored, "key press must flip showSecurityIgnored")
+}
+
+// TestSecurityIgnoreToggleNotHandledOffSecurityView verifies the toggle is
+// scoped: off a security view the key must not flip the ignored state (it
+// falls through to its global meaning, e.g. the label editor).
+func TestSecurityIgnoreToggleNotHandledOffSecurityView(t *testing.T) {
+	m := Model{}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"}
+
+	_, _, handled := m.handleExplorerSecurityViewKeys(keyMsg(ui.ActiveKeybindings.SecurityIgnoreToggle))
+
+	assert.False(t, handled, "ignore toggle must not fire off a security view")
+}
+
+// TestSecurityIgnoreToggleHelperOnSecurityView checks the gated helper in
+// isolation: on a security view it consumes the key and flips the state.
+func TestSecurityIgnoreToggleHelperOnSecurityView(t *testing.T) {
+	m := Model{}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "__security_falco__"}
+
+	res, _, handled := m.handleExplorerSecurityViewKeys(keyMsg(ui.ActiveKeybindings.SecurityIgnoreToggle))
+
+	require.True(t, handled)
+	assert.True(t, res.(Model).showSecurityIgnored)
+}

--- a/internal/app/security_ignore_toggle_key_test.go
+++ b/internal/app/security_ignore_toggle_key_test.go
@@ -51,3 +51,33 @@ func TestSecurityIgnoreToggleHelperOnSecurityView(t *testing.T) {
 	require.True(t, handled)
 	assert.True(t, res.(Model).showSecurityIgnored)
 }
+
+// TestSecurityIgnoreToggleKeyFullDispatch drives the FULL top-level key path
+// (handleKey -> ... -> handleExplorerKey -> handleExplorerActionKey) the way a
+// real keypress flows, on a security finding view in explorer mode with no
+// overlay. This is the layer the handler-level tests skip — exactly where the
+// original ctrl+i bug hid. Pressing the configured toggle key must flip the
+// state; pressing it off a security view must NOT.
+func TestSecurityIgnoreToggleKeyFullDispatch(t *testing.T) {
+	key := keyMsg(ui.ActiveKeybindings.SecurityIgnoreToggle)
+
+	t.Run("on security view toggles", func(t *testing.T) {
+		m := Model{} // mode zero value == modeExplorer, no overlay
+		m.nav.ResourceType = model.ResourceTypeEntry{Kind: "__security_heuristic__"}
+		m.middleItems = []model.Item{{Kind: "__security_finding_group__", Name: "no-limits", Extra: "no-limits"}}
+		m.setCursor(0)
+
+		res, _ := m.handleKey(key)
+		assert.True(t, res.(Model).showSecurityIgnored, "full key path must flip the toggle on a security view")
+	})
+
+	t.Run("off security view does not toggle", func(t *testing.T) {
+		m := Model{}
+		m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"}
+		m.middleItems = []model.Item{{Kind: "Pod", Name: "nginx", Namespace: "default"}}
+		m.setCursor(0)
+
+		res, _ := m.handleKey(key)
+		assert.False(t, res.(Model).showSecurityIgnored, "off a security view the key must not flip the toggle")
+	})
+}

--- a/internal/app/security_ignores.go
+++ b/internal/app/security_ignores.go
@@ -3,19 +3,27 @@ package app
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// SecurityIgnoreRule represents a single ignore entry.
+// SecurityIgnoreRule represents a single ignore entry. Scope is determined by
+// which of Namespace / Resource are set, in order of increasing specificity:
+//
+//	Namespace == "" && Resource == "" -> whole group, cluster-wide
+//	Namespace != "" && Resource == "" -> group within one namespace
+//	Resource  != ""                   -> one specific resource (ns encoded in key)
 type SecurityIgnoreRule struct {
-	Source    string `json:"source" yaml:"source"`                         // Security source name: "heuristic", "trivy-operator", "falco", "policy-report"
-	GroupKey  string `json:"group_key" yaml:"group_key"`                   // Finding group key (check label, CVE ID, rule name)
-	Resource  string `json:"resource,omitempty" yaml:"resource,omitempty"` // ResourceRef.Key() format: "ns/kind/name". Empty = global ignore.
+	Source    string `json:"source" yaml:"source"`                           // Security source name: "heuristic", "trivy-operator", "falco", "policy-report"
+	GroupKey  string `json:"group_key" yaml:"group_key"`                     // Finding group key (check label, CVE ID, rule name)
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"` // Namespace scope. Empty = any namespace. Ignored when Resource is set.
+	Resource  string `json:"resource,omitempty" yaml:"resource,omitempty"`   // ResourceRef.Key() format: "ns/kind/name". Empty = no resource scope.
 	Comment   string `json:"comment,omitempty" yaml:"comment,omitempty"`
 	CreatedAt string `json:"created_at" yaml:"created_at"` // RFC3339
 }
@@ -160,9 +168,11 @@ func addSecurityIgnore(state *SecurityIgnoreState, ctx string, rule SecurityIgno
 
 	existing := newContexts[ctx]
 
-	// Deduplicate: replace if same (Source, GroupKey, Resource) already exists.
+	// Deduplicate: replace if same (Source, GroupKey, Namespace, Resource)
+	// already exists.
 	for i, r := range existing {
-		if r.Source == rule.Source && r.GroupKey == rule.GroupKey && r.Resource == rule.Resource {
+		if r.Source == rule.Source && r.GroupKey == rule.GroupKey &&
+			r.Namespace == rule.Namespace && r.Resource == rule.Resource {
 			existing[i] = rule
 			newContexts[ctx] = existing
 			return &SecurityIgnoreState{Contexts: newContexts}
@@ -174,8 +184,9 @@ func addSecurityIgnore(state *SecurityIgnoreState, ctx string, rule SecurityIgno
 	return &SecurityIgnoreState{Contexts: newContexts}
 }
 
-// removeSecurityIgnore returns a NEW state with the matching rule removed.
-func removeSecurityIgnore(state *SecurityIgnoreState, ctx, source, groupKey, resource string) *SecurityIgnoreState {
+// removeSecurityIgnore returns a NEW state with the rule matching
+// (source, groupKey, namespace, resource) removed.
+func removeSecurityIgnore(state *SecurityIgnoreState, ctx, source, groupKey, namespace, resource string) *SecurityIgnoreState {
 	newContexts := make(map[string][]SecurityIgnoreRule, len(state.Contexts))
 	for k, v := range state.Contexts {
 		copied := make([]SecurityIgnoreRule, len(v))
@@ -186,7 +197,8 @@ func removeSecurityIgnore(state *SecurityIgnoreState, ctx, source, groupKey, res
 	existing := newContexts[ctx]
 	filtered := make([]SecurityIgnoreRule, 0, len(existing))
 	for _, r := range existing {
-		if r.Source == source && r.GroupKey == groupKey && r.Resource == resource {
+		if r.Source == source && r.GroupKey == groupKey &&
+			r.Namespace == namespace && r.Resource == resource {
 			continue
 		}
 		filtered = append(filtered, r)
@@ -196,25 +208,60 @@ func removeSecurityIgnore(state *SecurityIgnoreState, ctx, source, groupKey, res
 	return &SecurityIgnoreState{Contexts: newContexts}
 }
 
-// isGroupIgnored returns true if there is a global ignore rule (empty Resource)
-// for the given source and group key in the specified context.
+// namespaceFromResourceKey extracts the namespace from a ResourceRef.Key()
+// ("ns/kind/name"). Cluster-scoped findings have an empty namespace segment.
+func namespaceFromResourceKey(resourceKey string) string {
+	ns, _, _ := strings.Cut(resourceKey, "/")
+	return ns
+}
+
+// isGroupIgnored returns true only when the whole group is ignored cluster-wide
+// (a rule with neither a Namespace nor a Resource scope) for the given source
+// and group key. Namespace- and resource-scoped rules do NOT make the whole
+// group ignored, so the group row stays visible.
 func isGroupIgnored(state *SecurityIgnoreState, ctx, source, groupKey string) bool {
 	for _, r := range state.Contexts[ctx] {
-		if r.Source == source && r.GroupKey == groupKey && r.Resource == "" {
+		if r.Source == source && r.GroupKey == groupKey && r.Resource == "" && r.Namespace == "" {
 			return true
 		}
 	}
 	return false
 }
 
-// isResourceIgnored returns true if EITHER a global ignore (empty Resource)
-// OR a resource-specific ignore matches the given source, group key and resource key.
+// isNamespaceIgnored returns true if there is a namespace-scoped ignore rule
+// (Namespace set, Resource empty) for the given source/group/namespace.
+func isNamespaceIgnored(state *SecurityIgnoreState, ctx, source, groupKey, namespace string) bool {
+	if namespace == "" {
+		return false
+	}
+	for _, r := range state.Contexts[ctx] {
+		if r.Source == source && r.GroupKey == groupKey && r.Resource == "" && r.Namespace == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// isResourceIgnored returns true when a finding on resourceKey is hidden by ANY
+// matching rule, checked from least to most specific: a cluster-wide group
+// ignore, a namespace-scoped ignore for the resource's namespace, or a
+// resource-specific ignore. resourceKey is in ResourceRef.Key() form.
 func isResourceIgnored(state *SecurityIgnoreState, ctx, source, groupKey, resourceKey string) bool {
+	ns := namespaceFromResourceKey(resourceKey)
 	for _, r := range state.Contexts[ctx] {
 		if r.Source != source || r.GroupKey != groupKey {
 			continue
 		}
-		if r.Resource == "" || r.Resource == resourceKey {
+		switch {
+		case r.Resource != "":
+			if r.Resource == resourceKey {
+				return true
+			}
+		case r.Namespace != "":
+			if r.Namespace == ns {
+				return true
+			}
+		default: // neither scope set -> cluster-wide group ignore
 			return true
 		}
 	}
@@ -234,12 +281,12 @@ func isResourceSpecificIgnored(state *SecurityIgnoreState, ctx, source, groupKey
 	return false
 }
 
-// countIgnoredGroups returns the count of global ignores (rules with empty Resource)
-// for the given context.
+// countIgnoredGroups returns the count of cluster-wide group ignores (rules
+// with neither a namespace nor a resource scope) for the given context.
 func countIgnoredGroups(state *SecurityIgnoreState, ctx string) int {
 	count := 0
 	for _, r := range state.Contexts[ctx] {
-		if r.Resource == "" {
+		if r.Resource == "" && r.Namespace == "" {
 			count++
 		}
 	}
@@ -249,19 +296,40 @@ func countIgnoredGroups(state *SecurityIgnoreState, ctx string) int {
 // modelIgnoreChecker adapts SecurityIgnoreState to the k8s.IgnoreChecker
 // interface so the groupFindings engine can filter ignored entries. The
 // interface is defined in the k8s package; Go structural typing allows this
-// app-layer type to satisfy it without importing k8s.
+// app-layer type to satisfy it without importing k8s. It combines two
+// sources: the interactive per-cluster ignore-list (state) and the
+// declarative config-file glob patterns (patterns), snapshotted at
+// construction. The interactive action menu reads the state functions
+// directly, so config patterns never surface a misleading "Un-ignore".
 type modelIgnoreChecker struct {
-	state *SecurityIgnoreState
-	ctx   string
+	state    *SecurityIgnoreState
+	ctx      string
+	patterns []ui.SecurityIgnorePattern
 }
 
-// IsGroupIgnored returns true when the entire group is globally ignored.
+// newModelIgnoreChecker builds a checker for one cluster context, capturing a
+// snapshot of the config ignore patterns (read-only after load).
+func newModelIgnoreChecker(state *SecurityIgnoreState, ctx string) *modelIgnoreChecker {
+	return &modelIgnoreChecker{
+		state:    state,
+		ctx:      ctx,
+		patterns: ui.ConfigSecurityIgnorePatterns,
+	}
+}
+
+// IsGroupIgnored returns true when the entire group is ignored cluster-wide,
+// by either an interactive rule or an any-namespace config pattern.
 func (c *modelIgnoreChecker) IsGroupIgnored(source, groupKey string) bool {
-	return isGroupIgnored(c.state, c.ctx, source, groupKey)
+	return isGroupIgnored(c.state, c.ctx, source, groupKey) ||
+		patternIgnoresGroup(c.patterns, c.ctx, source, groupKey)
 }
 
-// IsResourceIgnored returns true when the specific resource within a group
-// is ignored (either via a resource-level rule or a global group ignore).
+// IsResourceIgnored returns true when the specific resource within a group is
+// ignored — by an interactive rule (group / namespace / resource scope) or a
+// matching config pattern.
 func (c *modelIgnoreChecker) IsResourceIgnored(source, groupKey, resourceKey string) bool {
-	return isResourceIgnored(c.state, c.ctx, source, groupKey, resourceKey)
+	if isResourceIgnored(c.state, c.ctx, source, groupKey, resourceKey) {
+		return true
+	}
+	return patternIgnoresResource(c.patterns, c.ctx, source, groupKey, namespaceFromResourceKey(resourceKey))
 }

--- a/internal/app/security_ignores_namespace_test.go
+++ b/internal/app/security_ignores_namespace_test.go
@@ -1,0 +1,140 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func TestNamespaceFromResourceKey(t *testing.T) {
+	assert.Equal(t, "default", namespaceFromResourceKey("default/Pod/web"))
+	assert.Equal(t, "kube-system", namespaceFromResourceKey("kube-system/Deployment/dns"))
+	assert.Equal(t, "", namespaceFromResourceKey("/ClusterRole/admin")) // cluster-scoped
+	assert.Equal(t, "", namespaceFromResourceKey(""))
+}
+
+func TestIsNamespaceIgnored(t *testing.T) {
+	state := &SecurityIgnoreState{Contexts: make(map[string][]SecurityIgnoreRule)}
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring",
+	})
+
+	assert.True(t, isNamespaceIgnored(state, "prod", "heuristic", "no-limits", "monitoring"))
+	assert.False(t, isNamespaceIgnored(state, "prod", "heuristic", "no-limits", "default"))
+	assert.False(t, isNamespaceIgnored(state, "prod", "heuristic", "no-limits", ""), "empty ns never matches")
+	assert.False(t, isNamespaceIgnored(state, "staging", "heuristic", "no-limits", "monitoring"))
+}
+
+// A namespace-scoped rule must NOT make the whole group count as ignored;
+// the group row stays visible and only the scoped namespace is filtered.
+func TestIsGroupIgnoredIgnoresNamespaceScopedRules(t *testing.T) {
+	state := &SecurityIgnoreState{Contexts: make(map[string][]SecurityIgnoreRule)}
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring",
+	})
+	assert.False(t, isGroupIgnored(state, "prod", "heuristic", "no-limits"))
+
+	// Adding a cluster-wide rule for the same group flips it.
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{Source: "heuristic", GroupKey: "no-limits"})
+	assert.True(t, isGroupIgnored(state, "prod", "heuristic", "no-limits"))
+}
+
+func TestIsResourceIgnoredNamespaceScope(t *testing.T) {
+	state := &SecurityIgnoreState{Contexts: make(map[string][]SecurityIgnoreRule)}
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring",
+	})
+
+	// Resources in the ignored namespace are hidden...
+	assert.True(t, isResourceIgnored(state, "prod", "heuristic", "no-limits", "monitoring/Pod/grafana"))
+	// ...resources in other namespaces are not.
+	assert.False(t, isResourceIgnored(state, "prod", "heuristic", "no-limits", "default/Pod/web"))
+	// ...and a cluster-scoped finding (empty ns) is not caught by the ns rule.
+	assert.False(t, isResourceIgnored(state, "prod", "heuristic", "no-limits", "/ClusterRole/admin"))
+}
+
+func TestAddSecurityIgnoreNamespaceDedupAndDistinct(t *testing.T) {
+	state := &SecurityIgnoreState{Contexts: make(map[string][]SecurityIgnoreRule)}
+
+	// Same (source, group, namespace) dedups.
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{Source: "h", GroupKey: "g", Namespace: "ns1", Comment: "a"})
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{Source: "h", GroupKey: "g", Namespace: "ns1", Comment: "b"})
+	require.Len(t, state.Contexts["prod"], 1)
+	assert.Equal(t, "b", state.Contexts["prod"][0].Comment)
+
+	// Different namespace is a distinct rule.
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{Source: "h", GroupKey: "g", Namespace: "ns2"})
+	require.Len(t, state.Contexts["prod"], 2)
+
+	// A namespace rule and a cluster-wide rule for the same group are distinct.
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{Source: "h", GroupKey: "g"})
+	require.Len(t, state.Contexts["prod"], 3)
+}
+
+func TestRemoveSecurityIgnoreNamespace(t *testing.T) {
+	state := &SecurityIgnoreState{Contexts: make(map[string][]SecurityIgnoreRule)}
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{Source: "h", GroupKey: "g", Namespace: "ns1"})
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{Source: "h", GroupKey: "g"}) // cluster-wide
+	require.Len(t, state.Contexts["prod"], 2)
+
+	// Removing the namespace rule leaves the cluster-wide rule intact.
+	state = removeSecurityIgnore(state, "prod", "h", "g", "ns1", "")
+	require.Len(t, state.Contexts["prod"], 1)
+	assert.Equal(t, "", state.Contexts["prod"][0].Namespace)
+}
+
+func TestSecurityIgnoresNamespaceRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
+	state := &SecurityIgnoreState{Contexts: make(map[string][]SecurityIgnoreRule)}
+	state = addSecurityIgnore(state, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring", Comment: "noisy in monitoring",
+	})
+	require.NoError(t, saveSecurityIgnores(state))
+
+	loaded := loadSecurityIgnores()
+	require.Len(t, loaded.Contexts["prod"], 1)
+	assert.Equal(t, "monitoring", loaded.Contexts["prod"][0].Namespace)
+	assert.Empty(t, loaded.Contexts["prod"][0].Resource)
+}
+
+// TestModelIgnoreCheckerCombinesStateAndConfig verifies the checker honors
+// BOTH the interactive YAML rules and the config-file glob patterns.
+func TestModelIgnoreCheckerCombinesStateAndConfig(t *testing.T) {
+	saved := ui.ConfigSecurityIgnorePatterns
+	t.Cleanup(func() { ui.ConfigSecurityIgnorePatterns = saved })
+
+	ui.ConfigSecurityIgnorePatterns = []ui.SecurityIgnorePattern{
+		{Cluster: "prod", Source: "trivy-operator", Group: "CVE-2024-*", Namespace: "kube-system"},
+		{Source: "falco", Group: "*"}, // any-namespace -> whole group
+	}
+
+	state := &SecurityIgnoreState{Contexts: map[string][]SecurityIgnoreRule{
+		"prod": {{Source: "heuristic", GroupKey: "manual-ignore"}}, // cluster-wide YAML rule
+	}}
+	c := newModelIgnoreChecker(state, "prod")
+
+	// YAML rule still works.
+	assert.True(t, c.IsGroupIgnored("heuristic", "manual-ignore"))
+	assert.True(t, c.IsResourceIgnored("heuristic", "manual-ignore", "default/Pod/x"))
+
+	// Config namespace-scoped pattern: hides the resource in kube-system only,
+	// and does NOT mark the whole group ignored.
+	assert.True(t, c.IsResourceIgnored("trivy-operator", "CVE-2024-1", "kube-system/Pod/x"))
+	assert.False(t, c.IsResourceIgnored("trivy-operator", "CVE-2024-1", "default/Pod/x"))
+	assert.False(t, c.IsGroupIgnored("trivy-operator", "CVE-2024-1"))
+
+	// Config any-namespace pattern hides the whole falco group, including
+	// cluster-scoped findings (empty namespace from "/ClusterRole/admin").
+	assert.True(t, c.IsGroupIgnored("falco", "any-rule"))
+	assert.True(t, c.IsResourceIgnored("falco", "any-rule", "default/Pod/x"))
+	assert.True(t, c.IsResourceIgnored("falco", "any-rule", "/ClusterRole/admin"))
+
+	// Cluster glob gates: a different context is unaffected by the prod pattern.
+	other := newModelIgnoreChecker(state, "staging")
+	assert.False(t, other.IsResourceIgnored("trivy-operator", "CVE-2024-1", "kube-system/Pod/x"))
+}

--- a/internal/app/security_ignores_test.go
+++ b/internal/app/security_ignores_test.go
@@ -72,7 +72,7 @@ func TestRemoveSecurityIgnore(t *testing.T) {
 	state = addSecurityIgnore(state, "prod", rule)
 	require.Len(t, state.Contexts["prod"], 1)
 
-	state = removeSecurityIgnore(state, "prod", "heuristic", "CVE-2024-1234", "")
+	state = removeSecurityIgnore(state, "prod", "heuristic", "CVE-2024-1234", "", "")
 	assert.Empty(t, state.Contexts["prod"])
 }
 
@@ -80,7 +80,7 @@ func TestRemoveSecurityIgnoreNonexistent(t *testing.T) {
 	state := &SecurityIgnoreState{Contexts: make(map[string][]SecurityIgnoreRule)}
 
 	// Should not panic on empty state.
-	result := removeSecurityIgnore(state, "prod", "heuristic", "CVE-NONE", "")
+	result := removeSecurityIgnore(state, "prod", "heuristic", "CVE-NONE", "", "")
 	assert.Empty(t, result.Contexts["prod"])
 }
 

--- a/internal/app/security_refresh.go
+++ b/internal/app/security_refresh.go
@@ -110,10 +110,7 @@ func (m *Model) refreshSecuritySources() {
 	if m.client != nil {
 		m.client.SetSecurityManager(mgr)
 		if m.securityIgnores != nil {
-			m.client.SetIgnoreChecker(&modelIgnoreChecker{
-				state: m.securityIgnores,
-				ctx:   resolvedCtx,
-			})
+			m.client.SetIgnoreChecker(newModelIgnoreChecker(m.securityIgnores, resolvedCtx))
 		}
 		m.client.SetShowIgnored(m.showSecurityIgnored)
 	}

--- a/internal/app/security_toggle_nocache_test.go
+++ b/internal/app/security_toggle_nocache_test.go
@@ -44,7 +44,8 @@ func TestSecurityIgnoreToggleDoesNotInvalidateCache(t *testing.T) {
 
 	m.handleExplorerActionKeySecurityIgnoreToggle()
 
-	_, _ = mgr.FetchAll(m.reqCtx, "kctx", "")
+	_, err := mgr.FetchAll(m.reqCtx, "kctx", "")
+	require.NoError(t, err, "the cached fetch must still succeed (not left in a broken state)")
 	require.Equal(t, int32(1), src.FetchCalls.Load(),
 		"show-ignored toggle must serve from cache, not trigger a re-scan")
 }
@@ -60,7 +61,8 @@ func TestSecurityIgnoreActionDoesNotInvalidateCache(t *testing.T) {
 
 	m.executeSecurityIgnoreAction("Ignore (Group)")
 
-	_, _ = mgr.FetchAll(m.reqCtx, "kctx", "")
+	_, err := mgr.FetchAll(m.reqCtx, "kctx", "")
+	require.NoError(t, err, "the cached fetch must still succeed (not left in a broken state)")
 	require.Equal(t, int32(1), src.FetchCalls.Load(),
 		"ignoring a finding must serve from cache, not trigger a re-scan")
 }

--- a/internal/app/security_toggle_nocache_test.go
+++ b/internal/app/security_toggle_nocache_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+// securityCacheModel primes a Model + manager whose FakeSource counts fetches,
+// so a test can assert whether an action re-scans (FetchCalls grows) or serves
+// from cache (FetchCalls stays put).
+func securityCacheModel(t *testing.T) (Model, *security.FakeSource, *security.Manager) {
+	t.Helper()
+	mgr := security.NewManager()
+	mgr.SetRefreshTTL(1 * time.Hour)
+	src := &security.FakeSource{
+		NameStr: "heuristic", Available: true,
+		Findings: []security.Finding{{ID: "1", Source: "heuristic"}},
+	}
+	mgr.Register(src)
+	m := baseModelBoost2()
+	m.securityManager = mgr
+	m.client.SetSecurityManager(mgr)
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "__security_heuristic__", APIGroup: model.SecurityVirtualAPIGroup,
+	}
+	m.securityIgnores = &SecurityIgnoreState{Contexts: map[string][]SecurityIgnoreRule{}}
+
+	_, err := mgr.FetchAll(m.reqCtx, "kctx", "")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), src.FetchCalls.Load(), "cache primed by first fetch")
+	return m, src, mgr
+}
+
+// Toggling show-ignored is a pure view filter (applied by groupFindings AFTER
+// the cache), so it must NOT bust the manager cache — re-scanning is the slow
+// path users reported as a multi-second delay.
+func TestSecurityIgnoreToggleDoesNotInvalidateCache(t *testing.T) {
+	m, src, mgr := securityCacheModel(t)
+
+	m.handleExplorerActionKeySecurityIgnoreToggle()
+
+	_, _ = mgr.FetchAll(m.reqCtx, "kctx", "")
+	require.Equal(t, int32(1), src.FetchCalls.Load(),
+		"show-ignored toggle must serve from cache, not trigger a re-scan")
+}
+
+// Ignoring a finding only changes the checker (also applied post-cache), so it
+// must not re-scan either.
+func TestSecurityIgnoreActionDoesNotInvalidateCache(t *testing.T) {
+	m, src, mgr := securityCacheModel(t)
+	m.middleItems = []model.Item{{
+		Kind: "__security_finding_group__", Name: "no-limits", Extra: "no-limits",
+	}}
+	m.setCursor(0)
+
+	m.executeSecurityIgnoreAction("Ignore (Group)")
+
+	_, _ = mgr.FetchAll(m.reqCtx, "kctx", "")
+	require.Equal(t, int32(1), src.FetchCalls.Load(),
+		"ignoring a finding must serve from cache, not trigger a re-scan")
+}

--- a/internal/app/security_warm_cache_test.go
+++ b/internal/app/security_warm_cache_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+// When the shared security scan is already cached, loadResources must serve the
+// source's finding list synchronously (a plain Cmd, off the scheduler) and
+// WITHOUT re-scanning — the L960 fast path that removes the redundant-looking
+// per-source "scan" tasks and cuts latency on a congested scheduler.
+func TestLoadResources_SecurityWarmCacheServesSyncWithoutScan(t *testing.T) {
+	mgr := security.NewManager()
+	mgr.SetRefreshTTL(time.Hour)
+	src := &security.FakeSource{
+		NameStr: "heuristic", Available: true,
+		Findings: []security.Finding{{
+			Source: "heuristic", Title: "priv",
+			Resource: security.ResourceRef{Kind: "Pod", Name: "x"},
+			Labels:   map[string]string{"check": "priv"},
+		}},
+	}
+	mgr.Register(src)
+
+	m := baseModelBoost2()
+	m.securityManager = mgr
+	m.client.SetSecurityManager(mgr)
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "__security_heuristic__", APIGroup: model.SecurityVirtualAPIGroup, Resource: "findings-heuristic",
+	}
+	kctx := m.nav.Context
+	ns := m.effectiveNamespace()
+
+	// Warm the shared scan under the model's own (context, namespace).
+	_, err := mgr.FetchAll(m.reqCtx, kctx, ns)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), src.FetchCalls.Load())
+
+	cmd := m.loadResources(false)
+	require.NotNil(t, cmd)
+	msg := cmd()
+
+	rl, ok := msg.(resourcesLoadedMsg)
+	require.True(t, ok, "warm cache must serve resourcesLoadedMsg synchronously (off the scheduler)")
+	assert.Len(t, rl.items, 1)
+	assert.Equal(t, int32(1), src.FetchCalls.Load(), "warm-cache serve must not trigger a re-scan")
+}

--- a/internal/app/tabs_security.go
+++ b/internal/app/tabs_security.go
@@ -35,9 +35,6 @@ func (m *Model) loadSecurityStateFromTab(t *TabState) {
 	}
 	m.client.SetShowIgnored(m.showSecurityIgnored)
 	if m.securityIgnores != nil {
-		m.client.SetIgnoreChecker(&modelIgnoreChecker{
-			state: m.securityIgnores,
-			ctx:   m.nav.Context,
-		})
+		m.client.SetIgnoreChecker(newModelIgnoreChecker(m.securityIgnores, m.nav.Context))
 	}
 }

--- a/internal/app/update_actions_security.go
+++ b/internal/app/update_actions_security.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/janosmiko/lfk/internal/security"
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 // executeActionSecurityFindings handles the "Security Findings" action.
@@ -20,15 +21,27 @@ func (m Model) executeActionSecurityFindings() Model {
 		m.setStatusMessage("Security findings still loading…", false)
 		return m
 	}
-	ref := security.ResourceRef{
-		Namespace: m.actionCtx.namespace,
-		Kind:      m.actionCtx.kind,
-		Name:      m.actionCtx.name,
+	// Count exactly what the SEC row badge shows: the selected item's own
+	// findings merged with its owner resources' (owner:N) findings. A bare
+	// actionCtx-ref query would miss owner-attributed findings (e.g. trivy
+	// CVEs on the Deployment that the Pod's badge surfaces), making the action
+	// and the badge disagree. Fall back to the actionCtx ref when no row is
+	// selected.
+	kind, name := m.actionCtx.kind, m.actionCtx.name
+	var counts security.SeverityCounts
+	if sel := m.selectedMiddleItem(); sel != nil {
+		counts = ui.MergedSecurityCounts(m.securityIndex, sel)
+		kind, name = sel.Kind, sel.Name
+	} else {
+		counts = m.securityIndex.For(security.ResourceRef{
+			Namespace: m.actionCtx.namespace,
+			Kind:      m.actionCtx.kind,
+			Name:      m.actionCtx.name,
+		})
 	}
-	counts := m.securityIndex.For(ref)
 	total := counts.Total()
 	if total == 0 {
-		m.setStatusMessage(fmt.Sprintf("No security findings on %s/%s", m.actionCtx.kind, m.actionCtx.name), false)
+		m.setStatusMessage(fmt.Sprintf("No security findings on %s/%s", kind, name), false)
 		return m
 	}
 	parts := []string{}
@@ -47,11 +60,11 @@ func (m Model) executeActionSecurityFindings() Model {
 	summary := summariseSeverityParts(parts)
 	if summary == "" {
 		m.setStatusMessage(fmt.Sprintf("%d security findings on %s/%s — open Security category for details",
-			total, m.actionCtx.kind, m.actionCtx.name), false)
+			total, kind, name), false)
 		return m
 	}
 	m.setStatusMessage(fmt.Sprintf("%d security findings (%s) on %s/%s — open Security category for details",
-		total, summary, m.actionCtx.kind, m.actionCtx.name), false)
+		total, summary, kind, name), false)
 	return m
 }
 

--- a/internal/app/update_actions_security_menu.go
+++ b/internal/app/update_actions_security_menu.go
@@ -62,7 +62,12 @@ func (m Model) openSecurityActionMenu() Model {
 	case "__security_affected_resource__":
 		groupKey := sel.Extra
 		resourceKey := sel.ColumnValue("__resource_key__")
+		namespace := sel.Namespace
 		groupIgnored := isGroupIgnored(m.securityIgnores, kctx, sourceName, groupKey)
+		nsIgnored := isNamespaceIgnored(m.securityIgnores, kctx, sourceName, groupKey, namespace)
+		// resourceIgnored is true when ANY scope (group / namespace / resource)
+		// already hides this row, so the "Ignore (...)" entries only offer
+		// strictly-broader scopes the user hasn't applied yet.
 		resourceIgnored := isResourceIgnored(m.securityIgnores, kctx, sourceName, groupKey, resourceKey)
 		if !groupIgnored {
 			items = append(items, model.Item{
@@ -71,7 +76,14 @@ func (m Model) openSecurityActionMenu() Model {
 				Status: "i",
 			})
 		}
-		if !resourceIgnored && !groupIgnored && resourceKey != "" {
+		if namespace != "" && !groupIgnored && !nsIgnored {
+			items = append(items, model.Item{
+				Name:   "Ignore (Namespace)",
+				Extra:  "Hide this finding for all resources in " + namespace,
+				Status: "n",
+			})
+		}
+		if !resourceIgnored && resourceKey != "" {
 			items = append(items, model.Item{
 				Name:   "Ignore (This Resource)",
 				Extra:  "Hide this specific resource from the group",
@@ -100,8 +112,9 @@ func (m Model) openSecurityActionMenu() Model {
 }
 
 // executeSecurityIgnoreAction handles Ignore / Un-ignore actions emitted by
-// openSecurityActionMenu. It mutates SecurityIgnoreState, dispatches the
-// disk persistence asynchronously (so an fsync stall on slow disks does
+// openSecurityActionMenu. It replaces m.securityIgnores with a new
+// SecurityIgnoreState (the add/remove helpers never mutate in place),
+// dispatches the disk persistence asynchronously (so an fsync stall on slow disks does
 // not freeze the UI), re-installs the IgnoreChecker on the client, busts
 // the manager cache, and refreshes the current level so the user sees the
 // result immediately. Persistence failures arrive via
@@ -124,6 +137,19 @@ func (m Model) executeSecurityIgnoreAction(actionLabel string) (tea.Model, tea.C
 		})
 		m.setStatusMessage("Ignored: "+groupKey, false)
 
+	case "Ignore (Namespace)":
+		namespace := sel.Namespace
+		if namespace == "" {
+			m.setStatusMessage("Cannot determine namespace", true)
+			return m, scheduleStatusClear()
+		}
+		m.securityIgnores = addSecurityIgnore(m.securityIgnores, kctx, SecurityIgnoreRule{
+			Source:    sourceName,
+			GroupKey:  groupKey,
+			Namespace: namespace,
+		})
+		m.setStatusMessage("Ignored in namespace "+namespace+": "+groupKey, false)
+
 	case "Ignore (This Resource)":
 		resourceKey := sel.ColumnValue("__resource_key__")
 		if resourceKey == "" {
@@ -138,22 +164,31 @@ func (m Model) executeSecurityIgnoreAction(actionLabel string) (tea.Model, tea.C
 		m.setStatusMessage("Ignored resource: "+resourceKey, false)
 
 	case "Un-ignore":
-		// Decide whether the un-ignore targets the per-resource rule or
-		// the group-level rule: prefer per-resource when it exists,
-		// otherwise drop the group rule.
-		resourceKey := ""
+		// Peel back the most specific matching rule first: resource, then
+		// namespace, then the cluster-wide group rule. Config-file glob
+		// ignores are read-only and intentionally not removable here.
+		namespace, resourceKey, rk := "", "", ""
 		if sel.Kind == "__security_affected_resource__" {
-			resourceKey = sel.ColumnValue("__resource_key__")
-			if !isResourceSpecificIgnored(m.securityIgnores, kctx, sourceName, groupKey, resourceKey) {
-				resourceKey = ""
+			rk = sel.ColumnValue("__resource_key__")
+			switch {
+			case isResourceSpecificIgnored(m.securityIgnores, kctx, sourceName, groupKey, rk):
+				resourceKey = rk
+			case isNamespaceIgnored(m.securityIgnores, kctx, sourceName, groupKey, sel.Namespace):
+				namespace = sel.Namespace
 			}
 		}
-		m.securityIgnores = removeSecurityIgnore(m.securityIgnores, kctx, sourceName, groupKey, resourceKey)
-		m.setStatusMessage("Un-ignored: "+groupKey, false)
+		m.securityIgnores = removeSecurityIgnore(m.securityIgnores, kctx, sourceName, groupKey, namespace, resourceKey)
+		msg := "Un-ignored: " + groupKey
+		// If a broader rule (or a read-only config pattern) still hides this
+		// row, say so — a bare "Un-ignored" would be misleading.
+		if rk != "" && isResourceIgnored(m.securityIgnores, kctx, sourceName, groupKey, rk) {
+			msg += " (still hidden by a broader rule)"
+		}
+		m.setStatusMessage(msg, false)
 	}
 
 	if m.client != nil {
-		m.client.SetIgnoreChecker(&modelIgnoreChecker{state: m.securityIgnores, ctx: kctx})
+		m.client.SetIgnoreChecker(newModelIgnoreChecker(m.securityIgnores, kctx))
 	}
 	if m.securityManager != nil {
 		m.securityManager.Invalidate()
@@ -182,7 +217,7 @@ func (m Model) dispatchSecurityActionIfApplicable(actionLabel string) (tea.Model
 		return m, nil, false
 	}
 	switch actionLabel {
-	case "Ignore (Group)", "Ignore (This Resource)", "Un-ignore":
+	case "Ignore (Group)", "Ignore (Namespace)", "Ignore (This Resource)", "Un-ignore":
 		mdl, cmd := m.executeSecurityIgnoreAction(actionLabel)
 		return mdl, cmd, true
 	case "Refresh":

--- a/internal/app/update_actions_security_menu.go
+++ b/internal/app/update_actions_security_menu.go
@@ -39,7 +39,7 @@ func (m Model) openSecurityActionMenu() Model {
 	}
 	var items []model.Item
 	kctx := m.nav.Context
-	sourceName := securitySourceFromKind(m.nav.ResourceType.Kind)
+	sourceName := m.securitySourceForAction(sel)
 
 	switch sel.Kind {
 	case "__security_finding_group__":
@@ -128,7 +128,14 @@ func (m Model) executeSecurityIgnoreAction(actionLabel string) (tea.Model, tea.C
 	}
 	kctx := m.nav.Context
 	groupKey := sel.Extra
-	sourceName := securitySourceFromKind(m.nav.ResourceType.Kind)
+	sourceName := m.securitySourceForAction(sel)
+	// Never write an ignore rule under an empty source — it would be
+	// unmatchable and silently hide nothing (or, worse, collide across
+	// sources). Refuse rather than persist a misattributed rule.
+	if sourceName == "" {
+		m.setStatusMessage("Cannot determine security source", true)
+		return m, scheduleStatusClear()
+	}
 
 	switch actionLabel {
 	case "Ignore (Group)":
@@ -243,6 +250,35 @@ func onSecurityView(m *Model) bool {
 		return true
 	}
 	return false
+}
+
+// securitySourceForAction resolves the security source id for an ignore/un-ignore
+// action. It prefers the navigated resource type's kind
+// ("__security_<source>__"), and when that is not a security source — e.g. the
+// menu was opened via the selected-item fallback while the nav kind is a normal
+// resource — falls back to the selected row: its hidden __source__ column
+// (finding-group and affected-resource rows carry it) or, for a sidebar source
+// entry, its "__security_<source>__" kind. Returns "" only when no source can
+// be determined, so callers refuse to write a misattributed (empty-source)
+// rule. Note securitySourceFromKind matches the sentinel kinds
+// ("__security_finding_group__" etc.) too, so those are handled via __source__
+// and excluded from the kind-based fallback.
+func (m Model) securitySourceForAction(sel *model.Item) string {
+	if s := securitySourceFromKind(m.nav.ResourceType.Kind); s != "" {
+		return s
+	}
+	if sel == nil {
+		return ""
+	}
+	if s := sel.ColumnValue("__source__"); s != "" {
+		return s
+	}
+	switch sel.Kind {
+	case "__security_finding_group__", "__security_affected_resource__":
+		return ""
+	default:
+		return securitySourceFromKind(sel.Kind)
+	}
 }
 
 // securitySourceFromKind extracts the source name from a security RT kind

--- a/internal/app/update_actions_security_menu.go
+++ b/internal/app/update_actions_security_menu.go
@@ -115,9 +115,10 @@ func (m Model) openSecurityActionMenu() Model {
 // openSecurityActionMenu. It replaces m.securityIgnores with a new
 // SecurityIgnoreState (the add/remove helpers never mutate in place),
 // dispatches the disk persistence asynchronously (so an fsync stall on slow disks does
-// not freeze the UI), re-installs the IgnoreChecker on the client, busts
-// the manager cache, and refreshes the current level so the user sees the
-// result immediately. Persistence failures arrive via
+// not freeze the UI), re-installs the IgnoreChecker on the client, and
+// refreshes the current level so the user sees the result immediately — a
+// cache-hit re-filter, not a re-scan (see the refresh return below).
+// Persistence failures arrive via
 // securityIgnoresSaveErrMsg and replace the optimistic success status with
 // a clear error.
 func (m Model) executeSecurityIgnoreAction(actionLabel string) (tea.Model, tea.Cmd) {
@@ -190,9 +191,10 @@ func (m Model) executeSecurityIgnoreAction(actionLabel string) (tea.Model, tea.C
 	if m.client != nil {
 		m.client.SetIgnoreChecker(newModelIgnoreChecker(m.securityIgnores, kctx))
 	}
-	if m.securityManager != nil {
-		m.securityManager.Invalidate()
-	}
+	// No manager-cache invalidation: ignoring changes only the checker, which
+	// groupFindings applies AFTER FetchAll's (filter-independent) cache. The
+	// refresh re-filters from cache instantly; invalidating would force a slow
+	// full re-scan. Explicit "Refresh" still invalidates (see dispatch).
 	return m, tea.Batch(saveSecurityIgnoresCmd(m.securityIgnores), m.refreshCurrentLevel(), scheduleStatusClear())
 }
 

--- a/internal/app/update_actions_security_menu_test.go
+++ b/internal/app/update_actions_security_menu_test.go
@@ -170,19 +170,52 @@ func TestDispatchSecurityActionOnSecurityView(t *testing.T) {
 
 // openSecurityActionMenuIfApplicable also fires via the selected-item fallback
 // when the nav resource type is a normal kind but a security row is selected.
+// The fallback must resolve the source from the row (via its hidden __source__
+// column) so an ignore action is attributed correctly — NOT written under an
+// empty source (the source must not collapse just because nav kind is "Pod").
 func TestOpenSecurityActionMenuFallbackBySelectedItem(t *testing.T) {
 	m := Model{}
-	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"} // normal kind
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"} // non-security nav kind
+	m.nav.Context = "prod"
 	m.securityIgnores = &SecurityIgnoreState{Contexts: map[string][]SecurityIgnoreRule{}}
 	m.middleItems = []model.Item{{
 		Kind:      "__security_affected_resource__",
 		Name:      "pod/grafana",
 		Namespace: "monitoring",
 		Extra:     "no-limits",
-		Columns:   []model.KeyValue{{Key: "__resource_key__", Value: "monitoring/Pod/grafana"}},
+		Columns: []model.KeyValue{
+			{Key: "__resource_key__", Value: "monitoring/Pod/grafana"},
+			{Key: "__source__", Value: "heuristic"},
+		},
 	}}
 	m.setCursor(0)
 
 	_, ok := m.openSecurityActionMenuIfApplicable()
-	assert.True(t, ok, "a selected security row must open the security menu even under a normal nav kind")
+	require.True(t, ok, "a selected security row must open the security menu even under a normal nav kind")
+
+	res, _ := m.executeSecurityIgnoreAction("Ignore (Group)")
+	rules := res.(Model).securityIgnores.Contexts["prod"]
+	require.Len(t, rules, 1, "the ignore rule must be written")
+	assert.Equal(t, "heuristic", rules[0].Source, "source resolved from the row, not collapsed to empty")
+	assert.Equal(t, "no-limits", rules[0].GroupKey)
+}
+
+// When the source cannot be resolved (non-security nav kind and a row without a
+// __source__ column), an ignore action must refuse rather than persist a rule
+// under an empty source.
+func TestExecuteSecurityIgnoreActionRefusesUnresolvedSource(t *testing.T) {
+	m := Model{}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"}
+	m.nav.Context = "prod"
+	m.securityIgnores = &SecurityIgnoreState{Contexts: map[string][]SecurityIgnoreRule{}}
+	m.middleItems = []model.Item{{
+		Kind: "__security_affected_resource__", Name: "x", Extra: "g",
+		Columns: []model.KeyValue{{Key: "__resource_key__", Value: "ns/Pod/x"}}, // no __source__
+	}}
+	m.setCursor(0)
+
+	res, _ := m.executeSecurityIgnoreAction("Ignore (Group)")
+	rm := res.(Model)
+	assert.Empty(t, rm.securityIgnores.Contexts["prod"], "no rule written when source is unresolved")
+	assert.Contains(t, rm.statusMessage, "source")
 }

--- a/internal/app/update_actions_security_menu_test.go
+++ b/internal/app/update_actions_security_menu_test.go
@@ -1,0 +1,188 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// securityMenuModel builds a Model positioned on a __security_affected_resource__
+// row of the heuristic source in context "prod", namespace "monitoring".
+func securityMenuModel(t *testing.T) Model {
+	t.Helper()
+	m := Model{}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "__security_heuristic__"}
+	m.nav.Context = "prod"
+	m.securityIgnores = &SecurityIgnoreState{Contexts: map[string][]SecurityIgnoreRule{}}
+	m.middleItems = []model.Item{{
+		Kind:      "__security_affected_resource__",
+		Name:      "pod/grafana",
+		Namespace: "monitoring",
+		Extra:     "no-limits", // group key
+		Columns:   []model.KeyValue{{Key: "__resource_key__", Value: "monitoring/Pod/grafana"}},
+	}}
+	m.setCursor(0)
+	return m
+}
+
+func menuItemNames(items []model.Item) []string {
+	names := make([]string, 0, len(items))
+	for _, it := range items {
+		names = append(names, it.Name)
+	}
+	return names
+}
+
+func TestSecurityActionMenuOffersNamespaceIgnore(t *testing.T) {
+	m := securityMenuModel(t)
+	m = m.openSecurityActionMenu()
+
+	names := menuItemNames(m.overlayItems)
+	assert.Contains(t, names, "Ignore (Group)")
+	assert.Contains(t, names, "Ignore (Namespace)")
+	assert.Contains(t, names, "Ignore (This Resource)")
+	assert.NotContains(t, names, "Un-ignore", "nothing ignored yet")
+}
+
+func TestSecurityActionMenuNamespaceIgnoreAddsRule(t *testing.T) {
+	m := securityMenuModel(t)
+	res, _ := m.executeSecurityIgnoreAction("Ignore (Namespace)")
+	rm := res.(Model)
+
+	rules := rm.securityIgnores.Contexts["prod"]
+	require.Len(t, rules, 1)
+	assert.Equal(t, "heuristic", rules[0].Source)
+	assert.Equal(t, "no-limits", rules[0].GroupKey)
+	assert.Equal(t, "monitoring", rules[0].Namespace)
+	assert.Empty(t, rules[0].Resource, "namespace rule must not pin a resource")
+	assert.Contains(t, rm.statusMessage, "monitoring")
+}
+
+// Once the namespace is ignored, the menu drops the namespace + resource
+// options (already covered) and offers Un-ignore instead.
+func TestSecurityActionMenuAfterNamespaceIgnore(t *testing.T) {
+	m := securityMenuModel(t)
+	m.securityIgnores = addSecurityIgnore(m.securityIgnores, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring",
+	})
+	m = m.openSecurityActionMenu()
+
+	names := menuItemNames(m.overlayItems)
+	assert.NotContains(t, names, "Ignore (Namespace)", "already namespace-ignored")
+	assert.NotContains(t, names, "Ignore (This Resource)", "namespace ignore already covers the resource")
+	assert.Contains(t, names, "Ignore (Group)", "escalating to whole-cluster is still allowed")
+	assert.Contains(t, names, "Un-ignore")
+}
+
+// Un-ignore peels the most specific rule first: with both a resource rule and
+// a namespace rule present, it removes the resource rule and leaves the
+// namespace rule intact.
+func TestSecurityActionMenuUnignorePrefersResourceRule(t *testing.T) {
+	m := securityMenuModel(t)
+	m.securityIgnores = addSecurityIgnore(m.securityIgnores, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring",
+	})
+	m.securityIgnores = addSecurityIgnore(m.securityIgnores, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Resource: "monitoring/Pod/grafana",
+	})
+
+	res, _ := m.executeSecurityIgnoreAction("Un-ignore")
+	rm := res.(Model)
+
+	rules := rm.securityIgnores.Contexts["prod"]
+	require.Len(t, rules, 1, "only the resource rule should be removed")
+	assert.Equal(t, "monitoring", rules[0].Namespace)
+	assert.Empty(t, rules[0].Resource)
+}
+
+// Un-ignore on an affected-resource row with ONLY a namespace rule peels that
+// namespace rule (the middle precedence rung).
+func TestSecurityActionMenuUnignoreNamespaceOnly(t *testing.T) {
+	m := securityMenuModel(t)
+	m.securityIgnores = addSecurityIgnore(m.securityIgnores, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring",
+	})
+
+	res, _ := m.executeSecurityIgnoreAction("Un-ignore")
+	rm := res.(Model)
+
+	assert.Empty(t, rm.securityIgnores.Contexts["prod"], "the namespace rule should be removed")
+}
+
+// Un-ignore from a finding-group row removes the cluster-wide group rule
+// (sel.Kind != affected_resource, so namespace/resource stay empty).
+func TestSecurityActionMenuUnignoreFromGroupRow(t *testing.T) {
+	m := securityMenuModel(t)
+	m.middleItems = []model.Item{{
+		Kind:  "__security_finding_group__",
+		Name:  "no-limits",
+		Extra: "no-limits",
+	}}
+	m.setCursor(0)
+	m.securityIgnores = addSecurityIgnore(m.securityIgnores, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits",
+	})
+
+	res, _ := m.executeSecurityIgnoreAction("Un-ignore")
+	rm := res.(Model)
+
+	assert.Empty(t, rm.securityIgnores.Contexts["prod"], "the cluster-wide group rule should be removed")
+}
+
+// When a broader rule still hides the row after un-ignore, the status message
+// says so instead of a misleading bare "Un-ignored".
+func TestSecurityActionMenuUnignoreWarnsWhenBroaderRuleRemains(t *testing.T) {
+	m := securityMenuModel(t)
+	// Both a namespace rule and a cluster-wide group rule (e.g. hand-edited YAML).
+	m.securityIgnores = addSecurityIgnore(m.securityIgnores, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits", Namespace: "monitoring",
+	})
+	m.securityIgnores = addSecurityIgnore(m.securityIgnores, "prod", SecurityIgnoreRule{
+		Source: "heuristic", GroupKey: "no-limits",
+	})
+
+	res, _ := m.executeSecurityIgnoreAction("Un-ignore")
+	rm := res.(Model)
+
+	assert.Contains(t, rm.statusMessage, "still hidden by a broader rule")
+}
+
+// dispatchSecurityActionIfApplicable must NOT intercept labels off a security
+// view, so a generic "Refresh" elsewhere keeps its normal semantics.
+func TestDispatchSecurityActionGatedOffSecurityView(t *testing.T) {
+	m := Model{}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"}
+
+	_, _, handled := m.dispatchSecurityActionIfApplicable("Refresh")
+	assert.False(t, handled, "off a security view the security dispatch must not fire")
+}
+
+func TestDispatchSecurityActionOnSecurityView(t *testing.T) {
+	for _, label := range []string{"Ignore (Group)", "Ignore (Namespace)", "Ignore (This Resource)", "Un-ignore", "Refresh"} {
+		m := securityMenuModel(t)
+		_, _, handled := m.dispatchSecurityActionIfApplicable(label)
+		assert.Truef(t, handled, "label %q must be handled on a security view", label)
+	}
+}
+
+// openSecurityActionMenuIfApplicable also fires via the selected-item fallback
+// when the nav resource type is a normal kind but a security row is selected.
+func TestOpenSecurityActionMenuFallbackBySelectedItem(t *testing.T) {
+	m := Model{}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"} // normal kind
+	m.securityIgnores = &SecurityIgnoreState{Contexts: map[string][]SecurityIgnoreRule{}}
+	m.middleItems = []model.Item{{
+		Kind:      "__security_affected_resource__",
+		Name:      "pod/grafana",
+		Namespace: "monitoring",
+		Extra:     "no-limits",
+		Columns:   []model.KeyValue{{Key: "__resource_key__", Value: "monitoring/Pod/grafana"}},
+	}}
+	m.setCursor(0)
+
+	_, ok := m.openSecurityActionMenuIfApplicable()
+	assert.True(t, ok, "a selected security row must open the security menu even under a normal nav kind")
+}

--- a/internal/app/update_actions_security_test.go
+++ b/internal/app/update_actions_security_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/security"
 )
 
@@ -53,4 +54,31 @@ func TestExecuteActionSecurityFindingsCounts(t *testing.T) {
 		"status message names the resource")
 	assert.Contains(t, msg, "Security category",
 		"hint points the user toward the drill-in path")
+}
+
+// TestExecuteActionSecurityFindingsMatchesBadgeOwnerAggregation locks in L959:
+// the action must report the SAME findings the SEC row badge shows, which
+// includes owner-attributed findings (e.g. a trivy CVE on the Deployment that
+// surfaces on the Pod row via owner:N). A bare per-ref query would say "No
+// security findings" while the badge shows one — the discrepancy users hit.
+func TestExecuteActionSecurityFindingsMatchesBadgeOwnerAggregation(t *testing.T) {
+	idx := security.BuildFindingIndex([]security.Finding{
+		{
+			ID: "1", Title: "CVE-x", Severity: security.SeverityCritical,
+			Resource: security.ResourceRef{Namespace: "default", Kind: "Deployment", Name: "api"},
+		},
+	})
+	m := Model{securityModelState: securityModelState{securityIndex: idx}}
+	m.middleItems = []model.Item{{
+		Kind: "Pod", Name: "api-xyz", Namespace: "default",
+		Columns: []model.KeyValue{{Key: "owner:0", Value: "apps/v1||Deployment||api"}},
+	}}
+	m.setCursor(0)
+	m.actionCtx = actionContext{kind: "Pod", name: "api-xyz", namespace: "default"}
+
+	updated := m.executeActionSecurityFindings()
+	assert.Contains(t, updated.statusMessage, "1 security findings",
+		"owner-attributed finding must be counted, matching the badge")
+	assert.Contains(t, updated.statusMessage, "1 critical")
+	assert.Contains(t, updated.statusMessage, "Pod/api-xyz")
 }

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -16,6 +16,12 @@ import (
 // Returns (model, cmd, handled) where handled indicates whether the key
 // was consumed. If not handled, the caller should fall through.
 func (m Model) handleExplorerActionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	// Security-view-scoped keys take precedence so they can shadow global
+	// action keys that are meaningless on a security view (e.g. the
+	// show-ignored toggle reuses LabelEditor's key on finding rows).
+	if ret, cmd, handled := m.handleExplorerSecurityViewKeys(msg); handled {
+		return ret, cmd, true
+	}
 	// Try navigation/scroll keybindings first.
 	if ret, cmd, handled := m.handleExplorerNavKeys(msg); handled {
 		return ret, cmd, true
@@ -122,8 +128,6 @@ func (m Model) handleExplorerToolKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 		return m.handleExplorerActionKeyTerminalToggle()
 	case kb.ToggleRare:
 		return m.handleExplorerActionKeyToggleRare()
-	case kb.SecurityIgnoreToggle:
-		return m.handleExplorerActionKeySecurityIgnoreToggle()
 	case kb.SecurityBadgeToggle:
 		return m.handleExplorerActionKeySecurityBadgeToggle()
 	}

--- a/internal/app/update_keys_actions_security.go
+++ b/internal/app/update_keys_actions_security.go
@@ -30,16 +30,18 @@ func (m Model) handleExplorerSecurityViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 
 // handleExplorerActionKeySecurityIgnoreToggle flips the show/hide-ignored
 // state, propagates it to the k8s client (which decides whether
-// groupFindings filters ignored entries), invalidates the manager cache
-// so the next list call re-emits the filtered set, and refreshes the
-// current level so the user sees the result immediately.
+// groupFindings filters ignored entries), and refreshes the current level so
+// the user sees the result immediately.
+//
+// It deliberately does NOT invalidate the manager cache. show-ignored is a
+// pure view filter applied by groupFindings AFTER FetchAll, whose cache holds
+// the raw findings keyed by context|namespace (filter-independent). The
+// refresh therefore hits the cache and re-filters instantly; invalidating
+// would force a full cluster re-scan — the multi-second delay users saw.
 func (m Model) handleExplorerActionKeySecurityIgnoreToggle() (tea.Model, tea.Cmd, bool) {
 	m.showSecurityIgnored = !m.showSecurityIgnored
 	if m.client != nil {
 		m.client.SetShowIgnored(m.showSecurityIgnored)
-	}
-	if m.securityManager != nil {
-		m.securityManager.Invalidate()
 	}
 	if m.showSecurityIgnored {
 		m.setStatusMessage("Showing ignored findings", false)

--- a/internal/app/update_keys_actions_security.go
+++ b/internal/app/update_keys_actions_security.go
@@ -6,7 +6,27 @@ package app
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/ui"
 )
+
+// handleExplorerSecurityViewKeys dispatches keys that are only meaningful on a
+// security view. It runs before the general explorer action keys so it can
+// shadow global bindings that make no sense on synthetic finding rows. It
+// currently owns the show-ignored toggle (kb.SecurityIgnoreToggle), which
+// reuses LabelEditor's "i" — the same context-gated reuse ClusterColorPicker
+// applies to the Logs key at the cluster picker. Off a security view it
+// returns handled=false with the model untouched, so the key keeps its normal
+// global meaning everywhere else.
+func (m Model) handleExplorerSecurityViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	if !onSecurityView(&m) {
+		return m, nil, false
+	}
+	if msg.String() == ui.ActiveKeybindings.SecurityIgnoreToggle {
+		return m.handleExplorerActionKeySecurityIgnoreToggle()
+	}
+	return m, nil, false
+}
 
 // handleExplorerActionKeySecurityIgnoreToggle flips the show/hide-ignored
 // state, propagates it to the k8s client (which decides whether

--- a/internal/k8s/security.go
+++ b/internal/k8s/security.go
@@ -217,9 +217,23 @@ func (c *Client) GetSecurityAffectedResources(ctx context.Context, contextName, 
 		}
 		return refs[i].Key() < refs[j].Key()
 	})
+	// Apply the same ignore policy as the group list (getSecurityFindings):
+	// hide ignored resources unless show-ignored is on, and when shown, tag
+	// them so the renderer can mark them. Without this the drill-in showed
+	// ignored resources unconditionally, contradicting the group's filtered
+	// affected count.
+	checker, showIgnored := c.securityIgnoreSnapshot()
 	items := make([]model.Item, 0, len(refs))
 	for _, ref := range refs {
-		items = append(items, affectedResourceToItem(ref, groupKey, matched))
+		ignored := checker != nil && checker.IsResourceIgnored(sourceName, groupKey, ref.Key())
+		if ignored && !showIgnored {
+			continue
+		}
+		item := affectedResourceToItem(ref, groupKey, matched)
+		if ignored {
+			item.Columns = append(item.Columns, model.KeyValue{Key: "__ignored__", Value: "true"})
+		}
+		items = append(items, item)
 	}
 	return items, nil
 }

--- a/internal/k8s/security.go
+++ b/internal/k8s/security.go
@@ -286,6 +286,9 @@ func (c *Client) affectedResourcesFromResult(res security.FetchResult, sourceNam
 			continue
 		}
 		item := affectedResourceToItem(ref, groupKey, matched)
+		// Carry the source (hidden) so the action menu can resolve it even when
+		// opened via the selected-item path with a non-security nav kind.
+		item.Columns = append(item.Columns, model.KeyValue{Key: "__source__", Value: sourceName})
 		if ignored {
 			item.Columns = append(item.Columns, model.KeyValue{Key: "__ignored__", Value: "true"})
 		}

--- a/internal/k8s/security.go
+++ b/internal/k8s/security.go
@@ -146,9 +146,14 @@ func (c *Client) getSecurityFindings(ctx context.Context, contextName, namespace
 	if err != nil {
 		return nil, fmt.Errorf("security fetch: %w", err)
 	}
-	// Surface the requested source's per-source error so the explorer
-	// renders an error state instead of an empty list — without this the
-	// caller sees "0 findings" indistinguishable from a fetch failure.
+	return c.groupSecurityFindings(res, sourceName)
+}
+
+// groupSecurityFindings turns a FetchResult into explorer items for one source:
+// it surfaces the source's per-source error (so the explorer shows an error
+// state rather than an empty list indistinguishable from a fetch failure),
+// then groups and ignore-filters. Shared by the scanning and cache-only paths.
+func (c *Client) groupSecurityFindings(res security.FetchResult, sourceName string) ([]model.Item, error) {
 	if srcErr, ok := res.Errors[sourceName]; ok && srcErr != nil {
 		return nil, fmt.Errorf("source %s: %w", sourceName, srcErr)
 	}
@@ -159,6 +164,28 @@ func (c *Client) getSecurityFindings(ctx context.Context, contextName, namespace
 		items = append(items, findingGroupToItem(g))
 	}
 	return items, nil
+}
+
+// GetSecurityFindingsCached returns the grouped findings for a security RT from
+// the manager cache ONLY (no scan). ok is false when the shared scan is not
+// cached / has expired, signalling the caller to fall back to a scanning fetch.
+// Lets the explorer render the source's finding list synchronously off the
+// scheduler whenever the (coalesced, cached) scan is already warm.
+func (c *Client) GetSecurityFindingsCached(contextName, namespace string, rt model.ResourceTypeEntry) ([]model.Item, bool, error) {
+	mgr := c.securityManager.Load()
+	if mgr == nil {
+		return nil, false, nil
+	}
+	sourceName := sourceNameFromKind(rt.Kind)
+	if sourceName == "" {
+		return nil, false, nil
+	}
+	res, ok := mgr.CachedFindings(contextName, namespace)
+	if !ok {
+		return nil, false, nil
+	}
+	items, err := c.groupSecurityFindings(res, sourceName)
+	return items, true, err
 }
 
 // GetSecurityAffectedResources returns the list of resources affected by
@@ -179,6 +206,35 @@ func (c *Client) GetSecurityAffectedResources(ctx context.Context, contextName, 
 	if err != nil {
 		return nil, fmt.Errorf("security fetch: %w", err)
 	}
+	return c.affectedResourcesFromResult(res, sourceName, groupKey)
+}
+
+// GetSecurityAffectedResourcesCached is the cache-only counterpart to
+// GetSecurityAffectedResources (no scan). ok is false on a cold/expired cache,
+// signalling the caller to fall back to a scanning fetch.
+func (c *Client) GetSecurityAffectedResourcesCached(contextName, namespace string, rt model.ResourceTypeEntry, groupKey string) ([]model.Item, bool, error) {
+	mgr := c.securityManager.Load()
+	if mgr == nil {
+		return nil, false, nil
+	}
+	sourceName := sourceNameFromKind(rt.Kind)
+	if sourceName == "" {
+		return nil, false, nil
+	}
+	res, ok := mgr.CachedFindings(contextName, namespace)
+	if !ok {
+		return nil, false, nil
+	}
+	items, err := c.affectedResourcesFromResult(res, sourceName, groupKey)
+	return items, true, err
+}
+
+// affectedResourcesFromResult builds the affected-resource items for one
+// finding group from a FetchResult: surfaces the source error, matches
+// findings by source+group, dedups + sorts resources, and applies the ignore
+// policy (hide when show-ignored is off; tag __ignored__ when on). Shared by
+// the scanning and cache-only paths.
+func (c *Client) affectedResourcesFromResult(res security.FetchResult, sourceName, groupKey string) ([]model.Item, error) {
 	// Surface the requested source's per-source error so a source-specific
 	// fetch failure isn't mistaken for "no affected resources".
 	if srcErr, ok := res.Errors[sourceName]; ok && srcErr != nil {

--- a/internal/k8s/security_affected_ignore_test.go
+++ b/internal/k8s/security_affected_ignore_test.go
@@ -1,0 +1,69 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+func affectedIgnoreClient() *Client {
+	mgr := security.NewManager()
+	mgr.Register(&security.FakeSource{
+		NameStr: "heuristic", Available: true,
+		Findings: []security.Finding{
+			{
+				Source: "heuristic", Title: "privileged", Severity: security.SeverityCritical,
+				Resource: security.ResourceRef{Namespace: "ns", Kind: "Pod", Name: "web"},
+				Labels:   map[string]string{"check": "privileged"},
+			},
+			{
+				Source: "heuristic", Title: "privileged", Severity: security.SeverityHigh,
+				Resource: security.ResourceRef{Namespace: "ns", Kind: "Pod", Name: "api"},
+				Labels:   map[string]string{"check": "privileged"},
+			},
+		},
+	})
+	c := &Client{}
+	c.SetSecurityManager(mgr)
+	return c
+}
+
+// With show-ignored off, the drill-in must filter ignored resources so it
+// matches the group's filtered affected count (previously it showed them all).
+func TestGetSecurityAffectedResources_HidesIgnoredWhenToggleOff(t *testing.T) {
+	c := affectedIgnoreClient()
+	c.SetIgnoreChecker(stubIgnoreChecker{resources: map[string]bool{"ns/Pod/api": true}})
+	c.SetShowIgnored(false)
+
+	items, err := c.GetSecurityAffectedResources(context.Background(), "kctx", "",
+		model.ResourceTypeEntry{Kind: "__security_heuristic__"}, "privileged")
+	require.NoError(t, err)
+	require.Len(t, items, 1, "the ignored resource must be filtered out")
+	assert.Equal(t, "pod/web", items[0].Name)
+	assert.Empty(t, items[0].ColumnValue("__ignored__"))
+}
+
+// With show-ignored on, both resources appear and the ignored one is tagged so
+// the renderer can mark it.
+func TestGetSecurityAffectedResources_TagsIgnoredWhenToggleOn(t *testing.T) {
+	c := affectedIgnoreClient()
+	c.SetIgnoreChecker(stubIgnoreChecker{resources: map[string]bool{"ns/Pod/api": true}})
+	c.SetShowIgnored(true)
+
+	items, err := c.GetSecurityAffectedResources(context.Background(), "kctx", "",
+		model.ResourceTypeEntry{Kind: "__security_heuristic__"}, "privileged")
+	require.NoError(t, err)
+	require.Len(t, items, 2, "both resources shown in show-ignored mode")
+
+	byName := make(map[string]model.Item, len(items))
+	for _, it := range items {
+		byName[it.Name] = it
+	}
+	assert.Equal(t, "true", byName["pod/api"].ColumnValue("__ignored__"), "ignored resource is tagged")
+	assert.Empty(t, byName["pod/web"].ColumnValue("__ignored__"), "active resource is not tagged")
+}

--- a/internal/k8s/security_cached_test.go
+++ b/internal/k8s/security_cached_test.go
@@ -1,0 +1,81 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+func cachedTestClient() (*Client, *security.FakeSource, *security.Manager) {
+	mgr := security.NewManager()
+	mgr.SetRefreshTTL(time.Hour)
+	src := &security.FakeSource{
+		NameStr: "heuristic", Available: true,
+		Findings: []security.Finding{
+			{
+				Source: "heuristic", Title: "privileged", Severity: security.SeverityCritical,
+				Resource: security.ResourceRef{Namespace: "ns", Kind: "Pod", Name: "web"},
+				Labels:   map[string]string{"check": "privileged"},
+			},
+			{
+				Source: "heuristic", Title: "privileged", Severity: security.SeverityHigh,
+				Resource: security.ResourceRef{Namespace: "ns", Kind: "Pod", Name: "api"},
+				Labels:   map[string]string{"check": "privileged"},
+			},
+		},
+	}
+	mgr.Register(src)
+	c := &Client{}
+	c.SetSecurityManager(mgr)
+	return c, src, mgr
+}
+
+func TestGetSecurityFindingsCached_ColdThenWarm(t *testing.T) {
+	c, src, mgr := cachedTestClient()
+	rt := model.ResourceTypeEntry{Kind: "__security_heuristic__"}
+
+	// Cold cache: not cached, and the cached getter must NOT scan.
+	items, ok, err := c.GetSecurityFindingsCached("kctx", "", rt)
+	require.NoError(t, err)
+	assert.False(t, ok, "cold cache reports not-cached")
+	assert.Nil(t, items)
+	assert.Equal(t, int32(0), src.FetchCalls.Load(), "cached getter must never trigger a scan")
+
+	// Warm the shared scan.
+	_, err = mgr.FetchAll(context.Background(), "kctx", "")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), src.FetchCalls.Load())
+
+	// Warm cache: returns the grouped findings with NO additional scan.
+	items, ok, err = c.GetSecurityFindingsCached("kctx", "", rt)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, items, 1, "two findings collapse into one 'privileged' group")
+	assert.Equal(t, "privileged", items[0].Name)
+	assert.Equal(t, int32(1), src.FetchCalls.Load(), "warm serve must not re-scan")
+}
+
+func TestGetSecurityAffectedResourcesCached_ColdThenWarm(t *testing.T) {
+	c, src, mgr := cachedTestClient()
+	rt := model.ResourceTypeEntry{Kind: "__security_heuristic__"}
+
+	_, ok, err := c.GetSecurityAffectedResourcesCached("kctx", "", rt, "privileged")
+	require.NoError(t, err)
+	assert.False(t, ok, "cold cache reports not-cached")
+	assert.Equal(t, int32(0), src.FetchCalls.Load())
+
+	_, err = mgr.FetchAll(context.Background(), "kctx", "")
+	require.NoError(t, err)
+
+	items, ok, err := c.GetSecurityAffectedResourcesCached("kctx", "", rt, "privileged")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, items, 2, "both affected pods")
+	assert.Equal(t, int32(1), src.FetchCalls.Load(), "warm serve must not re-scan")
+}

--- a/internal/k8s/security_group_ignore_test.go
+++ b/internal/k8s/security_group_ignore_test.go
@@ -1,0 +1,112 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+// stubIgnoreChecker mirrors the production modelIgnoreChecker semantics
+// (resource ignored when its group, namespace, OR exact resource matches) so
+// groupFindings is exercised through the real checker != nil branch — the
+// integration the app-layer predicate tests never reach.
+type stubIgnoreChecker struct {
+	groups     map[string]bool // group fully ignored cluster-wide
+	namespaces map[string]bool // group ignored within a namespace
+	resources  map[string]bool // specific resource ignored
+}
+
+func (s stubIgnoreChecker) IsGroupIgnored(_, groupKey string) bool {
+	return s.groups[groupKey]
+}
+
+func (s stubIgnoreChecker) IsResourceIgnored(_, groupKey, resourceKey string) bool {
+	if s.groups[groupKey] || s.resources[resourceKey] {
+		return true
+	}
+	ns, _, _ := strings.Cut(resourceKey, "/")
+	return s.namespaces[ns]
+}
+
+// privileged: pod-a, pod-b (default), pod-d (kube-system). host_pid: pod-c.
+func ignoreTestFindings() []security.Finding {
+	mk := func(id, check, ns, name string, sev security.Severity) security.Finding {
+		return security.Finding{
+			ID: id, Source: "heuristic", Title: check, Severity: sev,
+			Category: security.CategoryMisconfig,
+			Labels:   map[string]string{"check": check},
+			Resource: security.ResourceRef{Namespace: ns, Kind: "Pod", Name: name},
+		}
+	}
+	return []security.Finding{
+		mk("1", "privileged", "default", "pod-a", security.SeverityCritical),
+		mk("2", "privileged", "default", "pod-b", security.SeverityCritical),
+		mk("3", "host_pid", "default", "pod-c", security.SeverityHigh),
+		mk("4", "privileged", "kube-system", "pod-d", security.SeverityCritical),
+	}
+}
+
+func findGroup(groups []findingGroup, key string) *findingGroup {
+	for i := range groups {
+		if groups[i].Key == key {
+			return &groups[i]
+		}
+	}
+	return nil
+}
+
+// A cluster-wide group ignore removes the entire group from the list.
+func TestGroupFindings_Checker_GroupIgnoreOmitsWholeGroup(t *testing.T) {
+	checker := stubIgnoreChecker{groups: map[string]bool{"privileged": true}}
+	groups := groupFindings(ignoreTestFindings(), "heuristic", checker, false)
+
+	require.Len(t, groups, 1)
+	assert.Equal(t, "host_pid", groups[0].Key, "the ignored group must be gone")
+}
+
+// A namespace-scoped ignore keeps the group but drops resources in that namespace.
+func TestGroupFindings_Checker_NamespaceScopeReducesCount(t *testing.T) {
+	checker := stubIgnoreChecker{namespaces: map[string]bool{"kube-system": true}}
+	groups := groupFindings(ignoreTestFindings(), "heuristic", checker, false)
+
+	g := findGroup(groups, "privileged")
+	require.NotNil(t, g, "group stays visible under a namespace-scoped ignore")
+	assert.Equal(t, 2, g.Count, "kube-system/pod-d excluded; default pod-a, pod-b remain")
+	assert.False(t, g.Ignored, "a namespace-scoped ignore must not tag the whole group")
+}
+
+// A resource-scoped ignore drops only that resource.
+func TestGroupFindings_Checker_ResourceScopeDropsOneResource(t *testing.T) {
+	checker := stubIgnoreChecker{resources: map[string]bool{"default/Pod/pod-a": true}}
+	groups := groupFindings(ignoreTestFindings(), "heuristic", checker, false)
+
+	g := findGroup(groups, "privileged")
+	require.NotNil(t, g)
+	assert.Equal(t, 2, g.Count, "pod-a excluded; pod-b and pod-d remain")
+}
+
+// show-ignored mode reveals an ignored group AND tags it, which findingGroupToItem
+// surfaces as the __ignored__ column the view layer reads.
+func TestGroupFindings_Checker_ShowIgnoredTagsAndRevealsGroup(t *testing.T) {
+	checker := stubIgnoreChecker{groups: map[string]bool{"privileged": true}}
+	groups := groupFindings(ignoreTestFindings(), "heuristic", checker, true)
+
+	require.Len(t, groups, 2, "showIgnored keeps the ignored group in the list")
+	priv := findGroup(groups, "privileged")
+	require.NotNil(t, priv)
+	assert.True(t, priv.Ignored, "the cluster-wide-ignored group is tagged Ignored")
+	assert.Equal(t, 3, priv.Count, "all resources shown in show-ignored mode")
+
+	host := findGroup(groups, "host_pid")
+	require.NotNil(t, host)
+	assert.False(t, host.Ignored)
+
+	// The tag must surface on the rendered item via the __ignored__ column.
+	item := findingGroupToItem(*priv)
+	assert.Equal(t, "true", item.ColumnValue("__ignored__"))
+	assert.Empty(t, findingGroupToItem(*host).ColumnValue("__ignored__"))
+}

--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -101,6 +101,14 @@ func (m *Manager) SetRefreshTTL(d time.Duration) {
 	m.refreshTTL = d
 }
 
+// CachedFindings returns the cached FetchAll result for (kubeCtx, namespace)
+// without triggering a scan. ok is false when nothing is cached for that key
+// or the cache has expired. Lets callers serve the shared scan synchronously
+// off the scheduler when it is already warm.
+func (m *Manager) CachedFindings(kubeCtx, namespace string) (FetchResult, bool) {
+	return m.cachedFetch(kubeCtx + "|" + namespace)
+}
+
 // SetErrorTTL overrides the negative-cache TTL applied when every
 // source erred (no findings produced). Zero disables negative caching
 // entirely — only do that in tests where you want every call to refire.

--- a/internal/security/manager_cached_test.go
+++ b/internal/security/manager_cached_test.go
@@ -1,0 +1,37 @@
+package security
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CachedFindings must peek the FetchAll cache without scanning: cold for an
+// unseen key, warm after a FetchAll, and keyed by (context, namespace).
+func TestCachedFindings(t *testing.T) {
+	mgr := NewManager()
+	mgr.SetRefreshTTL(time.Hour)
+	src := &FakeSource{NameStr: "h", Available: true, Findings: []Finding{{ID: "1", Source: "h"}}}
+	mgr.Register(src)
+
+	_, ok := mgr.CachedFindings("kctx", "")
+	assert.False(t, ok, "cold cache before any fetch")
+	assert.Equal(t, int32(0), src.FetchCalls.Load(), "peek must not scan")
+
+	_, err := mgr.FetchAll(context.Background(), "kctx", "")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), src.FetchCalls.Load())
+
+	res, ok := mgr.CachedFindings("kctx", "")
+	require.True(t, ok, "warm after fetch")
+	require.Len(t, res.Findings, 1)
+	assert.Equal(t, int32(1), src.FetchCalls.Load(), "peek must not re-scan")
+
+	_, ok = mgr.CachedFindings("other-ctx", "")
+	assert.False(t, ok, "different context key is cold")
+	_, ok = mgr.CachedFindings("kctx", "ns1")
+	assert.False(t, ok, "different namespace key is cold")
+}

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -655,6 +655,12 @@ var ConfigSecurityEnabled = true
 // defaults to enabled.
 var ConfigSecuritySources = map[string]bool{}
 
+// ConfigSecurityIgnorePatterns holds the declarative, glob-based security
+// ignore rules from the `security.ignore_patterns` config section. Read-only
+// after load; consumed by the app layer's ignore checker alongside the
+// interactive per-cluster ignore-list.
+var ConfigSecurityIgnorePatterns []SecurityIgnorePattern
+
 // ConfigClusterSecurityEnabled maps context names to per-cluster
 // dashboard-enabled overrides; a value here wins over ConfigSecurityEnabled.
 var ConfigClusterSecurityEnabled = map[string]bool{}

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -211,6 +211,16 @@ func applySecurityConfig(cfg configFile) {
 	if cfg.Security.Sources != nil {
 		ConfigSecuritySources = cfg.Security.Sources
 	}
+	// Drop all-empty patterns so an accidental blank list item can't hide
+	// every finding.
+	patterns := make([]SecurityIgnorePattern, 0, len(cfg.Security.IgnorePatterns))
+	for _, p := range cfg.Security.IgnorePatterns {
+		if p.IsEmpty() {
+			continue
+		}
+		patterns = append(patterns, p)
+	}
+	ConfigSecurityIgnorePatterns = patterns
 }
 
 // applyDataAccessConfig applies the cluster-data-access settings:
@@ -308,6 +318,14 @@ func applyConfigMaps(cfg configFile, abbr map[string]string) {
 				}
 				if cc.Security.Sources != nil {
 					ConfigClusterSecuritySources[ctx] = cc.Security.Sources
+				}
+				// ignore_patterns is honored only in the top-level security
+				// section; per-cluster scoping is expressed via each pattern's
+				// `cluster` glob instead. Warn rather than silently drop.
+				if len(cc.Security.IgnorePatterns) > 0 {
+					logger.Warn("clusters.<ctx>.security.ignore_patterns is ignored; "+
+						"set ignore_patterns at the top-level security section and use the per-pattern 'cluster' glob",
+						"context", ctx)
 				}
 			}
 			if len(cc.Views) > 0 {

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -113,7 +113,12 @@ type Keybindings struct {
 	LocalClusterManager string `json:"local_cluster_manager" yaml:"local_cluster_manager"`
 
 	// SecurityIgnoreToggle flips the show/hide-ignored-findings state on
-	// the active security view and triggers a refresh.
+	// the active security view and triggers a refresh. Dispatched only when
+	// the user is on a security view, so it can reuse a key bound elsewhere
+	// (it shadows LabelEditor, which is meaningless on synthetic finding
+	// rows) — mirroring how ClusterColorPicker reuses the Logs key at the
+	// cluster picker. Must not be a terminal control-alias (ctrl+i/m/[);
+	// see TestDefaultKeybindingsNoUnreachableControlAliases.
 	SecurityIgnoreToggle string `json:"security_ignore_toggle" yaml:"security_ignore_toggle"`
 
 	// SecurityBadgeToggle shows/hides the per-resource SEC severity badge on
@@ -177,7 +182,10 @@ func DefaultKeybindings() Keybindings {
 		// Read-only mode
 		ReadOnlyToggle: "ctrl+r",
 
-		SecurityIgnoreToggle: "ctrl+i",
+		// "i" (not "ctrl+i": a terminal sends ctrl+i as Tab, so that binding
+		// could never fire). Gated to security views in the dispatcher, where
+		// it shadows the otherwise-meaningless LabelEditor ("i").
+		SecurityIgnoreToggle: "i",
 		SecurityBadgeToggle:  "B",
 
 		// Cluster color picker. Bound to Shift+L because the picker only

--- a/internal/ui/config_keybindings_test.go
+++ b/internal/ui/config_keybindings_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestDefaultKeybindingsNoUnreachableControlAliases guards against a whole
+// class of dead bindings: in a terminal, certain control-byte spellings are
+// indistinguishable from named keys, so bubbletea never emits the "ctrl+X"
+// form — a binding set to one can never fire.
+//
+//	ctrl+i == tab   (0x09)
+//	ctrl+m == enter (0x0d)
+//	ctrl+[ == esc   (0x1b)
+//
+// Only these three are rejected: their bytes map to a DIFFERENT key name in
+// bubbletea's table, so the "ctrl+X" spelling is never emitted. ctrl+h
+// (0x08->"ctrl+h"), ctrl+j (0x0a->"ctrl+j"), ctrl+@ (0x00->"ctrl+@") and
+// ctrl+_ (0x1f->"ctrl+_") ARE emitted under those names and remain valid.
+// The original SecurityIgnoreToggle = "ctrl+i" tripped exactly this trap.
+func TestDefaultKeybindingsNoUnreachableControlAliases(t *testing.T) {
+	unreachable := map[string]string{
+		"ctrl+i": "tab",
+		"ctrl+m": "enter",
+		"ctrl+[": "esc",
+	}
+
+	kb := DefaultKeybindings()
+	v := reflect.ValueOf(kb)
+	for i := range v.NumField() {
+		f := v.Field(i)
+		if f.Kind() != reflect.String {
+			continue
+		}
+		if named, bad := unreachable[f.String()]; bad {
+			t.Errorf("keybinding %s = %q is unreachable in a terminal (collides with %q); use %q or pick another key",
+				v.Type().Field(i).Name, f.String(), named, named)
+		}
+	}
+}

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -356,6 +356,43 @@ type securityConfig struct {
 	// or the internal source ids (trivy-operator, policy-report). Any source
 	// omitted from the map defaults to enabled.
 	Sources map[string]bool `json:"sources" yaml:"sources"`
+	// IgnorePatterns are declarative, glob-based ignore rules applied at load.
+	// They complement the interactive per-cluster ignore-list (managed with
+	// the action menu): config patterns are read-only and cannot be
+	// un-ignored from the UI, but the show-ignored toggle still reveals them.
+	// Honored ONLY in the top-level `security` section — per-cluster scoping
+	// is expressed via each pattern's `cluster` glob. A per-cluster block that
+	// sets ignore_patterns is ignored (with a warning).
+	IgnorePatterns []SecurityIgnorePattern `json:"ignore_patterns" yaml:"ignore_patterns"`
+}
+
+// SecurityIgnorePattern is a declarative ignore rule from the config file.
+// Each field is a glob (`*` and `?`); an empty field matches anything. A
+// finding is ignored when every non-empty field matches it. A pattern with
+// every field empty is treated as a no-op (skipped) to avoid silently hiding
+// all findings.
+type SecurityIgnorePattern struct {
+	// Cluster globs the kube-context name. Empty = any cluster.
+	Cluster string `json:"cluster,omitempty" yaml:"cluster,omitempty"`
+	// Source globs the security source id (heuristic, trivy-operator,
+	// policy-report, falco, ...). Empty = any source.
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+	// Group globs the finding group key (CVE id, check label, rule name).
+	// Empty = any group.
+	Group string `json:"group,omitempty" yaml:"group,omitempty"`
+	// Namespace globs the resource namespace. Empty (or `*`) = any namespace,
+	// which hides the whole group; a specific value scopes the ignore to that
+	// namespace only. Cluster-scoped findings have an empty namespace.
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	// Comment is a free-text note explaining why the rule exists.
+	Comment string `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+// IsEmpty reports whether the pattern has no match constraints (every glob
+// field empty). Such a pattern would match every finding, so it is dropped at
+// load and skipped at match time.
+func (p SecurityIgnorePattern) IsEmpty() bool {
+	return p.Cluster == "" && p.Source == "" && p.Group == "" && p.Namespace == ""
 }
 
 // RightsizingDefaultsConfig is the on-disk schema for the

--- a/internal/ui/config_security_test.go
+++ b/internal/ui/config_security_test.go
@@ -4,22 +4,43 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func saveSecurityGlobals(t *testing.T) {
 	t.Helper()
 	pe, ps := ConfigSecurityEnabled, ConfigSecuritySources
 	pce, pcs := ConfigClusterSecurityEnabled, ConfigClusterSecuritySources
+	pip := ConfigSecurityIgnorePatterns
 	t.Cleanup(func() {
 		ConfigSecurityEnabled = pe
 		ConfigSecuritySources = ps
 		ConfigClusterSecurityEnabled = pce
 		ConfigClusterSecuritySources = pcs
+		ConfigSecurityIgnorePatterns = pip
 	})
 	ConfigSecurityEnabled = true
 	ConfigSecuritySources = map[string]bool{}
 	ConfigClusterSecurityEnabled = map[string]bool{}
 	ConfigClusterSecuritySources = map[string]map[string]bool{}
+	ConfigSecurityIgnorePatterns = nil
+}
+
+func TestApplySecurityConfigIgnorePatterns(t *testing.T) {
+	saveSecurityGlobals(t)
+
+	cfg := configFile{Security: &securityConfig{
+		IgnorePatterns: []SecurityIgnorePattern{
+			{Source: "trivy-operator", Group: "CVE-2024-*", Namespace: "kube-system", Comment: "accepted"},
+			{},                        // no constraints -> dropped
+			{Comment: "comment only"}, // still no constraints -> dropped
+		},
+	}}
+	applySecurityConfig(cfg)
+
+	require.Len(t, ConfigSecurityIgnorePatterns, 1, "all-empty patterns must be dropped")
+	assert.Equal(t, "trivy-operator", ConfigSecurityIgnorePatterns[0].Source)
+	assert.Equal(t, "kube-system", ConfigSecurityIgnorePatterns[0].Namespace)
 }
 
 func TestResolveSecurityEnabled(t *testing.T) {

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -225,7 +225,11 @@ func plainNameCellWithBadge(name string, item *model.Item, nameW int) string {
 // truncated to make room). Gated callers (ActiveSecurityAvailable == false)
 // get an empty badge and the row renders identically to the pre-security UI.
 func styledNameCell(item model.Item, nameW int) string {
-	isDimmed := item.Status == "Succeeded" || item.Status == "Completed"
+	// Ignored security findings (revealed by the show-ignored toggle, tagged
+	// __ignored__ by groupFindings / GetSecurityAffectedResources) are dimmed
+	// so they read as de-emphasized next to active findings.
+	isDimmed := item.Status == "Succeeded" || item.Status == "Completed" ||
+		item.ColumnValue("__ignored__") == "true"
 	nameStyle := NormalStyle
 	if isDimmed {
 		nameStyle = DimStyle

--- a/internal/ui/explorer_format_ignored_test.go
+++ b/internal/ui/explorer_format_ignored_test.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestStyledNameCellDimsIgnoredRows verifies that a row tagged __ignored__
+// (a revealed-but-ignored security finding) renders with distinct, dimmed
+// styling versus an otherwise identical active row, so the show-ignored view
+// visually distinguishes ignored entries.
+func TestStyledNameCellDimsIgnoredRows(t *testing.T) {
+	orig := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(orig) })
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+
+	active := model.Item{Kind: "__security_finding_group__", Name: "CVE-2024-1"}
+	ignored := model.Item{
+		Kind:    "__security_finding_group__",
+		Name:    "CVE-2024-1",
+		Columns: []model.KeyValue{{Key: "__ignored__", Value: "true"}},
+	}
+
+	got := styledNameCell(ignored, 30)
+	want := styledNameCell(active, 30)
+	assert.NotEqual(t, want, got, "an __ignored__ row must render with distinct (dim) styling")
+}

--- a/internal/ui/explorer_sec_column.go
+++ b/internal/ui/explorer_sec_column.go
@@ -135,13 +135,23 @@ func securityBadgePlainForItem(item *model.Item) string {
 	return securityBadgePlain(counts)
 }
 
-// itemSecurityCounts returns the merged SeverityCounts for an item,
-// combining findings for the item itself with findings for its owner
-// resources (extracted from owner:N columns).
+// itemSecurityCounts returns the merged SeverityCounts for an item against the
+// active render-time index. Thin wrapper over MergedSecurityCounts.
 func itemSecurityCounts(item *model.Item) security.SeverityCounts {
-	counts := ActiveSecurityIndex.For(itemSecurityRef(item))
-	// Also check owner references so trivy findings (which reference the
-	// Deployment, not the Pod) show on Pod rows.
+	return MergedSecurityCounts(ActiveSecurityIndex, item)
+}
+
+// MergedSecurityCounts returns an item's own findings combined with its owner
+// resources' findings (from owner:N columns) — the exact aggregation the SEC
+// row badge shows (e.g. a Pod row includes its Deployment's trivy findings).
+// Exported so app-layer surfaces such as the "Security Findings" action report
+// the same numbers as the badge instead of a bare per-ref count. Returns zero
+// counts when idx or item is nil.
+func MergedSecurityCounts(idx *security.FindingIndex, item *model.Item) security.SeverityCounts {
+	if idx == nil || item == nil {
+		return security.SeverityCounts{}
+	}
+	counts := idx.For(itemSecurityRef(item))
 	for _, col := range item.Columns {
 		if len(col.Key) < 6 || col.Key[:6] != "owner:" {
 			continue
@@ -156,7 +166,7 @@ func itemSecurityCounts(item *model.Item) security.SeverityCounts {
 			Kind:      ownerKind,
 			Name:      ownerName,
 		}
-		oc := ActiveSecurityIndex.For(ownerRef)
+		oc := idx.For(ownerRef)
 		counts.Critical += oc.Critical
 		counts.High += oc.High
 		counts.Medium += oc.Medium

--- a/internal/ui/explorer_sec_column_merged_test.go
+++ b/internal/ui/explorer_sec_column_merged_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+// MergedSecurityCounts must combine an item's own findings with its owner
+// resources' findings (owner:N columns, value "APIVersion||Kind||Name"), the
+// same aggregation the SEC row badge uses.
+func TestMergedSecurityCounts_IncludesOwnerFindings(t *testing.T) {
+	idx := security.BuildFindingIndex([]security.Finding{
+		{ID: "1", Severity: security.SeverityCritical, Resource: security.ResourceRef{Namespace: "default", Kind: "Deployment", Name: "api"}},
+		{ID: "2", Severity: security.SeverityHigh, Resource: security.ResourceRef{Namespace: "default", Kind: "Pod", Name: "api-xyz"}},
+	})
+	item := &model.Item{
+		Kind: "Pod", Name: "api-xyz", Namespace: "default",
+		Columns: []model.KeyValue{{Key: "owner:0", Value: "apps/v1||Deployment||api"}},
+	}
+
+	counts := MergedSecurityCounts(idx, item)
+	assert.Equal(t, 1, counts.Critical, "owner (Deployment) critical merged in")
+	assert.Equal(t, 1, counts.High, "pod's own high counted")
+	assert.Equal(t, 2, counts.Total())
+}
+
+func TestMergedSecurityCounts_NilSafe(t *testing.T) {
+	assert.Equal(t, 0, MergedSecurityCounts(nil, &model.Item{}).Total())
+	assert.Equal(t, 0, MergedSecurityCounts(security.BuildFindingIndex(nil), nil).Total())
+}

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -113,6 +113,7 @@ func helpSections() []helpSection {
 				{kb.ThemeSelector, "Switch color scheme (" + kb.NewTab + ": toggle transparent bg)"},
 				{helpKeyDisplay(kb.TerminalToggle), "Cycle terminal mode (pty / exec / mux — mux skipped if no tmux/zellij detected)"},
 				{kb.SecurityBadgeToggle, "Show/hide the per-resource SEC severity badge on explorer rows"},
+				{kb.SecurityIgnoreToggle, "Show/hide ignored security findings (only on a security view)"},
 			},
 		},
 		{


### PR DESCRIPTION
Implements the security-finding visibility TODO cluster (L955–L957). Investigation found L955/L956 already shipped in #183 (checkboxes just never ticked) — and that the show-ignored toggle was **broken**.

## Changes

**fix(security): make the show-ignored toggle reachable (`ctrl+i` was dead)**
- `ctrl+i` is byte-identical to `Tab` (0x09); bubbletea emits `"tab"`, never `"ctrl+i"`, so the binding could never fire. Handler unit tests passed only because they bypassed the key string.
- Rebound `SecurityIgnoreToggle` to `i`, dispatched via a new gated `handleExplorerSecurityViewKeys` so it shadows the (meaningless) Label Editor only on security views — same idiom as `ClusterColorPicker` reusing the Logs key at the cluster picker.
- Added the toggle to the in-app help (was missing) + `keybindings.md`.
- Guard test `TestDefaultKeybindingsNoUnreachableControlAliases` rejects the whole dead class (`ctrl+i`/`ctrl+m`/`ctrl+[`).

**feat(security): namespace-scoped ignores + config-file glob patterns (L957)**
- `Namespace` field on `SecurityIgnoreRule`; scope precedence cluster-wide group > namespace > exact resource. New "Ignore (Namespace)" action; un-ignore peels the most specific rule first and warns when a broader rule still hides the row.
- New top-level `security.ignore_patterns` (cluster/source/group/namespace globs + comment) applied at load. The filter consults interactive YAML rules + config patterns together; the action menu reads YAML-only so config-only ignores never offer a misleading "Un-ignore". The `i` toggle still reveals config-hidden findings.
- Slash-agnostic `globMatch` (`*`/`?`); all-empty patterns dropped; per-cluster `ignore_patterns` warns (use the per-pattern `cluster` glob).

A multi-agent adversarial review raised 18 findings (16 confirmed); all real ones are addressed in this branch, including the 2 HIGH test-coverage gaps. One LOW enhancement (per-row ignored markers in show-ignored mode) is deferred.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` green (+31 new tests: glob matching, namespace-scope predicates, checker combination, cluster-scoped findings, action menu + dispatch gating, config load, and `groupFindings` driven end-to-end through a real checker incl. show-ignored tagging)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual: open Security → a source → a finding group → drill in; `x` shows Ignore (Group/Namespace/This Resource); `i` toggles ignored visibility on the security view (and is a no-op elsewhere)
- [ ] Manual: add a `security.ignore_patterns` entry; confirm matching findings hide and `i` reveals them