### PR TITLE
fix: show loader on startup instead of flashing empty states

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -103,6 +103,12 @@ type Model struct {
 	// Spinner for loading animation.
 	spinner spinner.Model
 
+	// initialSecuritySeedCmd holds the SEC-badge findings-cache seed command
+	// produced by refreshSecuritySources during NewModel. NewModel cannot
+	// return a command, so Init dispatches it (the read runs off the Update
+	// goroutine). Nil when security is disabled or no findings cache applies.
+	initialSecuritySeedCmd tea.Cmd
+
 	// Action context: which resource/kind the action targets.
 	actionCtx actionContext
 

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -38,7 +38,13 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	reqCtx, reqCancel := context.WithCancel(context.Background())
 	pinnedSt := loadPinnedState()
 	m := Model{
-		client:                     client,
+		client: client,
+		// Start in the loading state. Init() dispatches loadContexts()
+		// asynchronously, so the first frame renders before any
+		// contextsLoadedMsg arrives; loading=false there falls through to the
+		// "No items" / "No resource types found" empty states until the reply
+		// lands. The loaded-message handlers clear the flag once data arrives.
+		loading:                    true,
 		nav:                        model.NavigationState{Level: model.LevelClusters},
 		bookmarks:                  loadBookmarks(),
 		pendingSession:             loadSession(),

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -200,7 +200,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	// publishes it to the hook state.
 	installSecuritySourcesHook()
 	m.securityIgnores = loadSecurityIgnores()
-	m.refreshSecuritySources()
+	m.initialSecuritySeedCmd = m.refreshSecuritySources()
 
 	// Mirror main.go's startup mouse decision: capture is on unless the
 	// --no-mouse flag was set or config disabled it. The toggle keybinding

--- a/internal/app/app_init_cmd.go
+++ b/internal/app/app_init_cmd.go
@@ -27,6 +27,12 @@ func (m Model) Init() tea.Cmd {
 	// (metrics-server unreachable, RBAC denied, ...) reach the in-app
 	// log overlay instead of only the on-disk file.
 	cmds = append(cmds, waitForLoggerUI())
+	// Dispatch the SEC-badge findings-cache seed produced during NewModel. The
+	// disk read runs off the Update goroutine; refreshSecuritySources returns
+	// nil when security is disabled or no findings cache applies.
+	if m.initialSecuritySeedCmd != nil {
+		cmds = append(cmds, m.initialSecuritySeedCmd)
+	}
 	if m.watchMode {
 		cmds = append(cmds, scheduleWatchTick(m.watchInterval))
 	}

--- a/internal/app/app_init_test.go
+++ b/internal/app/app_init_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+)
+
+// TestNewModel_StartsInLoadingState guards against the startup empty-state
+// flash. Init() dispatches loadContexts() asynchronously, so Bubbletea renders
+// the first frame before any contextsLoadedMsg arrives. If the model is
+// constructed with loading=false, that frame falls through to the empty-state
+// messages ("No items", "No resource types found") until the reply lands.
+// Constructing with loading=true makes the first render show the spinner; the
+// loaded-message handlers (updateContextsLoaded, updateResourceTypes) clear the
+// flag once real data arrives.
+func TestNewModel_StartsInLoadingState(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := k8s.NewTestClient(nil, nil)
+	m := NewModel(client, StartupOptions{})
+	if !m.loading {
+		t.Fatal("NewModel must start in the loading state so the first render " +
+			"shows the spinner instead of flashing the empty-state messages")
+	}
+}

--- a/internal/app/commands_security.go
+++ b/internal/app/commands_security.go
@@ -288,6 +288,26 @@ func (m Model) updateSecurityFindingsLoaded(msg securityFindingsLoadedMsg) (Mode
 	return m, persist
 }
 
+// updateSecurityFindingsSeed applies the disk-cached SEC badge seed delivered
+// by securityFindingsSeedCmd. It is stale-while-revalidate: the seed is applied
+// only when no live scan has populated the index yet (m.securityIndex == nil)
+// and the context still matches, so a freshly-scanned index is never clobbered
+// by older cached data, and another cluster's findings never paint here. A nil
+// index is a cache miss and is ignored.
+func (m Model) updateSecurityFindingsSeed(msg securityFindingsSeedMsg) Model {
+	if msg.index == nil {
+		return m
+	}
+	if m.securityIndex != nil {
+		return m // a live scan already won; do not regress to stale data
+	}
+	if m.nav.Context != "" && msg.context != m.nav.Context {
+		return m
+	}
+	m.securityIndex = msg.index
+	return m
+}
+
 // loadSecurityAffectedResources fetches the resources affected by a
 // finding group and emits them as an ownedLoadedMsg so the existing
 // LevelOwned rendering picks them up. The group key comes from the

--- a/internal/app/messages_security.go
+++ b/internal/app/messages_security.go
@@ -26,6 +26,18 @@ type securityFindingsLoadedMsg struct {
 	errors    map[string]error
 }
 
+// securityFindingsSeedMsg carries the stale-while-revalidate SEC badge seed
+// read from the per-host findings cache. The disk read and index build run OFF
+// the Update goroutine (securityFindingsSeedCmd): the per-host cache file can be
+// tens of MB on clusters with many findings, and decoding it inline — the
+// previous behavior inside refreshSecuritySources — froze the UI for seconds at
+// startup and on context/tab switch. index is nil on a cache miss.
+type securityFindingsSeedMsg struct {
+	context   string
+	namespace string
+	index     *security.FindingIndex
+}
+
 // securityIgnoresSaveErrMsg is dispatched when the async ignore-state save
 // (via saveSecurityIgnoresCmd) fails. Successful saves emit no message — the
 // optimistic status set when the user pressed the action stays visible. The

--- a/internal/app/security_findings_seed_test.go
+++ b/internal/app/security_findings_seed_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/security"
+)
+
+// The findings cache read used to run synchronously inside
+// refreshSecuritySources on the Bubble Tea Update goroutine. On clusters with
+// many findings the per-host cache file is tens of MB and decoding it took
+// seconds, freezing the UI (static spinner, unresponsive quit) at startup and
+// on context/tab switch. The read is now deferred into securityFindingsSeedCmd
+// and applied via securityFindingsSeedMsg. These tests guard the
+// stale-while-revalidate ordering of that handler.
+
+func seedRef() security.ResourceRef {
+	return security.ResourceRef{Namespace: "default", Kind: "Pod", Name: "nginx"}
+}
+
+func seedIndex() *security.FindingIndex {
+	return security.BuildFindingIndex([]security.Finding{
+		{ID: "F1", Title: "crit", Severity: security.SeverityCritical, Resource: seedRef()},
+	})
+}
+
+func TestSecurityFindingsSeedAppliesWhenIndexNil(t *testing.T) {
+	m := newTestModelWithSecurity(t, security.NewManager(), "kctx")
+	require.Nil(t, m.securityIndex)
+
+	updated := m.updateSecurityFindingsSeed(securityFindingsSeedMsg{
+		context: "kctx",
+		index:   seedIndex(),
+	})
+
+	require.NotNil(t, updated.securityIndex,
+		"disk-cached seed must populate the badge index when none is loaded yet")
+	assert.Equal(t, 1, updated.securityIndex.For(seedRef()).Critical)
+}
+
+func TestSecurityFindingsSeedDoesNotClobberLiveScan(t *testing.T) {
+	m := newTestModelWithSecurity(t, security.NewManager(), "kctx")
+	live := security.BuildFindingIndex(nil)
+	m.securityIndex = live
+
+	updated := m.updateSecurityFindingsSeed(securityFindingsSeedMsg{
+		context: "kctx",
+		index:   seedIndex(),
+	})
+
+	assert.Same(t, live, updated.securityIndex,
+		"a live scan result already landed; the older disk seed must not overwrite it")
+}
+
+func TestSecurityFindingsSeedStaleContextDiscarded(t *testing.T) {
+	m := newTestModelWithSecurity(t, security.NewManager(), "current")
+
+	updated := m.updateSecurityFindingsSeed(securityFindingsSeedMsg{
+		context: "other-cluster",
+		index:   seedIndex(),
+	})
+
+	assert.Nil(t, updated.securityIndex,
+		"a seed for a different context must not paint badges on the active cluster")
+}
+
+func TestSecurityFindingsSeedNilIndexIgnored(t *testing.T) {
+	m := newTestModelWithSecurity(t, security.NewManager(), "kctx")
+
+	updated := m.updateSecurityFindingsSeed(securityFindingsSeedMsg{
+		context: "kctx",
+		index:   nil, // cache miss
+	})
+
+	assert.Nil(t, updated.securityIndex)
+}

--- a/internal/app/security_refresh.go
+++ b/internal/app/security_refresh.go
@@ -5,6 +5,8 @@
 package app
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/janosmiko/lfk/internal/security"
 	"github.com/janosmiko/lfk/internal/security/falco"
 	"github.com/janosmiko/lfk/internal/security/gatekeeper"
@@ -21,7 +23,12 @@ import (
 // fresh manager is wired into the k8s.Client and published to the
 // package-level hook state so model.SecuritySourcesFn picks it up on the
 // next sidebar render.
-func (m *Model) refreshSecuritySources() {
+// The returned command, when non-nil, reads the per-host findings cache off the
+// Update goroutine and emits securityFindingsSeedMsg to paint the SEC badges
+// (stale-while-revalidate). Callers must dispatch it; NewModel stores it for
+// Init to fire. Reading that cache inline here used to freeze the UI for seconds
+// on clusters with a large findings cache.
+func (m *Model) refreshSecuritySources() tea.Cmd {
 	// The manager is rebuilt below, so any prior probe for this slot is moot.
 	// Clearing the guard lets maybeProbeSecurityOnFocus re-probe the new (or
 	// re-selected) context the next time the user focuses the Security
@@ -46,7 +53,7 @@ func (m *Model) refreshSecuritySources() {
 			m.client.SetSecurityManager(nil)
 		}
 		setSecurityHookState(nil, nil)
-		return
+		return nil
 	}
 	mgr := security.NewManager()
 	if m.client != nil {
@@ -82,6 +89,7 @@ func (m *Model) refreshSecuritySources() {
 	// Seed availability from the per-host disk cache so the sidebar
 	// shows real entries immediately on subsequent runs. A nil/empty
 	// result triggers the loader entry until the live probe completes.
+	seedFindings := false
 	if cached := loadSecurityAvailabilityCacheForContext(m.client, resolvedCtx); len(cached) > 0 {
 		m.securityAvailabilityByName = cached
 		// Publish the cached availability as the manager's hint so an eager
@@ -92,18 +100,11 @@ func (m *Model) refreshSecuritySources() {
 		// with no new probe; an as-yet-uninspected cluster has no cache and
 		// stays fully lazy.
 		mgr.SetAvailability(resolvedCtx, cached)
-		// Stale-while-revalidate: paint SEC badges instantly from the
-		// last session's findings while the eager scan revalidates in the
-		// background (maybeEagerSecurityScan, fired at cluster open, replaces
-		// the index when fresh results land). Keyed by the effective
-		// namespace so the seed matches what the scan will fetch. A miss
-		// (no cache / expired) just leaves the index nil until the scan
-		// completes — the pre-cache behavior.
-		if cachedFindings := loadSecurityFindingsCacheForContext(
-			m.client, resolvedCtx, m.effectiveNamespace(), securityFindingsCacheTTL,
-		); cachedFindings != nil {
-			m.securityIndex = security.BuildFindingIndex(cachedFindings)
-		}
+		// A cached availability means this cluster was inspected before, so its
+		// findings cache is worth reading for the stale-while-revalidate badge
+		// seed. The read itself is deferred to securityFindingsSeedCmd (below)
+		// because the cache file can be tens of MB.
+		seedFindings = true
 	} else {
 		m.securityAvailabilityByName = make(map[string]bool)
 	}
@@ -119,4 +120,33 @@ func (m *Model) refreshSecuritySources() {
 	}
 	// Publish to the hook state so SecuritySourcesFn reads the new data.
 	setSecurityHookState(m.securityManager, m.securityAvailabilityByName)
+	if !seedFindings {
+		return nil
+	}
+	return m.securityFindingsSeedCmd(resolvedCtx, m.effectiveNamespace())
+}
+
+// securityFindingsSeedCmd reads the per-host findings cache and builds the SEC
+// badge index OFF the Update goroutine, delivering the result as a
+// securityFindingsSeedMsg. The per-host cache file can be tens of MB on
+// clusters with many findings; decoding it inline (the previous behavior in
+// refreshSecuritySources) froze the UI for seconds at startup and on
+// context/tab switch. Returns nil when no client is wired. A cache miss yields
+// a nil message, which Bubble Tea drops.
+func (m *Model) securityFindingsSeedCmd(resolvedCtx, namespace string) tea.Cmd {
+	client := m.client
+	if client == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		cached := loadSecurityFindingsCacheForContext(client, resolvedCtx, namespace, securityFindingsCacheTTL)
+		if cached == nil {
+			return nil
+		}
+		return securityFindingsSeedMsg{
+			context:   resolvedCtx,
+			namespace: namespace,
+			index:     security.BuildFindingIndex(cached),
+		}
+	}
 }

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -649,7 +649,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 		// sidebar seeds from the on-disk cache. Live availability probing is
 		// lazy (maybeProbeSecurityOnFocus) — it runs when the user focuses
 		// the Security category, not eagerly on every tab/context restore.
-		m.refreshSecuritySources()
+		securitySeedCmd := m.refreshSecuritySources()
 
 		// Load contexts for the left column breadcrumb.
 		contexts, _ := m.client.GetContexts()
@@ -671,7 +671,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 			m.clearRight()
 			m.setCursor(0)
 			m.loading = true
-			return m.loadResources(false)
+			return tea.Batch(securitySeedCmd, m.loadResources(false))
 		case model.LevelResourceTypes:
 			// At resource types level: left = contexts, middle = resource types.
 			m.leftItemsHistory = nil
@@ -680,11 +680,11 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 			m.itemCache[m.navKey()] = m.middleItems
 			m.clearRight()
 			m.clampCursor()
-			return m.loadPreview()
+			return tea.Batch(securitySeedCmd, m.loadPreview())
 		default:
 			// Clusters level or unknown: just load contexts.
 			m.loading = true
-			return m.refreshCurrentLevel()
+			return tea.Batch(securitySeedCmd, m.refreshCurrentLevel())
 		}
 	}
 	return nil

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -109,6 +109,8 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case securityFindingsLoadedMsg:
 		mdl, cmd := m.updateSecurityFindingsLoaded(msg)
 		return mdl, cmd, true
+	case securityFindingsSeedMsg:
+		return m.updateSecurityFindingsSeed(msg), nil, true
 	case securityIgnoresSaveErrMsg:
 		mdl, cmd := m.updateSecurityIgnoresSaveErr(msg)
 		return mdl, cmd, true

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -69,7 +69,7 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	// until the user navigates out and back in. Re-run refreshSecuritySources
 	// here so the manager + cached availability + dispatched probe all
 	// target sess.Context.
-	m.refreshSecuritySources()
+	securitySeedCmd := m.refreshSecuritySources()
 
 	m.leftItemsHistory = nil
 	m.leftItems = contexts
@@ -85,6 +85,9 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 	applySessionNamespaces(&m, sess.AllNamespaces, sess.Namespace, sess.SelectedNamespaces, sess.NsSelectionNegated)
 
 	var cmds []tea.Cmd
+	if securitySeedCmd != nil {
+		cmds = append(cmds, securitySeedCmd)
+	}
 	needsDiscovery := m.shouldFireDiscoveryFor(discoveryCtx)
 	if needsDiscovery {
 		m.markDiscoveryStarted(discoveryCtx)

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -315,7 +315,7 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	// findings (stale-while-revalidate), so nil-ing after would discard it.
 	m.securityIndex = nil
 	m.securityActiveGroup = ""
-	m.refreshSecuritySources()
+	securitySeedCmd := m.refreshSecuritySources()
 	m.nav.Level = model.LevelResourceTypes
 	// Capture whatever the right-pane preview was already displaying for
 	// this context (real discovery hit or seed fallback). We use this
@@ -351,6 +351,9 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	m.setStatusMessage(fmt.Sprintf("Context: %s", sel.Name), false)
 	m.saveCurrentSession()
 	cmds := []tea.Cmd{m.loadPreview(), scheduleStatusClear()}
+	if securitySeedCmd != nil {
+		cmds = append(cmds, securitySeedCmd)
+	}
 	// Security availability is probed lazily on first focus of the Security
 	// category (maybeProbeSecurityOnFocus), not eagerly on context switch, so
 	// switching clusters never triggers the aws credential plugin for a user


### PR DESCRIPTION
## Summary

On startup, lfk briefly flashed **"No items"** (middle column) and **"No resource types found"** (right pane) before the data loaded.

**Root cause:** `NewModel` (`internal/app/app_init.go`) constructed the model with the zero-value `loading == false`. `Init()` dispatches `loadContexts()` asynchronously, so Bubbletea renders the first frame *before* the `contextsLoadedMsg` reply arrives. The render code shows the spinner only when `loading == true` — otherwise it falls through to the empty-state messages:
- `RenderColumn` (`internal/ui/explorer.go:154`) → `"No items"`
- `renderRightClusters` (`internal/app/view_right.go:332`) → `"No resource types found"`

The codebase already treats `m.loading` as the "show spinner, not empty state" signal, and every loaded-message handler clears it when data arrives. The constructor was the one place that didn't arm it.

**Fix:** One line — initialize `loading: true` in the `NewModel` struct literal. The first render now shows the spinner; existing handlers clear the flag once contexts/resource types load.

## Test plan

- [x] Added regression test `TestNewModel_StartsInLoadingState` (fails before fix, passes after)
- [x] `go build ./...`
- [x] `go vet ./internal/app/`
- [x] `go test -race ./internal/app/`