### PR TITLE
test(app): sandbox state/config/data dirs so tests can't reset real pins

### DIFF
--- a/internal/app/main_test.go
+++ b/internal/app/main_test.go
@@ -6,13 +6,20 @@ import (
 	"testing"
 )
 
-// TestMain installs a per-package temporary XDG_STATE_HOME so any test that
-// reaches saveBookmarks, savePinned, saveSession, or any other state-file
-// writer cannot accidentally overwrite the developer's real
-// ~/.local/state/lfk/ files. Individual tests are still free to override
-// XDG_STATE_HOME via t.Setenv when they need a specific path; t.Setenv
-// restores the value automatically when the test finishes, so the package
-// default is preserved between tests.
+// TestMain redirects every config/state/data directory into a per-package
+// temp sandbox so any test that reaches savePinnedState, saveBookmarks,
+// saveSession, the log writer, or any other on-disk writer cannot overwrite
+// the developer's real lfk files (e.g. resetting pinned resource types).
+//
+// It UNSETS the LFK_* variables and SETS the XDG_* variables. paths.resolve
+// checks LFK_<X>_DIR before XDG_<X>_HOME, so a developer whose environment sets
+// LFK_STATE_DIR / LFK_CONFIG_DIR / LFK_DATA_DIR (portable installs, custom data
+// dirs) would otherwise bypass an XDG-only sandbox and have tests write to
+// their REAL files. Unsetting LFK_* (rather than pointing it at the sandbox)
+// is deliberate: it keeps XDG_* as the effective resolver, so individual tests
+// that isolate themselves with t.Setenv("XDG_STATE_HOME", t.TempDir()) keep
+// working — pointing LFK_* at the sandbox would override those per-test XDG
+// overrides and cross-contaminate tests.
 func TestMain(m *testing.M) {
 	os.Exit(runTests(m))
 }
@@ -22,12 +29,29 @@ func TestMain(m *testing.M) {
 func runTests(m *testing.M) int {
 	tmp, err := os.MkdirTemp("", "lfk-app-tests-")
 	if err != nil {
-		panic("test setup: cannot create temp XDG_STATE_HOME: " + err.Error())
+		panic("test setup: cannot create temp sandbox dir: " + err.Error())
 	}
 	defer func() { _ = os.RemoveAll(tmp) }()
 
-	if err := os.Setenv("XDG_STATE_HOME", filepath.Join(tmp, "state")); err != nil {
-		panic("test setup: cannot set XDG_STATE_HOME: " + err.Error())
+	// Drop any inherited LFK_* so they can't take precedence over the XDG
+	// sandbox below (and can't point tests at the developer's real files).
+	for _, k := range []string{"LFK_CONFIG_DIR", "LFK_STATE_DIR", "LFK_DATA_DIR"} {
+		if err := os.Unsetenv(k); err != nil {
+			panic("test setup: cannot unset " + k + ": " + err.Error())
+		}
+	}
+	// XDG_* now resolves everything into the sandbox (paths.resolve appends an
+	// "lfk" component). Code that reads XDG_STATE_HOME directly (e.g.
+	// security_ignores) is covered too.
+	xdg := map[string]string{
+		"XDG_CONFIG_HOME": filepath.Join(tmp, "config"),
+		"XDG_STATE_HOME":  filepath.Join(tmp, "state"),
+		"XDG_DATA_HOME":   filepath.Join(tmp, "data"),
+	}
+	for k, v := range xdg {
+		if err := os.Setenv(k, v); err != nil {
+			panic("test setup: cannot set " + k + ": " + err.Error())
+		}
 	}
 
 	return m.Run()

--- a/internal/app/state_isolation_test.go
+++ b/internal/app/state_isolation_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/paths"
+)
+
+// TestStateDirsAreSandboxed enforces that the test package's config/state/data
+// directories resolve inside the per-package temp sandbox (see TestMain), so no
+// test can clobber the developer's real lfk files — e.g. resetting pinned
+// resource types. This guards the LFK_*-precedence trap: paths.resolve checks
+// LFK_<X>_DIR before XDG_<X>_HOME, so an XDG-only sandbox is bypassed on any
+// machine whose environment sets LFK_STATE_DIR/LFK_CONFIG_DIR/LFK_DATA_DIR.
+func TestStateDirsAreSandboxed(t *testing.T) {
+	const marker = "lfk-app-tests-" // os.MkdirTemp prefix used by TestMain
+
+	cases := []struct {
+		name string
+		fn   func() (string, error)
+	}{
+		{"StateDir", paths.StateDir},
+		{"ConfigDir", paths.ConfigDir},
+		{"DataDir", paths.DataDir},
+	}
+	for _, c := range cases {
+		dir, err := c.fn()
+		require.NoError(t, err)
+		assert.Truef(t, strings.Contains(dir, marker),
+			"%s must resolve inside the test sandbox, got %q", c.name, dir)
+	}
+}
+
+// TestPinnedStateNeverTouchesRealFiles is the concrete regression for the
+// reported bug: pinned.yaml must resolve inside the sandbox, so saving pinned
+// types from a test never overwrites the developer's real file.
+func TestPinnedStateNeverTouchesRealFiles(t *testing.T) {
+	path := pinnedFilePath()
+	require.NotEmpty(t, path)
+	assert.Contains(t, path, "lfk-app-tests-",
+		"pinned.yaml must live in the test sandbox, not the real state dir")
+}


### PR DESCRIPTION
## Problem (CLAUDE-TODO L962)
"When the automated tests are running, my pinned resource types reset."

The `internal/app` `TestMain` sandboxed only `XDG_STATE_HOME`, but `paths.resolve` checks **`LFK_STATE_DIR` first** (`LFK_<X>_DIR` → `XDG_<X>_HOME` → home). A developer whose environment sets `LFK_STATE_DIR`/`LFK_CONFIG_DIR`/`LFK_DATA_DIR` (portable installs, custom data dirs) had the sandbox bypassed — so tests wrote `pinned.yaml` (and bookmarks, session, cluster colors, history, port-forward/local-cluster state, the log) to their **real** files, resetting pinned resource types on every `go test` run.

## Fix
`TestMain` now **unsets** the `LFK_*` vars and **sets** the `XDG_*` vars to a per-package temp sandbox.

- Unsetting `LFK_*` (rather than pointing it at the sandbox) is deliberate: it keeps `XDG_*` the effective resolver, so existing per-test isolation via `t.Setenv("XDG_STATE_HOME", t.TempDir())` keeps working. Pointing `LFK_*` at the sandbox would override those per-test overrides and cross-contaminate tests (it broke `TestLoadSessionNoFile` in an early iteration).
- Extends the sandbox to the config and data dirs too (previously only state).

## Tests
- `TestStateDirsAreSandboxed` — `StateDir`/`ConfigDir`/`DataDir` resolve inside the sandbox.
- `TestPinnedStateNeverTouchesRealFiles` — `pinned.yaml` resolves inside the sandbox (the concrete regression).

Test-only change. Verified: `go build/vet ./...`, `golangci-lint`, and `go test -race ./internal/app/` all clean; full app suite green.