### PR TITLE
fix: update nix vendorHash for go modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-3kQLUdKc8VYblYHFVh+iPl+mMfdnkHe138dMwPy50WQ=";
+            vendorHash = "sha256-i19f+Kqeh5kW5w8HKhD/ppboYzNBRIOb37pzWZhOAN4=";
 
             subPackages = [ "." ];
 


### PR DESCRIPTION
## Summary
- Updates the stale `vendorHash` in `flake.nix` to the current go modules hash for 0.13.3, fixing the hash mismatch on `nix run github:janosmiko/lfk`.

The new hash (`sha256-i19f+Kqeh5kW5w8HKhD/ppboYzNBRIOb37pzWZhOAN4=`) matches the `got:` value reported in the bug.

Fixes #341

## Test plan
- [x] `nix run github:janosmiko/lfk` builds and launches without a hash mismatch