### PR TITLE
feat(dashboard): show pod capacity headroom in cluster pod bar

### DIFF
--- a/internal/app/commands_dashboard.go
+++ b/internal/app/commands_dashboard.go
@@ -48,6 +48,7 @@ type dashboardData struct {
 	nodeItems      []model.Item
 	nodeCount      int
 	readyNodes     int
+	podCapacity    int64 // sum of nodes' allocatable pods (max schedulable)
 	pods           podStats
 	nsCount        int
 	warningEvents  []model.Item
@@ -241,11 +242,30 @@ func podOther(p podStats) int {
 	return max(p.total-p.running-p.pending-p.failed-p.succeeded, 0)
 }
 
+// podBarDenominator is the value the pod bar is measured against: cluster pod
+// capacity when it exceeds the scheduled total, otherwise the scheduled total
+// itself (capacity unknown, or already saturated). Using capacity makes the
+// bar's empty tail represent unallocated schedulable slots.
+func podBarDenominator(d dashboardData) int {
+	if d.podCapacity > int64(d.pods.total) {
+		return int(d.podCapacity)
+	}
+	return d.pods.total
+}
+
+// podUnallocated is the number of free schedulable pod slots: cluster capacity
+// minus the pods already scheduled. Zero when capacity is unknown or saturated.
+func podUnallocated(d dashboardData) int {
+	return int(max(d.podCapacity-int64(d.pods.total), 0))
+}
+
 // podSummaryStr is the inline status breakdown for the Pods row, e.g.
 // "361 Running · 39 Failed · 24 Succeeded". Only non-zero states are shown;
 // Succeeded is grey (terminal, not an error), Failed red, Pending amber, and
 // any uncounted pods show as a neutral "Other" so they never read as failures.
-// The categories and order mirror the bar segments so bar and text agree.
+// "Unallocated" (free schedulable slots = pod capacity − scheduled) is appended
+// when the cluster's pod capacity is known, mirroring the bar's empty tail. The
+// categories and order mirror the bar segments so bar and text agree.
 func podSummaryStr(d dashboardData) string {
 	parts := make([]string, 0, 5)
 	if d.pods.running > 0 {
@@ -262,6 +282,9 @@ func podSummaryStr(d dashboardData) string {
 	}
 	if other := podOther(d.pods); other > 0 {
 		parts = append(parts, ui.DimStyle.Render(fmt.Sprintf("%d Other", other)))
+	}
+	if unalloc := podUnallocated(d); unalloc > 0 {
+		parts = append(parts, ui.DimStyle.Render(fmt.Sprintf("%d Unallocated", unalloc)))
 	}
 	if len(parts) == 0 {
 		return ui.DimStyle.Render("no pods")
@@ -373,6 +396,25 @@ func (m Model) composeDashboard(data dashboardData) (content, events string) {
 	right = append(right, dashboardEventsColumn(data.allWarnings)...)
 	events = strings.Join(right, "\n")
 	return content, events
+}
+
+// sumPodCapacity adds up each node's allocatable pod count (the "Pods Alloc"
+// column populated from .status.allocatable.pods). This is the maximum number
+// of pods the cluster can schedule, used as the pod bar's denominator so the
+// unfilled tail reads as unallocated headroom rather than 100% utilization.
+func sumPodCapacity(nodeItems []model.Item) int64 {
+	var total int64
+	for _, n := range nodeItems {
+		for _, kv := range n.Columns {
+			if kv.Key == "Pods Alloc" {
+				if v, err := strconv.ParseInt(kv.Value, 10, 64); err == nil {
+					total += v
+				}
+				break
+			}
+		}
+	}
+	return total
 }
 
 // countPodStats tallies pod statuses.

--- a/internal/app/commands_dashboard_sections.go
+++ b/internal/app/commands_dashboard_sections.go
@@ -54,6 +54,7 @@ func fetchDashboardNodes(ctx context.Context, kctx string, client *k8s.Client) d
 	if err == nil {
 		data.nodeItems = nodeItems
 		data.nodeCount = len(nodeItems)
+		data.podCapacity = sumPodCapacity(nodeItems)
 		for _, n := range nodeItems {
 			if n.Status == "Ready" {
 				data.readyNodes++
@@ -112,6 +113,7 @@ func mergeDashboardSection(acc *dashboardData, partial dashboardData) {
 		acc.nodeItems = partial.nodeItems
 		acc.nodeCount = partial.nodeCount
 		acc.readyNodes = partial.readyNodes
+		acc.podCapacity = partial.podCapacity
 	}
 	if partial.pods.total > 0 {
 		acc.pods = partial.pods
@@ -178,12 +180,28 @@ func renderStackedBar(segments []struct {
 	if total <= 0 {
 		return "[" + strings.Repeat("░", width) + "]"
 	}
+	// When the segments fully pack the total, the last one absorbs the rounding
+	// remainder so no stray empty cells appear. When they sum to less than the
+	// total (e.g. scheduled pods below cluster pod capacity), the shortfall is
+	// genuine headroom and must render as empty cells, so the last segment is
+	// sized by its own proportion instead.
+	sumCounts := 0
+	for _, seg := range segments {
+		sumCounts += seg.count
+	}
+	packed := sumCounts >= total
 	var barBuilder strings.Builder
 	used := 0
 	for i, seg := range segments {
 		chars := int(float64(seg.count) / float64(total) * float64(width))
-		// Last segment gets remaining chars to avoid rounding issues.
-		if i == len(segments)-1 {
+		// Give any non-zero segment at least one cell so a handful of Failed or
+		// Pending pods in a large cluster stay visible instead of rounding away.
+		if seg.count > 0 && chars == 0 {
+			chars = 1
+		}
+		// Last segment absorbs the rounding remainder, but only when packed;
+		// otherwise the shortfall is real headroom and must stay empty.
+		if i == len(segments)-1 && packed {
 			chars = width - used
 		}
 		if chars < 0 {
@@ -229,7 +247,9 @@ func dashboardHeaderSection(lines []string, data dashboardData, w dashboardWidth
 	// Pods: status bar (green Running / amber Pending / red Failed / grey
 	// Succeeded) + inline breakdown. "Other" (Terminating/Unknown + rounding
 	// slack) is the neutral last segment so renderStackedBar's remainder-fill
-	// never paints leftover space red as phantom failures.
+	// never paints leftover space red as phantom failures. The denominator is
+	// the cluster's pod capacity (sum of nodes' allocatable pods) when known, so
+	// the unfilled tail reads as unallocated headroom rather than 100% usage.
 	if data.pods.total > 0 {
 		segments := []struct {
 			count int
@@ -241,7 +261,8 @@ func dashboardHeaderSection(lines []string, data dashboardData, w dashboardWidth
 			{data.pods.succeeded, ui.StatusOther},
 			{podOther(data.pods), ui.DimStyle},
 		}
-		podBar := renderStackedBar(segments, data.pods.total, w.bar)
+		denom := podBarDenominator(data)
+		podBar := renderStackedBar(segments, denom, w.bar)
 		lines = append(lines, dashboardMetricLines("Pods", podBar, podSummaryStr(data), w)...)
 	}
 	lines = append(lines, "")

--- a/internal/app/commands_dashboard_test.go
+++ b/internal/app/commands_dashboard_test.go
@@ -146,6 +146,86 @@ func TestPodOther(t *testing.T) {
 	assert.Equal(t, 0, podOther(podStats{total: 10, running: 8, failed: 5}))
 }
 
+func TestSumPodCapacity(t *testing.T) {
+	nodes := []model.Item{
+		{Columns: []model.KeyValue{{Key: "Pods Alloc", Value: "110"}, {Key: "CPU Alloc", Value: "4"}}},
+		{Columns: []model.KeyValue{{Key: "Pods Alloc", Value: "250"}}},
+		{Columns: []model.KeyValue{{Key: "CPU Alloc", Value: "8"}}},    // no Pods Alloc
+		{Columns: []model.KeyValue{{Key: "Pods Alloc", Value: "abc"}}}, // unparsable, skipped
+	}
+	assert.Equal(t, int64(360), sumPodCapacity(nodes))
+	assert.Equal(t, int64(0), sumPodCapacity(nil))
+}
+
+func TestPodBarDenominatorUsesCapacity(t *testing.T) {
+	// Capacity above scheduled total drives the denominator.
+	d := dashboardData{pods: podStats{total: 424}, podCapacity: 1100}
+	assert.Equal(t, 1100, podBarDenominator(d))
+	assert.Equal(t, 676, podUnallocated(d))
+
+	// Capacity unknown (0) falls back to the scheduled total; no headroom.
+	d = dashboardData{pods: podStats{total: 424}}
+	assert.Equal(t, 424, podBarDenominator(d))
+	assert.Equal(t, 0, podUnallocated(d))
+
+	// Saturated (scheduled >= capacity) never reports negative headroom.
+	d = dashboardData{pods: podStats{total: 1100}, podCapacity: 1100}
+	assert.Equal(t, 1100, podBarDenominator(d))
+	assert.Equal(t, 0, podUnallocated(d))
+}
+
+func TestPodSummaryShowsUnallocated(t *testing.T) {
+	s := stripANSI(podSummaryStr(dashboardData{
+		pods:        podStats{total: 424, running: 361, failed: 39, succeeded: 24},
+		podCapacity: 1100,
+	}))
+	assert.Contains(t, s, "361 Running")
+	assert.Contains(t, s, "676 Unallocated")
+
+	// Without capacity data, no Unallocated category appears.
+	noCap := stripANSI(podSummaryStr(dashboardData{
+		pods: podStats{total: 424, running: 361, failed: 39, succeeded: 24},
+	}))
+	assert.NotContains(t, noCap, "Unallocated")
+}
+
+func TestRenderStackedBarLeavesHeadroomBelowTotal(t *testing.T) {
+	// Segments summing to less than total (scheduled pods below pod capacity)
+	// must leave the unfilled tail as empty cells, not absorb it into the last
+	// segment.
+	segments := []struct {
+		count int
+		style lipgloss.Style
+	}{
+		{5, lipgloss.NewStyle()},
+	}
+	result := renderStackedBar(segments, 10, 20)
+	inner := stripANSI(result)
+	inner = inner[1 : len(inner)-1]
+	assert.Equal(t, 10, strings.Count(inner, "█"), "5/10 of a 20-wide bar is filled")
+	assert.Equal(t, 10, strings.Count(inner, "░"), "the remaining headroom is empty")
+}
+
+func TestRenderStackedBarKeepsTinySegmentsVisible(t *testing.T) {
+	// Mirrors a real cluster: 139 scheduled pods against 486 pod capacity in a
+	// 95-wide bar. A 1- or 2-pod segment is ~0.2-0.4 cells and would floor to 0,
+	// making Pending/Failed invisible. Each non-zero segment must claim >=1 cell.
+	segments := []struct {
+		count int
+		style lipgloss.Style
+	}{
+		{119, lipgloss.NewStyle()}, // running -> int(119/486*95) = 23
+		{2, lipgloss.NewStyle()},   // pending -> floors to 0, bumped to 1
+		{1, lipgloss.NewStyle()},   // failed  -> floors to 0, bumped to 1
+		{13, lipgloss.NewStyle()},  // succeeded -> int(13/486*95) = 2
+		{4, lipgloss.NewStyle()},   // other   -> floors to 0, bumped to 1
+	}
+	inner := stripANSI(renderStackedBar(segments, 486, 95))
+	inner = inner[1 : len(inner)-1]
+	assert.Equal(t, 28, strings.Count(inner, "█"), "23 + 1 + 1 + 2 + 1 filled cells")
+	assert.Equal(t, 67, strings.Count(inner, "░"), "remaining width is unallocated headroom")
+}
+
 func TestPodSummaryShowsOtherNotFailed(t *testing.T) {
 	// total exceeds the counted phases with zero failures: the leftover must
 	// read as Other, not as a phantom failure.

--- a/internal/k8s/client_populate_coverage_test.go
+++ b/internal/k8s/client_populate_coverage_test.go
@@ -456,6 +456,7 @@ func TestPopulate_NodeRolesAndTaints(t *testing.T) {
 			"allocatable": map[string]any{
 				"cpu":    "4",
 				"memory": "8Gi",
+				"pods":   "110",
 			},
 			"nodeInfo": map[string]any{
 				"kubeletVersion":          "v1.29.0",
@@ -473,6 +474,7 @@ func TestPopulate_NodeRolesAndTaints(t *testing.T) {
 	assert.Equal(t, "10.0.0.5", colMap["InternalIP"])
 	assert.Equal(t, "4", colMap["CPU Alloc"])
 	assert.Equal(t, "8Gi", colMap["Mem Alloc"])
+	assert.Equal(t, "110", colMap["Pods Alloc"])
 	assert.Equal(t, "v1.29.0", colMap["Version"])
 	assert.Equal(t, "Ubuntu 22.04", colMap["OS"])
 	assert.Equal(t, "containerd://1.7.2", colMap["Runtime"])

--- a/internal/k8s/client_populate_kinds.go
+++ b/internal/k8s/client_populate_kinds.go
@@ -61,6 +61,9 @@ func populateNodeStatus(ti *model.Item, status map[string]any) {
 		if mem, ok := alloc["memory"].(string); ok {
 			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Mem Alloc", Value: mem})
 		}
+		if pods, ok := alloc["pods"].(string); ok {
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pods Alloc", Value: pods})
+		}
 	}
 	if nodeInfo, ok := status["nodeInfo"].(map[string]any); ok {
 		if v, ok := nodeInfo["kubeletVersion"].(string); ok {


### PR DESCRIPTION
Closes #342

## Problem

The cluster dashboard's **Pods** bar was measured against the scheduled pod count, so it always rendered ~100% filled and gave no sense of how many more pods the cluster can take.

## Change

Measure the bar against **cluster pod capacity** — the sum of each node's `.status.allocatable.pods` — so the unfilled tail reads as unallocated schedulable slots.

| Before | After |
|---|---|
| `Pods [█████████████████] ` (always full) | `Pods [████░░░░░░░░░░░░░] ` (fill = scheduled, tail = headroom) |
| `119 Running · 2 Pending · 1 Failed · ...` | `... · 347 Unallocated` |

### Details

- Add a `Pods Alloc` node column populated from `.status.allocatable.pods` (alongside the existing CPU/Mem Alloc columns).
- Sum it into `dashboardData.podCapacity`; use it as the pod bar denominator (falls back to the scheduled total when capacity is unknown, e.g. nodes not yet fetched).
- Append `N Unallocated` to the inline pod summary.
- `renderStackedBar`: only let the last segment absorb the rounding remainder when the segments fully pack the total — otherwise the shortfall is genuine headroom and must render as empty cells.
- `renderStackedBar`: give any non-zero segment at least one cell, so a handful of Failed/Pending pods in a large cluster stay visible instead of rounding away. (Also benefits the node health bar: a single NotReady node among many is now visible.)

## Test plan

- [x] New unit tests: `Pods Alloc` column extraction, `sumPodCapacity`, `podBarDenominator`/`podUnallocated`, `Unallocated` in the pod summary, and `renderStackedBar` headroom + tiny-segment visibility (exact cell counts).
- [x] `go test ./...` passes (with `-race` on the touched packages).
- [x] `golangci-lint run ./...` — 0 issues.