### PR TITLE
fix: keep sort cycling stable when sort column is hidden (#339)

### DIFF
--- a/internal/app/app_sort.go
+++ b/internal/app/app_sort.go
@@ -5,15 +5,17 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// sortColumnIndex returns the index of sortColumnName in ActiveSortableColumns,
-// or 0 if not found.
-func sortColumnIndex(name string) int {
+// sortColumnIndex returns the index of name in ActiveSortableColumns and
+// whether it was found. Callers use the found flag to handle a sort column
+// that is hidden in the current layout (e.g. a wide-only column shown only in
+// fullscreen) rather than silently treating it as index 0 (issue #339).
+func sortColumnIndex(name string) (int, bool) {
 	for i, col := range ui.ActiveSortableColumns {
 		if col == name {
-			return i
+			return i, true
 		}
 	}
-	return 0
+	return 0, false
 }
 
 // sortPref records a user's chosen sort column and direction for a resource

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -219,6 +219,42 @@ func TestActionKeyLessCyclesSortPrev(t *testing.T) {
 	assert.Equal(t, "Status", result.sortColumnName)
 }
 
+// --- handleExplorerActionKey: cycling from a hidden sort column (issue #339) ---
+//
+// When the active sort column is not in the current layout's sortable set
+// (e.g. a wide-only column after leaving fullscreen), cycling must enter the
+// visible set at a predictable boundary rather than jumping past the first
+// column. Previously sortColumnIndex returned 0 for a missing column, so
+// `>` skipped Name and landed on the second column.
+
+func TestActionKeySortNextFromHiddenColumnLandsOnFirst(t *testing.T) {
+	m := baseExplorerModel()
+	m.sortColumnName = "Node" // wide-only, hidden in narrow mode
+	m.sortAscending = true
+	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
+	ui.ActiveSortableColumnCount = 3
+
+	ret, _, handled := m.handleExplorerActionKey(runeKey('>'))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.Equal(t, "Name", result.sortColumnName,
+		"next from a hidden sort column must land on the first visible column")
+}
+
+func TestActionKeySortPrevFromHiddenColumnLandsOnLast(t *testing.T) {
+	m := baseExplorerModel()
+	m.sortColumnName = "Node" // wide-only, hidden in narrow mode
+	m.sortAscending = true
+	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
+	ui.ActiveSortableColumnCount = 3
+
+	ret, _, handled := m.handleExplorerActionKey(runeKey('<'))
+	assert.True(t, handled)
+	result := ret.(Model)
+	assert.Equal(t, "Status", result.sortColumnName,
+		"prev from a hidden sort column must land on the last visible column")
+}
+
 // --- handleExplorerActionKey: sort keys are no-ops at picker levels ---
 //
 // At LevelClusters and LevelResourceTypes, sortMiddleItems() early-returns,

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -231,6 +231,12 @@ func TestActionKeySortNextFromHiddenColumnLandsOnFirst(t *testing.T) {
 	m := baseExplorerModel()
 	m.sortColumnName = "Node" // wide-only, hidden in narrow mode
 	m.sortAscending = true
+	oldCols := ui.ActiveSortableColumns
+	oldCount := ui.ActiveSortableColumnCount
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = oldCols
+		ui.ActiveSortableColumnCount = oldCount
+	})
 	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
 	ui.ActiveSortableColumnCount = 3
 
@@ -245,6 +251,12 @@ func TestActionKeySortPrevFromHiddenColumnLandsOnLast(t *testing.T) {
 	m := baseExplorerModel()
 	m.sortColumnName = "Node" // wide-only, hidden in narrow mode
 	m.sortAscending = true
+	oldCols := ui.ActiveSortableColumns
+	oldCount := ui.ActiveSortableColumnCount
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = oldCols
+		ui.ActiveSortableColumnCount = oldCount
+	})
 	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
 	ui.ActiveSortableColumnCount = 3
 

--- a/internal/app/update_keys_sort.go
+++ b/internal/app/update_keys_sort.go
@@ -12,7 +12,13 @@ func (m Model) handleExplorerActionKeySortNext() (tea.Model, tea.Cmd, bool) {
 	}
 	colCount := ui.ActiveSortableColumnCount
 	if colCount > 0 {
-		idx := sortColumnIndex(m.sortColumnName)
+		idx, ok := sortColumnIndex(m.sortColumnName)
+		if !ok {
+			// The active sort column is hidden in this layout (e.g. a
+			// wide-only column after leaving fullscreen). Enter the visible
+			// cycle at the first column instead of skipping past it.
+			idx = -1
+		}
 		idx = (idx + 1) % colCount
 		m.sortColumnName = ui.ActiveSortableColumns[idx]
 	}
@@ -29,7 +35,12 @@ func (m Model) handleExplorerActionKeySortPrev() (tea.Model, tea.Cmd, bool) {
 	}
 	colCount := ui.ActiveSortableColumnCount
 	if colCount > 0 {
-		idx := sortColumnIndex(m.sortColumnName)
+		idx, ok := sortColumnIndex(m.sortColumnName)
+		if !ok {
+			// The active sort column is hidden in this layout; enter the
+			// visible cycle at the last column (issue #339).
+			idx = colCount
+		}
 		idx = (idx - 1 + colCount) % colCount
 		m.sortColumnName = ui.ActiveSortableColumns[idx]
 	}


### PR DESCRIPTION
Fixes #339

## Problem

Sorting by a wide-only column (e.g. `Node`, `Pod IP`) in fullscreen, then leaving fullscreen, made the list appear to lose its sort.

## Root cause

The row data itself stays correctly sorted across the fullscreen round-trip — `sortMiddleItems` sorts on `m.sortColumnName` directly from `item.Columns`, which is populated regardless of fullscreen. The actual defect was in **sort cycling**:

`sortColumnIndex` returned `0` when the active sort column was absent from the current layout's `ActiveSortableColumns`. After leaving fullscreen, a wide-only sort column drops out of that set, so pressing `>` computed `(0+1)%n = 1` and jumped to the **second** column — silently corrupting the sort on the next keypress.

## Fix

- `sortColumnIndex` now returns `(int, bool)` so callers can detect a hidden sort column instead of treating it as index 0.
- `>` (next) from a hidden column enters the visible cycle at the **first** column; `<` (prev) enters at the **last** column. Predictable, no corruption.

The column stays hidden and the row order continues to reflect that column, matching the reporter's expected behavior.

## Test plan

- [x] Added TDD tests: `TestActionKeySortNextFromHiddenColumnLandsOnFirst`, `TestActionKeySortPrevFromHiddenColumnLandsOnLast` (confirmed RED before fix, GREEN after)
- [x] Existing sort cycling tests still pass
- [x] `go build ./...`, full `go test ./...`, `go vet`, gofumpt, `make lint` (0 issues)