### PR TITLE
feat(ui): sort-column highlight and width-aware columns

### DIFF
--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -32,14 +32,52 @@ func headerWithIndicator(label string, colName string, colWidth int) string {
 	if ind == "" {
 		return padRight(label, colWidth)
 	}
-	// Truncate label to make room for the indicator.
-	maxLabel := max(
-		// space + indicator
-		colWidth-2, 1)
+	// The indicator is one column wide and sits in the column's trailing
+	// spacing — directly after the label, no separating space. Only truncate
+	// the label when it genuinely doesn't fit, so a tight column like "RS"
+	// keeps both letters ("RS↑") instead of dropping one ("R ↑").
+	maxLabel := max(colWidth-1, 1)
 	if len(label) > maxLabel {
 		label = label[:maxLabel]
 	}
-	return padRight(label+" "+ind, colWidth)
+	return padRight(label+ind, colWidth)
+}
+
+// headerSegment is one cell of the table header: its pre-padded plain text and
+// the column key it represents. colName is empty for non-column padding (the
+// selection marker and the union tile gutter), which never matches the active
+// sort column.
+type headerSegment struct {
+	text    string
+	colName string
+}
+
+// renderStyledHeader renders the header segments into a single line capped at
+// width. The segment whose colName matches the active sort column is rendered
+// with SortActiveHeaderStyle (accent) so the sorted column stands out; every
+// other segment is dim+bold, matching the previous flat header. Truncation
+// happens on each segment's plain text before styling, so no ANSI escape
+// sequence is ever cut and styled cells stay self-contained.
+func renderStyledHeader(segments []headerSegment, width int) string {
+	var b strings.Builder
+	dimStyle := DimStyle.Bold(true) // derive once; reused for every inactive cell
+	remaining := width
+	for _, seg := range segments {
+		if remaining <= 0 {
+			break
+		}
+		text := seg.text
+		if lipgloss.Width(text) > remaining {
+			text = Truncate(text, remaining)
+		}
+		remaining -= lipgloss.Width(text)
+		if seg.colName != "" && seg.colName == ActiveSortColumnName {
+			b.WriteString(SortActiveHeaderStyle.Render(text))
+		} else {
+			b.WriteString(dimStyle.Render(text))
+		}
+	}
+	return b.String()
 }
 
 // plainExtraCell builds the plain-text cell for a single extra column.

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -72,6 +72,11 @@ type colInfo struct {
 	maxValW  int
 	count    int
 	hasArrow bool // true if any value in this column has a trend arrow
+	// minIdx is the smallest column index at which this key appears in any
+	// item. Taking the minimum across all rows makes the discovery order a
+	// function of the data alone, not of the current row ordering — see
+	// sortDiscoveryOrder.
+	minIdx int
 }
 
 // canonicalColumnPriority pins the display position of the volatile metrics
@@ -86,6 +91,23 @@ type colInfo struct {
 var canonicalColumnPriority = map[string]int{
 	"CPU": 0, "CPU%": 1, "CPU/R": 2, "CPU/L": 3,
 	"MEM": 4, "MEM%": 5, "MEM/R": 6, "MEM/L": 7,
+}
+
+// sortDiscoveryOrder reorders detected column keys in place into a canonical,
+// row-order-independent sequence: ascending by each key's minimum position
+// within an item (minIdx), ties broken by key name. Because minIdx is a
+// minimum over all rows, the result is identical no matter how the rows are
+// sorted, which is what keeps the visible columns stable while the user cycles
+// the sort key. Runs before stabilizeColumnOrder, which then pins the metrics
+// block ahead of everything else.
+func sortDiscoveryOrder(order []string, seen map[string]*colInfo) {
+	sort.SliceStable(order, func(i, j int) bool {
+		ii, jj := seen[order[i]].minIdx, seen[order[j]].minIdx
+		if ii != jj {
+			return ii < jj
+		}
+		return order[i] < order[j]
+	})
 }
 
 // stabilizeColumnOrder reorders detected column keys in place so the canonical
@@ -151,12 +173,14 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	seen := make(map[string]*colInfo)
 	var order []string
 	for _, item := range items {
-		for _, kv := range item.Columns {
+		for idx, kv := range item.Columns {
 			info, ok := seen[kv.Key]
 			if !ok {
-				info = &colInfo{key: kv.Key}
+				info = &colInfo{key: kv.Key, minIdx: idx}
 				seen[kv.Key] = info
 				order = append(order, kv.Key)
+			} else if idx < info.minIdx {
+				info.minIdx = idx
 			}
 			info.count++
 			if strings.HasPrefix(kv.Value, "↑ ") || strings.HasPrefix(kv.Value, "↓ ") {
@@ -172,6 +196,13 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	if len(order) == 0 {
 		return nil
 	}
+
+	// Reorder by canonical data position so the column set and order depend
+	// only on the data, never on how rows happen to be sorted. Without this,
+	// cycling the sort key reshuffled which heterogeneous columns (e.g. NODE
+	// vs PRIORITY CLASS, when an unscheduled Pod lacks NODE) were discovered
+	// first, flickering columns in and out at the width-budget boundary.
+	sortDiscoveryOrder(order, seen)
 
 	// Pin the metrics block to a canonical position before candidate
 	// selection so display order does not depend on the order the refresh
@@ -367,7 +398,33 @@ func selectColumnCandidates(seen map[string]*colInfo, order []string, kind strin
 	return autoDetectColumns(seen, order, items), true
 }
 
-// autoDetectColumns selects columns based on heuristic thresholds and blocked lists.
+// overflowHiddenColumns are blocked columns that stay hidden even when the
+// layout has spare width. Their values are long, multi-valued, URL/path-like,
+// or can contain newlines, so a fixed-width overflow cell only truncates them
+// to noise (and newlines break the single-line row layout). They remain
+// reachable via the column-toggle overlay. Compact blocked columns (IPs, Node,
+// QoS, Service Account, Priority Class, ...) are deliberately absent so they
+// can fill spare width as overflow — see autoDetectColumns.
+var overflowHiddenColumns = map[string]bool{
+	"Images": true, "Image": true, "Labels": true, "Annotations": true,
+	"Finalizers": true, "Selector": true, "Description": true, "References": true,
+	"Keys": true, "Health Message": true, "Sync Message": true, "Sync Errors": true,
+	"Repo": true, "Path": true, "Source": true, "Dest Server": true, "Used By": true,
+	"Deletion": true,
+}
+
+// autoDetectColumns selects columns based on heuristic thresholds and blocked
+// lists. It returns two groups concatenated: the primary columns (not blocked
+// in the current mode) followed by overflow columns — compact columns that the
+// mode blocks for space but which may fill spare width when the layout has room
+// after the primary columns and the name's content. fitExtraColumns adds them
+// in order and stops at the width budget, so overflow never pushes out a
+// primary column or shrinks NAME below its content width.
+//
+// Overflow is fullscreen-only: the split-view block list is intentionally
+// aggressive because the middle column shares width with the side panes, so
+// revealing extras there is left untouched. Fullscreen is the wide single-pane
+// layout where the spare width actually exists.
 func autoDetectColumns(seen map[string]*colInfo, order []string, items []model.Item) []string {
 	blocked := blockedColumnsForMode()
 	// Raw metrics columns are always blocked.
@@ -377,7 +434,7 @@ func autoDetectColumns(seen map[string]*colInfo, order []string, items []model.I
 
 	threshold := max(len(items)/5, 1)
 	alwaysShow := map[string]bool{"Condition": true}
-	var candidates []string
+	var primary, overflow []string
 	for _, key := range order {
 		// CRD additionalPrinterColumns get kubectl semantics: priority 0 is
 		// always shown (bypassing the threshold and blocked list), priority > 0
@@ -385,19 +442,25 @@ func autoDetectColumns(seen map[string]*colInfo, order []string, items []model.I
 		// the column-toggle overlay (which routes through ActiveSessionColumns).
 		if prio, ok := ActivePrinterColumns[key]; ok {
 			if prio == 0 {
-				candidates = append(candidates, key)
+				primary = append(primary, key)
 			}
 			continue
 		}
-		if blocked[key] || isHiddenColumnPrefix(key) {
+		if isHiddenColumnPrefix(key) {
 			continue
 		}
 		info := seen[key]
-		if info.count >= threshold || alwaysShow[key] {
-			candidates = append(candidates, key)
+		if info.count < threshold && !alwaysShow[key] {
+			continue
+		}
+		switch {
+		case !blocked[key]:
+			primary = append(primary, key)
+		case ActiveFullscreenMode && !overflowHiddenColumns[key]:
+			overflow = append(overflow, key)
 		}
 	}
-	return candidates
+	return append(primary, overflow...)
 }
 
 // isHiddenColumnPrefix returns true if the column key uses a prefix reserved for internal data.

--- a/internal/ui/explorer_format_columns_test.go
+++ b/internal/ui/explorer_format_columns_test.go
@@ -197,36 +197,23 @@ func TestCollectExtraColumns_CompactBlockedFillSpareWidth(t *testing.T) {
 	// Wide layout: spare width after the primary columns -> Service Account
 	// fills it; the verbose columns stay hidden.
 	wide := keysOf(collectExtraColumns(items, 400, 60, "Pod"))
-	if !containsKey2(wide, "Service Account") {
+	if !slices.Contains(wide, "Service Account") {
 		t.Errorf("compact blocked column Service Account must fill spare width, got %v", wide)
 	}
-	if containsKey2(wide, "Images") || containsKey2(wide, "Labels") {
+	if slices.Contains(wide, "Images") || slices.Contains(wide, "Labels") {
 		t.Errorf("verbose blocked columns must stay hidden, got %v", wide)
 	}
 	// Overflow is appended after the primary columns.
-	if i, j := indexOf(wide, "Pod IP"), indexOf(wide, "Service Account"); i >= 0 && j >= 0 && j < i {
+	if i, j := slices.Index(wide, "Pod IP"), slices.Index(wide, "Service Account"); i >= 0 && j >= 0 && j < i {
 		t.Errorf("overflow Service Account must come after primary columns, got %v", wide)
 	}
 
 	// Narrow layout: no room beyond the primary columns -> no overflow, and
 	// Service Account is not forced in.
 	narrow := keysOf(collectExtraColumns(items, 70, 50, "Pod"))
-	if containsKey2(narrow, "Service Account") {
+	if slices.Contains(narrow, "Service Account") {
 		t.Errorf("compact blocked column must not appear when there is no spare width, got %v", narrow)
 	}
-}
-
-func containsKey2(keys []string, key string) bool {
-	return indexOf(keys, key) >= 0
-}
-
-func indexOf(keys []string, key string) int {
-	for i, k := range keys {
-		if k == key {
-			return i
-		}
-	}
-	return -1
 }
 
 // TestSelectColumnCandidates_AutoDetectFlag verifies the fromAutoDetect signal

--- a/internal/ui/explorer_format_columns_test.go
+++ b/internal/ui/explorer_format_columns_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/janosmiko/lfk/internal/model"
@@ -107,6 +108,125 @@ func TestCollectExtraColumns_ConfiguredOrderNotReshuffled(t *testing.T) {
 	if got := keysOf(cols); len(got) != 3 || got[0] != "Duration" || got[1] != "Parent" || got[2] != "Created At" {
 		t.Errorf("configured column order must be preserved verbatim, got %v", got)
 	}
+}
+
+// TestCollectExtraColumns_OrderStableAcrossRowOrder is the regression for the
+// sort-cycling column flicker (issue: pressing the sort key reordered or
+// dropped extra columns). Column discovery used to follow first-seen order
+// across items in their current sorted sequence, so a heterogeneous list
+// (e.g. an unscheduled Pod with no NODE column) yielded a different column
+// order depending on which row was scanned first. The detected column set and
+// order must be a function of the data alone, never the row ordering.
+func TestCollectExtraColumns_OrderStableAcrossRowOrder(t *testing.T) {
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	defer func(orig map[string]int) { ActivePrinterColumns = orig }(ActivePrinterColumns)
+	defer func(orig bool) { ActiveFullscreenMode = orig }(ActiveFullscreenMode)
+	ActiveSessionColumns = nil
+	ActivePrinterColumns = nil
+	ActiveFullscreenMode = true
+
+	scheduled := func(name string) model.Item {
+		return model.Item{
+			Name: name, Namespace: "ns", Status: "Running", Kind: "Pod",
+			Columns: []model.KeyValue{
+				{Key: "QoS", Value: "Burstable"},
+				{Key: "Pod IP", Value: "10.0.0.1"},
+				{Key: "Node", Value: "node-a"},
+				{Key: "Priority Class", Value: "system"},
+			},
+		}
+	}
+	// An unscheduled Pod has no NODE column, so scanning it first used to
+	// surface "Priority Class" before "Node".
+	unscheduled := func(name string) model.Item {
+		return model.Item{
+			Name: name, Namespace: "ns", Status: "Pending", Kind: "Pod",
+			Columns: []model.KeyValue{
+				{Key: "QoS", Value: "BestEffort"},
+				{Key: "Pod IP", Value: "10.0.0.2"},
+				{Key: "Priority Class", Value: "system"},
+			},
+		}
+	}
+
+	forward := []model.Item{scheduled("a"), scheduled("b"), unscheduled("c")}
+	reversed := []model.Item{unscheduled("c"), scheduled("b"), scheduled("a")}
+
+	got1 := keysOf(collectExtraColumns(forward, 400, 40, "Pod"))
+	got2 := keysOf(collectExtraColumns(reversed, 400, 40, "Pod"))
+
+	if !slices.Equal(got1, got2) {
+		t.Errorf("extra-column order must not depend on row order:\n forward  = %v\n reversed = %v", got1, got2)
+	}
+	// Lock in the canonical data-position order (QoS, Pod IP, Node, Priority
+	// Class): columns sort by their position within an item, ties broken by
+	// key name so the result is deterministic.
+	want := []string{"QoS", "Pod IP", "Node", "Priority Class"}
+	if !slices.Equal(got1, want) {
+		t.Errorf("canonical column order = %v, want %v", got1, want)
+	}
+}
+
+// TestCollectExtraColumns_CompactBlockedFillSpareWidth verifies the issue-2
+// behaviour: on a wide layout, compact blocked columns (e.g. Service Account)
+// are revealed as low-priority overflow to fill the space NAME would otherwise
+// pad, while verbose blocked columns (Images, Labels) stay hidden. On a narrow
+// layout no overflow appears and NAME keeps the slack.
+func TestCollectExtraColumns_CompactBlockedFillSpareWidth(t *testing.T) {
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	defer func(orig map[string]int) { ActivePrinterColumns = orig }(ActivePrinterColumns)
+	defer func(orig bool) { ActiveFullscreenMode = orig }(ActiveFullscreenMode)
+	ActiveSessionColumns = nil
+	ActivePrinterColumns = nil
+	ActiveFullscreenMode = true
+
+	mk := func(name string) model.Item {
+		return model.Item{
+			Name: name, Namespace: "ns", Status: "Running", Kind: "Pod",
+			Columns: []model.KeyValue{
+				{Key: "QoS", Value: "Burstable"},
+				{Key: "Service Account", Value: "default"}, // blocked, compact -> overflow
+				{Key: "Pod IP", Value: "10.0.0.1"},
+				{Key: "Images", Value: "registry.example.com/team/app:v1.2.3"}, // verbose -> hidden
+				{Key: "Labels", Value: "app=x,tier=y,env=prod"},                // verbose -> hidden
+			},
+		}
+	}
+	items := []model.Item{mk("pod-a"), mk("pod-b"), mk("pod-c")}
+
+	// Wide layout: spare width after the primary columns -> Service Account
+	// fills it; the verbose columns stay hidden.
+	wide := keysOf(collectExtraColumns(items, 400, 60, "Pod"))
+	if !containsKey2(wide, "Service Account") {
+		t.Errorf("compact blocked column Service Account must fill spare width, got %v", wide)
+	}
+	if containsKey2(wide, "Images") || containsKey2(wide, "Labels") {
+		t.Errorf("verbose blocked columns must stay hidden, got %v", wide)
+	}
+	// Overflow is appended after the primary columns.
+	if i, j := indexOf(wide, "Pod IP"), indexOf(wide, "Service Account"); i >= 0 && j >= 0 && j < i {
+		t.Errorf("overflow Service Account must come after primary columns, got %v", wide)
+	}
+
+	// Narrow layout: no room beyond the primary columns -> no overflow, and
+	// Service Account is not forced in.
+	narrow := keysOf(collectExtraColumns(items, 70, 50, "Pod"))
+	if containsKey2(narrow, "Service Account") {
+		t.Errorf("compact blocked column must not appear when there is no spare width, got %v", narrow)
+	}
+}
+
+func containsKey2(keys []string, key string) bool {
+	return indexOf(keys, key) >= 0
+}
+
+func indexOf(keys []string, key string) int {
+	for i, k := range keys {
+		if k == key {
+			return i
+		}
+	}
+	return -1
 }
 
 // TestSelectColumnCandidates_AutoDetectFlag verifies the fromAutoDetect signal

--- a/internal/ui/explorer_format_test.go
+++ b/internal/ui/explorer_format_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/janosmiko/lfk/internal/model"
@@ -476,4 +477,108 @@ func TestFormatTableRowStyledOrdered_VisibleWidthAndContent(t *testing.T) {
 		"pod-1     prod    default   1/1   0   Running   5d  ",
 		ansi.Strip(got),
 		"ANSI-stripped styled row must match plain row layout")
+}
+
+// --- Sort-column header highlight (issue: highlight the active sort arrow) ---
+
+// TestRenderStyledHeader_ActiveColumnAccented verifies the header cell for the
+// active sort column (label + sort arrow) is rendered with SortActiveHeaderStyle
+// while every other header cell stays dim, so the sorted column stands out.
+func TestRenderStyledHeader_ActiveColumnAccented(t *testing.T) {
+	// Force color mode + a color profile + populated theme so the dim and
+	// accent styles emit distinguishable ANSI; restore the mutable globals
+	// afterwards. ConfigNoColor is pinned because a prior test may have left
+	// it set, which would route ApplyTheme through the no-color path and drop
+	// the profile back to Ascii.
+	origProfile := lipgloss.DefaultRenderer().ColorProfile()
+	origNoColor := ConfigNoColor
+	t.Cleanup(func() {
+		ConfigNoColor = origNoColor
+		lipgloss.DefaultRenderer().SetColorProfile(origProfile)
+		ApplyTheme(DefaultTheme())
+	})
+	ConfigNoColor = false
+	ApplyTheme(DefaultTheme())
+	// ApplyTheme restores the saved (Ascii, under test) profile, so force the
+	// profile last; styles carry color specs that resolve at render time.
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+
+	prev := ActiveSortColumnName
+	t.Cleanup(func() { ActiveSortColumnName = prev })
+	ActiveSortColumnName = "QoS"
+
+	segs := []headerSegment{
+		{text: "NAME      ", colName: "Name"},
+		{text: "QOS↑    ", colName: "QoS"},
+		{text: "AGE  ", colName: "Age"},
+	}
+	out := renderStyledHeader(segs, 200)
+
+	assert.Contains(t, out, SortActiveHeaderStyle.Render("QOS↑    "),
+		"active sort column header must use the accent style")
+	assert.Contains(t, out, DimStyle.Bold(true).Render("NAME      "),
+		"inactive header cells must stay dim+bold")
+	assert.NotContains(t, out, DimStyle.Bold(true).Render("QOS↑    "),
+		"active sort column must not be rendered dim")
+	// Visible content is preserved verbatim (styling adds no visible width).
+	assert.Equal(t, "NAME      QOS↑    AGE  ", ansi.Strip(out))
+}
+
+// TestHeaderWithIndicator_NoSpaceNoTruncate verifies the sort arrow sits in the
+// column's trailing spacing with no space before it, and does not eat the last
+// character of a tight column label (regression: "RS" sorted rendered "R ↑").
+func TestHeaderWithIndicator_NoSpaceNoTruncate(t *testing.T) {
+	prevCol, prevAsc := ActiveSortColumnName, ActiveSortAscending
+	t.Cleanup(func() { ActiveSortColumnName, ActiveSortAscending = prevCol, prevAsc })
+	ActiveSortAscending = true
+
+	// RS column: width 3 = "RS" (2) + 1 trailing spacing. The arrow uses the
+	// spacing slot: both letters kept, no leading space.
+	ActiveSortColumnName = "Restarts"
+	assert.Equal(t, "RS↑", headerWithIndicator("RS", "Restarts", 3))
+
+	// Wide column: arrow directly follows the label (no space), padded to width.
+	ActiveSortColumnName = "Status"
+	assert.Equal(t, "STATUS↑   ", headerWithIndicator("STATUS", "Status", 10))
+
+	// Descending shows the down arrow.
+	ActiveSortAscending = false
+	assert.Equal(t, "STATUS↓   ", headerWithIndicator("STATUS", "Status", 10))
+
+	// Not the sort column: plain padded label, no arrow.
+	ActiveSortColumnName = "Status"
+	assert.Equal(t, "READY ", headerWithIndicator("READY", "Ready", 6))
+}
+
+// TestRenderStyledHeader_NoActiveSortAllDim verifies that with no active sort
+// column every header cell is dim — the pre-highlight behaviour is unchanged.
+func TestRenderStyledHeader_NoActiveSortAllDim(t *testing.T) {
+	prev := ActiveSortColumnName
+	t.Cleanup(func() { ActiveSortColumnName = prev })
+	ActiveSortColumnName = ""
+
+	segs := []headerSegment{
+		{text: "NAME ", colName: "Name"},
+		{text: "AGE ", colName: "Age"},
+	}
+	out := renderStyledHeader(segs, 200)
+
+	want := DimStyle.Bold(true).Render("NAME ") + DimStyle.Bold(true).Render("AGE ")
+	assert.Equal(t, want, out)
+}
+
+// TestRenderStyledHeader_TruncatesToWidth verifies the header is capped at the
+// given width (matching the prior Truncate(hdr, width) behaviour).
+func TestRenderStyledHeader_TruncatesToWidth(t *testing.T) {
+	prev := ActiveSortColumnName
+	t.Cleanup(func() { ActiveSortColumnName = prev })
+	ActiveSortColumnName = ""
+
+	segs := []headerSegment{
+		{text: "NAMECOLUMN", colName: "Name"},
+		{text: "AGECOLUMN", colName: "Age"},
+	}
+	out := renderStyledHeader(segs, 6)
+	assert.Equal(t, 6, lipgloss.Width(ansi.Strip(out)+""))
+	assert.LessOrEqual(t, lipgloss.Width(out), 6)
 }

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -327,21 +327,23 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		age:      headerWithIndicator("AGE", "Age", ageW),
 	}
 
-	var hdrParts []string
+	var hdrSegments []headerSegment
 	if wantMarker {
-		hdrParts = append(hdrParts, "  ")
+		hdrSegments = append(hdrSegments, headerSegment{text: "  "})
 	}
 	if tileW > 0 {
 		// Reserve a blank cell in the header so the leading tile column
 		// stays aligned with the data rows below.
-		hdrParts = append(hdrParts, " ")
+		hdrSegments = append(hdrSegments, headerSegment{text: " "})
 	}
-	hdrParts = append(hdrParts, nameHeader)
+	hdrSegments = append(hdrSegments, headerSegment{text: nameHeader, colName: "Name"})
 	for _, key := range order {
-		hdrParts = append(hdrParts, headerCellForKey(key, colWidths, colHeaders, extraCols))
+		hdrSegments = append(hdrSegments, headerSegment{
+			text:    headerCellForKey(key, colWidths, colHeaders, extraCols),
+			colName: key,
+		})
 	}
-	hdr := strings.Join(hdrParts, "")
-	b.WriteString(DimStyle.Bold(true).Render(Truncate(hdr, width)))
+	b.WriteString(renderStyledHeader(hdrSegments, width))
 	height--
 
 	if ActiveMiddleScroll >= 0 {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -170,6 +170,13 @@ var (
 	HeaderIconStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(ColorPrimary))
 
+	// SortActiveHeaderStyle highlights the header label and sort arrow of the
+	// column the table is currently sorted by, so the active sort column reads
+	// distinctly against the dim of the inactive headers.
+	SortActiveHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color(ColorPrimary))
+
 	// Namespace indicator in top-right (kept for compat).
 	NamespaceStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(ColorWarning)).

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -246,6 +246,11 @@ func ApplyTheme(t Theme) {
 		Foreground(lipgloss.Color(t.Primary)).
 		Background(baseBg)
 
+	SortActiveHeaderStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color(t.Primary)).
+		Background(baseBg)
+
 	NamespaceStyle = lipgloss.NewStyle().
 		Foreground(lipgloss.Color(t.Warning)).
 		Bold(true).

--- a/internal/ui/theme_nocolor.go
+++ b/internal/ui/theme_nocolor.go
@@ -102,6 +102,7 @@ func applyNoColorTheme() {
 
 	HeaderStyle = lipgloss.NewStyle().Bold(true).Underline(true)
 	HeaderIconStyle = lipgloss.NewStyle()
+	SortActiveHeaderStyle = lipgloss.NewStyle().Bold(true).Underline(true)
 	NamespaceStyle = lipgloss.NewStyle().Bold(true).Padding(0, 1)
 
 	YamlViewStyle = lipgloss.NewStyle().Padding(1, 2)


### PR DESCRIPTION
## Summary

Four related improvements to the explorer table's sort/column UX:

1. **Highlight the active sort column.** The sorted column's header (label **and** `↑`/`↓` arrow) now renders in the accent color so it's easy to spot; the other headers stay dim. New per-cell `renderStyledHeader` replaces the single flat-dim header render.
2. **Stable column order across sorting.** Extra-column discovery used *first-seen order across the current (sorted) rows*, so cycling the sort key reshuffled heterogeneous columns (e.g. `NODE` vs `PRIORITY CLASS` when an unscheduled Pod has no `NODE`) and flickered columns in/out at the width-budget edge. Columns now order by canonical data position (`minIdx` + key tiebreak), independent of row order.
3. **Fill spare fullscreen width with compact hidden columns.** On a wide fullscreen layout, columns the mode blocks for space (e.g. `Service Account`) now appear as low-priority *overflow* after the normal columns instead of padding `NAME`. Verbose/multi-valued columns (`Images`, `Labels`, `Annotations`, `Selector`, …) stay hidden. Overflow is fullscreen-only; the split-view layout is untouched.
4. **Cleaner sort arrow.** Dropped the space before the arrow and stopped truncating tight headers — the arrow sits in the column's existing trailing spacing, so a 3-wide `RS` column renders `RS↑` instead of `R ↑`.

## Why

On ultrawide/fullscreen layouts the `NAME` column absorbed all spare width (big empty gap) while useful compact columns stayed hidden; cycling the sort key made columns appear/disappear and reorder; and the sort arrow was both unhighlighted and ate the last character of narrow headers.

## Test plan

- [x] New unit tests:
  - `TestCollectExtraColumns_OrderStableAcrossRowOrder` — column order independent of row order
  - `TestCollectExtraColumns_CompactBlockedFillSpareWidth` — compact blocked columns overflow on wide layouts, verbose ones stay hidden, none on narrow
  - `TestRenderStyledHeader_*` — active-column accent, all-dim when unsorted, width capping
  - `TestHeaderWithIndicator_NoSpaceNoTruncate` — `RS↑` / `STATUS↑` / `STATUS↓`, no space, no truncation
- [x] `go build ./...`
- [x] `go test -race ./...` — all packages pass
- [x] `golangci-lint run ./internal/ui/...` — 0 issues

## Notes

- No keybinding or config changes.
- Split-view column behavior is unchanged; the overflow reveal is fullscreen-only.