### PR TITLE
feat(preview): show full condition detail with severity coloring (#340)

### DIFF
--- a/internal/k8s/client_populate.go
+++ b/internal/k8s/client_populate.go
@@ -10,6 +10,15 @@ func populateResourceDetails(ti *model.Item, obj map[string]any, kind string) {
 	status, _ := obj["status"].(map[string]any)
 	spec, _ := obj["spec"].(map[string]any)
 
+	// Populate the per-condition detail section once, for every kind, from the
+	// standard status.conditions array. Kind-specific handlers below only add
+	// the compact at-a-glance summary to ti.Columns.
+	if status != nil {
+		if conditions, ok := status["conditions"].([]any); ok {
+			appendAllConditions(ti, conditions)
+		}
+	}
+
 	switch kind {
 	case "Pod":
 		populatePodDetails(ti, obj, status, spec)

--- a/internal/k8s/client_populate_argo.go
+++ b/internal/k8s/client_populate_argo.go
@@ -187,7 +187,6 @@ func populateArgoWorkflow(ti *model.Item, status map[string]any) {
 	if msg, ok := status["message"].(string); ok && msg != "" {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Message", Value: msg})
 	}
-	populateArgoWorkflowConditions(ti, status)
 	populateArgoWorkflowSteps(ti, status)
 }
 
@@ -209,29 +208,6 @@ func populateArgoWorkflowDuration(ti *model.Item, status map[string]any) {
 	}
 	dur := end.Sub(started).Truncate(time.Second)
 	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Duration", Value: dur.String()})
-}
-
-func populateArgoWorkflowConditions(ti *model.Item, status map[string]any) {
-	conditions, ok := status["conditions"].([]any)
-	if !ok {
-		return
-	}
-	for _, c := range conditions {
-		cond, ok := c.(map[string]any)
-		if !ok {
-			continue
-		}
-		condType, _ := cond["type"].(string)
-		condStatus, _ := cond["status"].(string)
-		condMessage, _ := cond["message"].(string)
-		if condType != "" {
-			ti.Conditions = append(ti.Conditions, model.ConditionEntry{
-				Type:    condType,
-				Status:  condStatus,
-				Message: condMessage,
-			})
-		}
-	}
 }
 
 func populateArgoWorkflowSteps(ti *model.Item, status map[string]any) {

--- a/internal/k8s/client_populate_ext_workflow_test.go
+++ b/internal/k8s/client_populate_ext_workflow_test.go
@@ -78,62 +78,9 @@ func TestPopulateArgoWorkflow(t *testing.T) {
 		assert.Equal(t, "workflow failed at step X", colMap["Message"])
 	})
 
-	t.Run("conditions are extracted", func(t *testing.T) {
-		ti := &model.Item{Name: "my-wf"}
-		status := map[string]any{
-			"conditions": []any{
-				map[string]any{
-					"type":    "SpecWarning",
-					"status":  "True",
-					"message": "deprecated feature used",
-				},
-				map[string]any{
-					"type":    "PodRunning",
-					"status":  "True",
-					"message": "",
-				},
-			},
-		}
-		populateArgoWorkflow(ti, status)
-
-		require.Len(t, ti.Conditions, 2)
-		assert.Equal(t, "SpecWarning", ti.Conditions[0].Type)
-		assert.Equal(t, "True", ti.Conditions[0].Status)
-		assert.Equal(t, "deprecated feature used", ti.Conditions[0].Message)
-		assert.Equal(t, "PodRunning", ti.Conditions[1].Type)
-	})
-
-	t.Run("conditions skips non-map entries", func(t *testing.T) {
-		ti := &model.Item{Name: "my-wf"}
-		status := map[string]any{
-			"conditions": []any{
-				"not-a-map",
-				map[string]any{
-					"type":   "PodRunning",
-					"status": "True",
-				},
-			},
-		}
-		populateArgoWorkflow(ti, status)
-
-		require.Len(t, ti.Conditions, 1)
-		assert.Equal(t, "PodRunning", ti.Conditions[0].Type)
-	})
-
-	t.Run("conditions with empty type is skipped", func(t *testing.T) {
-		ti := &model.Item{Name: "my-wf"}
-		status := map[string]any{
-			"conditions": []any{
-				map[string]any{
-					"type":   "",
-					"status": "True",
-				},
-			},
-		}
-		populateArgoWorkflow(ti, status)
-
-		assert.Empty(t, ti.Conditions)
-	})
+	// Note: the CONDITIONS detail section (ti.Conditions) is populated centrally
+	// in populateResourceDetails for every kind, not by populateArgoWorkflow.
+	// See TestAppendAllConditions and TestPopulateResourceDetails_Conditions.
 
 	t.Run("workflow nodes are walked in BFS order", func(t *testing.T) {
 		ti := &model.Item{Name: "my-wf"}
@@ -273,12 +220,6 @@ func TestPopulateArgoWorkflow(t *testing.T) {
 			"startedAt":  started.Format(time.RFC3339),
 			"finishedAt": finished.Format(time.RFC3339),
 			"message":    "workflow completed",
-			"conditions": []any{
-				map[string]any{
-					"type":   "Completed",
-					"status": "True",
-				},
-			},
 			"nodes": map[string]any{
 				"root": map[string]any{
 					"name":     "full-wf",
@@ -298,9 +239,6 @@ func TestPopulateArgoWorkflow(t *testing.T) {
 		assert.Equal(t, "8m0s", colMap["Duration"])
 		assert.Equal(t, "workflow completed", colMap["Message"])
 		assert.Equal(t, "Succeeded", colMap["step:final-step"])
-
-		require.Len(t, ti.Conditions, 1)
-		assert.Equal(t, "Completed", ti.Conditions[0].Type)
 	})
 
 	t.Run("invalid startedAt is ignored", func(t *testing.T) {

--- a/internal/k8s/client_populate_gitops_enrichments_test.go
+++ b/internal/k8s/client_populate_gitops_enrichments_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
@@ -450,6 +451,97 @@ func TestCertManagerEnrichments_NonCertificateKinds(t *testing.T) {
 			_, hasIssuer := colMap["Issuer"]
 			assert.False(t, hasDNS, "kind=%s should not emit DNS Names", kind)
 			assert.False(t, hasIssuer, "kind=%s should not emit Issuer", kind)
+		})
+	}
+}
+
+// ---- CONDITIONS detail section is populated for the details pane ----
+
+func TestConditionsDetail_CertManagerCertificate(t *testing.T) {
+	// A Certificate with multiple conditions: the compact column summary must
+	// still surface the Ready condition, and every condition must also be
+	// captured on ti.Conditions for the CONDITIONS detail section (issue #340).
+	obj := map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type": "Ready", "status": "True", "reason": "Ready",
+					"message":            "Certificate is up to date and has not expired",
+					"lastTransitionTime": "2026-04-01T09:55:54Z",
+				},
+				map[string]any{
+					"type": "Issuing", "status": "False", "reason": "Issued",
+					"message": "issuance succeeded",
+				},
+			},
+		},
+		"spec": map[string]any{},
+	}
+	ti := &model.Item{}
+	populateResourceDetails(ti, obj, "Certificate")
+
+	// Compact summary column (unchanged behavior).
+	colMap := columnsToMap(ti.Columns)
+	assert.Equal(t, "True", colMap["Ready"])
+
+	// Full detail section: every condition, exactly once (no double-populate).
+	if assert.Len(t, ti.Conditions, 2) {
+		assert.Equal(t, "Ready", ti.Conditions[0].Type)
+		assert.Equal(t, "Issuing", ti.Conditions[1].Type)
+		assert.False(t, ti.Conditions[0].LastTransitionTime.IsZero())
+	}
+}
+
+func TestConditionsDetail_FluxNoReadyFallbackNoDuplicate(t *testing.T) {
+	// A Flux resource whose conditions lack a Ready entry falls back to the
+	// generic column summary. The detail section must still contain each
+	// condition exactly once (appendAllConditions runs once, not per branch).
+	obj := map[string]any{
+		"spec": map[string]any{},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Reconciling", "status": "True", "reason": "Progressing"},
+				map[string]any{"type": "Stalled", "status": "False"},
+			},
+		},
+	}
+	ti := &model.Item{}
+	populateResourceDetails(ti, obj, "Kustomization")
+
+	assert.Len(t, ti.Conditions, 2, "each condition must appear exactly once")
+}
+
+func TestConditionsDetail_AcrossKinds(t *testing.T) {
+	// Conditions are populated centrally for every kind, including handlers
+	// that previously only built their own summary columns (ArgoCD Application,
+	// HPA) and core workloads that never surfaced conditions before (issue #340).
+	kinds := []struct {
+		kind  string
+		types []string
+	}{
+		{"Application", []string{"Healthy", "SyncError"}},    // ArgoCD
+		{"HorizontalPodAutoscaler", []string{"AbleToScale"}}, // HPA
+		{"Workflow", []string{"Completed"}},                  // Argo Workflows
+		{"Pod", []string{"PodScheduled", "Ready"}},           // core workload
+		{"FooBar", []string{"Ready"}},                        // unknown CRD (default branch)
+	}
+	for _, tc := range kinds {
+		t.Run(tc.kind, func(t *testing.T) {
+			conds := make([]any, len(tc.types))
+			for i, ct := range tc.types {
+				conds[i] = map[string]any{"type": ct, "status": "True"}
+			}
+			obj := map[string]any{
+				"spec":   map[string]any{},
+				"status": map[string]any{"conditions": conds},
+			}
+			ti := &model.Item{}
+			populateResourceDetails(ti, obj, tc.kind)
+
+			require.Len(t, ti.Conditions, len(tc.types))
+			for i, ct := range tc.types {
+				assert.Equal(t, ct, ti.Conditions[i].Type)
+			}
 		})
 	}
 }

--- a/internal/k8s/client_populate_helpers.go
+++ b/internal/k8s/client_populate_helpers.go
@@ -95,9 +95,37 @@ func populateMetadataFields(ti *model.Item, obj map[string]any) {
 	}
 }
 
-// extractGenericConditions extracts condition information from a status.conditions
-// array for generic CRD resources. It prefers the "Ready" condition; if not found,
-// it falls back to the last condition in the array.
+// appendAllConditions stores every well-formed condition on ti.Conditions for
+// the details pane's CONDITIONS section. It is the single source of that
+// section across all resource kinds; the column extractors below only produce
+// the compact at-a-glance summary in ti.Columns.
+func appendAllConditions(ti *model.Item, conditions []any) {
+	for _, c := range conditions {
+		cond, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		if condType == "" {
+			continue
+		}
+		condStatus, _ := cond["status"].(string)
+		condReason, _ := cond["reason"].(string)
+		condMessage, _ := cond["message"].(string)
+		ti.Conditions = append(ti.Conditions, model.ConditionEntry{
+			Type:               condType,
+			Status:             condStatus,
+			Reason:             condReason,
+			Message:            condMessage,
+			LastTransitionTime: parseConditionTime(cond),
+		})
+	}
+}
+
+// extractGenericConditions adds a compact, single-condition summary to
+// ti.Columns for generic CRD resources. It prefers the "Ready" condition; if
+// not found, it falls back to the last condition in the array. The full
+// per-condition detail is populated separately via appendAllConditions.
 func extractGenericConditions(ti *model.Item, conditions []any) {
 	var readyCond, trueCond, lastCond map[string]any
 	for _, c := range conditions {
@@ -108,22 +136,11 @@ func extractGenericConditions(ti *model.Item, conditions []any) {
 		lastCond = cond
 		condType, _ := cond["type"].(string)
 		condStatus, _ := cond["status"].(string)
-		condReason, _ := cond["reason"].(string)
-		condMessage, _ := cond["message"].(string)
 		if condType == "Ready" {
 			readyCond = cond
 		}
 		if condStatus == "True" {
 			trueCond = cond
-		}
-		// Store every condition for the details pane.
-		if condType != "" {
-			ti.Conditions = append(ti.Conditions, model.ConditionEntry{
-				Type:    condType,
-				Status:  condStatus,
-				Reason:  condReason,
-				Message: condMessage,
-			})
 		}
 	}
 
@@ -167,11 +184,23 @@ func extractGenericConditions(ti *model.Item, conditions []any) {
 		}
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Message", Value: condMessage})
 	}
-	if lastTransition, ok := chosen["lastTransitionTime"].(string); ok && lastTransition != "" {
-		if t, err := time.Parse(time.RFC3339, lastTransition); err == nil {
-			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Last Transition", Value: formatRelativeTime(t)})
-		}
+	if t := parseConditionTime(chosen); !t.IsZero() {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Last Transition", Value: formatRelativeTime(t)})
 	}
+}
+
+// parseConditionTime extracts the RFC3339 lastTransitionTime from a condition
+// map. It returns the zero time when the field is missing, empty, or unparsable.
+func parseConditionTime(cond map[string]any) time.Time {
+	s, ok := cond["lastTransitionTime"].(string)
+	if !ok || s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
 }
 
 // isNegativeConditionType returns true if the condition type name represents a

--- a/internal/k8s/client_populate_helpers_extra_test.go
+++ b/internal/k8s/client_populate_helpers_extra_test.go
@@ -254,6 +254,76 @@ func TestExtractGenericConditions_MissingBranches(t *testing.T) {
 	})
 }
 
+// --- appendAllConditions ---
+
+func TestAppendAllConditions(t *testing.T) {
+	t.Run("captures every condition, not just Ready", func(t *testing.T) {
+		ti := &model.Item{}
+		conditions := []any{
+			map[string]any{"type": "Initialized", "status": "True", "reason": "Init"},
+			map[string]any{"type": "Ready", "status": "True", "reason": "AllGood", "message": "ok"},
+		}
+
+		appendAllConditions(ti, conditions)
+
+		if assert.Len(t, ti.Conditions, 2) {
+			assert.Equal(t, "Initialized", ti.Conditions[0].Type)
+			assert.Equal(t, "Ready", ti.Conditions[1].Type)
+			assert.Equal(t, "AllGood", ti.Conditions[1].Reason)
+			assert.Equal(t, "ok", ti.Conditions[1].Message)
+		}
+	})
+
+	t.Run("non-map and empty-type entries are skipped", func(t *testing.T) {
+		ti := &model.Item{}
+		conditions := []any{
+			"not-a-map",
+			map[string]any{"status": "True"}, // empty type
+			map[string]any{"type": "Ready", "status": "False"},
+		}
+
+		appendAllConditions(ti, conditions)
+
+		if assert.Len(t, ti.Conditions, 1) {
+			assert.Equal(t, "Ready", ti.Conditions[0].Type)
+		}
+	})
+
+	t.Run("lastTransitionTime is parsed into the condition entry", func(t *testing.T) {
+		ti := &model.Item{}
+		conditions := []any{
+			map[string]any{
+				"type":               "Ready",
+				"status":             "True",
+				"lastTransitionTime": "2026-06-01T10:00:00Z",
+			},
+		}
+
+		appendAllConditions(ti, conditions)
+
+		if assert.Len(t, ti.Conditions, 1) {
+			want, _ := time.Parse(time.RFC3339, "2026-06-01T10:00:00Z")
+			assert.True(t, ti.Conditions[0].LastTransitionTime.Equal(want),
+				"got %v, want %v", ti.Conditions[0].LastTransitionTime, want)
+		}
+	})
+
+	t.Run("missing or invalid lastTransitionTime yields zero time", func(t *testing.T) {
+		ti := &model.Item{}
+		conditions := []any{
+			map[string]any{"type": "A", "status": "True"},
+			map[string]any{"type": "B", "status": "True", "lastTransitionTime": "not-a-time"},
+		}
+
+		appendAllConditions(ti, conditions)
+
+		if assert.Len(t, ti.Conditions, 2) {
+			assert.True(t, ti.Conditions[0].LastTransitionTime.IsZero())
+			assert.True(t, ti.Conditions[1].LastTransitionTime.IsZero())
+		}
+	})
+}
+
 // --- extractTemplateResources: missing no-containers-in-spec branch ---
 
 func TestExtractTemplateResources_NoContainersInTemplateSpec(t *testing.T) {

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -724,10 +724,9 @@ func TestExtractGenericConditions(t *testing.T) {
 		assert.Equal(t, "True", colMap["Ready"])
 		assert.Equal(t, "AllGood", colMap["Reason"])
 		assert.NotEmpty(t, colMap["Last Transition"])
-		// Conditions should be stored on the Conditions field, not as columns.
-		assert.Len(t, ti.Conditions, 2)
-		assert.Equal(t, "Initialized", ti.Conditions[0].Type)
-		assert.Equal(t, "Ready", ti.Conditions[1].Type)
+		// extractGenericConditions only produces the compact column summary;
+		// the per-condition detail section is populated by appendAllConditions.
+		assert.Empty(t, ti.Conditions)
 	})
 
 	t.Run("falls back to last condition", func(t *testing.T) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -158,10 +158,11 @@ type KeyValue struct {
 
 // ConditionEntry represents a single status condition for display in the details pane.
 type ConditionEntry struct {
-	Type    string
-	Status  string // "True" or "False"
-	Reason  string
-	Message string
+	Type               string
+	Status             string // "True", "False", or "Unknown"
+	Reason             string
+	Message            string
+	LastTransitionTime time.Time // zero when unknown/unset
 }
 
 // PinnedTypes lists resource-type pin keys (version-agnostic "group/resource",

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -71,8 +71,18 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		"Reason": true, "Message": true, "Health Message": true,
 	}
 
+	// When structured conditions are present, the dedicated CONDITIONS section
+	// below supersedes the bespoke per-condition summary columns (e.g. ArgoCD's
+	// "condition:<type>" rows and the truncated "Condition" roll-up), so skip
+	// them here to avoid showing the same condition two or three times. The
+	// list view is unaffected — it reads these columns directly, not via here.
+	hasConditions := len(item.Conditions) > 0
+
 	for _, kv := range item.Columns {
 		if metricsKeys[kv.Key] || tableKeys[kv.Key] || kv.Key == "Deletion" {
+			continue
+		}
+		if hasConditions && (kv.Key == "Condition" || strings.HasPrefix(kv.Key, "condition:")) {
 			continue
 		}
 		if strings.HasPrefix(kv.Key, "secret:") {
@@ -293,38 +303,54 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		}
 	}
 
-	// Render CONDITIONS section from item.Conditions with color coding.
+	// Render CONDITIONS section from item.Conditions. Each condition shows its
+	// type, status (as text, color-coded), and age on the header line, followed
+	// by the reason and the full (wrapped) message on indented lines.
 	if len(item.Conditions) > 0 && len(lines) < height {
 		lines = append(lines, "")
 		lines = append(lines, detailKeyStyle.Render("CONDITIONS"))
+
+		// Align the status column by padding type names to the widest one,
+		// capped so a single long type can't push everything off-screen.
+		typeWidth := 0
+		for _, cond := range item.Conditions {
+			if w := len([]rune(cond.Type)); w > typeWidth {
+				typeWidth = w
+			}
+		}
+		typeWidth = min(typeWidth, 22)
+
 		for _, cond := range item.Conditions {
 			if len(lines) >= height {
 				break
 			}
 
-			// Color the condition type based on status and type name.
-			typeStyle := DimStyle // False = greyed out
-			if cond.Status == "True" {
-				if isNegativeCondType(cond.Type) {
-					typeStyle = ErrorStyle // True + negative type = red
-				} else {
-					typeStyle = StatusRunning // True + positive type = green
-				}
+			// Color the type/status by condition polarity (see ConditionStyle).
+			style := ConditionStyle(cond.Type, cond.Status)
+
+			status := cond.Status
+			if status == "" {
+				status = "Unknown"
+			}
+			pad := max(typeWidth-len([]rune(cond.Type)), 0)
+			header := "  " + style.Render(cond.Type) + strings.Repeat(" ", pad+1) + style.Render(status)
+			if age := FormatAge(cond.LastTransitionTime); age != "-" {
+				header += "  " + DimStyle.Render(age)
+			}
+			lines = append(lines, header)
+
+			if cond.Reason != "" && len(lines) < height {
+				lines = append(lines, "    "+DimStyle.Render(cond.Reason))
 			}
 
-			line := "  " + typeStyle.Render(cond.Type)
-			if cond.Reason != "" {
-				line += DimStyle.Render(": " + cond.Reason)
-			}
-			lines = append(lines, line)
-
-			if cond.Message != "" && cond.Status != "True" {
+			if cond.Message != "" {
 				maxW := max(width-6, 10)
-				msg := cond.Message
-				if len(msg) > maxW {
-					msg = msg[:maxW-3] + "..."
+				for _, seg := range wrapText(cond.Message, maxW) {
+					if len(lines) >= height {
+						break
+					}
+					lines = append(lines, "    "+DimStyle.Render(seg))
 				}
-				lines = append(lines, "    "+DimStyle.Render(msg))
 			}
 		}
 	}
@@ -371,18 +397,6 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 	}
 
 	return strings.Join(lines, "\n")
-}
-
-// isNegativeCondType returns true if a condition type name represents a
-// negative/failure state (e.g., "Failed", "Error", "Degraded").
-func isNegativeCondType(condType string) bool {
-	lower := strings.ToLower(condType)
-	for _, neg := range []string{"fail", "error", "degrad"} {
-		if strings.Contains(lower, neg) {
-			return true
-		}
-	}
-	return false
 }
 
 // RenderPreviewEvents renders an event timeline section for the preview pane.

--- a/internal/ui/explorer_resource_test.go
+++ b/internal/ui/explorer_resource_test.go
@@ -469,6 +469,84 @@ func TestRenderResourceSummary(t *testing.T) {
 		result := RenderResourceSummary(item, "", 80, 30)
 		assert.Contains(t, result, "abc123")
 	})
+
+	t.Run("conditions render full detail including status, reason, message, and age", func(t *testing.T) {
+		item := &model.Item{
+			Name: "my-deploy",
+			Columns: []model.KeyValue{
+				{Key: "Node", Value: "node-1"},
+			},
+			Conditions: []model.ConditionEntry{
+				{
+					Type:               "Available",
+					Status:             "True",
+					Reason:             "MinimumReplicasAvailable",
+					Message:            "Deployment has minimum availability.",
+					LastTransitionTime: time.Now().Add(-2 * time.Hour),
+				},
+			},
+		}
+		result := stripANSI(RenderResourceSummary(item, "", 80, 40))
+
+		assert.Contains(t, result, "CONDITIONS")
+		assert.Contains(t, result, "Available")
+		// Status text must be visible (not color-only).
+		assert.Contains(t, result, "True")
+		assert.Contains(t, result, "MinimumReplicasAvailable")
+		// Message must show even though the status is "True".
+		assert.Contains(t, result, "Deployment has minimum availability.")
+		// Age derived from LastTransitionTime (kubectl-style "2h").
+		assert.Contains(t, result, "2h")
+	})
+
+	t.Run("condition with unknown status renders Unknown text", func(t *testing.T) {
+		item := &model.Item{
+			Name:    "my-crd",
+			Columns: []model.KeyValue{{Key: "Node", Value: "node-1"}},
+			Conditions: []model.ConditionEntry{
+				{Type: "Ready", Status: ""},
+			},
+		}
+		result := stripANSI(RenderResourceSummary(item, "", 80, 40))
+		assert.Contains(t, result, "Ready")
+		assert.Contains(t, result, "Unknown")
+	})
+
+	t.Run("bespoke condition summary columns are suppressed when structured conditions exist", func(t *testing.T) {
+		// ArgoCD emits "condition:<type>" rows and a truncated "Condition"
+		// roll-up. With structured conditions present, the CONDITIONS section
+		// supersedes them so the preview must not show them again.
+		item := &model.Item{
+			Name: "my-app",
+			Columns: []model.KeyValue{
+				{Key: "Health", Value: "Degraded"},
+				{Key: "condition:ComparisonError", Value: "rpc error (2h)"},
+				{Key: "Condition", Value: "ComparisonE~"},
+			},
+			Conditions: []model.ConditionEntry{
+				{Type: "ComparisonError", Status: "True", Message: "rpc error: failed to load target state"},
+			},
+		}
+		result := stripANSI(RenderResourceSummary(item, "", 72, 40))
+
+		assert.Contains(t, result, "HEALTH")                                 // unrelated status row kept
+		assert.NotContains(t, result, "COMPARISONERROR  rpc error (2h)")     // bespoke condition: row dropped
+		assert.NotContains(t, result, "ComparisonE~")                        // truncated roll-up dropped
+		assert.Contains(t, result, "rpc error: failed to load target state") // shown once, in CONDITIONS
+	})
+
+	t.Run("condition summary columns remain when no structured conditions", func(t *testing.T) {
+		// Without structured conditions, the bespoke columns are the only
+		// representation and must still render.
+		item := &model.Item{
+			Name: "my-app",
+			Columns: []model.KeyValue{
+				{Key: "condition:ComparisonError", Value: "rpc error (2h)"},
+			},
+		}
+		result := stripANSI(RenderResourceSummary(item, "", 72, 40))
+		assert.Contains(t, result, "COMPARISONERROR")
+	})
 }
 
 // --- RenderResourceTree (badge buckets) ---

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -118,11 +118,12 @@ var (
 	IconStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(ColorPrimary))
 
-	// Status colors: Green=running, Blue=progressing, Red=error, Grey=completed/other.
+	// Status colors: Green=running, Blue=progressing, Red=error, Grey=completed/other, Amber=warning.
 	StatusRunning     = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 	StatusProgressing = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary))
 	StatusFailed      = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError))
 	StatusOther       = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorDimmed))
+	StatusWarning     = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorWarning))
 
 	// Title bar (full-width background).
 	TitleBarStyle = lipgloss.NewStyle().
@@ -468,5 +469,136 @@ func StatusStyle(status string) lipgloss.Style {
 			return NormalStyle
 		}
 		return StatusOther
+	}
+}
+
+// condPolarity classifies how a status condition's type relates to health.
+type condPolarity int
+
+const (
+	condInfo    condPolarity = iota // neutral marker (Issuing, Progressing, Reconciling)
+	condReady                       // good when True, bad when False (Ready, Available, Synced)
+	condError                       // bad when True / present (Error, Failed, Degraded, Stalled)
+	condWarning                     // always amber (any "*Warning" type)
+)
+
+// conditionPolarities is a curated map of well-known custom-resource condition
+// types to their polarity. It makes the supported CRs explicit and overrides
+// the heuristic where the type name alone would misclassify (e.g. cert-manager
+// "Issuing", whose False state is normal, not a failure). Keys are lowercase.
+var conditionPolarities = map[string]condPolarity{
+	// ArgoCD Application (status-less; the type's presence is the signal).
+	"comparisonerror":         condError,
+	"invalidspecerror":        condError,
+	"unknownerror":            condError,
+	"syncerror":               condError,
+	"deletionerror":           condError,
+	"sharedresourcewarning":   condWarning,
+	"repeatedresourcewarning": condWarning,
+	"excludedresourcewarning": condWarning,
+	"orphanedresourcewarning": condWarning,
+	// cert-manager.
+	"ready":   condReady,
+	"issuing": condInfo, // actively issuing; False is the normal idle state
+	// external-secrets.
+	"secretsynced": condReady,
+	// FluxCD.
+	"reconciling": condInfo,
+	"stalled":     condError,
+	"healthy":     condReady,
+}
+
+var (
+	conditionErrorKeywords = []string{"error", "fail", "degrad", "invalid", "unhealthy", "pressure", "stalled", "lost", "backoff", "misconfig"}
+	conditionReadyKeywords = []string{"ready", "available", "synced", "healthy", "succeeded", "complete", "established", "approved", "provisioned", "bound", "scheduled", "initialized"}
+)
+
+// conditionPolarity returns the polarity of a condition type, consulting the
+// curated map first and falling back to a keyword heuristic.
+func conditionPolarity(condType string) condPolarity {
+	lower := strings.ToLower(condType)
+	if p, ok := conditionPolarities[lower]; ok {
+		return p
+	}
+	// Match keyword stems against whole camelCase tokens, not raw substrings,
+	// so negated types do not invert: "Unbound" -> ["unbound"] does not start
+	// with "bound", and "Incomplete" -> ["incomplete"] not with "complete".
+	tokens := conditionTokens(condType)
+	switch {
+	case tokenHasPrefix(tokens, []string{"warn"}):
+		return condWarning
+	case tokenHasPrefix(tokens, conditionErrorKeywords):
+		return condError
+	case tokenHasPrefix(tokens, conditionReadyKeywords):
+		return condReady
+	default:
+		return condInfo
+	}
+}
+
+// conditionTokens splits a PascalCase/camelCase condition type into lowercase
+// word tokens (e.g. "ContainersReady" -> ["containers", "ready"]). Runs of
+// non-letters and case transitions are token boundaries.
+func conditionTokens(condType string) []string {
+	var tokens []string
+	var cur []rune
+	flush := func() {
+		if len(cur) > 0 {
+			tokens = append(tokens, strings.ToLower(string(cur)))
+			cur = nil
+		}
+	}
+	for _, r := range condType {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			flush()
+			cur = append(cur, r)
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			cur = append(cur, r)
+		default:
+			flush()
+		}
+	}
+	flush()
+	return tokens
+}
+
+// tokenHasPrefix reports whether any token starts with one of the keyword stems.
+func tokenHasPrefix(tokens, keywords []string) bool {
+	for _, tok := range tokens {
+		for _, kw := range keywords {
+			if strings.HasPrefix(tok, kw) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ConditionStyle returns the color style for a status condition, combining its
+// type's polarity with its status value. Conditions without a True/False status
+// (e.g. ArgoCD application conditions) are colored by type polarity alone.
+func ConditionStyle(condType, status string) lipgloss.Style {
+	if status == "Unknown" {
+		return DimStyle
+	}
+	switch conditionPolarity(condType) {
+	case condWarning:
+		return StatusWarning
+	case condError:
+		if status == "False" {
+			return StatusRunning // a failure condition that is False = healthy
+		}
+		return StatusFailed // True or status-less = problem
+	case condReady:
+		if status == "False" {
+			return StatusFailed // a readiness condition that is False = problem
+		}
+		return StatusRunning // True or status-less = healthy
+	default: // condInfo
+		if status == "True" {
+			return StatusProgressing // active / in progress
+		}
+		return DimStyle // False or status-less = neutral
 	}
 }

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -79,6 +79,78 @@ func TestAgeStyle(t *testing.T) {
 	}
 }
 
+// --- ConditionStyle ---
+
+func TestConditionStyle(t *testing.T) {
+	fgKey := func(s lipgloss.Style) string {
+		fg := s.GetForeground()
+		r, g, b, a := fg.RGBA()
+		return fmt.Sprintf("%d:%d:%d:%d", r, g, b, a)
+	}
+	red := fgKey(StatusFailed)
+	green := fgKey(StatusRunning)
+	amber := fgKey(StatusWarning)
+	blue := fgKey(StatusProgressing)
+	dim := fgKey(DimStyle)
+
+	tests := []struct {
+		condType string
+		status   string
+		want     string
+		desc     string
+	}{
+		// ArgoCD application conditions are status-less; the type encodes severity.
+		{"ComparisonError", "", red, "argocd error"},
+		{"InvalidSpecError", "", red, "argocd error"},
+		{"SharedResourceWarning", "", amber, "argocd warning"},
+		{"OrphanedResourceWarning", "", amber, "argocd warning"},
+
+		// external-secrets / cert-manager / Flux readiness conditions.
+		{"SecretSynced", "True", green, "good when True"},
+		{"Ready", "True", green, "good when True"},
+		{"Ready", "False", red, "bad when False"},
+
+		// cert-manager Issuing: True is in-progress, False is the normal idle state.
+		{"Issuing", "True", blue, "in progress"},
+		{"Issuing", "False", dim, "idle is neutral, not an error"},
+
+		// Negative-polarity types invert: False is healthy.
+		{"Degraded", "True", red, "failing"},
+		{"Degraded", "False", green, "not degraded = healthy"},
+		{"Stalled", "True", red, "flux stalled (curated)"},
+
+		// Node pressure conditions (heuristic): True is bad.
+		{"MemoryPressure", "True", red, "pressure is bad"},
+		{"MemoryPressure", "False", green, "no pressure = healthy"},
+
+		// Warning suffix wins regardless of status.
+		{"DeprecationWarning", "True", amber, "warning suffix"},
+
+		// Unknown status is always neutral.
+		{"Ready", "Unknown", dim, "unknown is neutral"},
+		{"ComparisonError", "Unknown", dim, "unknown is neutral"},
+
+		// Unrecognized informational type: True in-progress, False neutral.
+		{"CustomFlag", "True", blue, "info True"},
+		{"CustomFlag", "False", dim, "info False"},
+
+		// Negated single-token types must NOT match a ready keyword by substring
+		// (token-prefix matching): "Unbound"/"Incomplete" fall through to info.
+		{"Unbound", "True", blue, "not classified as ready (no substring inversion)"},
+		{"Incomplete", "True", blue, "not classified as ready (no substring inversion)"},
+		{"Unavailable", "True", blue, "not classified as ready (no substring inversion)"},
+		// Multi-token positives still match the relevant token.
+		{"ContainersReady", "False", red, "ready token matched, False = problem"},
+		{"JobComplete", "True", green, "complete token matched, True = good"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.condType+"/"+tt.status, func(t *testing.T) {
+			got := fgKey(ConditionStyle(tt.condType, tt.status))
+			assert.Equal(t, tt.want, got, "%s %q: expected %s", tt.condType, tt.status, tt.desc)
+		})
+	}
+}
+
 // --- FillLinesBg ---
 
 // TestFillLinesBgReestablishesBgAfterShortReset guards issue #293's recurrence

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -189,6 +189,7 @@ func ApplyTheme(t Theme) {
 	StatusProgressing = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Primary)).Background(baseBg)
 	StatusFailed = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Error)).Background(baseBg)
 	StatusOther = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Dimmed)).Background(baseBg)
+	StatusWarning = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Warning)).Background(baseBg)
 
 	var barBg lipgloss.TerminalColor = lipgloss.NoColor{}
 	if !ConfigTransparentBg {

--- a/internal/ui/theme_nocolor.go
+++ b/internal/ui/theme_nocolor.go
@@ -83,6 +83,7 @@ func applyNoColorTheme() {
 	StatusProgressing = lipgloss.NewStyle()
 	StatusFailed = lipgloss.NewStyle().Bold(true)
 	StatusOther = lipgloss.NewStyle().Faint(true)
+	StatusWarning = lipgloss.NewStyle().Italic(true)
 
 	TitleBarStyle = lipgloss.NewStyle().Padding(0, 1)
 	TitleBreadcrumbStyle = lipgloss.NewStyle().Bold(true)


### PR DESCRIPTION
Closes #340

## Problem
The resource preview's CONDITIONS section showed only the condition **type** — status was conveyed by color alone, the message was hidden whenever status was `True`, and there was no timestamp. Worse, most resource kinds never populated the section at all: condition extraction was scattered across per-kind handlers, so cert-manager `Certificate`, ArgoCD `Application`, HPAs, and core workloads (Pod/Deployment/Node/Job) showed nothing.

## Changes
- **Full detail per condition** — explicit status text, reason, full wrapped message (no longer hidden on `True`), and a kubectl-style age (new `LastTransitionTime` on `model.ConditionEntry`).
- **Universal population** — `.Conditions` is now populated **once centrally** in `populateResourceDetails` for every kind via a single `appendAllConditions` helper. Removed the scattered per-handler population that caused the coverage gaps.
- **De-duplication** — ArgoCD apps previously rendered each condition up to three times in the preview (bespoke `condition:*` rows + truncated `Condition` roll-up + section). The preview now suppresses the bespoke rows when structured conditions exist; the list view is unaffected (reads `Columns` directly).
- **Severity coloring** — new `ConditionStyle` colors by condition *polarity* (error / ready / warning / info) combined with status, using a curated map for known CRs (ArgoCD `*Error`/`*Warning`, cert-manager `Issuing`/`Ready`, external-secrets `SecretSynced`, Flux `Stalled`/`Reconciling`) and a camelCase **token-prefix** heuristic fallback that avoids negated-type inversions (`Unbound`, `Incomplete`). Adds a theme-aware `StatusWarning` amber style.

### Examples
```
ComparisonError       (argocd, no status)  -> RED
SharedResourceWarning (argocd, no status)  -> AMBER
SecretSynced  True    (external-secrets)   -> GREEN
Ready         False                        -> RED
Issuing       False   (cert-manager)       -> dim (normal idle, curated)
Degraded      False                        -> GREEN
```

### cert-manager Certificate, before -> after
```
CONDITIONS                 CONDITIONS
  Ready                      Ready    True    63d
                               Ready
                               Certificate is up to date and has not expired
                             Issuing  False
                               Issued
                               The certificate has been successfully issued
```

## Testing
- `go test ./...` green; `go vet` + `golangci-lint` clean.
- New tests: `appendAllConditions`, central population across 5 kinds (incl. unknown CRD, no double-populate), cert-manager/Flux end-to-end, renderer detail + ArgoCD de-dup, and `ConditionStyle` polarity/status table incl. negated-type regressions.

## Notes
- Core workloads (Pod, Deployment, Node, Job, ...) now also surface their conditions in the preview — intentional, consistent with the issue's intent.
- Reviewed across three go-reviewer passes; all CRITICAL/HIGH findings addressed.