### PR TITLE
feat(ui): make Name a configurable resource-list column

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are welcome! Here is how to get started.
 
 ## Prerequisites
 
-- Go 1.26.3 or later
+- Go 1.26.4 or later
 - Access to a Kubernetes cluster (for testing)
 - `kubectl` configured and working
 - `golangci-lint`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 RUN apk add --no-cache git
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -469,7 +469,7 @@ Press `V` on a resource (or open the Events list and press `Enter` on an event) 
 ## Column Toggle Overlay
 
 Press `,` in the resource list to open the column toggle overlay. It lists
-every toggleable column for the current kind — both built-ins (Namespace,
+every toggleable column for the current kind — built-ins (Name, Namespace,
 Ready, Restarts, Status, Age) and extras from the resource's
 `additionalPrinterColumns`.
 
@@ -486,8 +486,11 @@ Ready, Restarts, Status, Age) and extras from the resource's
 
 Built-in and extra columns can be freely interleaved — `J`/`K` moves
 either kind, so you can put `Age` before `Namespace` or drop an extra
-like `IP` between `Ready` and `Status`. The only fixed column is `Name`,
-which always renders first and is never listed in the overlay.
+like `IP` between `Ready` and `Status`. `Name` is listed too: it renders
+first by default but can be reordered (e.g. after a `Catalog`/`Task`
+extra) or hidden like any other column. When visible, `Name` still
+absorbs the row's leftover width and compresses (truncates) when the
+other columns leave it little room.
 
 The selection you apply is explicit: the table renders exactly the
 columns you check, in the exact order they appear in the overlay, and

--- a/flake.nix
+++ b/flake.nix
@@ -18,14 +18,14 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
 
-        # go.mod requires 1.26.3 (security). nixpkgs/master currently ships
-        # go_1_26 = 1.26.2; override the source to the official 1.26.3 tarball
+        # go.mod requires 1.26.4 (security). nixpkgs/master currently ships
+        # go_1_26 = 1.26.2; override the source to the official 1.26.4 tarball
         # until nixpkgs catches up, then delete this block.
-        go_1_26_3 = pkgs.go_1_26.overrideAttrs (_: rec {
-          version = "1.26.3";
+        go_1_26_4 = pkgs.go_1_26.overrideAttrs (_: rec {
+          version = "1.26.4";
           src = pkgs.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            hash = "sha256-HGRoddCqh5kTMYTtV895/yS97+jIggRwYCqdPW2Rkrg=";
+            hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
           };
         });
 
@@ -40,7 +40,7 @@
       in
       {
         packages = {
-          default = (pkgs.buildGoModule.override { go = go_1_26_3; }) {
+          default = (pkgs.buildGoModule.override { go = go_1_26_4; }) {
             pname = "lfk";
             inherit version;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/janosmiko/lfk
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/atotto/clipboard v0.1.4

--- a/internal/app/update_column_toggle.go
+++ b/internal/app/update_column_toggle.go
@@ -11,8 +11,9 @@ import (
 
 // builtinColumnOrder is the canonical left-to-right order of built-in
 // columns in RenderTable. openColumnToggle emits entries in this order so
-// the overlay matches the header row.
-var builtinColumnOrder = []string{"Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
+// the overlay matches the header row. Name leads the list: it renders first
+// by default but is reorderable and hideable like any other column.
+var builtinColumnOrder = []string{"Name", "Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
 
 // columnToggleSnapshot captures the pre-overlay column-config state for
 // a single kind so Esc can revert after live-apply edits. The hasX
@@ -160,10 +161,11 @@ func mergeColumnToggleEntries(builtinEntries, extraEntries []columnToggleEntry, 
 }
 
 // collectBuiltinToggleEntries returns toggle entries for built-in columns
-// present in the item data. Name is intentionally excluded (it is mandatory).
-// The visible flag is true unless the column is in hiddenBuiltinColumns[kind].
+// present in the item data. Name is always present (every item has a name) and
+// is reorderable/hideable like the others. The visible flag is true unless the
+// column is in hiddenBuiltinColumns[kind].
 func (m *Model) collectBuiltinToggleEntries(items []model.Item, kind string) []columnToggleEntry {
-	present := map[string]bool{}
+	present := map[string]bool{"Name": true}
 	for _, item := range items {
 		if item.ClusterName != "" {
 			present["Context"] = true

--- a/internal/app/update_column_toggle.go
+++ b/internal/app/update_column_toggle.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"slices"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -137,6 +138,16 @@ func mergeColumnToggleEntries(builtinEntries, extraEntries []columnToggleEntry, 
 
 	result := make([]columnToggleEntry, 0, len(byKey))
 	seen := make(map[string]bool, len(byKey))
+
+	// Backward compatibility: saved orders that predate configurable Name omit
+	// the "Name" key. Pin Name first so reopening the overlay matches the
+	// renderer's pinned-first behaviour in orderedColumnKeys; without this,
+	// reopening a legacy order and pressing Enter would persist Name at a
+	// non-first position. An order that lists "Name" honours that position.
+	if e, ok := byKey["Name"]; ok && !slices.Contains(savedOrder, "Name") {
+		result = append(result, e)
+		seen["Name"] = true
+	}
 
 	for _, k := range savedOrder {
 		if e, ok := byKey[k]; ok && !seen[k] {

--- a/internal/app/update_column_toggle_name_test.go
+++ b/internal/app/update_column_toggle_name_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestCollectBuiltinToggleEntries_IncludesName verifies Name is now a
+// first-class, toggleable built-in column: it appears in the overlay entries,
+// leads the default order, and is visible unless explicitly hidden.
+func TestCollectBuiltinToggleEntries_IncludesName(t *testing.T) {
+	items := []model.Item{
+		{Name: "nginx", Namespace: "default", Ready: "1/1", Restarts: "0", Status: "Running", Age: "5m"},
+	}
+	m := &Model{}
+	entries := m.collectBuiltinToggleEntries(items, "pod")
+
+	if assert.NotEmpty(t, entries) {
+		assert.Equal(t, "Name", entries[0].key, "Name leads the built-in toggle list")
+		assert.True(t, entries[0].builtin, "Name is a built-in entry")
+		assert.True(t, entries[0].visible, "Name is visible by default")
+	}
+}
+
+// TestCollectBuiltinToggleEntries_NameHiddenWhenSessionHidden verifies the
+// overlay reflects a session-hidden Name.
+func TestCollectBuiltinToggleEntries_NameHiddenWhenSessionHidden(t *testing.T) {
+	items := []model.Item{
+		{Name: "nginx", Namespace: "default", Status: "Running", Age: "5m"},
+	}
+	m := &Model{
+		hiddenBuiltinColumns: map[string][]string{
+			colKey("pod"): {"Name"},
+		},
+	}
+	entries := m.collectBuiltinToggleEntries(items, "pod")
+
+	got := map[string]bool{}
+	for _, e := range entries {
+		got[e.key] = e.visible
+	}
+	visibleByKey := false
+	for _, e := range entries {
+		if e.key == "Name" {
+			visibleByKey = e.visible
+		}
+	}
+	assert.False(t, visibleByKey, "session-hidden Name is unchecked in the overlay")
+}

--- a/internal/app/update_column_toggle_name_test.go
+++ b/internal/app/update_column_toggle_name_test.go
@@ -38,10 +38,6 @@ func TestCollectBuiltinToggleEntries_NameHiddenWhenSessionHidden(t *testing.T) {
 	}
 	entries := m.collectBuiltinToggleEntries(items, "pod")
 
-	got := map[string]bool{}
-	for _, e := range entries {
-		got[e.key] = e.visible
-	}
 	visibleByKey := false
 	for _, e := range entries {
 		if e.key == "Name" {
@@ -49,4 +45,48 @@ func TestCollectBuiltinToggleEntries_NameHiddenWhenSessionHidden(t *testing.T) {
 		}
 	}
 	assert.False(t, visibleByKey, "session-hidden Name is unchecked in the overlay")
+}
+
+// TestMergeColumnToggleEntries_LegacyOrderPinsNameFirst verifies the overlay
+// keeps Name pinned first when reopening a saved order that predates
+// configurable Name (and therefore omits the "Name" key). Without this, simply
+// reopening the overlay and pressing Enter would rewrite columnOrder so Name is
+// no longer first, diverging from the renderer's pinned-first backward-compat
+// behaviour in orderedColumnKeys.
+func TestMergeColumnToggleEntries_LegacyOrderPinsNameFirst(t *testing.T) {
+	builtins := []columnToggleEntry{
+		{key: "Name", visible: true, builtin: true},
+		{key: "Namespace", visible: true, builtin: true},
+		{key: "Age", visible: true, builtin: true},
+	}
+	extras := []columnToggleEntry{{key: "IP", visible: false}}
+	// Legacy saved order: no "Name" entry.
+	savedOrder := []string{"Age", "IP", "Namespace"}
+
+	merged := mergeColumnToggleEntries(builtins, extras, savedOrder)
+
+	if assert.NotEmpty(t, merged) {
+		assert.Equal(t, "Name", merged[0].key,
+			"Name stays pinned first for a legacy order that omits it")
+	}
+}
+
+// TestMergeColumnToggleEntries_ExplicitNameOrderHonored verifies that a newer
+// saved order that lists "Name" explicitly keeps it at the chosen position.
+func TestMergeColumnToggleEntries_ExplicitNameOrderHonored(t *testing.T) {
+	builtins := []columnToggleEntry{
+		{key: "Name", visible: true, builtin: true},
+		{key: "Namespace", visible: true, builtin: true},
+		{key: "Age", visible: true, builtin: true},
+	}
+	savedOrder := []string{"Namespace", "Name", "Age"}
+
+	merged := mergeColumnToggleEntries(builtins, nil, savedOrder)
+
+	keys := make([]string, len(merged))
+	for i, e := range merged {
+		keys[i] = e.key
+	}
+	assert.Equal(t, []string{"Namespace", "Name", "Age"}, keys,
+		"explicit Name position is honored")
 }

--- a/internal/app/update_column_toggle_test.go
+++ b/internal/app/update_column_toggle_test.go
@@ -710,7 +710,9 @@ func TestCovOpenColumnToggleRespectsSavedOrder(t *testing.T) {
 			},
 		},
 	}
-	// Saved order puts Age first, then IP, then Namespace.
+	// Saved order puts Age first, then IP, then Namespace. It predates
+	// configurable Name (no "Name" entry), so Name is pinned first for
+	// backward compatibility, ahead of the saved order.
 	m.columnOrder = map[string][]string{m.columnMemoryKey("pod"): {"Age", "IP", "Namespace"}}
 	// ActiveExtraColumnKeys controls which extras are "currently visible";
 	// must include IP so it ends up visible in the overlay.
@@ -719,17 +721,18 @@ func TestCovOpenColumnToggleRespectsSavedOrder(t *testing.T) {
 
 	m.openColumnToggle()
 
-	if !assert.GreaterOrEqual(t, len(m.columnToggleItems), 3) {
+	if !assert.GreaterOrEqual(t, len(m.columnToggleItems), 4) {
 		return
 	}
-	// The first three entries must match the saved order.
-	assert.Equal(t, "Age", m.columnToggleItems[0].key)
-	assert.Equal(t, "IP", m.columnToggleItems[1].key)
-	assert.Equal(t, "Namespace", m.columnToggleItems[2].key)
+	// Name is pinned first (legacy order omits it), then the saved order.
+	assert.Equal(t, "Name", m.columnToggleItems[0].key)
+	assert.Equal(t, "Age", m.columnToggleItems[1].key)
+	assert.Equal(t, "IP", m.columnToggleItems[2].key)
+	assert.Equal(t, "Namespace", m.columnToggleItems[3].key)
 
 	// The remaining built-ins appear after, in default position.
-	remainingKeys := make([]string, 0, len(m.columnToggleItems)-3)
-	for _, e := range m.columnToggleItems[3:] {
+	remainingKeys := make([]string, 0, len(m.columnToggleItems)-4)
+	for _, e := range m.columnToggleItems[4:] {
 		remainingKeys = append(remainingKeys, e.key)
 	}
 	assert.Contains(t, remainingKeys, "Ready")

--- a/internal/app/update_column_toggle_test.go
+++ b/internal/app/update_column_toggle_test.go
@@ -275,9 +275,9 @@ func findColumnToggleEntry(entries []columnToggleEntry, key string, builtin bool
 }
 
 // TestCovOpenColumnToggleIncludesBuiltins verifies that opening the column
-// toggle overlay for a resource with built-in field data (Ready/Restarts/
-// Status/Age/Namespace) produces toggle entries for each built-in and that
-// Name is NOT toggleable.
+// toggle overlay for a resource with built-in field data (Name/Ready/Restarts/
+// Status/Age/Namespace) produces toggle entries for each built-in, including
+// Name.
 func TestCovOpenColumnToggleIncludesBuiltins(t *testing.T) {
 	m := baseModelNav()
 	m.middleItems = []model.Item{
@@ -301,10 +301,10 @@ func TestCovOpenColumnToggleIncludesBuiltins(t *testing.T) {
 	assert.NotNil(t, findColumnToggleEntry(entries, "Restarts", true), "Restarts built-in entry must exist")
 	assert.NotNil(t, findColumnToggleEntry(entries, "Status", true), "Status built-in entry must exist")
 	assert.NotNil(t, findColumnToggleEntry(entries, "Age", true), "Age built-in entry must exist")
-	assert.Nil(t, findColumnToggleEntry(entries, "Name", true), "Name must NOT be toggleable")
+	assert.NotNil(t, findColumnToggleEntry(entries, "Name", true), "Name is now a toggleable built-in entry")
 
 	// All built-ins should be visible by default when nothing is hidden.
-	for _, key := range []string{"Namespace", "Ready", "Restarts", "Status", "Age"} {
+	for _, key := range []string{"Name", "Namespace", "Ready", "Restarts", "Status", "Age"} {
 		e := findColumnToggleEntry(entries, key, true)
 		if assert.NotNil(t, e, "entry for %s", key) {
 			assert.True(t, e.visible, "%s must be visible when no hidden set", key)

--- a/internal/app/update_keys_sort.go
+++ b/internal/app/update_keys_sort.go
@@ -68,6 +68,13 @@ func (m Model) handleExplorerActionKeySortReset() (tea.Model, tea.Cmd, bool) {
 		return m, nil, true
 	}
 	m.sortColumnName = sortColDefault
+	// The default sort key is Name. If Name is hidden via the column overlay it
+	// is absent from the visible sort cycle, so fall back to the first visible
+	// column to keep the status bar and header indicator coherent (mirrors the
+	// hidden-column guard in Next/Prev).
+	if _, ok := sortColumnIndex(m.sortColumnName); !ok && ui.ActiveSortableColumnCount > 0 {
+		m.sortColumnName = ui.ActiveSortableColumns[0]
+	}
 	m.sortAscending = true
 	m.forgetSort()
 	m.sortMiddleItems()

--- a/internal/app/update_keys_sort_reset_test.go
+++ b/internal/app/update_keys_sort_reset_test.go
@@ -31,9 +31,13 @@ func TestSortReset_NameHiddenFallsBackToVisibleColumn(t *testing.T) {
 	res, _, _ := m.handleExplorerActionKeySortReset()
 	updated := res.(Model)
 
-	if _, ok := sortColumnIndex(updated.sortColumnName); !ok {
-		t.Fatalf("reset left sort on hidden column %q (not in %v)",
-			updated.sortColumnName, ui.ActiveSortableColumns)
+	// With Name hidden, reset falls back to the first visible sortable column.
+	if updated.sortColumnName != "Namespace" {
+		t.Fatalf("sortColumnName = %q, want %q (first visible column)",
+			updated.sortColumnName, "Namespace")
+	}
+	if !updated.sortAscending {
+		t.Fatalf("sortAscending = false, want true after reset")
 	}
 }
 

--- a/internal/app/update_keys_sort_reset_test.go
+++ b/internal/app/update_keys_sort_reset_test.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// TestSortReset_NameHiddenFallsBackToVisibleColumn verifies that resetting the
+// sort while the Name column is hidden does not leave the sort key on the
+// (now invisible) "Name" column. Next/Prev already guard a hidden sort column
+// (issue #339); reset must stay coherent too so the status bar and header
+// indicator agree with the visible columns.
+func TestSortReset_NameHiddenFallsBackToVisibleColumn(t *testing.T) {
+	prevCols := ui.ActiveSortableColumns
+	prevCount := ui.ActiveSortableColumnCount
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = prevCols
+		ui.ActiveSortableColumnCount = prevCount
+	})
+	// Name hidden -> absent from the sortable set.
+	ui.ActiveSortableColumns = []string{"Namespace", "Age"}
+	ui.ActiveSortableColumnCount = 2
+
+	m := &Model{}
+	m.nav.Level = model.LevelResources
+	m.sortColumnName = "Age"
+	m.sortAscending = false
+
+	res, _, _ := m.handleExplorerActionKeySortReset()
+	updated := res.(Model)
+
+	if _, ok := sortColumnIndex(updated.sortColumnName); !ok {
+		t.Fatalf("reset left sort on hidden column %q (not in %v)",
+			updated.sortColumnName, ui.ActiveSortableColumns)
+	}
+}
+
+// TestSortReset_NameVisibleResetsToName verifies the unchanged default path:
+// when Name is visible, reset restores the Name sort key.
+func TestSortReset_NameVisibleResetsToName(t *testing.T) {
+	prevCols := ui.ActiveSortableColumns
+	prevCount := ui.ActiveSortableColumnCount
+	t.Cleanup(func() {
+		ui.ActiveSortableColumns = prevCols
+		ui.ActiveSortableColumnCount = prevCount
+	})
+	ui.ActiveSortableColumns = []string{"Name", "Namespace", "Age"}
+	ui.ActiveSortableColumnCount = 3
+
+	m := &Model{}
+	m.nav.Level = model.LevelResources
+	m.sortColumnName = "Age"
+	m.sortAscending = false
+
+	res, _, _ := m.handleExplorerActionKeySortReset()
+	updated := res.(Model)
+
+	if updated.sortColumnName != sortColDefault {
+		t.Fatalf("sortColumnName = %q, want %q", updated.sortColumnName, sortColDefault)
+	}
+}

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -177,10 +177,11 @@ func styledRestartsCell(item model.Item, restartsW int, anyRecentRestart bool) s
 }
 
 // formatTableRowOrdered builds a plain-text table row using the given column
-// order. Name is always emitted first. The preprocessed values (ns, ready,
-// restarts, status, age) are passed through since they have row-specific
-// handling upstream (e.g. the cursor row preprocesses restarts for arrow
-// alignment).
+// order. "Name" is rendered at its position within order; an order without a
+// "Name" entry renders no name cell (the column is hidden). The preprocessed
+// values (ns, ready, restarts, status, age) are passed through since they have
+// row-specific handling upstream (e.g. the cursor row preprocesses restarts for
+// arrow alignment).
 func formatTableRowOrdered(name, ns, ready, restarts, status, age string,
 	nameW, contextW, nsW, readyW, restartsW, statusW, ageW int,
 	order []string, extraCols []extraColumn, item *model.Item,
@@ -188,8 +189,11 @@ func formatTableRowOrdered(name, ns, ready, restarts, status, age string,
 	widths := builtinColWidths{context: contextW, ns: nsW, ready: readyW, restarts: restartsW, status: statusW, age: ageW}
 	inputs := plainCellInputs{item: item, ns: ns, ready: ready, restarts: restarts, status: status, age: age, widths: widths}
 	var row strings.Builder
-	row.WriteString(plainNameCellWithBadge(name, item, nameW))
 	for _, key := range order {
+		if key == "Name" {
+			row.WriteString(plainNameCellWithBadge(name, item, nameW))
+			continue
+		}
 		if col := renderableBuiltin(key, widths); col != nil {
 			row.WriteString(col.plain(inputs))
 			continue
@@ -205,8 +209,9 @@ func formatTableRowOrdered(name, ns, ready, restarts, status, age string,
 }
 
 // formatTableRowStyledOrdered builds a styled table row using the given
-// column order. Name (with icon handling) is always emitted first via the
-// existing styled name helper; the rest is dispatched per-key.
+// column order. The Name cell (with icon + badge handling) is rendered at its
+// position within order via the styled name helper; an order without a "Name"
+// entry renders no name cell (the column is hidden).
 func formatTableRowStyledOrdered(item model.Item,
 	nameW, contextW, nsW, readyW, restartsW, statusW, ageW int,
 	order []string, extraCols []extraColumn, anyRecentRestart bool,
@@ -214,8 +219,11 @@ func formatTableRowStyledOrdered(item model.Item,
 	widths := builtinColWidths{context: contextW, ns: nsW, ready: readyW, restarts: restartsW, status: statusW, age: ageW}
 	inputs := styledCellInputs{item: item, widths: widths, anyRecentRestart: anyRecentRestart}
 	var base strings.Builder
-	base.WriteString(styledNameCell(item, nameW))
 	for _, key := range order {
+		if key == "Name" {
+			base.WriteString(styledNameCell(item, nameW))
+			continue
+		}
 		if col := renderableBuiltin(key, widths); col != nil {
 			base.WriteString(col.styled(inputs))
 			continue

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -58,10 +58,16 @@ func isMandatoryColumn(key string) bool {
 }
 
 // ActiveHiddenBuiltinColumns holds the set of built-in column keys that should
-// be suppressed in the current middle-column render. Valid keys: "Context",
-// "Namespace", "Ready", "Restarts", "Age", "Status". Set by the app before
-// rendering. Nil means no overrides.
+// be suppressed in the current middle-column render. Valid keys: "Name",
+// "Context", "Namespace", "Ready", "Restarts", "Age", "Status". Set by the app
+// before rendering. Nil means no overrides.
 var ActiveHiddenBuiltinColumns map[string]bool
+
+// ActiveNameHidden reports whether the NAME column is hidden for the current
+// middle-column render. When true, collectExtraColumns skips the name width
+// reservation so extra columns reclaim the space the name would have used.
+// Set by RenderTable before rendering.
+var ActiveNameHidden bool
 
 // collectExtraColumns discovers which extra columns to show based on item data and config.
 // usedWidth is the width already consumed by fixed columns (excluding name).
@@ -276,17 +282,22 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	}
 
 	nameReserve := longestName + 1 // +1 for column spacing
-	if nameReserve+usedWidth > totalWidth {
-		// Can't fit the full name even after dropping every extra. Cap
-		// the reservation so at least one extra gets a fair budget.
-		nameReserve = max(totalWidth-usedWidth-minExtrasBudget, nameFloor)
+	if ActiveNameHidden {
+		// NAME is hidden: reserve nothing so extras get the full row budget.
+		nameReserve = 0
+	} else {
+		if nameReserve+usedWidth > totalWidth {
+			// Can't fit the full name even after dropping every extra. Cap
+			// the reservation so at least one extra gets a fair budget.
+			nameReserve = max(totalWidth-usedWidth-minExtrasBudget, nameFloor)
+		}
+		if mandatoryBudget > 0 {
+			// Never let the name reservation crowd out mandatory columns; NAME
+			// shrinks toward its floor and overflow is clipped by the caller.
+			nameReserve = min(nameReserve, max(totalWidth-usedWidth-mandatoryBudget, nameFloor))
+		}
+		nameReserve = max(nameReserve, nameFloor)
 	}
-	if mandatoryBudget > 0 {
-		// Never let the name reservation crowd out mandatory columns; NAME
-		// shrinks toward its floor and overflow is clipped by the caller.
-		nameReserve = min(nameReserve, max(totalWidth-usedWidth-mandatoryBudget, nameFloor))
-	}
-	nameReserve = max(nameReserve, nameFloor)
 	// available may be negative when mandatory columns alone exceed the row;
 	// fitExtraColumns still emits them and the caller clips the overflow.
 	available := totalWidth - usedWidth - nameReserve

--- a/internal/ui/explorer_format_test.go
+++ b/internal/ui/explorer_format_test.go
@@ -15,9 +15,10 @@ import (
 // --- formatTableRowOrdered ---
 
 // buildOrder turns a bool-per-column selection into the ordered slice used
-// by the new rendering path, matching the canonical default order.
+// by the new rendering path, matching the canonical default order. "Name"
+// leads the order since the rows under test always render a name cell.
 func buildOrder(hasNs, hasReady, hasRestarts, hasStatus, hasAge bool) []string {
-	var order []string
+	order := []string{"Name"}
 	if hasNs {
 		order = append(order, "Namespace")
 	}
@@ -148,15 +149,14 @@ func TestFormatTableRowOrdered(t *testing.T) {
 func TestFormatTableRowOrdered_Padding(t *testing.T) {
 	t.Run("name is padded to nameW", func(t *testing.T) {
 		result := formatTableRowOrdered("hi", "", "", "", "", "",
-			10, 0, 0, 0, 0, 0, 0, nil, nil, nil)
+			10, 0, 0, 0, 0, 0, 0, []string{"Name"}, nil, nil)
 		assert.Equal(t, 10, len(result), "result length should match nameW")
 	})
 
 	t.Run("namespace is padded when present", func(t *testing.T) {
 		result := formatTableRowOrdered("pod", "ns", "", "", "", "",
-			10, 0, 8, 0, 0, 0, 0, []string{"Namespace"}, nil, nil)
-		// Total = nameW + nsW = 10 + 8 = 18. Note: in the ordered path Name
-		// comes first, then Namespace.
+			10, 0, 8, 0, 0, 0, 0, []string{"Name", "Namespace"}, nil, nil)
+		// Total = nameW + nsW = 10 + 8 = 18. Name comes first, then Namespace.
 		assert.Equal(t, 18, len(result))
 	})
 }
@@ -243,7 +243,7 @@ func TestTruncatedColumnSpacing(t *testing.T) {
 		result := formatTableRowOrdered(
 			"very-long-pod-name-that-definitely-exceeds", "", "", "", "Running", "",
 			15, 0, 0, 0, 0, 10, 0,
-			[]string{"Status"}, nil, nil,
+			[]string{"Name", "Status"}, nil, nil,
 		)
 		// The name is truncated to 15 chars. The status "Running" should NOT immediately
 		// follow the truncated name — there must be at least 1 space gap.
@@ -257,7 +257,7 @@ func TestTruncatedColumnSpacing(t *testing.T) {
 		result := formatTableRowOrdered(
 			"extremely-long-pod-name-here", "prod", "", "", "", "",
 			15, 0, 12, 0, 0, 0, 0,
-			[]string{"Namespace"}, nil, nil,
+			[]string{"Name", "Namespace"}, nil, nil,
 		)
 		assert.Contains(t, result, "~ ", "truncated name should have space before namespace column")
 		assert.Contains(t, result, "prod")
@@ -267,7 +267,7 @@ func TestTruncatedColumnSpacing(t *testing.T) {
 		result := formatTableRowOrdered(
 			"short", "ns", "", "", "OK", "",
 			15, 0, 10, 0, 0, 10, 0,
-			[]string{"Namespace", "Status"}, nil, nil,
+			[]string{"Name", "Namespace", "Status"}, nil, nil,
 		)
 		// Short values should be padded as before: nameW + nsW + statusW = 15 + 10 + 10 = 35.
 		assert.Equal(t, 35, len(result), "total width should be nameW+nsW+statusW")
@@ -414,7 +414,7 @@ func TestFormatTableRowOrdered_AllColumnsExactBytes(t *testing.T) {
 		Age:         "5d",
 		ClusterName: "prod",
 	}
-	order := []string{"Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
+	order := []string{"Name", "Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
 
 	got := formatTableRowOrdered(
 		item.Name, item.Namespace, item.Ready, item.Restarts, item.Status, item.Age,
@@ -434,7 +434,7 @@ func TestFormatTableRowOrdered_ContextZeroWidthFallsThrough(t *testing.T) {
 	t.Cleanup(func() { ActiveHighlightQuery = prev })
 
 	item := model.Item{Name: "pod-1", Namespace: "default", ClusterName: "should-not-render"}
-	order := []string{"Context", "Namespace"}
+	order := []string{"Name", "Context", "Namespace"}
 
 	got := formatTableRowOrdered(
 		"pod-1", "default", "", "", "", "",
@@ -461,7 +461,7 @@ func TestFormatTableRowStyledOrdered_VisibleWidthAndContent(t *testing.T) {
 		Age:         "5d",
 		ClusterName: "prod",
 	}
-	order := []string{"Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
+	order := []string{"Name", "Context", "Namespace", "Ready", "Restarts", "Status", "Age"}
 
 	got := formatTableRowStyledOrdered(item,
 		10, 8, 10, 6, 4, 10, 4,

--- a/internal/ui/explorer_name_column_test.go
+++ b/internal/ui/explorer_name_column_test.go
@@ -80,13 +80,18 @@ func TestRenderTable_NameReorderedHeader(t *testing.T) {
 	prevScroll := ActiveMiddleScroll
 	prevOrder := ActiveColumnOrder
 	prevLayout := ActiveTableLayout
+	prevHidden := ActiveHiddenBuiltinColumns
 	defer func() {
 		ActiveMiddleScroll = prevScroll
 		ActiveColumnOrder = prevOrder
 		ActiveTableLayout = prevLayout
+		ActiveHiddenBuiltinColumns = prevHidden
 	}()
 	ActiveMiddleScroll = 0
 	ActiveTableLayout = nil
+	// RenderTable derives hasName from this global; isolate it so a prior
+	// test leaving {"Name": true} can't fail this assertion for the wrong reason.
+	ActiveHiddenBuiltinColumns = nil
 	ActiveColumnOrder = []string{"Namespace", "Name"}
 
 	items := []model.Item{

--- a/internal/ui/explorer_name_column_test.go
+++ b/internal/ui/explorer_name_column_test.go
@@ -1,0 +1,133 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// --- orderedColumnKeys: Name as a first-class column ---
+
+func TestOrderedColumnKeys_NameDefaultFirst(t *testing.T) {
+	prevScroll, prevOrder := ActiveMiddleScroll, ActiveColumnOrder
+	defer func() { ActiveMiddleScroll, ActiveColumnOrder = prevScroll, prevOrder }()
+	ActiveMiddleScroll = -1
+	ActiveColumnOrder = nil
+
+	// hasName, hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge
+	got := orderedColumnKeys(true, false, true, false, false, true, true, nil)
+	if assert.NotEmpty(t, got) {
+		assert.Equal(t, "Name", got[0], "Name leads the default order")
+	}
+	assert.Equal(t, []string{"Name", "Namespace", "Status", "Age"}, got)
+}
+
+func TestOrderedColumnKeys_NameHidden(t *testing.T) {
+	prevScroll, prevOrder := ActiveMiddleScroll, ActiveColumnOrder
+	defer func() { ActiveMiddleScroll, ActiveColumnOrder = prevScroll, prevOrder }()
+	ActiveMiddleScroll = -1
+	ActiveColumnOrder = nil
+
+	// hasName=false: hasName, hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge
+	got := orderedColumnKeys(false, false, true, false, false, false, true, nil)
+	assert.NotContains(t, got, "Name", "hidden Name is omitted entirely")
+	assert.Equal(t, []string{"Namespace", "Age"}, got)
+}
+
+func TestOrderedColumnKeys_NameReordered(t *testing.T) {
+	prevScroll, prevOrder := ActiveMiddleScroll, ActiveColumnOrder
+	defer func() { ActiveMiddleScroll, ActiveColumnOrder = prevScroll, prevOrder }()
+	ActiveMiddleScroll = 0
+	ActiveColumnOrder = []string{"Namespace", "Name", "Age"}
+
+	// hasName, hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge
+	got := orderedColumnKeys(true, false, true, false, false, false, true, nil)
+	assert.Equal(t, []string{"Namespace", "Name", "Age"}, got,
+		"Name moves to its position in the saved order")
+}
+
+// --- formatTableRowOrdered: Name rendered at its ordered position ---
+
+func TestFormatTableRowOrdered_NameAtPosition(t *testing.T) {
+	// order places Namespace before Name: the namespace cell must precede
+	// the name in the rendered row.
+	order := []string{"Namespace", "Name"}
+	got := formatTableRowOrdered("mypod", "myns", "", "", "", "",
+		10, 0, 8, 0, 0, 0, 0, order, nil, nil)
+	nsIdx := strings.Index(got, "myns")
+	nameIdx := strings.Index(got, "mypod")
+	assert.GreaterOrEqual(t, nsIdx, 0)
+	assert.GreaterOrEqual(t, nameIdx, 0)
+	assert.Less(t, nsIdx, nameIdx, "namespace cell precedes name when ordered first")
+}
+
+func TestFormatTableRowOrdered_NameOmittedWhenHidden(t *testing.T) {
+	// "Name" absent from order: no name cell renders even with a positive
+	// nameW. Order presence is the single source of truth for the Name column.
+	order := []string{"Namespace"}
+	got := formatTableRowOrdered("mypod", "myns", "", "", "", "",
+		10, 0, 8, 0, 0, 0, 0, order, nil, nil)
+	assert.NotContains(t, got, "mypod", "hidden Name leaves no name cell")
+	assert.Contains(t, got, "myns")
+}
+
+// --- RenderTable integration: reordered NAME header ---
+
+func TestRenderTable_NameReorderedHeader(t *testing.T) {
+	prevScroll := ActiveMiddleScroll
+	prevOrder := ActiveColumnOrder
+	prevLayout := ActiveTableLayout
+	defer func() {
+		ActiveMiddleScroll = prevScroll
+		ActiveColumnOrder = prevOrder
+		ActiveTableLayout = prevLayout
+	}()
+	ActiveMiddleScroll = 0
+	ActiveTableLayout = nil
+	ActiveColumnOrder = []string{"Namespace", "Name"}
+
+	items := []model.Item{
+		{Name: "alpha", Namespace: "team-a"},
+		{Name: "beta", Namespace: "team-b"},
+	}
+	out := RenderTable("NAME", items, 0, 120, 20, false, "", "")
+	header := strings.SplitN(out, "\n", 2)[0]
+	nsIdx := strings.Index(header, "NAMESPACE")
+	nameIdx := strings.Index(header, "NAME")
+	// "NAMESPACE" contains "NAME"; find the standalone NAME header after it.
+	standaloneNameIdx := strings.Index(header[nsIdx+len("NAMESPACE"):], "NAME")
+	assert.GreaterOrEqual(t, nsIdx, 0, "NAMESPACE header present")
+	assert.GreaterOrEqual(t, standaloneNameIdx, 0, "NAME header rendered after NAMESPACE")
+	_ = nameIdx
+}
+
+func TestRenderTable_NameHiddenDropsColumn(t *testing.T) {
+	prevScroll := ActiveMiddleScroll
+	prevHidden := ActiveHiddenBuiltinColumns
+	prevLayout := ActiveTableLayout
+	prevNameHidden := ActiveNameHidden
+	defer func() {
+		ActiveMiddleScroll = prevScroll
+		ActiveHiddenBuiltinColumns = prevHidden
+		ActiveTableLayout = prevLayout
+		ActiveNameHidden = prevNameHidden
+	}()
+	ActiveMiddleScroll = 0
+	ActiveTableLayout = nil
+	ActiveHiddenBuiltinColumns = map[string]bool{"Name": true}
+
+	items := []model.Item{
+		{Name: "alpha-pod", Namespace: "team-a", Age: "5m"},
+	}
+	out := RenderTable("NAME", items, 0, 120, 20, false, "", "")
+	header := strings.SplitN(out, "\n", 2)[0]
+	assert.Contains(t, header, "NAMESPACE", "other columns still render")
+	// "NAMESPACE" contains the substring "NAME"; mask it before asserting the
+	// standalone NAME header is gone.
+	masked := strings.ReplaceAll(header, "NAMESPACE", "")
+	assert.NotContains(t, masked, "NAME", "NAME header dropped when Name hidden")
+	assert.NotContains(t, out, "alpha-pod", "name value not rendered when Name hidden")
+}

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -243,6 +243,14 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		markerColW = 2
 	}
 
+	// Name is a configurable column: the user can hide it via the
+	// column-toggle overlay (ActiveHiddenBuiltinColumns["Name"]). When hidden,
+	// ActiveNameHidden tells collectExtraColumns to skip the NAME width
+	// reservation so extras reclaim the freed space instead of leaving a gap.
+	nameHidden := ActiveMiddleScroll >= 0 && ActiveHiddenBuiltinColumns != nil && ActiveHiddenBuiltinColumns["Name"]
+	hasName := !nameHidden
+	ActiveNameHidden = nameHidden
+
 	var extraCols []extraColumn
 	if ActiveTableLayout != nil && ActiveTableLayout.Computed {
 		extraCols = ActiveTableLayout.ExtraCols
@@ -290,11 +298,12 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		}
 	}
 
-	order := orderedColumnKeys(hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge, extraCols)
+	order := orderedColumnKeys(hasName, hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge, extraCols)
 
 	if ActiveMiddleScroll >= 0 {
 		ActiveSortableColumns = ActiveSortableColumns[:0]
-		ActiveSortableColumns = append(ActiveSortableColumns, "Name")
+		// order now carries "Name" at its configured position, so the sortable
+		// list mirrors the on-screen column order directly.
 		ActiveSortableColumns = append(ActiveSortableColumns, order...)
 		ActiveSortableColumnCount = len(ActiveSortableColumns)
 		ActiveSortColumn = 0
@@ -312,6 +321,11 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 	}
 
 	nameW := max(width-contextW-nsW-readyW-restartsW-ageW-statusW-markerColW-extraTotalW-tileW, 10)
+	if nameHidden {
+		// No name cell is emitted (Name is absent from order); zero the width
+		// so the unused value can't be mistaken for a real reservation.
+		nameW = 0
+	}
 
 	if headerLabel == "" {
 		headerLabel = "NAME"
@@ -336,12 +350,12 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		// stays aligned with the data rows below.
 		hdrSegments = append(hdrSegments, headerSegment{text: " "})
 	}
-	hdrSegments = append(hdrSegments, headerSegment{text: nameHeader, colName: "Name"})
 	for _, key := range order {
-		hdrSegments = append(hdrSegments, headerSegment{
-			text:    headerCellForKey(key, colWidths, colHeaders, extraCols),
-			colName: key,
-		})
+		text := nameHeader
+		if key != "Name" {
+			text = headerCellForKey(key, colWidths, colHeaders, extraCols)
+		}
+		hdrSegments = append(hdrSegments, headerSegment{text: text, colName: key})
 	}
 	b.WriteString(renderStyledHeader(hdrSegments, width))
 	height--
@@ -355,10 +369,11 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		if tileW > 0 {
 			x += tileW
 		}
-		ActiveMiddleColumnLayout = append(ActiveMiddleColumnLayout, MiddleColumnRegion{Key: "Name", StartX: x, EndX: x + nameW})
-		x += nameW
 		for _, key := range order {
-			w := widthForColumnKey(key, colWidths, extraCols)
+			w := nameW
+			if key != "Name" {
+				w = widthForColumnKey(key, colWidths, extraCols)
+			}
 			ActiveMiddleColumnLayout = append(ActiveMiddleColumnLayout, MiddleColumnRegion{Key: key, StartX: x, EndX: x + w})
 			x += w
 		}

--- a/internal/ui/explorer_table_columns.go
+++ b/internal/ui/explorer_table_columns.go
@@ -1,5 +1,7 @@
 package ui
 
+import "slices"
+
 // isBuiltinColumnKey reports whether key is one of the fixed built-in item
 // field columns other than the union-only Context column. Context is excluded
 // because, when it isn't already requested via hasContext, an extras-defined
@@ -9,10 +11,15 @@ func isBuiltinColumnKey(key string) bool {
 	return ok && key != "Context"
 }
 
-// orderedColumnKeys returns the ordered list of column keys (excluding "Name")
-// that RenderTable should emit for a middle-column render.
-func orderedColumnKeys(hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge bool, extraCols []extraColumn) []string {
-	defaults := make([]string, 0, 6+len(extraCols))
+// orderedColumnKeys returns the ordered list of column keys that RenderTable
+// should emit for a middle-column render. "Name" is a first-class member of
+// the list (leading by default) so it can be reordered or hidden through the
+// same column-toggle machinery as every other column; hasName=false omits it.
+func orderedColumnKeys(hasName, hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge bool, extraCols []extraColumn) []string {
+	defaults := make([]string, 0, 7+len(extraCols))
+	if hasName {
+		defaults = append(defaults, "Name")
+	}
 	if hasContext {
 		defaults = append(defaults, "Context")
 	}
@@ -46,6 +53,16 @@ func orderedColumnKeys(hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasA
 
 	seen := make(map[string]bool, len(defaults))
 	ordered := make([]string, 0, len(defaults))
+
+	// Backward compatibility: saved orders that predate configurable Name omit
+	// the "Name" key. Without an explicit entry, Name keeps its historical
+	// pinned-first position instead of falling to the tail-append cleanup
+	// below. An order that DOES list "Name" (saved by the newer overlay)
+	// honours that position like any other column.
+	if visible["Name"] && !slices.Contains(ActiveColumnOrder, "Name") {
+		ordered = append(ordered, "Name")
+		seen["Name"] = true
+	}
 
 	for _, k := range ActiveColumnOrder {
 		if !visible[k] || seen[k] {


### PR DESCRIPTION
Closes #354.

## Summary

Makes the resource-list **Name** column a first-class, configurable column in the column-toggle overlay (`,`). Previously Name was hardcoded as always-first and never listed in the overlay. Now it can be **reordered** (`J`/`K`) and **hidden** (`Space`) like any other built-in column — e.g. arrange `Catalog, Task, Name` and hide `Namespace`.

When visible, Name still renders first by default, absorbs the row's leftover width, and compresses (truncates) when the other columns leave it little room.

## Changes

| Area | Change |
|---|---|
| `orderedColumnKeys` | `"Name"` is now a member of the column order. Backward-compat: saved orders predating this feature (no `"Name"` entry) keep Name pinned first; orders that explicitly list `"Name"` honor that position. |
| Row formatters | `formatTableRowOrdered` / `formatTableRowStyledOrdered` render the Name cell at its position in `order`; `"Name"` presence in the order is the single source of truth (no implicit prepend). |
| `RenderTable` | Computes `hasName` from `ActiveHiddenBuiltinColumns["Name"]`, sets `ActiveNameHidden`, unified header/layout/sortable loops. |
| `collectExtraColumns` | Drops the NAME width reservation when hidden so extras reclaim the freed space. |
| Overlay (`update_column_toggle.go`) | Lists Name; persists through the existing `columnOrder` / `hiddenBuiltinColumns` maps — no new plumbing. |
| Sort reset | Falls back to the first visible column when Name is hidden, mirroring the existing hidden-column guard in sort Next/Prev (issue #339). |
| Docs | `docs/keybindings.md` updated; removed the stale "Name is fixed / never listed" note. |

## Test plan

- [x] New unit/integration tests: `explorer_name_column_test.go`, `update_column_toggle_name_test.go`, `update_keys_sort_reset_test.go` (reorder, hide, default-first backward-compat, sort-reset coherence)
- [x] Updated tests that encoded the old "Name is mandatory" contract
- [x] `go build ./...`
- [x] `go test -race ./...` (no failures or data races)
- [x] `golangci-lint run ./internal/...` (0 issues)
- [x] `gofumpt` clean