### PR TITLE
fix(yaml): keep long scalars on one line in resource view (#355)

### DIFF
--- a/internal/k8s/client_operations.go
+++ b/internal/k8s/client_operations.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	yaml "gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -16,7 +18,6 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
@@ -60,11 +61,32 @@ func (c *Client) GetResourceYAML(ctx context.Context, contextName, namespace str
 
 	obj.SetManagedFields(nil)
 
-	data, err := yaml.Marshal(obj.Object)
+	data, err := marshalResourceYAML(obj.Object)
 	if err != nil {
 		return "", fmt.Errorf("marshalling to YAML: %w", err)
 	}
-	return reorderYAMLFields(string(data)), nil
+	return reorderYAMLFields(data), nil
+}
+
+// marshalResourceYAML renders a resource object to YAML for the YAML view.
+// It uses gopkg.in/yaml.v3 rather than sigs.k8s.io/yaml because the latter
+// wraps long scalar values at a hardcoded 80 columns (a yaml.v2 default),
+// which breaks both the layout and the per-line syntax highlighter for long
+// values such as status condition messages and Azure resource IDs (issue #355).
+// yaml.v3 keeps each scalar on a single line. SetIndent(2) preserves the
+// 2-space indentation the YAML view and folding logic expect.
+func marshalResourceYAML(obj map[string]any) (string, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(obj); err != nil {
+		_ = enc.Close()
+		return "", err
+	}
+	if err := enc.Close(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 // GetPodYAML returns the YAML for a pod.

--- a/internal/k8s/client_yaml_marshal_test.go
+++ b/internal/k8s/client_yaml_marshal_test.go
@@ -1,0 +1,79 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+// longScalar mirrors a real Kubernetes status condition message: a single
+// string value long enough that gopkg.in/yaml.v2 (used by sigs.k8s.io/yaml)
+// folds it across multiple physical lines at its hardcoded 80-column width.
+// See https://github.com/janosmiko/lfk/issues/355.
+const longScalar = `cannot compose resources: cannot check if composed resource "myappfullb3f4-queue-pe" is namespaced (a PrivateEndpoint named myappfullb3f4-queue-pe): failed to get restmapping: no matches for kind "PrivateEndpoint" in version "network.azure.m.upbound.io/v1beta1"`
+
+func TestMarshalResourceYAMLDoesNotWrapLongScalars(t *testing.T) {
+	obj := map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"message": longScalar},
+			},
+		},
+	}
+
+	out, err := marshalResourceYAML(obj)
+	if err != nil {
+		t.Fatalf("marshalResourceYAML: %v", err)
+	}
+
+	// The full value must survive on a single physical line. yaml.v2 would
+	// split it into three lines at ~80 columns, breaking both the visual
+	// layout and the per-line syntax highlighter.
+	if !strings.Contains(out, longScalar) {
+		t.Fatalf("long scalar was wrapped or altered; output:\n%s", out)
+	}
+
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(line, "is namespaced") && !strings.Contains(line, "cannot compose") {
+			t.Fatalf("scalar split across lines (continuation found alone):\n%s", out)
+		}
+	}
+}
+
+func TestMarshalResourceYAMLScalarTypesAndIndent(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"replicas": int64(3),
+			// Unstructured CRD integer fields often decode to float64; whole
+			// numbers must render without a trailing ".0" or scientific notation.
+			"observedGeneration": float64(3),
+			"ratio":              float64(1.5),
+			"enabled":            true,
+			"empty":              nil,
+			"version":            "123456789",
+			"items":              []any{"blob", "queue"},
+		},
+	}
+
+	out, err := marshalResourceYAML(obj)
+	if err != nil {
+		t.Fatalf("marshalResourceYAML: %v", err)
+	}
+
+	// Numeric strings stay quoted; ints/floats/bools/null render cleanly; no
+	// scientific notation for whole numbers. 2-space indentation is preserved.
+	for _, want := range []string{
+		"replicas: 3",
+		"observedGeneration: 3",
+		"ratio: 1.5",
+		"enabled: true",
+		"empty: null",
+		`version: "123456789"`,
+		"spec:",
+		"  items:",
+		"    - blob",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #355 — in the YAML resource view, long scalar values (Kubernetes status condition messages, long Azure resource IDs) were wrapped across multiple physical lines at a hardcoded ~80 columns. This caused **both** reported symptoms from a single root cause:

- **"Line wrapping not using full width"** — the value was folded at 80 cols regardless of terminal width (not lfk's own wrapping; the report's screenshot shows no `[WRAP]` mode).
- **"Syntax highlighting off"** — lfk's highlighter is per-line, so folded continuation lines were mis-parsed (e.g. `restmapping:` rendered as a *key*, `is namespaced...` as a plain value instead of string-green).

### Root cause
`GetResourceYAML` marshalled with `sigs.k8s.io/yaml`, which wraps `gopkg.in/yaml.v2` internally. yaml.v2 folds long scalars at a hardcoded `best_width = 80` with no public setter.

### Fix
Introduce `marshalResourceYAML`, backed by `gopkg.in/yaml.v3` (already a dependency) with `SetIndent(2)`. yaml.v3 keeps each scalar on a single line. `indentYAMLListItems` already re-indents sequences to the nested style yaml.v3 emits natively, so **displayed output is identical for normal cases** — only the broken 80-col fold is removed. The long value now highlights correctly (recognized as a single quoted string) and, in wrap mode, is split at the terminal width by lfk's own `WrapLine`.

## Test plan

- [x] New `client_yaml_marshal_test.go`: asserts long scalars stay on one physical line; verifies int64 / whole-number float64 / float / bool / null / numeric-string render correctly at 2-space indent (no scientific notation, numeric strings stay quoted).
- [x] `go test -race ./...` — all packages pass.
- [x] `golangci-lint run` — 0 issues; `go vet` / `gofmt` clean.
- [x] go-reviewer pass — no CRITICAL/HIGH findings.