### PR TITLE
feat: persist resource-list sort order and column layout across restarts

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -917,6 +917,7 @@ The application follows the [XDG Base Directory Specification](https://specifica
 | `$XDG_CONFIG_HOME/lfk/config.yaml` | Main configuration file (default: `~/.config/lfk/config.yaml`) |
 | `$XDG_STATE_HOME/lfk/bookmarks.yaml` | Saved bookmarks (default: `~/.local/state/lfk/bookmarks.yaml`) |
 | `$XDG_STATE_HOME/lfk/session.yaml` | Last session state, auto-managed (default: `~/.local/state/lfk/session.yaml`) |
+| `$XDG_STATE_HOME/lfk/sort_memory.yaml` | Per-context and per-resource-kind sort column/order, auto-managed (default: `~/.local/state/lfk/sort_memory.yaml`) |
 | `$XDG_STATE_HOME/lfk/pinned.yaml` | Per-context and per-union-set pinned CRD groups, managed via `p` key (default: `~/.local/state/lfk/pinned.yaml`) |
 | `$XDG_STATE_HOME/lfk/hidden_types.yaml` | Per-context and per-union-set hidden resource types, managed via the action menu (`x`) at the resource types level (default: `~/.local/state/lfk/hidden_types.yaml`) |
 | `~/.local/share/lfk/lfk.log` (default) | Application log file (configurable via `log_path`) |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -918,6 +918,7 @@ The application follows the [XDG Base Directory Specification](https://specifica
 | `$XDG_STATE_HOME/lfk/bookmarks.yaml` | Saved bookmarks (default: `~/.local/state/lfk/bookmarks.yaml`) |
 | `$XDG_STATE_HOME/lfk/session.yaml` | Last session state, auto-managed (default: `~/.local/state/lfk/session.yaml`) |
 | `$XDG_STATE_HOME/lfk/sort_memory.yaml` | Per-context and per-resource-kind sort column/order, auto-managed (default: `~/.local/state/lfk/sort_memory.yaml`) |
+| `$XDG_STATE_HOME/lfk/column_prefs.yaml` | Per-context and per-resource-kind column visibility/order from the `,` toggle overlay, auto-managed (default: `~/.local/state/lfk/column_prefs.yaml`) |
 | `$XDG_STATE_HOME/lfk/pinned.yaml` | Per-context and per-union-set pinned CRD groups, managed via `p` key (default: `~/.local/state/lfk/pinned.yaml`) |
 | `$XDG_STATE_HOME/lfk/hidden_types.yaml` | Per-context and per-union-set hidden resource types, managed via the action menu (`x`) at the resource types level (default: `~/.local/state/lfk/hidden_types.yaml`) |
 | `~/.local/share/lfk/lfk.log` (default) | Application log file (configurable via `log_path`) |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -55,7 +55,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `=` | Toggle sort direction (ascending/descending) |
 | `-` | Reset sort to default (Name ascending) |
 
-Your chosen sort is remembered per resource kind for the running session, so leaving a list and returning keeps your sort instead of resetting.
+Your chosen sort is remembered per resource kind and per cluster context, and persists across restarts (stored in `~/.local/state/lfk/sort_memory.yaml`), so leaving a list and returning — or quitting and reopening lfk — keeps your sort instead of resetting. Use `-` (reset) to drop a remembered sort.
 
 ## Modes & Settings
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -495,8 +495,10 @@ other columns leave it little room.
 The selection you apply is explicit: the table renders exactly the
 columns you check, in the exact order they appear in the overlay, and
 will not auto-fill the remaining space with unchecked columns. The
-chosen order is remembered per resource kind for the duration of the
-session (it is not persisted to disk). To start from a clean slate,
+chosen visibility and order are remembered per resource kind and per
+cluster context, and persist across restarts (stored in
+`~/.local/state/lfk/column_prefs.yaml`) — committed on `Enter`, cleared
+by `R`; `Esc` discards uncommitted edits. To start from a clean slate,
 press `c` to uncheck every entry at once, then space-select only the
 columns you want.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -147,7 +147,7 @@ type Model struct {
 
 	sortColumnName string              // which column to sort by (e.g. "Name", "Age")
 	sortAscending  bool                // true = ascending, false = descending
-	sortMemory     map[string]sortPref // remembered sort per resource kind (context+GVR), session-only
+	sortMemory     map[string]sortPref // remembered sort per resource kind (context+GVR), persisted to sort_memory.yaml
 	// Status message (temporary, shown in status bar).
 	statusMessage    string
 	statusMessageErr bool

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -39,6 +39,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	pinnedSt := loadPinnedState()
 	hiddenSt := loadHiddenTypesState()
 	sortMem := loadSortMemory()
+	colPrefs := loadColumnPrefs()
 	m := Model{
 		client: client,
 		// Start in the loading state. Init() dispatches loadContexts()
@@ -70,6 +71,9 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		sortColumnName:             sortColDefault,
 		sortAscending:              true,
 		sortMemory:                 sortMem,
+		sessionColumns:             colPrefs.sessionColumns,
+		hiddenBuiltinColumns:       colPrefs.hiddenBuiltinColumns,
+		columnOrder:                colPrefs.columnOrder,
 		cursorMemory:               make(map[string]int),
 		filterMemory:               make(map[string]savedFilter),
 		itemCache:                  make(map[string][]model.Item),

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -38,6 +38,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	reqCtx, reqCancel := context.WithCancel(context.Background())
 	pinnedSt := loadPinnedState()
 	hiddenSt := loadHiddenTypesState()
+	sortMem := loadSortMemory()
 	m := Model{
 		client: client,
 		// Start in the loading state. Init() dispatches loadContexts()
@@ -68,7 +69,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		localClusterFields:         localClusterFields{localClusterCache: loadLocalClusterState()},
 		sortColumnName:             sortColDefault,
 		sortAscending:              true,
-		sortMemory:                 make(map[string]sortPref),
+		sortMemory:                 sortMem,
 		cursorMemory:               make(map[string]int),
 		filterMemory:               make(map[string]savedFilter),
 		itemCache:                  make(map[string][]model.Item),
@@ -103,7 +104,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 			readOnly:           ui.ResolveReadOnly(contextName, opts.ReadOnly),
 			sortColumnName:     sortColDefault,
 			sortAscending:      true,
-			sortMemory:         make(map[string]sortPref),
+			sortMemory:         copyMapStringSortPref(sortMem),
 			warningEventsOnly:  true,
 			eventGrouping:      true,
 			allGroupsExpanded:  true,

--- a/internal/app/app_sort.go
+++ b/internal/app/app_sort.go
@@ -60,7 +60,9 @@ func (m *Model) rememberSort() {
 	if m.sortMemory == nil {
 		m.sortMemory = make(map[string]sortPref)
 	}
-	m.sortMemory[key] = sortPref{column: m.sortColumnName, ascending: m.sortAscending}
+	pref := sortPref{column: m.sortColumnName, ascending: m.sortAscending}
+	m.sortMemory[key] = pref
+	persistRememberedSort(key, pref)
 }
 
 // forgetSort drops any remembered sort for the resource kind currently in
@@ -70,6 +72,7 @@ func (m *Model) rememberSort() {
 func (m *Model) forgetSort() {
 	if key, ok := m.currentSortKey(); ok {
 		delete(m.sortMemory, key)
+		persistForgottenSort(key)
 	}
 }
 

--- a/internal/app/app_sort_memory_test.go
+++ b/internal/app/app_sort_memory_test.go
@@ -142,3 +142,46 @@ func TestRememberSort_SkipsWhenSortNotApplicable(t *testing.T) {
 		t.Fatalf("sortMemory has %d entries, want 0 at non-sortable level", len(m.sortMemory))
 	}
 }
+
+// TestRememberSort_PersistsAcrossRestart verifies a user sort change is written
+// to the state file so it survives an app restart (issue #353): rememberSort
+// persists, and a fresh loadSortMemory recovers the same preference.
+func TestRememberSort_PersistsAcrossRestart(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	rt := model.ResourceTypeEntry{APIGroup: "apps", APIVersion: "v1", Resource: "deployments", Kind: "Deployment"}
+	m := &Model{sortMemory: make(map[string]sortPref)}
+	m.nav = model.NavigationState{Level: model.LevelResources, Context: "ctx", ResourceType: rt}
+	m.sortColumnName = "CPU"
+	m.sortAscending = false
+	m.rememberSort()
+
+	// Simulate a restart: load fresh from disk.
+	reloaded := loadSortMemory()
+	ref := ui.ResourceRef{Group: "apps", Version: "v1", Resource: "deployments", Kind: "Deployment"}
+	got, ok := reloaded[sortMemoryKey(ref, "ctx")]
+	if !ok {
+		t.Fatalf("remembered sort not persisted; reloaded map = %v", reloaded)
+	}
+	if got.column != "CPU" || got.ascending {
+		t.Fatalf("reloaded sort = %q asc=%v, want CPU desc", got.column, got.ascending)
+	}
+}
+
+// TestForgetSort_PersistsRemoval verifies the sort-reset action persists the
+// removal, so a reset survives a restart instead of resurrecting the old sort.
+func TestForgetSort_PersistsRemoval(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	rt := model.ResourceTypeEntry{APIGroup: "apps", APIVersion: "v1", Resource: "deployments", Kind: "Deployment"}
+	m := &Model{sortMemory: make(map[string]sortPref)}
+	m.nav = model.NavigationState{Level: model.LevelResources, Context: "ctx", ResourceType: rt}
+	m.sortColumnName = "CPU"
+	m.sortAscending = false
+	m.rememberSort()
+	m.forgetSort()
+
+	if reloaded := loadSortMemory(); len(reloaded) != 0 {
+		t.Fatalf("reloaded map has %d entries after reset, want 0", len(reloaded))
+	}
+}

--- a/internal/app/column_prefs.go
+++ b/internal/app/column_prefs.go
@@ -1,0 +1,184 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
+)
+
+// persistedColumnPrefs is the on-disk form of a single kind's committed column
+// layout: display order, visible extra columns, and hidden built-in columns.
+type persistedColumnPrefs struct {
+	Order []string `json:"order,omitempty" yaml:"order,omitempty"`
+	// VisibleExtras has no omitempty: a non-nil empty slice means "user
+	// explicitly configured no extra columns" and must round-trip distinctly
+	// from an absent entry (auto-detect). See applySessionColumnsForKind.
+	VisibleExtras  []string `json:"visible_extras" yaml:"visible_extras"`
+	HiddenBuiltins []string `json:"hidden_builtins,omitempty" yaml:"hidden_builtins,omitempty"`
+}
+
+// ColumnPrefsState is the on-disk schema for committed per-kind column layouts,
+// scoped by kube context then Kind (matching columnMemoryKey). It mirrors the
+// sort-memory state file.
+type ColumnPrefsState struct {
+	Contexts map[string]map[string]persistedColumnPrefs `json:"contexts" yaml:"contexts"`
+}
+
+// columnPrefsFilePath returns the path to the column-prefs state file.
+func columnPrefsFilePath() string {
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "column_prefs.yaml")
+}
+
+// loadColumnPrefsState reads the raw nested state from disk, returning an empty
+// (never nil Contexts) value when the file is missing or corrupt.
+func loadColumnPrefsState() ColumnPrefsState {
+	empty := ColumnPrefsState{Contexts: map[string]map[string]persistedColumnPrefs{}}
+	path := columnPrefsFilePath()
+	if path == "" {
+		return empty
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Warn("Failed to read column-prefs state", "error", err, "path", path)
+		}
+		return empty
+	}
+	var s ColumnPrefsState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		logger.Warn("Column-prefs file is corrupt; starting fresh", "error", err, "path", path)
+		return empty
+	}
+	if s.Contexts == nil {
+		s.Contexts = map[string]map[string]persistedColumnPrefs{}
+	}
+	return s
+}
+
+// saveColumnPrefsState writes the nested state to disk.
+func saveColumnPrefsState(s ColumnPrefsState) error {
+	path := columnPrefsFilePath()
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// columnPrefMaps bundles the three in-memory column maps for seeding the model.
+type columnPrefMaps struct {
+	sessionColumns       map[string][]string
+	hiddenBuiltinColumns map[string][]string
+	columnOrder          map[string][]string
+}
+
+// loadColumnPrefs reads committed column layouts from disk and flattens them
+// into the three "context\x00kind"-keyed maps the model uses. All three maps are
+// non-nil. A persisted entry always carries VisibleExtras (a committed layout
+// always records the visible-extras set, possibly empty); Order and
+// HiddenBuiltins are populated only when present.
+func loadColumnPrefs() columnPrefMaps {
+	maps := columnPrefMaps{
+		sessionColumns:       map[string][]string{},
+		hiddenBuiltinColumns: map[string][]string{},
+		columnOrder:          map[string][]string{},
+	}
+	state := loadColumnPrefsState()
+	for ctx, kinds := range state.Contexts {
+		for kind, p := range kinds {
+			key := ctx + "\x00" + kind
+			extras := p.VisibleExtras
+			if extras == nil {
+				extras = []string{}
+			}
+			maps.sessionColumns[key] = extras
+			if len(p.HiddenBuiltins) > 0 {
+				maps.hiddenBuiltinColumns[key] = p.HiddenBuiltins
+			}
+			if len(p.Order) > 0 {
+				maps.columnOrder[key] = p.Order
+			}
+		}
+	}
+	return maps
+}
+
+// persistColumnPrefsEntry writes one kind's committed column layout to disk,
+// merging with other contexts/kinds so a commit for one never drops another's.
+// Best-effort. Runs only on the single Bubble Tea Update goroutine (commit/reset
+// handlers), so the load-modify-save is never concurrent.
+func persistColumnPrefsEntry(key string, p persistedColumnPrefs) {
+	ctx, kind, ok := strings.Cut(key, "\x00")
+	if !ok {
+		return
+	}
+	state := loadColumnPrefsState()
+	if state.Contexts[ctx] == nil {
+		state.Contexts[ctx] = map[string]persistedColumnPrefs{}
+	}
+	state.Contexts[ctx][kind] = p
+	if err := saveColumnPrefsState(state); err != nil {
+		logger.Error("Failed to persist column prefs", "error", err)
+	}
+}
+
+// persistForgottenColumnPrefs removes one kind's column layout from disk (the
+// reset action or a total-clear commit), leaving every other entry intact.
+func persistForgottenColumnPrefs(key string) {
+	ctx, kind, ok := strings.Cut(key, "\x00")
+	if !ok {
+		return
+	}
+	state := loadColumnPrefsState()
+	kinds, ok := state.Contexts[ctx]
+	if !ok {
+		return
+	}
+	if _, ok := kinds[kind]; !ok {
+		return
+	}
+	delete(kinds, kind)
+	if len(kinds) == 0 {
+		delete(state.Contexts, ctx)
+	}
+	if err := saveColumnPrefsState(state); err != nil {
+		logger.Error("Failed to persist column prefs", "error", err)
+	}
+}
+
+// persistColumnPrefs persists (or clears) the committed column layout for the
+// kind currently shown in the middle column. Called on Enter (commit) and R
+// (reset) from the column-toggle overlay — never on live-apply, so an Esc that
+// reverts the in-memory maps leaves the on-disk layout untouched.
+func (m *Model) persistColumnPrefs() {
+	key := m.columnMemoryKey(m.middleColumnKind())
+	extras, ok := m.sessionColumns[key]
+	if !ok {
+		// No session entry means the layout was reset / cleared; drop it.
+		persistForgottenColumnPrefs(key)
+		return
+	}
+	if extras == nil {
+		extras = []string{}
+	}
+	persistColumnPrefsEntry(key, persistedColumnPrefs{
+		Order:          m.columnOrder[key],
+		VisibleExtras:  extras,
+		HiddenBuiltins: m.hiddenBuiltinColumns[key],
+	})
+}

--- a/internal/app/column_prefs_test.go
+++ b/internal/app/column_prefs_test.go
@@ -15,11 +15,13 @@ import (
 
 func TestColumnPrefsFilePath(t *testing.T) {
 	t.Run("uses XDG_STATE_HOME", func(t *testing.T) {
+		t.Setenv("LFK_STATE_DIR", "") // takes precedence over XDG; clear it
 		t.Setenv("XDG_STATE_HOME", "/custom/state")
 		assert.Equal(t, "/custom/state/lfk/column_prefs.yaml", columnPrefsFilePath())
 	})
 
 	t.Run("falls back to home", func(t *testing.T) {
+		t.Setenv("LFK_STATE_DIR", "")
 		t.Setenv("XDG_STATE_HOME", "")
 		assert.Contains(t, columnPrefsFilePath(), filepath.Join(".local", "state", "lfk", "column_prefs.yaml"))
 	})
@@ -64,7 +66,6 @@ func TestLoadColumnPrefsMissingFile(t *testing.T) {
 func TestLoadColumnPrefsCorrupt(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("LFK_STATE_DIR", dir)
-	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "column_prefs.yaml"), []byte("{bad: ["), 0o644))
 
 	maps := loadColumnPrefs()

--- a/internal/app/column_prefs_test.go
+++ b/internal/app/column_prefs_test.go
@@ -1,0 +1,196 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// --- columnPrefsFilePath ---
+
+func TestColumnPrefsFilePath(t *testing.T) {
+	t.Run("uses XDG_STATE_HOME", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", "/custom/state")
+		assert.Equal(t, "/custom/state/lfk/column_prefs.yaml", columnPrefsFilePath())
+	})
+
+	t.Run("falls back to home", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", "")
+		assert.Contains(t, columnPrefsFilePath(), filepath.Join(".local", "state", "lfk", "column_prefs.yaml"))
+	})
+}
+
+// --- save/load round-trip via the delta API ---
+
+func TestColumnPrefsRoundTrip(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	persistColumnPrefsEntry("prod\x00Deployment", persistedColumnPrefs{
+		Order:          []string{"Name", "cpu", "Status"},
+		VisibleExtras:  []string{"cpu"},
+		HiddenBuiltins: []string{"Age"},
+	})
+	persistColumnPrefsEntry("dev\x00Pod", persistedColumnPrefs{
+		Order:         []string{"Name", "Status"},
+		VisibleExtras: []string{},
+	})
+
+	maps := loadColumnPrefs()
+	assert.Equal(t, []string{"cpu"}, maps.sessionColumns["prod\x00Deployment"])
+	assert.Equal(t, []string{"Age"}, maps.hiddenBuiltinColumns["prod\x00Deployment"])
+	assert.Equal(t, []string{"Name", "cpu", "Status"}, maps.columnOrder["prod\x00Deployment"])
+
+	// "no extras" round-trips as a non-nil empty slice (auto-detect off).
+	got, ok := maps.sessionColumns["dev\x00Pod"]
+	require.True(t, ok)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestLoadColumnPrefsMissingFile(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+	maps := loadColumnPrefs()
+	assert.NotNil(t, maps.sessionColumns)
+	assert.NotNil(t, maps.hiddenBuiltinColumns)
+	assert.NotNil(t, maps.columnOrder)
+	assert.Empty(t, maps.sessionColumns)
+}
+
+func TestLoadColumnPrefsCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LFK_STATE_DIR", dir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "column_prefs.yaml"), []byte("{bad: ["), 0o644))
+
+	maps := loadColumnPrefs()
+	assert.Empty(t, maps.sessionColumns)
+	assert.Empty(t, maps.columnOrder)
+}
+
+// --- delta persistence merges rather than clobbering ---
+
+func TestPersistColumnPrefsEntryMerges(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	persistColumnPrefsEntry("prod\x00Deployment", persistedColumnPrefs{VisibleExtras: []string{"cpu"}})
+	persistColumnPrefsEntry("prod\x00Pod", persistedColumnPrefs{VisibleExtras: []string{"mem"}})
+
+	maps := loadColumnPrefs()
+	assert.Equal(t, []string{"cpu"}, maps.sessionColumns["prod\x00Deployment"])
+	assert.Equal(t, []string{"mem"}, maps.sessionColumns["prod\x00Pod"])
+}
+
+func TestPersistForgottenColumnPrefsRemovesOnlyTarget(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	persistColumnPrefsEntry("prod\x00Deployment", persistedColumnPrefs{VisibleExtras: []string{"cpu"}})
+	persistColumnPrefsEntry("prod\x00Pod", persistedColumnPrefs{VisibleExtras: []string{"mem"}})
+
+	persistForgottenColumnPrefs("prod\x00Pod")
+
+	maps := loadColumnPrefs()
+	_, hasDep := maps.sessionColumns["prod\x00Deployment"]
+	_, hasPod := maps.sessionColumns["prod\x00Pod"]
+	assert.True(t, hasDep)
+	assert.False(t, hasPod)
+}
+
+func TestPersistForgottenColumnPrefsNoEntryIsNoop(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+	persistForgottenColumnPrefs("prod\x00Deployment") // nothing persisted yet
+	assert.Empty(t, loadColumnPrefs().sessionColumns)
+}
+
+// --- model-level commit / reset persistence ---
+
+func TestPersistColumnPrefs_CommitsCurrentKind(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	m := &Model{
+		sessionColumns:       map[string][]string{"prod\x00Deployment": {"cpu"}},
+		hiddenBuiltinColumns: map[string][]string{"prod\x00Deployment": {"Age"}},
+		columnOrder:          map[string][]string{"prod\x00Deployment": {"Name", "cpu"}},
+	}
+	m.nav.Context = "prod"
+	m.nav.ResourceType.Kind = "Deployment"
+	m.nav.Level = 0 // forces middleColumnKind to fall back appropriately; overridden below
+
+	// Drive the key explicitly to avoid depending on middleColumnKind internals.
+	key := m.columnMemoryKey(m.middleColumnKind())
+	m.sessionColumns[key] = m.sessionColumns["prod\x00Deployment"]
+	m.hiddenBuiltinColumns[key] = m.hiddenBuiltinColumns["prod\x00Deployment"]
+	m.columnOrder[key] = m.columnOrder["prod\x00Deployment"]
+
+	m.persistColumnPrefs()
+
+	maps := loadColumnPrefs()
+	assert.Equal(t, []string{"cpu"}, maps.sessionColumns[key])
+	assert.Equal(t, []string{"Age"}, maps.hiddenBuiltinColumns[key])
+	assert.Equal(t, []string{"Name", "cpu"}, maps.columnOrder[key])
+}
+
+// TestColumnToggleEnterPersists drives the real Enter-commit handler and
+// verifies the committed layout reaches disk and survives a reload (the
+// restart path).
+func TestColumnToggleEnterPersists(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	m := baseModelCov()
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods"}
+	m.nav.Context = "prod"
+	m.columnToggleItems = []columnToggleEntry{
+		{key: "Name", visible: true, builtin: true},
+		{key: "Ready", visible: false, builtin: true},
+		{key: "IP", visible: true, builtin: false},
+	}
+
+	m.handleColumnToggleKeyEnter()
+
+	key := "prod\x00pod"
+	maps := loadColumnPrefs()
+	assert.Equal(t, []string{"IP"}, maps.sessionColumns[key])
+	assert.Equal(t, []string{"Ready"}, maps.hiddenBuiltinColumns[key])
+	assert.Equal(t, []string{"Name", "IP"}, maps.columnOrder[key])
+}
+
+// TestColumnToggleResetPersists verifies R drops the persisted layout so a
+// reset survives a restart.
+func TestColumnToggleResetPersists(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	persistColumnPrefsEntry("prod\x00pod", persistedColumnPrefs{VisibleExtras: []string{"IP"}})
+
+	m := baseModelCov()
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods"}
+	m.nav.Context = "prod"
+	// Seed the in-memory entry so R has something to clear.
+	m.sessionColumns = map[string][]string{"prod\x00pod": {"IP"}}
+
+	m.handleColumnToggleKeyR()
+
+	assert.Empty(t, loadColumnPrefs().sessionColumns)
+}
+
+func TestPersistColumnPrefs_ResetRemovesEntry(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	m := &Model{
+		sessionColumns:       map[string][]string{},
+		hiddenBuiltinColumns: map[string][]string{},
+		columnOrder:          map[string][]string{},
+	}
+	m.nav.Context = "prod"
+	m.nav.ResourceType.Kind = "Deployment"
+	key := m.columnMemoryKey(m.middleColumnKind())
+
+	// Commit then clear (mirrors the overlay's R reset path: maps emptied first).
+	persistColumnPrefsEntry(key, persistedColumnPrefs{VisibleExtras: []string{"cpu"}})
+	m.persistColumnPrefs() // sessionColumns has no key -> forgotten
+
+	assert.Empty(t, loadColumnPrefs().sessionColumns)
+}

--- a/internal/app/portable_dirs_test.go
+++ b/internal/app/portable_dirs_test.go
@@ -20,6 +20,7 @@ func TestPortableStateDir(t *testing.T) {
 	}{
 		{"session", sessionFilePath(), filepath.Join(stateDir, "session.yaml")},
 		{"sort-memory", sortMemoryFilePath(), filepath.Join(stateDir, "sort_memory.yaml")},
+		{"column-prefs", columnPrefsFilePath(), filepath.Join(stateDir, "column_prefs.yaml")},
 		{"pinned", pinnedFilePath(), filepath.Join(stateDir, "pinned.yaml")},
 		{"bookmarks", bookmarksFilePath(), filepath.Join(stateDir, "bookmarks.yaml")},
 		{"cluster-colors", clusterColorsFilePath(), filepath.Join(stateDir, "cluster-colors.yaml")},

--- a/internal/app/portable_dirs_test.go
+++ b/internal/app/portable_dirs_test.go
@@ -19,6 +19,7 @@ func TestPortableStateDir(t *testing.T) {
 		want string
 	}{
 		{"session", sessionFilePath(), filepath.Join(stateDir, "session.yaml")},
+		{"sort-memory", sortMemoryFilePath(), filepath.Join(stateDir, "sort_memory.yaml")},
 		{"pinned", pinnedFilePath(), filepath.Join(stateDir, "pinned.yaml")},
 		{"bookmarks", bookmarksFilePath(), filepath.Join(stateDir, "bookmarks.yaml")},
 		{"cluster-colors", clusterColorsFilePath(), filepath.Join(stateDir, "cluster-colors.yaml")},

--- a/internal/app/sort_memory.go
+++ b/internal/app/sort_memory.go
@@ -1,0 +1,135 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
+)
+
+// persistedSortPref is the on-disk form of sortPref. sortPref's fields are
+// unexported (so they never leak across packages); this mirror exposes them for
+// YAML serialisation.
+type persistedSortPref struct {
+	Column    string `json:"column" yaml:"column"`
+	Ascending bool   `json:"ascending" yaml:"ascending"`
+}
+
+// SortMemoryState is the on-disk schema for remembered per-kind sort
+// preferences. It mirrors HiddenTypesState/PinnedState scoping: a kube context
+// maps to a set of resource kinds (keyed by GVR) and their chosen sort. The
+// in-memory representation flattens this to a "context\x00gvr" keyed map; see
+// sortMemoryKey in app_sort.go.
+type SortMemoryState struct {
+	Contexts map[string]map[string]persistedSortPref `json:"contexts" yaml:"contexts"`
+}
+
+// sortMemoryFilePath returns the path to the sort-memory state file.
+func sortMemoryFilePath() string {
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "sort_memory.yaml")
+}
+
+// sortMemoryToState converts the in-memory "context\x00gvr" keyed map into the
+// nested on-disk shape. Keys missing the separator are dropped defensively.
+func sortMemoryToState(mem map[string]sortPref) SortMemoryState {
+	s := SortMemoryState{Contexts: make(map[string]map[string]persistedSortPref)}
+	for key, pref := range mem {
+		context, gvr, ok := strings.Cut(key, "\x00")
+		if !ok {
+			continue
+		}
+		if s.Contexts[context] == nil {
+			s.Contexts[context] = make(map[string]persistedSortPref)
+		}
+		s.Contexts[context][gvr] = persistedSortPref{Column: pref.column, Ascending: pref.ascending}
+	}
+	return s
+}
+
+// sortMemoryFromState flattens the nested on-disk shape back into the in-memory
+// "context\x00gvr" keyed map. Never nil.
+func sortMemoryFromState(s SortMemoryState) map[string]sortPref {
+	mem := make(map[string]sortPref)
+	for context, kinds := range s.Contexts {
+		for gvr, pref := range kinds {
+			mem[context+"\x00"+gvr] = sortPref{column: pref.Column, ascending: pref.Ascending}
+		}
+	}
+	return mem
+}
+
+// loadSortMemory reads remembered sort preferences from disk, returning an empty
+// (never nil) map when the file is missing or corrupt.
+func loadSortMemory() map[string]sortPref {
+	path := sortMemoryFilePath()
+	if path == "" {
+		return make(map[string]sortPref)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Warn("Failed to read sort-memory state", "error", err, "path", path)
+		}
+		return make(map[string]sortPref)
+	}
+	var s SortMemoryState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		logger.Warn("Sort-memory file is corrupt; starting fresh", "error", err, "path", path)
+		return make(map[string]sortPref)
+	}
+	return sortMemoryFromState(s)
+}
+
+// saveSortMemory writes remembered sort preferences to disk.
+func saveSortMemory(mem map[string]sortPref) error {
+	path := sortMemoryFilePath()
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(sortMemoryToState(mem))
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// persistRememberedSort writes a single remembered sort pref to disk, merging it
+// with prefs persisted by other tabs/contexts so a sort in one tab never
+// clobbers another's (sortMemory is per-tab; the state file is shared).
+// Best-effort: a write failure means the sort won't survive the next restart, so
+// log it for disk-full / permissions diagnosis from lfk.log.
+//
+// The load-modify-save is unsynchronised. Callers run on the single Bubble Tea
+// Update goroutine (rememberSort/forgetSort from key and mouse handlers), so the
+// sequence is never concurrent; do not call this from a background goroutine.
+func persistRememberedSort(key string, pref sortPref) {
+	mem := loadSortMemory()
+	mem[key] = pref
+	if err := saveSortMemory(mem); err != nil {
+		logger.Error("Failed to persist sort memory", "error", err)
+	}
+}
+
+// persistForgottenSort removes a single sort pref from disk (the sort-reset
+// action), leaving every other remembered sort intact. Best-effort.
+func persistForgottenSort(key string) {
+	mem := loadSortMemory()
+	if _, ok := mem[key]; !ok {
+		return
+	}
+	delete(mem, key)
+	if err := saveSortMemory(mem); err != nil {
+		logger.Error("Failed to persist sort memory", "error", err)
+	}
+}

--- a/internal/app/sort_memory_test.go
+++ b/internal/app/sort_memory_test.go
@@ -13,12 +13,14 @@ import (
 
 func TestSortMemoryFilePath(t *testing.T) {
 	t.Run("uses XDG_STATE_HOME", func(t *testing.T) {
+		t.Setenv("LFK_STATE_DIR", "") // takes precedence over XDG; clear it
 		t.Setenv("XDG_STATE_HOME", "/custom/state")
 		path := sortMemoryFilePath()
 		assert.Equal(t, "/custom/state/lfk/sort_memory.yaml", path)
 	})
 
 	t.Run("falls back to home", func(t *testing.T) {
+		t.Setenv("LFK_STATE_DIR", "")
 		t.Setenv("XDG_STATE_HOME", "")
 		path := sortMemoryFilePath()
 		assert.Contains(t, path, filepath.Join(".local", "state", "lfk", "sort_memory.yaml"))
@@ -53,7 +55,6 @@ func TestLoadSortMemoryMissingFile(t *testing.T) {
 func TestLoadSortMemoryCorrupt(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("LFK_STATE_DIR", dir)
-	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sort_memory.yaml"), []byte("{not: valid: yaml: ["), 0o644))
 
 	got := loadSortMemory()
@@ -61,14 +62,14 @@ func TestLoadSortMemoryCorrupt(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func TestLoadSortMemorySkipsMalformedKeys(t *testing.T) {
+func TestLoadSortMemoryRebuildsValidKeys(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("LFK_STATE_DIR", dir)
 
-	// A persisted file with a context holding one entry; the in-memory key is
-	// rebuilt as context\x00gvr, so a well-formed file always yields valid keys.
+	// The nested on-disk shape is flattened back to context\x00gvr keys. (The
+	// malformed-key skip lives on the save side and is covered by
+	// TestSortMemoryToStateSkipsMalformedKeys.)
 	yaml := "contexts:\n  prod:\n    apps/v1/deployments:\n      column: Ready\n      ascending: false\n"
-	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sort_memory.yaml"), []byte(yaml), 0o644))
 
 	got := loadSortMemory()

--- a/internal/app/sort_memory_test.go
+++ b/internal/app/sort_memory_test.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- sortMemoryFilePath ---
+
+func TestSortMemoryFilePath(t *testing.T) {
+	t.Run("uses XDG_STATE_HOME", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", "/custom/state")
+		path := sortMemoryFilePath()
+		assert.Equal(t, "/custom/state/lfk/sort_memory.yaml", path)
+	})
+
+	t.Run("falls back to home", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", "")
+		path := sortMemoryFilePath()
+		assert.Contains(t, path, filepath.Join(".local", "state", "lfk", "sort_memory.yaml"))
+	})
+}
+
+// --- save / load round-trip ---
+
+func TestSortMemoryRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LFK_STATE_DIR", dir)
+
+	mem := map[string]sortPref{
+		"prod\x00apps/v1/deployments": {column: "Ready", ascending: false},
+		"prod\x00/v1/pods":            {column: "Status", ascending: true},
+		"dev\x00/v1/pods":             {column: "Name", ascending: true},
+	}
+
+	require.NoError(t, saveSortMemory(mem))
+
+	got := loadSortMemory()
+	assert.Equal(t, mem, got)
+}
+
+func TestLoadSortMemoryMissingFile(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+	got := loadSortMemory()
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestLoadSortMemoryCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LFK_STATE_DIR", dir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sort_memory.yaml"), []byte("{not: valid: yaml: ["), 0o644))
+
+	got := loadSortMemory()
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestLoadSortMemorySkipsMalformedKeys(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LFK_STATE_DIR", dir)
+
+	// A persisted file with a context holding one entry; the in-memory key is
+	// rebuilt as context\x00gvr, so a well-formed file always yields valid keys.
+	yaml := "contexts:\n  prod:\n    apps/v1/deployments:\n      column: Ready\n      ascending: false\n"
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sort_memory.yaml"), []byte(yaml), 0o644))
+
+	got := loadSortMemory()
+	assert.Equal(t, map[string]sortPref{
+		"prod\x00apps/v1/deployments": {column: "Ready", ascending: false},
+	}, got)
+}
+
+// --- conversion helpers ---
+
+func TestSortMemoryStateConversion(t *testing.T) {
+	mem := map[string]sortPref{
+		"prod\x00apps/v1/deployments": {column: "Ready", ascending: false},
+		"prod\x00/v1/pods":            {column: "Status", ascending: true},
+	}
+
+	state := sortMemoryToState(mem)
+	require.Len(t, state.Contexts, 1)
+	assert.Equal(t, persistedSortPref{Column: "Ready", Ascending: false}, state.Contexts["prod"]["apps/v1/deployments"])
+	assert.Equal(t, persistedSortPref{Column: "Status", Ascending: true}, state.Contexts["prod"]["/v1/pods"])
+
+	// Round-trips back to the same in-memory map.
+	assert.Equal(t, mem, sortMemoryFromState(state))
+}
+
+func TestSortMemoryToStateSkipsMalformedKeys(t *testing.T) {
+	mem := map[string]sortPref{
+		"nogvrkey":                    {column: "Name", ascending: true}, // missing \x00 separator
+		"prod\x00apps/v1/deployments": {column: "Ready", ascending: false},
+	}
+	state := sortMemoryToState(mem)
+	require.Len(t, state.Contexts, 1)
+	assert.Equal(t, persistedSortPref{Column: "Ready", Ascending: false}, state.Contexts["prod"]["apps/v1/deployments"])
+}
+
+// --- delta persistence merges rather than clobbering ---
+
+func TestPersistRememberedSortMerges(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	// Tab A persists a sort for deployments.
+	persistRememberedSort("prod\x00apps/v1/deployments", sortPref{column: "Ready", ascending: false})
+	// Tab B (different kind) persists its own sort; must not drop tab A's.
+	persistRememberedSort("prod\x00/v1/pods", sortPref{column: "Status", ascending: true})
+
+	got := loadSortMemory()
+	assert.Equal(t, map[string]sortPref{
+		"prod\x00apps/v1/deployments": {column: "Ready", ascending: false},
+		"prod\x00/v1/pods":            {column: "Status", ascending: true},
+	}, got)
+}
+
+func TestPersistForgottenSortRemovesOnlyTarget(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+
+	persistRememberedSort("prod\x00apps/v1/deployments", sortPref{column: "Ready", ascending: false})
+	persistRememberedSort("prod\x00/v1/pods", sortPref{column: "Status", ascending: true})
+
+	persistForgottenSort("prod\x00/v1/pods")
+
+	got := loadSortMemory()
+	assert.Equal(t, map[string]sortPref{
+		"prod\x00apps/v1/deployments": {column: "Ready", ascending: false},
+	}, got)
+}
+
+// TestBuildSessionTabStateSeedsSortMemory verifies a session-restored tab
+// (the restart path for issue #353) loads persisted sort prefs from disk rather
+// than starting blank, which would otherwise override the model's loaded memory
+// when the tab is activated.
+func TestBuildSessionTabStateSeedsSortMemory(t *testing.T) {
+	t.Setenv("LFK_STATE_DIR", t.TempDir())
+	require.NoError(t, saveSortMemory(map[string]sortPref{
+		"prod\x00apps/v1/deployments": {column: "Ready", ascending: false},
+	}))
+
+	tab := buildSessionTabState(&SessionTab{Context: "prod", AllNamespaces: true}, nil)
+	assert.Equal(t, sortPref{column: "Ready", ascending: false}, tab.sortMemory["prod\x00apps/v1/deployments"])
+}
+
+// --- empty map persists without creating an unreadable file ---
+
+func TestSaveSortMemoryEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LFK_STATE_DIR", dir)
+	require.NoError(t, saveSortMemory(map[string]sortPref{}))
+	got := loadSortMemory()
+	assert.Empty(t, got)
+}

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -195,10 +195,13 @@ func buildSessionTabState(st *SessionTab, discovered []model.ResourceTypeEntry) 
 		allGroupsExpanded: true,
 		cursorMemory:      make(map[string]int),
 		filterMemory:      make(map[string]savedFilter),
-		sortMemory:        make(map[string]sortPref),
-		itemCache:         make(map[string][]model.Item),
-		selectedItems:     make(map[string]bool),
-		selectionAnchor:   -1,
+		// Seed from disk so a session-restored tab keeps the sort the user
+		// chose before quitting (issue #353); a blank map here would override
+		// the model's loaded memory when this tab is activated.
+		sortMemory:      loadSortMemory(),
+		itemCache:       make(map[string][]model.Item),
+		selectedItems:   make(map[string]bool),
+		selectionAnchor: -1,
 	}
 
 	if st.AllNamespaces {

--- a/internal/app/update_column_toggle.go
+++ b/internal/app/update_column_toggle.go
@@ -551,6 +551,11 @@ func (m Model) handleColumnToggleKeyEnter() (tea.Model, tea.Cmd) {
 	// the snapshot so a future Esc-after-reopen doesn't restore stale
 	// state.
 	m.applyColumnToggleState()
+	// Persist the committed layout (issue #353 follow-up). Live-apply during
+	// the overlay only touches in-memory maps; the on-disk layout is written
+	// here on commit so an Esc that reverts via the snapshot never leaks an
+	// uncommitted edit to disk.
+	m.persistColumnPrefs()
 	m.overlay = overlayNone
 	m.columnToggleItems = nil
 	m.columnToggleSnapshot = columnToggleSnapshot{}
@@ -568,8 +573,13 @@ func (m Model) handleColumnToggleKeyR() (tea.Model, tea.Cmd) {
 	if m.columnOrder != nil {
 		delete(m.columnOrder, key)
 	}
+	// Drop the persisted layout too, so the reset survives a restart.
+	m.persistColumnPrefs()
 	m.overlay = overlayNone
 	m.columnToggleItems = nil
+	// Match Enter: drop the snapshot so a future reopen can't restore stale
+	// pre-reset state.
+	m.columnToggleSnapshot = columnToggleSnapshot{}
 	m.setStatusMessage("Columns reset to default", false)
 	return m, scheduleStatusClear()
 }


### PR DESCRIPTION
## Summary

Persists resource-list view preferences across app restarts, so quitting and reopening lfk keeps how you set up each list. Closes #353 (sort order) and extends the same persistence to column visibility/order from the `,` toggle overlay. Mirrors the existing `session.yaml` / `hidden_types.yaml` state-file pattern.

### Sort order (#353) — `~/.local/state/lfk/sort_memory.yaml`
- Persist the existing per-kind sort memory (keyed by context + GVR).
- Per-key merge/delete so a sort in one tab never clobbers another tab's saved sort (sortMemory is per-tab; the file is shared).
- Load at startup into the model + `tab[0]`; seed session-restored tabs from disk (the actual restart path).

### Column layout — `~/.local/state/lfk/column_prefs.yaml`
- Persist the column-toggle overlay's committed layout: visible extras, hidden built-ins, and display order (keyed by context + Kind).
- **Commit-only**: written on `Enter` (commit) and `R` (reset), never on live-apply — so an `Esc` that reverts edits via the snapshot leaves the on-disk layout untouched.
- These three maps are **Model-global** (scoped per context+kind, shared across tabs) rather than per-tab — the natural scope for a "how I view this kind in this cluster" preference, and it keeps persistence to a single source of truth.
- `visible_extras` round-trips a non-nil empty slice ("user configured no extras") distinctly from absent (auto-detect).

### Robustness
A remembered sort column or layout that no longer exists degrades gracefully (sort falls back to the Name tiebreaker; unknown columns are simply not rendered) — a removed CRD field never breaks the list.

## Docs
- `docs/config-reference.md` — two new state-file table entries.
- `docs/keybindings.md` — corrected the stale "session-only" / "not persisted to disk" notes for both sort and column toggle.

## Test plan
- [x] New unit + handler-level tests: persistence round-trip, corrupt/missing files, per-key merge, reset-removal, commit-only invariant, session-restore seeding, nil-vs-empty round-trip.
- [x] Full suite passes with `-race`.
- [x] `gofumpt` clean; `golangci-lint run ./...` -> 0 issues.
- [x] Two Go-reviewer passes; all HIGH findings fixed.
- [ ] Manual: sort + reorder/hide columns, quit, reopen -> both preserved; `R` reset and `-` sort-reset survive restart.