### PR TITLE
feat(preview): list status summary band in resource-type preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Every contribution is appreciated and helps make LFK sustainable. Thank you for 
 - **YAML preview** in the right column with syntax highlighting
 - **Full-screen YAML viewer** with scrollable output, search, section folding (`Tab`/`z`), and in-place editing
 - **Resource details** summary in split preview (toggle with `Shift+P`)
+- **List status summary** band pinned at the bottom of the children pane (like the resource-usage footer) when hovering a resource type in the resource-type list — always shows the resource count, plus a colored status rollup for kinds with a health signal (ArgoCD Application health/sync, Pod phase, workload ready ratios, Node readiness, Namespace/PV/PVC phase, Flux & cert-manager Ready) so you can confirm a whole list is healthy without drilling in
 - **Inline log viewer** with streaming, search, line numbers, word wrap, follow mode, timestamps toggle, previous container logs, container filter, tail-first loading, line jump, structured preview pane (`P`: parses the selected line as JSON or logfmt, falls back to plain text), and automatic reconnect across init-container transitions (stays attached as each init container finishes and the next one starts)
 - **Inline describe view** with scrollable output
 - **Secret viewing/editing** with decode toggle (`Ctrl+S`) and dedicated editor (`e`)

--- a/internal/app/preview_summary_band_test.go
+++ b/internal/app/preview_summary_band_test.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func argoAppItem(health, sync string) model.Item {
+	return model.Item{
+		Kind: "Application",
+		Columns: []model.KeyValue{
+			{Key: "Health", Value: health},
+			{Key: "Sync Status", Value: sync},
+		},
+	}
+}
+
+// resourceTypeModel builds a Model parked on the resource-type list with the
+// cursor on a single hovered type row, and the given resources previewed in the
+// children pane (rightItems).
+func resourceTypeModel(typeRow model.Item, preview []model.Item) Model {
+	return Model{
+		nav:         model.NavigationState{Level: model.LevelResourceTypes},
+		middleItems: []model.Item{typeRow},
+		rightItems:  preview,
+	}
+}
+
+func TestPreviewSummaryBand_ArgoApplications(t *testing.T) {
+	m := resourceTypeModel(
+		model.Item{Kind: "Application", Name: "Applications"},
+		[]model.Item{argoAppItem("Healthy", "Synced"), argoAppItem("Degraded", "OutOfSync")},
+	)
+
+	plain := ansi.Strip(m.previewSummaryBand(70))
+	assert.Contains(t, plain, "Applications")
+	assert.Contains(t, plain, "Health")
+	assert.Contains(t, plain, "Degraded")
+	assert.Contains(t, plain, "Sync")
+	assert.Contains(t, plain, "OutOfSync")
+}
+
+func TestPreviewSummaryBand_CountOnlyForStatuslessKind(t *testing.T) {
+	// Statusless kinds still get a band — just the resource count, no status bar.
+	m := resourceTypeModel(
+		model.Item{Kind: "ConfigMap", Name: "ConfigMaps"},
+		[]model.Item{{Kind: "ConfigMap", Name: "a"}, {Kind: "ConfigMap", Name: "b"}},
+	)
+	plain := ansi.Strip(m.previewSummaryBand(70))
+	assert.Contains(t, plain, "2 ConfigMaps")
+	assert.NotContains(t, plain, "Status")
+}
+
+func TestPreviewSummaryBand_NodeReadiness(t *testing.T) {
+	m := resourceTypeModel(
+		model.Item{Kind: "Node", Name: "Nodes"},
+		[]model.Item{{Kind: "Node", Status: "Ready"}, {Kind: "Node", Status: "NotReady"}},
+	)
+	plain := ansi.Strip(m.previewSummaryBand(70))
+	assert.Contains(t, plain, "Nodes")
+	assert.Contains(t, plain, "Ready")
+	assert.Contains(t, plain, "NotReady")
+}
+
+func TestPreviewSummaryBand_EmptyForSyntheticTypeRow(t *testing.T) {
+	// Security source / dashboard / port-forward rows carry a "__"-prefixed
+	// Kind and must not get a status rollup even if rightItems are present.
+	m := resourceTypeModel(
+		model.Item{Kind: model.SecurityLoaderKind, Name: "Security"},
+		[]model.Item{{Kind: "Pod", Status: "Running"}},
+	)
+	assert.Empty(t, m.previewSummaryBand(70))
+}
+
+func TestPreviewSummaryBand_EmptyBeforePreviewLoads(t *testing.T) {
+	m := resourceTypeModel(model.Item{Kind: "Application", Name: "Applications"}, nil)
+	assert.Empty(t, m.previewSummaryBand(70), "no band until the children preview has loaded")
+}
+
+func TestPreviewSummaryBand_HiddenAfterDrillingIn(t *testing.T) {
+	// Once drilled into the resource list (LevelResources), the band is gone —
+	// it is a resource-type-list affordance only.
+	m := Model{
+		nav:         model.NavigationState{Level: model.LevelResources, ResourceType: model.ResourceTypeEntry{Kind: "Application"}},
+		middleItems: []model.Item{argoAppItem("Healthy", "Synced")},
+		rightItems:  []model.Item{argoAppItem("Healthy", "Synced")},
+	}
+	assert.Empty(t, m.previewSummaryBand(70))
+}

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -51,12 +51,19 @@ func (m *Model) clampPreviewScroll() {
 		colHeight-- // tab bar
 	}
 
-	// Compute footer lines (must match renderRightColumn).
-	footerLines := 0
+	// Compute footer lines (must match renderRightColumn): the metrics rollup
+	// and/or the list summary band are pinned to the bottom and excluded from
+	// the scrollable area.
+	var footerParts []string
 	if !m.fullYAMLPreview && m.metricsContent != "" {
-		sep := ui.DimStyle.Render(strings.Repeat("\u2500", innerW))
-		footer := sep + "\n" + m.metricsContent
-		footerLines = strings.Count(footer, "\n") + 1
+		footerParts = append(footerParts, ui.DimStyle.Render(strings.Repeat("\u2500", innerW)), m.metricsContent)
+	}
+	if band := m.previewSummaryBand(innerW); band != "" {
+		footerParts = append(footerParts, ui.DimStyle.Render(strings.Repeat("\u2500", innerW)), band)
+	}
+	footerLines := 0
+	if len(footerParts) > 0 {
+		footerLines = strings.Count(strings.Join(footerParts, "\n"), "\n") + 1
 	}
 
 	// Compute scrollable viewport height (must match renderRightColumn).
@@ -101,13 +108,51 @@ func (m *Model) clampPreviewScroll() {
 	}
 }
 
+// previewSummaryBand renders the aggregate status band pinned at the bottom of
+// the children pane while hovering a resource type in the resource-type list — a
+// rollup of that type's resources (e.g. ArgoCD Application health / sync) so the
+// list can be assessed without drilling in. It is derived synchronously from the
+// already-loaded preview items, so it costs no API calls and cannot block the
+// UI. Returns "" unless we are at the resource-type list previewing a real,
+// summarisable kind.
+func (m Model) previewSummaryBand(width int) string {
+	if m.nav.Level != model.LevelResourceTypes {
+		return ""
+	}
+	sel := m.selectedMiddleItem()
+	// Synthetic rows (dashboards, security sources, port-forwards, captures,
+	// collapsed groups) all carry a "__"-prefixed Kind and have no status
+	// rollup; real resource types carry their Kubernetes Kind.
+	if sel == nil || strings.HasPrefix(sel.Kind, "__") {
+		return ""
+	}
+	items := m.rightItems
+	if len(items) == 0 {
+		return ""
+	}
+	summary := ui.BuildListSummary(sel.Kind, items)
+	label := sel.Name
+	if label == "" {
+		label = sel.Kind
+	}
+	return ui.RenderListSummary(summary, label, width)
+}
+
 func (m Model) renderRightColumn(width, height int) string {
-	// Build the pinned footer: only resource usage (metrics) is pinned.
+	// Build the pinned footer (bottom of the pane): resource usage (metrics)
+	// and the list summary band, each preceded by a separator. They are
+	// mutually exclusive in practice (metrics at the resource levels, the band
+	// at the resource-type list), but both are handled uniformly here.
 	var footerParts []string
 	if !m.fullYAMLPreview && m.metricsContent != "" {
 		footerParts = append(footerParts,
 			ui.DimStyle.Render(strings.Repeat("\u2500", width)),
 			m.metricsContent)
+	}
+	if band := m.previewSummaryBand(width); band != "" {
+		footerParts = append(footerParts,
+			ui.DimStyle.Render(strings.Repeat("─", width)),
+			band)
 	}
 
 	// Reserve height for the pinned footer.
@@ -170,7 +215,8 @@ func (m Model) renderRightColumn(width, height int) string {
 	}
 	result = strings.Join(lines, "\n")
 
-	// Assemble: pinned header (children) + scrollable content + pinned footer (metrics).
+	// Assemble: pinned header (children) + scrollable content + pinned footer
+	// (metrics and/or the list summary band).
 	if pinnedHeader != "" {
 		result = pinnedHeader + "\n" + result
 	}

--- a/internal/k8s/client_populate.go
+++ b/internal/k8s/client_populate.go
@@ -40,6 +40,8 @@ func populateResourceDetails(ti *model.Item, obj map[string]any, kind string) {
 		populateSecretDetails(ti, obj)
 	case "Node":
 		populateNodeDetails(ti, obj, status, spec)
+	case "Namespace":
+		populateNamespaceDetails(ti, status)
 	case "PersistentVolumeClaim":
 		populatePVCDetails(ti, status, spec)
 	case "CronJob":

--- a/internal/k8s/client_populate_kinds.go
+++ b/internal/k8s/client_populate_kinds.go
@@ -13,6 +13,31 @@ func populateNodeDetails(ti *model.Item, obj map[string]any, status, spec map[st
 	populateNodeStatus(ti, status)
 	populateNodeUnschedulable(ti, spec)
 	populateNodeTaints(ti, spec)
+	if s := nodeReadyStatus(status); s != "" {
+		ti.Status = s
+	}
+}
+
+// nodeReadyStatus derives a node's at-a-glance status ("Ready"/"NotReady") from
+// its Ready condition. Returns "" when the condition is absent so callers leave
+// Status untouched. Cordon state is surfaced separately via the Unschedulable
+// column, keeping the status (and its rollup) to clean Ready/NotReady buckets.
+func nodeReadyStatus(status map[string]any) string {
+	conds, _ := status["conditions"].([]any)
+	for _, c := range conds {
+		cond, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := cond["type"].(string); t != "Ready" {
+			continue
+		}
+		if s, _ := cond["status"].(string); s == "True" {
+			return "Ready"
+		}
+		return "NotReady"
+	}
+	return ""
 }
 
 func populateNodeRoles(ti *model.Item, obj map[string]any) {

--- a/internal/k8s/client_populate_misc.go
+++ b/internal/k8s/client_populate_misc.go
@@ -9,6 +9,17 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 )
 
+// populateNamespaceDetails sets the namespace's lifecycle phase
+// (Active/Terminating) as its at-a-glance status.
+func populateNamespaceDetails(ti *model.Item, status map[string]any) {
+	if status == nil {
+		return
+	}
+	if phase, ok := status["phase"].(string); ok && phase != "" {
+		ti.Status = phase
+	}
+}
+
 func populateIngressClass(ti *model.Item, obj map[string]any) {
 	metadata, _ := obj["metadata"].(map[string]any)
 	annotations, _ := metadata["annotations"].(map[string]any)

--- a/internal/k8s/client_populate_node_namespace_test.go
+++ b/internal/k8s/client_populate_node_namespace_test.go
@@ -1,0 +1,45 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestNodeReadyStatus(t *testing.T) {
+	ready := map[string]any{
+		"conditions": []any{
+			map[string]any{"type": "MemoryPressure", "status": "False"},
+			map[string]any{"type": "Ready", "status": "True"},
+		},
+	}
+	assert.Equal(t, "Ready", nodeReadyStatus(ready))
+
+	notReady := map[string]any{
+		"conditions": []any{
+			map[string]any{"type": "Ready", "status": "False"},
+		},
+	}
+	assert.Equal(t, "NotReady", nodeReadyStatus(notReady))
+
+	// No Ready condition and nil status leave the status untouched.
+	assert.Equal(t, "", nodeReadyStatus(map[string]any{"conditions": []any{}}))
+	assert.Equal(t, "", nodeReadyStatus(nil))
+}
+
+func TestPopulateNamespaceDetails(t *testing.T) {
+	ti := &model.Item{Kind: "Namespace"}
+	populateNamespaceDetails(ti, map[string]any{"phase": "Active"})
+	assert.Equal(t, "Active", ti.Status)
+
+	term := &model.Item{Kind: "Namespace"}
+	populateNamespaceDetails(term, map[string]any{"phase": "Terminating"})
+	assert.Equal(t, "Terminating", term.Status)
+
+	// Nil/empty status leaves Status untouched.
+	empty := &model.Item{Kind: "Namespace"}
+	populateNamespaceDetails(empty, nil)
+	assert.Equal(t, "", empty.Status)
+}

--- a/internal/ui/listsummary.go
+++ b/internal/ui/listsummary.go
@@ -1,0 +1,300 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// SummaryBucket is one value group within a summary dimension (e.g. 12 "Healthy").
+type SummaryBucket struct {
+	Value string
+	Count int
+}
+
+// SummaryBar is a single breakdown dimension (e.g. "Health") over a resource
+// list, with its value buckets ordered worst-first.
+type SummaryBar struct {
+	Label   string
+	Total   int
+	Buckets []SummaryBucket
+}
+
+// ListSummary aggregates the status of an in-memory resource list for the
+// preview-pane header band. It is purely derived from data already loaded for
+// the list, so building it costs no API calls.
+type ListSummary struct {
+	Total int
+	Bars  []SummaryBar
+}
+
+// Empty reports whether the summary has nothing worth rendering.
+func (s ListSummary) Empty() bool { return len(s.Bars) == 0 }
+
+// summaryDimension extracts a groupable status value from an item.
+type summaryDimension struct {
+	label   string
+	valueOf func(model.Item) string
+}
+
+// summaryDimensions returns the breakdown axes for a kind, in render order, or
+// nil when the kind has no meaningful status rollup. Only curated kinds are
+// summarised: grouping an arbitrary kind by Item.Status surfaces noise — e.g.
+// StorageClass/IngressClass/PriorityClass set Status to a "default"-class
+// marker, not health — so the summary is opt-in per kind rather than universal.
+//
+// Signal source by kind:
+//   - ArgoCD Application(Set): the Health and Sync columns.
+//   - Pod / Job / PV / PVC / Node / Namespace: the resource's own Status
+//     (phase / readiness).
+//   - Workloads (Deployment, StatefulSet, DaemonSet, ReplicaSet): the
+//     ready/desired replica ratio, since these carry no Status.
+//   - Flux & cert-manager resources: their "Ready" condition column.
+//
+// Kinds without any dimension still get a count-only band (just the header);
+// see RenderListSummary.
+func summaryDimensions(kind string) []summaryDimension {
+	switch kind {
+	case "Application", "ApplicationSet":
+		return []summaryDimension{
+			{label: "Health", valueOf: columnValueFn("Health")},
+			{label: "Sync", valueOf: columnValueFn("Sync Status")},
+		}
+	case "Pod", "Job", "PersistentVolume", "PersistentVolumeClaim", "Node", "Namespace":
+		return []summaryDimension{{label: "Status", valueOf: statusValue}}
+	case "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet":
+		return []summaryDimension{{label: "Status", valueOf: readyRatioValue}}
+	case "Kustomization", "GitRepository", "HelmRepository", "HelmChart",
+		"OCIRepository", "Bucket", "ImageRepository", "ImagePolicy",
+		"ImageUpdateAutomation", "Certificate", "CertificateRequest",
+		"Issuer", "ClusterIssuer":
+		return []summaryDimension{{label: "Status", valueOf: readyConditionValue}}
+	default:
+		return nil
+	}
+}
+
+func statusValue(it model.Item) string { return it.Status }
+
+func columnValueFn(key string) func(model.Item) string {
+	return func(it model.Item) string { return it.ColumnValue(key) }
+}
+
+// readyRatioValue maps a workload's "ready/desired" replica count to a coarse
+// status bucket: "Ready" when all desired replicas are ready (including a
+// scaled-to-zero 0/0), "NotReady" otherwise. Returns "" when absent/unparseable
+// so the item is skipped.
+func readyRatioValue(it model.Item) string {
+	r, d, ok := parseReadyRatio(it.Ready)
+	if !ok {
+		return ""
+	}
+	if r >= d {
+		return "Ready"
+	}
+	return "NotReady"
+}
+
+// readyConditionValue maps a Flux/cert-manager "Ready" condition (True/False/
+// Unknown) to a coarse status bucket.
+func readyConditionValue(it model.Item) string {
+	switch it.ColumnValue("Ready") {
+	case "True":
+		return "Ready"
+	case "False", "Unknown":
+		return "NotReady"
+	default:
+		return ""
+	}
+}
+
+func parseReadyRatio(ready string) (readyN, desiredN int, ok bool) {
+	a, b, found := strings.Cut(ready, "/")
+	if !found {
+		return 0, 0, false
+	}
+	r, errR := strconv.Atoi(strings.TrimSpace(a))
+	d, errD := strconv.Atoi(strings.TrimSpace(b))
+	if errR != nil || errD != nil {
+		return 0, 0, false
+	}
+	return r, d, true
+}
+
+// BuildListSummary aggregates items into per-dimension buckets for the kind.
+// Dimensions with no populated values are omitted, so the result is Empty when
+// there is nothing meaningful to show.
+func BuildListSummary(kind string, items []model.Item) ListSummary {
+	s := ListSummary{Total: len(items)}
+	for _, dim := range summaryDimensions(kind) {
+		if bar := buildSummaryBar(dim, items); bar.Total > 0 {
+			s.Bars = append(s.Bars, bar)
+		}
+	}
+	return s
+}
+
+func buildSummaryBar(dim summaryDimension, items []model.Item) SummaryBar {
+	counts := make(map[string]int)
+	for _, it := range items {
+		v := strings.TrimSpace(dim.valueOf(it))
+		if v == "" {
+			continue
+		}
+		counts[v]++
+	}
+	bar := SummaryBar{Label: dim.label}
+	for v, c := range counts {
+		bar.Buckets = append(bar.Buckets, SummaryBucket{Value: v, Count: c})
+		bar.Total += c
+	}
+	// Worst-first: failed before progressing before ok, then by count (desc)
+	// and value (asc) so ordering is fully deterministic.
+	sort.Slice(bar.Buckets, func(i, j int) bool {
+		bi, bj := bar.Buckets[i], bar.Buckets[j]
+		if ri, rj := StatusSeverityRank(bi.Value), StatusSeverityRank(bj.Value); ri != rj {
+			return ri < rj
+		}
+		if bi.Count != bj.Count {
+			return bi.Count > bj.Count
+		}
+		return bi.Value < bj.Value
+	})
+	return bar
+}
+
+const summaryBarCells = 14
+
+// RenderListSummary renders the summary as a compact band: a header line with
+// the total resource count, then one proportional colored bar per dimension.
+// Kinds with no status dimension still get the header (a count-only band).
+// Returns "" only when there is nothing to count. Every line is truncated to
+// width.
+func RenderListSummary(s ListSummary, kindLabel string, width int) string {
+	if s.Total == 0 || width <= 0 {
+		return ""
+	}
+
+	labelW := 0
+	for _, bar := range s.Bars {
+		if len(bar.Label) > labelW {
+			labelW = len(bar.Label)
+		}
+	}
+
+	header := DimStyle.Bold(true).Render("SUMMARY") + DimStyle.Render(fmt.Sprintf("  %d %s", s.Total, kindLabel))
+	lines := []string{ansi.Truncate(header, width, "")}
+	for _, bar := range s.Bars {
+		line := fmt.Sprintf("%-*s ", labelW, bar.Label) + renderSummaryBar(bar) + "  " + renderSummaryLegend(bar)
+		lines = append(lines, ansi.Truncate(line, width, ""))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderSummaryBar(bar SummaryBar) string {
+	counts := make([]int, len(bar.Buckets))
+	for i, b := range bar.Buckets {
+		counts[i] = b.Count
+	}
+	cells := allocateCells(counts, bar.Total, summaryBarCells)
+	var sb strings.Builder
+	for i, b := range bar.Buckets {
+		if cells[i] <= 0 {
+			continue
+		}
+		sb.WriteString(StatusStyle(b.Value).Render(strings.Repeat("█", cells[i])))
+	}
+	return sb.String()
+}
+
+func renderSummaryLegend(bar SummaryBar) string {
+	parts := make([]string, 0, len(bar.Buckets))
+	for _, b := range bar.Buckets {
+		parts = append(parts, StatusStyle(b.Value).Render(fmt.Sprintf("%d %s", b.Count, b.Value)))
+	}
+	return strings.Join(parts, "  ")
+}
+
+// allocateCells distributes cells across buckets proportional to their counts,
+// always summing to exactly cells. Every nonzero bucket is guaranteed at least
+// one cell so rare-but-important statuses (e.g. a handful of Errors among
+// hundreds of Running pods) stay visible rather than rounding away. When there
+// are more nonzero buckets than cells, the first `cells` buckets in input order
+// — which callers pass worst-first — each get one cell and the rest get none.
+func allocateCells(counts []int, total, cells int) []int {
+	out := make([]int, len(counts))
+	if total <= 0 || cells <= 0 {
+		return out
+	}
+
+	var nz []int
+	for i, c := range counts {
+		if c > 0 {
+			nz = append(nz, i)
+		}
+	}
+	if len(nz) == 0 {
+		return out
+	}
+	// Can't fit one cell each: give the most severe (input order) a cell.
+	if len(nz) >= cells {
+		for _, i := range nz[:cells] {
+			out[i] = 1
+		}
+		return out
+	}
+
+	// Proportional floor, raised to a minimum of one per nonzero bucket.
+	rem := make([]float64, len(counts))
+	used := 0
+	for _, i := range nz {
+		exact := float64(counts[i]) * float64(cells) / float64(total)
+		out[i] = max(int(exact), 1)
+		rem[i] = exact - float64(out[i]) // negative when bumped up to 1
+		used += out[i]
+	}
+
+	// The min-1 floor can overshoot; reclaim from the largest buckets (never
+	// below 1) until we are back within budget.
+	for used > cells {
+		best := -1
+		for _, i := range nz {
+			if out[i] <= 1 {
+				continue
+			}
+			if best == -1 || out[i] > out[best] {
+				best = i
+			}
+		}
+		if best == -1 {
+			break
+		}
+		out[best]--
+		used--
+	}
+
+	// Hand out any remaining cells by largest fractional remainder.
+	for used < cells {
+		best := -1
+		for _, i := range nz {
+			if rem[i] < 0 {
+				continue
+			}
+			if best == -1 || rem[i] > rem[best] {
+				best = i
+			}
+		}
+		if best == -1 {
+			break
+		}
+		out[best]++
+		rem[best] = -1
+		used++
+	}
+	return out
+}

--- a/internal/ui/listsummary_test.go
+++ b/internal/ui/listsummary_test.go
@@ -1,0 +1,275 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func argoApp(health, sync string) model.Item {
+	return model.Item{
+		Kind: "Application",
+		Columns: []model.KeyValue{
+			{Key: "Health", Value: health},
+			{Key: "Sync Status", Value: sync},
+		},
+	}
+}
+
+func TestBuildListSummary_ArgoApplication(t *testing.T) {
+	items := []model.Item{
+		argoApp("Healthy", "Synced"),
+		argoApp("Healthy", "Synced"),
+		argoApp("Degraded", "OutOfSync"),
+		argoApp("Progressing", "Synced"),
+	}
+
+	s := BuildListSummary("Application", items)
+
+	assert.Equal(t, 4, s.Total)
+	require.Len(t, s.Bars, 2, "Application summary should have Health and Sync bars")
+
+	health := s.Bars[0]
+	assert.Equal(t, "Health", health.Label)
+	assert.Equal(t, 4, health.Total)
+	// Worst-first ordering: Degraded (error) before Progressing before Healthy (ok).
+	require.Len(t, health.Buckets, 3)
+	assert.Equal(t, "Degraded", health.Buckets[0].Value)
+	assert.Equal(t, 1, health.Buckets[0].Count)
+	assert.Equal(t, "Healthy", health.Buckets[2].Value)
+	assert.Equal(t, 2, health.Buckets[2].Count)
+
+	sync := s.Bars[1]
+	assert.Equal(t, "Sync", sync.Label)
+	assert.Equal(t, 4, sync.Total)
+	require.Len(t, sync.Buckets, 2)
+	// OutOfSync (progressing/amber) ranks before Synced (ok).
+	assert.Equal(t, "OutOfSync", sync.Buckets[0].Value)
+	assert.Equal(t, "Synced", sync.Buckets[1].Value)
+	assert.Equal(t, 3, sync.Buckets[1].Count)
+}
+
+func TestBuildListSummary_GenericStatus(t *testing.T) {
+	items := []model.Item{
+		{Kind: "Pod", Status: "Running"},
+		{Kind: "Pod", Status: "Running"},
+		{Kind: "Pod", Status: "CrashLoopBackOff"},
+		{Kind: "Pod", Status: "Pending"},
+	}
+
+	s := BuildListSummary("Pod", items)
+
+	assert.Equal(t, 4, s.Total)
+	require.Len(t, s.Bars, 1)
+	bar := s.Bars[0]
+	assert.Equal(t, "Status", bar.Label)
+	assert.Equal(t, 4, bar.Total)
+	require.Len(t, bar.Buckets, 3)
+	// Failed first, then Pending (progressing), then Running (ok).
+	assert.Equal(t, "CrashLoopBackOff", bar.Buckets[0].Value)
+	assert.Equal(t, "Pending", bar.Buckets[1].Value)
+	assert.Equal(t, "Running", bar.Buckets[2].Value)
+}
+
+// Worst-first ordering must hold even in no-color mode, where the status
+// styles carry no foreground — so ordering cannot be derived from color.
+func TestBuildListSummary_OrderingHoldsInNoColorMode(t *testing.T) {
+	prevNoColor := ConfigNoColor
+	prevTheme := ActiveTheme
+	ConfigNoColor = true
+	applyNoColorTheme()
+	t.Cleanup(func() {
+		ConfigNoColor = prevNoColor
+		ApplyTheme(prevTheme)
+	})
+
+	items := []model.Item{
+		{Kind: "Pod", Status: "Running"},
+		{Kind: "Pod", Status: "Running"},
+		{Kind: "Pod", Status: "CrashLoopBackOff"},
+		{Kind: "Pod", Status: "Pending"},
+	}
+	bar := BuildListSummary("Pod", items).Bars[0]
+	require.Len(t, bar.Buckets, 3)
+	assert.Equal(t, "CrashLoopBackOff", bar.Buckets[0].Value, "failed must sort first regardless of color profile")
+	assert.Equal(t, "Pending", bar.Buckets[1].Value)
+	assert.Equal(t, "Running", bar.Buckets[2].Value)
+}
+
+func TestBuildListSummary_WorkloadReadyRollup(t *testing.T) {
+	// StatefulSets/DaemonSets/Deployments carry Ready ("x/y") but no Status.
+	items := []model.Item{
+		{Kind: "StatefulSet", Ready: "3/3"},
+		{Kind: "StatefulSet", Ready: "3/3"},
+		{Kind: "StatefulSet", Ready: "1/3"},
+		{Kind: "StatefulSet", Ready: "0/0"}, // scaled to zero counts as Ready
+	}
+	s := BuildListSummary("StatefulSet", items)
+	require.Len(t, s.Bars, 1)
+	bar := s.Bars[0]
+	assert.Equal(t, "Status", bar.Label)
+	assert.Equal(t, 4, bar.Total)
+	require.Len(t, bar.Buckets, 2)
+	// NotReady (progressing) sorts before Ready (ok).
+	assert.Equal(t, "NotReady", bar.Buckets[0].Value)
+	assert.Equal(t, 1, bar.Buckets[0].Count)
+	assert.Equal(t, "Ready", bar.Buckets[1].Value)
+	assert.Equal(t, 3, bar.Buckets[1].Count)
+}
+
+func TestBuildListSummary_PodUsesStatusNotReady(t *testing.T) {
+	// Pods are summarised by Status (phase), not the ready ratio.
+	items := []model.Item{
+		{Kind: "Pod", Status: "Running", Ready: "1/1"},
+		{Kind: "Pod", Status: "CrashLoopBackOff", Ready: "0/1"},
+	}
+	s := BuildListSummary("Pod", items)
+	require.Len(t, s.Bars, 1)
+	assert.Equal(t, "CrashLoopBackOff", s.Bars[0].Buckets[0].Value)
+	assert.Equal(t, "Running", s.Bars[0].Buckets[1].Value)
+}
+
+func TestBuildListSummary_FluxReadyCondition(t *testing.T) {
+	mk := func(ready string) model.Item {
+		return model.Item{Kind: "Kustomization", Columns: []model.KeyValue{{Key: "Ready", Value: ready}}}
+	}
+	items := []model.Item{mk("True"), mk("True"), mk("False"), mk("Unknown")}
+	s := BuildListSummary("Kustomization", items)
+	require.Len(t, s.Bars, 1)
+	bar := s.Bars[0]
+	require.Len(t, bar.Buckets, 2)
+	assert.Equal(t, "NotReady", bar.Buckets[0].Value)
+	assert.Equal(t, 2, bar.Buckets[0].Count) // False + Unknown
+	assert.Equal(t, "Ready", bar.Buckets[1].Value)
+	assert.Equal(t, 2, bar.Buckets[1].Count)
+}
+
+func TestBuildListSummary_NoiseKindsHaveNoStatusBars(t *testing.T) {
+	// StorageClass/IngressClass/PriorityClass set Status to a "default"-class
+	// marker — not health — so they get no status bar (only a count-only band).
+	for _, kind := range []string{"StorageClass", "IngressClass", "PriorityClass"} {
+		items := []model.Item{
+			{Kind: kind, Status: "default"},
+			{Kind: kind},
+			{Kind: kind},
+		}
+		s := BuildListSummary(kind, items)
+		assert.Truef(t, s.Empty(), "%s should produce no status bars", kind)
+		assert.Equal(t, 3, s.Total)
+	}
+}
+
+func TestBuildListSummary_EmptyList(t *testing.T) {
+	s := BuildListSummary("Pod", nil)
+	assert.Equal(t, 0, s.Total)
+	assert.True(t, s.Empty())
+}
+
+func TestBuildListSummary_StatuslessKindHasNoBars(t *testing.T) {
+	items := []model.Item{
+		{Kind: "ConfigMap", Name: "a"},
+		{Kind: "ConfigMap", Name: "b"},
+	}
+	s := BuildListSummary("ConfigMap", items)
+	assert.Equal(t, 2, s.Total)
+	assert.True(t, s.Empty(), "kinds whose items carry no status should produce no summary bars")
+}
+
+func TestBuildListSummary_PartialValuesIgnoresEmpties(t *testing.T) {
+	items := []model.Item{
+		argoApp("Healthy", "Synced"),
+		argoApp("", ""), // e.g. status not yet populated
+	}
+	s := BuildListSummary("Application", items)
+	require.Len(t, s.Bars, 2)
+	// Only the one populated value is counted; empties are skipped.
+	assert.Equal(t, 1, s.Bars[0].Total)
+	require.Len(t, s.Bars[0].Buckets, 1)
+	assert.Equal(t, "Healthy", s.Bars[0].Buckets[0].Value)
+}
+
+func TestRenderListSummary_ContainsCountsAndFitsWidth(t *testing.T) {
+	items := []model.Item{
+		argoApp("Healthy", "Synced"),
+		argoApp("Degraded", "OutOfSync"),
+	}
+	s := BuildListSummary("Application", items)
+
+	out := RenderListSummary(s, "Applications", 60)
+	require.NotEmpty(t, out)
+
+	plain := ansi.Strip(out)
+	assert.Contains(t, plain, "Applications")
+	assert.Contains(t, plain, "Healthy")
+	assert.Contains(t, plain, "Degraded")
+	assert.Contains(t, plain, "OutOfSync")
+
+	for line := range strings.SplitSeq(plain, "\n") {
+		assert.LessOrEqual(t, ansi.StringWidth(line), 60, "line exceeds width: %q", line)
+	}
+}
+
+func TestAllocateCells_KeepsRareBucketsVisible(t *testing.T) {
+	// Real case: 391 pods, worst-first order. Error and PodInitializing are a
+	// tiny fraction but must still get a visible cell.
+	counts := []int{6, 2, 318, 64} // Error, PodInitializing, Running, Succeeded
+	cells := allocateCells(counts, 391, summaryBarCells)
+
+	sum := 0
+	for i, c := range counts {
+		assert.GreaterOrEqualf(t, cells[i], 1, "nonzero bucket %d must get >=1 cell", i)
+		sum += cells[i]
+		_ = c
+	}
+	assert.Equal(t, summaryBarCells, sum, "cells must sum to the bar width")
+}
+
+func TestAllocateCells_MoreBucketsThanCells(t *testing.T) {
+	counts := []int{5, 4, 3, 2, 1} // 5 buckets, only 3 cells
+	cells := allocateCells(counts, 15, 3)
+
+	sum := 0
+	for _, c := range cells {
+		sum += c
+	}
+	assert.Equal(t, 3, sum)
+	// The first three (most severe, by input order) each get a cell.
+	assert.Equal(t, []int{1, 1, 1, 0, 0}, cells)
+}
+
+func TestRenderListSummary_CountOnlyForStatuslessKind(t *testing.T) {
+	s := BuildListSummary("ConfigMap", []model.Item{{Kind: "ConfigMap"}, {Kind: "ConfigMap"}})
+	out := ansi.Strip(RenderListSummary(s, "ConfigMaps", 60))
+	assert.Contains(t, out, "2 ConfigMaps")
+	assert.NotContains(t, out, "Status", "statusless kinds get a header-only band")
+	assert.Equal(t, 1, strings.Count(out, "\n")+1, "header line only, no bars")
+}
+
+func TestRenderListSummary_BlankWhenNoItems(t *testing.T) {
+	s := BuildListSummary("ConfigMap", nil)
+	assert.Empty(t, RenderListSummary(s, "ConfigMaps", 60))
+}
+
+func TestBuildListSummary_NodeAndNamespace(t *testing.T) {
+	nodes := BuildListSummary("Node", []model.Item{
+		{Kind: "Node", Status: "Ready"},
+		{Kind: "Node", Status: "Ready"},
+		{Kind: "Node", Status: "NotReady"},
+	})
+	require.Len(t, nodes.Bars, 1)
+	assert.Equal(t, "NotReady", nodes.Bars[0].Buckets[0].Value)
+	assert.Equal(t, "Ready", nodes.Bars[0].Buckets[1].Value)
+
+	ns := BuildListSummary("Namespace", []model.Item{
+		{Kind: "Namespace", Status: "Active"},
+		{Kind: "Namespace", Status: "Terminating"},
+	})
+	require.Len(t, ns.Bars, 1)
+	assert.Equal(t, "Terminating", ns.Bars[0].Buckets[0].Value)
+	assert.Equal(t, "Active", ns.Bars[0].Buckets[1].Value)
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -430,31 +430,47 @@ func AgeStyle(age string) lipgloss.Style {
 	}
 }
 
-// StatusStyle returns the appropriate style for a resource status string.
-func StatusStyle(status string) lipgloss.Style {
+// statusSev classifies a resource status string into a severity bucket. It is
+// the single source of truth shared by StatusStyle (which maps it to a color)
+// and StatusSeverityRank (which maps it to an ordering), so coloring and
+// severity ordering can never drift — and the ordering stays correct in
+// no-color mode, where the styles carry no distinguishing foreground.
+type statusSev int
+
+const (
+	sevUnknown     statusSev = iota // unknown non-empty status -> dimmed
+	sevBlank                        // "" -> neutral
+	sevDefault                      // literal "default" -> primary
+	sevNormal                       // "Normal" event type -> dim
+	sevRunning                      // healthy / ready / synced
+	sevDone                         // succeeded / completed
+	sevProgressing                  // pending / progressing / out-of-sync / warning
+	sevFailed                       // failed / degraded / errored
+)
+
+func statusSeverity(status string) statusSev {
 	switch status {
 	case "default":
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Background(BaseBg)
+		return sevDefault
 	case "Running", "Active", "Bound", "Available", "Ready",
 		"Healthy", "Healthy/Synced", "Synced",
 		"Deployed",
 		"SecretSynced", "Created", "Updated", "Valid":
-		return StatusRunning
+		return sevRunning
 	case "Succeeded", "Completed",
 		"Superseded":
-		return StatusOther
+		return sevDone
 	case "Pending", "ContainerCreating", "PodInitializing", "Terminating",
 		"Waiting", "Init", "NotReady",
 		"Progressing", "Progressing/Synced", "Progressing/OutOfSync",
 		"Missing", "Suspended", "Unknown", "Reconciling",
 		"Healthy/OutOfSync", "Missing/OutOfSync", "Suspended/OutOfSync",
 		"OutOfSync",
-		"Pending-install", "Pending-upgrade", "Pending-rollback", "Uninstalling":
-		return StatusProgressing
-	case "Warning":
-		return StatusProgressing
+		"Pending-install", "Pending-upgrade", "Pending-rollback", "Uninstalling",
+		"Warning":
+		return sevProgressing
 	case "Normal":
-		return DimStyle
+		return sevNormal
 	case "Failed", "CrashLoopBackOff", "Error", "ImagePullBackOff", "Terminated",
 		"Degraded", "Degraded/Synced", "Degraded/OutOfSync",
 		"Missing/Synced",
@@ -463,12 +479,50 @@ func StatusStyle(status string) lipgloss.Style {
 		model.MissingRefStatus,
 		"UpdateFailed", "FailedScheduling",
 		"InvalidStoreConfiguration", "InvalidProviderConfig", "ValidationFailed":
-		return StatusFailed
+		return sevFailed
 	default:
 		if status == "" {
-			return NormalStyle
+			return sevBlank
 		}
+		return sevUnknown
+	}
+}
+
+// StatusStyle returns the appropriate style for a resource status string.
+func StatusStyle(status string) lipgloss.Style {
+	switch statusSeverity(status) {
+	case sevDefault:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Background(BaseBg)
+	case sevRunning:
+		return StatusRunning
+	case sevDone:
 		return StatusOther
+	case sevProgressing:
+		return StatusProgressing
+	case sevNormal:
+		return DimStyle
+	case sevFailed:
+		return StatusFailed
+	case sevBlank:
+		return NormalStyle
+	default: // sevUnknown
+		return StatusOther
+	}
+}
+
+// StatusSeverityRank orders a status string worst-first (0 = most severe) for
+// status rollups and summaries. Derived from statusSeverity so it tracks
+// StatusStyle and works regardless of color profile.
+func StatusSeverityRank(status string) int {
+	switch statusSeverity(status) {
+	case sevFailed:
+		return 0
+	case sevProgressing:
+		return 2
+	case sevRunning:
+		return 3
+	default: // done / normal / default / blank / unknown
+		return 4
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #352. Adds an aggregate status rollup pinned to the **bottom of the children pane** (like the resource-usage footer) while hovering a resource type in the resource-type list — so you can confirm a whole list is healthy without drilling in.

- **Always shows the resource count**; adds a colored status bar for kinds with a health signal.
- **Curated per-kind registry** — kinds whose `Status` isn't a health signal (StorageClass/IngressClass/PriorityClass `"default"` marker) get a count-only band, not a noise bar.
- **Rare statuses stay visible** — the bar guarantees every nonzero bucket ≥1 cell, worst-first, so a handful of `Error` pods among hundreds of `Running` still show red.
- **No-color safe** — severity ordering and color share one source of truth (`StatusStyle`/`statusSeverity`).
- **Synchronous, in-memory only** — no API calls, no background worker (deliberately avoids the GUI-freeze risk).

### Kinds with a status rollup
| Source | Kinds |
|---|---|
| ArgoCD | Application, ApplicationSet (Health + Sync) |
| Workloads (ready ratio) | Deployment, StatefulSet, DaemonSet, ReplicaSet |
| Own Status/phase | Pod, Job, PersistentVolume, PersistentVolumeClaim, Node, Namespace |
| Flux & cert-manager | Kustomization, GitRepository, HelmRepository, …, Certificate, Issuer, … (Ready condition) |

Node readiness (`Ready`/`NotReady`) and Namespace phase (`Active`/`Terminating`) are now populated so both the list and the rollup have a signal.

## Test plan
- [x] `go test ./...` (full suite)
- [x] `go test -race ./internal/ui/ ./internal/app/ ./internal/k8s/`
- [x] `go vet` + `golangci-lint run` (0 issues)
- [x] Unit tests: aggregation (ArgoCD/workloads/Flux/Node/Namespace), worst-first ordering incl. no-color mode, cell allocation (rare-bucket visibility, more-buckets-than-cells), count-only band for statusless/noise kinds
- [x] Integration tests: band placement (resource-type list only, hidden after drill-in / synthetic rows / full-YAML), filter behavior
- [x] Manual check against a live cluster with ArgoCD + workloads