### PR TITLE
fix(ui): compress Name so configured columns survive the three-pane list (#354)

### DIFF
--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -254,7 +254,11 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	//
 	// minExtrasBudget = capped column (maxColW + spacing). Tracks the
 	// same maxColW used below so the budget scales with fullscreen mode.
+	// compressedNameFloor is the smaller floor used when the user has
+	// explicitly configured the columns: there NAME yields so the chosen
+	// columns survive (issue #354).
 	const nameFloor = 20
+	const compressedNameFloor = len("NAME") + 1
 	maxColW := 20
 	if ActiveFullscreenMode {
 		maxColW = 40
@@ -282,10 +286,29 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	}
 
 	nameReserve := longestName + 1 // +1 for column spacing
-	if ActiveNameHidden {
+	switch {
+	case ActiveNameHidden:
 		// NAME is hidden: reserve nothing so extras get the full row budget.
 		nameReserve = 0
-	} else {
+	case !fromAutoDetect:
+		// Explicitly configured columns (column-toggle overlay or
+		// views.<kind>.columns) are authoritative. The default longestName/20
+		// reservation starves them in the narrow three-pane list, so the same
+		// config that renders fully in the wide full screen list silently drops
+		// trailing columns (issue #354). Reserve only what the configured
+		// columns leave after their capped widths and let NAME compress to a
+		// small floor; NAME still reclaims any leftover via the caller's nameW,
+		// so wide panes are unchanged.
+		configuredBudget := 0
+		for _, key := range candidates {
+			w, _ := extraColWidth(seen[key], key, maxColW)
+			configuredBudget += w
+		}
+		nameReserve = max(totalWidth-usedWidth-configuredBudget, compressedNameFloor)
+		if nameReserve > longestName+1 {
+			nameReserve = max(longestName+1, compressedNameFloor)
+		}
+	default:
 		if nameReserve+usedWidth > totalWidth {
 			// Can't fit the full name even after dropping every extra. Cap
 			// the reservation so at least one extra gets a fair budget.
@@ -301,7 +324,11 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	// available may be negative when mandatory columns alone exceed the row;
 	// fitExtraColumns still emits them and the caller clips the overflow.
 	available := totalWidth - usedWidth - nameReserve
-	if available < 8 && mandatoryBudget == 0 {
+	// The "too tight to bother" bail-out is an auto-detect heuristic only.
+	// Explicitly configured columns are authoritative, so let fitExtraColumns
+	// surface whatever physically fits instead of dropping the whole set when
+	// the pane is very narrow (issue #354).
+	if available < 8 && mandatoryBudget == 0 && fromAutoDetect {
 		return nil
 	}
 

--- a/internal/ui/explorer_format_columns_test.go
+++ b/internal/ui/explorer_format_columns_test.go
@@ -216,6 +216,88 @@ func TestCollectExtraColumns_CompactBlockedFillSpareWidth(t *testing.T) {
 	}
 }
 
+// TestCollectExtraColumns_ConfiguredColumnsCompressNameInNarrowPane is the
+// regression for issue #354: an explicitly configured column set (the column-
+// toggle overlay, surfaced here as ActiveSessionColumns) rendered fully in the
+// wide fullscreen list but lost trailing columns in the regular three-pane
+// list. The default 20-char NAME reservation starved the narrow pane and
+// fitExtraColumns dropped the tail. Configured columns are authoritative, so
+// NAME must compress to let them all fit; in a wide pane the same config keeps
+// rendering every column.
+func TestCollectExtraColumns_ConfiguredColumnsCompressNameInNarrowPane(t *testing.T) {
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	defer func(orig map[string]int) { ActivePrinterColumns = orig }(ActivePrinterColumns)
+	defer func(orig bool) { ActiveFullscreenMode = orig }(ActiveFullscreenMode)
+	defer func(orig bool) { ActiveNameHidden = orig }(ActiveNameHidden)
+	ActivePrinterColumns = nil
+	ActiveNameHidden = false
+
+	// A moderately long name (35 chars) plus three configured columns whose
+	// values are ~7 chars wide. In the narrow pane the old name reservation
+	// (longestName+1 = 36) leaves room for at most one column.
+	const name = "deployment-frontend-web-server-blue"
+	mk := func(suffix string) model.Item {
+		return model.Item{
+			Name:   name + suffix,
+			Status: "Running",
+			Columns: []model.KeyValue{
+				{Key: "Catalog", Value: "buildah"},
+				{Key: "Task", Value: "compile"},
+				{Key: "Chore", Value: "nightly"},
+			},
+		}
+	}
+	items := []model.Item{mk("-a"), mk("-b"), mk("-c")}
+
+	// User explicitly configured these three columns via the overlay.
+	ActiveSessionColumns = []string{"Catalog", "Task", "Chore"}
+
+	// Regular three-pane list: narrow middle column.
+	ActiveFullscreenMode = false
+	narrow := keysOf(collectExtraColumns(items, 70, 20, "ChoreTask"))
+	for _, want := range []string{"Catalog", "Task", "Chore"} {
+		if !slices.Contains(narrow, want) {
+			t.Errorf("configured column %q must survive in the narrow three-pane list, got %v", want, narrow)
+		}
+	}
+
+	// Full screen list: the same config must still render every column.
+	ActiveFullscreenMode = true
+	wide := keysOf(collectExtraColumns(items, 200, 20, "ChoreTask"))
+	for _, want := range []string{"Catalog", "Task", "Chore"} {
+		if !slices.Contains(wide, want) {
+			t.Errorf("configured column %q must survive in the full screen list, got %v", want, wide)
+		}
+	}
+}
+
+// TestCollectExtraColumns_ConfiguredColumnSurvivesVeryNarrowPane covers the
+// boundary where the auto-detect "available < 8" bail-out would otherwise drop
+// an explicitly configured column that still physically fits. The bail-out is
+// an auto-detect heuristic and must not apply to authoritative configured sets.
+func TestCollectExtraColumns_ConfiguredColumnSurvivesVeryNarrowPane(t *testing.T) {
+	defer func(orig []string) { ActiveSessionColumns = orig }(ActiveSessionColumns)
+	defer func(orig map[string]int) { ActivePrinterColumns = orig }(ActivePrinterColumns)
+	defer func(orig bool) { ActiveFullscreenMode = orig }(ActiveFullscreenMode)
+	defer func(orig bool) { ActiveNameHidden = orig }(ActiveNameHidden)
+	ActivePrinterColumns = nil
+	ActiveNameHidden = false
+	ActiveFullscreenMode = false
+
+	// Short name and one configured column with a short value (colW = 5).
+	items := []model.Item{
+		{Name: "po", Columns: []model.KeyValue{{Key: "Task", Value: "ok"}}},
+		{Name: "px", Columns: []model.KeyValue{{Key: "Task", Value: "no"}}},
+	}
+	ActiveSessionColumns = []string{"Task"}
+
+	// totalWidth 30, usedWidth 20 -> available 5, below the 8-char bail-out.
+	cols := keysOf(collectExtraColumns(items, 30, 20, "Pod"))
+	if !slices.Contains(cols, "Task") {
+		t.Errorf("configured column must survive a very narrow pane that fits it, got %v", cols)
+	}
+}
+
 // TestSelectColumnCandidates_AutoDetectFlag verifies the fromAutoDetect signal
 // is true only on the auto-detect path, not for session or config overrides.
 func TestSelectColumnCandidates_AutoDetectFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the remaining open complaint in #354: explicitly configured columns (column-toggle overlay or `views.<kind>.columns`) rendered fully in the **full-screen** resource list but lost trailing columns in the **regular three-pane** list.

**Root cause:** `collectExtraColumns` reserved width for the NAME column based on the longest name (floored at 20 chars). The wide full-screen pane fits NAME plus all configured columns; the narrow three-pane middle column (~51% width) does not, so `fitExtraColumns` dropped the tail. Same config, two outcomes.

**Fix:**
- New `case !fromAutoDetect` branch in `collectExtraColumns`: for authoritative (user/config) column sets, reserve only what the configured columns leave after their capped widths and let NAME compress to a small floor (`len("NAME")+1`). NAME still reclaims any leftover via the caller's `nameW = width − builtins − extraTotalW`, and a clamp to `longestName+1` keeps **wide/full-screen panes byte-for-byte unchanged** (no regression to the path that already works).
- Gated the `available < 8` "too tight to bother" bail-out on `fromAutoDetect`, so it stays an auto-detect heuristic and never silently drops columns the user explicitly chose (a second, narrower instance of the same bug).

## Test plan

- [x] New `TestCollectExtraColumns_ConfiguredColumnsCompressNameInNarrowPane` — configured columns survive both the narrow three-pane and the full-screen list (RED before, GREEN after).
- [x] New `TestCollectExtraColumns_ConfiguredColumnSurvivesVeryNarrowPane` — boundary where the old `<8` guard would have dropped a column that still fits.
- [x] `go test ./...` passes.
- [x] `golangci-lint run internal/ui/...` clean.
- [x] Manual check in a normal-width terminal: configure several columns for a resource type, confirm they all show in the regular list (matching full screen). Not done here (no live cluster).

No docs/help/keybinding changes — fixes existing behavior; the `,` overlay and its bindings are unchanged.