### PR TITLE
fix(preview): let the right pane scroll long lists to the bottom

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -403,6 +403,12 @@ type Model struct {
 	// Preview scroll offset for the right column.
 	previewScroll int
 
+	// previewMeasure memoizes the scrollable right-pane content line count so
+	// scrolling a large list doesn't re-render the whole list on every keystroke
+	// in clampPreviewScroll. Recomputed only when the content/layout key changes.
+	previewMeasureKey   previewMeasureKey
+	previewMeasureLines int
+
 	// Mouse capture runtime state. mouseAvailable is true when mouse
 	// capture was enabled at startup (no --no-mouse flag and config allows
 	// it); mouseCaptured tracks the current runtime state so the toggle

--- a/internal/app/preview_scroll_test.go
+++ b/internal/app/preview_scroll_test.go
@@ -130,3 +130,22 @@ func TestPreviewScroll_MeasureMemoized(t *testing.T) {
 		t.Errorf("measure did not shrink after list shrank: %d >= %d", got, grown)
 	}
 }
+
+// TestPreviewScroll_CursorChangeInvalidatesMeasure guards against a stale
+// measurement after a cursor-driven preview change. The memo key is coarse
+// (e.g. it does not capture the split details-summary length), so the
+// content-reset paths must clear the cache or a new selection could be clamped
+// against the previous preview's line count.
+func TestPreviewScroll_CursorChangeInvalidatesMeasure(t *testing.T) {
+	m := resourceTypePreview(scrollPodItems(500))
+	m.measureScrollableLines(100, 40)
+	if m.previewMeasureLines == 0 {
+		t.Fatal("precondition: expected a cached measurement")
+	}
+
+	m.invalidatePreviewForCursorChange()
+
+	if m.previewMeasureLines != 0 {
+		t.Errorf("cursor-change invalidation must clear the cached measurement, got %d", m.previewMeasureLines)
+	}
+}

--- a/internal/app/preview_scroll_test.go
+++ b/internal/app/preview_scroll_test.go
@@ -110,6 +110,41 @@ func TestPreviewScroll_LongTextDetailsReachBottom(t *testing.T) {
 	}
 }
 
+// TestPreviewScroll_ListWindowed verifies the list preview renders a window
+// starting at the scroll position (sticky header), so a deep scroll shows the
+// items around previewScroll rather than rendering the whole list from the top.
+func TestPreviewScroll_ListWindowed(t *testing.T) {
+	m := resourceTypePreview(scrollPodItems(1000))
+	m.previewScroll = 500
+
+	out := ansi.Strip(m.renderRightColumn(80, 46))
+
+	// The sticky header keeps the column label visible.
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("windowed list should keep a header line, got:\n%s", out)
+	}
+	// Top data row is the item at previewScroll; rows from the very top are not
+	// rendered at all (windowed, not sliced from a full render).
+	if top := topPodIndex(m); top != 500 {
+		t.Errorf("windowed top item = pod-%d, want pod-500", top)
+	}
+	if strings.Contains(out, "pod-0 ") {
+		t.Errorf("item far above the window must not be rendered")
+	}
+
+	// At the top (previewScroll=0) the window starts at the first item.
+	m.previewScroll = 0
+	if top := topPodIndex(m); top != 0 {
+		t.Errorf("at previewScroll=0 the top item must be pod-0, got pod-%d", top)
+	}
+
+	// At the last item index the window clamps and still shows the final item.
+	m.previewScroll = 999
+	if !strings.Contains(ansi.Strip(m.renderRightColumn(80, 46)), "pod-999") {
+		t.Errorf("windowing must keep the last item visible at the maximum offset")
+	}
+}
+
 // TestPreviewScroll_NoDeadBandAtBottom verifies that one scroll-up from the
 // bottom moves the viewport by exactly one row — previously previewScroll could
 // overshoot into a dead band where scroll-up did nothing until it unwound below

--- a/internal/app/preview_scroll_test.go
+++ b/internal/app/preview_scroll_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
@@ -70,6 +71,42 @@ func TestPreviewScroll_ReachesBottomForLongList(t *testing.T) {
 		if got := maxPodIndexVisible(m); got != n-1 {
 			t.Errorf("n=%d: last item (pod-%d) never reached; highest visible = pod-%d", n, n-1, got)
 		}
+	}
+}
+
+// TestPreviewScroll_LongTextDetailsReachBottom is the regression for a
+// ConfigMap (or any resource) whose details exceed the pane height — e.g. a
+// multi-line `data:` value. The scroll measurement must reflect the true
+// content length, not a capped floor, so the last line is reachable.
+func TestPreviewScroll_LongTextDetailsReachBottom(t *testing.T) {
+	var body strings.Builder
+	for i := range 300 {
+		fmt.Fprintf(&body, "    config line %d\n", i)
+	}
+	cm := model.Item{
+		Kind: "ConfigMap", Name: "varnish", Namespace: "ns", Age: "1d",
+		Columns: []model.KeyValue{
+			{Key: "Data", Value: "1 keys"},
+			{Key: "data:default.vcl.tmpl", Value: body.String()},
+		},
+	}
+	m := Model{
+		nav:         model.NavigationState{Level: model.LevelResources, ResourceType: model.ResourceTypeEntry{Kind: "ConfigMap"}},
+		middleItems: []model.Item{cm},
+		width:       120, height: 50,
+	}
+	m.cursors[model.LevelResources] = 0
+
+	innerW := 41
+	contentHeight := max(m.height-4, 3)
+	measured := m.measureScrollableLines(innerW, contentHeight)
+	trueLines := strings.Count(m.renderRightColumnContent(innerW, 1<<20), "\n") + 1
+
+	if measured != trueLines {
+		t.Errorf("measured line count must equal true content: measured=%d true=%d", measured, trueLines)
+	}
+	if measured <= 200 {
+		t.Errorf("long multi-line data value should measure past the old 200 cap, got %d", measured)
 	}
 }
 

--- a/internal/app/preview_scroll_test.go
+++ b/internal/app/preview_scroll_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 func scrollPodItems(n int) []model.Item {
@@ -110,38 +111,69 @@ func TestPreviewScroll_LongTextDetailsReachBottom(t *testing.T) {
 	}
 }
 
-// TestPreviewScroll_ListWindowed verifies the list preview renders a window
-// starting at the scroll position (sticky header), so a deep scroll shows the
-// items around previewScroll rather than rendering the whole list from the top.
+// TestPreviewScroll_ListWindowed verifies the windowed list render is
+// byte-equivalent to the old line-slice path (it is a pure performance change):
+// previewScroll is a display-line offset where line 0 is the header and line i
+// is item i-1, so a scrolled view drops the header and starts at item
+// previewScroll-1 — never shifted by a row.
 func TestPreviewScroll_ListWindowed(t *testing.T) {
 	m := resourceTypePreview(scrollPodItems(1000))
-	m.previewScroll = 500
 
-	out := ansi.Strip(m.renderRightColumn(80, 46))
-
-	// The sticky header keeps the column label visible.
-	if !strings.Contains(out, "NAME") {
-		t.Errorf("windowed list should keep a header line, got:\n%s", out)
-	}
-	// Top data row is the item at previewScroll; rows from the very top are not
-	// rendered at all (windowed, not sliced from a full render).
-	if top := topPodIndex(m); top != 500 {
-		t.Errorf("windowed top item = pod-%d, want pod-500", top)
-	}
-	if strings.Contains(out, "pod-0 ") {
-		t.Errorf("item far above the window must not be rendered")
-	}
-
-	// At the top (previewScroll=0) the window starts at the first item.
+	// At the top: header visible, first data row is pod-0.
 	m.previewScroll = 0
+	out0 := ansi.Strip(m.renderRightColumn(80, 46))
+	if !strings.Contains(out0, "NAME") {
+		t.Errorf("header must be visible at the top of the list")
+	}
 	if top := topPodIndex(m); top != 0 {
-		t.Errorf("at previewScroll=0 the top item must be pod-0, got pod-%d", top)
+		t.Errorf("top item at scroll 0 = pod-%d, want pod-0", top)
 	}
 
-	// At the last item index the window clamps and still shows the final item.
+	// Scrolled: header scrolls off (like every other preview), and the top data
+	// row is item previewScroll-1 (line previewScroll), matching the line-slice.
+	m.previewScroll = 500
+	out500 := ansi.Strip(m.renderRightColumn(80, 46))
+	if strings.Contains(out500, "NAME") {
+		t.Errorf("header should scroll off the top once scrolled")
+	}
+	if top := topPodIndex(m); top != 499 {
+		t.Errorf("top item at scroll 500 = pod-%d, want pod-499", top)
+	}
+	if strings.Contains(out500, "pod-0 ") {
+		t.Errorf("items far above the window must not be rendered")
+	}
+
+	// Max offset still shows the last item.
 	m.previewScroll = 999
 	if !strings.Contains(ansi.Strip(m.renderRightColumn(80, 46)), "pod-999") {
-		t.Errorf("windowing must keep the last item visible at the maximum offset")
+		t.Errorf("last item must remain reachable at the maximum offset")
+	}
+}
+
+// TestPreviewScroll_ListWindowedEquivalence pins the windowed render to the
+// reference line-slice output across scroll positions, proving the optimization
+// changes nothing the user sees.
+func TestPreviewScroll_ListWindowedEquivalence(t *testing.T) {
+	const width = 80
+	m := resourceTypePreview(scrollPodItems(1000))
+
+	// Reference: full content rendered from the top, then line-sliced (the old
+	// behaviour). ActiveRightScroll<0 disables windowing for this measurement.
+	ui.ActiveRightScroll = -1
+	full := strings.Split(ansi.Strip(m.renderRightColumnContent(width, 1<<20)), "\n")
+
+	// Only compare the upper content rows; the bottom of the pane holds the pinned
+	// summary-band footer, which is not part of the scrollable content. 40 rows is
+	// safely within the content region for a height of 46.
+	const contentRows = 40
+	for _, p := range []int{0, 1, 137, 500, 953} {
+		m.previewScroll = p
+		got := strings.Split(ansi.Strip(m.renderRightColumn(width, 46)), "\n")
+		for i := 0; i < contentRows && i < len(got) && p+i < len(full); i++ {
+			if got[i] != full[p+i] {
+				t.Fatalf("scroll=%d row=%d: windowed %q != line-slice %q", p, i, got[i], full[p+i])
+			}
+		}
 	}
 }
 

--- a/internal/app/preview_scroll_test.go
+++ b/internal/app/preview_scroll_test.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func scrollPodItems(n int) []model.Item {
+	items := make([]model.Item, n)
+	for i := range items {
+		items[i] = model.Item{
+			Kind: "Pod", Name: fmt.Sprintf("pod-%d", i),
+			Namespace: "default", Status: "Running", Ready: "1/1",
+		}
+	}
+	return items
+}
+
+func resourceTypePreview(items []model.Item) Model {
+	return Model{
+		nav:         model.NavigationState{Level: model.LevelResourceTypes},
+		middleItems: []model.Item{{Kind: "Pod", Name: "Pods"}},
+		rightItems:  items,
+		width:       120,
+		height:      50,
+	}
+}
+
+var rePodIdx = regexp.MustCompile(`pod-(\d+)`)
+
+// maxPodIndexVisible returns the highest pod index present in the rendered
+// right column, or -1 if none.
+func maxPodIndexVisible(m Model) int {
+	out := ansi.Strip(m.renderRightColumn(80, 46))
+	maxIdx := -1
+	for _, mm := range rePodIdx.FindAllStringSubmatch(out, -1) {
+		if v, err := strconv.Atoi(mm[1]); err == nil && v > maxIdx {
+			maxIdx = v
+		}
+	}
+	return maxIdx
+}
+
+func topPodIndex(m Model) int {
+	out := ansi.Strip(m.renderRightColumn(80, 46))
+	if mm := rePodIdx.FindStringSubmatch(out); mm != nil {
+		v, _ := strconv.Atoi(mm[1])
+		return v
+	}
+	return -1
+}
+
+// TestPreviewScroll_ReachesBottomForLongList is the regression for the right-pane
+// scroll freezing partway down a long list: previewScroll used to cap at ~150
+// regardless of list length because the content measurement was capped, so the
+// bottom of a few-hundred-item list was unreachable.
+func TestPreviewScroll_ReachesBottomForLongList(t *testing.T) {
+	for _, n := range []int{120, 300, 1000} {
+		m := resourceTypePreview(scrollPodItems(n))
+		for range n + 50 {
+			mdl, _, _ := m.handleExplorerActionKeyPreviewDown()
+			m = mdl.(Model)
+		}
+		if got := maxPodIndexVisible(m); got != n-1 {
+			t.Errorf("n=%d: last item (pod-%d) never reached; highest visible = pod-%d", n, n-1, got)
+		}
+	}
+}
+
+// TestPreviewScroll_NoDeadBandAtBottom verifies that one scroll-up from the
+// bottom moves the viewport by exactly one row — previously previewScroll could
+// overshoot into a dead band where scroll-up did nothing until it unwound below
+// the real maximum.
+func TestPreviewScroll_NoDeadBandAtBottom(t *testing.T) {
+	m := resourceTypePreview(scrollPodItems(300))
+	for range 400 {
+		mdl, _, _ := m.handleExplorerActionKeyPreviewDown()
+		m = mdl.(Model)
+	}
+	topAtBottom := topPodIndex(m)
+
+	mdl, _, _ := m.handleExplorerActionKeyPreviewUp()
+	m = mdl.(Model)
+	topAfterUp := topPodIndex(m)
+
+	if topAfterUp != topAtBottom-1 {
+		t.Errorf("scroll-up at bottom did not move viewport by one: top %d -> %d (want %d)",
+			topAtBottom, topAfterUp, topAtBottom-1)
+	}
+}
+
+// TestPreviewScroll_MeasureMemoized verifies the line-count measurement is
+// cached across scroll keystrokes (it only recomputes when the content key
+// changes), which is what keeps scrolling a large list cheap.
+func TestPreviewScroll_MeasureMemoized(t *testing.T) {
+	m := resourceTypePreview(scrollPodItems(500))
+
+	innerW, scrollableH := 100, 40
+	first := m.measureScrollableLines(innerW, scrollableH)
+	if first <= 500 {
+		t.Fatalf("expected measured lines > item count (got %d)", first)
+	}
+	cachedKey := m.previewMeasureKey
+
+	// Same inputs -> cache hit, identical result, key unchanged.
+	if got := m.measureScrollableLines(innerW, scrollableH); got != first {
+		t.Errorf("memoized measure changed without input change: %d != %d", got, first)
+	}
+	if m.previewMeasureKey != cachedKey {
+		t.Errorf("measure key changed on a cache hit")
+	}
+
+	// Changing the list length invalidates the cache and recomputes.
+	m.rightItems = scrollPodItems(900)
+	grown := m.measureScrollableLines(innerW, scrollableH)
+	if grown <= first {
+		t.Errorf("measure did not grow after list grew: %d <= %d", grown, first)
+	}
+
+	// Shrinking the list must also recompute downward (not return the stale
+	// larger value).
+	m.rightItems = scrollPodItems(10)
+	if got := m.measureScrollableLines(innerW, scrollableH); got >= grown {
+		t.Errorf("measure did not shrink after list shrank: %d >= %d", got, grown)
+	}
+}

--- a/internal/app/update_navigation_invalidate.go
+++ b/internal/app/update_navigation_invalidate.go
@@ -32,6 +32,7 @@ func (m *Model) invalidatePreviewForCursorChange() {
 	m.rightItems = nil
 	m.previewYAML = ""
 	m.previewScroll = 0
+	m.previewMeasureLines = 0 // recompute the scroll measurement for the new selection's preview
 	m.resourceTree = nil
 	m.loading = true
 	m.previewLoading = true

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -135,20 +135,16 @@ func (m *Model) measureScrollableLines(innerW, scrollableH int) int {
 		return m.previewMeasureLines
 	}
 
-	// Keep the historical floor so tree / container / details previews (whose
-	// length the cheap bounds below don't capture) measure as before; extend it
-	// to cover long lists and YAML so those scroll all the way down. No right-pane
-	// renderer pads up to its height argument, so an oversized measure height adds
-	// no phantom lines.
-	measureH := max(scrollableH*3, 200)
-	if n := len(m.rightItems) + 4; n > measureH { // table: header + rows + slack
-		measureH = n
-	}
-	if yaml != "" {
-		if yl := strings.Count(yaml, "\n") + 1; yl > measureH {
-			measureH = yl
-		}
-	}
+	// Measure at a height large enough to hold any realistic content so the true
+	// line count is captured and the pane can scroll to the very end — long
+	// resource lists AND long text details (e.g. a ConfigMap with a multi-line
+	// data value). Every right-pane renderer only truncates at its height
+	// argument, never pads up to it (RenderTable / RenderYAMLContent /
+	// RenderResourceSummary / RenderResourceTree / detail renderers), so an
+	// oversized measure height never invents phantom lines. This render is
+	// memoized on previewMeasureKey, so the O(content) cost is paid once per
+	// content change, not per scroll keystroke.
+	const measureH = 1 << 20
 
 	var totalLines int
 	if key.split {

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -241,26 +241,41 @@ func (m Model) renderRightColumn(width, height int) string {
 	// Render the scrollable content. For the resource-type list preview the
 	// content is a plain item table that can be very long, so render it windowed
 	// (only the visible rows) via ActiveRightScroll \u2014 each frame is O(viewport)
-	// instead of O(scroll position). Other content (details, YAML, tree) is small
-	// and uses the generic render-then-slice path below.
+	// instead of O(scroll position). The output is kept byte-identical to the
+	// generic render-then-slice path so windowing is a pure performance change:
+	// previewScroll is a display-line offset where line 0 is the table header and
+	// line i (i>=1) is rightItems[i-1], so a scrolled view drops the header and
+	// starts at item previewScroll-1. We render that window (one extra row to
+	// replace the dropped header) and strip the header line. Other content
+	// (details, YAML, tree) is small and uses the generic path below.
 	listPreview := m.isRightListPreview()
 	var result string
-	if listPreview {
+	switch {
+	case listPreview && m.previewScroll == 0:
 		prev := ui.ActiveRightScroll
-		ui.ActiveRightScroll = m.previewScroll
+		ui.ActiveRightScroll = 0
 		result = m.renderRightColumnContent(width, contentHeight)
 		ui.ActiveRightScroll = prev
-	} else {
-		renderHeight := contentHeight + m.previewScroll
-		if m.hasSplitPreview() {
-			result = m.renderDetailsOnly(width, renderHeight)
+	case listPreview:
+		prev := ui.ActiveRightScroll
+		ui.ActiveRightScroll = m.previewScroll - 1 // line previewScroll == item previewScroll-1
+		result = m.renderRightColumnContent(width, contentHeight+1)
+		ui.ActiveRightScroll = prev
+		if i := strings.IndexByte(result, '\n'); i >= 0 { // drop the header line
+			result = result[i+1:]
 		} else {
-			result = m.renderRightColumnContent(width, renderHeight)
+			result = ""
 		}
-		// Append events to scrollable content (events scroll with the details).
-		if !m.fullYAMLPreview && m.previewEventsContent != "" {
-			result += "\n" + ui.DimStyle.Render(strings.Repeat("\u2500", width)) + "\n" + m.previewEventsContent
-		}
+	case m.hasSplitPreview():
+		result = m.renderDetailsOnly(width, contentHeight+m.previewScroll)
+	default:
+		result = m.renderRightColumnContent(width, contentHeight+m.previewScroll)
+	}
+
+	// Append events to scrollable content (events scroll with the details).
+	// Lists have no events; their scroll is already applied above.
+	if !listPreview && !m.fullYAMLPreview && m.previewEventsContent != "" {
+		result += "\n" + ui.DimStyle.Render(strings.Repeat("\u2500", width)) + "\n" + m.previewEventsContent
 	}
 
 	// Apply preview scroll to the scrollable content. The windowed list path is

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -18,6 +18,7 @@ func (m *Model) clearRight() {
 	m.yamlView.sections = nil
 	m.previewYAML = ""
 	m.previewScroll = 0
+	m.previewMeasureLines = 0 // force the scroll measurement to recompute for the new preview
 	m.metricsContent = ""
 	m.previewEventsContent = ""
 	m.metricsData = nil
@@ -83,29 +84,86 @@ func (m *Model) clampPreviewScroll() {
 		}
 	}
 
-	// Get the scrollable content line count.
-	// Use the actual scrollable height (not 10000) to avoid inflated YAML fill.
-	measureH := max(
-		// enough headroom for scroll, but not inflated
-		scrollableH*3, 200)
-	var totalLines int
-	if m.hasSplitPreview() {
-		fullContent := m.renderDetailsOnly(innerW, measureH)
-		totalLines = strings.Count(fullContent, "\n") + 1
-	} else {
-		fullContent := m.renderRightColumnContent(innerW, measureH)
-		totalLines = strings.Count(fullContent, "\n") + 1
-	}
-
-	// Include events in the scrollable content (they scroll with details).
-	if !m.fullYAMLPreview && m.previewEventsContent != "" {
-		totalLines += 1 + strings.Count(m.previewEventsContent, "\n") + 1 // separator + event lines
-	}
-
+	totalLines := m.measureScrollableLines(innerW, scrollableH)
 	maxScroll := max(totalLines-scrollableH, 0)
 	if m.previewScroll > maxScroll {
 		m.previewScroll = maxScroll
 	}
+}
+
+// previewMeasureKey fingerprints the inputs that determine the scrollable
+// right-pane line count, so measureScrollableLines can memoize the result and
+// avoid re-rendering a large list on every scroll keystroke.
+type previewMeasureKey struct {
+	innerW      int
+	scrollableH int
+	rightLen    int
+	level       model.Level
+	split       bool
+	mapView     bool
+	fullYAML    bool
+	yamlLen     int
+	dashLen     int
+	eventsLen   int
+}
+
+// measureScrollableLines returns the line count of the scrollable right-pane
+// content, memoized on previewMeasureKey. The expensive measurement renders the
+// content once at a height tall enough to hold all of it (so a long list or YAML
+// document can scroll to the end — see the issue where the right pane froze
+// ~halfway down a few-hundred-item list because the height was capped). While
+// the user scrolls, the key is unchanged so this is O(1); it recomputes only
+// when the content or layout changes.
+func (m *Model) measureScrollableLines(innerW, scrollableH int) int {
+	yaml := m.previewYAML
+	if yaml == "" {
+		yaml = m.yamlView.content
+	}
+	key := previewMeasureKey{
+		innerW:      innerW,
+		scrollableH: scrollableH,
+		rightLen:    len(m.rightItems),
+		level:       m.nav.Level,
+		split:       m.hasSplitPreview(),
+		mapView:     m.mapView,
+		fullYAML:    m.fullYAMLPreview,
+		yamlLen:     len(yaml),
+		dashLen:     len(m.dashboardPreview) + len(m.monitoringPreview),
+		eventsLen:   len(m.previewEventsContent),
+	}
+	if key == m.previewMeasureKey && m.previewMeasureLines > 0 {
+		return m.previewMeasureLines
+	}
+
+	// Keep the historical floor so tree / container / details previews (whose
+	// length the cheap bounds below don't capture) measure as before; extend it
+	// to cover long lists and YAML so those scroll all the way down. No right-pane
+	// renderer pads up to its height argument, so an oversized measure height adds
+	// no phantom lines.
+	measureH := max(scrollableH*3, 200)
+	if n := len(m.rightItems) + 4; n > measureH { // table: header + rows + slack
+		measureH = n
+	}
+	if yaml != "" {
+		if yl := strings.Count(yaml, "\n") + 1; yl > measureH {
+			measureH = yl
+		}
+	}
+
+	var totalLines int
+	if key.split {
+		totalLines = strings.Count(m.renderDetailsOnly(innerW, measureH), "\n") + 1
+	} else {
+		totalLines = strings.Count(m.renderRightColumnContent(innerW, measureH), "\n") + 1
+	}
+	// Events scroll with the details content (excluded in full-YAML mode).
+	if !m.fullYAMLPreview && m.previewEventsContent != "" {
+		totalLines += 1 + strings.Count(m.previewEventsContent, "\n") + 1 // separator + event lines
+	}
+
+	m.previewMeasureKey = key
+	m.previewMeasureLines = totalLines
+	return totalLines
 }
 
 // previewSummaryBand renders the aggregate status band pinned at the bottom of

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -218,7 +218,10 @@ func (m Model) renderRightColumn(width, height int) string {
 	}
 	contentHeight := max(height-footerLines, 3)
 
-	// Pin children table at the top when in split preview mode.
+	// Pin children table at the top when in split preview mode. This RenderTable
+	// is cursor-less but runs before ActiveRightScroll is set below, and split
+	// preview (LevelResources/Owned) is mutually exclusive with the windowed list
+	// preview (LevelResourceTypes), so it never picks up the windowing.
 	pinnedHeader := ""
 	pinnedHeaderLines := 0
 	if m.hasSplitPreview() {
@@ -235,23 +238,35 @@ func (m Model) renderRightColumn(width, height int) string {
 		}
 	}
 
-	// Render the scrollable content (details only when split preview, full content otherwise).
-	renderHeight := contentHeight + m.previewScroll
+	// Render the scrollable content. For the resource-type list preview the
+	// content is a plain item table that can be very long, so render it windowed
+	// (only the visible rows) via ActiveRightScroll \u2014 each frame is O(viewport)
+	// instead of O(scroll position). Other content (details, YAML, tree) is small
+	// and uses the generic render-then-slice path below.
+	listPreview := m.isRightListPreview()
 	var result string
-	if m.hasSplitPreview() {
-		result = m.renderDetailsOnly(width, renderHeight)
+	if listPreview {
+		prev := ui.ActiveRightScroll
+		ui.ActiveRightScroll = m.previewScroll
+		result = m.renderRightColumnContent(width, contentHeight)
+		ui.ActiveRightScroll = prev
 	} else {
-		result = m.renderRightColumnContent(width, renderHeight)
+		renderHeight := contentHeight + m.previewScroll
+		if m.hasSplitPreview() {
+			result = m.renderDetailsOnly(width, renderHeight)
+		} else {
+			result = m.renderRightColumnContent(width, renderHeight)
+		}
+		// Append events to scrollable content (events scroll with the details).
+		if !m.fullYAMLPreview && m.previewEventsContent != "" {
+			result += "\n" + ui.DimStyle.Render(strings.Repeat("\u2500", width)) + "\n" + m.previewEventsContent
+		}
 	}
 
-	// Append events to scrollable content (events scroll with the details).
-	if !m.fullYAMLPreview && m.previewEventsContent != "" {
-		result += "\n" + ui.DimStyle.Render(strings.Repeat("\u2500", width)) + "\n" + m.previewEventsContent
-	}
-
-	// Apply preview scroll to the scrollable content only.
+	// Apply preview scroll to the scrollable content. The windowed list path is
+	// already positioned at previewScroll, so only the generic path slices here.
 	lines := strings.Split(result, "\n")
-	if m.previewScroll > 0 {
+	if !listPreview && m.previewScroll > 0 {
 		if m.previewScroll >= len(lines) {
 			m.previewScroll = len(lines) - 1
 		}
@@ -279,6 +294,38 @@ func (m Model) renderRightColumn(width, height int) string {
 	}
 
 	return result
+}
+
+// isRightListPreview reports whether the right pane's scrollable content is the
+// plain resource list shown while hovering a resource type (renderRightDefault's
+// RenderTable over rightItems). Only this path honours ActiveRightScroll, so the
+// windowed render in renderRightColumn is gated on it; every other case
+// (dashboards, security sources, union members rendered with RenderColumn,
+// details/YAML/tree) falls back to the generic render-then-slice path.
+func (m Model) isRightListPreview() bool {
+	if m.nav.Level != model.LevelResourceTypes || m.mapView || m.fullYAMLPreview {
+		return false
+	}
+	if len(m.rightItems) == 0 || m.isUnionSentinel() {
+		return false
+	}
+	sel := m.selectedMiddleItem()
+	if sel == nil || strings.HasPrefix(sel.Kind, "__") {
+		return false
+	}
+	if sel.Extra == "__overview__" || sel.Extra == "__monitoring__" {
+		return false
+	}
+	// Windowing maps previewScroll (a line offset) to an item index, which only
+	// holds when each item is exactly one line. Category headers/separators break
+	// that 1:1 mapping, so fall back to the generic line-slice path if any item
+	// carries a category (instance lists normally don't).
+	for i := range m.rightItems {
+		if m.rightItems[i].Category != "" {
+			return false
+		}
+	}
+	return true
 }
 
 // hasSplitPreview returns true when the right column shows children + details (split view).

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -76,6 +76,16 @@ var ActiveTableLayout *TableLayoutCache
 // Same semantics as ActiveMiddleScroll.
 var ActiveLeftScroll int
 
+// ActiveRightScroll windows a non-cursor RenderTable (the right preview pane's
+// resource list) to start at this item index, so a long list renders only the
+// visible rows instead of every row from the top down (which made each frame
+// O(scroll position)). Column widths are still computed over all items, so the
+// layout stays stable while scrolling. -1 (the default) means "no windowing".
+// It applies only to a cursor-less RenderTable (cursor < 0); the middle column
+// always renders with a real cursor, so it is never affected and none of its
+// click/sort globals are touched.
+var ActiveRightScroll = -1
+
 // ActiveMiddleLineMap maps display line numbers (0-based, relative to content
 // start after the column/table header) to item indices. A value of -1 means
 // the line is non-clickable (separator or category header). Built during

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -455,6 +455,15 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		}
 	}
 
+	// Right preview pane: window the list to start at ActiveRightScroll so only
+	// the visible rows render, regardless of how far the user has scrolled. Gated
+	// on the cursor-less render (cursor < 0) so the middle column — which always
+	// renders with a real cursor — is never affected, and ActiveRightScroll
+	// defaults to -1 everywhere else.
+	if cursor < 0 && ActiveRightScroll >= 0 {
+		startIdx = min(ActiveRightScroll, max(len(items)-1, 0))
+	}
+
 	usedLines := 0
 	endIdx := startIdx
 	for endIdx < len(items) {


### PR DESCRIPTION
## Summary

The right-pane preview scroll (`J`/`shift+J` and the mouse wheel) froze partway down a long resource list and could not reach the bottom; scrolling back left a **dead band** where nothing moved until the counter unwound below ~150. On a ~300-item list this hit around halfway.

**Root cause:** `clampPreviewScroll` measured the scrollable content by rendering it at a **capped** height (`max(scrollableH*3, 200)`), so for any list longer than ~200 rows `maxScroll` computed to the same ~150 regardless of list length. It also re-rendered the whole content on every keystroke (O(n) per tick → O(n²) scroll-through), which made large lists feel frozen.

Confirmed before the fix (instrumented): max `previewScroll` reached was **157 for lists of 300, 1k, 5k, and 20k items alike**.

## Fix

1. **Measure against the real content.** `measureScrollableLines` keeps the historical floor for tree/container/details previews but extends it to the list length and the YAML line count, so those scroll all the way down. Verified that no right-pane renderer (`RenderTable`, `RenderYAMLContent`, `RenderResourceSummary`, `RenderResourceTree`) pads *up* to its height argument — they only truncate — so an oversized measure height adds no phantom lines (the old cap's "inflated fill" concern is stale).
2. **Memoize the measurement** on a content/layout key (`previewMeasureKey`) so scrolling a large list is O(1) per keystroke instead of re-rendering the list each tick; `clearRight` resets it so a new preview recomputes.

After the fix (instrumented): reaches the last item for 300/1k/5k/20k lists, no dead band, and per-keystroke cost on a 20k-item list dropped from ~3ms to **<0.5ms** (28µs at 300 items).

## Test plan

- [x] `TestPreviewScroll_ReachesBottomForLongList` — last item of 120/300/1000-item lists is reachable.
- [x] `TestPreviewScroll_NoDeadBandAtBottom` — one scroll-up from the bottom moves the viewport by exactly one row.
- [x] `TestPreviewScroll_MeasureMemoized` — measurement is cached on a stable key and recomputes on grow/shrink.
- [x] `go test ./...` passes; `golangci-lint run internal/app/...` clean; full binary builds.
- [ ] Manual: scroll a few-hundred-item resource type's right pane to the bottom and back (not run here — no live cluster).

Reviewed by the go-reviewer agent (no CRITICAL/HIGH); added the shrink-case test it suggested.