### PR TITLE
feat: alias shift+down/shift+up to half-page scroll (closes #369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `k` / `Up` | Move cursor up |
 | `gg` / `Home` | Jump to top of list |
 | `G` / `End` | Jump to bottom of list |
-| `Ctrl+D` / `Ctrl+U` | Half-page scroll down/up |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page scroll down/up |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Full-page scroll down/up |
 | `Enter` | Open full-screen YAML view / navigate into |
 | `z` | Toggle expand/collapse all resource groups / toggle event grouping (Events view) |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -13,7 +13,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `gg` / `Home` | Jump to top of list |
 | `G` / `End` | Jump to bottom of list |
 | `Enter` | Open full-screen YAML view / navigate into |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `z` | Toggle expand/collapse all resource groups / toggle event grouping in the Events list |
 | `p` | Pin/unpin resource type (at resource types level) |
@@ -220,7 +220,7 @@ a single-character slot.
 | `f` | Filter — narrows the visible list to lines matching the query |
 | `Esc` | Cascades: clear active search → clear active filter → close help |
 | `j` / `k` | Scroll down/up |
-| `Ctrl+D` / `Ctrl+U` | Half-page scroll down/up |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page scroll down/up |
 | `Ctrl+F` / `Ctrl+B` / `PgDown` / `PgUp` | Full-page scroll |
 | `g` / `G` | Jump to top / bottom |
 | `q` / `?` / `F1` | Close help |
@@ -243,7 +243,7 @@ a single-character slot.
 | `gg` / `Home` | Jump to top |
 | `G` / `End` | Jump to bottom |
 | `123G` | Jump to line number |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
@@ -276,7 +276,7 @@ a single-character slot.
 | `123w` / `123b` / `123e` (and capitals) | Apply word/WORD motion N times |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
 | `123G` | Jump to line number |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
@@ -309,7 +309,7 @@ a single-character slot.
 | `123w` / `123b` / `123e` (and capitals) | Apply word/WORD motion N times |
 | `gg` / `Home` | Jump to top |
 | `G` / `End` | Jump to bottom |
-| `Ctrl+D` / `Ctrl+U` | Half page down / up |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half page down / up |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Full page down / up |
 | `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
@@ -406,7 +406,7 @@ from `terminal:` in the config.
 | `Tab` | Switch cursor side (side-by-side mode) |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
 | `123G` | Jump to line number |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
@@ -447,7 +447,7 @@ Press `V` on a resource (or open the Events list and press `Enter` on an event) 
 | `gg` / `Home` | Jump to top |
 | `G` / `End` | Jump to bottom |
 | `123G` | Jump to specific line number |
-| `Ctrl+D` / `Ctrl+U` | Half page down / up |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half page down / up |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Full page down / up |
 | `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
@@ -568,7 +568,7 @@ The editor picks one of two modes based on the value being edited:
 | `Esc` | Cancel the in-progress edit |
 | `←` / `→` | Move cursor left / right |
 | `↑` / `↓` | Move cursor up / down (preserves byte column on the prev/next `\n`-delimited line; pane mode only) |
-| `Ctrl+D` / `Ctrl+U` | Scroll cursor down / up by half a page (pane mode only) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Scroll cursor down / up by half a page (pane mode only) |
 | `Ctrl+F` / `Ctrl+B` | Scroll cursor down / up by a full page (pane mode only) |
 | `Ctrl+A` / `Ctrl+E` | Move cursor to start / end of the **current line** (vim-like `0` / `$`) |
 | `Backspace` | Delete the character before the cursor |
@@ -591,7 +591,7 @@ The editor picks one of two modes based on the value being edited:
 | `n` / `N` | Next / previous search match (recursive: auto-drills into children / searches parent) |
 | `r` | Recursive field browser (browse all nested fields with filter) |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `q` | Close API explorer |
 | `Esc` | Go back one level / close at root |
@@ -606,7 +606,7 @@ The editor picks one of two modes based on the value being edited:
 | `a` | Toggle all/allowed-only permissions |
 | `s` | Switch subject (User/Group/SA) |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `Tab` | Toggle to **Who-Can** (reverse RBAC: verb + resource → subjects) |
 | `q` / `Esc` | Clear search / close |
@@ -631,7 +631,7 @@ fires a fresh query so the right pane updates as you browse.
 | `j` / `k` (or `↓` / `↑`) | Move the resource cursor (re-queries for the new resource) |
 | `J` / `K` | Scroll the subjects column (right pane) without moving the resource cursor |
 | `g` / `G` (or `Home` / `End`) | Jump to top / bottom of the resource list |
-| `Ctrl+D` / `Ctrl+U` | Half page down / up in the resource list |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half page down / up in the resource list |
 | `Ctrl+F` / `Ctrl+B` (or `PgDn` / `PgUp`) | Full page down / up in the resource list |
 | `←` / `→` (or `h` / `l`) | Cycle the verb chip (`get` `list` `watch` `create` `update` `patch` `delete` `*`) |
 | `/` | Filter the resource list by substring (Enter to accept, Esc to clear) |
@@ -654,7 +654,7 @@ grants apply everywhere); RoleBindings outside the active scope are excluded.
 | `j` / `k` | Navigate subjects |
 | `/` | Filter subjects by name |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `Enter` | Select subject |
 | `Esc` | Clear filter / close |
@@ -665,7 +665,7 @@ grants apply everywhere); RoleBindings outside the active scope are excluded.
 |---|---|
 | `j` / `k` | Scroll up/down |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `q` / `Esc` | Close visualizer |
 
@@ -704,7 +704,7 @@ existing recommendations stay visually similar after the upgrade).
 | `<` | Cycle to the previous headroom multiplier (wraps around; same snap behavior as `>`) |
 | `j` / `k` | Scroll up / down |
 | `g` / `G` (or `Home` / `End`) | Jump to top / bottom |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` (or `PgDn` / `PgUp`) | Page down / up (full page) |
 | `esc` / `q` | Close |
 
@@ -735,7 +735,7 @@ Invalid config values are dropped at startup with a warning in the error log.
 |---|---|
 | `j` / `k` | Move cursor up/down |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
-| `Ctrl+D` / `Ctrl+U` | Page down / up (half page) |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `V` | Line visual selection |
 | `v` | Character visual selection (from cursor column) |
@@ -1063,7 +1063,7 @@ last logs, and describe for the failing container in one tabbed panel.
 | `p`            | Toggle previous / current logs (Logs tab only)            |
 | `j` / `k`      | Scroll within tab body                                    |
 | `g` / `G`      | Jump to top / bottom of tab body                          |
-| `Ctrl+D` / `Ctrl+U` | Half-page down / up                                  |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page down / up                                  |
 | `Ctrl+F` / `Ctrl+B` | Full-page down / up (also `PgDn` / `PgUp`)           |
 | `Shift+R`      | Refresh — re-fetch all sections, preserves cursor state  |
 | `Esc` / `q`    | Close overlay                                             |
@@ -1093,7 +1093,7 @@ on the right. `Tab` toggles which pane has focus.
 | `Enter` / `Space` | If on wave header: toggle wave collapse. If on placeholder: toggle phase collapse. If on resource: no-op |
 | `Tab` / `Shift+Tab` | Switch focus to sidebar |
 | `g` / `G` | First / last visible body row |
-| `Ctrl+D` / `Ctrl+U` | Half-page scroll |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page scroll |
 | `Ctrl+F` / `Ctrl+B` (or `PgDn` / `PgUp`) | Full-page scroll |
 
 **Shared:**
@@ -1145,7 +1145,7 @@ For Service targets, an endpoint picker appears first:
 | `Y` | Copy pcap path to system clipboard; marks capture saved |
 | `/` | Search within live table |
 | `j` / `k` | Scroll older / newer (tail-anchored: `0` = latest at bottom) |
-| `Ctrl+D` / `Ctrl+U` | Half-page scroll older / newer |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page scroll older / newer |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Full-page scroll older / newer |
 | `g` / `G` | Jump to oldest / return to live (latest) |
 

--- a/internal/app/cluster_color_overlay.go
+++ b/internal/app/cluster_color_overlay.go
@@ -114,10 +114,10 @@ func (m Model) handleClusterColorOverlayKey(key string) (tea.Model, tea.Cmd) {
 			m.clusterColorOverlayCursor = (m.clusterColorOverlayCursor - 1 + rows) % rows
 		}
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.clusterColorOverlayCursor = clampOverlayCursor(m.clusterColorOverlayCursor, 10, rows-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.clusterColorOverlayCursor = clampOverlayCursor(m.clusterColorOverlayCursor, -10, rows-1)
 		return m, nil
 	case "ctrl+f", "pgdown":

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -182,9 +182,9 @@ func (m Model) handleObjectExplorerNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			rt.cursor = n - 1
 			rt.previewScroll = 0
 		}
-	case kb.PageDown, "pgdown", "ctrl+f":
+	case kb.PageDown, "pgdown", "ctrl+f", "shift+down":
 		m.moveObjectExplorerCursor(max(m.objectExplorerBodyHeight()/2, 1))
-	case kb.PageUp, "pgup", "ctrl+b":
+	case kb.PageUp, "pgup", "ctrl+b", "shift+up":
 		m.moveObjectExplorerCursor(-max(m.objectExplorerBodyHeight()/2, 1))
 	}
 	m.clampObjectExplorerScroll()

--- a/internal/app/objectexplorer_find.go
+++ b/internal/app/objectexplorer_find.go
@@ -63,9 +63,9 @@ func (m Model) handleObjectExplorerFindKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		rt.findCursor = 0
 	case "G", "end":
 		rt.findCursor = max(n-1, 0)
-	case "ctrl+d", "pgdown":
+	case "ctrl+d", "pgdown", "shift+down":
 		rt.findCursor = min(rt.findCursor+visible/2, max(n-1, 0))
-	case "ctrl+u", "pgup":
+	case "ctrl+u", "pgup", "shift+up":
 		rt.findCursor = max(rt.findCursor-visible/2, 0)
 	}
 	m.clampFindScroll()

--- a/internal/app/ptyexec.go
+++ b/internal/app/ptyexec.go
@@ -127,9 +127,9 @@ func (m Model) handleExecKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.execSwitchTab((m.activeTab - 1 + len(m.tabs)) % len(m.tabs))
 		case "t":
 			return m.execNewTab()
-		case "ctrl+u":
+		case "ctrl+u", "shift+up":
 			return m.execScrollBy(-(m.execViewportRows() / 2)), nil
-		case "ctrl+d":
+		case "ctrl+d", "shift+down":
 			return m.execScrollBy(m.execViewportRows() / 2), nil
 		case "ctrl+b":
 			return m.execScrollBy(-m.execViewportRows()), nil

--- a/internal/app/shift_page_alias_test.go
+++ b/internal/app/shift_page_alias_test.go
@@ -1,0 +1,168 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// shift+up / shift+down are aliases for ctrl+u / ctrl+d (half-page scroll),
+// mirroring how pgup / pgdown alias ctrl+b / ctrl+f. These tests assert the
+// alias produces the same observable movement as the real key across the
+// representative scroll handlers, and that the alias does NOT leak into
+// text-input contexts where ctrl+u means "delete to start of line".
+
+func manyLines(n int) string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = "x"
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestShiftDownAliasesCtrlDInExplorerList(t *testing.T) {
+	items := make([]model.Item, 50)
+	for i := range items {
+		items[i] = model.Item{Name: "pod", Kind: "Pod"}
+	}
+	build := func() Model {
+		m := baseExplorerModel()
+		m.middleItems = items
+		m.setCursor(0)
+		return m
+	}
+
+	realRet, _, _ := build().handleExplorerActionKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	aliasRet, _, handled := build().handleExplorerActionKey(tea.KeyMsg{Type: tea.KeyShiftDown})
+	assert.True(t, handled, "shift+down must be handled as half-page down")
+	realM, aliasM := realRet.(Model), aliasRet.(Model)
+	assert.Greater(t, aliasM.cursor(), 0)
+	assert.Equal(t, realM.cursor(), aliasM.cursor())
+}
+
+func TestShiftUpAliasesCtrlUInExplorerList(t *testing.T) {
+	items := make([]model.Item, 50)
+	for i := range items {
+		items[i] = model.Item{Name: "pod", Kind: "Pod"}
+	}
+	build := func() Model {
+		m := baseExplorerModel()
+		m.middleItems = items
+		m.setCursor(40)
+		return m
+	}
+
+	realRet, _, _ := build().handleExplorerActionKey(tea.KeyMsg{Type: tea.KeyCtrlU})
+	aliasRet, _, handled := build().handleExplorerActionKey(tea.KeyMsg{Type: tea.KeyShiftUp})
+	assert.True(t, handled, "shift+up must be handled as half-page up")
+	realM, aliasM := realRet.(Model), aliasRet.(Model)
+	assert.Less(t, aliasM.cursor(), 40)
+	assert.Equal(t, realM.cursor(), aliasM.cursor())
+}
+
+func TestShiftArrowAliasesInYAMLView(t *testing.T) {
+	build := func() Model {
+		return Model{
+			width: 80, height: 30, mode: modeYAML,
+			yamlView: yamlViewState{
+				content:   manyLines(100),
+				collapsed: map[string]bool{},
+				cursor:    50,
+			},
+			tabs: []TabState{{}},
+		}
+	}
+	rd, _ := build().handleYAMLKey(keyMsg("ctrl+d"))
+	ad, _ := build().handleYAMLKey(keyMsg("shift+down"))
+	assert.Equal(t, rd.(Model).yamlView.cursor, ad.(Model).yamlView.cursor)
+	assert.NotEqual(t, 50, ad.(Model).yamlView.cursor, "shift+down must move the cursor")
+
+	ru, _ := build().handleYAMLKey(keyMsg("ctrl+u"))
+	au, _ := build().handleYAMLKey(keyMsg("shift+up"))
+	assert.Equal(t, ru.(Model).yamlView.cursor, au.(Model).yamlView.cursor)
+	assert.NotEqual(t, 50, au.(Model).yamlView.cursor, "shift+up must move the cursor")
+}
+
+func TestShiftArrowAliasesInDiffView(t *testing.T) {
+	content := manyLines(200)
+	build := func() Model {
+		return Model{
+			width: 80, height: 40, mode: modeDiff,
+			diffView: diffViewState{
+				left: content, right: content,
+				leftName: "before", rightName: "after",
+				cursor: 50,
+			},
+			tabs: []TabState{{}},
+		}
+	}
+	rd, _ := build().handleDiffKey(keyMsg("ctrl+d"))
+	ad, _ := build().handleDiffKey(keyMsg("shift+down"))
+	assert.Equal(t, rd.(Model).diffView.cursor, ad.(Model).diffView.cursor)
+	assert.NotEqual(t, 50, ad.(Model).diffView.cursor)
+
+	ru, _ := build().handleDiffKey(keyMsg("ctrl+u"))
+	au, _ := build().handleDiffKey(keyMsg("shift+up"))
+	assert.Equal(t, ru.(Model).diffView.cursor, au.(Model).diffView.cursor)
+	assert.NotEqual(t, 50, au.(Model).diffView.cursor)
+}
+
+func TestShiftArrowAliasesInDescribeView(t *testing.T) {
+	build := func() Model {
+		m := baseModelDescribe()
+		m.describeView.cursor = 5
+		return m
+	}
+	rd, _ := build().handleDescribeKey(keyMsg("ctrl+d"))
+	ad, _ := build().handleDescribeKey(keyMsg("shift+down"))
+	assert.Equal(t, rd.(Model).describeView.cursor, ad.(Model).describeView.cursor)
+	assert.Greater(t, ad.(Model).describeView.cursor, 5)
+
+	ru, _ := build().handleDescribeKey(keyMsg("ctrl+u"))
+	au, _ := build().handleDescribeKey(keyMsg("shift+up"))
+	assert.Equal(t, ru.(Model).describeView.cursor, au.(Model).describeView.cursor)
+	assert.Less(t, au.(Model).describeView.cursor, 5)
+}
+
+func TestShiftArrowAliasesInLogView(t *testing.T) {
+	build := func() Model {
+		m := basePush4Model()
+		m.mode = modeLogs
+		m.logView.lines = strings.Split(manyLines(100), "\n")
+		m.logView.cursor = 50
+		return m
+	}
+	rd, _ := build().handleLogKey(keyMsg("ctrl+d"))
+	ad, _ := build().handleLogKey(keyMsg("shift+down"))
+	assert.Equal(t, rd.(Model).logView.cursor, ad.(Model).logView.cursor)
+	assert.NotEqual(t, 50, ad.(Model).logView.cursor)
+
+	ru, _ := build().handleLogKey(keyMsg("ctrl+u"))
+	au, _ := build().handleLogKey(keyMsg("shift+up"))
+	assert.Equal(t, ru.(Model).logView.cursor, au.(Model).logView.cursor)
+	assert.NotEqual(t, 50, au.(Model).logView.cursor)
+}
+
+// Regression: in a text input, ctrl+u clears the line. shift+up must NOT
+// inherit that behavior — it should leave the input untouched.
+func TestShiftUpDoesNotClearFilterInput(t *testing.T) {
+	m := baseExplorerModel()
+	m.filterInput.Value = "nginx"
+
+	ret, _ := m.handleFilterKey(keyMsg("shift+up"))
+	assert.Equal(t, "nginx", ret.(Model).filterInput.Value,
+		"shift+up must not clear the filter input the way ctrl+u does")
+}
+
+func TestShiftUpDoesNotClearSearchInput(t *testing.T) {
+	m := baseExplorerModel()
+	m.searchInput.Value = "error"
+
+	ret, _ := m.handleSearchKey(keyMsg("shift+up"))
+	assert.Equal(t, "error", ret.(Model).searchInput.Value,
+		"shift+up must not clear the search input the way ctrl+u does")
+}

--- a/internal/app/status_clear.go
+++ b/internal/app/status_clear.go
@@ -35,7 +35,7 @@ func (m Model) clearStatusOnNavigationKey(msg tea.KeyMsg) Model {
 	switch msg.String() {
 	case kb.Down, "down", kb.Up, "up", kb.Left, "left", kb.Right, "right",
 		kb.JumpTop, kb.JumpBottom, "end", "home",
-		kb.PageDown, kb.PageUp, kb.PageForward, kb.PageBack, "pgdown", "pgup",
+		kb.PageDown, kb.PageUp, kb.PageForward, kb.PageBack, "pgdown", "pgup", "shift+down", "shift+up",
 		kb.PreviewDown, kb.PreviewUp,
 		kb.LevelCluster, kb.LevelTypes, kb.LevelResources,
 		kb.JumpBack, kb.JumpOwner,

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -647,6 +647,10 @@ func keyMsg(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyPgUp}
 	case "pgdown":
 		return tea.KeyMsg{Type: tea.KeyPgDown}
+	case "shift+up":
+		return tea.KeyMsg{Type: tea.KeyShiftUp}
+	case "shift+down":
+		return tea.KeyMsg{Type: tea.KeyShiftDown}
 	case "home":
 		return tea.KeyMsg{Type: tea.KeyHome}
 	case "end":

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -521,10 +521,10 @@ func (m Model) handleBookmarkNavKey(msg tea.KeyMsg, filtered []model.Bookmark) (
 			m.overlayCursor = maxIdx
 		}
 		return m, true
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, 10, maxIdx)
 		return m, true
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -10, maxIdx)
 		return m, true
 	case "ctrl+f", "pgdown":

--- a/internal/app/update_cani.go
+++ b/internal/app/update_cani.go
@@ -387,7 +387,7 @@ func (m Model) handleCanIKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.canIResourceScroll = 0
 		return m, nil
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		halfPage := visibleLines / 2
 		m.canIGroupCursor = min(m.canIGroupCursor+halfPage, max(groupCount-1, 0))
 		maxScroll := max(groupCount-visibleLines, 0)
@@ -395,7 +395,7 @@ func (m Model) handleCanIKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.canIResourceScroll = 0
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		halfPage := visibleLines / 2
 		m.canIGroupCursor = max(m.canIGroupCursor-halfPage, 0)
 		m.canIGroupScroll = max(m.canIGroupScroll-halfPage, 0)
@@ -508,11 +508,11 @@ func (m Model) handleCanISubjectNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -1, len(items)-1)
 		return m, nil
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, 10, len(items)-1)
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -10, len(items)-1)
 		return m, nil
 

--- a/internal/app/update_column_toggle.go
+++ b/internal/app/update_column_toggle.go
@@ -297,11 +297,11 @@ func (m Model) handleColumnToggleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k", "up":
 		return m.handleColumnToggleKeyK()
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.columnToggleCursor = clampOverlayCursor(m.columnToggleCursor, 10, maxIdx)
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.columnToggleCursor = clampOverlayCursor(m.columnToggleCursor, -10, maxIdx)
 		return m, nil
 

--- a/internal/app/update_describe.go
+++ b/internal/app/update_describe.go
@@ -83,10 +83,10 @@ func (m Model) handleDescribeNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.describeWordMotion(key, lines)
 		}
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		step := vimScrollStep(&m.describeView.lineInput, &m.describeView.scrollOption, m.describeContentHeight())
 		return m.describePageMove(step, maxIdx)
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		step := vimScrollStep(&m.describeView.lineInput, &m.describeView.scrollOption, m.describeContentHeight())
 		return m.describePageMove(-step, maxIdx)
 	case "ctrl+f", "pgdown":
@@ -311,13 +311,13 @@ func (m Model) handleDescribeVisualKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.pendingG = true
 		}
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.describeView.cursor += scrollStep(m.describeView.scrollOption, m.describeContentHeight())
 		if m.describeView.cursor > maxIdx {
 			m.describeView.cursor = maxIdx
 		}
 		m.ensureDescribeCursorVisible()
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.describeView.cursor -= scrollStep(m.describeView.scrollOption, m.describeContentHeight())
 		if m.describeView.cursor < 0 {
 			m.describeView.cursor = 0

--- a/internal/app/update_diff.go
+++ b/internal/app/update_diff.go
@@ -159,7 +159,7 @@ func (m Model) handleDiffNormalKey(msg tea.KeyMsg, foldRegions []ui.DiffFoldRegi
 		m.diffView.cursor = 0
 		m.diffView.scroll = 0
 		return m, nil
-	case "ctrl+d", "ctrl+u", "ctrl+f", "ctrl+b", "pgdown", "pgup":
+	case "ctrl+d", "ctrl+u", "ctrl+f", "ctrl+b", "pgdown", "pgup", "shift+down", "shift+up":
 		return m.diffPageMoveByKey(msg.String(), maxCursor, visibleLines, maxScroll)
 	case "0":
 		if m.diffView.lineInput != "" {
@@ -325,10 +325,10 @@ func (m Model) handleDiffSearchNav(key string, foldRegions []ui.DiffFoldRegion, 
 // fall back to half-viewport). `<C-f>`/`<C-b>` scroll `count` full pages.
 func (m Model) diffPageMoveByKey(key string, maxCursor, visibleLines, maxScroll int) (tea.Model, tea.Cmd) {
 	switch key {
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		step := vimScrollStep(&m.diffView.lineInput, &m.diffView.scrollOption, visibleLines)
 		m.diffView.cursor = min(m.diffView.cursor+step, maxCursor)
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		step := vimScrollStep(&m.diffView.lineInput, &m.diffView.scrollOption, visibleLines)
 		m.diffView.cursor = max(m.diffView.cursor-step, 0)
 	case "ctrl+f", "pgdown":
@@ -441,11 +441,11 @@ func (m Model) handleDiffVisualKey(msg tea.KeyMsg, foldRegions []ui.DiffFoldRegi
 		m.diffView.cursor = maxCursor
 		m.ensureDiffCursorVisible(visibleLines, maxScroll)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.diffView.cursor = min(m.diffView.cursor+scrollStep(m.diffView.scrollOption, visibleLines), maxCursor)
 		m.ensureDiffCursorVisible(visibleLines, maxScroll)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.diffView.cursor = max(m.diffView.cursor-scrollStep(m.diffView.scrollOption, visibleLines), 0)
 		m.ensureDiffCursorVisible(visibleLines, maxScroll)
 		return m, nil

--- a/internal/app/update_explain.go
+++ b/internal/app/update_explain.go
@@ -234,9 +234,9 @@ func (m Model) handleExplainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "0":
 		return m.handleExplainKeyZero()
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		return m.handleExplainPageMove(visibleLines/2, fieldCount, visibleLines)
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		return m.handleExplainPageMove(-visibleLines/2, fieldCount, visibleLines)
 	case "ctrl+f", "pgdown":
 		return m.handleExplainPageMove(visibleLines, fieldCount, visibleLines)
@@ -425,13 +425,13 @@ func (m Model) handleExplainSearchOverlayNormalKey(msg tea.KeyMsg) (tea.Model, t
 		}
 		return m, nil
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		halfPage := visibleLines / 2
 		m.explainRecursiveCursor = min(m.explainRecursiveCursor+halfPage, max(resultCount-1, 0))
 		m.explainRecursiveScroll = min(m.explainRecursiveScroll+halfPage, max(resultCount-visibleLines, 0))
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		halfPage := visibleLines / 2
 		m.explainRecursiveCursor = max(m.explainRecursiveCursor-halfPage, 0)
 		m.explainRecursiveScroll = max(m.explainRecursiveScroll-halfPage, 0)

--- a/internal/app/update_finalizer.go
+++ b/internal/app/update_finalizer.go
@@ -53,11 +53,11 @@ func (m Model) handleFinalizerSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.finalizerSearchCursor = maxIdx
 		return m, nil
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, 10, maxIdx)
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, -10, maxIdx)
 		return m, nil
 

--- a/internal/app/update_help.go
+++ b/internal/app/update_help.go
@@ -61,11 +61,11 @@ func (m Model) handleHelpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.helpScroll = 9999
 		m.clampHelpScroll()
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.helpScroll += m.height / 2
 		m.clampHelpScroll()
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.helpScroll -= m.height / 2
 		if m.helpScroll < 0 {
 			m.helpScroll = 0

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -42,9 +42,9 @@ func (m Model) handleExplorerNavKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) 
 		return m.handleExplorerActionKeyAllNamespaces()
 	case kb.QuotaDashboard:
 		return m.handleExplorerActionKeyQuotaDashboard()
-	case kb.PageDown:
+	case kb.PageDown, "shift+down":
 		return m.handleExplorerActionKeyPageDown()
-	case kb.PageUp:
+	case kb.PageUp, "shift+up":
 		return m.handleExplorerActionKeyPageUp()
 	case kb.PageForward, "pgdown":
 		return m.handleExplorerActionKeyPageForward()

--- a/internal/app/update_logs.go
+++ b/internal/app/update_logs.go
@@ -36,10 +36,10 @@ func (m Model) handleLogMovementKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	case "k", "up":
 		ret, cmd := m.handleLogKeyK()
 		return ret, cmd, true
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		ret := m.handleLogKeyCtrlD()
 		return ret, nil, true
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		ret, cmd := m.handleLogKeyCtrlU()
 		return ret, cmd, true
 	case "ctrl+f", "pgdown":
@@ -220,9 +220,9 @@ func (m Model) handleLogVisualKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleLogVisualKeyG()
 	case "g":
 		return m.handleLogVisualKeyG2()
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		return m.handleLogVisualKeyCtrlD()
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		return m.handleLogVisualKeyCtrlU()
 	case "ctrl+c":
 		m.logView.visualMode = false

--- a/internal/app/update_orphans.go
+++ b/internal/app/update_orphans.go
@@ -153,9 +153,9 @@ func (m Model) handleOrphansKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m.orphansJumpCursor(0)
 	case "G", "end":
 		return m.orphansJumpCursor(len(m.orphans.visibleItems()) - 1)
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		return m.orphansMoveCursor(+max(m.orphansVisibleLines()/2, 1))
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		return m.orphansMoveCursor(-max(m.orphansVisibleLines()/2, 1))
 	case "ctrl+f", "pgdown":
 		return m.orphansMoveCursor(+max(m.orphansVisibleLines(), 1))

--- a/internal/app/update_overlays_capture.go
+++ b/internal/app/update_overlays_capture.go
@@ -303,10 +303,10 @@ func (m Model) updateOverlayCaptureLive(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case msg.String() == "k":
 		m.captureOverlay.scrollOffset++
 		return m, nil
-	case msg.String() == "ctrl+d":
+	case msg.String() == "ctrl+d", msg.String() == "shift+down":
 		m.captureOverlay.scrollOffset = max(m.captureOverlay.scrollOffset-m.captureScrollHalfPage(), 0)
 		return m, nil
-	case msg.String() == "ctrl+u":
+	case msg.String() == "ctrl+u", msg.String() == "shift+up":
 		m.captureOverlay.scrollOffset += m.captureScrollHalfPage()
 		return m, nil
 	case msg.String() == "ctrl+f", msg.String() == "pgdown":

--- a/internal/app/update_overlays_colorscheme.go
+++ b/internal/app/update_overlays_colorscheme.go
@@ -79,12 +79,12 @@ func (m Model) handleColorschemeNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.previewSchemeAtCursor(filtered)
 		return m, nil
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.schemeCursor = clampOverlayCursor(m.schemeCursor, 10, selectableCount-1)
 		m.previewSchemeAtCursor(filtered)
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.schemeCursor = clampOverlayCursor(m.schemeCursor, -10, selectableCount-1)
 		m.previewSchemeAtCursor(filtered)
 		return m, nil

--- a/internal/app/update_overlays_crash_investigator.go
+++ b/internal/app/update_overlays_crash_investigator.go
@@ -64,11 +64,11 @@ func (m Model) handleCrashInvestigatorOverlayKey(msg tea.KeyMsg) (tea.Model, tea
 		// Sentinel — renderer clamps to maxScroll.
 		m.crashInv.setScroll(m.scrollKey(), 999999)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		// Half-page (vim) — renderer clamps to maxScroll.
 		m.crashInv.bumpScroll(m.scrollKey(), +10)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.crashInv.bumpScroll(m.scrollKey(), -10)
 		return m, nil
 	case "ctrl+f", "pgdown":

--- a/internal/app/update_overlays_editors_edit_mode.go
+++ b/internal/app/update_overlays_editors_edit_mode.go
@@ -53,10 +53,10 @@ func handleEditPanePageKey(m Model, valInput *TextInput, col int, key string, ti
 	}
 	_, pageH := editValuePaneDims(m, titleH)
 	switch key {
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		editPaneMoveByLines(valInput, max(pageH/2, 1))
 		return true
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		editPaneMoveByLines(valInput, -max(pageH/2, 1))
 		return true
 	case "ctrl+f":

--- a/internal/app/update_overlays_errorlog.go
+++ b/internal/app/update_overlays_errorlog.go
@@ -140,14 +140,14 @@ func (m Model) handleErrorLogOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.errorLogLineInput += key
 		return m, nil
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.errorLogLineInput = ""
 		halfPage := maxVisible / 2
 		m.errorLogCursorLine = min(m.errorLogCursorLine+halfPage, maxCursor)
 		m.errorLogScroll = m.errorLogEnsureCursorVisible(maxVisible, maxScroll)
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.errorLogLineInput = ""
 		halfPage := maxVisible / 2
 		m.errorLogCursorLine = max(m.errorLogCursorLine-halfPage, 0)

--- a/internal/app/update_overlays_events.go
+++ b/internal/app/update_overlays_events.go
@@ -238,12 +238,12 @@ func (m Model) handleEventTimelineMovementKey(msg tea.KeyMsg) (Model, bool) {
 		return m.handleEventTimelineOverlayKeyE(), true
 	case "E":
 		return m.handleEventTimelineOverlayKeyE2(), true
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		step := vimScrollStep(&m.eventTimelineLineInput, &m.eventTimelineScrollOption, m.eventContentHeight())
 		m.eventTimelineCursor = min(m.eventTimelineCursor+step, maxIdx)
 		m.ensureEventCursorVisible()
 		return m, true
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		return m.handleEventTimelineOverlayKeyCtrlU(), true
 	case "ctrl+f", "pgdown":
 		n := consumeCountPrefix(&m.eventTimelineLineInput)
@@ -349,10 +349,10 @@ func (m *Model) handleEventTimelineVisualMovement(key string, maxIdx int) {
 		} else {
 			m.pendingG = true
 		}
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.eventTimelineCursor = min(m.eventTimelineCursor+scrollStep(m.eventTimelineScrollOption, m.eventContentHeight()), maxIdx)
 		m.ensureEventCursorVisible()
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.eventTimelineCursor = max(m.eventTimelineCursor-scrollStep(m.eventTimelineScrollOption, m.eventContentHeight()), 0)
 		m.ensureEventCursorVisible()
 	default:

--- a/internal/app/update_overlays_logs.go
+++ b/internal/app/update_overlays_logs.go
@@ -65,10 +65,10 @@ func (m Model) handlePodSelectOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k", "up", "ctrl+p":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -1, len(items)-1)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, 10, len(items)-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -10, len(items)-1)
 		return m, nil
 	case "ctrl+c":
@@ -132,10 +132,10 @@ func (m Model) handleLogPodSelectOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 	case "k", "up", "ctrl+p":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -1, len(items)-1)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, 10, len(items)-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -10, len(items)-1)
 		return m, nil
 	case "ctrl+c":
@@ -315,10 +315,10 @@ func (m Model) handleLogContainerSelectOverlayKey(msg tea.KeyMsg) (tea.Model, te
 	case "k", "up", "ctrl+p":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -1, len(items)-1)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, 10, len(items)-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -10, len(items)-1)
 		return m, nil
 	case "P", "\\":

--- a/internal/app/update_overlays_misc.go
+++ b/internal/app/update_overlays_misc.go
@@ -52,10 +52,10 @@ func (m Model) handleNetworkPolicyOverlayKey(msg tea.KeyMsg) Model {
 			m.netpolLineInput += "0"
 			return m
 		}
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.netpolLineInput = ""
 		m.netpolScroll += m.height / 2
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.netpolLineInput = ""
 		m.netpolScroll -= m.height / 2
 		if m.netpolScroll < 0 {
@@ -209,11 +209,11 @@ func (m Model) handleAlertsOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.alertsLineInput += "0"
 			return m, nil
 		}
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.alertsLineInput = ""
 		m.alertsScroll += 10
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.alertsLineInput = ""
 		m.alertsScroll = max(m.alertsScroll-10, 0)
 		return m, nil

--- a/internal/app/update_overlays_rightsizing.go
+++ b/internal/app/update_overlays_rightsizing.go
@@ -65,10 +65,10 @@ func (m Model) handleRightsizingOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 	case "G", "end":
 		m.rightsizing.scroll = clampRightsizingScroll(m, math.MaxInt32)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.rightsizing.scroll = clampRightsizingScroll(m, m.rightsizing.scroll+rightsizingVisibleRows(m)/2)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.rightsizing.scroll = clampRightsizingScroll(m, m.rightsizing.scroll-rightsizingVisibleRows(m)/2)
 		return m, nil
 	case "ctrl+f", "pgdown":

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -229,11 +229,11 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -1, len(items)-1)
 		return m, nil
 
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, 10, len(items)-1)
 		return m, nil
 
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.overlayCursor = clampOverlayCursor(m.overlayCursor, -10, len(items)-1)
 		return m, nil
 
@@ -420,10 +420,10 @@ func (m Model) handleTemplateOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "down", "j", "ctrl+n":
 		m.templateCursor = clampOverlayCursor(m.templateCursor, 1, len(filtered)-1)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.templateCursor = clampOverlayCursor(m.templateCursor, 10, len(filtered)-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.templateCursor = clampOverlayCursor(m.templateCursor, -10, len(filtered)-1)
 		return m, nil
 	case "ctrl+f", "pgdown":

--- a/internal/app/update_overlays_selectors_helm.go
+++ b/internal/app/update_overlays_selectors_helm.go
@@ -20,10 +20,10 @@ func (m Model) handleRollbackOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k", "up":
 		m.rollbackCursor = clampOverlayCursor(m.rollbackCursor, -1, len(m.rollbackRevisions)-1)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.rollbackCursor = clampOverlayCursor(m.rollbackCursor, 10, len(m.rollbackRevisions)-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.rollbackCursor = clampOverlayCursor(m.rollbackCursor, -10, len(m.rollbackRevisions)-1)
 		return m, nil
 	case "ctrl+f", "pgdown":
@@ -102,10 +102,10 @@ func (m Model) handleHelmRollbackOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 	case "k", "up":
 		m.helmRollbackCursor = clampOverlayCursor(m.helmRollbackCursor, -1, len(m.helmRollbackRevisions)-1)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.helmRollbackCursor = clampOverlayCursor(m.helmRollbackCursor, 10, len(m.helmRollbackRevisions)-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.helmRollbackCursor = clampOverlayCursor(m.helmRollbackCursor, -10, len(m.helmRollbackRevisions)-1)
 		return m, nil
 	case "ctrl+f", "pgdown":
@@ -181,10 +181,10 @@ func (m Model) handleHelmHistoryOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 	case "k", "up":
 		m.helmHistoryCursor = clampOverlayCursor(m.helmHistoryCursor, -1, len(m.helmHistoryRevisions)-1)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.helmHistoryCursor = clampOverlayCursor(m.helmHistoryCursor, 10, len(m.helmHistoryRevisions)-1)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.helmHistoryCursor = clampOverlayCursor(m.helmHistoryCursor, -10, len(m.helmHistoryRevisions)-1)
 		return m, nil
 	case "ctrl+f", "pgdown":

--- a/internal/app/update_overlays_sync_wave.go
+++ b/internal/app/update_overlays_sync_wave.go
@@ -161,12 +161,12 @@ func (m Model) handleSyncWaveBodyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.syncWave.bodyCursor = syncWaveBodyCursor{waveIdx: last.waveIdx, resourceIdx: last.resourceIdx}
 		adjustBodyScrollToCursor(&m.syncWave, len(rows)-1, viewport)
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		cur = min(cur+10, len(rows)-1)
 		m.syncWave.bodyCursor = syncWaveBodyCursor{waveIdx: rows[cur].waveIdx, resourceIdx: rows[cur].resourceIdx}
 		adjustBodyScrollToCursor(&m.syncWave, cur, viewport)
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		cur = max(cur-10, 0)
 		m.syncWave.bodyCursor = syncWaveBodyCursor{waveIdx: rows[cur].waveIdx, resourceIdx: rows[cur].resourceIdx}
 		adjustBodyScrollToCursor(&m.syncWave, cur, viewport)

--- a/internal/app/update_overlays_tasks.go
+++ b/internal/app/update_overlays_tasks.go
@@ -65,11 +65,11 @@ func (m Model) handleBackgroundTasksOverlayKey(msg tea.KeyMsg) (tea.Model, tea.C
 		m.tasksOverlayScroll = m.clampTasksOverlayScroll(m.tasksOverlayScroll - 1)
 		m = m.maybeFreezeHistory()
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.tasksOverlayScroll = m.clampTasksOverlayScroll(m.tasksOverlayScroll + tasksOverlayScrollStep)
 		m = m.maybeFreezeHistory()
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.tasksOverlayScroll = m.clampTasksOverlayScroll(m.tasksOverlayScroll - tasksOverlayScrollStep)
 		m = m.maybeFreezeHistory()
 		return m, nil

--- a/internal/app/update_whocan.go
+++ b/internal/app/update_whocan.go
@@ -122,9 +122,9 @@ func (m Model) handleWhoCanKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "G", "end":
 		visible := m.whoCanVisibleResources()
 		return m.whoCanJumpCursor(len(visible) - 1)
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		return m.whoCanMoveCursor(+m.whoCanVisibleLines() / 2)
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		return m.whoCanMoveCursor(-m.whoCanVisibleLines() / 2)
 	case "ctrl+f", "pgdown":
 		return m.whoCanMoveCursor(+m.whoCanVisibleLines())

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -221,9 +221,9 @@ func (m Model) handleYAMLNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.yamlView.cursor = 0
 		m.ensureYAMLCursorVisible()
 		return m, nil
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		return m.handleYAMLNormalHalfPageDown(totalVisible)
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		return m.handleYAMLKeyCtrlU()
 	case "ctrl+f", "pgdown":
 		return m.handleYAMLNormalPageDown(totalVisible)

--- a/internal/app/update_yaml_visual.go
+++ b/internal/app/update_yaml_visual.go
@@ -69,14 +69,14 @@ func (m Model) handleYAMLVisualKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "G":
 		return m.handleYAMLVisualG(totalVisible, maxScroll)
-	case "ctrl+d":
+	case "ctrl+d", "shift+down":
 		m.yamlView.cursor += scrollStep(m.yamlView.scrollOption, m.yamlViewportLines())
 		if m.yamlView.cursor >= totalVisible {
 			m.yamlView.cursor = totalVisible - 1
 		}
 		m.ensureYAMLCursorVisible()
 		return m, nil
-	case "ctrl+u":
+	case "ctrl+u", "shift+up":
 		m.yamlView.cursor -= scrollStep(m.yamlView.scrollOption, m.yamlViewportLines())
 		if m.yamlView.cursor < 0 {
 			m.yamlView.cursor = 0

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -16,7 +16,7 @@ func helpSections() []helpSection {
 				{kb.Up + " / Up", "Move up"},
 				{kb.JumpTop + kb.JumpTop + " / Home", "Jump to top"},
 				{kb.JumpBottom + " / End", "Jump to bottom"},
-				{helpKeyDisplay(kb.PageDown) + " / " + helpKeyDisplay(kb.PageUp), "Half-page scroll down / up"},
+				{helpKeyDisplay(kb.PageDown) + " / " + helpKeyDisplay(kb.PageUp) + " / Shift+↓ / Shift+↑", "Half-page scroll down / up"},
 				{helpKeyDisplay(kb.PageForward) + " / " + helpKeyDisplay(kb.PageBack) + " / PgDn / PgUp", "Full-page scroll down / up"},
 				{kb.Enter, "Open YAML view / navigate into"},
 				{kb.LevelCluster + "/" + kb.LevelTypes + "/" + kb.LevelResources, "Jump to clusters/types/resources level"},


### PR DESCRIPTION
Closes #369.

## What

Bind `shift+down` / `shift+up` as aliases for `ctrl+d` / `ctrl+u` (half-page scroll), mirroring the existing `pgdown` / `pgup` → `ctrl+f` / `ctrl+b` full-page aliasing. `ctrl+u` / `ctrl+d` stay bound — nothing is removed or remapped.

The request in #369 was for an easier-to-reach half-page key than the awkward `ctrl+u`; an alias delivers that without disturbing existing vim-style bindings.

## Scope

- Aliases added to every half-page scroll/navigation dispatch site (main list, YAML, logs, describe, diff, exec/pty, and all overlays) plus the diff key-router and the navigation status-clear list — 88 sites across 32 files.
- **Excluded** the text-input "clear-line" sites (filter, search, log-search, confirm-type dialog, command bar). There `ctrl+u` means *delete to start of line*; aliasing `shift+up` to it would be surprising. A regression test guards that `shift+up` leaves these inputs untouched.
- `shift+up`/`shift+down` are confirmed as the literal key strings emitted by bubbletea v1.3.10, so no input-layer changes were required.

## Docs & help

- `docs/keybindings.md` (18 half-page rows) and `README.md` list the new aliases.
- In-app **Navigation** help lists them on the half-page line (mirrors how the full-page line lists `PgDn`/`PgUp`).
- Per-view compact help tables left unchanged — adding to them widened the key column and re-wrapped descriptions.

## Tests

New `shift_page_alias_test.go`:
- `shift+down` == `ctrl+d` and `shift+up` == `ctrl+u` across explorer / YAML / diff / describe / logs.
- Regression: `shift+up` does not clear the filter or search input.

## Verification

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run ./...` — 0 issues

## Notes for review

- **Exec / PTY mode:** aliases were added there too, consistent with `ctrl+u`/`ctrl+d` already being intercepted for scrollback rather than forwarded to the shell. Open to leaving shift+arrows forwarded instead if preferred.
- **Hint bar:** unchanged — `pgup`/`pgdown` aliases aren't shown there either, and the primary `ctrl+d`/`ctrl+u` keys still display.