### PR TITLE
feat: YAML viewer O-jump to Object Explorer + attribute path in title

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -265,7 +265,7 @@ a single-character slot.
 | `I` | Open the API Explorer at the schema of the attribute under the cursor |
 | `q` / `Esc` | Back to explorer |
 
-The title bar shows the attribute path under the cursor (e.g. `spec.containers[0].image`), like the Object Explorer location.
+The top breadcrumb shows the resource name and the attribute path under the cursor (e.g. `lfk > ctx > Pods > my-pod > spec.containers[0].image`), like the Object Explorer location.
 
 ## Describe View
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -261,7 +261,11 @@ a single-character slot.
 | `Z` | Toggle all folds (collapse/expand all) |
 | `Ctrl+W` / `>` | Toggle line wrapping |
 | `Ctrl+E` | Edit resource in `$KUBE_EDITOR` or `$EDITOR` |
+| `O` | Switch to the Object Explorer at the attribute under the cursor (keeps position) |
+| `I` | Open the API Explorer at the schema of the attribute under the cursor |
 | `q` / `Esc` | Back to explorer |
+
+The title bar shows the attribute path under the cursor (e.g. `spec.containers[0].image`), like the Object Explorer location.
 
 ## Describe View
 

--- a/internal/app/breadcrumb_viewers_test.go
+++ b/internal/app/breadcrumb_viewers_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// The fullscreen viewers (logs, exec, describe, diff, events) must surface the
+// object they show in the top breadcrumb, the same way the YAML viewer and the
+// Object Explorer do. Each case is exercised through explorerDrillPath, which
+// builds the trailing breadcrumb segment(s).
+
+func TestDrillPathLogsShowsPodAndContainer(t *testing.T) {
+	m := Model{mode: modeLogs, nav: model.NavigationState{Level: model.LevelResources}}
+	m.actionCtx.name = "my-pod"
+	assert.Equal(t, []string{"my-pod"}, m.explorerDrillPath())
+
+	m.actionCtx.containerName = "web"
+	assert.Equal(t, []string{"my-pod", "web"}, m.explorerDrillPath())
+}
+
+func TestDrillPathExecShowsPodAndContainer(t *testing.T) {
+	m := Model{mode: modeExec, nav: model.NavigationState{Level: model.LevelResources}}
+	m.actionCtx.name = "my-pod"
+	m.actionCtx.containerName = "web"
+	assert.Equal(t, []string{"my-pod", "web"}, m.explorerDrillPath())
+}
+
+func TestDrillPathDescribeShowsResource(t *testing.T) {
+	m := Model{mode: modeDescribe, nav: model.NavigationState{Level: model.LevelResources}}
+	m.actionCtx.name = "my-deploy"
+	assert.Equal(t, []string{"my-deploy"}, m.explorerDrillPath())
+}
+
+func TestDrillPathEventViewerShowsResourceOrNothing(t *testing.T) {
+	m := Model{mode: modeEventViewer, nav: model.NavigationState{Level: model.LevelResources}}
+	m.actionCtx.name = "my-pod"
+	assert.Equal(t, []string{"my-pod"}, m.explorerDrillPath())
+
+	// Cluster-wide events (no target) add nothing.
+	m.actionCtx.name = ""
+	assert.Nil(t, m.explorerDrillPath())
+}
+
+func TestDrillPathDiffShowsBothNames(t *testing.T) {
+	m := Model{mode: modeDiff, nav: model.NavigationState{Level: model.LevelResources}}
+	m.diffView.leftName = "pod-a"
+	m.diffView.rightName = "pod-b"
+	assert.Equal(t, []string{"pod-a ↔ pod-b"}, m.explorerDrillPath())
+}
+
+// At the containers level the nav breadcrumb already ends with the pod
+// (OwnedName), so the drill path must not repeat it — only the container.
+func TestDrillPathLogsDedupsPodAtContainerLevel(t *testing.T) {
+	m := Model{
+		mode: modeLogs,
+		nav: model.NavigationState{
+			Level:     model.LevelContainers,
+			OwnedName: "my-pod",
+		},
+	}
+	m.actionCtx.name = "my-pod" // same pod the nav breadcrumb already shows
+	m.actionCtx.containerName = "web"
+	assert.Equal(t, []string{"web"}, m.explorerDrillPath())
+}

--- a/internal/app/breadcrumb_viewers_test.go
+++ b/internal/app/breadcrumb_viewers_test.go
@@ -8,6 +8,19 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 )
 
+// resourceTitleLabel is the shared "Kind namespace/name" formatter that keeps
+// every viewer sub-title consistent for the same resource.
+func TestResourceTitleLabel(t *testing.T) {
+	assert.Equal(t, "Pod argo-cd/argocd-redis-ha-server-2",
+		resourceTitleLabel("Pod", "argo-cd", "argocd-redis-ha-server-2"))
+	// Cluster-scoped: no namespace segment.
+	assert.Equal(t, "Node ip-10-0-0-1", resourceTitleLabel("Node", "", "ip-10-0-0-1"))
+	// Unknown kind: just namespace/name.
+	assert.Equal(t, "default/my-pod", resourceTitleLabel("", "default", "my-pod"))
+	// Bare name.
+	assert.Equal(t, "x", resourceTitleLabel("", "", "x"))
+}
+
 // The fullscreen viewers (logs, exec, describe, diff, events) must surface the
 // object they show in the top breadcrumb, the same way the YAML viewer and the
 // Object Explorer do. Each case is exercised through explorerDrillPath, which

--- a/internal/app/commands_exec.go
+++ b/internal/app/commands_exec.go
@@ -102,7 +102,11 @@ func (m Model) execKubectlDescribe() tea.Cmd {
 		args = append(args, "-n", ns)
 	}
 
-	title := fmt.Sprintf("Describe: %s/%s", rt.Resource, name)
+	titleNs := ""
+	if rt.Namespaced {
+		titleNs = ns
+	}
+	title := "Describe: " + resourceTitleLabel(m.actionCtx.kind, titleNs, name)
 
 	return m.trackBgTask(scheduler.KindSubprocess, title, bgtaskTarget(m.actionCtx.context, ns), func() tea.Msg {
 		cmd := exec.Command(kubectlPath, args...)

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -42,11 +42,11 @@ func (m Model) execKubectlExec() tea.Cmd {
 		if rows < 5 {
 			rows = 24
 		}
-		title := fmt.Sprintf("Exec: %s/%s", m.actionNamespace(), m.actionCtx.name)
+		title := "Exec: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 		return startPTYExecCmd(cmd, title, cols, rows)
 	}
 
-	title := fmt.Sprintf("Exec: %s/%s", m.actionNamespace(), m.actionCtx.name)
+	title := "Exec: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 	return runInteractiveShellExec(cmd, title, "Exec", true)
 }
 

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -80,7 +80,7 @@ func (m Model) openObjectExplorer() (tea.Model, tea.Cmd) {
 	}
 	m.objectExplorerView = objectExplorerState{
 		root:  sel.Raw,
-		title: sel.Kind + "/" + sel.Name,
+		title: resourceTitleLabel(sel.Kind, sel.Namespace, sel.Name),
 		name:  sel.Name,
 	}
 	m.objectExplorerView.level = model.ObjectFieldsAt(sel.Raw, nil)

--- a/internal/app/objectexplorer_find_test.go
+++ b/internal/app/objectexplorer_find_test.go
@@ -82,7 +82,7 @@ func TestObjectExplorerFind_EscFromFilterKeepsOverlay(t *testing.T) {
 func TestObjectExplorerFind_OverlayRenders(t *testing.T) {
 	m := openFind(t)
 	c, w, h := m.renderOverlayObjectExplorerFind()
-	assert.Contains(t, c, "Find in Chore/chore-1")
+	assert.Contains(t, c, "Find in Chore chore-1")
 	assert.Contains(t, c, "matches")      // subtitle count
 	assert.NotContains(t, c, "esc close") // hotkeys live in the bottom hint bar, not the overlay
 	assert.Positive(t, w)

--- a/internal/app/objectexplorer_test.go
+++ b/internal/app/objectexplorer_test.go
@@ -58,7 +58,7 @@ func TestOpenObjectExplorer_RootLevel(t *testing.T) {
 	result, _ := m.openObjectExplorer()
 	m = result.(Model)
 	assert.Equal(t, modeObjectExplorer, m.mode)
-	assert.Equal(t, "Chore/chore-1", m.objectExplorerView.title)
+	assert.Equal(t, "Chore chore-1", m.objectExplorerView.title)
 	// Root keys sorted.
 	keys := make([]string, len(m.objectExplorerView.level))
 	for i, f := range m.objectExplorerView.level {
@@ -354,7 +354,7 @@ func TestYAML_OOpensFreshTreeWhenOpenedViaEnter(t *testing.T) {
 	mdl, _ := m.handleYAMLKey(key("O"))
 	m = mdl.(Model)
 	assert.Equal(t, modeObjectExplorer, m.mode)
-	assert.Equal(t, "Chore/chore-1", m.objectExplorerView.title)
+	assert.Equal(t, "Chore chore-1", m.objectExplorerView.title)
 	assert.Empty(t, m.objectExplorerView.path) // fresh at root
 }
 
@@ -380,7 +380,7 @@ func TestObjectExplorer_QClosesAndViewRenders(t *testing.T) {
 	m = result.(Model)
 
 	out := m.viewObjectExplorer()
-	assert.Contains(t, out, "Object Explorer: Chore/chore-1")
+	assert.Contains(t, out, "Object Explorer: Chore chore-1")
 	assert.Contains(t, out, "PARENT")
 	assert.Contains(t, out, "status")
 

--- a/internal/app/objectexplorer_test.go
+++ b/internal/app/objectexplorer_test.go
@@ -276,7 +276,7 @@ func TestObjectExplorer_FullYAMLHandoff(t *testing.T) {
 	assert.Equal(t, modeExplorer, m.yamlReturnMode) // reset for the next open
 }
 
-func TestYAML_PReturnsToPreservedTree(t *testing.T) {
+func TestYAML_OReturnsToPreservedTree(t *testing.T) {
 	m := objectExplorerModel(t)
 	result, _ := m.openObjectExplorer()
 	m = result.(Model)
@@ -285,12 +285,12 @@ func TestYAML_PReturnsToPreservedTree(t *testing.T) {
 	m = pressTree(m, key("l"))
 	require.Len(t, m.objectExplorerView.path, 1)
 
-	// Open YAML from the tree (P), then P again returns to the preserved tree.
+	// Open YAML from the tree (P), then O returns to the preserved tree.
 	mdl, _ := m.handleObjectExplorerKey(key("P"))
 	m = mdl.(Model)
 	require.Equal(t, modeYAML, m.mode)
 
-	mdl, _ = m.handleYAMLKey(key("P"))
+	mdl, _ = m.handleYAMLKey(key("O"))
 	m = mdl.(Model)
 	assert.Equal(t, modeObjectExplorer, m.mode)
 	assert.Equal(t, []string{"status"}, m.objectExplorerView.path) // position preserved
@@ -336,7 +336,7 @@ func TestYAMLCursorSync_TreeFollowsYAMLCursor(t *testing.T) {
 	m.yamlView.content = choreDisplayedYAML
 	m.yamlView.cursor = 13
 
-	mdl, _ := m.handleYAMLKey(key("P"))
+	mdl, _ := m.handleYAMLKey(key("O"))
 	m = mdl.(Model)
 	assert.Equal(t, modeObjectExplorer, m.mode)
 	assert.Equal(t, []string{"status", "steps", "[1]"}, m.objectExplorerView.path)
@@ -345,13 +345,13 @@ func TestYAMLCursorSync_TreeFollowsYAMLCursor(t *testing.T) {
 	assert.Equal(t, "phase", sel.Key)
 }
 
-func TestYAML_POpensFreshTreeWhenOpenedViaEnter(t *testing.T) {
-	// YAML opened normally (not from the tree): P opens a fresh tree.
+func TestYAML_OOpensFreshTreeWhenOpenedViaEnter(t *testing.T) {
+	// YAML opened normally (not from the tree): O opens a fresh tree.
 	m := objectExplorerModel(t)
 	m.mode = modeYAML
 	m.yamlReturnMode = modeExplorer // as set by the Enter path
 
-	mdl, _ := m.handleYAMLKey(key("P"))
+	mdl, _ := m.handleYAMLKey(key("O"))
 	m = mdl.(Model)
 	assert.Equal(t, modeObjectExplorer, m.mode)
 	assert.Equal(t, "Chore/chore-1", m.objectExplorerView.title)

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -100,20 +100,15 @@ func (m Model) executeActionLogsWithTail(pendingLabel string, tailLines int) (te
 	m.logView.cursor = 0 // will track end as lines stream in with follow mode
 	m.logView.visualMode = false
 	m.logView.visualStart = 0
-	isTail := pendingLabel == "Tail Logs"
-	if m.actionCtx.containerName != "" {
-		if isTail {
-			m.logView.title = fmt.Sprintf("Logs (tail): %s/%s [%s]", m.actionNamespace(), m.actionCtx.name, m.actionCtx.containerName)
-		} else {
-			m.logView.title = fmt.Sprintf("Logs: %s/%s [%s]", m.actionNamespace(), m.actionCtx.name, m.actionCtx.containerName)
-		}
-	} else {
-		if isTail {
-			m.logView.title = fmt.Sprintf("Logs (tail): %s/%s", m.actionNamespace(), m.actionCtx.name)
-		} else {
-			m.logView.title = fmt.Sprintf("Logs: %s/%s", m.actionNamespace(), m.actionCtx.name)
-		}
+	verb := "Logs"
+	if pendingLabel == "Tail Logs" {
+		verb = "Logs (tail)"
 	}
+	label := resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
+	if m.actionCtx.containerName != "" {
+		label += " [" + m.actionCtx.containerName + "]"
+	}
+	m.logView.title = verb + ": " + label
 	return m, m.startLogStream()
 }
 

--- a/internal/app/update_overlays_logs.go
+++ b/internal/app/update_overlays_logs.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -112,7 +111,7 @@ func (m Model) handleLogPodSelectOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 			m.logView.tailLines = ui.ConfigLogTailLines
 			m.logView.hasMoreHistory = true
 			m.logView.loadingHistory = false
-			m.logView.title = fmt.Sprintf("Logs: %s/%s", m.actionNamespace(), m.actionCtx.name)
+			m.logView.title = "Logs: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 			return m, m.startLogStream()
 		}
 		return m, nil
@@ -167,7 +166,7 @@ func (m *Model) applyLogPodSelection(sel model.Item) tea.Cmd {
 		m.actionCtx.kind = m.logView.parentKind
 		m.actionCtx.name = m.logView.parentName
 		m.actionCtx.containerName = ""
-		m.logView.title = fmt.Sprintf("Logs: %s/%s (all pods)", m.actionNamespace(), m.logView.parentName)
+		m.logView.title = "Logs: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.logView.parentName) + " (all pods)"
 	} else {
 		// Specific pod selected.
 		m.actionCtx.name = sel.Name
@@ -176,7 +175,7 @@ func (m *Model) applyLogPodSelection(sel model.Item) tea.Cmd {
 			m.actionCtx.namespace = sel.Namespace
 		}
 		m.actionCtx.containerName = ""
-		m.logView.title = fmt.Sprintf("Logs: %s/%s", m.actionNamespace(), m.actionCtx.name)
+		m.logView.title = "Logs: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 	}
 	return m.startLogStream()
 }
@@ -433,7 +432,7 @@ func (m *Model) restartLogStreamForContainerFilter() tea.Cmd {
 
 // buildLogTitle constructs the log title, including selected container names if filtered.
 func (m *Model) buildLogTitle() string {
-	base := fmt.Sprintf("Logs: %s/%s", m.actionNamespace(), m.actionCtx.name)
+	base := "Logs: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 	if len(m.logView.selectedContainers) > 0 && len(m.logView.selectedContainers) < len(m.logView.containers) {
 		base += " [" + strings.Join(m.logView.selectedContainers, ", ") + "]"
 	}

--- a/internal/app/update_pod_msgs.go
+++ b/internal/app/update_pod_msgs.go
@@ -96,7 +96,7 @@ func (m Model) updatePodLogSelect(msg podLogSelectMsg) (tea.Model, tea.Cmd) {
 			m.logView.loadingHistory = false
 			m.logView.cursor = 0
 			m.logView.visualMode = false
-			m.logView.title = fmt.Sprintf("Logs: %s/%s", m.actionNamespace(), m.actionCtx.name)
+			m.logView.title = "Logs: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 			return m, m.startLogStream()
 		}
 		// Multiple pods; show inline pod selector overlay with "All Pods" at top.

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -157,7 +157,7 @@ func (m Model) handleYAMLNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "?", "f1":
 		return m.handleYAMLKeyQuestion()
-	case "P":
+	case "O":
 		return m.handleYAMLKeyObjectExplorer()
 	case "I":
 		return m.openExplainAtObjectPath(m.yamlCursorPath(), modeYAML)
@@ -570,11 +570,11 @@ func (m Model) handleYAMLKeyCtrlV() (tea.Model, tea.Cmd) {
 }
 
 // handleYAMLKeyObjectExplorer switches from the YAML viewer to the Object Explorer
-// browser (P), positioning the tree on the node under the YAML cursor. When the
+// browser (O), positioning the tree on the node under the YAML cursor. When the
 // viewer was opened from the tree, it reuses the preserved tree; otherwise
-// (opened via Enter) it opens a fresh tree for the current resource. Together
-// with P in the tree (open YAML), P toggles between the two views with the
-// cursor kept in sync.
+// (opened via Enter) it opens a fresh tree for the current resource. The tree
+// returns to the YAML viewer with P (open full YAML), keeping the cursor in
+// sync in both directions.
 func (m Model) handleYAMLKeyObjectExplorer() (tea.Model, tea.Cmd) {
 	segs := m.yamlCursorPath()
 	if m.yamlReturnMode == modeObjectExplorer && m.objectExplorerView.root != nil {

--- a/internal/app/view_modes_event_viewer.go
+++ b/internal/app/view_modes_event_viewer.go
@@ -11,7 +11,7 @@ import (
 func (m Model) viewEventViewer() string {
 	titleText := "Event Timeline"
 	if m.actionCtx.name != "" {
-		titleText += " - " + m.actionCtx.name
+		titleText += ": " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 	}
 	titleText += viewModeIndicators(m.eventTimelineWrap, rune(m.eventTimelineVisualMode), m.eventTimelineSearchQuery)
 	title := ui.ViewTitle(m.width, titleText)

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -130,13 +130,37 @@ func (m Model) explorerDrillPath() []string {
 		// breadcrumb does not already show it) and the cursor's attribute path,
 		// e.g. "… > Pods > pod-name > spec.nodeSelector".
 		var segs []string
-		if name := m.yamlResourceName(); name != "" && m.nav.ResourceName != name && m.nav.OwnedName != name {
+		if name := m.nameNotInNav(m.yamlResourceName()); name != "" {
 			segs = append(segs, name)
 		}
 		if path := m.yamlCursorPath(); len(path) > 0 {
 			segs = append(segs, formatObjectPath(path))
 		}
 		return segs
+	case modeLogs, modeExec:
+		// Logs/exec target a resource (and a container when drilled in). The
+		// action context tracks the live target — logs even update it on pod
+		// re-selection — so the breadcrumb follows the currently shown pod.
+		var segs []string
+		if name := m.nameNotInNav(m.actionCtx.name); name != "" {
+			segs = append(segs, name)
+		}
+		if c := m.actionCtx.containerName; c != "" {
+			segs = append(segs, c)
+		}
+		return segs
+	case modeDescribe, modeEventViewer:
+		if name := m.nameNotInNav(m.actionCtx.name); name != "" {
+			return []string{name}
+		}
+	case modeDiff:
+		// Diff compares two resources; name both.
+		switch {
+		case m.diffView.leftName != "" && m.diffView.rightName != "":
+			return []string{m.diffView.leftName + " ↔ " + m.diffView.rightName}
+		case m.diffView.leftName != "":
+			return []string{m.diffView.leftName}
+		}
 	case modeObjectExplorer:
 		// The Object Explorer adds the resource name (when the nav breadcrumb
 		// does not already show it) and the path to the cursor item, formatted
@@ -166,6 +190,16 @@ func (m Model) explorerDrillPath() []string {
 		}
 	}
 	return nil
+}
+
+// nameNotInNav returns name unless the nav breadcrumb already ends with it (as
+// ResourceName or OwnedName), in which case it returns "" so the drill path
+// does not duplicate a segment the breadcrumb already shows.
+func (m Model) nameNotInNav(name string) string {
+	if name == "" || name == m.nav.ResourceName || name == m.nav.OwnedName {
+		return ""
+	}
+	return name
 }
 
 // cursorBreadcrumbSegment returns the trailing breadcrumb segment for the

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -192,6 +192,22 @@ func (m Model) explorerDrillPath() []string {
 	return nil
 }
 
+// resourceTitleLabel formats a resource identifier as "Kind namespace/name",
+// shared by the fullscreen viewer sub-titles (YAML, Object Explorer, logs,
+// describe, exec, events) so the same resource reads identically across views.
+// The namespace is dropped for cluster-scoped resources (empty namespace) and
+// the kind when it is unknown.
+func resourceTitleLabel(kind, namespace, name string) string {
+	label := name
+	if namespace != "" {
+		label = namespace + "/" + name
+	}
+	if kind != "" {
+		label = kind + " " + label
+	}
+	return label
+}
+
 // nameNotInNav returns name unless the nav breadcrumb already ends with it (as
 // ResourceName or OwnedName), in which case it returns "" so the drill path
 // does not duplicate a segment the breadcrumb already shows.

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -125,6 +125,18 @@ func (m Model) explorerDrillPath() []string {
 		if seg := m.cursorBreadcrumbSegment(); seg != "" {
 			return []string{seg}
 		}
+	case modeYAML:
+		// Mirror the Object Explorer: append the resource name (when the nav
+		// breadcrumb does not already show it) and the cursor's attribute path,
+		// e.g. "… > Pods > pod-name > spec.nodeSelector".
+		var segs []string
+		if name := m.yamlResourceName(); name != "" && m.nav.ResourceName != name && m.nav.OwnedName != name {
+			segs = append(segs, name)
+		}
+		if path := m.yamlCursorPath(); len(path) > 0 {
+			segs = append(segs, formatObjectPath(path))
+		}
+		return segs
 	case modeObjectExplorer:
 		// The Object Explorer adds the resource name (when the nav breadcrumb
 		// does not already show it) and the path to the cursor item, formatted

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -187,33 +187,25 @@ func (m Model) viewYAML() string {
 }
 
 func (m Model) yamlTitle() string {
-	title := m.yamlTitleLabel()
-	// Show the attribute path under the cursor, mirroring how the Object
-	// Explorer always surfaces the current location.
-	if segs := m.yamlCursorPath(); len(segs) > 0 {
-		title += "  " + formatObjectPath(segs)
-	}
-	return title
-}
-
-// yamlTitleLabel returns the resource label portion of the YAML viewer title
-// ("YAML: ns/name"), without the cursor attribute path.
-func (m Model) yamlTitleLabel() string {
-	switch m.nav.Level {
-	case model.LevelResources:
-		sel := m.selectedMiddleItem()
-		if sel != nil {
-			return fmt.Sprintf("YAML: %s/%s", m.namespace, sel.Name)
-		}
-	case model.LevelOwned:
-		sel := m.selectedMiddleItem()
-		if sel != nil {
-			return fmt.Sprintf("YAML: %s/%s", m.namespace, sel.Name)
-		}
-	case model.LevelContainers:
-		return fmt.Sprintf("YAML: %s/%s", m.namespace, m.nav.OwnedName)
+	if name := m.yamlResourceName(); name != "" {
+		return fmt.Sprintf("YAML: %s/%s", m.namespace, name)
 	}
 	return "YAML"
+}
+
+// yamlResourceName returns the name of the resource whose YAML is displayed,
+// or "" when it can't be resolved. Shared by the viewer sub-title and the top
+// breadcrumb's drill path (see explorerDrillPath).
+func (m Model) yamlResourceName() string {
+	switch m.nav.Level {
+	case model.LevelResources, model.LevelOwned:
+		if sel := m.selectedMiddleItem(); sel != nil {
+			return sel.Name
+		}
+	case model.LevelContainers:
+		return m.nav.OwnedName
+	}
+	return ""
 }
 
 // yamlCursorCol returns the current cursor column position within the YAML line.

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -187,15 +187,34 @@ func (m Model) viewYAML() string {
 }
 
 func (m Model) yamlTitle() string {
-	if name := m.yamlResourceName(); name != "" {
-		return fmt.Sprintf("YAML: %s/%s", m.namespace, name)
+	if label := m.yamlResourceLabel(); label != "" {
+		return "YAML: " + label
 	}
 	return "YAML"
 }
 
+// yamlResourceLabel formats the displayed resource as "Kind namespace/name"
+// (see resourceTitleLabel) so the YAML sub-title matches the Object Explorer
+// and the other viewers for the same resource.
+func (m Model) yamlResourceLabel() string {
+	switch m.nav.Level {
+	case model.LevelResources, model.LevelOwned:
+		if sel := m.selectedMiddleItem(); sel != nil {
+			ns := sel.Namespace
+			if ns == "" {
+				ns = m.namespace
+			}
+			return resourceTitleLabel(sel.Kind, ns, sel.Name)
+		}
+	case model.LevelContainers:
+		return resourceTitleLabel("Pod", m.namespace, m.nav.OwnedName)
+	}
+	return ""
+}
+
 // yamlResourceName returns the name of the resource whose YAML is displayed,
-// or "" when it can't be resolved. Shared by the viewer sub-title and the top
-// breadcrumb's drill path (see explorerDrillPath).
+// or "" when it can't be resolved. Used by the top breadcrumb's drill path
+// (see explorerDrillPath).
 func (m Model) yamlResourceName() string {
 	switch m.nav.Level {
 	case model.LevelResources, model.LevelOwned:

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -48,7 +48,7 @@ func (m Model) viewYAML() string {
 			{Key: "tab/z", Desc: "fold"},
 			{Key: "ctrl+w/>", Desc: "wrap"},
 			{Key: "ctrl+e", Desc: "edit"},
-			{Key: "P", Desc: "object explorer"},
+			{Key: "O", Desc: "object explorer"},
 			{Key: "I", Desc: "explain"},
 			{Key: "q/esc", Desc: "back"},
 		}
@@ -187,6 +187,18 @@ func (m Model) viewYAML() string {
 }
 
 func (m Model) yamlTitle() string {
+	title := m.yamlTitleLabel()
+	// Show the attribute path under the cursor, mirroring how the Object
+	// Explorer always surfaces the current location.
+	if segs := m.yamlCursorPath(); len(segs) > 0 {
+		title += "  " + formatObjectPath(segs)
+	}
+	return title
+}
+
+// yamlTitleLabel returns the resource label portion of the YAML viewer title
+// ("YAML: ns/name"), without the cursor attribute path.
+func (m Model) yamlTitleLabel() string {
 	switch m.nav.Level {
 	case model.LevelResources:
 		sel := m.selectedMiddleItem()

--- a/internal/app/view_yaml_test.go
+++ b/internal/app/view_yaml_test.go
@@ -51,7 +51,7 @@ func TestYamlTitle(t *testing.T) {
 				},
 				namespace: "staging",
 			},
-			expected: "YAML: staging/my-pod-xyz",
+			expected: "YAML: Pod staging/my-pod-xyz",
 		},
 		{
 			name: "LevelResources with no items",

--- a/internal/app/yaml_objectexplorer_jump_test.go
+++ b/internal/app/yaml_objectexplorer_jump_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// yamlOEJumpModel returns a YAML viewer that was opened from the Object
+// Explorer, so the preserved tree (root) is reused on jump-back.
+func yamlOEJumpModel() Model {
+	m := Model{
+		width: 80, height: 30, mode: modeYAML,
+		yamlReturnMode: modeObjectExplorer,
+		yamlView: yamlViewState{
+			content:   "spec:\n  replicas: 3",
+			collapsed: map[string]bool{},
+			cursor:    1,
+		},
+		tabs: []TabState{{}},
+	}
+	m.objectExplorerView.root = map[string]any{
+		"spec": map[string]any{"replicas": int64(3)},
+	}
+	m.objectExplorerView.level = model.ObjectFieldsAt(m.objectExplorerView.root, nil)
+	return m
+}
+
+// L963: O is the Object Explorer key everywhere, so it must trigger the
+// transitive jump from the YAML viewer (previously bound to P).
+func TestYAMLKeyOJumpsToObjectExplorer(t *testing.T) {
+	m := yamlOEJumpModel()
+	ret, _ := m.handleYAMLNormalKey(keyMsg("O"))
+	rm := ret.(Model)
+	assert.Equal(t, modeObjectExplorer, rm.mode, "O must switch to the Object Explorer")
+}
+
+// P no longer performs the jump (replaced by O).
+func TestYAMLKeyPNoLongerJumpsToObjectExplorer(t *testing.T) {
+	m := yamlOEJumpModel()
+	ret, _ := m.handleYAMLNormalKey(keyMsg("P"))
+	rm := ret.(Model)
+	assert.Equal(t, modeYAML, rm.mode, "P must no longer switch to the Object Explorer")
+}
+
+// L964: the YAML viewer title bar shows the attribute path under the cursor.
+func TestYamlTitleShowsCursorPath(t *testing.T) {
+	m := Model{
+		nav:       model.NavigationState{Level: model.LevelResources},
+		namespace: "default",
+		middleItems: []model.Item{
+			{Name: "my-pod"},
+		},
+		yamlView: yamlViewState{
+			content:   "spec:\n  replicas: 3",
+			collapsed: map[string]bool{},
+			cursor:    1,
+		},
+	}
+	title := m.yamlTitle()
+	assert.True(t, strings.HasPrefix(title, "YAML: default/my-pod"),
+		"title keeps the resource label, got %q", title)
+	assert.Contains(t, title, "spec.replicas",
+		"title must show the cursor attribute path, got %q", title)
+}
+
+// Locks the title format: resource label, two-space gap, dotted path (no
+// leading dot — matching formatObjectPath used by yank/find elsewhere).
+func TestYamlTitlePathFormat(t *testing.T) {
+	m := Model{
+		nav:         model.NavigationState{Level: model.LevelResources},
+		namespace:   "default",
+		middleItems: []model.Item{{Name: "my-pod"}},
+		yamlView: yamlViewState{
+			content:   "spec:\n  replicas: 3",
+			collapsed: map[string]bool{},
+			cursor:    0, // "spec:" — a single root key still yields ["spec"]
+		},
+	}
+	// cursor on "spec:" resolves to the top-level key path.
+	assert.Equal(t, "YAML: default/my-pod  spec", m.yamlTitle())
+}

--- a/internal/app/yaml_objectexplorer_jump_test.go
+++ b/internal/app/yaml_objectexplorer_jump_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,13 +45,16 @@ func TestYAMLKeyPNoLongerJumpsToObjectExplorer(t *testing.T) {
 	assert.Equal(t, modeYAML, rm.mode, "P must no longer switch to the Object Explorer")
 }
 
-// L964: the YAML viewer title bar shows the attribute path under the cursor.
-func TestYamlTitleShowsCursorPath(t *testing.T) {
+// L964: the top breadcrumb shows the resource name + the cursor's attribute
+// path while in the YAML viewer, mirroring the Object Explorer location. The
+// path lives in the breadcrumb (top title bar), not the viewer's sub-title.
+func TestYAMLBreadcrumbDrillPathShowsNameAndPath(t *testing.T) {
 	m := Model{
+		mode:      modeYAML,
 		nav:       model.NavigationState{Level: model.LevelResources},
 		namespace: "default",
 		middleItems: []model.Item{
-			{Name: "my-pod"},
+			{Name: "my-pod", Kind: "Pod"},
 		},
 		yamlView: yamlViewState{
 			content:   "spec:\n  replicas: 3",
@@ -60,16 +62,14 @@ func TestYamlTitleShowsCursorPath(t *testing.T) {
 			cursor:    1,
 		},
 	}
-	title := m.yamlTitle()
-	assert.True(t, strings.HasPrefix(title, "YAML: default/my-pod"),
-		"title keeps the resource label, got %q", title)
-	assert.Contains(t, title, "spec.replicas",
-		"title must show the cursor attribute path, got %q", title)
+	// At LevelResources the nav breadcrumb stops at the type, so the YAML
+	// drill path must contribute both the resource name and the attribute path.
+	assert.Equal(t, []string{"my-pod", "spec.replicas"}, m.explorerDrillPath())
 }
 
-// Locks the title format: resource label, two-space gap, dotted path (no
-// leading dot — matching formatObjectPath used by yank/find elsewhere).
-func TestYamlTitlePathFormat(t *testing.T) {
+// The viewer sub-title keeps only the resource label (no attribute path — that
+// now lives in the breadcrumb).
+func TestYamlTitleHasNoPath(t *testing.T) {
 	m := Model{
 		nav:         model.NavigationState{Level: model.LevelResources},
 		namespace:   "default",
@@ -77,9 +77,26 @@ func TestYamlTitlePathFormat(t *testing.T) {
 		yamlView: yamlViewState{
 			content:   "spec:\n  replicas: 3",
 			collapsed: map[string]bool{},
-			cursor:    0, // "spec:" — a single root key still yields ["spec"]
+			cursor:    1,
 		},
 	}
-	// cursor on "spec:" resolves to the top-level key path.
-	assert.Equal(t, "YAML: default/my-pod  spec", m.yamlTitle())
+	assert.Equal(t, "YAML: default/my-pod", m.yamlTitle())
+}
+
+// The resource name appears in the breadcrumb even when the cursor is on the
+// root line (no attribute path yet) — fixing "open YAML and the resource name
+// isn't shown".
+func TestYAMLBreadcrumbDrillPathShowsNameWithoutPath(t *testing.T) {
+	m := Model{
+		mode:        modeYAML,
+		nav:         model.NavigationState{Level: model.LevelResources},
+		namespace:   "default",
+		middleItems: []model.Item{{Name: "my-pod", Kind: "Pod"}},
+		yamlView: yamlViewState{
+			content:   "spec:\n  replicas: 3",
+			collapsed: map[string]bool{},
+			cursor:    0, // "spec:" resolves to ["spec"]
+		},
+	}
+	assert.Equal(t, []string{"my-pod", "spec"}, m.explorerDrillPath())
 }

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -210,7 +210,7 @@ func helpSections() []helpSection {
 				{"Ctrl+W / >", "Toggle line wrapping"},
 				{"Ctrl+E", "Edit resource in editor"},
 				{"O", "Switch to the Object Explorer at the attribute under the cursor"},
-				{"I", "Open the API Explorer at the schema definition of the item under the cursor"},
+				{"I", "Open the API Explorer at the schema of the attribute under the cursor"},
 				{"q/Esc", "Back to explorer (or to the Object Explorer if opened from there)"},
 			},
 		},

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -209,7 +209,7 @@ func helpSections() []helpSection {
 				{"Z", "Toggle all folds (collapse/expand)"},
 				{"Ctrl+W / >", "Toggle line wrapping"},
 				{"Ctrl+E", "Edit resource in editor"},
-				{"P", "Switch to the Object Explorer for this resource"},
+				{"O", "Switch to the Object Explorer at the attribute under the cursor"},
 				{"I", "Open the API Explorer at the schema definition of the item under the cursor"},
 				{"q/Esc", "Back to explorer (or to the Object Explorer if opened from there)"},
 			},


### PR DESCRIPTION
Implements the next two CLAUDE-TODO items (both YAML-viewer ↔ Object Explorer).

## 1. `O` jumps from the YAML viewer to the Object Explorer

The cursor-preserving (transitive) jump from the full-screen YAML viewer to the Object Explorer was bound to `P`. `O` — the key that opens the Object Explorer everywhere else — did nothing in the viewer, which is why "shift+O isn't working" (reported in the todo).

Rebound the jump from `P` to `O`. The Object Explorer still returns to the YAML viewer with `P` (open full YAML), so the round-trip is `O` → / `P` ←. Cursor/path sync in both directions is unchanged.

## 2. Attribute path in the YAML viewer title bar

The YAML viewer title now shows the attribute path under the cursor, e.g.:

```
YAML: default/my-pod  spec.containers[0].image
```

mirroring how the Object Explorer always surfaces the current location. Rendered via the existing `formatObjectPath` (same form as path yank / find), so it's consistent app-wide. The path disappears when there's no resolvable path (empty doc).

## Tests

New `yaml_objectexplorer_jump_test.go`:
- `O` switches the YAML viewer to the Object Explorer; `P` no longer does.
- `yamlTitle` shows the cursor attribute path; format locked (`label` + two-space gap + dotted path).

Existing P-jump tests in `objectexplorer_test.go` retargeted from `P` to `O` (Object-Explorer-side `P`→YAML unchanged).

## Docs

- In-app help (YAML View section): `P` → `O`.
- `docs/keybindings.md` YAML View: added `O` and `I` rows + a note that the title bar shows the cursor path.

## Verification

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run ./...` — 0 issues

## Note

The YAML→Object Explorer key choice (`O` only, replacing `P`) was confirmed with the maintainer before implementing.