### PR TITLE
feat: add JSON Schema for config.yaml with editor autocompletion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,17 @@ Reuse existing TUI primitives instead of hand-rolling. Look for a shared helper 
 - User feedback goes through `setStatusMessage(msg, isErr)` + return `scheduleStatusClear()` — never print inline or block.
 - Renderers read `ui.Active*` globals (security, columns) set in `View()` right before render; don't read them elsewhere.
 
+## Configuration Settings
+
+Adding or changing a config key is not done until ALL of these are updated together — in the same PR:
+
+- **Struct + apply**: add the field to `configFile` (or its sub-struct) in `internal/ui/config_load.go` and wire it through `applyConfigOptions` / `applyConfigMaps` (`internal/ui/config_apply.go`) into its `Config*` runtime global.
+- **Schema**: add the property (correct type, enum, default, description) to `docs/config.schema.json`. `TestConfigSchemaTopLevelInSync` / `TestConfigSchemaKeybindingsInSync` fail if you forget a top-level or keybinding key.
+- **Docs**: update the field table in `docs/config-reference.md` AND add a commented example to `docs/config-example.yaml`. Keep entries concise and consistent with their peers.
+- **Tests**: assert the YAML→global wiring in `internal/ui/config_wiring_test.go` (`TestLoadConfig_AllSettingsWired`) and record the field in `wiringCoveredFields`. `TestConfigFile_EveryFieldHasWiringCoverage` fails until you do. Add focused unit tests for any validation/clamping/union-shape parsing.
+
+These four tests are the forcing function — a new setting that skips the schema, the wiring test, or the coverage map will not pass CI.
+
 ---
 
 ## Success Metrics

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -1,6 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/janosmiko/lfk/main/docs/config.schema.json
 # lfk - Full Configuration Example
 # Place this file at ~/.config/lfk/config.yaml
 # All fields are optional — only specify what you want to override.
+#
+# The modeline above enables autocompletion and validation in editors running
+# a YAML language server. See docs/config-reference.md for the full reference.
 
 # ─── Color Scheme ──────────────────────────────────────────────────────────────
 # Built-in color scheme. 460+ themes are available (generated from ghostty themes).

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -2,6 +2,16 @@
 
 The configuration file is located at `~/.config/lfk/config.yaml`. All fields are optional — only the values you specify will override the defaults.
 
+## Editor autocompletion (JSON Schema)
+
+A JSON Schema is published at [`docs/config.schema.json`](config.schema.json). Add this modeline to the top of your `config.yaml` to get autocompletion, inline docs, and typo warnings in any editor running a YAML language server (VS Code's [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml), Neovim with `yamlls`, etc.):
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/janosmiko/lfk/main/docs/config.schema.json
+```
+
+Prefer a local copy? Point `$schema` at a relative or absolute path instead of the URL.
+
 ## Top-Level Fields
 
 | Field | Type | Default | Description |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1,0 +1,581 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/janosmiko/lfk/main/docs/config.schema.json",
+  "title": "lfk configuration",
+  "description": "Schema for the lfk config file (config.yaml). All fields are optional; only the values you set override the defaults. See docs/config-reference.md for full descriptions.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "colorscheme": {
+      "type": "string",
+      "description": "Built-in color scheme name (e.g. \"tokyonight-storm\", \"dracula\", \"nord\"). Supports dual-mode syntax for auto dark/light switching: \"dark:X,light:Y\".",
+      "default": "tokyonight-storm"
+    },
+    "theme": {
+      "anyOf": [{ "$ref": "#/definitions/theme" }, { "type": "null" }]
+    },
+    "keybindings": {
+      "anyOf": [{ "$ref": "#/definitions/keybindings" }, { "type": "null" }]
+    },
+    "log_path": {
+      "type": "string",
+      "description": "Path to the application log file. Defaults to ~/.local/share/lfk/lfk.log."
+    },
+    "kubeconfig_dir": {
+      "description": "Directory (or list of directories) recursively scanned for kubeconfig files, in addition to ~/.kube/config and KUBECONFIG. Tilde paths expand against $HOME.",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } },
+        { "type": "null" }
+      ]
+    },
+    "abbreviations": {
+      "type": ["object", "null"],
+      "description": "Custom search abbreviation overrides/extensions. Maps a short alias to a full resource type name (e.g. \"po\": \"pod\").",
+      "additionalProperties": { "type": "string" }
+    },
+    "icons": {
+      "type": "string",
+      "description": "Icon display mode. \"auto\" detects Nerd Font terminals. Overridable at runtime with the LFK_ICONS env var.",
+      "enum": ["auto", "unicode", "nerdfont", "simple", "emoji", "none"],
+      "default": "auto"
+    },
+    "resource_columns": {
+      "type": ["object", "null"],
+      "description": "Per-resource-type column lists, keyed by Kind name (case-insensitive). Deprecated: prefer \"views\".",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "views": {
+      "type": ["object", "null"],
+      "description": "Per-resource-type column and sort configuration, keyed by GVR (\"apps/v1/deployments\") or Kind (\"deployment\", case-insensitive).",
+      "additionalProperties": { "$ref": "#/definitions/view" }
+    },
+    "dashboard": {
+      "type": "boolean",
+      "description": "Show the cluster dashboard when entering a context. Set false to go directly to resource types.",
+      "default": true
+    },
+    "custom_actions": {
+      "type": ["object", "null"],
+      "description": "User-defined actions per resource type, keyed by Kind name (e.g. \"Pod\").",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/customAction" }
+      }
+    },
+    "filter_presets": {
+      "type": ["object", "null"],
+      "description": "User-defined quick filter presets per resource type, keyed by Kind name (case-insensitive).",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/filterPreset" }
+      }
+    },
+    "terminal": {
+      "type": "string",
+      "description": "How exec/shell commands run: \"pty\" (embedded in the TUI), \"exec\" (takes over the terminal), or \"mux\" (open in a new tmux/zellij window or pane).",
+      "enum": ["pty", "exec", "mux"],
+      "default": "pty"
+    },
+    "scrollback_lines": {
+      "type": "integer",
+      "description": "Per-tab capacity of the embedded PTY scrollback ring buffer. Clamped to [100, 100000]. Only meaningful in pty mode.",
+      "default": 5000
+    },
+    "pinned_groups": {
+      "type": ["array", "null"],
+      "description": "CRD API groups to pin after built-in categories (e.g. [\"karpenter.sh\", \"monitoring.coreos.com\"]).",
+      "items": { "type": "string" }
+    },
+    "pinned_types": {
+      "type": ["array", "null"],
+      "description": "Version-agnostic resource-type pin keys (\"group/resource\", e.g. \"apps/deployments\") to move into the top-level Pinned section.",
+      "items": { "type": "string" }
+    },
+    "monitoring": {
+      "type": ["object", "null"],
+      "description": "Per-cluster monitoring endpoint configuration. Keys are context names or the special key \"_global\".",
+      "additionalProperties": { "$ref": "#/definitions/monitoringConfig" }
+    },
+    "tips": {
+      "type": "boolean",
+      "description": "Show a random tip in the status bar on startup.",
+      "default": true
+    },
+    "log_tail_lines": {
+      "type": "integer",
+      "description": "Number of log lines loaded initially via --tail. Scrolling to the top loads older history.",
+      "default": 1000
+    },
+    "log_tail_lines_short": {
+      "type": "integer",
+      "description": "Number of log lines loaded by the action menu \"Tail Logs\" entry. Non-positive values are ignored.",
+      "default": 10
+    },
+    "log_render_ansi": {
+      "type": "boolean",
+      "description": "Render ANSI SGR sequences (color, bold, underline) emitted by log producers. Set false to strip them. Toggle at runtime with :set ansi / :set noansi.",
+      "default": true
+    },
+    "scrolloff": {
+      "type": "integer",
+      "description": "Number of lines to keep visible above/below the cursor when scrolling.",
+      "default": 5
+    },
+    "confirm_on_exit": {
+      "type": "boolean",
+      "description": "Show a quit confirmation when pressing ctrl+c on the last tab. Set false to exit immediately.",
+      "default": true
+    },
+    "dim_overlay": {
+      "type": "boolean",
+      "description": "Fade the rest of the screen while any overlay is up. Set false for terminals where SGR faint looks awkward.",
+      "default": true
+    },
+    "transparent_background": {
+      "type": "boolean",
+      "description": "Use the terminal's own background for bars and surfaces. Selection highlights remain opaque.",
+      "default": false
+    },
+    "mouse": {
+      "type": "boolean",
+      "description": "Capture mouse input for click navigation, scroll, and tab switching. Set false to allow native terminal text selection.",
+      "default": true
+    },
+    "watch_interval": {
+      "type": "string",
+      "description": "Polling interval used in watch mode, as a Go duration string (e.g. \"2s\", \"500ms\", \"1m\"). Clamped to [500ms, 10m].",
+      "default": "2s"
+    },
+    "clusters": {
+      "type": ["object", "null"],
+      "description": "Per-cluster configuration overrides, keyed by context name.",
+      "additionalProperties": { "$ref": "#/definitions/clusterConfig" }
+    },
+    "no_color": {
+      "type": "boolean",
+      "description": "Strip foreground/background colors from all styles (monochrome). The NO_COLOR env var takes precedence.",
+      "default": false
+    },
+    "secret_lazy_loading": {
+      "type": "boolean",
+      "description": "When true, Secret listing fetches metadata only and decoded values load on hover. Faster in clusters with many large Secrets.",
+      "default": false
+    },
+    "informer_cache": {
+      "description": "List strategy: \"off\" round-trips every list, \"auto\" promotes a resource type to a shared informer above 1000 items, \"always\" opens a watch eagerly. Legacy bool form: true -> always, false -> off.",
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "string", "enum": ["off", "auto", "always"] },
+        { "type": "null" }
+      ],
+      "default": "auto"
+    },
+    "min_contrast_ratio": {
+      "type": "number",
+      "description": "Normalized readability knob in [0.0, 1.0]. Above zero, foreground colors are nudged in HSL lightness to meet a minimum WCAG contrast ratio. 0.175 is approximately AA, 0.3 is approximately AAA.",
+      "minimum": 0,
+      "maximum": 1,
+      "default": 0
+    },
+    "read_only": {
+      "type": "boolean",
+      "description": "Disable all mutating actions globally. Per-context overrides under clusters.<name>.read_only and the --read-only CLI flag take precedence.",
+      "default": false
+    },
+    "show_rare_types": {
+      "type": "boolean",
+      "description": "Show rarely-used resource types (CSI internals, admission webhooks, leases, runtime classes, the \"Advanced\" category) from startup, as if the H toggle were pressed.",
+      "default": false
+    },
+    "security": {
+      "anyOf": [{ "$ref": "#/definitions/securityConfig" }, { "type": "null" }]
+    },
+    "rightsizing_defaults": {
+      "anyOf": [{ "$ref": "#/definitions/rightsizingDefaults" }, { "type": "null" }]
+    },
+    "kubeshark": {
+      "anyOf": [{ "$ref": "#/definitions/kubeshark" }, { "type": "null" }]
+    },
+    "scheduler": {
+      "anyOf": [{ "$ref": "#/definitions/scheduler" }, { "type": "null" }]
+    },
+    "union_sets": {
+      "description": "Named multi-cluster groups expanded by the --union-set <name> CLI flag. Accepts a list of entries or a map keyed by set name.",
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/unionSet" }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "contexts": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/unionSetContext" }
+              },
+              "namespace": { "type": "string" }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "theme": {
+      "type": "object",
+      "description": "Custom color theme overrides applied on top of the selected colorscheme. Values are hex colors (e.g. \"#7aa2f7\") or terminal color names/ANSI codes.",
+      "additionalProperties": false,
+      "properties": {
+        "primary": { "type": "string" },
+        "secondary": { "type": "string" },
+        "text": { "type": "string" },
+        "selected_fg": { "type": "string" },
+        "selected_bg": { "type": "string" },
+        "border": { "type": "string" },
+        "dimmed": { "type": "string" },
+        "error": { "type": "string" },
+        "warning": { "type": "string" },
+        "purple": { "type": "string" },
+        "base": { "type": "string" },
+        "bar_bg": { "type": "string" },
+        "surface": { "type": "string" }
+      }
+    },
+    "keybindings": {
+      "type": "object",
+      "description": "Custom keybinding overrides. Each value is a key string (e.g. \"j\", \"ctrl+d\", \"alt+ctrl+y\"). Avoid ctrl+i / ctrl+m / ctrl+[ (terminals emit these as tab/enter/esc).",
+      "additionalProperties": false,
+      "properties": {
+        "left": { "type": "string" },
+        "right": { "type": "string" },
+        "down": { "type": "string" },
+        "up": { "type": "string" },
+        "enter": { "type": "string" },
+        "jump_top": { "type": "string" },
+        "jump_bottom": { "type": "string" },
+        "page_down": { "type": "string" },
+        "page_up": { "type": "string" },
+        "page_forward": { "type": "string" },
+        "page_back": { "type": "string" },
+        "level_cluster": { "type": "string" },
+        "level_types": { "type": "string" },
+        "level_resources": { "type": "string" },
+        "preview_down": { "type": "string" },
+        "preview_up": { "type": "string" },
+        "jump_owner": { "type": "string" },
+        "jump_back": { "type": "string" },
+        "help": { "type": "string" },
+        "filter": { "type": "string" },
+        "search": { "type": "string" },
+        "next_match": { "type": "string" },
+        "prev_match": { "type": "string" },
+        "toggle_preview": { "type": "string" },
+        "resource_map": { "type": "string" },
+        "fullscreen": { "type": "string" },
+        "filter_presets": { "type": "string" },
+        "error_log": { "type": "string" },
+        "secret_toggle": { "type": "string" },
+        "finalizer_search": { "type": "string" },
+        "api_explorer": { "type": "string" },
+        "object_explorer": { "type": "string" },
+        "rbac_browser": { "type": "string" },
+        "theme_selector": { "type": "string" },
+        "command_bar": { "type": "string" },
+        "watch_mode": { "type": "string" },
+        "sort_next": { "type": "string" },
+        "sort_prev": { "type": "string" },
+        "sort_flip": { "type": "string" },
+        "sort_reset": { "type": "string" },
+        "save_resource": { "type": "string" },
+        "monitoring": { "type": "string" },
+        "quota_dashboard": { "type": "string" },
+        "tasks_overlay": { "type": "string" },
+        "expand_collapse": { "type": "string" },
+        "pin_group": { "type": "string" },
+        "column_toggle": { "type": "string" },
+        "toggle_rare": { "type": "string" },
+        "orphan_overlay": { "type": "string" },
+        "namespace_selector": { "type": "string" },
+        "all_namespaces": { "type": "string" },
+        "action_menu": { "type": "string" },
+        "logs": { "type": "string" },
+        "label_editor": { "type": "string" },
+        "secret_editor": { "type": "string" },
+        "create_template": { "type": "string" },
+        "refresh": { "type": "string" },
+        "restart": { "type": "string" },
+        "exec": { "type": "string" },
+        "edit": { "type": "string" },
+        "describe": { "type": "string" },
+        "delete": { "type": "string" },
+        "force_delete": { "type": "string" },
+        "scale": { "type": "string" },
+        "open_browser": { "type": "string" },
+        "copy_name": { "type": "string" },
+        "copy_yaml": { "type": "string" },
+        "paste_apply": { "type": "string" },
+        "diff": { "type": "string" },
+        "toggle_select": { "type": "string" },
+        "select_range": { "type": "string" },
+        "select_all": { "type": "string" },
+        "new_tab": { "type": "string" },
+        "next_tab": { "type": "string" },
+        "prev_tab": { "type": "string" },
+        "set_mark": { "type": "string" },
+        "open_marks": { "type": "string" },
+        "terminal_toggle": { "type": "string" },
+        "mouse_toggle": { "type": "string" },
+        "readonly_toggle": { "type": "string" },
+        "cluster_color_picker": { "type": "string" },
+        "local_cluster_manager": { "type": "string" },
+        "security_ignore_toggle": { "type": "string" },
+        "security_badge_toggle": { "type": "string" }
+      }
+    },
+    "view": {
+      "type": "object",
+      "description": "Ordered columns and an optional default sort column for a resource type.",
+      "additionalProperties": false,
+      "properties": {
+        "columns": {
+          "type": "array",
+          "description": "Ordered column specs. Each is a built-in name or a custom \"Name:.jsonPath\" spec; append flags after \"|\" (e.g. \"|W\" for wide-only).",
+          "items": { "type": "string" }
+        },
+        "sort_column": {
+          "type": "string",
+          "description": "Default sort column, optionally with direction: \"COL\", \"COL:asc\", or \"COL:desc\"."
+        }
+      }
+    },
+    "customAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "command", "key"],
+      "properties": {
+        "label": { "type": "string", "description": "Action menu label." },
+        "command": { "type": "string", "description": "Shell command template (supports template variables; see config-reference.md)." },
+        "key": { "type": "string", "description": "Shortcut key that triggers the action." },
+        "description": { "type": "string", "description": "Help text shown in the action menu." },
+        "read_only_safe": {
+          "type": "boolean",
+          "description": "Declare the action does not change cluster state, so it stays available in read-only mode. Defaults to false (treated as mutating).",
+          "default": false
+        }
+      }
+    },
+    "filterPreset": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "Preset label." },
+        "key": { "type": "string", "description": "Shortcut key in the filter presets overlay." },
+        "match": { "$ref": "#/definitions/filterMatch" }
+      }
+    },
+    "filterMatch": {
+      "type": "object",
+      "description": "Match criteria, AND-ed together. When invert is true the result is negated.",
+      "additionalProperties": false,
+      "properties": {
+        "status": { "type": "string", "description": "Match rows whose Status equals this value." },
+        "ready_not": { "type": "boolean", "description": "Match rows that are NOT Ready." },
+        "restarts_gt": { "type": "integer", "description": "Match rows whose restart count exceeds this value." },
+        "column": { "type": "string", "description": "Column name to match against (used with column_value)." },
+        "column_value": { "type": "string", "description": "Value the named column must equal." },
+        "invert": { "type": "boolean", "description": "Negate the combined match result." }
+      }
+    },
+    "monitoringConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "prometheus": { "$ref": "#/definitions/monitoringEndpoint" },
+        "alertmanager": { "$ref": "#/definitions/monitoringEndpoint" },
+        "node_metrics": {
+          "type": "string",
+          "description": "Node metrics source. Defaults to auto-detect.",
+          "enum": ["prometheus", "metrics-api"]
+        }
+      }
+    },
+    "monitoringEndpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "namespaces": {
+          "type": "array",
+          "description": "Namespaces to search for the monitoring service.",
+          "items": { "type": "string" }
+        },
+        "services": {
+          "type": "array",
+          "description": "Service names to try.",
+          "items": { "type": "string" }
+        },
+        "port": {
+          "type": "string",
+          "description": "Port number (default: \"9090\" for prometheus, \"9093\" for alertmanager)."
+        }
+      }
+    },
+    "clusterConfig": {
+      "type": "object",
+      "description": "Per-cluster overrides for one context.",
+      "additionalProperties": false,
+      "properties": {
+        "resource_columns": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "views": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/view" }
+        },
+        "read_only": {
+          "type": "boolean",
+          "description": "Override the global read_only setting for this context."
+        },
+        "security": { "$ref": "#/definitions/securityConfig" },
+        "k8s_client_qps": {
+          "type": "integer",
+          "description": "Override the foreground REST client QPS for this context."
+        },
+        "k8s_client_burst": {
+          "type": "integer",
+          "description": "Override the foreground REST client burst for this context."
+        }
+      }
+    },
+    "securityConfig": {
+      "type": "object",
+      "description": "Built-in security-findings dashboard configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Turn the security dashboard on or off.",
+          "default": true
+        },
+        "sources": {
+          "type": "object",
+          "description": "Enable/disable individual sources. Keys accept friendly names (heuristic, trivy, kyverno, kubescape, falco, gatekeeper) or internal ids (trivy-operator, policy-report). Omitted sources default to enabled.",
+          "additionalProperties": { "type": "boolean" }
+        },
+        "ignore_patterns": {
+          "type": "array",
+          "description": "Declarative glob-based ignore rules applied at load. Honored only in the top-level security section.",
+          "items": { "$ref": "#/definitions/securityIgnorePattern" }
+        }
+      }
+    },
+    "securityIgnorePattern": {
+      "type": "object",
+      "description": "A finding is ignored when every non-empty field matches it. Fields support glob (* and ?). An all-empty pattern is dropped.",
+      "additionalProperties": false,
+      "properties": {
+        "cluster": { "type": "string", "description": "Globs the kube-context name. Empty = any cluster." },
+        "source": { "type": "string", "description": "Globs the security source id. Empty = any source." },
+        "group": { "type": "string", "description": "Globs the finding group key (CVE id, check label, rule name). Empty = any group." },
+        "namespace": { "type": "string", "description": "Globs the resource namespace. Empty or * = any namespace." },
+        "comment": { "type": "string", "description": "Free-text note explaining why the rule exists." }
+      }
+    },
+    "rightsizingDefaults": {
+      "type": "object",
+      "description": "Initial strategy and headroom for the right-sizing advisor on its first overlay open of the session.",
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["vpa", "prom_max_1d", "prom_avg_1d", "prom_p95_7d", "snapshot"]
+        },
+        "headroom": {
+          "type": "number",
+          "description": "Headroom multiplier. Must match one of the picker presets.",
+          "enum": [1.0, 1.1, 1.25, 1.5, 1.75, 2.0]
+        }
+      }
+    },
+    "kubeshark": {
+      "type": "object",
+      "description": "Kubeshark hand-off backend for the Traffic Capture overlay.",
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where Service kubeshark-hub lives. Defaults to \"kubeshark\".",
+          "default": "kubeshark"
+        }
+      }
+    },
+    "scheduler": {
+      "type": "object",
+      "description": "Runtime knobs for the priority task scheduler. All fields optional; missing keys fall back to compiled defaults.",
+      "additionalProperties": false,
+      "properties": {
+        "workers_per_context": { "type": "integer" },
+        "critical_reserved_slots": { "type": "integer" },
+        "low_reserved_slots": { "type": "integer" },
+        "default_timeout": { "type": "string", "description": "Go duration string (e.g. \"30s\")." },
+        "timeouts_by_kind": {
+          "type": "object",
+          "description": "Per-kind timeout overrides. Values are Go duration strings.",
+          "additionalProperties": { "type": "string" }
+        },
+        "k8s_client_qps": { "type": "integer" },
+        "k8s_client_burst": { "type": "integer" },
+        "show_priority_in_tasks_overlay": { "type": "boolean" },
+        "aging_threshold": {
+          "type": "integer",
+          "description": "Bounds priority starvation: a background task runs after at most this many higher-priority dispatches. 0 disables aging."
+        }
+      }
+    },
+    "unionSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "description": "Identifier used by --union-set to reference this entry." },
+        "contexts": {
+          "type": "array",
+          "description": "Cluster entries to merge in this union view.",
+          "items": { "$ref": "#/definitions/unionSetContext" }
+        },
+        "namespace": { "type": "string", "description": "Namespace lfk opens in when this set is selected. --namespace overrides it." }
+      }
+    },
+    "unionSetContext": {
+      "description": "One cluster within a union set. A bare string is the context name; an object adds an optional per-set color and namespace.",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "context": { "type": "string" },
+            "name": { "type": "string", "description": "Alias for context." },
+            "color": {
+              "type": "string",
+              "description": "Per-set row tile color. Invalid values are dropped (untinted).",
+              "enum": ["red", "yellow", "green", "blue", "magenta", "cyan", "white", "gray"]
+            },
+            "namespace": { "type": "string" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/ui/config_schema_test.go
+++ b/internal/ui/config_schema_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// schemaDoc is the minimal shape of docs/config.schema.json needed to assert
+// that the on-disk JSON Schema stays in sync with the Go config structs.
+type schemaDoc struct {
+	Properties  map[string]json.RawMessage `json:"properties"`
+	Definitions map[string]struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	} `json:"definitions"`
+}
+
+func loadConfigSchema(t *testing.T) schemaDoc {
+	t.Helper()
+	// Test runs from internal/ui; the schema lives at the repo's docs/ dir.
+	path := filepath.Join("..", "..", "docs", "config.schema.json")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "read %s", path)
+
+	var doc schemaDoc
+	require.NoError(t, json.Unmarshal(data, &doc), "schema is not valid JSON")
+	return doc
+}
+
+// jsonTagNames returns the json tag names (sans options like ",omitempty") of
+// every field on the given struct type.
+func jsonTagNames(t reflect.Type) []string {
+	names := make([]string, 0, t.NumField())
+	for f := range t.Fields() {
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// TestConfigSchemaTopLevelInSync guards against schema drift: every json field
+// on configFile must have a matching property in the schema's top-level
+// properties. When a new config key is added, this fails until the schema is
+// updated too.
+func TestConfigSchemaTopLevelInSync(t *testing.T) {
+	doc := loadConfigSchema(t)
+	for _, name := range jsonTagNames(reflect.TypeFor[configFile]()) {
+		_, ok := doc.Properties[name]
+		require.Truef(t, ok, "config field %q missing from docs/config.schema.json top-level properties", name)
+	}
+}
+
+// TestConfigSchemaKeybindingsInSync guards the keybindings definition, the most
+// error-prone list (80+ entries) to keep aligned by hand.
+func TestConfigSchemaKeybindingsInSync(t *testing.T) {
+	doc := loadConfigSchema(t)
+	def, ok := doc.Definitions["keybindings"]
+	require.True(t, ok, "schema missing definitions.keybindings")
+	for _, name := range jsonTagNames(reflect.TypeFor[Keybindings]()) {
+		_, ok := def.Properties[name]
+		require.Truef(t, ok, "keybinding %q missing from schema definitions.keybindings.properties", name)
+	}
+}

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -1,0 +1,424 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// fullConfigYAML sets every configFile field to a distinctive, non-default
+// value so the wiring test can prove each one flows from YAML through
+// LoadConfig into its resolved runtime global. Keep it in sync with
+// configFile when adding settings (TestConfigFile_EveryFieldHasWiringCoverage
+// enforces this).
+const fullConfigYAML = `
+colorscheme: dracula
+log_path: /tmp/lfk-wiring-test.log
+icons: nerdfont
+dashboard: false
+terminal: mux
+scrollback_lines: 8000
+pinned_groups: [karpenter.sh]
+pinned_types: [argoproj.io/applications]
+tips: false
+log_tail_lines: 250
+log_tail_lines_short: 7
+log_render_ansi: false
+scrolloff: 9
+confirm_on_exit: false
+dim_overlay: false
+transparent_background: true
+mouse: false
+watch_interval: 3s
+no_color: true
+secret_lazy_loading: true
+informer_cache: always
+min_contrast_ratio: 0.5
+read_only: true
+show_rare_types: true
+kubeconfig_dir: /tmp/lfk-kcfg
+abbreviations:
+  zz: pod
+keybindings:
+  refresh: ctrl+f5
+resource_columns:
+  Pod: [IP, Node]
+views:
+  deployment:
+    columns: [Name]
+    sort_column: Name
+custom_actions:
+  Pod:
+    - label: Ping
+      command: echo ping
+      key: ctrl+z
+      description: ping the pod
+filter_presets:
+  Pod:
+    - name: Pending
+      key: p
+      match:
+        status: Pending
+monitoring:
+  _global:
+    node_metrics: prometheus
+    prometheus:
+      namespaces: [monitoring]
+      services: [prom]
+      port: "9090"
+kubeshark:
+  namespace: traffic-ns
+security:
+  enabled: false
+  sources:
+    trivy: false
+    heuristic: true
+  ignore_patterns:
+    - cluster: prod
+      source: trivy-operator
+      comment: noisy
+rightsizing_defaults:
+  strategy: prom_max_1d
+  headroom: 1.5
+scheduler:
+  workers_per_context: 10
+  critical_reserved_slots: 2
+  low_reserved_slots: 3
+  default_timeout: 45s
+  aging_threshold: 4
+  show_priority_in_tasks_overlay: false
+  k8s_client_qps: 77
+  k8s_client_burst: 144
+  timeouts_by_kind:
+    Metrics: 90s
+union_sets:
+  staging:
+    namespace: stg
+    contexts:
+      - context: ctxA
+        color: green
+clusters:
+  ctx1:
+    read_only: true
+    k8s_client_qps: 33
+    k8s_client_burst: 66
+    resource_columns:
+      Pod: [IP, Node]
+    views:
+      deployment:
+        columns: [Name]
+        sort_column: Name
+    security:
+      enabled: false
+      sources:
+        falco: false
+`
+
+// TestLoadConfig_AllSettingsWired writes a config that exercises every setting
+// and asserts each one reaches its resolved runtime global. This is the
+// end-to-end proof that YAML keys are wired, not just parsed.
+func TestLoadConfig_AllSettingsWired(t *testing.T) {
+	restore := snapshotAllConfigGlobals(t)
+	defer restore()
+
+	// resolveIconMode honors LFK_ICONS and applyConfigOptions honors NO_COLOR;
+	// an empty value reads as "unset" in both (they test != ""), so the
+	// assertions reflect the config file alone. t.Setenv auto-restores.
+	t.Setenv("LFK_ICONS", "")
+	t.Setenv("NO_COLOR", "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(fullConfigYAML), 0o600))
+
+	LoadConfig(path)
+
+	// Identity / pipeline-level settings.
+	assert.Equal(t, "dracula", ActiveSchemeName, "colorscheme")
+	assert.Equal(t, "/tmp/lfk-wiring-test.log", ConfigLogPath, "log_path")
+	assert.Equal(t, "ctrl+f5", ActiveKeybindings.Refresh, "keybindings")
+	assert.Equal(t, "pod", SearchAbbreviations["zz"], "abbreviations")
+
+	// Scalar settings (applyConfigOptions).
+	assert.Equal(t, "nerdfont", IconMode, "icons")
+	assert.False(t, ConfigDashboard, "dashboard")
+	assert.Equal(t, TerminalModeMux, ConfigTerminalMode, "terminal")
+	assert.Equal(t, 8000, ConfigScrollbackLines, "scrollback_lines")
+	assert.Equal(t, []string{"karpenter.sh"}, ConfigPinnedGroups, "pinned_groups")
+	assert.Equal(t, []string{"argoproj.io/applications"}, ConfigPinnedTypes, "pinned_types")
+	assert.False(t, ConfigTipsEnabled, "tips")
+	assert.Equal(t, 250, ConfigLogTailLines, "log_tail_lines")
+	assert.Equal(t, 7, ConfigLogTailLinesShort, "log_tail_lines_short")
+	assert.False(t, ConfigLogRenderAnsi, "log_render_ansi")
+	assert.Equal(t, 9, ConfigScrollOff, "scrolloff")
+	assert.False(t, ConfigConfirmOnExit, "confirm_on_exit")
+	assert.False(t, ConfigDimOverlay, "dim_overlay")
+	assert.True(t, ConfigTransparentBg, "transparent_background")
+	assert.False(t, ConfigMouse, "mouse")
+	assert.Equal(t, 3*time.Second, ConfigWatchInterval, "watch_interval")
+	assert.True(t, ConfigNoColor, "no_color")
+	assert.True(t, ConfigSecretLazyLoading, "secret_lazy_loading")
+	assert.Equal(t, InformerCacheAlways, ConfigInformerCacheMode, "informer_cache")
+	assert.InDelta(t, 0.5, ConfigMinContrastRatio, 1e-9, "min_contrast_ratio")
+	assert.True(t, ConfigReadOnly, "read_only")
+	assert.True(t, ConfigShowRareTypes, "show_rare_types")
+	assert.Equal(t, []string{"/tmp/lfk-kcfg"}, ConfigKubeconfigDirs, "kubeconfig_dir")
+	assert.Equal(t, "traffic-ns", ConfigKubesharkNamespace, "kubeshark")
+
+	// security section.
+	assert.False(t, ConfigSecurityEnabled, "security.enabled")
+	assert.Equal(t, map[string]bool{"trivy": false, "heuristic": true}, ConfigSecuritySources, "security.sources")
+	require.Len(t, ConfigSecurityIgnorePatterns, 1, "security.ignore_patterns")
+	assert.Equal(t, "prod", ConfigSecurityIgnorePatterns[0].Cluster)
+
+	// rightsizing_defaults.
+	assert.Equal(t, model.StrategyPromMax1D, model.ConfigDefaultRightsizingStrategy, "rightsizing_defaults.strategy")
+	assert.InDelta(t, 1.5, model.ConfigDefaultRightsizingHeadroom, 1e-9, "rightsizing_defaults.headroom")
+
+	// scheduler section (+ global k8s client rate).
+	assert.Equal(t, 10, scheduler.ConfigWorkersPerContext, "scheduler.workers_per_context")
+	assert.Equal(t, 2, scheduler.ConfigCriticalReserved, "scheduler.critical_reserved_slots")
+	assert.Equal(t, 3, scheduler.ConfigLowReserved, "scheduler.low_reserved_slots")
+	assert.Equal(t, 45*time.Second, scheduler.ConfigDefaultTimeout, "scheduler.default_timeout")
+	assert.Equal(t, 4, scheduler.ConfigAgingThreshold, "scheduler.aging_threshold")
+	assert.False(t, scheduler.ConfigShowPriorityInOverlay, "scheduler.show_priority_in_tasks_overlay")
+	assert.Equal(t, 90*time.Second, scheduler.ConfigTimeoutsByKind[scheduler.KindMetrics], "scheduler.timeouts_by_kind")
+	assert.Equal(t, 77, ConfigK8sClientQPS, "scheduler.k8s_client_qps")
+	assert.Equal(t, 144, ConfigK8sClientBurst, "scheduler.k8s_client_burst")
+
+	// monitoring.
+	require.Contains(t, model.ConfigMonitoring, "_global", "monitoring")
+	assert.Equal(t, "prometheus", model.ConfigMonitoring["_global"].NodeMetrics)
+
+	// union_sets (map form).
+	require.Len(t, ConfigUnionSets, 1, "union_sets")
+	assert.Equal(t, "staging", ConfigUnionSets[0].Name)
+	assert.Equal(t, "stg", ConfigUnionSets[0].Namespace)
+	require.Len(t, ConfigUnionSets[0].Contexts, 1)
+	assert.Equal(t, "ctxA", ConfigUnionSets[0].Contexts[0].Context)
+	assert.Equal(t, "green", ConfigUnionSets[0].Contexts[0].Color)
+
+	// Top-level maps (applyConfigMaps).
+	assert.Equal(t, []string{"IP", "Node"}, ConfigResourceColumns["pod"], "resource_columns")
+	require.Contains(t, ConfigViews, "deployment", "views")
+	require.NotNil(t, ConfigViews["deployment"])
+	require.Contains(t, ConfigCustomActions, "Pod", "custom_actions")
+	assert.Equal(t, "Ping", ConfigCustomActions["Pod"][0].Label)
+	require.Contains(t, ConfigFilterPresets, "pod", "filter_presets")
+	assert.Equal(t, "Pending", ConfigFilterPresets["pod"][0].Match.Status)
+
+	// Per-cluster overrides (clusters.<ctx>.*).
+	assert.True(t, ConfigClusterReadOnly["ctx1"], "clusters.read_only")
+	assert.Equal(t, 33, ConfigClusterK8sClientQPS["ctx1"], "clusters.k8s_client_qps")
+	assert.Equal(t, 66, ConfigClusterK8sClientBurst["ctx1"], "clusters.k8s_client_burst")
+	assert.Equal(t, []string{"IP", "Node"}, ConfigClusterResourceColumns["ctx1"]["pod"], "clusters.resource_columns")
+	require.Contains(t, ConfigClusterViews, "ctx1", "clusters.views")
+	require.Contains(t, ConfigClusterViews["ctx1"], "deployment")
+	assert.False(t, ConfigClusterSecurityEnabled["ctx1"], "clusters.security.enabled")
+	assert.Equal(t, map[string]bool{"falco": false}, ConfigClusterSecuritySources["ctx1"], "clusters.security.sources")
+}
+
+// wiringCoveredFields records, for every configFile json field, where its
+// YAML->runtime wiring is asserted. TestConfigFile_EveryFieldHasWiringCoverage
+// fails if a field is added (or removed) without updating this map, forcing new
+// settings to ship with a wiring test.
+var wiringCoveredFields = map[string]string{
+	"colorscheme":            "TestLoadConfig_AllSettingsWired + TestApplyColorscheme_*",
+	"theme":                  "TestMergeThemeOverrides (mergeThemeOverrides is the LoadConfig wiring point)",
+	"keybindings":            "TestLoadConfig_AllSettingsWired + config_keybindings_test.go",
+	"log_path":               "TestLoadConfig_AllSettingsWired",
+	"abbreviations":          "TestLoadConfig_AllSettingsWired",
+	"icons":                  "TestLoadConfig_AllSettingsWired",
+	"resource_columns":       "TestLoadConfig_AllSettingsWired",
+	"views":                  "TestLoadConfig_AllSettingsWired",
+	"dashboard":              "TestLoadConfig_AllSettingsWired",
+	"custom_actions":         "TestLoadConfig_AllSettingsWired",
+	"filter_presets":         "TestLoadConfig_AllSettingsWired",
+	"terminal":               "TestLoadConfig_AllSettingsWired",
+	"scrollback_lines":       "TestLoadConfig_AllSettingsWired",
+	"pinned_groups":          "TestLoadConfig_AllSettingsWired",
+	"pinned_types":           "TestLoadConfig_AllSettingsWired",
+	"monitoring":             "TestLoadConfig_AllSettingsWired",
+	"tips":                   "TestLoadConfig_AllSettingsWired",
+	"log_tail_lines":         "TestLoadConfig_AllSettingsWired",
+	"log_tail_lines_short":   "TestLoadConfig_AllSettingsWired",
+	"log_render_ansi":        "TestLoadConfig_AllSettingsWired",
+	"scrolloff":              "TestLoadConfig_AllSettingsWired",
+	"confirm_on_exit":        "TestLoadConfig_AllSettingsWired",
+	"dim_overlay":            "TestLoadConfig_AllSettingsWired",
+	"transparent_background": "TestLoadConfig_AllSettingsWired",
+	"mouse":                  "TestLoadConfig_AllSettingsWired",
+	"watch_interval":         "TestLoadConfig_AllSettingsWired",
+	"clusters":               "TestLoadConfig_AllSettingsWired",
+	"no_color":               "TestLoadConfig_AllSettingsWired",
+	"secret_lazy_loading":    "TestLoadConfig_AllSettingsWired",
+	"informer_cache":         "TestLoadConfig_AllSettingsWired",
+	"min_contrast_ratio":     "TestLoadConfig_AllSettingsWired",
+	"read_only":              "TestLoadConfig_AllSettingsWired",
+	"show_rare_types":        "TestLoadConfig_AllSettingsWired",
+	"security":               "TestLoadConfig_AllSettingsWired",
+	"rightsizing_defaults":   "TestLoadConfig_AllSettingsWired",
+	"kubeshark":              "TestLoadConfig_AllSettingsWired",
+	"scheduler":              "TestLoadConfig_AllSettingsWired",
+	"kubeconfig_dir":         "TestLoadConfig_AllSettingsWired",
+	"union_sets":             "TestLoadConfig_AllSettingsWired",
+}
+
+// TestConfigFile_EveryFieldHasWiringCoverage is a forcing function: it fails if
+// a configFile field lacks an entry in wiringCoveredFields (a new setting was
+// added without a wiring test) or if the map names a field that no longer
+// exists (stale entry).
+func TestConfigFile_EveryFieldHasWiringCoverage(t *testing.T) {
+	fields := map[string]bool{}
+	for f := range reflect.TypeFor[configFile]().Fields() {
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		fields[name] = true
+		require.Containsf(t, wiringCoveredFields, name,
+			"config field %q has no wiring-test coverage entry; add an assertion in config_wiring_test.go and record it in wiringCoveredFields", name)
+	}
+	for name := range wiringCoveredFields {
+		require.Truef(t, fields[name], "wiringCoveredFields names %q, which is not a configFile field anymore; remove the stale entry", name)
+	}
+}
+
+// snapshotAllConfigGlobals captures every runtime global the config apply path
+// can mutate and returns a restore closure. Scalars are restored first, then
+// ApplyTheme(origTheme) last so it rebuilds style globals against the restored
+// no-color / contrast settings.
+func snapshotAllConfigGlobals(t *testing.T) func() {
+	t.Helper()
+
+	origTheme := ActiveTheme
+	origScheme := ActiveSchemeName
+	origKB := ActiveKeybindings
+	origAbbr := SearchAbbreviations
+	origLogPath := ConfigLogPath
+	origIcon := IconMode
+	origDashboard := ConfigDashboard
+	origTerminal := ConfigTerminalMode
+	origScrollback := ConfigScrollbackLines
+	origPinnedGroups := ConfigPinnedGroups
+	origPinnedTypes := ConfigPinnedTypes
+	origUnionSets := ConfigUnionSets
+	origTips := ConfigTipsEnabled
+	origTail := ConfigLogTailLines
+	origTailShort := ConfigLogTailLinesShort
+	origAnsi := ConfigLogRenderAnsi
+	origScrollOff := ConfigScrollOff
+	origConfirm := ConfigConfirmOnExit
+	origDim := ConfigDimOverlay
+	origTransparent := ConfigTransparentBg
+	origMouse := ConfigMouse
+	origWatch := ConfigWatchInterval
+	origNoColor := ConfigNoColor
+	origKubeconfig := ConfigKubeconfigDirs
+	origSecretLazy := ConfigSecretLazyLoading
+	origKubeshark := ConfigKubesharkNamespace
+	origInformer := ConfigInformerCacheMode
+	origContrast := ConfigMinContrastRatio
+	origReadOnly := ConfigReadOnly
+	origShowRare := ConfigShowRareTypes
+	origSecEnabled := ConfigSecurityEnabled
+	origSecSources := ConfigSecuritySources
+	origSecIgnore := ConfigSecurityIgnorePatterns
+	origQPS := ConfigK8sClientQPS
+	origBurst := ConfigK8sClientBurst
+	origResCols := ConfigResourceColumns
+	origViews := ConfigViews
+	origCustom := ConfigCustomActions
+	origPresets := ConfigFilterPresets
+	origClusterReadOnly := ConfigClusterReadOnly
+	origClusterResCols := ConfigClusterResourceColumns
+	origClusterViews := ConfigClusterViews
+	origClusterSecEnabled := ConfigClusterSecurityEnabled
+	origClusterSecSources := ConfigClusterSecuritySources
+	origClusterQPS := ConfigClusterK8sClientQPS
+	origClusterBurst := ConfigClusterK8sClientBurst
+
+	origMonitoring := model.ConfigMonitoring
+	origRSStrategy := model.ConfigDefaultRightsizingStrategy
+	origRSHeadroom := model.ConfigDefaultRightsizingHeadroom
+
+	origWorkers := scheduler.ConfigWorkersPerContext
+	origCritical := scheduler.ConfigCriticalReserved
+	origLow := scheduler.ConfigLowReserved
+	origDefTimeout := scheduler.ConfigDefaultTimeout
+	origByKind := scheduler.ConfigTimeoutsByKind
+	origShowPrio := scheduler.ConfigShowPriorityInOverlay
+	origAging := scheduler.ConfigAgingThreshold
+
+	return func() {
+		ActiveSchemeName = origScheme
+		ActiveKeybindings = origKB
+		SearchAbbreviations = origAbbr
+		ConfigLogPath = origLogPath
+		IconMode = origIcon
+		ConfigDashboard = origDashboard
+		ConfigTerminalMode = origTerminal
+		ConfigScrollbackLines = origScrollback
+		ConfigPinnedGroups = origPinnedGroups
+		ConfigPinnedTypes = origPinnedTypes
+		ConfigUnionSets = origUnionSets
+		ConfigTipsEnabled = origTips
+		ConfigLogTailLines = origTail
+		ConfigLogTailLinesShort = origTailShort
+		ConfigLogRenderAnsi = origAnsi
+		ConfigScrollOff = origScrollOff
+		ConfigConfirmOnExit = origConfirm
+		ConfigDimOverlay = origDim
+		ConfigTransparentBg = origTransparent
+		ConfigMouse = origMouse
+		ConfigWatchInterval = origWatch
+		ConfigNoColor = origNoColor
+		ConfigKubeconfigDirs = origKubeconfig
+		ConfigSecretLazyLoading = origSecretLazy
+		ConfigKubesharkNamespace = origKubeshark
+		ConfigInformerCacheMode = origInformer
+		ConfigMinContrastRatio = origContrast
+		ConfigReadOnly = origReadOnly
+		ConfigShowRareTypes = origShowRare
+		ConfigSecurityEnabled = origSecEnabled
+		ConfigSecuritySources = origSecSources
+		ConfigSecurityIgnorePatterns = origSecIgnore
+		ConfigK8sClientQPS = origQPS
+		ConfigK8sClientBurst = origBurst
+		ConfigResourceColumns = origResCols
+		ConfigViews = origViews
+		ConfigCustomActions = origCustom
+		ConfigFilterPresets = origPresets
+		ConfigClusterReadOnly = origClusterReadOnly
+		ConfigClusterResourceColumns = origClusterResCols
+		ConfigClusterViews = origClusterViews
+		ConfigClusterSecurityEnabled = origClusterSecEnabled
+		ConfigClusterSecuritySources = origClusterSecSources
+		ConfigClusterK8sClientQPS = origClusterQPS
+		ConfigClusterK8sClientBurst = origClusterBurst
+
+		model.ConfigMonitoring = origMonitoring
+		model.ConfigDefaultRightsizingStrategy = origRSStrategy
+		model.ConfigDefaultRightsizingHeadroom = origRSHeadroom
+
+		scheduler.ConfigWorkersPerContext = origWorkers
+		scheduler.ConfigCriticalReserved = origCritical
+		scheduler.ConfigLowReserved = origLow
+		scheduler.ConfigDefaultTimeout = origDefTimeout
+		scheduler.ConfigTimeoutsByKind = origByKind
+		scheduler.ConfigShowPriorityInOverlay = origShowPrio
+		scheduler.ConfigAgingThreshold = origAging
+
+		ApplyTheme(origTheme)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a JSON Schema for `config.yaml` so editors running a YAML language server give autocompletion, inline docs, and typo/enum warnings. Users opt in with a modeline at the top of their config:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/janosmiko/lfk/main/docs/config.schema.json
```

Works in VS Code (redhat.vscode-yaml), Neovim `yamlls`, and any other YAML LSP.

## What's included

| File | Change |
|---|---|
| `docs/config.schema.json` | **New** — Draft-07 schema for all top-level + nested fields (theme, all keybindings, views, custom actions, filter presets, monitoring, clusters, security, scheduler, union sets, …). Union types (`informer_cache`, `kubeconfig_dir`, `union_sets`) and enums match the Go code. |
| `docs/config-example.yaml` | Added the schema modeline |
| `docs/config-reference.md` | New "Editor autocompletion (JSON Schema)" section |
| `internal/ui/config_schema_test.go` | **New** — reflection check that every `configFile`/`Keybindings` field has a schema property |
| `internal/ui/config_wiring_test.go` | **New** — end-to-end wiring tests (see below) |
| `CLAUDE.md` | Require new settings to update struct, schema, docs, and tests together |

## Drift guards (forcing functions)

Four tests ensure config settings, schema, and tests stay in lockstep:

- `TestConfigSchemaTopLevelInSync` / `TestConfigSchemaKeybindingsInSync` — every config/keybinding field must have a schema property.
- `TestLoadConfig_AllSettingsWired` — loads a config exercising **every** setting and asserts each YAML key reaches its runtime global (scalars, maps, scheduler, security, rightsizing, union sets, monitoring, per-cluster overrides).
- `TestConfigFile_EveryFieldHasWiringCoverage` — fails if a new field lacks a wiring assertion.

A new setting that skips the schema, docs, or wiring assertion will not pass CI.

## Design notes

- `additionalProperties: false` on fixed objects (top level, theme, keybindings) catches typos; left open on user-keyed maps.
- Container fields allow `null` so empty section headers (`clusters:` with the body commented out) don't get flagged — matching lfk's own tolerance.

## Test plan

- [x] Schema is valid Draft-07; `docs/config-example.yaml` validates clean
- [x] Negative checks: typos and bad enum values are rejected
- [x] `go test ./...` — all packages pass
- [x] `internal/ui` passes with `-race`
- [x] gofumpt + golangci-lint clean (pre-commit hook: 0 issues)