### PR TITLE
fix: route mouse wheel to the pane under the pointer in Object Explorer and log viewer

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -854,6 +854,7 @@ or `Esc` to cancel.
 | Wheel up/down inside a centered overlay | Scroll the list cursor (same as `j` / `k` / arrow keys) |
 | Scroll wheel over middle pane | Move the row selection up/down |
 | Scroll wheel over right pane | Scroll the preview under the pointer |
+| Scroll wheel in the Object Explorer / log viewer | Same per-pane routing — over the preview pane it scrolls the preview, over the list it moves the cursor |
 | `Ctrl+Option+Y` | Toggle mouse capture — release it to select text where `Shift+Drag` doesn't work, press again to re-enable |
 | Shift+Drag | Select text (host terminal) |
 | Shift+Option+Drag (macOS) / Alt+Drag (Linux, Windows) | Block-select text inside the embedded PTY |

--- a/internal/app/update_mouse.go
+++ b/internal/app/update_mouse.go
@@ -62,23 +62,21 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 	// Handle mouse scroll in log viewer mode.
 	if m.mode == modeLogs {
+		return m.handleLogsMouse(msg)
+	}
+
+	// Object Explorer wheel: route by the pointer column. Over the right
+	// (preview) pane the wheel scrolls the YAML preview; over the left and
+	// middle panes it moves the tree cursor — mirroring the main explorer's
+	// per-pane wheel routing (#379). Non-wheel mouse falls through so
+	// tab-bar clicks keep working.
+	if m.mode == modeObjectExplorer {
 		switch msg.Button {
 		case tea.MouseButtonWheelUp:
-			m.logView.follow = false
-			if m.logView.scroll > 0 {
-				m.logView.scroll -= 3
-				if m.logView.scroll < 0 {
-					m.logView.scroll = 0
-				}
-			}
-			cmd := m.maybeLoadMoreHistory()
-			return m, cmd
+			return m.handleObjectExplorerWheel(msg.X, -1)
 		case tea.MouseButtonWheelDown:
-			m.logView.follow = false
-			m.logView.scroll += 3
-			m.clampLogScroll()
+			return m.handleObjectExplorerWheel(msg.X, 1)
 		}
-		return m, nil
 	}
 
 	// Wheel scroll in the other full-screen viewer modes (YAML, Describe,
@@ -165,6 +163,93 @@ func (m Model) handleExplorerWheel(x, delta int) (tea.Model, tea.Cmd) {
 	}
 	// Left and middle panes: move the selection cursor.
 	return m.moveCursor(delta)
+}
+
+// handleObjectExplorerWheel routes a wheel tick in the Object Explorer to
+// the pane under the pointer at x. Over the right (preview) pane it scrolls
+// the YAML preview, mirroring the J/K keys; over the left and middle panes
+// it moves the tree cursor, mirroring j/k. dir is -1 (up) or +1 (down);
+// each tick moves wheelStep lines to match the other viewers' wheel feel.
+func (m Model) handleObjectExplorerWheel(x, dir int) (tea.Model, tea.Cmd) {
+	const wheelStep = 3
+	rt := &m.objectExplorerView
+	if x >= m.objectExplorerRightPaneStart() {
+		// Scroll-up is a plain decrement with a zero floor; scroll-down
+		// increments and clamps to the preview content height (which
+		// re-marshals the node YAML, so only do it when scrolling down).
+		rt.previewScroll += dir * wheelStep
+		if dir < 0 {
+			if rt.previewScroll < 0 {
+				rt.previewScroll = 0
+			}
+		} else {
+			m.clampObjectExplorerPreviewScroll()
+		}
+		return m, nil
+	}
+	m.moveObjectExplorerCursor(dir * wheelStep)
+	m.clampObjectExplorerScroll()
+	return m, nil
+}
+
+// handleLogsMouse routes a mouse event in the log viewer. The wheel scrolls
+// the pane under the pointer: over the preview side panel it scrolls the
+// structured preview (mirroring the J/K keys); over the log stream it scrolls
+// the log — the same per-pane routing as the explorers (#379). Non-wheel
+// mouse is a no-op.
+func (m Model) handleLogsMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if logW, previewW := splitLogPreviewWidth(m.width); m.logView.previewVisible && previewW > 0 && msg.X >= logW {
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			return m.scrollLogPreviewWheel(-1), nil
+		case tea.MouseButtonWheelDown:
+			return m.scrollLogPreviewWheel(1), nil
+		}
+	}
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		m.logView.follow = false
+		if m.logView.scroll > 0 {
+			m.logView.scroll -= 3
+			if m.logView.scroll < 0 {
+				m.logView.scroll = 0
+			}
+		}
+		return m, m.maybeLoadMoreHistory()
+	case tea.MouseButtonWheelDown:
+		m.logView.follow = false
+		m.logView.scroll += 3
+		m.clampLogScroll()
+	}
+	return m, nil
+}
+
+// scrollLogPreviewWheel scrolls the log preview side panel by wheelStep rows
+// in dir (-1 up, +1 down), reusing the J/K key handlers so the clamping math
+// lives in one place. Callers gate on previewVisible and a non-zero panel
+// width before calling.
+func (m Model) scrollLogPreviewWheel(dir int) Model {
+	const wheelStep = 3
+	for range wheelStep {
+		if dir < 0 {
+			m = m.handleLogKeyK2()
+		} else {
+			m = m.handleLogKeyJ2()
+		}
+	}
+	return m
+}
+
+// objectExplorerRightPaneStart returns the screen x at which the Object
+// Explorer's right (preview) pane begins. It mirrors the column math in
+// ui.RenderObjectExplorerView: an outer frame border (1 cell) precedes the
+// left and middle columns, each of which adds 2 border cells around its
+// content width (padding is folded into the width).
+func (m Model) objectExplorerRightPaneStart() int {
+	usable := m.width - 8
+	leftW := max(10, usable*12/100)
+	middleW := max(10, usable*51/100)
+	return 1 + (leftW + 2) + (middleW + 2)
 }
 
 // columnBoundaries returns the x boundaries between left/middle and
@@ -414,11 +499,12 @@ func (m *Model) tabAtX(x int) int {
 }
 
 // isViewerMode returns true for full-screen content viewers that don't
-// have native wheel-scroll handling. modeLogs and modeExplorer have
-// their own wheel paths and are handled separately.
+// have native wheel-scroll handling. modeLogs, modeExplorer, and
+// modeObjectExplorer have their own per-pane wheel paths and are handled
+// separately.
 func isViewerMode(mode viewMode) bool {
 	switch mode {
-	case modeYAML, modeDescribe, modeDiff, modeHelp, modeExplain, modeObjectExplorer:
+	case modeYAML, modeDescribe, modeDiff, modeHelp, modeExplain:
 		return true
 	}
 	return false

--- a/internal/app/update_mouse_logpreview_test.go
+++ b/internal/app/update_mouse_logpreview_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+// In the log viewer the wheel must scroll the pane under the pointer: over
+// the preview side panel it scrolls the structured preview, over the log
+// stream it scrolls the log. Mirrors the Object Explorer per-pane routing
+// (#379). width 140 -> preview panel begins at x = logW (84).
+
+func logPreviewWheelModel() Model {
+	return Model{
+		mode: modeLogs,
+		logView: logViewState{
+			title:          "Logs",
+			lines:          []string{scrollOverflowJSON},
+			cursor:         0,
+			previewVisible: true,
+		},
+		tabs:   []TabState{{}},
+		width:  140,
+		height: 10, // small enough to force preview overflow
+	}
+}
+
+func TestLogWheel_PreviewPaneScrollsPreview(t *testing.T) {
+	m := logPreviewWheelModel()
+	logW, previewW := splitLogPreviewWidth(m.width)
+	assert.Greater(t, previewW, 0, "preview panel must be visible at this width")
+
+	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: logW + 2})
+	rm := ret.(Model)
+	assert.Greater(t, rm.logView.previewScroll, 0,
+		"wheel down over the preview panel must scroll the preview")
+	assert.Equal(t, 0, rm.logView.scroll,
+		"the main log must not be scrolled by a preview-pane wheel")
+}
+
+func TestLogWheel_PreviewPaneClampsAtTop(t *testing.T) {
+	m := logPreviewWheelModel()
+	m.logView.previewScroll = 2
+	logW, _ := splitLogPreviewWidth(m.width)
+
+	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp, X: logW + 2})
+	rm := ret.(Model)
+	assert.Equal(t, 0, rm.logView.previewScroll,
+		"wheel up must clamp the preview scroll at the top")
+}
+
+func TestLogWheel_LogPaneScrollsLog(t *testing.T) {
+	m := logPreviewWheelModel()
+	logW, _ := splitLogPreviewWidth(m.width)
+
+	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: logW - 10})
+	rm := ret.(Model)
+	assert.False(t, rm.logView.follow,
+		"wheel over the log stream must take the main-log path (disables follow)")
+	assert.Equal(t, 0, rm.logView.previewScroll,
+		"wheel over the log stream must not scroll the preview")
+}
+
+func TestLogWheel_PreviewHiddenScrollsLog(t *testing.T) {
+	m := logPreviewWheelModel()
+	m.logView.previewVisible = false
+	logW, _ := splitLogPreviewWidth(m.width)
+
+	// Even with the pointer where the panel would be, a hidden panel means
+	// the wheel scrolls the log.
+	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: logW + 2})
+	rm := ret.(Model)
+	assert.False(t, rm.logView.follow, "hidden preview: wheel must scroll the log")
+	assert.Equal(t, 0, rm.logView.previewScroll, "hidden preview: previewScroll stays 0")
+}

--- a/internal/app/update_mouse_logpreview_test.go
+++ b/internal/app/update_mouse_logpreview_test.go
@@ -13,11 +13,17 @@ import (
 // (#379). width 140 -> preview panel begins at x = logW (84).
 
 func logPreviewWheelModel() Model {
+	// Enough lines to overflow the log viewport (logContentHeight = height-5
+	// = 5 here) so wheel-down on the log pane actually advances logView.scroll.
+	lines := make([]string, 12)
+	for i := range lines {
+		lines[i] = scrollOverflowJSON
+	}
 	return Model{
 		mode: modeLogs,
 		logView: logViewState{
 			title:          "Logs",
-			lines:          []string{scrollOverflowJSON},
+			lines:          lines,
 			cursor:         0,
 			previewVisible: true,
 		},
@@ -59,6 +65,8 @@ func TestLogWheel_LogPaneScrollsLog(t *testing.T) {
 	rm := ret.(Model)
 	assert.False(t, rm.logView.follow,
 		"wheel over the log stream must take the main-log path (disables follow)")
+	assert.Greater(t, rm.logView.scroll, 0,
+		"wheel over the log stream must advance the main log scroll")
 	assert.Equal(t, 0, rm.logView.previewScroll,
 		"wheel over the log stream must not scroll the preview")
 }
@@ -73,5 +81,6 @@ func TestLogWheel_PreviewHiddenScrollsLog(t *testing.T) {
 	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: logW + 2})
 	rm := ret.(Model)
 	assert.False(t, rm.logView.follow, "hidden preview: wheel must scroll the log")
+	assert.Greater(t, rm.logView.scroll, 0, "hidden preview: wheel must advance the log scroll")
 	assert.Equal(t, 0, rm.logView.previewScroll, "hidden preview: previewScroll stays 0")
 }

--- a/internal/app/update_mouse_objectexplorer_test.go
+++ b/internal/app/update_mouse_objectexplorer_test.go
@@ -56,7 +56,7 @@ func TestObjectExplorerWheel_MiddlePaneMovesCursor(t *testing.T) {
 	m := openObjectExplorerOnStatus(t)
 	m.objectExplorerView.cursor = 0
 	m.objectExplorerView.previewScroll = 5
-	x := m.objectExplorerRightPaneStart() - 10 // inside the middle pane
+	x := 0 // far-left: in the left/middle band, never the right pane
 
 	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: x})
 	rm := ret.(Model)

--- a/internal/app/update_mouse_objectexplorer_test.go
+++ b/internal/app/update_mouse_objectexplorer_test.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// In the Object Explorer the wheel must scroll the pane under the pointer:
+// over the right (preview) pane it scrolls the YAML, over the left/middle
+// panes it moves the tree cursor — matching the main explorer's per-pane
+// routing (#379). A short window forces the preview to be scrollable.
+
+// openObjectExplorerOnStatus opens the explorer with the cursor on the
+// "status" node (a multi-line subtree) and a short window so the preview
+// pane can scroll.
+func openObjectExplorerOnStatus(t *testing.T) Model {
+	t.Helper()
+	m := objectExplorerModel(t)
+	result, _ := m.openObjectExplorer()
+	m = result.(Model)
+	m.height = 8 // previewPaneHeight = height-5 = 3, well under the YAML length
+	// Root keys are sorted [apiVersion, kind, metadata, status]; status is last.
+	m.objectExplorerView.cursor = len(m.objectExplorerView.level) - 1
+	require.Greater(t, len(m.selectedNodeYAML()), 0, "status node must have a preview")
+	return m
+}
+
+func TestObjectExplorerWheel_RightPaneScrollsPreview(t *testing.T) {
+	m := openObjectExplorerOnStatus(t)
+	cursorBefore := m.objectExplorerView.cursor
+	x := m.objectExplorerRightPaneStart() + 2 // inside the preview pane
+
+	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: x})
+	rm := ret.(Model)
+	assert.Greater(t, rm.objectExplorerView.previewScroll, 0,
+		"wheel down over the right pane must scroll the preview")
+	assert.Equal(t, cursorBefore, rm.objectExplorerView.cursor,
+		"wheel over the right pane must not move the tree cursor")
+}
+
+func TestObjectExplorerWheel_RightPaneClampsAtTop(t *testing.T) {
+	m := openObjectExplorerOnStatus(t)
+	m.objectExplorerView.previewScroll = 2
+	x := m.objectExplorerRightPaneStart() + 2
+
+	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp, X: x})
+	rm := ret.(Model)
+	assert.Equal(t, 0, rm.objectExplorerView.previewScroll,
+		"wheel up must clamp the preview scroll at the top")
+}
+
+func TestObjectExplorerWheel_MiddlePaneMovesCursor(t *testing.T) {
+	m := openObjectExplorerOnStatus(t)
+	m.objectExplorerView.cursor = 0
+	m.objectExplorerView.previewScroll = 5
+	x := m.objectExplorerRightPaneStart() - 10 // inside the middle pane
+
+	ret, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: x})
+	rm := ret.(Model)
+	assert.Greater(t, rm.objectExplorerView.cursor, 0,
+		"wheel down over the middle pane must move the tree cursor")
+	assert.Equal(t, 0, rm.objectExplorerView.previewScroll,
+		"moving the cursor must reset the preview scroll")
+}


### PR DESCRIPTION
## Summary

Fixes #379. In the Object Explorer (`O`), scrolling the mouse wheel over the right YAML preview pane wrongly moved the middle tree cursor instead of scrolling the preview. The Object Explorer fell into the generic `isViewerMode` wheel path, which synthesizes `j`/`k` keypresses regardless of pointer position. The main explorer already solved this with per-pane wheel routing; this wires the Object Explorer (and the log viewer) into the same pattern.

While verifying other multi-pane views, the **log viewer** turned out to have the identical bug: its wheel always scrolled the main log stream, even when the pointer was over the structured **preview side panel**. Fixed here too for consistency.

## Changes

- **Object Explorer** (`handleObjectExplorerWheel`): wheel over the right (preview) pane scrolls the YAML preview; over the left/middle panes it moves the tree cursor. `objectExplorerRightPaneStart` mirrors the column math in `RenderObjectExplorerView`.
- **Log viewer** (`handleLogsMouse` + `scrollLogPreviewWheel`): wheel over the preview side panel scrolls the structured preview (reusing the `J`/`K` handlers so clamping stays in one place); the log stream scrolls otherwise.
- Removed `modeObjectExplorer` from `isViewerMode` now that it has native per-pane handling.
- Extracted the log mouse handling into `handleLogsMouse` to keep `handleMouse` under the gocyclo cap.
- Documented the per-pane wheel behavior in `docs/keybindings.md`.

## Verification sweep

| View | Wheel routing |
|---|---|
| Main explorer | Already per-pane (unchanged) |
| Object Explorer | Fixed |
| Log viewer preview panel | Fixed |
| Explain / "API Explorer" | No bug — DESCRIPTION pane has no independent scroll |
| Centered list overlays | Correct — single list |
| Fullscreen/custom overlays (Can-I, Who-Can, NetworkPolicy) | Wheel swallowed by design (keyboard-only) |

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/app/ ./internal/ui/`
- [x] `golangci-lint run ./...` (0 issues)
- [x] New tests: `update_mouse_objectexplorer_test.go` (right pane scrolls preview / clamps at top; middle pane moves cursor & resets preview scroll) and `update_mouse_logpreview_test.go` (preview pane scrolls preview / clamps; log pane scrolls log; hidden preview falls back to log)
- [ ] Manual: `O` on a resource with a nested status, scroll wheel over the YAML preview → preview scrolls; over the list → cursor moves. In the log viewer with `P` preview on, scroll over the panel vs the stream.