### PR TITLE
fix: wrap long lines in diff viewer instead of truncating (#386)

### DIFF
--- a/internal/ui/overlay_diff.go
+++ b/internal/ui/overlay_diff.go
@@ -363,13 +363,16 @@ func RenderUnifiedDiffView(left, right, leftName, rightName string, scroll, widt
 
 	var maxScroll int
 	if wrap {
-		// Wrap mode: long lines wrap to multiple rows. Scroll indexes whole
-		// content lines (one per visible diff line), matching the cursor model.
+		// Wrap mode clamps per logical line, not per page: one diff line can
+		// expand to several visual rows, so page-fill clamping (which mixes a
+		// visual-row count with a logical-line count) doesn't apply. Scroll
+		// indexes whole content lines, matching the cursor model, and stops at
+		// the last line so it stays reachable.
 		maxScroll = max(totalContent-1, 0)
 		scroll = min(max(scroll, 0), maxScroll)
 		rendered = append(rendered, buildWrappedUnifiedRows(rawDiffLines, visLines, scroll, contentMaxLines, contentWidth, gutterWidth, lineNumbers, searchQuery, cursor, uStyles, cursorStyleU)...)
 	} else {
-		// Clamp scroll on content lines only.
+		// Non-wrap: one row per line, so clamp to keep the last page full.
 		maxScroll = max(totalContent-contentMaxLines, 0)
 		scroll = min(max(scroll, 0), maxScroll)
 

--- a/internal/ui/overlay_diff.go
+++ b/internal/ui/overlay_diff.go
@@ -123,9 +123,12 @@ func RenderDiffView(left, right, leftName, rightName string, scroll, width, heig
 		gutterWidth = len(fmt.Sprintf("%d", len(rawDiffLines))) + 1 // digits + space
 	}
 
-	// Calculate column widths: split the available content area in half with a separator.
-	// -1 for cursor gutter (> or space).
-	colWidth := max((width-8-gutterWidth*2)/2, 10)
+	// Calculate column widths: split the available content area in half with a
+	// separator. Budget per row = border+padding (4) + two cursor indicators
+	// (2) + " | " separator (3) = 9, plus a line-number gutter on each side.
+	// Under-budgeting here lets a fully-filled wrapped row exceed the border
+	// width, which makes lipgloss re-wrap it and shears the two columns apart.
+	colWidth := max((width-9-gutterWidth*2)/2, 10)
 
 	// Build header.
 	gutterPad := strings.Repeat(" ", gutterWidth)
@@ -146,141 +149,15 @@ func RenderDiffView(left, right, leftName, rightName string, scroll, width, heig
 		scroll = 0
 	}
 
-	// Visible slice.
-	visible := visLines[scroll:]
-	if len(visible) > maxLines {
-		visible = visible[:maxLines]
-	}
-
-	// Track left/right line numbers independently by counting from the start.
-	leftNum, rightNum := 1, 1
-	for i := 0; i < len(visLines) && i < scroll; i++ {
-		vl := visLines[i]
-		if vl.IsFoldPlaceholder || vl.Original < 0 {
-			continue
-		}
-		switch rawDiffLines[vl.Original].status {
-		case '=':
-			leftNum++
-			rightNum++
-		case '<':
-			leftNum++
-		case '>':
-			rightNum++
-		}
-	}
-
 	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Background(SurfaceBg)
 
-	// Precompute visual selection range.
-	selStart, selEnd := -1, -1
-	if vp.VisualMode {
-		selStart = min(vp.VisualStart, cursor)
-		selEnd = max(vp.VisualStart, cursor)
-	}
-
-	rows := make([]string, 0, len(visible))
-	for ri, vl := range visible {
-		visIdx := ri + scroll
-		isCursorLine := visIdx == cursor
-
-		// Show cursor indicator on the active side.
-		leftCursorInd := " "
-		rightCursorInd := " "
-		if isCursorLine {
-			if vp.CursorSide == 0 {
-				leftCursorInd = cursorStyle.Render(">")
-			} else {
-				rightCursorInd = cursorStyle.Render(">")
-			}
-		}
-
-		if vl.IsFoldPlaceholder {
-			placeholder := DiffFoldPlaceholderText(vl.HiddenCount)
-			gutterPadL := strings.Repeat(" ", gutterWidth)
-			leftPlaceholder := padToWidth(placeholder, colWidth)
-			rightPlaceholder := padToWidth(placeholder, colWidth)
-			row := leftCursorInd + gutterPadL + leftPlaceholder + separatorStyle.Render(" | ") + rightCursorInd + gutterPadL + rightPlaceholder
-			rows = append(rows, row)
-			continue
-		}
-		dl := rawDiffLines[vl.Original]
-
-		isSelected := vp.VisualMode && visIdx >= selStart && visIdx <= selEnd
-
-		var leftCol, rightCol, leftGutter, rightGutter string
-		switch dl.status {
-		case '=':
-			var leftText, rightText string
-			// Apply visual selection on the active side.
-			if isSelected {
-				leftText, rightText = applyDiffVisualSelection(dl.left, dl.right, vp, visIdx, selStart, selEnd, colWidth)
-			} else {
-				if searchQuery != "" {
-					leftText = normalStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.left, colWidth), searchQuery))
-					rightText = normalStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.right, colWidth), searchQuery))
-				} else {
-					leftText = normalStyle.Render(truncateToWidth(dl.left, colWidth))
-					rightText = normalStyle.Render(truncateToWidth(dl.right, colWidth))
-				}
-			}
-			// Block cursor on cursor line (non-visual mode).
-			if isCursorLine && !vp.VisualMode {
-				if vp.CursorSide == 0 {
-					leftText = RenderCursorAtCol(leftText, dl.left, vp.CursorCol)
-				} else {
-					rightText = RenderCursorAtCol(rightText, dl.right, vp.CursorCol)
-				}
-			}
-			leftCol = leftText
-			rightCol = rightText
-			if lineNumbers {
-				leftGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, leftNum))
-				rightGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, rightNum))
-			}
-			leftNum++
-			rightNum++
-		case '<':
-			var leftText string
-			if isSelected && vp.CursorSide == 0 {
-				leftText = applyDiffVisualSide(dl.left, vp, visIdx, selStart, selEnd)
-			} else if searchQuery != "" {
-				leftText = removedStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.left, colWidth), searchQuery))
-			} else {
-				leftText = removedStyle.Render(truncateToWidth(dl.left, colWidth))
-			}
-			if isCursorLine && !vp.VisualMode && vp.CursorSide == 0 {
-				leftText = RenderCursorAtCol(leftText, dl.left, vp.CursorCol)
-			}
-			leftCol = leftText
-			rightCol = ""
-			if lineNumbers {
-				leftGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, leftNum))
-				rightGutter = strings.Repeat(" ", gutterWidth)
-			}
-			leftNum++
-		case '>':
-			var rightText string
-			if isSelected && vp.CursorSide == 1 {
-				rightText = applyDiffVisualSide(dl.right, vp, visIdx, selStart, selEnd)
-			} else if searchQuery != "" {
-				rightText = addedStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.right, colWidth), searchQuery))
-			} else {
-				rightText = addedStyle.Render(truncateToWidth(dl.right, colWidth))
-			}
-			if isCursorLine && !vp.VisualMode && vp.CursorSide == 1 {
-				rightText = RenderCursorAtCol(rightText, dl.right, vp.CursorCol)
-			}
-			leftCol = ""
-			rightCol = rightText
-			if lineNumbers {
-				leftGutter = strings.Repeat(" ", gutterWidth)
-				rightGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, rightNum))
-			}
-			rightNum++
-		}
-		row := leftCursorInd + leftGutter + padToWidth(leftCol, colWidth) + separatorStyle.Render(" | ") + rightCursorInd + rightGutter + padToWidth(rightCol, colWidth)
-		rows = append(rows, row)
+	var rows []string
+	if wrap {
+		// Wrap mode: long values wrap within their column instead of truncating.
+		st := diffSideStyles{removed: removedStyle, added: addedStyle, normal: normalStyle, cursor: cursorStyle, separator: separatorStyle}
+		rows = buildWrappedDiffRows(rawDiffLines, visLines, scroll, maxLines, colWidth, gutterWidth, lineNumbers, searchQuery, cursor, vp.CursorSide, st)
+	} else {
+		rows = buildSideBySideRows(rawDiffLines, visLines, scroll, maxLines, colWidth, gutterWidth, lineNumbers, searchQuery, cursor, vp, normalStyle, removedStyle, addedStyle, cursorStyle, separatorStyle)
 	}
 
 	// Pad rows to fill available height so content fills the border.
@@ -382,6 +259,12 @@ func RenderUnifiedDiffView(left, right, leftName, rightName string, scroll, widt
 		gutterWidth = len(fmt.Sprintf("%d", len(rawDiffLines)+2)) + 1 // +2 for header lines
 	}
 
+	// Content width = border(2) + padding(2) + leading indicator(1) + gutter.
+	// Lines are truncated (non-wrap) or wrapped (wrap) to this width so the
+	// border never has to wrap them itself.
+	contentWidth := max(width-5-gutterWidth, 10)
+	uStyles := diffUnifiedStyles{removed: removedStyle, added: addedStyle, normal: normalStyle}
+
 	// Precompute visual selection range.
 	selStart, selEnd := -1, -1
 	if vp.VisualMode {
@@ -414,55 +297,23 @@ func RenderUnifiedDiffView(left, right, leftName, rightName string, scroll, widt
 
 		isSelected := vp.VisualMode && vi >= selStart && vi <= selEnd
 		isCursorLine := vi == cursor
-		// Get the plain content for this line (without +/- prefix).
-		var plainContent string
-		if dl.left != "" {
-			plainContent = dl.left
-		} else {
-			plainContent = dl.right
-		}
 
-		switch dl.status {
-		case '=':
-			content := " " + dl.left
-			if isSelected {
-				content = applyDiffVisualSide(content, vp, vi, selStart, selEnd)
-			} else if searchQuery != "" {
-				content = normalStyle.Render(highlightDiffSearchInLine(content, searchQuery))
-			} else {
-				content = normalStyle.Render(content)
-			}
-			if isCursorLine && !vp.VisualMode {
-				content = RenderCursorAtCol(content, " "+plainContent, vp.CursorCol)
-			}
-			lines = append(lines, unifiedLine{text: gutter + content, plain: " " + plainContent, visIdx: vi})
-		case '<':
-			content := "-" + dl.left
-			if isSelected {
-				content = applyDiffVisualSide(content, vp, vi, selStart, selEnd)
-			} else if searchQuery != "" {
-				content = removedStyle.Render(highlightDiffSearchInLine(content, searchQuery))
-			} else {
-				content = removedStyle.Render(content)
-			}
-			if isCursorLine && !vp.VisualMode {
-				content = RenderCursorAtCol(content, "-"+plainContent, vp.CursorCol)
-			}
-			lines = append(lines, unifiedLine{text: gutter + content, plain: "-" + plainContent, visIdx: vi})
-		case '>':
-			content := "+" + dl.right
-			if isSelected {
-				content = applyDiffVisualSide(content, vp, vi, selStart, selEnd)
-			} else if searchQuery != "" {
-				content = addedStyle.Render(highlightDiffSearchInLine(content, searchQuery))
-			} else {
-				content = addedStyle.Render(content)
-			}
-			if isCursorLine && !vp.VisualMode {
-				content = RenderCursorAtCol(content, "+"+plainContent, vp.CursorCol)
-			}
-			lines = append(lines, unifiedLine{text: gutter + content, plain: "+" + plainContent, visIdx: vi})
+		// Truncate to the content width so the border never re-wraps the line.
+		prefix, text, style := unifiedLineParts(dl, uStyles)
+		plain := truncateToWidth(prefix+text, contentWidth)
+		var content string
+		switch {
+		case isSelected:
+			content = applyDiffVisualSide(plain, vp, vi, selStart, selEnd)
+		case searchQuery != "":
+			content = style.Render(highlightDiffSearchInLine(plain, searchQuery))
+		default:
+			content = style.Render(plain)
 		}
+		if isCursorLine && !vp.VisualMode {
+			content = RenderCursorAtCol(content, plain, vp.CursorCol)
+		}
+		lines = append(lines, unifiedLine{text: gutter + content, plain: plain, visIdx: vi})
 	}
 
 	titleText := "Resource Diff (unified)"
@@ -500,34 +351,38 @@ func RenderUnifiedDiffView(left, right, leftName, rightName string, scroll, widt
 
 	// Content area = maxLines minus header lines.
 	contentMaxLines := max(maxLines-len(headerLines), 1)
-
-	// Clamp scroll on content lines only.
 	totalContent := len(contentLines)
-	maxScroll := max(totalContent-contentMaxLines, 0)
-	if scroll > maxScroll {
-		scroll = maxScroll
-	}
-	if scroll < 0 {
-		scroll = 0
-	}
 
-	// Visible content slice.
-	visibleContent := contentLines[scroll:]
-	if len(visibleContent) > contentMaxLines {
-		visibleContent = visibleContent[:contentMaxLines]
-	}
+	cursorStyleU := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Background(SurfaceBg)
 
 	// Build rendered lines: headers first, then scrollable content.
-	cursorStyleU := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Background(SurfaceBg)
 	var rendered []string
 	for _, hl := range headerLines {
 		rendered = append(rendered, " "+hl.text)
 	}
-	for _, ul := range visibleContent {
-		if ul.visIdx == cursor {
-			rendered = append(rendered, cursorStyleU.Render(">")+ul.text)
-		} else {
-			rendered = append(rendered, " "+ul.text)
+
+	var maxScroll int
+	if wrap {
+		// Wrap mode: long lines wrap to multiple rows. Scroll indexes whole
+		// content lines (one per visible diff line), matching the cursor model.
+		maxScroll = max(totalContent-1, 0)
+		scroll = min(max(scroll, 0), maxScroll)
+		rendered = append(rendered, buildWrappedUnifiedRows(rawDiffLines, visLines, scroll, contentMaxLines, contentWidth, gutterWidth, lineNumbers, searchQuery, cursor, uStyles, cursorStyleU)...)
+	} else {
+		// Clamp scroll on content lines only.
+		maxScroll = max(totalContent-contentMaxLines, 0)
+		scroll = min(max(scroll, 0), maxScroll)
+
+		visibleContent := contentLines[scroll:]
+		if len(visibleContent) > contentMaxLines {
+			visibleContent = visibleContent[:contentMaxLines]
+		}
+		for _, ul := range visibleContent {
+			if ul.visIdx == cursor {
+				rendered = append(rendered, cursorStyleU.Render(">")+ul.text)
+			} else {
+				rendered = append(rendered, " "+ul.text)
+			}
 		}
 	}
 

--- a/internal/ui/overlay_diff_wrap.go
+++ b/internal/ui/overlay_diff_wrap.go
@@ -1,0 +1,344 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// diffSideStyles bundles the colors used by the side-by-side wrap renderer.
+type diffSideStyles struct {
+	removed   lipgloss.Style
+	added     lipgloss.Style
+	normal    lipgloss.Style
+	cursor    lipgloss.Style
+	separator lipgloss.Style
+}
+
+// diffUnifiedStyles bundles the colors used by the unified wrap renderer.
+type diffUnifiedStyles struct {
+	removed lipgloss.Style
+	added   lipgloss.Style
+	normal  lipgloss.Style
+}
+
+// diffLineNumsBefore returns the left/right source line numbers reached just
+// before the given visible-line index, so a partial scroll keeps the gutter
+// numbers correct.
+func diffLineNumsBefore(raw []diffLine, vis []VisibleDiffLine, upto int) (int, int) {
+	leftNum, rightNum := 1, 1
+	for i := 0; i < len(vis) && i < upto; i++ {
+		vl := vis[i]
+		if vl.IsFoldPlaceholder || vl.Original < 0 {
+			continue
+		}
+		switch raw[vl.Original].status {
+		case '=':
+			leftNum++
+			rightNum++
+		case '<':
+			leftNum++
+		case '>':
+			rightNum++
+		}
+	}
+	return leftNum, rightNum
+}
+
+// unifiedLineNumBefore returns the 1-based unified line number for the first
+// rendered row at the given scroll offset, counting only real diff lines so
+// fold placeholders never advance the gutter number (matching the non-wrap
+// path).
+func unifiedLineNumBefore(vis []VisibleDiffLine, scroll int) int {
+	lineNum := 1
+	for i := 0; i < len(vis) && i < scroll; i++ {
+		if !vis[i].IsFoldPlaceholder && vis[i].Original >= 0 {
+			lineNum++
+		}
+	}
+	return lineNum
+}
+
+// wrapColumn hard-wraps text to width columns, always returning at least one
+// (possibly empty) sub-line so an absent diff side still occupies a row and
+// keeps the two columns vertically aligned.
+func wrapColumn(text string, width int) []string {
+	if text == "" {
+		return []string{""}
+	}
+	return WrapLine(text, width)
+}
+
+// subAt returns the i-th sub-line or "" when i is past the end.
+func subAt(subs []string, i int) string {
+	if i < len(subs) {
+		return subs[i]
+	}
+	return ""
+}
+
+// styleDiffSub applies the diff color (and search highlight, if any) to one
+// wrapped sub-line.
+func styleDiffSub(text string, style lipgloss.Style, searchQuery string) string {
+	if text == "" {
+		return ""
+	}
+	if searchQuery != "" {
+		return style.Render(highlightDiffSearchInLine(text, searchQuery))
+	}
+	return style.Render(text)
+}
+
+// unifiedLineParts returns the prefix character, content text, and style for a
+// unified diff line.
+func unifiedLineParts(dl diffLine, st diffUnifiedStyles) (string, string, lipgloss.Style) {
+	switch dl.status {
+	case '<':
+		return "-", dl.left, st.removed
+	case '>':
+		return "+", dl.right, st.added
+	default:
+		return " ", dl.left, st.normal
+	}
+}
+
+// buildWrappedDiffRows renders side-by-side diff rows with hard line wrapping.
+// Long values wrap to multiple rows within their column instead of being
+// truncated. The block cursor and visual selection are not drawn in wrap mode
+// (they need fixed-width column math); the cursor line still gets its ">"
+// indicator and search matches are still highlighted.
+func buildWrappedDiffRows(raw []diffLine, vis []VisibleDiffLine, scroll, maxLines, colWidth, gutterWidth int, lineNumbers bool, searchQuery string, cursor, cursorSide int, st diffSideStyles) []string {
+	leftNum, rightNum := diffLineNumsBefore(raw, vis, scroll)
+	sep := st.separator.Render(" | ")
+	emptyGutter := strings.Repeat(" ", gutterWidth)
+	rows := make([]string, 0, maxLines)
+
+	for vi := scroll; vi < len(vis) && len(rows) < maxLines; vi++ {
+		vl := vis[vi]
+		leftInd, rightInd := " ", " "
+		if vi == cursor {
+			if cursorSide == 0 {
+				leftInd = st.cursor.Render(">")
+			} else {
+				rightInd = st.cursor.Render(">")
+			}
+		}
+
+		if vl.IsFoldPlaceholder {
+			ph := padToWidth(DiffFoldPlaceholderText(vl.HiddenCount), colWidth)
+			rows = append(rows, leftInd+emptyGutter+ph+sep+rightInd+emptyGutter+ph)
+			continue
+		}
+
+		dl := raw[vl.Original]
+		leftText, rightText, leftStyle, rightStyle, showLeftNum, showRightNum := sideBySideParts(dl, st)
+
+		leftSubs := wrapColumn(leftText, colWidth)
+		rightSubs := wrapColumn(rightText, colWidth)
+		subCount := max(len(leftSubs), len(rightSubs))
+		for r := 0; r < subCount && len(rows) < maxLines; r++ {
+			li, ri := " ", " "
+			lg, rg := emptyGutter, emptyGutter
+			if r == 0 {
+				li, ri = leftInd, rightInd
+				if lineNumbers {
+					if showLeftNum {
+						lg = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, leftNum))
+					}
+					if showRightNum {
+						rg = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, rightNum))
+					}
+				}
+			}
+			lcell := padToWidth(styleDiffSub(subAt(leftSubs, r), leftStyle, searchQuery), colWidth)
+			rcell := padToWidth(styleDiffSub(subAt(rightSubs, r), rightStyle, searchQuery), colWidth)
+			rows = append(rows, li+lg+lcell+sep+ri+rg+rcell)
+		}
+
+		switch dl.status {
+		case '=':
+			leftNum++
+			rightNum++
+		case '<':
+			leftNum++
+		case '>':
+			rightNum++
+		}
+	}
+	return rows
+}
+
+// sideBySideParts splits a diff line into its left/right text, styles, and
+// which gutters should show a line number.
+func sideBySideParts(dl diffLine, st diffSideStyles) (leftText, rightText string, leftStyle, rightStyle lipgloss.Style, showLeftNum, showRightNum bool) {
+	switch dl.status {
+	case '<':
+		return dl.left, "", st.removed, st.normal, true, false
+	case '>':
+		return "", dl.right, st.normal, st.added, false, true
+	default:
+		return dl.left, dl.right, st.normal, st.normal, true, true
+	}
+}
+
+// buildSideBySideRows renders the side-by-side diff rows in non-wrap mode:
+// long values are truncated to the column width and the block cursor and
+// visual selection are drawn. Extracted from RenderDiffView so the wrap and
+// non-wrap paths can share the surrounding layout scaffolding.
+func buildSideBySideRows(raw []diffLine, vis []VisibleDiffLine, scroll, maxLines, colWidth, gutterWidth int, lineNumbers bool, searchQuery string, cursor int, vp DiffVisualParams, normalStyle, removedStyle, addedStyle, cursorStyle, separatorStyle lipgloss.Style) []string { //nolint:gocyclo // diff row layout: inherent per-status (=/</>) branching
+	visible := vis[scroll:]
+	if len(visible) > maxLines {
+		visible = visible[:maxLines]
+	}
+
+	leftNum, rightNum := diffLineNumsBefore(raw, vis, scroll)
+
+	selStart, selEnd := -1, -1
+	if vp.VisualMode {
+		selStart = min(vp.VisualStart, cursor)
+		selEnd = max(vp.VisualStart, cursor)
+	}
+
+	rows := make([]string, 0, len(visible))
+	for ri, vl := range visible {
+		visIdx := ri + scroll
+		isCursorLine := visIdx == cursor
+
+		leftCursorInd := " "
+		rightCursorInd := " "
+		if isCursorLine {
+			if vp.CursorSide == 0 {
+				leftCursorInd = cursorStyle.Render(">")
+			} else {
+				rightCursorInd = cursorStyle.Render(">")
+			}
+		}
+
+		if vl.IsFoldPlaceholder {
+			placeholder := DiffFoldPlaceholderText(vl.HiddenCount)
+			gutterPadL := strings.Repeat(" ", gutterWidth)
+			leftPlaceholder := padToWidth(placeholder, colWidth)
+			rightPlaceholder := padToWidth(placeholder, colWidth)
+			row := leftCursorInd + gutterPadL + leftPlaceholder + separatorStyle.Render(" | ") + rightCursorInd + gutterPadL + rightPlaceholder
+			rows = append(rows, row)
+			continue
+		}
+		dl := raw[vl.Original]
+
+		isSelected := vp.VisualMode && visIdx >= selStart && visIdx <= selEnd
+
+		var leftCol, rightCol, leftGutter, rightGutter string
+		switch dl.status {
+		case '=':
+			var leftText, rightText string
+			// Apply visual selection on the active side.
+			if isSelected {
+				leftText, rightText = applyDiffVisualSelection(dl.left, dl.right, vp, visIdx, selStart, selEnd, colWidth)
+			} else {
+				if searchQuery != "" {
+					leftText = normalStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.left, colWidth), searchQuery))
+					rightText = normalStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.right, colWidth), searchQuery))
+				} else {
+					leftText = normalStyle.Render(truncateToWidth(dl.left, colWidth))
+					rightText = normalStyle.Render(truncateToWidth(dl.right, colWidth))
+				}
+			}
+			// Block cursor on cursor line (non-visual mode).
+			if isCursorLine && !vp.VisualMode {
+				if vp.CursorSide == 0 {
+					leftText = RenderCursorAtCol(leftText, dl.left, vp.CursorCol)
+				} else {
+					rightText = RenderCursorAtCol(rightText, dl.right, vp.CursorCol)
+				}
+			}
+			leftCol = leftText
+			rightCol = rightText
+			if lineNumbers {
+				leftGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, leftNum))
+				rightGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, rightNum))
+			}
+			leftNum++
+			rightNum++
+		case '<':
+			var leftText string
+			if isSelected && vp.CursorSide == 0 {
+				leftText = applyDiffVisualSide(dl.left, vp, visIdx, selStart, selEnd)
+			} else if searchQuery != "" {
+				leftText = removedStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.left, colWidth), searchQuery))
+			} else {
+				leftText = removedStyle.Render(truncateToWidth(dl.left, colWidth))
+			}
+			if isCursorLine && !vp.VisualMode && vp.CursorSide == 0 {
+				leftText = RenderCursorAtCol(leftText, dl.left, vp.CursorCol)
+			}
+			leftCol = leftText
+			rightCol = ""
+			if lineNumbers {
+				leftGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, leftNum))
+				rightGutter = strings.Repeat(" ", gutterWidth)
+			}
+			leftNum++
+		case '>':
+			var rightText string
+			if isSelected && vp.CursorSide == 1 {
+				rightText = applyDiffVisualSide(dl.right, vp, visIdx, selStart, selEnd)
+			} else if searchQuery != "" {
+				rightText = addedStyle.Render(highlightDiffSearchInLine(truncateToWidth(dl.right, colWidth), searchQuery))
+			} else {
+				rightText = addedStyle.Render(truncateToWidth(dl.right, colWidth))
+			}
+			if isCursorLine && !vp.VisualMode && vp.CursorSide == 1 {
+				rightText = RenderCursorAtCol(rightText, dl.right, vp.CursorCol)
+			}
+			leftCol = ""
+			rightCol = rightText
+			if lineNumbers {
+				leftGutter = strings.Repeat(" ", gutterWidth)
+				rightGutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, rightNum))
+			}
+			rightNum++
+		}
+		row := leftCursorInd + leftGutter + padToWidth(leftCol, colWidth) + separatorStyle.Render(" | ") + rightCursorInd + rightGutter + padToWidth(rightCol, colWidth)
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// buildWrappedUnifiedRows renders unified diff content rows with hard line
+// wrapping. The cursor line keeps its ">" indicator; column cursor and visual
+// selection are not drawn in wrap mode.
+func buildWrappedUnifiedRows(raw []diffLine, vis []VisibleDiffLine, scroll, contentMaxLines, contentWidth, gutterWidth int, lineNumbers bool, searchQuery string, cursor int, st diffUnifiedStyles, cursorStyle lipgloss.Style) []string {
+	rows := make([]string, 0, contentMaxLines)
+	lineNum := unifiedLineNumBefore(vis, scroll)
+	emptyGutter := strings.Repeat(" ", gutterWidth)
+
+	for vi := scroll; vi < len(vis) && len(rows) < contentMaxLines; vi++ {
+		vl := vis[vi]
+		ind := " "
+		if vi == cursor {
+			ind = cursorStyle.Render(">")
+		}
+
+		if vl.IsFoldPlaceholder {
+			rows = append(rows, ind+emptyGutter+DiffFoldPlaceholderText(vl.HiddenCount))
+			continue
+		}
+
+		prefix, text, style := unifiedLineParts(raw[vl.Original], st)
+		subs := wrapColumn(prefix+text, contentWidth)
+		for r := 0; r < len(subs) && len(rows) < contentMaxLines; r++ {
+			rowInd := " "
+			gutter := emptyGutter
+			if r == 0 {
+				rowInd = ind
+				if lineNumbers {
+					gutter = DimStyle.Render(fmt.Sprintf("%*d ", gutterWidth-1, lineNum))
+				}
+			}
+			rows = append(rows, rowInd+gutter+styleDiffSub(subs[r], style, searchQuery))
+		}
+		lineNum++
+	}
+	return rows
+}

--- a/internal/ui/overlay_diff_wrap_test.go
+++ b/internal/ui/overlay_diff_wrap_test.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A value far wider than any column; wrapping must render every "x", while
+// truncation drops most of them and leaves a "~" marker.
+const wrapFillLen = 200
+
+func longDiffLine() string {
+	return "field: " + strings.Repeat("x", wrapFillLen)
+}
+
+// --- side-by-side ---
+
+func TestRenderDiffView_WrapShowsFullLine(t *testing.T) {
+	left := "a: 1\n" + longDiffLine()
+	right := "a: 1\n" + longDiffLine()
+
+	wrapped := stripANSI(RenderDiffView(left, right, "l", "r", 0, 80, 30, false, true, "", nil, nil, false, "", 0, DiffVisualParams{}, ""))
+	assert.GreaterOrEqual(t, strings.Count(wrapped, "x"), wrapFillLen, "wrap must render the whole line, not truncate it")
+	assert.NotContains(t, wrapped, "~", "wrap mode must not emit the truncation marker")
+}
+
+func TestRenderDiffView_NoWrapTruncates(t *testing.T) {
+	left := "a: 1\n" + longDiffLine()
+	right := "a: 1\n" + longDiffLine()
+
+	truncated := stripANSI(RenderDiffView(left, right, "l", "r", 0, 80, 30, false, false, "", nil, nil, false, "", 0, DiffVisualParams{}, ""))
+	assert.Contains(t, truncated, "~", "non-wrap mode truncates long lines with a marker")
+	assert.Less(t, strings.Count(truncated, "x"), wrapFillLen, "non-wrap mode must drop the truncated tail")
+}
+
+func TestRenderDiffView_WrapKeepsColumnAlignment(t *testing.T) {
+	left := "a: 1\n" + longDiffLine()
+	right := "a: 1\n" + longDiffLine()
+	out := stripANSI(RenderDiffView(left, right, "l", "r", 0, 80, 30, false, true, "", nil, nil, false, "", 0, DiffVisualParams{}, ""))
+	// Every wrapped content row keeps the side-by-side separator.
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(line, "xxx") {
+			assert.Contains(t, line, "|", "wrapped continuation rows keep the column separator")
+		}
+	}
+}
+
+// unifiedLineNumBefore must count only real diff lines, skipping fold
+// placeholders, so wrapped gutter numbers match the non-wrap path.
+func TestUnifiedLineNumBefore_SkipsFoldPlaceholders(t *testing.T) {
+	vis := []VisibleDiffLine{
+		{Original: 0},
+		{IsFoldPlaceholder: true, Original: -1},
+		{Original: 5},
+		{Original: 6},
+	}
+	// Before index 0: line 1. The placeholder at index 1 must not advance the
+	// count, so index 2 and 3 are lines 2 and 3.
+	assert.Equal(t, 1, unifiedLineNumBefore(vis, 0))
+	assert.Equal(t, 2, unifiedLineNumBefore(vis, 1)) // one real line before
+	assert.Equal(t, 2, unifiedLineNumBefore(vis, 2)) // placeholder skipped
+	assert.Equal(t, 3, unifiedLineNumBefore(vis, 3))
+}
+
+// --- unified ---
+
+func TestRenderUnifiedDiffView_WrapShowsFullLine(t *testing.T) {
+	left := "a: 1\n" + longDiffLine()
+	right := "a: 1\n" + longDiffLine()
+
+	wrapped := stripANSI(RenderUnifiedDiffView(left, right, "l", "r", 0, 80, 30, false, true, "", nil, nil, false, "", 0, DiffVisualParams{}, ""))
+	assert.GreaterOrEqual(t, strings.Count(wrapped, "x"), wrapFillLen, "unified wrap must render the whole line")
+	assert.NotContains(t, wrapped, "~", "unified wrap must not truncate")
+}
+
+func TestRenderUnifiedDiffView_NoWrapTruncates(t *testing.T) {
+	left := "a: 1\n" + longDiffLine()
+	right := "a: 1\n" + longDiffLine()
+
+	truncated := stripANSI(RenderUnifiedDiffView(left, right, "l", "r", 0, 80, 30, false, false, "", nil, nil, false, "", 0, DiffVisualParams{}, ""))
+	// Non-wrap unified must truncate itself rather than leak the line past the
+	// border and let lipgloss re-wrap it uncontrollably.
+	assert.Contains(t, truncated, "~", "non-wrap unified truncates long lines")
+	assert.Less(t, strings.Count(truncated, "x"), wrapFillLen, "non-wrap unified drops the truncated tail")
+}


### PR DESCRIPTION
## Summary

Fixes #386 — the diff viewer's wrap toggle did not actually wrap long lines.

The `wrap` flag was cosmetic: `RenderDiffView` and `RenderUnifiedDiffView` only added `[WRAP]` to the title while always truncating content. Two defects:

- **Side-by-side** (default): long YAML values were truncated with `~`; toggling wrap (`>` / `Ctrl+W`) did nothing.
- **Unified**: non-wrap lines were not truncated either, so the lipgloss border's `Width()` re-wrapped them uncontrollably — the broken line breaks in the report.

Also fixes a latent off-by-one in `colWidth`: side-by-side rows were `width-3` wide, one char over the border's `width-4` budget. Non-wrap mode hid it via trailing-space trimming, but a fully-filled wrapped row sheared the two columns apart.

## Changes

- `internal/ui/overlay_diff_wrap.go` (new): `buildWrappedDiffRows` / `buildWrappedUnifiedRows` hard-wrap via the existing `WrapLine` (`ansi.Hardwrap`), preserving column alignment, per-side gutter line numbers, the `>` cursor indicator, and search highlighting. Extracts the original non-wrap loop into `buildSideBySideRows`.
- `internal/ui/overlay_diff.go`: both renderers branch on `wrap`; unified non-wrap now truncates to content width; `colWidth` constant `8 → 9`.
- Wrap mode intentionally drops block-cursor / visual-selection rendering, mirroring the describe viewer's simplified wrap path.

No new keybinding or config — the `>` (or `Ctrl+W`) toggle and `diff_viewer.wrap` setting already exist and are documented.

## Before / after (side-by-side, wrap on)

```
Before: │  field: xxxxxxxxxxxxxxxxxxxxxxxxxxxx~ |  field:        │   (truncated)
After:  │  field: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx |  field: xxxxxxx │
        │ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx | xxxxxxxxxxxxxxx │   (wrapped, aligned)
```

## Test plan

- [x] New tests in `overlay_diff_wrap_test.go` (wrap shows full line; non-wrap truncates; column alignment; fold line-number counting)
- [x] `go test -race ./internal/ui/ ./internal/app/` — green
- [x] `golangci-lint run internal/ui/...` — 0 issues
- [x] Visual check of both modes with a realistic pod diff
