### PR TITLE
fix(security): eliminate findings-cache memory spike (#387)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -463,3 +463,26 @@ Trade-off: the Type column is dropped from the list (metadata-only fetch
 doesn't include it) and there's a small per-hover fetch for decoded values
 (cached thereafter). See [Configuration Reference](config-reference.md#secret-lazy-loading)
 for details.
+
+## Diagnostics
+
+Two opt-in environment variables help diagnose performance and memory issues.
+Both are off by default.
+
+| Variable | Effect |
+|---|---|
+| `LFK_PPROF_ADDR` | Serves Go `pprof` on the given **loopback** address (e.g. `127.0.0.1:6060`). Non-loopback addresses are refused. |
+| `LFK_MEMSTATS_INTERVAL` | Logs heap and goroutine counts to the app log on each interval (Go duration, e.g. `30s`; clamped to a 1s floor). |
+
+```bash
+# Periodic memory snapshots in the app log (heap_objects, goroutines, ...)
+LFK_MEMSTATS_INTERVAL=30s lfk
+
+# Capture a heap profile while lfk runs
+LFK_PPROF_ADDR=127.0.0.1:6060 lfk
+go tool pprof http://127.0.0.1:6060/debug/pprof/heap
+```
+
+Reading a suspected leak: rising `heap_objects` with a flat `goroutines`
+count points at an unbounded cache or buffer; a steadily climbing
+`goroutines` count points at a watch or stream that is never stopped.

--- a/internal/app/security_findings_cache.go
+++ b/internal/app/security_findings_cache.go
@@ -8,14 +8,13 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
-
-	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
@@ -33,12 +32,20 @@ var securityFindingsCacheMu sync.Mutex
 
 // securityFindingsCacheSchemaVersion bumps when the on-disk shape changes.
 // A mismatch is treated as a miss so an older binary never decodes a
-// forward-incompatible file into garbage findings.
-const securityFindingsCacheSchemaVersion = 1
+// forward-incompatible file into garbage findings. Version 1 was the YAML
+// format (issue #387); version 2 is JSON with raw per-namespace entries.
+const securityFindingsCacheSchemaVersion = 2
 
 // securityFindingsCacheFilename is the per-host basename. Distinct from the
-// availability cache so both can live in the same per-host directory.
-const securityFindingsCacheFilename = "lfk-security-findings.yaml"
+// availability cache so both can live in the same per-host directory. JSON, not
+// YAML: the file can be tens of MB and sigs.k8s.io/yaml's YAML->JSON->struct
+// decode of the whole thing was the dominant startup memory spike (issue #387).
+const securityFindingsCacheFilename = "lfk-security-findings.json"
+
+// securityFindingsCacheLegacyFilename is the pre-#387 YAML basename. New code
+// never reads it; saveSecurityFindingsCacheForHost removes it so the large
+// legacy file does not linger.
+const securityFindingsCacheLegacyFilename = "lfk-security-findings.yaml"
 
 // securityFindingsCacheTTL bounds how stale a disk-seeded badge paint may be.
 // Findings older than this are not painted at startup (a miss), so a cluster
@@ -47,14 +54,26 @@ const securityFindingsCacheFilename = "lfk-security-findings.yaml"
 // regardless; this only gates the instant pre-scan paint.
 const securityFindingsCacheTTL = time.Hour
 
-// securityFindingsCacheState is the on-disk shape: one file per cluster API
-// host, holding findings keyed by namespace ("" = all-namespaces). Each entry
-// carries its own scannedAt so per-namespace TTL is independent.
-type securityFindingsCacheState struct {
-	SchemaVersion int                              `json:"schema_version"`
-	Namespaces    map[string]securityFindingsEntry `json:"namespaces"`
+// securityFindingsCacheReleaseThreshold: when the on-disk cache exceeds this,
+// seeding it reads and tokenizes the whole file, briefly allocating well beyond
+// the retained badge index. Go's background scavenger returns that memory to the
+// OS only slowly — on Windows it left the process RSS pinned at the spike for the
+// rest of the session (issue #387) — so the seed proactively frees it.
+const securityFindingsCacheReleaseThreshold = 4 << 20 // 4 MiB
+
+// securityFindingsCacheFile is the on-disk envelope: one file per cluster API
+// host, holding findings keyed by namespace ("" = all-namespaces). Per-namespace
+// entries are kept as raw JSON so a load (or a save touching one namespace)
+// never decodes the findings of the other namespaces — the reflect-heavy decode
+// of every namespace's findings was the dominant allocation in the startup
+// memory spike (issue #387).
+type securityFindingsCacheFile struct {
+	SchemaVersion int                        `json:"schema_version"`
+	Namespaces    map[string]json.RawMessage `json:"namespaces"`
 }
 
+// securityFindingsEntry is one namespace's payload; each carries its own
+// scannedAt so per-namespace TTL is independent.
 type securityFindingsEntry struct {
 	ScannedAt time.Time          `json:"scanned_at"`
 	Findings  []security.Finding `json:"findings"`
@@ -73,10 +92,24 @@ func securityFindingsCacheFilePathForHost(host string) string {
 	return filepath.Join(base, "discovery", k8s.CacheHostDir(host), securityFindingsCacheFilename)
 }
 
-// readFindingsCacheFile loads and validates the whole per-host state. Returns
-// nil on any failure (missing, corrupt, schema mismatch) so callers fall
-// through to a live scan.
-func readFindingsCacheFile(host string) *securityFindingsCacheState {
+// securityFindingsCacheLegacyPathForHost returns the pre-#387 YAML cache path,
+// or "" when it can't be resolved. Only used to clean up the legacy file.
+func securityFindingsCacheLegacyPathForHost(host string) string {
+	if host == "" {
+		return ""
+	}
+	base := k8s.DiscoveryCacheBaseDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "discovery", k8s.CacheHostDir(host), securityFindingsCacheLegacyFilename)
+}
+
+// readFindingsCacheFile loads and validates the per-host envelope. Returns nil
+// on any failure (missing, corrupt, schema mismatch) so callers fall through to
+// a live scan. Per-namespace findings are NOT decoded here — they stay as raw
+// JSON until a specific namespace is requested (see loadSecurityFindingsCacheForHost).
+func readFindingsCacheFile(host string) *securityFindingsCacheFile {
 	path := securityFindingsCacheFilePathForHost(host)
 	if path == "" {
 		return nil
@@ -88,29 +121,36 @@ func readFindingsCacheFile(host string) *securityFindingsCacheState {
 		}
 		return nil
 	}
-	var s securityFindingsCacheState
-	if err := yaml.Unmarshal(data, &s); err != nil {
+	var f securityFindingsCacheFile
+	if err := json.Unmarshal(data, &f); err != nil {
 		logger.Warn("Security findings cache is corrupt; ignoring", "host", k8s.CacheHostDir(host), "error", err)
 		return nil
 	}
-	if s.SchemaVersion != securityFindingsCacheSchemaVersion {
+	if f.SchemaVersion != securityFindingsCacheSchemaVersion {
 		logger.Info("Security findings cache schema mismatch; ignoring",
-			"host", k8s.CacheHostDir(host), "got", s.SchemaVersion, "want", securityFindingsCacheSchemaVersion)
+			"host", k8s.CacheHostDir(host), "got", f.SchemaVersion, "want", securityFindingsCacheSchemaVersion)
 		return nil
 	}
-	return &s
+	return &f
 }
 
 // loadSecurityFindingsCacheForHost returns the cached findings for (host,
 // namespace) when present and newer than ttl, else nil (a miss). A nil return
-// is the signal to fall through to a live scan.
+// is the signal to fall through to a live scan. Only the requested namespace's
+// entry is decoded; a corrupt sibling namespace cannot block a healthy one.
 func loadSecurityFindingsCacheForHost(host, namespace string, ttl time.Duration) []security.Finding {
-	s := readFindingsCacheFile(host)
-	if s == nil {
+	f := readFindingsCacheFile(host)
+	if f == nil {
 		return nil
 	}
-	entry, ok := s.Namespaces[namespace]
+	raw, ok := f.Namespaces[namespace]
 	if !ok {
+		return nil
+	}
+	var entry securityFindingsEntry
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		logger.Warn("Security findings cache namespace entry corrupt; ignoring",
+			"host", k8s.CacheHostDir(host), "namespace", namespace, "error", err)
 		return nil
 	}
 	if ttl > 0 && time.Since(entry.ScannedAt) > ttl {
@@ -136,28 +176,33 @@ func saveSecurityFindingsCacheForHost(host, namespace string, findings []securit
 	if findings == nil {
 		findings = []security.Finding{}
 	}
-	// Merge into any existing state so a save for one namespace doesn't wipe
-	// the others. A corrupt/missing file just starts fresh. The read-modify-
-	// write is serialized within this process by securityFindingsCacheMu (saves
-	// run on background goroutines, no longer the Update loop). Two lfk
-	// instances saving different namespaces of the same host concurrently can
-	// still lose one entry (last rename wins) — acceptable for a best-effort,
-	// TTL-bounded cache; the lost entry is re-derived by the next scan.
-	securityFindingsCacheMu.Lock()
-	defer securityFindingsCacheMu.Unlock()
-	state := readFindingsCacheFile(host)
-	if state == nil {
-		state = &securityFindingsCacheState{SchemaVersion: securityFindingsCacheSchemaVersion}
-	}
-	if state.Namespaces == nil {
-		state.Namespaces = make(map[string]securityFindingsEntry)
-	}
-	state.Namespaces[namespace] = securityFindingsEntry{
+	entryBytes, err := json.Marshal(securityFindingsEntry{
 		ScannedAt: scannedAt.UTC(),
 		Findings:  findings,
+	})
+	if err != nil {
+		return err
 	}
+	// Merge into any existing file so a save for one namespace doesn't wipe the
+	// others. Other namespaces are carried as raw JSON, never re-decoded. A
+	// corrupt/missing file just starts fresh. The read-modify-write is
+	// serialized within this process by securityFindingsCacheMu (saves run on
+	// background goroutines, no longer the Update loop). Two lfk instances
+	// saving different namespaces of the same host concurrently can still lose
+	// one entry (last rename wins) — acceptable for a best-effort, TTL-bounded
+	// cache; the lost entry is re-derived by the next scan.
+	securityFindingsCacheMu.Lock()
+	defer securityFindingsCacheMu.Unlock()
+	file := readFindingsCacheFile(host)
+	if file == nil {
+		file = &securityFindingsCacheFile{SchemaVersion: securityFindingsCacheSchemaVersion}
+	}
+	if file.Namespaces == nil {
+		file.Namespaces = make(map[string]json.RawMessage)
+	}
+	file.Namespaces[namespace] = json.RawMessage(entryBytes)
 
-	data, err := yaml.Marshal(state)
+	data, err := json.Marshal(file)
 	if err != nil {
 		return err
 	}
@@ -168,7 +213,15 @@ func saveSecurityFindingsCacheForHost(host, namespace string, findings []securit
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
-	return writeFileDurable(path, data, 0o600)
+	if err := writeFileDurable(path, data, 0o600); err != nil {
+		return err
+	}
+	// Best-effort: drop a pre-#387 YAML cache so the large legacy file does not
+	// linger on disk. Ignored when absent.
+	if legacy := securityFindingsCacheLegacyPathForHost(host); legacy != "" {
+		_ = os.Remove(legacy)
+	}
+	return nil
 }
 
 // updateSecurityFindingsCacheForContext resolves the context to its host and
@@ -182,6 +235,29 @@ func updateSecurityFindingsCacheForContext(client *k8s.Client, contextName, name
 		return nil
 	}
 	return saveSecurityFindingsCacheForHost(host, namespace, findings, time.Now().UTC())
+}
+
+// securityFindingsCacheFileSizeForContext returns the on-disk size of the
+// per-host findings cache, or 0 when it can't be resolved or stat'd. Used to
+// decide whether a seed parse was large enough to warrant returning the
+// transient memory to the OS (issue #387).
+func securityFindingsCacheFileSizeForContext(client *k8s.Client, contextName string) int64 {
+	if client == nil || contextName == "" {
+		return 0
+	}
+	host := client.HostForContext(contextName)
+	if host == "" {
+		return 0
+	}
+	path := securityFindingsCacheFilePathForHost(host)
+	if path == "" {
+		return 0
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }
 
 // loadSecurityFindingsCacheForContext resolves the context's host and returns

--- a/internal/app/security_findings_cache_migration_test.go
+++ b/internal/app/security_findings_cache_migration_test.go
@@ -1,0 +1,105 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSecurityFindingsCache_WrittenAsJSON verifies the on-disk format is JSON
+// (issue #387 switched off sigs.k8s.io/yaml, whose YAML->JSON->struct decode of
+// a tens-of-MB file was the dominant startup allocation).
+func TestSecurityFindingsCache_WrittenAsJSON(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "default", sampleFindings(), time.Now().UTC()))
+
+	path := securityFindingsCacheFilePathForHost(host)
+	assert.Equal(t, ".json", filepath.Ext(path), "cache file uses a .json extension")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(data, &envelope), "file content must be valid JSON")
+	assert.Contains(t, envelope, "namespaces")
+}
+
+// TestSecurityFindingsCache_LazyDecodeIgnoresOtherNamespaces proves a load
+// decodes only the requested namespace: a sibling namespace whose entry is
+// undecodable must not affect (or block) loading a healthy namespace.
+func TestSecurityFindingsCache_LazyDecodeIgnoresOtherNamespaces(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+
+	goodEntry, err := json.Marshal(securityFindingsEntry{ScannedAt: time.Now().UTC(), Findings: sampleFindings()})
+	require.NoError(t, err)
+	// ns-bad has a structurally valid object but findings of the wrong type,
+	// so decoding it into securityFindingsEntry fails.
+	file := map[string]any{
+		"schema_version": securityFindingsCacheSchemaVersion,
+		"namespaces": map[string]any{
+			"ns-good": json.RawMessage(goodEntry),
+			"ns-bad":  json.RawMessage(`{"scanned_at":"2026-01-01T00:00:00Z","findings":"not-an-array"}`),
+		},
+	}
+	data, err := json.Marshal(file)
+	require.NoError(t, err)
+	path := securityFindingsCacheFilePathForHost(host)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	got := loadSecurityFindingsCacheForHost(host, "ns-good", time.Hour)
+	require.Len(t, got, 2, "healthy namespace loads despite a corrupt sibling")
+	assert.Equal(t, "CVE-2024-1", got[0].ID)
+
+	assert.Nil(t, loadSecurityFindingsCacheForHost(host, "ns-bad", time.Hour),
+		"a corrupt namespace entry is a graceful miss, not a panic")
+}
+
+// TestSecurityFindingsCache_LegacyYAMLIsMissAndRemovedOnSave verifies a
+// pre-migration YAML cache is ignored (new code reads only the .json path) and
+// is cleaned up on the next save so the large legacy file does not linger.
+func TestSecurityFindingsCache_LegacyYAMLIsMissAndRemovedOnSave(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+
+	legacy := securityFindingsCacheLegacyPathForHost(host)
+	require.NotEmpty(t, legacy)
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacy), 0o700))
+	require.NoError(t, os.WriteFile(legacy, []byte("schema_version: 1\nnamespaces: {}\n"), 0o600))
+
+	assert.Nil(t, loadSecurityFindingsCacheForHost(host, "default", time.Hour),
+		"legacy YAML cache is not read by the JSON loader")
+
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "default", sampleFindings(), time.Now().UTC()))
+	_, err := os.Stat(legacy)
+	assert.True(t, errors.Is(err, fs.ErrNotExist), "legacy YAML file is removed on save")
+	_, err = os.Stat(securityFindingsCacheFilePathForHost(host))
+	assert.NoError(t, err, "JSON cache file is written")
+}
+
+// TestSecurityFindingsCache_SavePreservesOtherNamespaces verifies the
+// read-modify-write keeps other namespaces' entries (which are carried as raw
+// JSON, never re-decoded) when one namespace is updated.
+func TestSecurityFindingsCache_SavePreservesOtherNamespaces(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	host := "https://api.example.test:6443"
+
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "ns-a", sampleFindings(), time.Now().UTC()))
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "ns-b", sampleFindings()[:1], time.Now().UTC()))
+
+	assert.Len(t, loadSecurityFindingsCacheForHost(host, "ns-a", time.Hour), 2, "first namespace survives the second save")
+	assert.Len(t, loadSecurityFindingsCacheForHost(host, "ns-b", time.Hour), 1, "second namespace stored")
+
+	// A third save updates ns-a; ns-b must still be intact.
+	require.NoError(t, saveSecurityFindingsCacheForHost(host, "ns-a", sampleFindings()[:1], time.Now().UTC()))
+	assert.Len(t, loadSecurityFindingsCacheForHost(host, "ns-a", time.Hour), 1, "ns-a updated")
+	assert.Len(t, loadSecurityFindingsCacheForHost(host, "ns-b", time.Hour), 1, "ns-b preserved across ns-a update")
+}

--- a/internal/app/security_findings_cache_test.go
+++ b/internal/app/security_findings_cache_test.go
@@ -100,7 +100,7 @@ func TestSecurityFindingsCacheMissReturnsNil(t *testing.T) {
 // TestSecurityFindingsCacheZeroFindingsRoundTrip verifies a clean scan with
 // zero findings is a real cached result (non-nil), not indistinguishable from
 // a miss — nil must normalize to an empty slice on save so it survives the
-// YAML null round-trip.
+// JSON null round-trip.
 func TestSecurityFindingsCacheZeroFindingsRoundTrip(t *testing.T) {
 	t.Setenv("KUBECACHEDIR", t.TempDir())
 	host := "https://api.example.test:6443"

--- a/internal/app/security_refresh.go
+++ b/internal/app/security_refresh.go
@@ -5,6 +5,8 @@
 package app
 
 import (
+	"runtime/debug"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/janosmiko/lfk/internal/security"
@@ -136,6 +138,15 @@ func (m *Model) securityFindingsSeedCmd(resolvedCtx, namespace string) tea.Cmd {
 		return nil
 	}
 	return func() tea.Msg {
+		// Reading a large cache file tokenizes the whole thing, briefly
+		// allocating well beyond the live retained index — even on a TTL miss,
+		// where nothing is returned. Hand those transient pages back to the OS
+		// now rather than waiting on the slow background scavenger (issue #387).
+		// Deferred so it covers both the miss and hit paths; runs off the Update
+		// goroutine, so the GC pause is invisible to the UI.
+		if securityFindingsCacheFileSizeForContext(client, resolvedCtx) > securityFindingsCacheReleaseThreshold {
+			defer debug.FreeOSMemory()
+		}
 		cached := loadSecurityFindingsCacheForContext(client, resolvedCtx, namespace, securityFindingsCacheTTL)
 		if cached == nil {
 			return nil

--- a/internal/profiling/memstats.go
+++ b/internal/profiling/memstats.go
@@ -1,0 +1,96 @@
+// Package profiling provides lightweight, opt-in runtime memory diagnostics.
+//
+// The mem-stats logger periodically records heap and goroutine counts to the
+// application log so a slow leak shows up as a monotonically rising series
+// without needing an attached pprof client. Pair it with the pprof endpoint
+// (LFK_PPROF_ADDR) when a heap profile is needed: goroutines climbing points
+// at a goroutine/watch leak, flat goroutines with rising heap_objects points
+// at an unbounded cache or buffer.
+package profiling
+
+import (
+	"context"
+	"runtime"
+	"time"
+)
+
+// MinInterval is the smallest accepted sampling interval. Sampling calls
+// runtime.ReadMemStats, which briefly stops the world, so we refuse anything
+// tighter than this to keep the diagnostic itself from perturbing the process.
+const MinInterval = 1 * time.Second
+
+const bytesPerMiB = 1024 * 1024
+
+// MemSample is a point-in-time snapshot of process memory and goroutine usage.
+type MemSample struct {
+	HeapAllocBytes  uint64
+	HeapInuseBytes  uint64
+	HeapObjects     uint64
+	StackInuseBytes uint64
+	SysBytes        uint64
+	NumGoroutine    int
+	NumGC           uint32
+}
+
+// Sample reads current runtime memory statistics and the live goroutine count.
+func Sample() MemSample {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return MemSample{
+		HeapAllocBytes:  ms.HeapAlloc,
+		HeapInuseBytes:  ms.HeapInuse,
+		HeapObjects:     ms.HeapObjects,
+		StackInuseBytes: ms.StackInuse,
+		SysBytes:        ms.Sys,
+		NumGoroutine:    runtime.NumGoroutine(),
+		NumGC:           ms.NumGC,
+	}
+}
+
+// LogFields renders a sample as structured key/value pairs for slog-style
+// logging. Byte counts are reported in MiB for readability; HeapObjects and
+// goroutines are the leak-class discriminators and are reported raw.
+func LogFields(s MemSample) []any {
+	return []any{
+		"heap_alloc_mib", s.HeapAllocBytes / bytesPerMiB,
+		"heap_inuse_mib", s.HeapInuseBytes / bytesPerMiB,
+		"heap_objects", s.HeapObjects,
+		"stack_inuse_mib", s.StackInuseBytes / bytesPerMiB,
+		"sys_mib", s.SysBytes / bytesPerMiB,
+		"goroutines", s.NumGoroutine,
+		"num_gc", s.NumGC,
+	}
+}
+
+// NormalizeInterval validates a requested sampling interval. A non-positive
+// interval disables sampling (ok=false); anything below MinInterval is clamped
+// up to MinInterval.
+func NormalizeInterval(d time.Duration) (interval time.Duration, ok bool) {
+	if d <= 0 {
+		return 0, false
+	}
+	if d < MinInterval {
+		return MinInterval, true
+	}
+	return d, true
+}
+
+// StartMemStatsLogger samples memory stats every interval and passes each
+// sample to emit, until ctx is cancelled. It runs the loop in a new goroutine
+// and returns immediately. The caller is expected to have already validated
+// interval via NormalizeInterval.
+func StartMemStatsLogger(ctx context.Context, interval time.Duration, emit func(MemSample)) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		emit(Sample()) // baseline at startup, before the first tick
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				emit(Sample())
+			}
+		}
+	}()
+}

--- a/internal/profiling/memstats_test.go
+++ b/internal/profiling/memstats_test.go
@@ -1,0 +1,117 @@
+package profiling
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSample_ReturnsLiveProcessStats(t *testing.T) {
+	s := Sample()
+
+	// A running Go process always has at least the goroutine calling this
+	// test plus the runtime's own, and a non-zero heap reservation.
+	if s.NumGoroutine < 1 {
+		t.Errorf("NumGoroutine = %d, want >= 1", s.NumGoroutine)
+	}
+	if s.SysBytes == 0 {
+		t.Error("SysBytes = 0, want > 0")
+	}
+	if s.HeapObjects == 0 {
+		t.Error("HeapObjects = 0, want > 0")
+	}
+}
+
+func TestLogFields_KeysValuesAndOrder(t *testing.T) {
+	s := MemSample{
+		HeapAllocBytes:  12 * 1024 * 1024, // 12 MiB
+		HeapInuseBytes:  16 * 1024 * 1024, // 16 MiB
+		HeapObjects:     123456,
+		StackInuseBytes: 2 * 1024 * 1024,  // 2 MiB
+		SysBytes:        64 * 1024 * 1024, // 64 MiB
+		NumGoroutine:    42,
+		NumGC:           7,
+	}
+
+	got := LogFields(s)
+
+	want := []any{
+		"heap_alloc_mib", uint64(12),
+		"heap_inuse_mib", uint64(16),
+		"heap_objects", uint64(123456),
+		"stack_inuse_mib", uint64(2),
+		"sys_mib", uint64(64),
+		"goroutines", 42,
+		"num_gc", uint32(7),
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("LogFields len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("LogFields[%d] = %v (%T), want %v (%T)", i, got[i], got[i], want[i], want[i])
+		}
+	}
+}
+
+func TestStartMemStatsLogger_EmitsBaselineThenStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var mu sync.Mutex
+	var count int
+	done := make(chan struct{})
+
+	StartMemStatsLogger(ctx, MinInterval, func(MemSample) {
+		mu.Lock()
+		count++
+		if count == 1 {
+			close(done) // baseline fired before any tick
+		}
+		mu.Unlock()
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("baseline sample was not emitted")
+	}
+
+	cancel()
+	// Give the goroutine a moment to observe cancellation, then confirm it
+	// is no longer emitting.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	stable := count
+	mu.Unlock()
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if count != stable {
+		t.Errorf("logger kept emitting after cancel: %d -> %d", stable, count)
+	}
+}
+
+func TestNormalizeInterval_ClampsAndRejects(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     time.Duration
+		want   time.Duration
+		wantOK bool
+	}{
+		{"zero disables", 0, 0, false},
+		{"negative disables", -5 * time.Second, 0, false},
+		{"below floor clamps up", 100 * time.Millisecond, MinInterval, true},
+		{"at floor kept", MinInterval, MinInterval, true},
+		{"normal kept", 30 * time.Second, 30 * time.Second, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := NormalizeInterval(tt.in)
+			if ok != tt.wantOK || got != tt.want {
+				t.Errorf("NormalizeInterval(%v) = (%v, %v), want (%v, %v)", tt.in, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -21,6 +22,7 @@ import (
 	"github.com/janosmiko/lfk/internal/completion"
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/profiling"
 	"github.com/janosmiko/lfk/internal/ui"
 	"github.com/janosmiko/lfk/internal/version"
 )
@@ -173,6 +175,24 @@ func runTUI(opts app.StartupOptions) error {
 				logger.Warn("pprof server stopped", "error", err)
 			}
 		}()
+	}
+
+	// Optional periodic memory diagnostics for chasing leaks (issue #387).
+	// Off by default; set LFK_MEMSTATS_INTERVAL=30s to log heap and goroutine
+	// counts to the app log on each tick. A slow leak shows up as rising
+	// heap_objects (cache/buffer leak) or rising goroutines (watch/stream
+	// leak). Use alongside LFK_PPROF_ADDR for a full heap profile.
+	if raw := os.Getenv("LFK_MEMSTATS_INTERVAL"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return fmt.Errorf("LFK_MEMSTATS_INTERVAL: %w", err)
+		}
+		if interval, ok := profiling.NormalizeInterval(d); ok {
+			logger.Info("starting memstats logger", "interval", interval)
+			profiling.StartMemStatsLogger(context.Background(), interval, func(s profiling.MemSample) {
+				logger.Info("memstats", profiling.LogFields(s)...)
+			})
+		}
 	}
 
 	// Redirect os.Stderr to capture output from exec credential plugins (e.g., AWS SSO


### PR DESCRIPTION
Closes #387

## Summary

Fixes the memory "leak" in #387 — memory climbing to 2-3 GB on the landing view and never released, reproducible **idle with one tab**.

Profiling (added in the first commit) showed it is **not** a growing-object leak: live heap stays ~10 MB. The culprit is the per-host security-findings cache (`lfk-security-findings.yaml`, tens of MB), read and **YAML-unmarshalled wholesale** on every cluster open / tab switch, decoding *every* namespace. That single path was **93.7% of all allocation** — one parse of a 39 MB file churned ~1.1 GB, peaked 1.44M live objects, and inflated process RSS to ~869 MB that Go never returned to the OS (worse on Windows).

## Changes

**`feat(diagnostics)`** — opt-in `LFK_MEMSTATS_INTERVAL` logger (heap/goroutine/sys counts to the app log) used to diagnose this; documented alongside the existing `LFK_PPROF_ADDR`.

**`fix(security)`** — three fixes:
1. **JSON instead of YAML** (`encoding/json`), dropping the YAML→JSON→struct double-conversion. Filename `.yaml`→`.json`, `schema_version` 1→2; legacy file removed on next save.
2. **Lazy per-namespace decode** — entries kept as `json.RawMessage`, so a load decodes only the requested namespace. Saves preserve other namespaces byte-for-byte without re-decoding.
3. **`debug.FreeOSMemory()`** after a >4 MiB seed parse (off the Update goroutine) to return transient pages instead of waiting on the slow scavenger.

## Verified on a real cluster (52,805-finding cache)

| Metric | Before | After |
|---|---|---|
| Idle RSS (`sys`) | **869 MiB**, pinned | **162 MiB**, flat |
| Total allocation | 1249 MB | 239 MB |

A ~5.4× reduction; extrapolates to the reported 2-3 GB on Windows.

## Not included

Bounding/pruning the cache file at the source (it stores full CVE/policy text for 52k findings when badges only need counts/severity) — a larger design change, worth a follow-up.

## Test plan

- [x] New migration tests (TDD): JSON-on-disk, lazy decode ignores a corrupt sibling namespace, legacy `.yaml` graceful-miss + cleanup, save preserves other namespaces
- [x] Existing round-trip / TTL / perms / zero-findings tests pass
- [x] Full module suite, `go test -race`, `go vet`, `golangci-lint` all green
- [x] `go-reviewer` pass (no CRITICAL); HIGH (schema bump) + consistency notes applied
- [x] Empirically verified RSS 869 MB → 162 MB idle on the affected cluster