### PR TITLE
fix(logs): bound live log buffer to stop unbounded memory growth (#387)

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -162,6 +162,7 @@ log_path: /tmp/lfk.log
 #   show_preview: true      # structured preview side panel shown on open
 #   show_prefixes: true     # [pod/name/container] line prefixes shown on open
 #   show_timestamps: false  # log line timestamps hidden on open
+#   max_lines: 50000        # max retained log lines per tab (oldest dropped); clamped [1000, 1000000]
 
 # ─── Viewer Defaults ─────────────────────────────────────────────────────────
 # Startup defaults for the fullscreen YAML / diff / describe viewers. A toggle

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -149,6 +149,7 @@ log_viewer:
 | `show_preview` | bool | `true` | Startup default for the structured preview side panel. Runtime toggle: `toggle_preview` (`P`). |
 | `show_prefixes` | bool | `true` | Startup default for the `[pod/name/container]` line prefixes. Runtime toggle: `toggle_prefixes` (`p`). |
 | `show_timestamps` | bool | `false` | Startup default for log line timestamps. Runtime toggle: `toggle_timestamps` (`s`). |
+| `max_lines` | int | `50000` | Max streamed log lines retained per tab; once exceeded, the oldest lines are dropped so a long-running follow stays bounded in memory. Clamped to `[1000, 1000000]`. |
 
 The deprecated flat keys `log_tail_lines`, `log_tail_lines_short`, and `log_render_ansi` are still accepted as aliases; when both a flat key and its `log_viewer` equivalent are set, `log_viewer` wins.
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -595,6 +595,11 @@
           "type": "boolean",
           "description": "Startup default for log line timestamps (runtime toggle: s). Set true to start with timestamps shown.",
           "default": false
+        },
+        "max_lines": {
+          "type": "integer",
+          "description": "Maximum streamed log lines retained per tab; once exceeded, the oldest lines are dropped so a long-running follow does not grow memory without bound. Clamped to [1000, 1000000].",
+          "default": 50000
         }
       }
     },

--- a/internal/app/log_buffer.go
+++ b/internal/app/log_buffer.go
@@ -1,0 +1,41 @@
+package app
+
+import "github.com/janosmiko/lfk/internal/ui"
+
+// logBufferTrimSlack is how far a live log buffer may grow past
+// ui.ConfigLogMaxLines before the oldest lines are dropped. Trimming copies
+// the retained tail into a fresh slice so the old backing array is freed (a
+// plain reslice would keep the whole array alive, defeating the cap).
+// Batching the copy over this many lines keeps the amortised append cost O(1)
+// instead of O(n) once the cap is reached.
+const logBufferTrimSlack = 4096
+
+// capLogLines drops the oldest lines from buf once it grows past
+// ui.ConfigLogMaxLines + logBufferTrimSlack, returning the trimmed slice and
+// the number of leading lines removed so callers can shift absolute offsets
+// (scroll, cursor, visual anchor). It is a no-op until the slack is exceeded,
+// and disabled entirely when the cap is non-positive.
+func capLogLines(buf []string) ([]string, int) {
+	maxLines := ui.ConfigLogMaxLines
+	if maxLines <= 0 || len(buf) <= maxLines+logBufferTrimSlack {
+		return buf, 0
+	}
+	drop := len(buf) - maxLines
+	out := make([]string, maxLines)
+	copy(out, buf[drop:])
+	return out, drop
+}
+
+// shiftLogOffset moves an absolute log-line offset back by drop, clamping at
+// zero, so scroll / cursor / visual anchors keep pointing at the same content
+// after the oldest lines are trimmed. A negative offset (e.g. an inactive
+// cursor of -1) is returned unchanged.
+func shiftLogOffset(offset, drop int) int {
+	if offset < 0 {
+		return offset
+	}
+	if offset < drop {
+		return 0
+	}
+	return offset - drop
+}

--- a/internal/app/log_buffer_test.go
+++ b/internal/app/log_buffer_test.go
@@ -1,0 +1,123 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/ui"
+	"github.com/stretchr/testify/assert"
+)
+
+// withLogMaxLines sets ConfigLogMaxLines for the duration of a test and
+// restores it afterwards.
+func withLogMaxLines(t *testing.T, n int) {
+	t.Helper()
+	orig := ui.ConfigLogMaxLines
+	ui.ConfigLogMaxLines = n
+	t.Cleanup(func() { ui.ConfigLogMaxLines = orig })
+}
+
+func TestCapLogLines_NoTrimUnderCapPlusSlack(t *testing.T) {
+	withLogMaxLines(t, 10)
+	buf := make([]string, 10+logBufferTrimSlack) // exactly at the threshold
+	out, drop := capLogLines(buf)
+	assert.Equal(t, 0, drop, "no trim at cap+slack")
+	assert.Len(t, out, 10+logBufferTrimSlack)
+}
+
+func TestCapLogLines_TrimsToCap(t *testing.T) {
+	withLogMaxLines(t, 10)
+	total := 10 + logBufferTrimSlack + 5
+	buf := make([]string, total)
+	for i := range buf {
+		buf[i] = string(rune('a' + i%26))
+	}
+	want := append([]string(nil), buf[total-10:]...)
+
+	out, drop := capLogLines(buf)
+	assert.Equal(t, total-10, drop, "drops everything past the cap")
+	assert.Len(t, out, 10, "retains exactly the cap")
+	assert.Equal(t, want, out, "keeps the newest lines")
+}
+
+func TestCapLogLines_DisabledWhenCapNonPositive(t *testing.T) {
+	withLogMaxLines(t, 0)
+	buf := make([]string, 100000)
+	out, drop := capLogLines(buf)
+	assert.Equal(t, 0, drop)
+	assert.Len(t, out, 100000)
+}
+
+func TestShiftLogOffset(t *testing.T) {
+	tests := []struct {
+		offset, drop, want int
+	}{
+		{-1, 5, -1}, // inactive cursor preserved
+		{0, 5, 0},   // already at top
+		{3, 5, 0},   // inside the dropped region clamps to top
+		{5, 5, 0},   // boundary clamps to top
+		{10, 4, 6},  // shifted back by drop
+		{100, 50, 50},
+	}
+	for _, tc := range tests {
+		assert.Equalf(t, tc.want, shiftLogOffset(tc.offset, tc.drop),
+			"shiftLogOffset(%d, %d)", tc.offset, tc.drop)
+	}
+}
+
+// TestUpdateLogLine_ActivePathBounded is the regression guard for issue #387:
+// streaming many lines into the active log view must not grow without bound.
+func TestUpdateLogLine_ActivePathBounded(t *testing.T) {
+	withLogMaxLines(t, 10)
+	ch := make(chan string)
+	m := Model{
+		mode:    modeLogs,
+		width:   80,
+		height:  40,
+		tabs:    []TabState{{}},
+		logView: logViewState{ch: ch, cursor: 2, scroll: 1, follow: false, wrap: true, wrapTopSkip: 3},
+	}
+
+	total := 10 + logBufferTrimSlack + 200
+	for range total {
+		ret, _ := m.updateLogLine(logLineMsg{line: "x", ch: ch})
+		m = ret.(Model)
+	}
+
+	assert.LessOrEqual(t, len(m.logView.lines), 10+logBufferTrimSlack,
+		"live buffer must stay bounded, not grow to %d", total)
+	// cursor (2) and scroll (1) were inside the first dropped region -> clamped.
+	assert.Equal(t, 0, m.logView.cursor, "cursor clamped after trim")
+	assert.Equal(t, 0, m.logView.scroll, "scroll clamped after trim")
+	assert.Equal(t, 0, m.logView.wrapTopSkip, "wrapTopSkip reset after trim")
+}
+
+// TestUpdateLogLine_BackgroundTabBounded guards the background-tab drain path
+// (a tab whose log stream is still live while another tab is focused).
+func TestUpdateLogLine_BackgroundTabBounded(t *testing.T) {
+	withLogMaxLines(t, 10)
+	bgCh := make(chan string)
+	activeCh := make(chan string)
+	m := Model{
+		mode:      modeLogs,
+		width:     80,
+		height:    40,
+		activeTab: 0,
+		tabs: []TabState{
+			{}, // active tab
+			{logCh: bgCh, logCursor: 3, logScroll: 2, logWrapTopSkip: 4}, // background tab streaming
+		},
+		logView: logViewState{ch: activeCh},
+	}
+
+	total := 10 + logBufferTrimSlack + 50
+	for range total {
+		ret, _ := m.updateLogLine(logLineMsg{line: "y", ch: bgCh})
+		m = ret.(Model)
+	}
+
+	assert.LessOrEqual(t, len(m.tabs[1].logLines), 10+logBufferTrimSlack,
+		"background buffer must stay bounded")
+	assert.Equal(t, 0, m.tabs[1].logCursor, "background cursor clamped after trim")
+	assert.Equal(t, 0, m.tabs[1].logScroll, "background scroll clamped after trim")
+	assert.Equal(t, 0, m.tabs[1].logWrapTopSkip, "background wrapTopSkip reset after trim")
+}

--- a/internal/app/update_exec_log_msgs.go
+++ b/internal/app/update_exec_log_msgs.go
@@ -70,6 +70,17 @@ func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 			if m.tabs[i].logCh == msg.ch {
 				if !msg.done {
 					m.tabs[i].logLines = append(m.tabs[i].logLines, msg.line)
+					// Bound the background tab's buffer; shift its saved
+					// offsets so restoring the tab lands on the same content.
+					if trimmed, drop := capLogLines(m.tabs[i].logLines); drop > 0 {
+						m.tabs[i].logLines = trimmed
+						m.tabs[i].logScroll = shiftLogOffset(m.tabs[i].logScroll, drop)
+						m.tabs[i].logCursor = shiftLogOffset(m.tabs[i].logCursor, drop)
+						m.tabs[i].logVisualStart = shiftLogOffset(m.tabs[i].logVisualStart, drop)
+						// scroll now points at a different source line; the
+						// old sub-line skip no longer applies.
+						m.tabs[i].logWrapTopSkip = 0
+					}
 					// Continue draining: re-issue waitForLogLine for that channel.
 					ch := msg.ch
 					return m, func() tea.Msg {
@@ -105,6 +116,18 @@ func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 		m.logView.autoReconnectAttempt = 0
 	}
 	m.logView.lines = append(m.logView.lines, msg.line)
+	// Bound the live buffer so a long-running follow doesn't grow memory
+	// without limit (issue #387). Shift absolute offsets back by the number
+	// of dropped lines; in follow mode they're recomputed just below.
+	if trimmed, drop := capLogLines(m.logView.lines); drop > 0 {
+		m.logView.lines = trimmed
+		m.logView.scroll = shiftLogOffset(m.logView.scroll, drop)
+		m.logView.cursor = shiftLogOffset(m.logView.cursor, drop)
+		m.logView.visualStart = shiftLogOffset(m.logView.visualStart, drop)
+		// scroll now points at a different source line; the old sub-line
+		// skip no longer applies (follow mode recomputes it just below).
+		m.logView.wrapTopSkip = 0
+	}
 	if m.logView.follow {
 		m.logView.scroll, m.logView.wrapTopSkip = m.logMaxScrollAndSkip()
 		m.logView.cursor = len(m.logView.lines) - 1

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -259,6 +259,31 @@ func applyLogViewerConfig(cfg configFile) {
 	applyBoolPtr(lv.ShowPreview, &ConfigLogShowPreview)
 	applyBoolPtr(lv.ShowPrefixes, &ConfigLogShowPrefixes)
 	applyBoolPtr(lv.ShowTimestamps, &ConfigLogShowTimestamps)
+	applyLogMaxLines(lv.MaxLines)
+}
+
+// applyLogMaxLines clamps a log_viewer.max_lines override into
+// [LogMaxLinesMin, LogMaxLinesMax] and applies it. A nil or zero value keeps
+// the compiled default so an omitted (or stray 0) key never disables the cap.
+func applyLogMaxLines(src *int) {
+	if src == nil || *src == 0 {
+		return
+	}
+	v := *src
+	clamped := v
+	if v < LogMaxLinesMin {
+		clamped = LogMaxLinesMin
+	} else if v > LogMaxLinesMax {
+		clamped = LogMaxLinesMax
+	}
+	if clamped != v {
+		logger.Warn("log_viewer.max_lines out of range; clamped",
+			"value", v,
+			"min", LogMaxLinesMin,
+			"max", LogMaxLinesMax,
+			"applied", clamped)
+	}
+	ConfigLogMaxLines = clamped
 }
 
 // applyViewerDefaults wires the YAML / diff / describe viewer startup-toggle

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -315,6 +315,10 @@ type LogViewerConfig struct {
 	// ShowTimestamps: startup default for log line timestamps (toggle s).
 	// Default false.
 	ShowTimestamps *bool `json:"show_timestamps" yaml:"show_timestamps"`
+	// MaxLines: max streamed log lines retained per tab before the oldest are
+	// dropped. Default 50000. Clamped to [1000, 1000000]. Bounds memory for a
+	// long-running follow.
+	MaxLines *int `json:"max_lines" yaml:"max_lines"`
 }
 
 // YAMLViewerConfig is the on-disk schema for the yaml_viewer section. Every

--- a/internal/ui/config_log_buffer.go
+++ b/internal/ui/config_log_buffer.go
@@ -1,0 +1,17 @@
+package ui
+
+// LogMaxLines clamps for the live log-viewer buffer. The default of 50000 is
+// generous for inspecting a busy stream while bounding per-tab memory; the
+// floor stops a typo from making the viewer near-useless; the ceiling caps a
+// single tab's retained log lines. Oldest lines are dropped past the cap.
+const (
+	LogMaxLinesDefault = 50_000
+	LogMaxLinesMin     = 1_000
+	LogMaxLinesMax     = 1_000_000
+)
+
+// ConfigLogMaxLines bounds the number of streamed log lines retained per tab
+// in the log viewer; once exceeded, the oldest lines are dropped so a
+// long-running follow does not grow memory without bound. Set via the
+// `log_viewer.max_lines:` config key.
+var ConfigLogMaxLines = LogMaxLinesDefault

--- a/internal/ui/config_log_viewer_test.go
+++ b/internal/ui/config_log_viewer_test.go
@@ -16,6 +16,7 @@ func snapshotLogViewerGlobals(t *testing.T) {
 	prevPreview := ConfigLogShowPreview
 	prevPrefixes := ConfigLogShowPrefixes
 	prevTimestamps := ConfigLogShowTimestamps
+	prevMaxLines := ConfigLogMaxLines
 	t.Cleanup(func() {
 		ConfigLogTailLines = prevTail
 		ConfigLogTailLinesShort = prevShort
@@ -23,6 +24,7 @@ func snapshotLogViewerGlobals(t *testing.T) {
 		ConfigLogShowPreview = prevPreview
 		ConfigLogShowPrefixes = prevPrefixes
 		ConfigLogShowTimestamps = prevTimestamps
+		ConfigLogMaxLines = prevMaxLines
 	})
 	// Reset to compiled defaults before each test.
 	ConfigLogTailLines = 1000
@@ -31,6 +33,7 @@ func snapshotLogViewerGlobals(t *testing.T) {
 	ConfigLogShowPreview = true
 	ConfigLogShowPrefixes = true
 	ConfigLogShowTimestamps = false
+	ConfigLogMaxLines = LogMaxLinesDefault
 }
 
 // TestLogViewer_GroupAppliesAllFields verifies the canonical log_viewer group
@@ -54,6 +57,29 @@ func TestLogViewer_GroupAppliesAllFields(t *testing.T) {
 	assert.False(t, ConfigLogShowPreview, "show_preview")
 	assert.False(t, ConfigLogShowPrefixes, "show_prefixes")
 	assert.True(t, ConfigLogShowTimestamps, "show_timestamps")
+}
+
+// TestLogViewer_MaxLinesAppliesAndClamps verifies the buffer cap is wired and
+// clamped to [LogMaxLinesMin, LogMaxLinesMax].
+func TestLogViewer_MaxLinesAppliesAndClamps(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want int
+	}{
+		{"in range", "log_viewer:\n  max_lines: 25000\n", 25000},
+		{"below floor", "log_viewer:\n  max_lines: 5\n", LogMaxLinesMin},
+		{"above ceiling", "log_viewer:\n  max_lines: 9999999\n", LogMaxLinesMax},
+		{"zero keeps default", "log_viewer:\n  max_lines: 0\n", LogMaxLinesDefault},
+		{"omitted keeps default", "log_viewer:\n  show_timestamps: true\n", LogMaxLinesDefault},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshotLogViewerGlobals(t)
+			LoadConfig(writeConfigFile(t, tc.yaml))
+			assert.Equal(t, tc.want, ConfigLogMaxLines)
+		})
+	}
 }
 
 // TestLogViewer_DeprecatedFlatAliasesStillApply verifies the legacy flat keys

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -37,6 +37,7 @@ log_viewer:
   show_preview: false
   show_prefixes: false
   show_timestamps: true
+  max_lines: 12345
 yaml_viewer:
   wrap: true
 diff_viewer:
@@ -180,6 +181,7 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	assert.False(t, ConfigLogShowPreview, "log_viewer.show_preview")
 	assert.False(t, ConfigLogShowPrefixes, "log_viewer.show_prefixes")
 	assert.True(t, ConfigLogShowTimestamps, "log_viewer.show_timestamps")
+	assert.Equal(t, 12345, ConfigLogMaxLines, "log_viewer.max_lines")
 	assert.True(t, ConfigYAMLViewerWrap, "yaml_viewer.wrap")
 	assert.True(t, ConfigDiffViewerWrap, "diff_viewer.wrap")
 	assert.False(t, ConfigDiffViewerLineNumbers, "diff_viewer.line_numbers")
@@ -360,6 +362,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 	origShowPreview := ConfigLogShowPreview
 	origShowPrefixes := ConfigLogShowPrefixes
 	origShowTimestamps := ConfigLogShowTimestamps
+	origLogMaxLines := ConfigLogMaxLines
 	origYAMLWrap := ConfigYAMLViewerWrap
 	origDiffWrap := ConfigDiffViewerWrap
 	origDiffLineNums := ConfigDiffViewerLineNumbers
@@ -432,6 +435,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 		ConfigLogShowPreview = origShowPreview
 		ConfigLogShowPrefixes = origShowPrefixes
 		ConfigLogShowTimestamps = origShowTimestamps
+		ConfigLogMaxLines = origLogMaxLines
 		ConfigYAMLViewerWrap = origYAMLWrap
 		ConfigDiffViewerWrap = origDiffWrap
 		ConfigDiffViewerLineNumbers = origDiffLineNums


### PR DESCRIPTION
## Summary

Closes the still-open part of #387. The reporter's symptom — memory **climbing during normal work in 2 tabs and never released** — is a *growing* leak. The fix shipped in 0.14.1 (#390) addressed only a one-time *spike* (the findings-cache YAML parse at startup), so the leak persisted.

Root cause: the log viewer's live line buffer (`logView.lines`, and background tabs' `logLines`) was an unbounded `[]string` that only ever appended while a log stream was active — the only resets are `= nil` on stream/mode switch. Following logs in multiple tabs accumulates every line in RAM forever → GBs, never released. (The exec PTY already uses a bounded ring; the log viewer did not. The existing `tailLines > 100000` guard caps only *backward history pagination*, not live appends.)

## Changes

- **`internal/app/log_buffer.go`** (new): `capLogLines` drops the oldest lines once the buffer exceeds cap + 4096-line slack, copying the retained tail into a fresh slice so the old backing array is GC'd (amortized O(1) on the append hot path — a plain reslice would retain the whole array). `shiftLogOffset` rebases absolute offsets.
- **`update_exec_log_msgs.go`**: both the active-view and background-tab stream paths now trim and rebase `scroll`/`cursor`/`visualStart`/`wrapTopSkip` so the viewport stays on the same content (background offsets stay consistent with `loadTab` restore).
- **New config key `log_viewer.max_lines`** (default `50000`, clamped `[1000, 1000000]`), fully wired: struct + apply/clamp, JSON schema, `config-reference.md`, `config-example.yaml`, and wiring/coverage tests. Consts live in `config_log_buffer.go` to keep `config.go` under the 800-line cap.

## Scope note

History pagination (prepend) can still exceed the cap since trimming is append-side only, but that is user-driven and bounded by the existing 100,000-line guard — not the unbounded-stream leak this fixes.

## Test plan

- [x] New unit + model-level regression tests for both stream paths (bounded buffer, offset rebasing, `wrapTopSkip` reset)
- [x] `log_viewer.max_lines` apply/clamp + wiring tests
- [x] `go build ./...`
- [x] `go test -race ./internal/app ./internal/ui` and full `go test ./...` (pass)
- [x] `golangci-lint` clean
- [x] `go-reviewer` pass — one HIGH (stale `wrapTopSkip` after trim) found and fixed + test-guarded