### PR TITLE
test: guard against diff side-by-side column bleed (#386)

### DIFF
--- a/internal/ui/overlay_diff_wrap_test.go
+++ b/internal/ui/overlay_diff_wrap_test.go
@@ -64,6 +64,28 @@ func TestUnifiedLineNumBefore_SkipsFoldPlaceholders(t *testing.T) {
 	assert.Equal(t, 3, unifiedLineNumBefore(vis, 3))
 }
 
+// A truncated cell that fills its column exactly (ends in "~", no trailing
+// space) exposed the colWidth off-by-one in issue #386: the row was one cell
+// over the border budget, so lipgloss re-wrapped it and the tail bled to
+// column 0. lipgloss.Width can't catch this (every re-wrapped fragment still
+// measures <= width); a bled row is instead detectable as a content-bearing
+// body line missing the " | " column separator. Markers Q/Z are absent from
+// the title, border, and hint bar, so any match is real diff content.
+func TestRenderDiffView_NoWrapDoesNotBleed(t *testing.T) {
+	left := "a: 1\nlongkey: " + strings.Repeat("Q", 300) + "\nz: 9\n"
+	right := "a: 1\nlongkey: " + strings.Repeat("Z", 300) + "\nz: 9\n"
+	for _, lineNumbers := range []bool{true, false} {
+		for w := 60; w <= 200; w++ {
+			out := stripANSI(RenderDiffView(left, right, "left", "right", 0, w, 24, lineNumbers, false, "", nil, nil, false, "", 0, DiffVisualParams{}, ""))
+			for line := range strings.SplitSeq(out, "\n") {
+				if strings.ContainsAny(line, "QZ") && !strings.Contains(line, "|") {
+					t.Fatalf("w=%d lineNumbers=%v: diff content bled past its column (row has content but no separator): %q", w, lineNumbers, line)
+				}
+			}
+		}
+	}
+}
+
 // --- unified ---
 
 func TestRenderUnifiedDiffView_WrapShowsFullLine(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a regression test for the diff-viewer column bleed reported in #386 and fixed in #388. No production code changes — the bug is already fixed on `main`; this locks in the fix.

## Why a new kind of assertion

The bug: a fully-filled non-wrap cell (ends in `~`, no trailing space) was one cell over the border budget, so lipgloss re-wrapped the row and the tail bled to **column 0** (visible in the issue screenshot as content under the line-number gutter).

`lipgloss.Width` can't detect this — once lipgloss re-wraps an over-long row, every resulting fragment measures ≤ width. The reliable signature is a **content-bearing body line missing the ` | ` column separator**, which is what the test asserts.

## Test

`TestRenderDiffView_NoWrapDoesNotBleed` fills a column exactly (markers `Q`/`Z`, absent from title/border/hint chrome) across widths 60–200 with line numbers on and off, and fails if any content row lacks the separator.

Verified: **fails on pre-fix `22678ec`** (reproduces the bleed), **passes on current `main`**.

## Test plan

- [x] `go test ./internal/ui/ -run TestRenderDiffView_NoWrapDoesNotBleed`
- [x] Full `internal/ui` suite green