### PR TITLE
chore: address Chocolatey package guidelines

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -148,8 +148,9 @@ winget:
 
 chocolateys:
   - name: lfk
-    title: "lfk"
+    title: "LFK (Lightning Fast Kubernetes navigator)"
     authors: janosmiko
+    package_source_url: "https://github.com/janosmiko/lfk"
     project_url: "https://github.com/janosmiko/lfk"
     icon_url: "https://raw.githubusercontent.com/janosmiko/lfk/main/docs/imgs/github-header.png"
     copyright: "{{ .Now.Format \"2006\" }} janosmiko"


### PR DESCRIPTION
## Summary

Addresses the Guideline items the Chocolatey automated review flagged on the first `lfk` submission (0.10.4). All are Guidelines (non-blocking), fixed in the GoReleaser `chocolateys` config:

- **Add `packageSourceUrl`** (`package_source_url`) — links to where the package source lives, distinct from `projectSourceUrl`.
- **Descriptive `title`** — `"LFK (Lightning Fast Kubernetes navigator)"` instead of `"lfk"`, which matched the package id exactly.

`projectSourceUrl` already points to the software source on GitHub, so it is kept as-is. The maintainer-equals-author item is a Note (no action — I am the software author).

## Context

The moderator offered to reject the queued 0.10.4 so a version matching the current software (0.14.1) can be pushed. These config fixes apply to that resubmission.

## Test plan

- [x] `goreleaser check` validates the config