### PR TITLE
fix: stop preview-pane wheel from scrolling the pane to its left

### DIFF
--- a/internal/app/update_mouse_scroll_clobber_test.go
+++ b/internal/app/update_mouse_scroll_clobber_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// Issue #398: wheel over the right (preview) pane runs clampPreviewScroll in
+// the Update path, which renders right-pane content (cursor=-1). Those renders
+// must not touch the persistent pane-scroll globals the View path maintains —
+// RenderTable/RenderColumn write ActiveMiddleScroll/ActiveLeftScroll
+// unconditionally, and VimScrollOff with cursor=-1 returns 0, so an unguarded
+// render zeroes the left/middle viewport and the pane visibly jumps.
+
+// saveScrollGlobals pins the scroll globals to known values and restores the
+// originals on cleanup.
+func saveScrollGlobals(t *testing.T, middle, left int) {
+	t.Helper()
+	prevMiddle, prevLeft := ui.ActiveMiddleScroll, ui.ActiveLeftScroll
+	prevLineMap := ui.ActiveMiddleLineMap
+	t.Cleanup(func() {
+		ui.ActiveMiddleScroll, ui.ActiveLeftScroll = prevMiddle, prevLeft
+		ui.ActiveMiddleLineMap = prevLineMap
+	})
+	ui.ActiveMiddleScroll, ui.ActiveLeftScroll = middle, left
+}
+
+// Wheel over the right pane at LevelResourceTypes: the (memoized) measure
+// render of the preview table must not clobber the middle/left scroll state.
+func TestWheelOverRightPaneKeepsScrollGlobalsMeasurePath(t *testing.T) {
+	saveScrollGlobals(t, 7, 4)
+
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResourceTypes
+	m.middleItems = []model.Item{
+		{Name: "Pods", Kind: "ResourceType", Extra: "/v1/pods"},
+	}
+	m.setCursor(0)
+	m.rightItems = []model.Item{
+		{Name: "pod-a", Kind: "Pod", Namespace: "default"},
+		{Name: "pod-b", Kind: "Pod", Namespace: "default"},
+	}
+
+	// X=100 is the right pane (>= middleEnd=77 at width 120).
+	_, _ = m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: 100})
+
+	assert.Equal(t, 7, ui.ActiveMiddleScroll, "measure render must not clobber the middle pane scroll")
+	assert.Equal(t, 4, ui.ActiveLeftScroll, "measure render must not clobber the left pane scroll")
+}
+
+// Wheel over the right pane at LevelResources with a split preview: the
+// pinned-header table render inside clampPreviewScroll runs on every tick
+// (not memoized) and must not clobber the scroll state or the click line map.
+func TestWheelOverRightPaneKeepsScrollGlobalsSplitPreview(t *testing.T) {
+	saveScrollGlobals(t, 7, 4)
+	ui.ActiveMiddleLineMap = []int{0, 1, 2}
+
+	m := baseExplorerModel() // LevelResources, Kind "Pod" -> hasSplitPreview
+	m.rightItems = []model.Item{
+		{Name: "container-a", Kind: "Container"},
+	}
+
+	_, _ = m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: 100})
+
+	assert.Equal(t, 7, ui.ActiveMiddleScroll, "split-preview render must not clobber the middle pane scroll")
+	assert.Equal(t, 4, ui.ActiveLeftScroll, "split-preview render must not clobber the left pane scroll")
+	assert.Equal(t, []int{0, 1, 2}, ui.ActiveMiddleLineMap, "split-preview render must not rebuild the middle click map from right-pane items")
+}
+
+// The preview J/K keys clamp through the same path as the wheel; guard them too.
+func TestClampPreviewScrollKeepsScrollGlobals(t *testing.T) {
+	saveScrollGlobals(t, 9, 2)
+
+	m := baseExplorerModel()
+	m.rightItems = []model.Item{
+		{Name: "container-a", Kind: "Container"},
+	}
+	m.previewScroll = 50
+	m.clampPreviewScroll()
+
+	assert.Equal(t, 9, ui.ActiveMiddleScroll, "clamp must not clobber the middle pane scroll")
+	assert.Equal(t, 2, ui.ActiveLeftScroll, "clamp must not clobber the left pane scroll")
+}

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -32,6 +32,23 @@ func (m *Model) clearRight() {
 // clampPreviewScroll prevents scrolling past the preview content.
 // Only details+events scroll; pinned header (children) and footer (resource usage) are excluded.
 func (m *Model) clampPreviewScroll() {
+	// This runs in the Update path (preview wheel/keys) and renders right-pane
+	// content below (the split pinned header and the measurement render), all
+	// with cursor=-1. Park the persistent pane-scroll globals around those
+	// renders: RenderTable/RenderColumn would otherwise reset ActiveMiddleScroll
+	// / ActiveLeftScroll to 0 (VimScrollOff with cursor=-1), making the pane to
+	// the left visibly jump (issue #398). ActiveMiddleLineMap is saved too:
+	// RenderTable rebuilds it (from the right pane's items, here) under the
+	// same >= 0 gate. The View path applies this guard around its right-pane
+	// render in viewExplorerThreeCol.
+	savedMiddleScroll, savedLeftScroll := ui.ActiveMiddleScroll, ui.ActiveLeftScroll
+	savedLineMap := ui.ActiveMiddleLineMap
+	ui.ActiveMiddleScroll, ui.ActiveLeftScroll = -1, -1
+	defer func() {
+		ui.ActiveMiddleScroll, ui.ActiveLeftScroll = savedMiddleScroll, savedLeftScroll
+		ui.ActiveMiddleLineMap = savedLineMap
+	}()
+
 	// The fullscreen dashboard reuses previewScroll but renders entirely
 	// different content (cluster overview / monitoring), so bound it against
 	// that content instead of the right-column preview.


### PR DESCRIPTION
Fixes #398

## Root cause

`clampPreviewScroll()` runs in the bubbletea **Update** path — on every mouse-wheel tick over the right (preview) pane and on the preview scroll keys — and renders right-pane content with `cursor=-1`:

- the split-preview pinned-header `RenderTable` (`view_right.go`), on **every tick** at `LevelResources` for kinds with children — the "definitely happens" case
- the memoized `measureScrollableLines` render, **once per content change** (preview load, watch tick, events arriving) — the "sometimes happens" case

`ui.RenderTable` / `ui.RenderColumn` persist the viewport into the package globals `ui.ActiveMiddleScroll` / `ui.ActiveLeftScroll` whenever the global is `>= 0`, and `VimScrollOff` with `cursor=-1` returns 0 — so each unguarded Update-path render zeroed the left/middle pane's persistent scroll (and rebuilt `ActiveMiddleLineMap` from the right pane's items). The next `View()` re-derived the viewport from 0, and the pane to the left of the one being scrolled visibly jumped.

The View path already guards against exactly this: `viewExplorerThreeCol` saves both globals, parks them at -1 around its right-pane render, and restores them. The Update path had no such guard.

Reproduced end-to-end (lfk in tmux against a kind cluster, injected SGR wheel sequences): the first wheel tick over the preview pane shifted the resource-kinds list viewport by ~12 rows with its cursor unchanged.

## Fix

Apply the same park-at-(-1)/restore guard at the top of `clampPreviewScroll`, covering `ActiveMiddleScroll`, `ActiveLeftScroll`, and `ActiveMiddleLineMap`. All Update-path callers (wheel, preview J/K, dashboard scroll keys) route through this one function.

## Test plan

- [x] TDD red/green: three new regression tests in `internal/app/update_mouse_scroll_clobber_test.go` reproduced the clobber before the fix (globals zeroed, click map rebuilt from right-pane items) and pass after:
  - wheel over the right pane at `LevelResourceTypes` (measure path) preserves both scroll globals
  - wheel over the right pane with a split preview preserves the globals and `ActiveMiddleLineMap`
  - direct `clampPreviewScroll()` (preview key path) preserves the globals
- [x] `go build ./...`, `go test ./...`, `go test -race ./internal/app/ ./internal/ui/`, `go vet`, `golangci-lint` — all green