### PR TITLE
fix: pin the affected-resources table while finding-group details scroll

### DIFF
--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -122,6 +122,10 @@ type previewMeasureKey struct {
 	yamlLen     int
 	dashLen     int
 	eventsLen   int
+	// selName invalidates the memo when the middle selection changes while
+	// every layout dimension stays equal — e.g. two security finding groups
+	// with the same affected count but different description lengths.
+	selName string
 }
 
 // measureScrollableLines returns the line count of the scrollable right-pane
@@ -147,6 +151,9 @@ func (m *Model) measureScrollableLines(innerW, scrollableH int) int {
 		yamlLen:     len(yaml),
 		dashLen:     len(m.dashboardPreview) + len(m.monitoringPreview),
 		eventsLen:   len(m.previewEventsContent),
+	}
+	if sel := m.selectedMiddleItem(); sel != nil {
+		key.selName = sel.Name
 	}
 	if key == m.previewMeasureKey && m.previewMeasureLines > 0 {
 		return m.previewMeasureLines
@@ -368,6 +375,12 @@ func (m Model) hasSplitPreview() bool {
 	if m.nav.Level == model.LevelResources && (m.resourceTypeHasChildren() || m.nav.ResourceType.Kind == "Pod") && len(m.rightItems) > 0 {
 		return true
 	}
+	// Security finding groups split the same way: affected resources pinned
+	// on top, group details scrolling below — so previewScroll never pushes
+	// the table out of view.
+	if m.isSecurityGroupSplit() {
+		return true
+	}
 	if m.nav.Level == model.LevelOwned {
 		sel := m.selectedMiddleItem()
 		if sel != nil && sel.Kind == "Pod" && len(m.rightItems) > 0 {
@@ -377,12 +390,26 @@ func (m Model) hasSplitPreview() bool {
 	return false
 }
 
+// isSecurityGroupSplit reports whether the right pane previews a security
+// finding group with its affected resources loaded.
+func (m Model) isSecurityGroupSplit() bool {
+	if m.nav.Level != model.LevelResources || len(m.rightItems) == 0 {
+		return false
+	}
+	sel := m.selectedMiddleItem()
+	return sel != nil && sel.Kind == "__security_finding_group__"
+}
+
 // renderDetailsOnly renders the details portion (without children table) for the right column.
 // The returned string contains a "DETAILS" header line followed by the summary
 // body, and fits within the requested height (body capped at height-1 to
 // reserve one line for the header).
 func (m Model) renderDetailsOnly(width, height int) string {
 	sel := m.selectedMiddleItem()
+	// Security finding groups carry their own title line; no DETAILS header.
+	if sel != nil && sel.Kind == "__security_finding_group__" {
+		return ui.RenderFindingGroupDetails(*sel, nil, width, height)
+	}
 	detailsHeader := ui.DimStyle.Bold(true).Render("DETAILS")
 	bodyHeight := max(height-1, 1)
 	var bottomContent string
@@ -521,12 +548,11 @@ func (m Model) renderRightResources(width, height int) string {
 	if sel != nil && sel.Kind == "__security_finding__" {
 		return ui.RenderFindingDetails(*sel, width, height)
 	}
-	// Security finding groups: split view — affected resources table on
-	// top + group details on the bottom, the same shape as Deployment > Pods.
+	// Security finding groups with affected rows render via the split-preview
+	// machinery in renderRightColumn (pinned affected table + scrolling
+	// details, the same shape as Deployment > Pods), so this path is only
+	// reached before the affected resources have loaded.
 	if sel != nil && sel.Kind == "__security_finding_group__" {
-		if len(m.rightItems) > 0 {
-			return m.renderSecurityGroupSplitPreview(sel, width, height)
-		}
 		if m.previewLoading {
 			return ui.DimStyle.Render(m.spinner.View() + " Loading affected resources...")
 		}
@@ -606,20 +632,6 @@ func (m Model) renderRightDefault(width, height int) string {
 	return m.withSessionColumnsForKind(m.rightColumnKind(), func() string {
 		return ui.RenderTable(strings.ToUpper(m.ownedChildKindLabel()), m.rightItems, -1, width, height, m.loading, m.spinner.View(), "", false)
 	})
-}
-
-// renderSecurityGroupSplitPreview renders a split view for a security
-// finding group: affected resources table on top, group details on the
-// bottom — the same layout as Deployment > Pods.
-func (m Model) renderSecurityGroupSplitPreview(sel *model.Item, width, height int) string {
-	childrenHeight := max((height-2)/3, 2)
-	detailsHeight := max(height-childrenHeight-2, 1)
-
-	childrenContent := ui.RenderTable("AFFECTED RESOURCES", m.rightItems, -1, width, childrenHeight, m.loading, m.spinner.View(), "", false)
-	separator := ui.DimStyle.Render(strings.Repeat("─", width))
-	detailsContent := ui.RenderFindingGroupDetails(*sel, nil, width, detailsHeight)
-
-	return childrenContent + "\n" + separator + "\n" + detailsContent
 }
 
 // renderSplitPreview renders the right column as a split: top children table, bottom details.
@@ -726,6 +738,10 @@ func (m Model) ownedItemKindLabel() string {
 // ownedChildKindLabel returns the label for the children of the selected owned item,
 // shown in the right column (e.g., Containers within a selected Pod).
 func (m Model) ownedChildKindLabel() string {
+	// Security finding groups pin their affected-resources table on top.
+	if m.isSecurityGroupSplit() {
+		return "Affected Resources"
+	}
 	// At the owned level, if the selected item is a Pod, right column shows containers.
 	if m.nav.Level == model.LevelOwned {
 		sel := m.selectedMiddleItem()

--- a/internal/app/view_right_security_split_test.go
+++ b/internal/app/view_right_security_split_test.go
@@ -1,0 +1,94 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// securityGroupPreviewModel builds a model standing on a finding group at
+// LevelResources with a loaded affected-resources list and a description long
+// enough to need scrolling.
+func securityGroupPreviewModel() Model {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "__security_advisor__", APIGroup: "_security"}
+	m.middleItems = []model.Item{{
+		Name:  "single_replica",
+		Kind:  "__security_finding_group__",
+		Extra: "single_replica",
+		Columns: []model.KeyValue{
+			{Key: "Severity", Value: "LOW"},
+			{Key: "Affected", Value: "12"},
+			{Key: "Description", Value: strings.Repeat("advisory paragraph that wraps over many lines. ", 40)},
+		},
+	}}
+	m.setCursor(0)
+	m.rightItems = make([]model.Item, 12)
+	for i := range m.rightItems {
+		m.rightItems[i] = model.Item{
+			Name:      fmt.Sprintf("deploy-%02d", i),
+			Kind:      "__security_affected_resource__",
+			Namespace: "prod",
+			Columns:   []model.KeyValue{{Key: "__severity__", Value: "LOW"}},
+		}
+	}
+	return m
+}
+
+// TestSecurityGroupPreviewPinsAffectedWhileDetailsScroll guards the split
+// behaviour of the finding-group preview: scrolling the pane (shift+j / mouse
+// wheel -> previewScroll) must scroll only the group details below the
+// separator; the affected-resources table stays pinned on top. Before the fix
+// the whole assembled pane (table + details) scrolled as one buffer, pushing
+// the table out of view.
+func TestSecurityGroupPreviewPinsAffectedWhileDetailsScroll(t *testing.T) {
+	m := securityGroupPreviewModel()
+
+	unscrolled := stripANSI(m.renderRightColumn(60, 24))
+	require.Contains(t, unscrolled, "AFFECTED RESOURCES")
+	require.Contains(t, unscrolled, "deploy-00")
+	require.Contains(t, unscrolled, "single_replica", "details title visible before scrolling")
+
+	m.previewScroll = 3
+	scrolled := stripANSI(m.renderRightColumn(60, 24))
+	assert.Contains(t, scrolled, "AFFECTED RESOURCES",
+		"affected-resources table must stay pinned while the details scroll")
+	assert.Contains(t, scrolled, "deploy-00",
+		"pinned table rows must not scroll away")
+	assert.NotContains(t, scrolled, "single_replica",
+		"details title must scroll out of view (only the details portion scrolls)")
+}
+
+// TestSecurityGroupPreviewSplitGating verifies the split only engages with
+// affected rows present — while loading (no rows) the pane falls back to the
+// non-split details rendering.
+func TestSecurityGroupPreviewSplitGating(t *testing.T) {
+	m := securityGroupPreviewModel()
+	assert.True(t, m.hasSplitPreview(), "finding group with affected rows splits")
+
+	m.rightItems = nil
+	assert.False(t, m.hasSplitPreview(), "no affected rows -> no split")
+}
+
+// TestSecurityGroupPreviewClampUsesDetailsOnly verifies clampPreviewScroll
+// bounds the scroll against the details portion only (not the assembled
+// table+details buffer): with a short description the max scroll is small even
+// though the affected table adds many lines.
+func TestSecurityGroupPreviewClampUsesDetailsOnly(t *testing.T) {
+	m := securityGroupPreviewModel()
+	m.middleItems[0].Columns = []model.KeyValue{
+		{Key: "Severity", Value: "LOW"},
+		{Key: "Affected", Value: "12"},
+		{Key: "Description", Value: "short"},
+	}
+	m.previewScroll = 10_000
+	m.clampPreviewScroll()
+	assert.Less(t, m.previewScroll, 40,
+		"clamp must bound scroll to the short details content, not leave it unbounded")
+}

--- a/internal/app/view_right_security_split_test.go
+++ b/internal/app/view_right_security_split_test.go
@@ -76,6 +76,31 @@ func TestSecurityGroupPreviewSplitGating(t *testing.T) {
 	assert.False(t, m.hasSplitPreview(), "no affected rows -> no split")
 }
 
+// TestMeasureScrollableLinesRecomputesOnSelectionChange guards the selName
+// memo-key field: switching between two finding groups whose layout
+// dimensions are identical (same affected count, level, split state) but
+// whose descriptions differ in length must recompute the scrollable line
+// count instead of returning the stale memoized value.
+func TestMeasureScrollableLinesRecomputesOnSelectionChange(t *testing.T) {
+	m := securityGroupPreviewModel()
+	short := m.middleItems[0]
+	short.Name = "short_group"
+	short.Columns = []model.KeyValue{
+		{Key: "Severity", Value: "LOW"},
+		{Key: "Affected", Value: "12"},
+		{Key: "Description", Value: "one line"},
+	}
+	m.middleItems = append(m.middleItems, short)
+
+	m.setCursor(0) // long description
+	longLines := m.measureScrollableLines(60, 20)
+	m.setCursor(1) // short description, every other key dimension unchanged
+	shortLines := m.measureScrollableLines(60, 20)
+
+	assert.Less(t, shortLines, longLines,
+		"selection change must invalidate the memoized line count")
+}
+
 // TestSecurityGroupPreviewClampUsesDetailsOnly verifies clampPreviewScroll
 // bounds the scroll against the details portion only (not the assembled
 // table+details buffer): with a short description the max scroll is small even


### PR DESCRIPTION
## Summary

- Fixes the scroll bug in the security finding-group preview (reproducible in Advisor, Falco, Heuristic — any source): shift+j / mouse wheel scrolled the affected-resources table and the description together as one buffer, pushing the table out of view.
- Finding groups now go through the existing split-preview machinery (`hasSplitPreview`) — the same path Deployment > Pods uses — so the affected-resources table is a pinned header and `previewScroll` moves only the group details below the separator. The bespoke `renderSecurityGroupSplitPreview` (which assembled both into one scrollable string) is removed.
- Scroll clamping and the memoized line measurement follow automatically since all three consumers (`clampPreviewScroll`, `measureScrollableLines`, `renderRightColumn`) share `hasSplitPreview`. The memo key now also includes the selected item name so the scroll bound recomputes when switching between two groups with otherwise identical layout dimensions.

## Test plan

- [x] New TUI tests: pinned table survives `previewScroll > 0` while the details title scrolls out; split gates on affected rows being loaded; clamp bounds against the details portion only
- [x] `go test -race ./...` green, `golangci-lint` 0 issues