### PR TITLE
fix(exec): use cmd.exe/PowerShell when exec-ing into Windows pods

### DIFF
--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -395,6 +395,7 @@ type actionContext struct {
 	namespace     string // namespace of the target resource (captured at action time)
 	context       string // kubeconfig context name (captured at action time)
 	containerName string // container name (for exec/logs at container level)
+	os            string // pod OS ("windows"/"linux"/""); resolved before exec to pick the shell
 	image         string // container image (for vuln scan at container level)
 	resourceType  model.ResourceTypeEntry
 	columns       []model.KeyValue // additional item columns (e.g., Node, IP) for custom action templates

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -13,6 +15,70 @@ import (
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/ui"
 )
+
+// execPodOSResolvedMsg carries the result of the pre-exec pod-OS lookup back to
+// the Update loop so it can launch kubectl exec with the right shell. A lookup
+// failure or unknown OS is reported as an empty podOS (the Linux shell default),
+// so there is no error to propagate here.
+type execPodOSResolvedMsg struct {
+	podOS string
+}
+
+// detectExecPodOSCmd resolves the selected pod's OS in the background (a single
+// pod GET, off the Bubble Tea event loop) and emits execPodOSResolvedMsg. On
+// error the message still fires with an empty podOS so exec falls back to the
+// Linux shell rather than blocking — Windows is the only OS that needs special
+// handling, and a transient lookup failure shouldn't break Linux exec.
+func (m Model) detectExecPodOSCmd() tea.Cmd {
+	client := m.client
+	kctx := m.actionCtx.context
+	ns := m.actionNamespace()
+	name := m.actionCtx.name
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		podOS, err := client.GetPodOS(ctx, kctx, ns, name)
+		if err != nil {
+			logger.Warn("Could not resolve pod OS for exec; defaulting to Linux shell", "pod", name, "error", err)
+			return execPodOSResolvedMsg{}
+		}
+		return execPodOSResolvedMsg{podOS: podOS}
+	}
+}
+
+// updateExecPodOSResolved fires once the pre-exec pod-OS lookup completes. It
+// records the resolved OS on the action context and launches kubectl exec with
+// the matching shell. A non-nil err is already downgraded to an empty podOS by
+// detectExecPodOSCmd, so this path always proceeds to exec.
+func (m Model) updateExecPodOSResolved(msg execPodOSResolvedMsg) (tea.Model, tea.Cmd) {
+	m.actionCtx.os = msg.podOS
+	return m, m.execKubectlExec()
+}
+
+// linuxExecShellCmd is the POSIX shell bootstrap used to exec into Linux
+// containers: clear the screen, then prefer bash, then ash, then plain sh.
+const linuxExecShellCmd = "clear; command -v bash >/dev/null && exec bash || { command -v ash >/dev/null && exec ash || exec sh; }"
+
+// windowsExecShellCmd prefers PowerShell and falls back to cmd.exe when it is
+// absent (e.g. nanoserver base images, which ship only cmd.exe). cmd's `||`
+// runs the fallback when powershell.exe is missing or exits non-zero.
+const windowsExecShellCmd = "powershell.exe -NoLogo -NoProfile || cmd.exe"
+
+// execShellArgs builds the `kubectl exec` argument list for an interactive
+// shell, selecting the shell by pod OS. Windows pods (podOS "windows") get a
+// cmd.exe-launched PowerShell→cmd fallback; everything else (including an empty
+// podOS, meaning detection failed or the field is unset) gets the Linux shell
+// chain. displayCtx is the kubectl --context name; container is optional.
+func execShellArgs(name, namespace, displayCtx, container, podOS string) []string {
+	args := []string{"exec", "-it", name, "-n", namespace, "--context", displayCtx}
+	if container != "" {
+		args = append(args, "-c", container)
+	}
+	if strings.EqualFold(podOS, "windows") {
+		return append(args, "--", "cmd.exe", "/c", windowsExecShellCmd)
+	}
+	return append(args, "--", "/bin/sh", "-c", linuxExecShellCmd)
+}
 
 func (m Model) execKubectlExec() tea.Cmd {
 	kubectlPath, err := exec.LookPath("kubectl")
@@ -23,11 +89,7 @@ func (m Model) execKubectlExec() tea.Cmd {
 	}
 
 	ns := m.actionNamespace()
-	args := []string{"exec", "-it", m.actionCtx.name, "-n", ns, "--context", m.kubectlContext(m.actionCtx.context)}
-	if m.actionCtx.containerName != "" {
-		args = append(args, "-c", m.actionCtx.containerName)
-	}
-	args = append(args, "--", "/bin/sh", "-c", "clear; command -v bash >/dev/null && exec bash || { command -v ash >/dev/null && exec ash || exec sh; }")
+	args := execShellArgs(m.actionCtx.name, ns, m.kubectlContext(m.actionCtx.context), m.actionCtx.containerName, m.actionCtx.os)
 
 	logger.Info("Starting kubectl exec", "args", strings.Join(args, " "))
 	cmd := exec.Command(kubectlPath, args...)

--- a/internal/app/commands_exec_shell_test.go
+++ b/internal/app/commands_exec_shell_test.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateExecPodOSResolved verifies the resolved OS is recorded on the
+// action context and an exec command is launched.
+func TestUpdateExecPodOSResolved(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent") // make execKubectlExec return its error cmd (no kubectl)
+	m := basePush80v3Model()
+	m.actionCtx = actionContext{name: "win-pod", namespace: "default", context: "test-ctx", containerName: "app"}
+
+	mm, cmd := m.updateExecPodOSResolved(execPodOSResolvedMsg{podOS: "windows"})
+	m = mm.(Model)
+	assert.Equal(t, "windows", m.actionCtx.os, "resolved OS must be recorded for shell selection")
+	require.NotNil(t, cmd, "must launch an exec command")
+}
+
+func TestExecShellArgs_LinuxWithContainer(t *testing.T) {
+	got := execShellArgs("pod-1", "ns", "ctx", "app", "linux")
+	assert.Equal(t, []string{
+		"exec", "-it", "pod-1", "-n", "ns", "--context", "ctx", "-c", "app",
+		"--", "/bin/sh", "-c",
+		"clear; command -v bash >/dev/null && exec bash || { command -v ash >/dev/null && exec ash || exec sh; }",
+	}, got)
+}
+
+func TestExecShellArgs_LinuxDefaultWhenUnknown(t *testing.T) {
+	// Empty OS (detection failed/unknown) falls back to the Linux shell chain.
+	got := execShellArgs("pod-1", "ns", "ctx", "", "")
+	assert.Equal(t, []string{
+		"exec", "-it", "pod-1", "-n", "ns", "--context", "ctx",
+		"--", "/bin/sh", "-c",
+		"clear; command -v bash >/dev/null && exec bash || { command -v ash >/dev/null && exec ash || exec sh; }",
+	}, got)
+}
+
+func TestExecShellArgs_Windows(t *testing.T) {
+	got := execShellArgs("win-pod", "ns", "ctx", "app", "windows")
+	assert.Equal(t, []string{
+		"exec", "-it", "win-pod", "-n", "ns", "--context", "ctx", "-c", "app",
+		"--", "cmd.exe", "/c", "powershell.exe -NoLogo -NoProfile || cmd.exe",
+	}, got)
+}
+
+func TestExecShellArgs_WindowsCaseInsensitive(t *testing.T) {
+	// spec.os.name is lowercase by API contract, but be defensive.
+	got := execShellArgs("win-pod", "ns", "ctx", "", "Windows")
+	assert.Contains(t, got, "cmd.exe")
+	assert.NotContains(t, got, "/bin/sh")
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -435,6 +435,9 @@ func (m Model) updateEditorResultMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case execPTYExitMsg:
 		mdl := m.updateExecPTYExit(msg)
 		return mdl, nil, true
+	case execPodOSResolvedMsg:
+		mdl, cmd := m.updateExecPodOSResolved(msg)
+		return mdl, cmd, true
 	case execPTYStartMsg:
 		mdl, cmd := m.updateExecPTYStart(msg)
 		return mdl, cmd, true

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -138,8 +138,10 @@ func (m Model) executeActionExec() (tea.Model, tea.Cmd) {
 	if m.actionCtx.containerName != "" {
 		cArg = " -c " + m.actionCtx.containerName
 	}
-	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl exec -it %s%s -n %s --context %s -- /bin/sh -c 'clear; command -v bash >/dev/null && exec bash || { command -v ash >/dev/null && exec ash || exec sh; }'", name, cArg, ns, ctx))
-	return m, m.execKubectlExec()
+	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl exec -it %s%s -n %s --context %s -- <shell> (auto-selected by pod OS)", name, cArg, ns, ctx))
+	// Resolve the pod OS first (off the event loop), then launch exec with the
+	// matching shell — Linux pods get sh/bash, Windows pods get cmd/PowerShell.
+	return m, m.detectExecPodOSCmd()
 }
 
 // executeActionAttach handles the "Attach" action.

--- a/internal/k8s/client_data.go
+++ b/internal/k8s/client_data.go
@@ -286,6 +286,29 @@ func (c *Client) GetPodResourceRequests(ctx context.Context, contextName, namesp
 	return cpuReq, cpuLim, memReq, memLim, nil
 }
 
+// GetPodOS returns the operating system of a pod, used to pick the right
+// interactive shell on exec. It reads the GA spec.os.name field first
+// (set by the API server / admission for Windows pods), then falls back to
+// the kubernetes.io/os node selector. Returns "" when neither is present,
+// which callers treat as the default (Linux) shell.
+func (c *Client) GetPodOS(ctx context.Context, contextName, namespace, podName string) (string, error) {
+	cs, err := c.clientsetForContext(contextName)
+	if err != nil {
+		return "", err
+	}
+	pod, err := cs.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting pod %s/%s: %w", namespace, podName, err)
+	}
+	if pod.Spec.OS != nil && pod.Spec.OS.Name != "" {
+		return string(pod.Spec.OS.Name), nil
+	}
+	if osLabel := pod.Spec.NodeSelector["kubernetes.io/os"]; osLabel != "" {
+		return osLabel, nil
+	}
+	return "", nil
+}
+
 // TriggerCronJob creates a Job from a CronJob template.
 func (c *Client) TriggerCronJob(ctx context.Context, contextName, namespace, cronJobName string) (string, error) {
 	logger.Info("Triggering CronJob", "context", contextName, "namespace", namespace, "cronjob", cronJobName)

--- a/internal/k8s/client_podos_test.go
+++ b/internal/k8s/client_podos_test.go
@@ -1,0 +1,71 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetPodOS_SpecOSName(t *testing.T) {
+	winOS := corev1.Windows
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "win-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{OS: &corev1.PodOS{Name: winOS}},
+	}
+	c := newFakeClient(k8sfake.NewClientset(pod), nil)
+
+	got, err := c.GetPodOS(context.Background(), "ctx", "default", "win-pod")
+	require.NoError(t, err)
+	assert.Equal(t, "windows", got)
+}
+
+func TestGetPodOS_NodeSelectorFallback(t *testing.T) {
+	// No spec.os; OS only discoverable via the kubernetes.io/os node selector.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "win-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeSelector: map[string]string{"kubernetes.io/os": "windows"}},
+	}
+	c := newFakeClient(k8sfake.NewClientset(pod), nil)
+
+	got, err := c.GetPodOS(context.Background(), "ctx", "default", "win-pod")
+	require.NoError(t, err)
+	assert.Equal(t, "windows", got)
+}
+
+func TestGetPodOS_Linux(t *testing.T) {
+	linuxOS := corev1.Linux
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "linux-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{OS: &corev1.PodOS{Name: linuxOS}},
+	}
+	c := newFakeClient(k8sfake.NewClientset(pod), nil)
+
+	got, err := c.GetPodOS(context.Background(), "ctx", "default", "linux-pod")
+	require.NoError(t, err)
+	assert.Equal(t, "linux", got)
+}
+
+func TestGetPodOS_Unknown(t *testing.T) {
+	// Neither spec.os nor a kubernetes.io/os selector — returns "".
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{},
+	}
+	c := newFakeClient(k8sfake.NewClientset(pod), nil)
+
+	got, err := c.GetPodOS(context.Background(), "ctx", "default", "plain-pod")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestGetPodOS_NotFound(t *testing.T) {
+	c := newFakeClient(k8sfake.NewClientset(), nil)
+	_, err := c.GetPodOS(context.Background(), "ctx", "default", "missing")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Fixes #406 — exec into Windows containers failed with `Error exit status 1` because the exec command hardcoded `/bin/sh -c "…"`, which does not exist in Windows containers.

## Changes
- **Native OS detection** (`client.GetPodOS`): reads the GA `spec.os.name` field, falling back to the `kubernetes.io/os` node selector. No heuristics — stays within first-class API fields.
- **Async resolution** (`detectExecPodOSCmd`): the pod-OS lookup runs in a background `tea.Cmd` (5s timeout), off the Bubble Tea event loop, then `execPodOSResolvedMsg` drives the launch. A blocking pod GET on the Update loop would freeze the TUI.
- **Windows shell**: `cmd.exe /c "powershell.exe -NoLogo -NoProfile || cmd.exe"` — PowerShell on servercore, `cmd.exe` fallback on nanoserver (which lacks PowerShell).
- **Linux unchanged**: bash → ash → sh chain. A failed or unknown OS lookup also falls back to the Linux shell, so non-Windows exec is unaffected.

## Scope
Covers the `Exec` action. `Attach` is OS-agnostic (no shell). `Debug` (ephemeral/debug containers) still uses `sh` — Windows debug containers are a separate, rarer concern left out of this PR.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/ ./internal/k8s/ ./internal/ui/`
- [x] `go test -race ./internal/app/`
- [x] `golangci-lint run` (0 issues), gofumpt clean
- [x] Unit: `GetPodOS` (spec.os.name / nodeSelector / linux / unknown / not-found); `execShellArgs` (linux/windows/container variants); `updateExecPodOSResolved`
- [ ] Manual (needs a Windows pod): Exec opens PowerShell on servercore, cmd.exe on nanoserver
- [ ] Manual: Linux exec still opens bash/sh as before
