### PR TITLE
fix(preview): follow the list's sorting and column config in list previews

### DIFF
--- a/internal/app/app_sort.go
+++ b/internal/app/app_sort.go
@@ -83,20 +83,38 @@ func (m *Model) forgetSort() {
 // kinds (port-forwards, captures, union dashboards) are no-ops — pass an empty
 // ResourceRef.Kind or skip the call entirely at those sites.
 func (m *Model) applyKindSortDefault(rt ui.ResourceRef, context string) {
+	m.sortColumnName, m.sortAscending = m.kindSortPref(rt, context)
+}
+
+// kindSortPref resolves the sort column/direction a list of the given resource
+// type renders with, without mutating the model: session sort memory first,
+// then the configured view's SortColumn, then the built-in default ("Name",
+// ascending). Shared by applyKindSortDefault and the right-pane list preview
+// so the preview order matches the drilled-in list (issue #408).
+func (m *Model) kindSortPref(rt ui.ResourceRef, context string) (column string, ascending bool) {
 	if rt.Resource != "" {
 		if p, ok := m.sortMemory[sortMemoryKey(rt, context)]; ok {
-			m.sortColumnName = p.column
-			m.sortAscending = p.ascending
-			return
+			return p.column, p.ascending
 		}
 	}
 	if v, ok := ui.ResolveView(rt, context); ok && v.SortColumn != "" {
-		m.sortColumnName = v.SortColumn
-		m.sortAscending = v.SortAsc
+		return v.SortColumn, v.SortAsc
+	}
+	return sortColDefault, true
+}
+
+// sortPreviewItems sorts a right-pane preview list in place exactly as the
+// drilled-in list of rt renders it — session sort memory, then view config,
+// then Name ascending (issue #408). Synthetic previews (port-forwards,
+// captures, union dashboards) carry a zero-valued rt and keep their fetch
+// order.
+func (m *Model) sortPreviewItems(items []model.Item, rt model.ResourceTypeEntry) {
+	if rt.Resource == "" {
 		return
 	}
-	m.sortColumnName = sortColDefault
-	m.sortAscending = true
+	ref := ui.ResourceRef{Group: rt.APIGroup, Version: rt.APIVersion, Resource: rt.Resource, Kind: rt.Kind}
+	col, asc := m.kindSortPref(ref, m.nav.Context)
+	sortItemsByColumn(items, col, asc, rt.Kind)
 }
 
 // applyResourceTypeSortDefault is a convenience wrapper around applyKindSortDefault

--- a/internal/app/preview_sort_test.go
+++ b/internal/app/preview_sort_test.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// Issue #408: hovering a resource type renders its list in the right pane;
+// the preview must use the same sort the drilled-in list will (sort memory,
+// then view config, then Name ascending) instead of API fetch order.
+
+func previewPodsRT() model.ResourceTypeEntry {
+	return model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1", Namespaced: true}
+}
+
+func TestPreviewListAppliesRememberedSort(t *testing.T) {
+	origViews := ui.ConfigViews
+	t.Cleanup(func() { ui.ConfigViews = origViews })
+	ui.ConfigViews = nil
+
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.nav.Context = "test-ctx" // pin explicitly: the sortMemory key below depends on it
+	ref := ui.ResourceRef{Version: "v1", Resource: "pods", Kind: "Pod"}
+	m.sortMemory = map[string]sortPref{
+		sortMemoryKey(ref, "test-ctx"): {column: "Status", ascending: false},
+	}
+
+	items := []model.Item{
+		{Name: "a", Kind: "Pod", Status: "Running"}, // priority 0
+		{Name: "b", Kind: "Pod", Status: "Failed"},  // priority 2
+		{Name: "c", Kind: "Pod", Status: "Pending"}, // priority 1
+	}
+	res, _ := m.Update(resourcesLoadedMsg{items: items, forPreview: true, rt: previewPodsRT()})
+	rm := res.(Model)
+
+	want := []string{"b", "c", "a"} // Status descending: Failed, Pending, Running
+	if len(rm.rightItems) != 3 {
+		t.Fatalf("rightItems = %d items, want 3", len(rm.rightItems))
+	}
+	for i, name := range want {
+		if rm.rightItems[i].Name != name {
+			t.Fatalf("rightItems[%d] = %q, want %q (remembered Status desc sort not applied)", i, rm.rightItems[i].Name, name)
+		}
+	}
+}
+
+func TestPreviewListAppliesViewConfigSort(t *testing.T) {
+	origViews := ui.ConfigViews
+	t.Cleanup(func() { ui.ConfigViews = origViews })
+	v, err := ui.BuildView(&ui.ConfigView{SortColumn: "Restarts:desc"})
+	if err != nil {
+		t.Fatalf("BuildView: %v", err)
+	}
+	ui.ConfigViews = map[string]*ui.View{"/v1/pods": v}
+
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+
+	items := []model.Item{
+		{Name: "a", Kind: "Pod", Restarts: "1"},
+		{Name: "b", Kind: "Pod", Restarts: "7"},
+		{Name: "c", Kind: "Pod", Restarts: "3"},
+	}
+	res, _ := m.Update(resourcesLoadedMsg{items: items, forPreview: true, rt: previewPodsRT()})
+	rm := res.(Model)
+
+	want := []string{"b", "c", "a"}
+	for i, name := range want {
+		if rm.rightItems[i].Name != name {
+			t.Fatalf("rightItems[%d] = %q, want %q (view Restarts:desc sort not applied)", i, rm.rightItems[i].Name, name)
+		}
+	}
+}
+
+func TestPreviewListDefaultsToNameAscending(t *testing.T) {
+	origViews := ui.ConfigViews
+	t.Cleanup(func() { ui.ConfigViews = origViews })
+	ui.ConfigViews = nil
+
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+
+	items := []model.Item{
+		{Name: "charlie", Kind: "Pod"},
+		{Name: "alpha", Kind: "Pod"},
+		{Name: "bravo", Kind: "Pod"},
+	}
+	res, _ := m.Update(resourcesLoadedMsg{items: items, forPreview: true, rt: previewPodsRT()})
+	rm := res.(Model)
+
+	want := []string{"alpha", "bravo", "charlie"}
+	for i, name := range want {
+		if rm.rightItems[i].Name != name {
+			t.Fatalf("rightItems[%d] = %q, want %q (default Name asc sort not applied)", i, rm.rightItems[i].Name, name)
+		}
+	}
+}
+
+// Synthetic previews (no resource type) must keep their fetch order.
+func TestPreviewListWithoutResourceTypeKeepsOrder(t *testing.T) {
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+
+	items := []model.Item{
+		{Name: "zeta"},
+		{Name: "alpha"},
+	}
+	res, _ := m.Update(resourcesLoadedMsg{items: items, forPreview: true})
+	rm := res.(Model)
+
+	if rm.rightItems[0].Name != "zeta" || rm.rightItems[1].Name != "alpha" {
+		t.Fatalf("synthetic preview reordered: %q, %q", rm.rightItems[0].Name, rm.rightItems[1].Name)
+	}
+}
+
+// sortItemsByColumn carries the Event LastSeen default override so a default-
+// sorted Event preview matches the drilled-in Event list (most recent first).
+func TestSortItemsByColumnEventDefaultLastSeen(t *testing.T) {
+	now := time.Now()
+	items := []model.Item{
+		{Name: "old", Kind: "Event", LastSeen: now.Add(-time.Hour)},
+		{Name: "new", Kind: "Event", LastSeen: now},
+		{Name: "mid", Kind: "Event", LastSeen: now.Add(-time.Minute)},
+	}
+	sortItemsByColumn(items, sortColDefault, true, "Event")
+	want := []string{"new", "mid", "old"}
+	for i, name := range want {
+		if items[i].Name != name {
+			t.Fatalf("items[%d] = %q, want %q", i, items[i].Name, name)
+		}
+	}
+}

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -32,19 +32,29 @@ func (m *Model) sortMiddleItems() {
 		// items the caller may want to keep in their original sequence.
 		return
 	}
-	asc := m.sortAscending
+	m.middleItemsRev++
+	sortItemsByColumn(m.middleItems, colName, m.sortAscending, m.nav.ResourceType.Kind)
+}
+
+// sortItemsByColumn sorts items in place by colName/asc with the shared
+// stable tiebreaker chain. Used for the middle column (sortMiddleItems) and
+// for the right-pane list preview so both render in the same order (issue
+// #408). kind supplies the Event LastSeen default override.
+func sortItemsByColumn(items []model.Item, colName string, asc bool, kind string) {
+	if colName == "" {
+		return
+	}
 
 	// Events default to LastSeen ordering (most recent first) when the
 	// user hasn't explicitly chosen a different column. The override
 	// uses a sentinel that comparePrimaryColumn recognizes, without
 	// injecting "Last Seen" into the sortable-column cycle.
-	if colName == sortColDefault && m.nav.ResourceType.Kind == "Event" {
+	if colName == sortColDefault && kind == "Event" {
 		colName = sortColEventLastSeen
 	}
 
-	m.middleItemsRev++
-	sort.SliceStable(m.middleItems, func(i, j int) bool {
-		a, b := m.middleItems[i], m.middleItems[j]
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
 
 		// Metrics-less rows ("n/a") always sort last, in BOTH directions.
 		// This cannot live inside comparePrimaryColumn: the asc/desc sign

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -355,47 +355,6 @@ func (m Model) updateResourcesLoaded(msg resourcesLoadedMsg) (tea.Model, tea.Cmd
 	return mdl, cmd
 }
 
-func (m Model) updateResourcesLoadedPreview(msg resourcesLoadedMsg) Model {
-	m.previewLoading = false
-	msg.items = m.filterLoadedItemsBySelectedNamespaces(msg.items)
-	// Prime itemCache under the drill-in navKey so loadResources can serve
-	// the list instantly and skip a redundant fetch when the user drills
-	// in or re-hovers this rt later. Only do this when msg.rt carries a
-	// real resource — synthetic previews (port-forwards, dashboards) have
-	// a zero-valued rt and must not write an empty-resource key. The
-	// fingerprint records the fetch-affecting state so the shortcut can
-	// detect later invalidations (namespace switch, allNS toggle,
-	// multi-select update) without relying on requestGen, which
-	// navigateChild bumps before child handlers even run.
-	if msg.rt.Resource != "" {
-		drillInKey := m.nav.Context + "/" + msg.rt.Resource
-		m.itemCache[drillInKey] = msg.items
-		m.cacheFingerprints[drillInKey] = m.fetchFingerprint()
-	}
-	m.rightItems = msg.items
-	// Filter events in children view to warnings-only when enabled.
-	if m.warningEventsOnly && len(m.rightItems) > 0 && m.rightItems[0].Kind == "Event" {
-		filtered := make([]model.Item, 0, len(m.rightItems))
-		for _, item := range m.rightItems {
-			if item.Status == "Warning" {
-				filtered = append(filtered, item)
-			}
-		}
-		m.rightItems = filtered
-	}
-	// Collapse duplicate events so noisy pods don't drown out the preview.
-	// The preview pane is always a summary, so we follow the main list's
-	// grouping toggle without offering a separate control — toggling `z` in
-	// the Events view also affects the preview shown for other resources.
-	if m.eventGrouping && len(m.rightItems) > 0 && m.rightItems[0].Kind == "Event" {
-		m.rightItems = groupEvents(m.rightItems)
-	}
-	if len(m.rightItems) == 0 {
-		logger.Info("No child resources found", "resourceType", m.nav.ResourceType.Kind, "resource", m.nav.ResourceName)
-	}
-	return m
-}
-
 func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea.Cmd) {
 	msg.items = m.filterLoadedItemsBySelectedNamespaces(msg.items)
 	if len(msg.items) == 0 {

--- a/internal/app/update_resources_loaded_preview.go
+++ b/internal/app/update_resources_loaded_preview.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func (m Model) updateResourcesLoadedPreview(msg resourcesLoadedMsg) Model {
+	m.previewLoading = false
+	msg.items = m.filterLoadedItemsBySelectedNamespaces(msg.items)
+	// Copy before sorting: the fresh-cache shortcut in loadResources hands
+	// this handler the itemCache slice itself, and sorting that in place
+	// would reorder a list other model fields may still alias.
+	msg.items = append([]model.Item(nil), msg.items...)
+	// Sort before the cache priming below so the drill-in shortcut serves
+	// the same order the preview showed.
+	m.sortPreviewItems(msg.items, msg.rt)
+	// Prime itemCache under the drill-in navKey so loadResources can serve
+	// the list instantly and skip a redundant fetch when the user drills
+	// in or re-hovers this rt later. Only do this when msg.rt carries a
+	// real resource — synthetic previews (port-forwards, dashboards) have
+	// a zero-valued rt and must not write an empty-resource key. The
+	// fingerprint records the fetch-affecting state so the shortcut can
+	// detect later invalidations (namespace switch, allNS toggle,
+	// multi-select update) without relying on requestGen, which
+	// navigateChild bumps before child handlers even run.
+	if msg.rt.Resource != "" {
+		drillInKey := m.nav.Context + "/" + msg.rt.Resource
+		m.itemCache[drillInKey] = msg.items
+		m.cacheFingerprints[drillInKey] = m.fetchFingerprint()
+	}
+	m.rightItems = msg.items
+	// Filter events in children view to warnings-only when enabled.
+	if m.warningEventsOnly && len(m.rightItems) > 0 && m.rightItems[0].Kind == "Event" {
+		filtered := make([]model.Item, 0, len(m.rightItems))
+		for _, item := range m.rightItems {
+			if item.Status == "Warning" {
+				filtered = append(filtered, item)
+			}
+		}
+		m.rightItems = filtered
+	}
+	// Collapse duplicate events so noisy pods don't drown out the preview.
+	// The preview pane is always a summary, so we follow the main list's
+	// grouping toggle without offering a separate control — toggling `z` in
+	// the Events view also affects the preview shown for other resources.
+	if m.eventGrouping && len(m.rightItems) > 0 && m.rightItems[0].Kind == "Event" {
+		m.rightItems = groupEvents(m.rightItems)
+	}
+	if len(m.rightItems) == 0 {
+		logger.Info("No child resources found", "resourceType", m.nav.ResourceType.Kind, "resource", m.nav.ResourceName)
+	}
+	return m
+}

--- a/internal/app/update_resources_loaded_preview.go
+++ b/internal/app/update_resources_loaded_preview.go
@@ -5,6 +5,10 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 )
 
+// updateResourcesLoadedPreview handles a resourcesLoadedMsg destined for the
+// right preview pane: it sorts the items the way the drilled-in list renders
+// them (issue #408), primes the drill-in itemCache, and applies the Event
+// warnings-only filter and grouping before exposing the list as rightItems.
 func (m Model) updateResourcesLoadedPreview(msg resourcesLoadedMsg) Model {
 	m.previewLoading = false
 	msg.items = m.filterLoadedItemsBySelectedNamespaces(msg.items)

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -58,9 +58,9 @@ func isMandatoryColumn(key string) bool {
 }
 
 // ActiveHiddenBuiltinColumns holds the set of built-in column keys that should
-// be suppressed in the current middle-column render. Valid keys: "Name",
-// "Context", "Namespace", "Ready", "Restarts", "Age", "Status". Set by the app
-// before rendering. Nil means no overrides.
+// be suppressed in the current table render (middle column or right-pane
+// preview). Valid keys: "Name", "Context", "Namespace", "Ready", "Restarts",
+// "Age", "Status". Set by the app before rendering. Nil means no overrides.
 var ActiveHiddenBuiltinColumns map[string]bool
 
 // ActiveNameHidden reports whether the NAME column is hidden for the current

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -12,6 +12,13 @@ import (
 
 // RenderTable renders items in a table format with column headers for resource views.
 // headerLabel is used as the first column header; defaults to "NAME" if empty.
+//
+// Column-config contract: RenderTable applies the Active* column globals
+// (ActiveSessionColumns, ActiveHiddenBuiltinColumns, ActiveColumnOrder,
+// ActivePrinterColumns) to every render, including cursor-less right-pane
+// previews (issue #408). A cursor-less call site must scope those globals to
+// the rendered kind via withSessionColumnsForKind (app layer), or it silently
+// inherits whatever kind's config was applied last in the frame.
 func RenderTable(headerLabel string, items []model.Item, cursor int, width, height int, loading bool, spinnerView string, errMsg string, showMarker ...bool) string { //nolint:gocyclo // rendering function with inherent layout complexity
 	var b strings.Builder
 
@@ -86,7 +93,11 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 			}
 		}
 
-		if ActiveMiddleScroll >= 0 && ActiveHiddenBuiltinColumns != nil {
+		// Applies to the middle column AND cursor-less right-pane previews:
+		// every preview call site swaps in the rendered kind's config via
+		// withSessionColumnsForKind, so honoring it here keeps the preview
+		// list's columns identical to the drilled-in list (issue #408).
+		if ActiveHiddenBuiltinColumns != nil {
 			if ActiveHiddenBuiltinColumns["Context"] {
 				hasContext = false
 			}
@@ -247,7 +258,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 	// column-toggle overlay (ActiveHiddenBuiltinColumns["Name"]). When hidden,
 	// ActiveNameHidden tells collectExtraColumns to skip the NAME width
 	// reservation so extras reclaim the freed space instead of leaving a gap.
-	nameHidden := ActiveMiddleScroll >= 0 && ActiveHiddenBuiltinColumns != nil && ActiveHiddenBuiltinColumns["Name"]
+	nameHidden := ActiveHiddenBuiltinColumns != nil && ActiveHiddenBuiltinColumns["Name"]
 	hasName := !nameHidden
 	ActiveNameHidden = nameHidden
 

--- a/internal/ui/explorer_table_columns.go
+++ b/internal/ui/explorer_table_columns.go
@@ -12,9 +12,12 @@ func isBuiltinColumnKey(key string) bool {
 }
 
 // orderedColumnKeys returns the ordered list of column keys that RenderTable
-// should emit for a middle-column render. "Name" is a first-class member of
-// the list (leading by default) so it can be reordered or hidden through the
-// same column-toggle machinery as every other column; hasName=false omits it.
+// should emit. ActiveColumnOrder applies to the middle column and to
+// cursor-less right-pane previews alike — preview call sites swap in the
+// rendered kind's config via withSessionColumnsForKind (issue #408). "Name"
+// is a first-class member of the list (leading by default) so it can be
+// reordered or hidden through the same column-toggle machinery as every
+// other column; hasName=false omits it.
 func orderedColumnKeys(hasName, hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge bool, extraCols []extraColumn) []string {
 	defaults := make([]string, 0, 7+len(extraCols))
 	if hasName {
@@ -42,7 +45,7 @@ func orderedColumnKeys(hasName, hasContext, hasNs, hasReady, hasRestarts, hasSta
 		defaults = append(defaults, "Age")
 	}
 
-	if ActiveMiddleScroll < 0 || ActiveColumnOrder == nil {
+	if ActiveColumnOrder == nil {
 		return defaults
 	}
 

--- a/internal/ui/explorer_table_extra_test.go
+++ b/internal/ui/explorer_table_extra_test.go
@@ -136,7 +136,11 @@ func TestRenderTable(t *testing.T) {
 		assert.NotContains(t, result, "STATUS", "STATUS header must be suppressed")
 	})
 
-	t.Run("ActiveHiddenBuiltinColumns ignored for non-middle render", func(t *testing.T) {
+	t.Run("ActiveHiddenBuiltinColumns applies to non-middle render", func(t *testing.T) {
+		// Right-pane preview renders (ActiveMiddleScroll = -1) swap in the
+		// rendered kind's config via withSessionColumnsForKind, so hidden
+		// built-ins apply there too — the preview list must show the same
+		// columns as the drilled-in list (issue #408).
 		origMS := ActiveMiddleScroll
 		ActiveMiddleScroll = -1 // non-middle render (child/right pane)
 		defer func() { ActiveMiddleScroll = origMS }()
@@ -153,7 +157,7 @@ func TestRenderTable(t *testing.T) {
 			{Name: "nginx", Ready: "1/1", Age: "5m"},
 		}
 		result := RenderTable("NAME", items, 0, 80, 20, false, "", "")
-		assert.Contains(t, result, "READY", "READY header must be shown for non-middle renders")
+		assert.NotContains(t, result, "READY", "READY header must be suppressed for non-middle renders too")
 	})
 
 	t.Run("items with namespace show NAMESPACE header", func(t *testing.T) {

--- a/internal/ui/explorer_table_preview_columns_test.go
+++ b/internal/ui/explorer_table_preview_columns_test.go
@@ -12,14 +12,38 @@ import (
 // built-ins and explicit order, applied via withSessionColumnsForKind —
 // must still take effect so the preview matches the drilled-in list.
 
-func TestRenderTableCursorlessHonorsHiddenBuiltinColumns(t *testing.T) {
+// resetColumnGlobals snapshots every column-config global RenderTable reads
+// and restores it on cleanup, then sets deterministic defaults so the test
+// outcome cannot depend on state left behind by other tests.
+func resetColumnGlobals(t *testing.T) {
+	t.Helper()
 	origHidden := ActiveHiddenBuiltinColumns
+	origOrder := ActiveColumnOrder
+	origSession := ActiveSessionColumns
+	origPrinter := ActivePrinterColumns
 	origScroll := ActiveMiddleScroll
+	origLayout := ActiveTableLayout
+	origNameHidden := ActiveNameHidden
 	t.Cleanup(func() {
 		ActiveHiddenBuiltinColumns = origHidden
+		ActiveColumnOrder = origOrder
+		ActiveSessionColumns = origSession
+		ActivePrinterColumns = origPrinter
 		ActiveMiddleScroll = origScroll
+		ActiveTableLayout = origLayout
+		ActiveNameHidden = origNameHidden
 	})
+	ActiveHiddenBuiltinColumns = nil
+	ActiveColumnOrder = nil
+	ActiveSessionColumns = nil
+	ActivePrinterColumns = nil
 	ActiveMiddleScroll = -1
+	ActiveTableLayout = nil
+	ActiveNameHidden = false
+}
+
+func TestRenderTableCursorlessHonorsHiddenBuiltinColumns(t *testing.T) {
+	resetColumnGlobals(t)
 	ActiveHiddenBuiltinColumns = map[string]bool{"Status": true, "Age": true}
 
 	items := []model.Item{
@@ -34,13 +58,7 @@ func TestRenderTableCursorlessHonorsHiddenBuiltinColumns(t *testing.T) {
 }
 
 func TestRenderTableCursorlessHonorsColumnOrder(t *testing.T) {
-	origOrder := ActiveColumnOrder
-	origScroll := ActiveMiddleScroll
-	t.Cleanup(func() {
-		ActiveColumnOrder = origOrder
-		ActiveMiddleScroll = origScroll
-	})
-	ActiveMiddleScroll = -1
+	resetColumnGlobals(t)
 	ActiveColumnOrder = []string{"Age", "Status"}
 
 	items := []model.Item{
@@ -59,14 +77,7 @@ func TestRenderTableCursorlessHonorsColumnOrder(t *testing.T) {
 }
 
 func TestRenderTableCursorlessHonorsHiddenNameColumn(t *testing.T) {
-	origHidden := ActiveHiddenBuiltinColumns
-	origScroll := ActiveMiddleScroll
-	t.Cleanup(func() {
-		ActiveHiddenBuiltinColumns = origHidden
-		ActiveMiddleScroll = origScroll
-		ActiveNameHidden = false
-	})
-	ActiveMiddleScroll = -1
+	resetColumnGlobals(t)
 	ActiveHiddenBuiltinColumns = map[string]bool{"Name": true}
 
 	items := []model.Item{

--- a/internal/ui/explorer_table_preview_columns_test.go
+++ b/internal/ui/explorer_table_preview_columns_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Issue #408: the right preview pane renders cursor-less with
+// ActiveMiddleScroll parked at -1. The user's column config — hidden
+// built-ins and explicit order, applied via withSessionColumnsForKind —
+// must still take effect so the preview matches the drilled-in list.
+
+func TestRenderTableCursorlessHonorsHiddenBuiltinColumns(t *testing.T) {
+	origHidden := ActiveHiddenBuiltinColumns
+	origScroll := ActiveMiddleScroll
+	t.Cleanup(func() {
+		ActiveHiddenBuiltinColumns = origHidden
+		ActiveMiddleScroll = origScroll
+	})
+	ActiveMiddleScroll = -1
+	ActiveHiddenBuiltinColumns = map[string]bool{"Status": true, "Age": true}
+
+	items := []model.Item{
+		{Name: "pod-a", Kind: "Pod", Status: "Running", Age: "5m"},
+		{Name: "pod-b", Kind: "Pod", Status: "Pending", Age: "1m"},
+	}
+	out := stripANSI(RenderTable("POD", items, -1, 60, 10, false, "", "", false))
+	header := strings.SplitN(out, "\n", 2)[0]
+	if strings.Contains(header, "STATUS") || strings.Contains(header, "AGE") {
+		t.Fatalf("hidden built-in columns rendered in cursor-less preview header: %q", header)
+	}
+}
+
+func TestRenderTableCursorlessHonorsColumnOrder(t *testing.T) {
+	origOrder := ActiveColumnOrder
+	origScroll := ActiveMiddleScroll
+	t.Cleanup(func() {
+		ActiveColumnOrder = origOrder
+		ActiveMiddleScroll = origScroll
+	})
+	ActiveMiddleScroll = -1
+	ActiveColumnOrder = []string{"Age", "Status"}
+
+	items := []model.Item{
+		{Name: "pod-a", Kind: "Pod", Status: "Running", Age: "5m"},
+	}
+	out := stripANSI(RenderTable("POD", items, -1, 60, 10, false, "", "", false))
+	header := strings.SplitN(out, "\n", 2)[0]
+	ageIdx := strings.Index(header, "AGE")
+	statusIdx := strings.Index(header, "STATUS")
+	if ageIdx < 0 || statusIdx < 0 {
+		t.Fatalf("expected AGE and STATUS in header, got %q", header)
+	}
+	if ageIdx > statusIdx {
+		t.Fatalf("ActiveColumnOrder ignored in cursor-less preview: header %q", header)
+	}
+}
+
+func TestRenderTableCursorlessHonorsHiddenNameColumn(t *testing.T) {
+	origHidden := ActiveHiddenBuiltinColumns
+	origScroll := ActiveMiddleScroll
+	t.Cleanup(func() {
+		ActiveHiddenBuiltinColumns = origHidden
+		ActiveMiddleScroll = origScroll
+		ActiveNameHidden = false
+	})
+	ActiveMiddleScroll = -1
+	ActiveHiddenBuiltinColumns = map[string]bool{"Name": true}
+
+	items := []model.Item{
+		{Name: "pod-a", Kind: "Pod", Status: "Running"},
+	}
+	out := stripANSI(RenderTable("POD", items, -1, 60, 10, false, "", "", false))
+	header := strings.SplitN(out, "\n", 2)[0]
+	if strings.Contains(header, "POD") {
+		t.Fatalf("hidden Name column rendered in cursor-less preview header: %q", header)
+	}
+}


### PR DESCRIPTION
Fixes #408.

The right-pane preview list (shown while hovering a resource type) rendered in API fetch order with default columns instead of matching what the drilled-in list view shows. Two independent root causes:

## Sorting

`m.rightItems` was never sorted — the middle column sorts via `sortMiddleItems` using per-kind sort memory / view config, but `updateResourcesLoadedPreview` assigned fetched items as-is.

- Extracted the `sortMiddleItems` comparator/tiebreaker core into a shared `sortItemsByColumn`, and the sort-pref resolution chain (session sort memory → `views` config `SortColumn` → Name ascending) into `kindSortPref`, so the preview and the drilled-in list resolve and apply the sort identically (including the Event "Last Seen" default).
- New `sortPreviewItems` applies it on preview loads. Items are copied first because the fresh-cache shortcut hands the handler the `itemCache` slice itself.
- `updateResourcesLoadedPreview` moved verbatim to `update_resources_loaded_preview.go` to stay under the 800-line file cap.

## Columns

`RenderTable` and `orderedColumnKeys` honored `ActiveHiddenBuiltinColumns`, hidden-Name, and `ActiveColumnOrder` only when `ActiveMiddleScroll >= 0` — i.e. only for the middle column. The preview renders cursor-less with that scroll parked at -1, so the user's hidden/reordered columns were ignored even though `withSessionColumnsForKind` already swaps in the correct per-kind config at every cursor-less call site (the gates predate that scoping). Dropped the gates and documented the scoping contract on `RenderTable`. This also fixes column config for the pinned children tables in split previews.

## Test plan

- [x] New app tests: remembered sort, view-config sort, default Name-ascending, synthetic previews keep fetch order, Event LastSeen default override
- [x] New UI tests: cursor-less `RenderTable` honors hidden built-ins, column order, and hidden Name
- [x] Inverted the existing UI test that asserted the old middle-column-only gating
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...`, `golangci-lint run` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)