### PR TITLE
feat(netpol): show network policies affecting a pod or service

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 
 - **Resource templates**: Create resources from 25+ built-in templates (`a`, `/` to search); includes a Custom Resource template as a starting point
 - **Port forwarding** from the action menu (with local port setting and browser open); manage active forwards via the Networking group
+- **Network policy visualizer**: Visualize a NetworkPolicy's ingress/egress rules (`x` → `N` on a NetworkPolicy), or list every policy affecting a Pod or Service (`x` → "Network Policies" on the resource) — including which backing pods a policy covers
 - **Clipboard support**: Copy resource name (`y`), open copy-as picker (`Y`: YAML / JSON / Table), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
 - **Bookmarks**: Save favorite resource paths for quick navigation
 - **Orphan detection**: Press `Shift+Z` (or run bare `:orphans`) to open the cluster-wide orphan overview across 11 kinds — Pods, Secrets, ConfigMaps, Services, PVCs, HPAs, PDBs, NetworkPolicies, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings. Per-list filters are still available via the filter-preset overlay (`.`) on each kind, or jump straight to a filtered view with `:orphans <kind>` (e.g., `:orphans secrets`). A strict / lenient toggle (`s`) flips between "truly unused" and "currently idle but referenced by workload templates" (e.g. CronJob between firings). Auto-excludes Helm release Secrets, ServiceAccount tokens, owner-managed resources, and `kube-root-ca.crt`.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -690,6 +690,12 @@ grants apply everywhere); RoleBindings outside the active scope are excluded.
 
 ## Network Policy Visualizer
 
+Opens via the action menu (`x` → "Visualize", default key `N`) on a NetworkPolicy,
+or via `x` → "Network Policies" (`N`) on a Pod or Service to see every policy
+whose pod selector matches the pod (or the service's backing pods). When no
+policy selects the resource, the view says so explicitly — no policy
+restrictions apply.
+
 | Key | Action |
 |---|---|
 | `j` / `k` | Scroll up/down |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -939,7 +939,7 @@ Press `:` to open the command bar. It supports four types of input:
 The action menu (`x` key) shows context-specific actions based on the resource type:
 
 ### Pod Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies whose pod selector matches this pod), `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `V` Events
 
 ### Deployment Actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `R` Rollback, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
@@ -951,7 +951,7 @@ The action menu (`x` key) shows context-specific actions based on the resource t
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
 ### Service Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `c` Capture Traffic, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies affecting the service's backing pods), `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
 
 ### Secret Actions
 `e` Secret Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -140,7 +140,7 @@ category, and every entry maps to a constant in `app_types.go`.
 | `overlayQuotaDashboard`  | `Q`, `:quota`                   | Per-namespace ResourceQuota usage.                              |
 | `overlayEventTimeline`   | `V`                             | Cluster-wide events grouped by object.                          |
 | `overlayAlerts`          | from monitoring view            | Active Prometheus alerts.                                       |
-| `overlayNetworkPolicy`   | from netpol view                | Visualize selected NetworkPolicy.                               |
+| `overlayNetworkPolicy`   | action menu → `N` on NetworkPolicy / Pod / Service | Visualize a NetworkPolicy, or every policy affecting a Pod / Service. |
 | `overlayCanI`            | `U` → can-i flow (after subject) | Display can-i evaluation results.                               |
 | `overlayAutoSync`        | ArgoCD app                      | Toggle auto-sync settings.                                      |
 | `overlaySyncWave`        | action menu → `W` on Application | Per-Application ArgoCD sync wave timeline.                      |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -630,8 +630,11 @@ type Model struct {
 	alertsScroll    int             // scroll position in alerts overlay
 	alertsLineInput string          // digit buffer for 123G jump-to-line
 
-	// Network policy visualizer state.
+	// Network policy visualizer state. netpolData holds the single-policy
+	// view (Visualize on a NetworkPolicy); netpolsData the multi-policy view
+	// (Network Policies on a Pod/Service). Exactly one is set at a time.
 	netpolData      *k8s.NetworkPolicyInfo
+	netpolsData     *k8s.NetpolsForResource
 	netpolScroll    int
 	netpolLineInput string // digit buffer for 123G jump-to-line
 

--- a/internal/app/commands_load_preview.go
+++ b/internal/app/commands_load_preview.go
@@ -403,6 +403,32 @@ func (m Model) loadNetworkPolicy() tea.Cmd {
 	)
 }
 
+// loadNetworkPoliciesForResource fetches the network policies that select the
+// pod or service in the action context, for the "Network Policies" action.
+func (m Model) loadNetworkPoliciesForResource() tea.Cmd {
+	client := m.client
+	kctx := m.actionCtx.context
+	ns := m.actionCtx.namespace
+	name := m.actionCtx.name
+	kind := m.actionCtx.kind
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"Network Policies: "+kind+"/"+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			var info *k8s.NetpolsForResource
+			var err error
+			if kind == "Service" {
+				info, err = client.GetNetworkPoliciesForService(ctx, kctx, ns, name)
+			} else {
+				info, err = client.GetNetworkPoliciesForPod(ctx, kctx, ns, name)
+			}
+			return netpolsForResourceLoadedMsg{info: info, err: err}
+		},
+	)
+}
+
 // loadHelmValues runs `helm get values` and returns the output as a message.
 // If allValues is true, the --all flag is included to show computed defaults too.
 func (m Model) loadHelmValues(allValues bool) tea.Cmd {

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -536,6 +536,13 @@ type netpolLoadedMsg struct {
 	err  error
 }
 
+// netpolsForResourceLoadedMsg carries the network policies affecting a pod or
+// service, for the "Network Policies" action.
+type netpolsForResourceLoadedMsg struct {
+	info *k8s.NetpolsForResource
+	err  error
+}
+
 // previewEventsLoadedMsg carries events for the preview pane.
 type previewEventsLoadedMsg struct {
 	events []k8s.EventInfo

--- a/internal/app/netpols_action_test.go
+++ b/internal/app/netpols_action_test.go
@@ -1,0 +1,224 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func netpolTestPodObj(name, namespace string, lbls map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: lbls},
+	}
+}
+
+// netpolsTestModel returns a Model whose dynamic fake knows the pods,
+// services, and networkpolicies GVRs, with scheduler workers started.
+func netpolsTestModel(t *testing.T, objs ...runtime.Object) Model {
+	t.Helper()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}:                             "PodList",
+		{Group: "", Version: "v1", Resource: "services"}:                         "ServiceList",
+		{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}: "NetworkPolicyList",
+	}
+	m := baseModelWithFakeDynamic(gvrToListKind, objs...)
+	m.scheduler.StartWorkers()
+	t.Cleanup(m.scheduler.StopWorkers)
+	return m
+}
+
+func TestLoadNetworkPoliciesForResource_Pod(t *testing.T) {
+	m := netpolsTestModel(t,
+		netpolTestPodObj("my-pod", "default", map[string]string{"app": "web"}))
+	m = withActionCtx(m, "my-pod", "default", "Pod", model.ResourceTypeEntry{})
+	cmd := m.loadNetworkPoliciesForResource()
+	msg := execCmd(t, cmd)
+	result, ok := msg.(netpolsForResourceLoadedMsg)
+	require.True(t, ok)
+	require.NoError(t, result.err)
+	assert.Equal(t, "Pod", result.info.Kind)
+	assert.Equal(t, "my-pod", result.info.Name)
+	assert.Empty(t, result.info.Policies)
+}
+
+func TestLoadNetworkPoliciesForResource_PodNotFound(t *testing.T) {
+	m := netpolsTestModel(t)
+	m = withActionCtx(m, "missing-pod", "default", "Pod", model.ResourceTypeEntry{})
+	cmd := m.loadNetworkPoliciesForResource()
+	msg := execCmd(t, cmd)
+	result, ok := msg.(netpolsForResourceLoadedMsg)
+	require.True(t, ok)
+	assert.Error(t, result.err)
+}
+
+func TestLoadNetworkPoliciesForResource_Service(t *testing.T) {
+	svc := &corev1.Service{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+	}
+	m := netpolsTestModel(t, svc,
+		netpolTestPodObj("web-1", "default", map[string]string{"app": "web"}))
+	m = withActionCtx(m, "my-svc", "default", "Service", model.ResourceTypeEntry{})
+	cmd := m.loadNetworkPoliciesForResource()
+	msg := execCmd(t, cmd)
+	result, ok := msg.(netpolsForResourceLoadedMsg)
+	require.True(t, ok)
+	require.NoError(t, result.err)
+	assert.Equal(t, "Service", result.info.Kind)
+	assert.Equal(t, []string{"web-1"}, result.info.BackingPods)
+}
+
+func TestExecuteActionNetworkPolicies(t *testing.T) {
+	m := netpolsTestModel(t,
+		netpolTestPodObj("my-pod", "default", map[string]string{"app": "web"}))
+	m = withActionCtx(m, "my-pod", "default", "Pod", model.ResourceTypeEntry{})
+	mdl, cmd, ok := m.executeActionCoreK8s("Network Policies")
+	require.True(t, ok, "Network Policies must be dispatched")
+	require.NotNil(t, cmd)
+	result := mdl.(Model)
+	assert.True(t, result.loading)
+}
+
+func TestUpdateNetpolsForResourceLoaded(t *testing.T) {
+	m := baseOverlayModel()
+	info := &k8s.NetpolsForResource{Kind: "Pod", Name: "my-pod", Namespace: "default"}
+	result, _ := m.Update(netpolsForResourceLoadedMsg{info: info})
+	mdl := result.(Model)
+	assert.Equal(t, overlayNetworkPolicy, mdl.overlay)
+	assert.Equal(t, info, mdl.netpolsData)
+	assert.Equal(t, 0, mdl.netpolScroll)
+	assert.False(t, mdl.loading)
+}
+
+func TestUpdateNetpolsForResourceLoadedError(t *testing.T) {
+	m := baseOverlayModel()
+	result, cmd := m.Update(netpolsForResourceLoadedMsg{err: assert.AnError})
+	mdl := result.(Model)
+	assert.NotEqual(t, overlayNetworkPolicy, mdl.overlay)
+	assert.Nil(t, mdl.netpolsData)
+	assert.NotEmpty(t, mdl.statusMessage)
+	assert.NotNil(t, cmd)
+}
+
+func TestRenderOverlayNetworkPoliciesMulti(t *testing.T) {
+	m := baseOverlayModel()
+	m.overlay = overlayNetworkPolicy
+	m.netpolsData = &k8s.NetpolsForResource{
+		Kind:      "Pod",
+		Name:      "my-pod",
+		Namespace: "default",
+		Policies: []k8s.NetpolForResource{
+			{
+				NetworkPolicyInfo: k8s.NetworkPolicyInfo{
+					Name:        "allow-web",
+					Namespace:   "default",
+					PodSelector: map[string]string{"app": "web"},
+					PolicyTypes: []string{"Ingress"},
+					IngressRules: []k8s.NetpolRule{
+						{
+							Ports: []k8s.NetpolPort{{Protocol: "TCP", Port: "80"}},
+							Peers: []k8s.NetpolPeer{{Type: "Pod", Selector: map[string]string{"role": "frontend"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	bg := strings.Repeat("bg\n", 10)
+	result := stripANSI(m.renderOverlay(bg))
+	assert.Contains(t, result, "Pod: my-pod")
+	assert.Contains(t, result, "allow-web")
+}
+
+func TestRenderOverlayNetworkPoliciesMultiEmpty(t *testing.T) {
+	m := baseOverlayModel()
+	m.overlay = overlayNetworkPolicy
+	m.netpolsData = &k8s.NetpolsForResource{Kind: "Pod", Name: "my-pod", Namespace: "default"}
+	bg := strings.Repeat("bg\n", 10)
+	result := stripANSI(m.renderOverlay(bg))
+	assert.Contains(t, result, "No network policies")
+}
+
+// tallNetpolModel returns a model showing a multi-policy overlay whose
+// content is much taller than the viewport, so scrolling is exercised.
+func tallNetpolModel() Model {
+	m := baseOverlayModel()
+	m.overlay = overlayNetworkPolicy
+	policies := make([]k8s.NetpolForResource, 10)
+	for i := range policies {
+		policies[i] = k8s.NetpolForResource{NetworkPolicyInfo: k8s.NetworkPolicyInfo{
+			Name:        "policy-" + string(rune('a'+i)),
+			Namespace:   "default",
+			PolicyTypes: []string{"Ingress", "Egress"},
+		}}
+	}
+	m.netpolsData = &k8s.NetpolsForResource{
+		Kind: "Pod", Name: "my-pod", Namespace: "default", Policies: policies,
+	}
+	return m
+}
+
+// Pressing down past the bottom must not run the scroll counter ahead: a
+// single up keypress afterwards must immediately move the view.
+func TestNetpolOverlayScrollClampedAtBottom(t *testing.T) {
+	m := tallNetpolModel()
+	maxScroll := m.netpolMaxScroll()
+	require.Positive(t, maxScroll)
+
+	for range maxScroll + 50 {
+		m = m.handleNetworkPolicyOverlayKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	}
+	assert.Equal(t, maxScroll, m.netpolScroll, "j must clamp at the bottom")
+
+	m = m.handleNetworkPolicyOverlayKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	assert.Equal(t, maxScroll-1, m.netpolScroll, "first k after the bottom must scroll up")
+}
+
+func TestNetpolOverlayPagingClampedAtBottom(t *testing.T) {
+	m := tallNetpolModel()
+	maxScroll := m.netpolMaxScroll()
+	require.Positive(t, maxScroll)
+
+	for range 20 {
+		m = m.handleNetworkPolicyOverlayKey(tea.KeyMsg{Type: tea.KeyCtrlF})
+	}
+	assert.Equal(t, maxScroll, m.netpolScroll, "ctrl+f must clamp at the bottom")
+
+	for range 20 {
+		m = m.handleNetworkPolicyOverlayKey(tea.KeyMsg{Type: tea.KeyCtrlD})
+	}
+	assert.Equal(t, maxScroll, m.netpolScroll, "ctrl+d must clamp at the bottom")
+}
+
+func TestNetpolOverlayJumpToBottomClamped(t *testing.T) {
+	m := tallNetpolModel()
+	maxScroll := m.netpolMaxScroll()
+
+	m = m.handleNetworkPolicyOverlayKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("G")})
+	assert.Equal(t, maxScroll, m.netpolScroll, "G must land exactly on the bottom")
+
+	m.netpolScroll = 0
+	m = m.handleNetworkPolicyOverlayKey(tea.KeyMsg{Type: tea.KeyEnd})
+	assert.Equal(t, maxScroll, m.netpolScroll, "end must land exactly on the bottom")
+}
+
+func TestNetpolOverlayEscClearsMultiData(t *testing.T) {
+	m := baseOverlayModel()
+	m.overlay = overlayNetworkPolicy
+	m.netpolsData = &k8s.NetpolsForResource{Kind: "Pod", Name: "my-pod", Namespace: "default"}
+	result := m.handleNetworkPolicyOverlayKey(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.Equal(t, overlayNone, result.overlay)
+	assert.Nil(t, result.netpolsData)
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -347,8 +347,8 @@ func (m Model) updateActionResultMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case alertsLoadedMsg:
 		mdl, cmd := m.updateAlertsLoaded(msg)
 		return mdl, cmd, true
-	case netpolLoadedMsg:
-		mdl, cmd := m.updateNetpolLoaded(msg)
+	case netpolLoadedMsg, netpolsForResourceLoadedMsg:
+		mdl, cmd := m.routeNetpolMsg(msg)
 		return mdl, cmd, true
 	case orphansLoadedMsg:
 		mdl, cmd := m.handleOrphansLoaded(msg)

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -444,6 +444,9 @@ func (m Model) executeActionCoreK8s(actionLabel string) (tea.Model, tea.Cmd, boo
 	case "Events":
 		mdl, cmd := m.executeActionEvents()
 		return mdl, cmd, true
+	case "Network Policies":
+		mdl, cmd := m.executeActionNetworkPolicies()
+		return mdl, cmd, true
 	}
 	return m, nil, false
 }

--- a/internal/app/update_actions_misc.go
+++ b/internal/app/update_actions_misc.go
@@ -170,6 +170,12 @@ func (m Model) executeActionVisualize() (tea.Model, tea.Cmd) {
 	return m, m.loadNetworkPolicy()
 }
 
+func (m Model) executeActionNetworkPolicies() (tea.Model, tea.Cmd) {
+	m.loading = true
+	m.setStatusMessage("Loading network policies...", false)
+	return m, m.loadNetworkPoliciesForResource()
+}
+
 func (m Model) executeActionDefault(actionLabel string) (tea.Model, tea.Cmd) {
 	if ca, ok := findCustomAction(m.actionCtx.kind, actionLabel); ok {
 		// Custom actions are arbitrary shell commands. Block them in

--- a/internal/app/update_nav_pckeys_test.go
+++ b/internal/app/update_nav_pckeys_test.go
@@ -948,12 +948,23 @@ func TestPCKeysExplainEndJumpsToBottom(t *testing.T) {
 // --- Network Policy Visualizer (handleNetworkPolicyOverlayKey) ------------------
 
 func netpolModel() Model {
+	// Enough rules that the content is far taller than the viewport, so
+	// paging keys have room to move before hitting the scroll bound.
+	rules := make([]k8s.NetpolRule, 30)
+	for i := range rules {
+		rules[i] = k8s.NetpolRule{Peers: []k8s.NetpolPeer{{Type: "All"}}}
+	}
 	return Model{
 		overlay:      overlayNetworkPolicy,
 		netpolScroll: 0,
-		tabs:         []TabState{{}},
-		width:        80,
-		height:       40,
+		netpolData: &k8s.NetworkPolicyInfo{
+			Name: "tall-policy", Namespace: "default",
+			PolicyTypes:  []string{"Ingress"},
+			IngressRules: rules,
+		},
+		tabs:   []TabState{{}},
+		width:  80,
+		height: 40,
 	}
 }
 
@@ -993,9 +1004,10 @@ func TestPCKeysNetworkPolicyEndJumpsToBottom(t *testing.T) {
 	m.netpolScroll = 0
 	m.netpolLineInput = "42"
 	r := m.handleNetworkPolicyOverlayKey(keyMsg("end"))
-	// G with no line input jumps to 9999 (sentinel clamped at render time).
-	assert.Equal(t, 9999, r.netpolScroll,
-		"end should match G (9999) regardless of netpolLineInput")
+	// End matches G with no line input: jump exactly to the bottom.
+	assert.Equal(t, m.netpolMaxScroll(), r.netpolScroll,
+		"end should match G (bottom) regardless of netpolLineInput")
+	assert.Positive(t, r.netpolScroll)
 	assert.Empty(t, r.netpolLineInput, "end should clear netpolLineInput")
 }
 

--- a/internal/app/update_overlays_misc.go
+++ b/internal/app/update_overlays_misc.go
@@ -16,9 +16,10 @@ func (m Model) handleNetworkPolicyOverlayKey(msg tea.KeyMsg) Model {
 		m.netpolLineInput = ""
 		m.overlay = overlayNone
 		m.netpolData = nil
+		m.netpolsData = nil
 	case "j", "down":
 		m.netpolLineInput = ""
-		m.netpolScroll++
+		m.netpolScroll = min(m.netpolScroll+1, m.netpolMaxScroll())
 	case "k", "up":
 		m.netpolLineInput = ""
 		if m.netpolScroll > 0 {
@@ -39,10 +40,9 @@ func (m Model) handleNetworkPolicyOverlayKey(msg tea.KeyMsg) Model {
 			if lineNum > 0 {
 				lineNum--
 			}
-			m.netpolScroll = lineNum
+			m.netpolScroll = min(lineNum, m.netpolMaxScroll())
 		} else {
-			// Jump to bottom: will be clamped during rendering.
-			m.netpolScroll = 9999
+			m.netpolScroll = m.netpolMaxScroll()
 		}
 	case "1", "2", "3", "4", "5", "6", "7", "8", "9":
 		m.netpolLineInput += msg.String()
@@ -54,30 +54,23 @@ func (m Model) handleNetworkPolicyOverlayKey(msg tea.KeyMsg) Model {
 		}
 	case "ctrl+d", "shift+down":
 		m.netpolLineInput = ""
-		m.netpolScroll += m.height / 2
+		m.netpolScroll = min(m.netpolScroll+m.height/2, m.netpolMaxScroll())
 	case "ctrl+u", "shift+up":
 		m.netpolLineInput = ""
-		m.netpolScroll -= m.height / 2
-		if m.netpolScroll < 0 {
-			m.netpolScroll = 0
-		}
+		m.netpolScroll = max(m.netpolScroll-m.height/2, 0)
 	case "ctrl+f", "pgdown":
 		m.netpolLineInput = ""
-		m.netpolScroll += m.height
+		m.netpolScroll = min(m.netpolScroll+m.height, m.netpolMaxScroll())
 	case "ctrl+b", "pgup":
 		m.netpolLineInput = ""
-		m.netpolScroll -= m.height
-		if m.netpolScroll < 0 {
-			m.netpolScroll = 0
-		}
+		m.netpolScroll = max(m.netpolScroll-m.height, 0)
 	case "home":
 		m.pendingG = false
 		m.netpolLineInput = ""
 		m.netpolScroll = 0
 	case "end":
 		m.netpolLineInput = ""
-		// Jump to bottom: will be clamped during rendering (matches G behavior).
-		m.netpolScroll = 9999
+		m.netpolScroll = m.netpolMaxScroll()
 	default:
 		m.netpolLineInput = ""
 	}

--- a/internal/app/update_overlays_test.go
+++ b/internal/app/update_overlays_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
@@ -249,6 +250,9 @@ func TestEventTimelineCtrlBScrollsBackFullPage(t *testing.T) {
 // --- handleNetworkPolicyOverlayKey ---
 
 func TestNetworkPolicyOverlayKeyNavigation(t *testing.T) {
+	// expectedScroll -1 means "the bottom" (resolved per model below); scroll
+	// moves are clamped against the loaded content, so the fixture needs
+	// content taller than every expected position.
 	tests := []struct {
 		name           string
 		key            tea.KeyMsg
@@ -262,7 +266,7 @@ func TestNetworkPolicyOverlayKeyNavigation(t *testing.T) {
 		{name: "j scrolls down", key: runeKey('j'), startScroll: 0, height: 40, expectedScroll: 1},
 		{name: "k scrolls up", key: runeKey('k'), startScroll: 5, height: 40, expectedScroll: 4},
 		{name: "k at zero stays", key: runeKey('k'), startScroll: 0, height: 40, expectedScroll: 0},
-		{name: "G jumps to bottom", key: runeKey('G'), startScroll: 0, height: 40, expectedScroll: 9999},
+		{name: "G jumps to bottom", key: runeKey('G'), startScroll: 0, height: 40, expectedScroll: -1},
 		{name: "ctrl+d half page down", key: tea.KeyMsg{Type: tea.KeyCtrlD}, startScroll: 0, height: 40, expectedScroll: 20},
 		{name: "ctrl+u half page up", key: tea.KeyMsg{Type: tea.KeyCtrlU}, startScroll: 30, height: 40, expectedScroll: 10},
 		{name: "ctrl+u clamps to zero", key: tea.KeyMsg{Type: tea.KeyCtrlU}, startScroll: 5, height: 40, expectedScroll: 0},
@@ -272,19 +276,22 @@ func TestNetworkPolicyOverlayKeyNavigation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Model{
-				overlay:      overlayNetworkPolicy,
-				netpolScroll: tt.startScroll,
-				tabs:         []TabState{{}},
-				width:        80,
-				height:       tt.height,
+			m := netpolModel()
+			m.netpolScroll = tt.startScroll
+			m.height = tt.height
+			expected := tt.expectedScroll
+			if expected == -1 {
+				expected = m.netpolMaxScroll()
+				require.Positive(t, expected)
 			}
+			require.GreaterOrEqual(t, m.netpolMaxScroll(), expected,
+				"fixture content too short for this case")
 			result := m.handleNetworkPolicyOverlayKey(tt.key)
 			if tt.expectClosed {
 				assert.Equal(t, overlayNone, result.overlay)
 				assert.Nil(t, result.netpolData)
 			} else {
-				assert.Equal(t, tt.expectedScroll, result.netpolScroll)
+				assert.Equal(t, expected, result.netpolScroll)
 			}
 		})
 	}

--- a/internal/app/update_rbac_msgs.go
+++ b/internal/app/update_rbac_msgs.go
@@ -131,6 +131,17 @@ func (m Model) updateAlertsLoaded(msg alertsLoadedMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// routeNetpolMsg dispatches single- and multi-policy load results.
+func (m Model) routeNetpolMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case netpolLoadedMsg:
+		return m.updateNetpolLoaded(msg)
+	case netpolsForResourceLoadedMsg:
+		return m.updateNetpolsForResourceLoaded(msg)
+	}
+	return m, nil
+}
+
 func (m Model) updateNetpolLoaded(msg netpolLoadedMsg) (tea.Model, tea.Cmd) {
 	m.loading = false
 	if msg.err != nil {
@@ -138,6 +149,20 @@ func (m Model) updateNetpolLoaded(msg netpolLoadedMsg) (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 	m.netpolData = msg.info
+	m.netpolsData = nil
+	m.netpolScroll = 0
+	m.overlay = overlayNetworkPolicy
+	return m, nil
+}
+
+func (m Model) updateNetpolsForResourceLoaded(msg netpolsForResourceLoadedMsg) (tea.Model, tea.Cmd) {
+	m.loading = false
+	if msg.err != nil {
+		m.setStatusMessage(fmt.Sprintf("Failed to load network policies: %v", msg.err), true)
+		return m, scheduleStatusClear()
+	}
+	m.netpolsData = msg.info
+	m.netpolData = nil
 	m.netpolScroll = 0
 	m.overlay = overlayNetworkPolicy
 	return m, nil

--- a/internal/app/view_overlay_netpol.go
+++ b/internal/app/view_overlay_netpol.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// renderOverlayNetworkPolicy renders the network policy visualizer: the
+// single-policy view when netpolData is set (Visualize on a NetworkPolicy),
+// or the multi-policy view when netpolsData is set (Network Policies on a
+// Pod/Service).
+// netpolOverlayDims returns the overlay frame width and its inner content
+// area. The key handler derives scroll bounds from the same numbers the
+// renderer draws with.
+func (m Model) netpolOverlayDims() (w, innerW, innerH int) {
+	w, h := min(100, m.width-6), min(35, m.height-4)
+	return w, w - 4, h - 2
+}
+
+// netpolMaxScroll returns the bottom scroll position for the currently
+// loaded netpol overlay content; 0 when nothing is loaded.
+func (m Model) netpolMaxScroll() int {
+	_, innerW, innerH := m.netpolOverlayDims()
+	switch {
+	case m.netpolsData != nil:
+		return ui.OverlayMaxScroll(ui.NetworkPoliciesOverlayLineCount(convertNetpolsForResource(m.netpolsData), innerW), innerH)
+	case m.netpolData != nil:
+		return ui.OverlayMaxScroll(ui.NetworkPolicyOverlayLineCount(convertNetpolInfo(*m.netpolData), innerW), innerH)
+	}
+	return 0
+}
+
+func (m Model) renderOverlayNetworkPolicy(background string) string {
+	if m.netpolData == nil && m.netpolsData == nil {
+		return ""
+	}
+	w, innerW, innerH := m.netpolOverlayDims()
+	var netpolContent string
+	if m.netpolsData != nil {
+		netpolContent = ui.RenderNetworkPoliciesOverlay(convertNetpolsForResource(m.netpolsData), m.netpolScroll, innerW, innerH)
+	} else {
+		netpolContent = ui.RenderNetworkPolicyOverlay(convertNetpolInfo(*m.netpolData), m.netpolScroll, innerW, innerH)
+	}
+	netpolContent = ui.FillLinesBg(netpolContent, innerW, ui.SurfaceBg)
+	overlay := ui.OverlayStyle.Width(w).Render(netpolContent)
+	bg := ui.PadToHeight(background, m.height)
+	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
+}
+
+// convertNetpolInfo converts a k8s network policy info into its ui entry.
+func convertNetpolInfo(info k8s.NetworkPolicyInfo) ui.NetworkPolicyEntry {
+	entry := ui.NetworkPolicyEntry{
+		Name: info.Name, Namespace: info.Namespace,
+		PodSelector: info.PodSelector, PolicyTypes: info.PolicyTypes,
+		AffectedPods: info.AffectedPods,
+	}
+	for _, r := range info.IngressRules {
+		entry.IngressRules = append(entry.IngressRules, convertNetpolRule(r))
+	}
+	for _, r := range info.EgressRules {
+		entry.EgressRules = append(entry.EgressRules, convertNetpolRule(r))
+	}
+	return entry
+}
+
+// convertNetpolsForResource converts the multi-policy k8s result into its ui entry.
+func convertNetpolsForResource(info *k8s.NetpolsForResource) ui.ResourceNetpolsEntry {
+	entry := ui.ResourceNetpolsEntry{
+		Kind:        info.Kind,
+		Name:        info.Name,
+		Namespace:   info.Namespace,
+		NoSelector:  info.NoSelector,
+		BackingPods: info.BackingPods,
+	}
+	for _, pol := range info.Policies {
+		polEntry := convertNetpolInfo(pol.NetworkPolicyInfo)
+		polEntry.MatchedPods = pol.MatchedPods
+		entry.Policies = append(entry.Policies, polEntry)
+	}
+	return entry
+}
+
+// convertNetpolRule converts a k8s.NetpolRule to a ui.NetpolRuleEntry.
+func convertNetpolRule(r k8s.NetpolRule) ui.NetpolRuleEntry {
+	re := ui.NetpolRuleEntry{}
+	for _, p := range r.Ports {
+		re.Ports = append(re.Ports, ui.NetpolPortEntry{Protocol: p.Protocol, Port: p.Port})
+	}
+	for _, p := range r.Peers {
+		re.Peers = append(re.Peers, ui.NetpolPeerEntry{
+			Type: p.Type, Selector: p.Selector,
+			CIDR: p.CIDR, Except: p.Except, Namespace: p.Namespace,
+		})
+	}
+	return re
+}

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
-	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -518,30 +517,6 @@ func (m Model) renderOverlayCanISubject(background string) string {
 	return ui.PlaceOverlay(m.width, m.height, overlay, canIBg)
 }
 
-func (m Model) renderOverlayNetworkPolicy(background string) string {
-	if m.netpolData == nil {
-		return ""
-	}
-	entry := ui.NetworkPolicyEntry{
-		Name: m.netpolData.Name, Namespace: m.netpolData.Namespace,
-		PodSelector: m.netpolData.PodSelector, PolicyTypes: m.netpolData.PolicyTypes,
-		AffectedPods: m.netpolData.AffectedPods,
-	}
-	for _, r := range m.netpolData.IngressRules {
-		entry.IngressRules = append(entry.IngressRules, convertNetpolRule(r))
-	}
-	for _, r := range m.netpolData.EgressRules {
-		entry.EgressRules = append(entry.EgressRules, convertNetpolRule(r))
-	}
-	w, h := min(100, m.width-6), min(35, m.height-4)
-	innerW, innerH := w-4, h-2
-	netpolContent := ui.RenderNetworkPolicyOverlay(entry, m.netpolScroll, innerW, innerH)
-	netpolContent = ui.FillLinesBg(netpolContent, innerW, ui.SurfaceBg)
-	overlay := ui.OverlayStyle.Width(w).Render(netpolContent)
-	bg := ui.PadToHeight(background, m.height)
-	return ui.PlaceOverlay(m.width, m.height, overlay, bg)
-}
-
 func (m Model) renderOverlayFullscreen(background string) string {
 	var overlay string
 	switch m.overlay {
@@ -639,21 +614,6 @@ func (m Model) renderOverlayFinalizerSearch() (string, int, int) {
 		m.finalizerSearchPattern, m.finalizerSearchFilter, m.finalizerSearchFilterActive,
 		m.finalizerSearchLoading, w, h,
 	), w, h
-}
-
-// convertNetpolRule converts a k8s.NetpolRule to a ui.NetpolRuleEntry.
-func convertNetpolRule(r k8s.NetpolRule) ui.NetpolRuleEntry {
-	re := ui.NetpolRuleEntry{}
-	for _, p := range r.Ports {
-		re.Ports = append(re.Ports, ui.NetpolPortEntry{Protocol: p.Protocol, Port: p.Port})
-	}
-	for _, p := range r.Peers {
-		re.Peers = append(re.Peers, ui.NetpolPeerEntry{
-			Type: p.Type, Selector: p.Selector,
-			CIDR: p.CIDR, Except: p.Except, Namespace: p.Namespace,
-		})
-	}
-	return re
 }
 
 // renderCanIOverlay renders the Can-I browser overlay on top of the

--- a/internal/k8s/netpol.go
+++ b/internal/k8s/netpol.go
@@ -73,6 +73,17 @@ func (c *Client) GetNetworkPolicyInfo(ctx context.Context, kubeCtx, namespace, n
 		return info, nil
 	}
 
+	populateNetpolSpec(info, spec)
+
+	// Find affected pods matching the pod selector.
+	info.AffectedPods = findAffectedPods(ctx, dynClient, namespace, info.PodSelector)
+
+	return info, nil
+}
+
+// populateNetpolSpec fills selector, policy types, and rules from a
+// NetworkPolicy spec map.
+func populateNetpolSpec(info *NetworkPolicyInfo, spec map[string]any) {
 	// Extract podSelector.
 	if podSel, ok := spec["podSelector"].(map[string]any); ok {
 		if matchLabels, ok := podSel["matchLabels"].(map[string]any); ok {
@@ -103,11 +114,6 @@ func (c *Client) GetNetworkPolicyInfo(ctx context.Context, kubeCtx, namespace, n
 			info.EgressRules = append(info.EgressRules, parseNetpolRule(rule, "to"))
 		}
 	}
-
-	// Find affected pods matching the pod selector.
-	info.AffectedPods = findAffectedPods(ctx, dynClient, namespace, info.PodSelector)
-
-	return info, nil
 }
 
 // parseNetpolRule extracts ports and peers from a single ingress/egress rule.

--- a/internal/k8s/netpol_matching.go
+++ b/internal/k8s/netpol_matching.go
@@ -1,0 +1,193 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// NetpolsForResource holds the network policies that select a pod or a
+// service's backing pods, shown by the "Network Policies" action.
+type NetpolsForResource struct {
+	Kind        string // "Pod" or "Service"
+	Name        string
+	Namespace   string
+	NoSelector  bool     // Service only: the service defines no pod selector
+	BackingPods []string // Service only: pods backing the service
+	Policies    []NetpolForResource
+}
+
+// NetpolForResource is a matching policy plus, for services, the subset of
+// the service's backing pods it selects.
+type NetpolForResource struct {
+	NetworkPolicyInfo
+	MatchedPods []string // Service only: backing pods this policy selects
+}
+
+// GetNetworkPoliciesForPod returns the NetworkPolicies in the pod's namespace
+// whose podSelector selects the given pod.
+func (c *Client) GetNetworkPoliciesForPod(ctx context.Context, kubeCtx, namespace, podName string) (*NetpolsForResource, error) {
+	dynClient, err := c.dynamicForContext(kubeCtx)
+	if err != nil {
+		return nil, fmt.Errorf("creating dynamic client: %w", err)
+	}
+
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	pod, err := dynClient.Resource(podGVR).Namespace(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting pod %s: %w", podName, err)
+	}
+	podLabels := labels.Set(pod.GetLabels())
+
+	policies, pods, err := listNetpolsAndPods(ctx, dynClient, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("loading policies for pod %s: %w", podName, err)
+	}
+
+	result := &NetpolsForResource{Kind: "Pod", Name: podName, Namespace: namespace}
+	for i := range policies {
+		sel, info := parseNetpolForMatch(&policies[i])
+		if sel == nil || !sel.Matches(podLabels) {
+			continue
+		}
+		info.AffectedPods = matchingPodNames(pods, sel)
+		result.Policies = append(result.Policies, NetpolForResource{NetworkPolicyInfo: *info})
+	}
+	sortNetpolsByName(result.Policies)
+	return result, nil
+}
+
+// GetNetworkPoliciesForService returns the NetworkPolicies in the service's
+// namespace that select at least one of the service's backing pods. Each
+// returned policy records which backing pods it covers, since a policy may
+// select only a subset of them.
+func (c *Client) GetNetworkPoliciesForService(ctx context.Context, kubeCtx, namespace, svcName string) (*NetpolsForResource, error) {
+	dynClient, err := c.dynamicForContext(kubeCtx)
+	if err != nil {
+		return nil, fmt.Errorf("creating dynamic client: %w", err)
+	}
+
+	svcGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	svc, err := dynClient.Resource(svcGVR).Namespace(namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting service %s: %w", svcName, err)
+	}
+
+	result := &NetpolsForResource{Kind: "Service", Name: svcName, Namespace: namespace}
+
+	selector, _, _ := unstructured.NestedStringMap(svc.Object, "spec", "selector")
+	if len(selector) == 0 {
+		// ExternalName services or manually-managed endpoints: pod-selector
+		// based policies cannot be resolved against this service.
+		result.NoSelector = true
+		return result, nil
+	}
+	svcSelector := labels.SelectorFromSet(selector)
+
+	policies, pods, err := listNetpolsAndPods(ctx, dynClient, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("loading policies for service %s: %w", svcName, err)
+	}
+
+	result.BackingPods = matchingPodNames(pods, svcSelector)
+
+	// A policy counts if it selects at least one backing pod. This includes
+	// namespace-wide policies (empty podSelector): they do apply to the
+	// service's pods, and the per-policy coverage line shows the extent.
+	for i := range policies {
+		sel, info := parseNetpolForMatch(&policies[i])
+		if sel == nil {
+			continue
+		}
+		var matched []string
+		for _, p := range pods {
+			podLabels := labels.Set(p.GetLabels())
+			if svcSelector.Matches(podLabels) && sel.Matches(podLabels) {
+				matched = append(matched, p.GetName())
+			}
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		sort.Strings(matched)
+		info.AffectedPods = matchingPodNames(pods, sel)
+		result.Policies = append(result.Policies, NetpolForResource{NetworkPolicyInfo: *info, MatchedPods: matched})
+	}
+	sortNetpolsByName(result.Policies)
+	return result, nil
+}
+
+// listNetpolsAndPods lists the namespace's network policies and pods in two
+// calls, so per-policy matching happens locally instead of one API list per
+// policy.
+func listNetpolsAndPods(ctx context.Context, dynClient dynamic.Interface, namespace string) ([]unstructured.Unstructured, []unstructured.Unstructured, error) {
+	netpolGVR := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
+	polList, err := dynClient.Resource(netpolGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing network policies: %w", err)
+	}
+
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	podList, err := dynClient.Resource(podGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing pods: %w", err)
+	}
+
+	return polList.Items, podList.Items, nil
+}
+
+// parseNetpolForMatch parses a NetworkPolicy object into a label selector and
+// a display info struct. The selector honors both matchLabels and
+// matchExpressions; an empty podSelector selects all pods in the namespace.
+// Returns a nil selector if the podSelector cannot be parsed.
+func parseNetpolForMatch(obj *unstructured.Unstructured) (labels.Selector, *NetworkPolicyInfo) {
+	info := &NetworkPolicyInfo{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+
+	// An absent or empty podSelector selects all pods in the namespace, so
+	// the zero LabelSelector (-> labels.Everything) is the correct default.
+	var ls metav1.LabelSelector
+	spec, _ := obj.Object["spec"].(map[string]any)
+	if spec != nil {
+		populateNetpolSpec(info, spec)
+		if podSel, found, _ := unstructured.NestedMap(spec, "podSelector"); found {
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(podSel, &ls); err != nil {
+				return nil, info
+			}
+		}
+	}
+	sel, err := metav1.LabelSelectorAsSelector(&ls)
+	if err != nil {
+		return nil, info
+	}
+	return sel, info
+}
+
+// matchingPodNames returns the sorted names of pods whose labels match the
+// selector.
+func matchingPodNames(pods []unstructured.Unstructured, sel labels.Selector) []string {
+	var names []string
+	for _, p := range pods {
+		if sel.Matches(labels.Set(p.GetLabels())) {
+			names = append(names, p.GetName())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// sortNetpolsByName sorts policies alphabetically for deterministic display.
+func sortNetpolsByName(policies []NetpolForResource) {
+	sort.Slice(policies, func(i, j int) bool {
+		return policies[i].Name < policies[j].Name
+	})
+}

--- a/internal/k8s/netpol_matching_test.go
+++ b/internal/k8s/netpol_matching_test.go
@@ -1,0 +1,263 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func netpolMatchFakeDyn(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}:                             "PodList",
+		{Group: "", Version: "v1", Resource: "services"}:                         "ServiceList",
+		{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}: "NetworkPolicyList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, objects...)
+}
+
+func testPod(name string, lbls map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+			"labels":    lbls,
+		},
+	}}
+}
+
+func testNetpol(name string, spec map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": spec,
+	}}
+}
+
+func testService(name string, selector map[string]any) *unstructured.Unstructured {
+	spec := map[string]any{}
+	if selector != nil {
+		spec["selector"] = selector
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": spec,
+	}}
+}
+
+func TestGetNetworkPoliciesForPod_MatchesByLabels(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testPod("web-1", map[string]any{"app": "web", "tier": "frontend"}),
+		testPod("db-1", map[string]any{"app": "db"}),
+		testNetpol("allow-web", map[string]any{
+			"podSelector": map[string]any{
+				"matchLabels": map[string]any{"app": "web"},
+			},
+			"policyTypes": []any{"Ingress"},
+			"ingress": []any{
+				map[string]any{
+					"from": []any{
+						map[string]any{"podSelector": map[string]any{
+							"matchLabels": map[string]any{"app": "db"},
+						}},
+					},
+				},
+			},
+		}),
+		testNetpol("allow-db", map[string]any{
+			"podSelector": map[string]any{
+				"matchLabels": map[string]any{"app": "db"},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	require.NoError(t, err)
+	assert.Equal(t, "Pod", info.Kind)
+	assert.Equal(t, "web-1", info.Name)
+	assert.Equal(t, "default", info.Namespace)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "allow-web", info.Policies[0].Name)
+	assert.Equal(t, []string{"Ingress"}, info.Policies[0].PolicyTypes)
+	require.Len(t, info.Policies[0].IngressRules, 1)
+	assert.Equal(t, []string{"web-1"}, info.Policies[0].AffectedPods)
+}
+
+func TestGetNetworkPoliciesForPod_EmptySelectorMatchesAll(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testPod("web-1", map[string]any{"app": "web"}),
+		testNetpol("default-deny", map[string]any{
+			"podSelector": map[string]any{},
+			"policyTypes": []any{"Ingress", "Egress"},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	require.NoError(t, err)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "default-deny", info.Policies[0].Name)
+}
+
+func TestGetNetworkPoliciesForPod_MatchExpressions(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testPod("web-1", map[string]any{"app": "web"}),
+		testPod("api-1", map[string]any{"app": "api"}),
+		testNetpol("expr-policy", map[string]any{
+			"podSelector": map[string]any{
+				"matchExpressions": []any{
+					map[string]any{
+						"key":      "app",
+						"operator": "In",
+						"values":   []any{"web", "worker"},
+					},
+				},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	require.NoError(t, err)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "expr-policy", info.Policies[0].Name)
+
+	info, err = c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "api-1")
+	require.NoError(t, err)
+	assert.Empty(t, info.Policies)
+}
+
+func TestGetNetworkPoliciesForPod_NoMatch(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testPod("web-1", map[string]any{"app": "web"}),
+		testNetpol("allow-db", map[string]any{
+			"podSelector": map[string]any{
+				"matchLabels": map[string]any{"app": "db"},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	require.NoError(t, err)
+	assert.Empty(t, info.Policies)
+}
+
+func TestGetNetworkPoliciesForPod_SpecLessPolicy(t *testing.T) {
+	noSpec := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata": map[string]any{
+			"name":      "spec-less",
+			"namespace": "default",
+		},
+	}}
+	dyn := netpolMatchFakeDyn(
+		testPod("web-1", map[string]any{"app": "web"}),
+		noSpec,
+	)
+	c := NewTestClient(nil, dyn)
+
+	// No spec means an absent podSelector, which selects all pods.
+	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	require.NoError(t, err)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "spec-less", info.Policies[0].Name)
+}
+
+func TestGetNetworkPoliciesForPod_PodNotFound(t *testing.T) {
+	dyn := netpolMatchFakeDyn()
+	c := NewTestClient(nil, dyn)
+
+	_, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "missing")
+	require.Error(t, err)
+}
+
+func TestGetNetworkPoliciesForPod_SortedByName(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testPod("web-1", map[string]any{"app": "web"}),
+		testNetpol("zz-policy", map[string]any{
+			"podSelector": map[string]any{},
+		}),
+		testNetpol("aa-policy", map[string]any{
+			"podSelector": map[string]any{},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	require.NoError(t, err)
+	require.Len(t, info.Policies, 2)
+	assert.Equal(t, "aa-policy", info.Policies[0].Name)
+	assert.Equal(t, "zz-policy", info.Policies[1].Name)
+}
+
+func TestGetNetworkPoliciesForService_MatchesBackingPods(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testService("web-svc", map[string]any{"app": "web"}),
+		testPod("web-1", map[string]any{"app": "web", "track": "stable"}),
+		testPod("web-2", map[string]any{"app": "web", "track": "canary"}),
+		testPod("db-1", map[string]any{"app": "db"}),
+		// Selects only the canary subset of the service's backing pods.
+		testNetpol("canary-only", map[string]any{
+			"podSelector": map[string]any{
+				"matchLabels": map[string]any{"track": "canary"},
+			},
+		}),
+		// Selects no backing pods at all.
+		testNetpol("db-only", map[string]any{
+			"podSelector": map[string]any{
+				"matchLabels": map[string]any{"app": "db"},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "web-svc")
+	require.NoError(t, err)
+	assert.Equal(t, "Service", info.Kind)
+	assert.Equal(t, "web-svc", info.Name)
+	assert.Equal(t, []string{"web-1", "web-2"}, info.BackingPods)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "canary-only", info.Policies[0].Name)
+	assert.Equal(t, []string{"web-2"}, info.Policies[0].MatchedPods)
+}
+
+func TestGetNetworkPoliciesForService_NoSelector(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testService("external-svc", nil),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "external-svc")
+	require.NoError(t, err)
+	assert.True(t, info.NoSelector)
+	assert.Empty(t, info.Policies)
+}
+
+func TestGetNetworkPoliciesForService_ServiceNotFound(t *testing.T) {
+	dyn := netpolMatchFakeDyn()
+	c := NewTestClient(nil, dyn)
+
+	_, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "missing")
+	require.Error(t, err)
+}

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -89,6 +89,7 @@ func actionsForCoreKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Startup Analysis", Description: "Analyze pod startup timing", Key: "S"},
 			{Label: "Crash Investigator", Description: "Investigate crash loop / failing pod", Key: "I"},
 			{Label: "Capture Traffic", Description: "Capture network packets to pcap", Key: "c"},
+			{Label: "Network Policies", Description: "Show network policies affecting this pod", Key: "N"},
 			{Label: "Go to Node", Description: "Navigate to the node hosting this pod", Key: "g"},
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
@@ -123,6 +124,7 @@ func actionsForCoreKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Delete", Description: "Delete this service", Key: "D"},
 			{Label: "Debug Pod", Description: "Run alpine debug pod in namespace", Key: "b"},
 			{Label: "Capture Traffic", Description: "Capture packets on a backing pod", Key: "c"},
+			{Label: "Network Policies", Description: "Show network policies affecting this service's pods", Key: "N"},
 			{Label: "Events", Description: "Show related events", Key: "V"},
 		}, true
 	case "Secret":

--- a/internal/model/actions_netpol_test.go
+++ b/internal/model/actions_netpol_test.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkPoliciesActionPresent(t *testing.T) {
+	for _, kind := range []string{"Pod", "Service"} {
+		t.Run(kind, func(t *testing.T) {
+			items := ActionsForKind(kind)
+			found := false
+			for _, it := range items {
+				if it.Label == "Network Policies" {
+					found = true
+					assert.Equal(t, "N", it.Key)
+					assert.NotEmpty(t, it.Description)
+					break
+				}
+			}
+			assert.True(t, found, "%q must offer the Network Policies action item", kind)
+		})
+	}
+}
+
+func TestNetworkPoliciesActionAbsentForUnsupported(t *testing.T) {
+	for _, kind := range []string{"ConfigMap", "Secret", "Node", "NetworkPolicy"} {
+		t.Run(kind, func(t *testing.T) {
+			items := ActionsForKind(kind)
+			for _, it := range items {
+				assert.NotEqual(t, "Network Policies", it.Label,
+					"%q must not offer the Network Policies action item", kind)
+			}
+		})
+	}
+}
+
+func TestNetworkPoliciesActionKeysUnique(t *testing.T) {
+	for _, kind := range []string{"Pod", "Service"} {
+		t.Run(kind, func(t *testing.T) {
+			keys := make(map[string]string)
+			for _, a := range ActionsForKind(kind) {
+				prev, dup := keys[a.Key]
+				assert.False(t, dup, "duplicate key %q used by %q and %q", a.Key, prev, a.Label)
+				keys[a.Key] = a.Label
+			}
+		})
+	}
+}

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -356,7 +356,7 @@ func helpSections() []helpSection {
 			},
 		},
 		{
-			title: "Network Policy Visualizer", context: "Network Policy",
+			title: "Network Policy Visualizer", context: "Network Policy / Pod / Service",
 			bindings: []helpEntry{
 				{"j/k", "Scroll up/down"},
 				{"gg/G / Home/End", "Top/bottom"},

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -122,6 +122,18 @@ type NetworkPolicyEntry struct {
 	IngressRules []NetpolRuleEntry
 	EgressRules  []NetpolRuleEntry
 	AffectedPods []string
+	MatchedPods  []string // multi-policy view from a Service: backing pods this policy selects
+}
+
+// ResourceNetpolsEntry holds the policies affecting a pod or service for the
+// multi-policy view opened from the resource's action menu.
+type ResourceNetpolsEntry struct {
+	Kind        string // "Pod" or "Service"
+	Name        string
+	Namespace   string
+	NoSelector  bool     // Service only: the service defines no pod selector
+	BackingPods []string // Service only: pods backing the service
+	Policies    []NetworkPolicyEntry
 }
 
 // NetpolRuleEntry holds a single ingress/egress rule for rendering.

--- a/internal/ui/overlay_network.go
+++ b/internal/ui/overlay_network.go
@@ -14,6 +14,12 @@ import (
 // The overlay shows pod selector, policy types, affected pods, and a visual diagram
 // of ingress/egress rules using box-drawing characters and arrows.
 func RenderNetworkPolicyOverlay(info NetworkPolicyEntry, scroll, width, height int) string {
+	return renderScrollableLines(buildNetpolOverlayLines(info, width), scroll, width, height)
+}
+
+// buildNetpolOverlayLines composes the full (unscrolled) line list for the
+// single-policy view.
+func buildNetpolOverlayLines(info NetworkPolicyEntry, width int) []string {
 	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Background(SurfaceBg)
 	arrowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Background(SurfaceBg)
 	boxBorderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorBorder)).Background(SurfaceBg)
@@ -25,8 +31,33 @@ func RenderNetworkPolicyOverlay(info NetworkPolicyEntry, scroll, width, height i
 	targetLabel := renderNetpolTargetLabel(info)
 	lines = append(lines, renderNetpolDirectionRules(info, targetLabel, width, sectionStyle, boxBorderStyle, arrowStyle, labelStyle, cidrStyle, greenStyle)...)
 	lines = append(lines, "")
+	return flattenRenderedLines(lines)
+}
 
-	return renderScrollableLines(lines, scroll, height)
+// flattenRenderedLines splits multi-row entries into physical rows. Styles
+// with vertical padding (e.g. OverlayTitleStyle) render embedded newlines;
+// scrolling must operate on terminal rows or the overlay height shifts as a
+// multi-row entry enters or leaves the viewport.
+func flattenRenderedLines(lines []string) []string {
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, strings.Split(l, "\n")...)
+	}
+	return out
+}
+
+// NetworkPolicyOverlayLineCount returns the total line count of the
+// single-policy view at the given width, for scroll clamping.
+func NetworkPolicyOverlayLineCount(info NetworkPolicyEntry, width int) int {
+	return len(buildNetpolOverlayLines(info, width))
+}
+
+// OverlayMaxScroll returns the bottom scroll position for a scrollable
+// overlay body of lineCount lines in a viewport of the given height. Must
+// stay in sync with renderScrollableLines.
+func OverlayMaxScroll(lineCount, height int) int {
+	maxVisible := max(height, 3)
+	return max(lineCount-maxVisible, 0)
 }
 
 // renderNetpolHeader renders the title, pod selector, affected pods, and policy types sections.
@@ -149,25 +180,41 @@ func sortedKeys(m map[string]string) []string {
 }
 
 // renderScrollableLines applies scroll/clamp logic and returns the visible body string.
-func renderScrollableLines(lines []string, scroll, height int) string {
-	maxVisible := max(height-1, 3)
-	maxScroll := max(len(lines)-maxVisible, 0)
+// Lines wider than width are truncated: an over-wide line would wrap inside
+// the overlay frame and change the overlay height while scrolling. When the
+// content overflows the viewport, each row gets the shared right-edge
+// scrollbar cell (same look as the list overlays).
+func renderScrollableLines(lines []string, scroll, width, height int) string {
+	maxVisible := max(height, 3)
+	maxScroll := OverlayMaxScroll(len(lines), height)
 	if scroll > maxScroll {
 		scroll = maxScroll
 	}
 	if scroll < 0 {
 		scroll = 0
 	}
+	showScrollbar := maxScroll > 0 && width > 2
+	lineWidth := width
+	if showScrollbar {
+		lineWidth = width - 2 // leave room for " " + scrollbar cell
+	}
 	end := min(scroll+maxVisible, len(lines))
-	visible := lines[scroll:end]
+	visible := make([]string, 0, maxVisible)
+	for _, line := range lines[scroll:end] {
+		if lineWidth > 0 && lipgloss.Width(line) > lineWidth {
+			line = ansi.Truncate(line, lineWidth, "~")
+		}
+		visible = append(visible, line)
+	}
 	for len(visible) < maxVisible {
 		visible = append(visible, "")
 	}
-	body := strings.Join(visible, "\n")
-	if maxScroll > 0 {
-		body += "\n" + DimStyle.Render(fmt.Sprintf(" [%d/%d]", scroll+1, maxScroll+1))
+	if showScrollbar {
+		for i, line := range visible {
+			visible[i] = padRight(line, lineWidth) + " " + renderScrollbar(i, maxVisible, len(lines), scroll)
+		}
 	}
-	return body
+	return strings.Join(visible, "\n")
 }
 
 // renderNetpolRuleDiagram renders a visual diagram for a single ingress/egress rule.
@@ -275,7 +322,13 @@ func renderNetpolRuleDiagram(
 			arrow = arrowSt.Render(" -----> ")
 		}
 
-		boxLines := renderTwoBoxes(leftBox, rightBox, arrow, boxBorder, width)
+		// The diagram is indented by 2 columns below, so cap the boxes 2
+		// short of the available width or the indented lines overflow it.
+		boxWidth := width
+		if boxWidth > 0 {
+			boxWidth -= 2
+		}
+		boxLines := renderTwoBoxes(leftBox, rightBox, arrow, boxBorder, boxWidth)
 		for _, bl := range boxLines {
 			lines = append(lines, "  "+bl)
 		}

--- a/internal/ui/overlay_network_multi.go
+++ b/internal/ui/overlay_network_multi.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// RenderNetworkPoliciesOverlay renders the multi-policy view opened from a
+// pod or service action menu: every network policy that selects the resource,
+// stacked, with the same diagrams as the single-policy visualizer.
+func RenderNetworkPoliciesOverlay(info ResourceNetpolsEntry, scroll, width, height int) string {
+	return renderScrollableLines(buildNetpolsOverlayLines(info, width), scroll, width, height)
+}
+
+// NetworkPoliciesOverlayLineCount returns the total line count of the
+// multi-policy view at the given width, for scroll clamping.
+func NetworkPoliciesOverlayLineCount(info ResourceNetpolsEntry, width int) int {
+	return len(buildNetpolsOverlayLines(info, width))
+}
+
+// buildNetpolsOverlayLines composes the full (unscrolled) line list for the
+// multi-policy view.
+func buildNetpolsOverlayLines(info ResourceNetpolsEntry, width int) []string {
+	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Background(SurfaceBg)
+	arrowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Background(SurfaceBg)
+	boxBorderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorBorder)).Background(SurfaceBg)
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPurple)).Background(SurfaceBg)
+	cidrStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorOrange)).Background(SurfaceBg)
+	sectionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Underline(true).Background(SurfaceBg)
+
+	var lines []string
+	lines = append(lines, OverlayTitleStyle.Render(fmt.Sprintf("Network Policies: %s: %s", info.Kind, info.Name)))
+	lines = append(lines, OverlayDimStyle.Render(fmt.Sprintf("  Namespace: %s", info.Namespace)))
+	lines = append(lines, "")
+
+	switch {
+	case info.NoSelector:
+		lines = append(lines, OverlayWarningStyle.Render("  Service has no pod selector"))
+		lines = append(lines, OverlayDimStyle.Render("  Pod-selector based network policies cannot be matched against it."))
+	case len(info.Policies) == 0:
+		lines = append(lines, greenStyle.Render(fmt.Sprintf("  No network policies select this %s", strings.ToLower(info.Kind))))
+		lines = append(lines, OverlayDimStyle.Render("  No policy restrictions apply: all traffic allowed."))
+	default:
+		lines = append(lines, renderNetpolMultiBody(info, width, greenStyle, labelStyle, sectionStyle, boxBorderStyle, arrowStyle, cidrStyle)...)
+	}
+	lines = append(lines, "")
+	return flattenRenderedLines(lines)
+}
+
+// renderNetpolMultiBody renders the summary line and the stacked per-policy
+// sections.
+func renderNetpolMultiBody(info ResourceNetpolsEntry, width int, greenStyle, labelStyle, sectionStyle, boxBorderStyle, arrowStyle, cidrStyle lipgloss.Style) []string {
+	var lines []string
+
+	var summary string
+	if len(info.Policies) == 1 {
+		summary = fmt.Sprintf("1 network policy selects this %s", strings.ToLower(info.Kind))
+	} else {
+		summary = fmt.Sprintf("%d network policies select this %s", len(info.Policies), strings.ToLower(info.Kind))
+	}
+	lines = append(lines, fmt.Sprintf("  %s", greenStyle.Render(summary)))
+	if info.Kind == "Service" {
+		lines = append(lines, OverlayDimStyle.Render(fmt.Sprintf("  Backing pods: %d", len(info.BackingPods))))
+	}
+	lines = append(lines, "")
+
+	divider := OverlayDimStyle.Render(strings.Repeat("─", max(width-2, 10)))
+	for _, pol := range info.Policies {
+		lines = append(lines, divider)
+		lines = append(lines, renderNetpolHeader(pol, greenStyle, labelStyle, sectionStyle)...)
+		if info.Kind == "Service" {
+			lines = append(lines, renderNetpolCoverage(pol, info, greenStyle)...)
+		}
+		targetLabel := renderNetpolTargetLabel(pol)
+		lines = append(lines, renderNetpolDirectionRules(pol, targetLabel, width, sectionStyle, boxBorderStyle, arrowStyle, labelStyle, cidrStyle, greenStyle)...)
+	}
+	return lines
+}
+
+// renderNetpolCoverage renders which of the service's backing pods a policy
+// selects, since a policy may cover only a subset of them.
+func renderNetpolCoverage(pol NetworkPolicyEntry, info ResourceNetpolsEntry, greenStyle lipgloss.Style) []string {
+	var lines []string
+	coverage := fmt.Sprintf("%d of %d backing pod(s)", len(pol.MatchedPods), len(info.BackingPods))
+	style := greenStyle
+	if len(pol.MatchedPods) < len(info.BackingPods) {
+		style = OverlayWarningStyle
+	}
+	lines = append(lines, fmt.Sprintf("  %s %s",
+		OverlayNormalStyle.Render("Covers:"),
+		style.Render(coverage)))
+	maxShow := 10
+	shown := min(len(pol.MatchedPods), maxShow)
+	for _, name := range pol.MatchedPods[:shown] {
+		lines = append(lines, fmt.Sprintf("    %s", OverlayDimStyle.Render(name)))
+	}
+	if len(pol.MatchedPods) > maxShow {
+		lines = append(lines, fmt.Sprintf("    %s", OverlayDimStyle.Render(fmt.Sprintf("... and %d more", len(pol.MatchedPods)-maxShow))))
+	}
+	lines = append(lines, "")
+	return lines
+}

--- a/internal/ui/overlay_network_multi_test.go
+++ b/internal/ui/overlay_network_multi_test.go
@@ -1,0 +1,242 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- RenderNetworkPoliciesOverlay ---
+
+func TestRenderNetworkPoliciesOverlay_PodWithPolicies(t *testing.T) {
+	info := ResourceNetpolsEntry{
+		Kind:      "Pod",
+		Name:      "web-1",
+		Namespace: "default",
+		Policies: []NetworkPolicyEntry{
+			{
+				Name:        "allow-web",
+				Namespace:   "default",
+				PodSelector: map[string]string{"app": "web"},
+				PolicyTypes: []string{"Ingress"},
+				IngressRules: []NetpolRuleEntry{
+					{
+						Ports: []NetpolPortEntry{{Protocol: "TCP", Port: "80"}},
+						Peers: []NetpolPeerEntry{{Type: "Pod", Selector: map[string]string{"app": "db"}}},
+					},
+				},
+			},
+			{
+				Name:        "default-deny",
+				Namespace:   "default",
+				PolicyTypes: []string{"Ingress", "Egress"},
+			},
+		},
+	}
+	result := RenderNetworkPoliciesOverlay(info, 0, 80, 60)
+	assert.Contains(t, result, "Pod: web-1")
+	assert.Contains(t, result, "allow-web")
+	assert.Contains(t, result, "default-deny")
+	assert.Contains(t, result, "2 network policies")
+}
+
+func TestRenderNetworkPoliciesOverlay_NoPolicies(t *testing.T) {
+	info := ResourceNetpolsEntry{
+		Kind:      "Pod",
+		Name:      "web-1",
+		Namespace: "default",
+	}
+	result := RenderNetworkPoliciesOverlay(info, 0, 80, 40)
+	assert.Contains(t, result, "No network policies")
+	assert.Contains(t, result, "all traffic allowed")
+}
+
+func TestRenderNetworkPoliciesOverlay_ServiceCoveredPods(t *testing.T) {
+	info := ResourceNetpolsEntry{
+		Kind:        "Service",
+		Name:        "web-svc",
+		Namespace:   "default",
+		BackingPods: []string{"web-1", "web-2"},
+		Policies: []NetworkPolicyEntry{
+			{
+				Name:        "canary-only",
+				Namespace:   "default",
+				PodSelector: map[string]string{"track": "canary"},
+				MatchedPods: []string{"web-2"},
+			},
+		},
+	}
+	result := RenderNetworkPoliciesOverlay(info, 0, 80, 60)
+	assert.Contains(t, result, "Service: web-svc")
+	assert.Contains(t, result, "canary-only")
+	// Partial coverage must be visible: the policy covers 1 of 2 backing pods.
+	assert.Contains(t, result, "1 of 2 backing pod(s)")
+	assert.Contains(t, result, "web-2")
+}
+
+// wideNetpolEntry returns a policy whose diagram boxes hit the width cap, to
+// exercise truncation paths.
+func wideNetpolEntry() NetworkPolicyEntry {
+	return NetworkPolicyEntry{
+		Name:        "very-long-network-policy-name-that-keeps-going",
+		Namespace:   "default",
+		PodSelector: map[string]string{"app.kubernetes.io/name": "a-very-long-application-name"},
+		PolicyTypes: []string{"Ingress", "Egress"},
+		IngressRules: []NetpolRuleEntry{
+			{
+				Ports: []NetpolPortEntry{{Protocol: "TCP", Port: "8080"}},
+				Peers: []NetpolPeerEntry{{
+					Type:      "Namespace+Pod",
+					Selector:  map[string]string{"app.kubernetes.io/component": "an-extremely-long-component-value"},
+					Namespace: "team-with-a-very-long-namespace-label-value",
+				}},
+			},
+		},
+		EgressRules: []NetpolRuleEntry{
+			{
+				Peers: []NetpolPeerEntry{{Type: "CIDR", CIDR: "10.0.0.0/8", Except: []string{"10.0.1.0/24"}}},
+			},
+		},
+	}
+}
+
+// Every rendered line must fit within the requested width at every scroll
+// position; over-wide lines wrap inside the overlay frame and change its
+// height while scrolling.
+func TestRenderNetworkPolicyOverlay_LinesNeverExceedWidth(t *testing.T) {
+	const width, height = 60, 12
+	info := wideNetpolEntry()
+	total := NetworkPolicyOverlayLineCount(info, width)
+	for scroll := 0; scroll <= total; scroll++ {
+		out := RenderNetworkPolicyOverlay(info, scroll, width, height)
+		for line := range strings.SplitSeq(out, "\n") {
+			assert.LessOrEqual(t, lipgloss.Width(line), width,
+				"scroll=%d line %q exceeds width", scroll, line)
+		}
+	}
+}
+
+// The rendered height must not depend on the scroll position.
+func TestRenderNetworkPolicyOverlay_HeightStableAcrossScroll(t *testing.T) {
+	const width, height = 60, 12
+	info := wideNetpolEntry()
+	base := strings.Count(RenderNetworkPolicyOverlay(info, 0, width, height), "\n")
+	total := NetworkPolicyOverlayLineCount(info, width)
+	for scroll := 1; scroll <= total; scroll++ {
+		got := strings.Count(RenderNetworkPolicyOverlay(info, scroll, width, height), "\n")
+		assert.Equal(t, base, got, "height changed at scroll=%d", scroll)
+	}
+}
+
+// Short titles are the regression case: OverlayTitleStyle carries bottom
+// padding, so its Render output spans two terminal rows. If that lands in
+// the line list as one entry, the overlay height shifts by a row whenever
+// it scrolls in or out of view. (Long titles masked this: width truncation
+// cut the line before the embedded newline.)
+func TestRenderNetworkPolicyOverlay_HeightStableWithShortTitle(t *testing.T) {
+	const width, height = 80, 10
+	info := NetworkPolicyEntry{
+		Name:        "vault",
+		Namespace:   "vault",
+		PolicyTypes: []string{"Ingress"},
+		IngressRules: []NetpolRuleEntry{
+			{Peers: []NetpolPeerEntry{{Type: "All"}}},
+			{Peers: []NetpolPeerEntry{{Type: "All"}}},
+			{Peers: []NetpolPeerEntry{{Type: "All"}}},
+		},
+	}
+	base := strings.Count(RenderNetworkPolicyOverlay(info, 0, width, height), "\n")
+	total := NetworkPolicyOverlayLineCount(info, width)
+	for scroll := 1; scroll <= total; scroll++ {
+		got := strings.Count(RenderNetworkPolicyOverlay(info, scroll, width, height), "\n")
+		assert.Equal(t, base, got, "height changed at scroll=%d", scroll)
+	}
+}
+
+func TestRenderNetworkPoliciesOverlay_HeightStableWithShortTitle(t *testing.T) {
+	const width, height = 80, 10
+	info := ResourceNetpolsEntry{
+		Kind:      "Pod",
+		Name:      "vault-3",
+		Namespace: "vault",
+		Policies: []NetworkPolicyEntry{
+			{
+				Name: "vault", Namespace: "vault", PolicyTypes: []string{"Ingress"},
+				IngressRules: []NetpolRuleEntry{
+					{Peers: []NetpolPeerEntry{{Type: "All"}}},
+					{Peers: []NetpolPeerEntry{{Type: "All"}}},
+				},
+			},
+		},
+	}
+	base := strings.Count(RenderNetworkPoliciesOverlay(info, 0, width, height), "\n")
+	total := NetworkPoliciesOverlayLineCount(info, width)
+	for scroll := 1; scroll <= total; scroll++ {
+		got := strings.Count(RenderNetworkPoliciesOverlay(info, scroll, width, height), "\n")
+		assert.Equal(t, base, got, "height changed at scroll=%d", scroll)
+	}
+}
+
+func TestRenderNetworkPoliciesOverlay_LinesNeverExceedWidth(t *testing.T) {
+	const width, height = 60, 12
+	info := ResourceNetpolsEntry{
+		Kind:        "Service",
+		Name:        "a-service-with-quite-a-long-name",
+		Namespace:   "default",
+		BackingPods: []string{"web-1", "web-2"},
+		Policies:    []NetworkPolicyEntry{wideNetpolEntry(), wideNetpolEntry()},
+	}
+	total := NetworkPoliciesOverlayLineCount(info, width)
+	for scroll := 0; scroll <= total; scroll++ {
+		out := RenderNetworkPoliciesOverlay(info, scroll, width, height)
+		for line := range strings.SplitSeq(out, "\n") {
+			assert.LessOrEqual(t, lipgloss.Width(line), width,
+				"scroll=%d line %q exceeds width", scroll, line)
+		}
+	}
+}
+
+func TestOverlayMaxScroll(t *testing.T) {
+	// 50 lines in a height-12 viewport leaves 38 hidden.
+	assert.Equal(t, 38, OverlayMaxScroll(50, 12))
+	// Content shorter than the viewport never scrolls.
+	assert.Equal(t, 0, OverlayMaxScroll(5, 12))
+}
+
+// Overflowing content shows the shared right-edge scrollbar instead of a
+// [n/m] line indicator.
+func TestRenderNetworkPolicyOverlay_ScrollbarReplacesIndicator(t *testing.T) {
+	const width, height = 80, 10
+	info := wideNetpolEntry()
+	out := RenderNetworkPolicyOverlay(info, 0, width, height)
+	assert.Contains(t, out, "█", "overflowing content must show a scrollbar thumb")
+	assert.Contains(t, out, "│", "overflowing content must show the scrollbar track")
+	assert.NotContains(t, out, "[1/", "the [n/m] indicator must be gone")
+
+	// The thumb must move as the view scrolls: at the bottom the first
+	// visible row is track, not thumb.
+	bottom := RenderNetworkPolicyOverlay(info, OverlayMaxScroll(NetworkPolicyOverlayLineCount(info, width), height), width, height)
+	topRows := strings.SplitN(out, "\n", 2)
+	bottomRows := strings.SplitN(bottom, "\n", 2)
+	assert.True(t, strings.HasSuffix(topRows[0], "█"), "thumb starts at the top row")
+	assert.False(t, strings.HasSuffix(bottomRows[0], "█"), "thumb must leave the top row when scrolled to the bottom")
+}
+
+func TestRenderNetworkPolicyOverlay_NoScrollbarWhenContentFits(t *testing.T) {
+	info := NetworkPolicyEntry{Name: "tiny", Namespace: "default"}
+	out := RenderNetworkPolicyOverlay(info, 0, 80, 40)
+	assert.NotContains(t, out, "█")
+}
+
+func TestRenderNetworkPoliciesOverlay_ServiceNoSelector(t *testing.T) {
+	info := ResourceNetpolsEntry{
+		Kind:       "Service",
+		Name:       "external-svc",
+		Namespace:  "default",
+		NoSelector: true,
+	}
+	result := RenderNetworkPoliciesOverlay(info, 0, 80, 40)
+	assert.Contains(t, result, "no pod selector")
+}


### PR DESCRIPTION
## Summary

Implements items (a) and (b) of #409 — making the Network Policy visualizer discoverable from the resources it affects.

- New **"Network Policies"** action (key `N`) on **Pod** and **Service** action menus. Opens the visualizer overlay listing every NetworkPolicy whose `podSelector` matches the pod, or any of the service's backing pods.
- Matching uses real label-selector semantics (`matchLabels` + `matchExpressions`; empty/absent selector = all pods). Policies and pods are listed once per call — no per-policy queries.
- For Services, each policy shows **which backing pods it covers** (highlighted when partial, e.g. a policy that only selects a canary track).
- Explicit empty states: "No network policies select this pod — all traffic allowed", and a warning for selectorless (ExternalName-style) services.

Also hardens the shared visualizer scrolling (both the new multi-policy view and the original single-policy "Visualize"):

- **Stable overlay height while scrolling** — diagram indent overflow capped, multi-row styled entries (title bottom-padding) flattened into physical rows, over-wide lines truncated.
- **Scroll clamped at the content bottom** in the key handler — `k` responds immediately after over-scrolling; `G`/`End` jump exactly to the bottom.
- The `[n/m]` indicator is replaced with the **shared right-edge scrollbar** used by list overlays.

Item (c) of #409 (CiliumNetworkPolicy / CiliumClusterwideNetworkPolicy support) follows in a separate PR.

## Test plan

- [x] k8s reverse-lookup unit tests: label matching incl. matchExpressions, empty/absent selectors, spec-less policies, sorting, service backing-pod resolution and partial coverage, selectorless services
- [x] UI renderer tests: stacked rendering, empty states, coverage line, line-width invariant at every scroll position, height stability across scrolls (incl. the short-title regression), scrollbar presence/movement
- [x] App wiring tests: action menu entries + key uniqueness, dispatch, scheduler-routed load, message handling, overlay rendering, esc clears state, scroll clamping (j/paging/G/End)
- [x] Full suite with `-race`, `go vet`, `golangci-lint` clean
- [x] go-reviewer pass; CRITICAL/HIGH findings fixed