### PR TITLE
feat(actions): order action menus by hotkey; sync doc inventories

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -936,58 +936,59 @@ Press `:` to open the command bar. It supports four types of input:
 
 ## Action Menu Items
 
-The action menu (`x` key) shows context-specific actions based on the resource type:
+The action menu (`x` key) shows context-specific actions based on the resource type.
+Items below are listed by hotkey; the in-app menu groups them by task instead.
 
 ### Pod Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies whose pod selector matches this pod), `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `V` Events
+`A` Attach, `b` Debug Pod, `B` Debug, `c` Capture Traffic, `D` Delete, `E` Edit, `g` Go to Node, `I` Crash Investigator, `l` Tail Logs (last N lines + follow), `L` Logs (full), `N` Network Policies (policies whose pod selector matches this pod), `p` Port Forward, `s` Exec, `S` Startup Analysis, `v` Describe, `V` Events, `X` Force Delete, `y` Security Findings, `z` Right-sizing
 
 ### Deployment Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `R` Rollback, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
+`A` Attach, `b` Debug Pod, `D` Delete, `E` Edit, `l` Tail Logs (last N lines + follow), `L` Logs (full), `p` Port Forward, `r` Restart, `R` Rollback, `s` Exec, `S` Scale, `v` Describe, `V` Events, `y` Security Findings, `z` Right-sizing
 
 ### StatefulSet Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
+`A` Attach, `b` Debug Pod, `D` Delete, `E` Edit, `l` Tail Logs (last N lines + follow), `L` Logs (full), `p` Port Forward, `r` Restart, `s` Exec, `S` Scale, `v` Describe, `V` Events, `y` Security Findings, `z` Right-sizing
 
 ### DaemonSet Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
+`A` Attach, `b` Debug Pod, `D` Delete, `E` Edit, `l` Tail Logs (last N lines + follow), `L` Logs (full), `p` Port Forward, `r` Restart, `s` Exec, `v` Describe, `V` Events, `y` Security Findings, `z` Right-sizing
 
 ### Service Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies affecting the service's backing pods), `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`A` Attach (to pod behind service), `b` Debug Pod, `c` Capture Traffic, `D` Delete, `E` Edit, `l` Tail Logs (last N lines + follow), `L` Logs (full), `N` Network Policies (policies affecting the service's backing pods), `p` Port Forward, `s` Exec (into pod behind service), `v` Describe, `V` Events
 
 ### Secret Actions
-`e` Secret Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
+`b` Debug Pod, `D` Delete, `e` Secret Editor, `E` Edit, `l` Labels / Annotations, `P` Permissions, `v` Describe, `V` Events
 
 ### ConfigMap Actions
-`e` ConfigMap Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
+`b` Debug Pod, `D` Delete, `e` ConfigMap Editor, `E` Edit, `l` Labels / Annotations, `P` Permissions, `v` Describe, `V` Events
 
 ### Node Actions
-`c` Cordon, `u` Uncordon, `n` Drain, `t` Taint, `T` Untaint, `s` Shell, `v` Describe, `E` Edit, `b` Debug Pod, `V` Events
+`b` Debug Pod, `c` Cordon, `E` Edit, `n` Drain, `s` Shell, `t` Taint, `T` Untaint, `u` Uncordon, `v` Describe, `V` Events
 
 ### Job Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `b` Debug Pod, `V` Events
+`A` Attach, `b` Debug Pod, `D` Delete, `E` Edit, `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `v` Describe, `V` Events, `X` Force Delete, `y` Security Findings, `z` Right-sizing
 
 ### CronJob Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `t` Trigger (create Job), `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
+`A` Attach, `b` Debug Pod, `D` Delete, `E` Edit, `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `t` Trigger (create Job), `v` Describe, `V` Events, `y` Security Findings, `z` Right-sizing
 
 ### ArgoCD Application Actions
-`s` Sync, `a` Sync (Apply Only), `f` Diff, `R` Refresh, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`a` Sync (Apply Only), `A` Configure AutoSync, `b` Debug Pod, `D` Delete, `E` Edit, `R` Refresh, `s` Sync, `T` Terminate Sync, `v` Describe, `V` Events, `W` Sync Wave Timeline
 
 ### Helm Release Actions
-`u` Values, `A` All Values, `E` Edit Values, `d` Diff, `U` Upgrade, `R` Rollback, `h` History, `v` Describe, `D` Delete, `b` Debug Pod, `V` Events
+`A` All Values, `b` Debug Pod, `d` Diff, `D` Delete (uninstall), `E` Edit Values, `h` History, `R` Rollback, `u` Values, `U` Upgrade, `v` Describe, `V` Events
 
 ### Ingress Actions
-`o` Open in Browser, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`b` Debug Pod, `D` Delete, `E` Edit, `o` Open in Browser, `v` Describe, `V` Events
 
 ### PVC Actions
-`g` Go to Pod, `b` Debug Mount, `B` Debug Pod, `v` Describe, `E` Edit, `D` Delete, `V` Events
+`b` Debug Mount, `B` Debug Pod, `D` Delete, `E` Edit, `g` Go to Pod, `r` Resize, `v` Describe, `V` Events
 
 ### Default Actions (all other resources)
-`v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
+`b` Debug Pod, `D` Delete, `E` Edit, `l` Labels / Annotations, `P` Permissions, `v` Describe, `V` Events
 
 ### Bulk Actions (when items multi-selected)
-`D` Delete, `X` Force Delete, `S` Scale, `r` Restart
+`d` Diff (compare two), `D` Delete, `l` Labels / Annotations, `L` Logs, `r` Restart, `S` Scale, `X` Force Delete
 
 ArgoCD Application bulk actions (when Application resources are multi-selected):
-`s` Sync, `a` Sync (Apply Only), `R` Refresh
+`a` Sync (Apply Only), `R` Refresh, `s` Sync
 
 Custom actions defined in the config file appear after the built-in actions.
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -937,7 +937,8 @@ Press `:` to open the command bar. It supports four types of input:
 ## Action Menu Items
 
 The action menu (`x` key) shows context-specific actions based on the resource type.
-Items below are listed by hotkey; the in-app menu groups them by task instead.
+Both the in-app menu and the lists below are ordered by hotkey (lowercase before
+uppercase); custom actions appear after the built-in ones.
 
 ### Pod Actions
 `A` Attach, `b` Debug Pod, `B` Debug, `c` Capture Traffic, `D` Delete, `E` Edit, `g` Go to Node, `I` Crash Investigator, `l` Tail Logs (last N lines + follow), `L` Logs (full), `N` Network Policies (policies whose pod selector matches this pod), `p` Port Forward, `s` Exec, `S` Startup Analysis, `v` Describe, `V` Events, `X` Force Delete, `y` Security Findings, `z` Right-sizing

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -1,7 +1,32 @@
 package model
 
-// ActionsForContainer returns the action menu items for a container.
+import (
+	"sort"
+	"strings"
+)
+
+// sortActionsByKey orders menu items by hotkey, case-insensitively, with
+// lowercase before uppercase on ties, so every action menu reads as a
+// hotkey index. Sorts in place and returns the slice for chaining.
+func sortActionsByKey(items []ActionMenuItem) []ActionMenuItem {
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i].Key, items[j].Key
+		la, lb := strings.ToLower(a), strings.ToLower(b)
+		if la != lb {
+			return la < lb
+		}
+		return a > b // same letter: lowercase ('b' > 'B') first
+	})
+	return items
+}
+
+// ActionsForContainer returns the action menu items for a container,
+// ordered by hotkey.
 func ActionsForContainer() []ActionMenuItem {
+	return sortActionsByKey(actionsForContainerGrouped())
+}
+
+func actionsForContainerGrouped() []ActionMenuItem {
 	return []ActionMenuItem{
 		{Label: "Tail Logs", Description: "Tail the last 10 lines and follow", Key: "l"},
 		{Label: "Logs", Description: "View container logs", Key: "L"},
@@ -14,10 +39,13 @@ func ActionsForContainer() []ActionMenuItem {
 	}
 }
 
-// ActionsForBulk returns the action menu items available for bulk operations.
-// Kind-specific bulk actions are prepended when kind is non-empty, matching the
-// single-resource action menu order where kind-specific actions appear first.
+// ActionsForBulk returns the action menu items available for bulk
+// operations, ordered by hotkey.
 func ActionsForBulk(kind string) []ActionMenuItem {
+	return sortActionsByKey(actionsForBulkGrouped(kind))
+}
+
+func actionsForBulkGrouped(kind string) []ActionMenuItem {
 	var kindActions []ActionMenuItem //nolint:prealloc // size depends on kind
 	switch kind {
 	case "Application":
@@ -50,6 +78,10 @@ func ActionsForBulk(kind string) []ActionMenuItem {
 // will land on a follow-up that distinguishes Service-by-APIGroup. Revision /
 // Configuration / Route are Knative-only kinds and route here.
 func ActionsForKind(kind string) []ActionMenuItem {
+	return sortActionsByKey(actionsForKindGrouped(kind))
+}
+
+func actionsForKindGrouped(kind string) []ActionMenuItem {
 	if actions, ok := actionsForCoreKind(kind); ok {
 		return actions
 	}
@@ -613,23 +645,25 @@ func ActionsForClusterPicker(keys ClusterPickerKeys) []ActionMenuItem {
 	}
 }
 
-// ActionsForPortForward returns the action menu items for a port forward entry.
+// ActionsForPortForward returns the action menu items for a port forward
+// entry, ordered by hotkey.
 func ActionsForPortForward() []ActionMenuItem {
-	return []ActionMenuItem{
+	return sortActionsByKey([]ActionMenuItem{
 		{Label: "Stop", Description: "Stop this port forward", Key: "s"},
 		{Label: "Restart", Description: "Restart this port forward", Key: "r"},
 		{Label: "Remove", Description: "Remove this entry", Key: "D"},
 		{Label: "Open in Browser", Description: "Open localhost port in browser", Key: "O"},
-	}
+	})
 }
 
-// ActionsForCapture returns the action menu items for a capture entry.
+// ActionsForCapture returns the action menu items for a capture entry,
+// ordered by hotkey.
 func ActionsForCapture() []ActionMenuItem {
-	return []ActionMenuItem{
+	return sortActionsByKey([]ActionMenuItem{
 		{Label: "Open", Description: "Re-open the capture overlay attached to this entry", Key: "o"},
 		{Label: "Stop", Description: "Stop a running capture", Key: "s"},
 		{Label: "Delete File", Description: "Delete the on-disk pcap file", Key: "D"},
-	}
+	})
 }
 
 // MonitoringEndpoint defines a custom monitoring service endpoint.

--- a/internal/model/actions_sort_test.go
+++ b/internal/model/actions_sort_test.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// actionKeysSorted reports whether menu items are ordered by hotkey,
+// case-insensitively, with lowercase before uppercase on ties.
+func actionKeysSorted(t *testing.T, items []ActionMenuItem) {
+	t.Helper()
+	for i := 1; i < len(items); i++ {
+		a, b := items[i-1].Key, items[i].Key
+		la, lb := strings.ToLower(a), strings.ToLower(b)
+		ordered := la < lb || (la == lb && a >= b)
+		assert.True(t, ordered, "items out of hotkey order: %q (%s) before %q (%s)",
+			a, items[i-1].Label, b, items[i].Label)
+	}
+}
+
+func TestActionMenusSortedByHotkey(t *testing.T) {
+	kinds := []string{
+		"Pod", "Service", "Deployment", "StatefulSet", "DaemonSet", "Node",
+		"Job", "CronJob", "Secret", "ConfigMap", "NetworkPolicy", "Ingress",
+		"PersistentVolumeClaim", "Application", "HelmRelease", "Workflow",
+		"SomeUnknownKind",
+	}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			actionKeysSorted(t, ActionsForKind(kind))
+		})
+	}
+}
+
+func TestAuxiliaryActionMenusSortedByHotkey(t *testing.T) {
+	t.Run("container", func(t *testing.T) {
+		actionKeysSorted(t, ActionsForContainer())
+	})
+	t.Run("bulk generic", func(t *testing.T) {
+		actionKeysSorted(t, ActionsForBulk(""))
+	})
+	t.Run("bulk application", func(t *testing.T) {
+		actionKeysSorted(t, ActionsForBulk("Application"))
+	})
+	t.Run("port forward", func(t *testing.T) {
+		actionKeysSorted(t, ActionsForPortForward())
+	})
+	t.Run("capture", func(t *testing.T) {
+		actionKeysSorted(t, ActionsForCapture())
+	})
+}
+
+func TestSortActionsByKey_TieBreak(t *testing.T) {
+	items := sortActionsByKey([]ActionMenuItem{
+		{Label: "Upper", Key: "B"},
+		{Label: "Lower", Key: "b"},
+		{Label: "First", Key: "a"},
+	})
+	assert.Equal(t, []string{"a", "b", "B"}, []string{items[0].Key, items[1].Key, items[2].Key},
+		"lowercase must sort before uppercase on the same letter")
+}

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -237,10 +237,9 @@ func TestActionsForBulkApplication(t *testing.T) {
 	assert.Contains(t, labels, "Refresh", "Application bulk should include Refresh")
 	// Should still have generic bulk actions.
 	assert.Contains(t, labels, "Delete")
-	// ArgoCD actions should appear before generic actions.
-	assert.Equal(t, "Sync", actions[0].Label, "Sync should be first")
-	assert.Equal(t, "Sync (Apply Only)", actions[1].Label, "Sync (Apply Only) should be second")
-	assert.Equal(t, "Refresh", actions[2].Label, "Refresh should be third")
+	// Items are ordered by hotkey: a, d, D, l, L, r, R, s, S, X.
+	assert.Equal(t, "Sync (Apply Only)", actions[0].Label, "'a' sorts first")
+	assert.Equal(t, "Diff", actions[1].Label, "'d' sorts second")
 }
 
 func TestActionsForPortForward(t *testing.T) {


### PR DESCRIPTION
## Summary

Two related changes (follow-up to the CodeRabbit finding on #412):

**1. In-app action menus are now ordered by hotkey.** Every menu (resource kinds, containers, bulk, port-forward and capture entries) sorts case-insensitively by key, lowercase before uppercase on ties, so the menu reads as a hotkey index. Custom actions still appear after the built-in ones. Bulk menus previously prepended kind-specific actions; those now sort with the rest.

**2. The `docs/keybindings.md` Action Menu Items inventories are rebuilt from `actions.go` and sorted the same way.** Drift fixed (verified item-by-item):

- **Pod**: missing `g` Go to Node and `y` Security Findings
- **Deployment / StatefulSet / DaemonSet / Job / CronJob**: missing `y` Security Findings
- **ArgoCD Application**: documented a nonexistent `f` Diff action; missing `A` Configure AutoSync, `T` Terminate Sync, `W` Sync Wave Timeline
- **PVC**: missing `r` Resize
- **Bulk**: missing `L` Logs, `l` Labels / Annotations, `d` Diff (compare two)

Based on `feat/netpol-pod-service-actions` (inventories include the new `N` Network Policies entries from #412); retarget to `main` after #412 merges.

## Test plan

- [x] New `TestActionMenusSortedByHotkey` / `TestAuxiliaryActionMenusSortedByHotkey` assert hotkey order for 17 kinds plus container/bulk/port-forward/capture menus
- [x] `TestSortActionsByKey_TieBreak` covers the lowercase-before-uppercase tie rule
- [x] `TestActionsForBulkApplication` updated to the new ordering contract
- [x] Full suite with `-race`, `golangci-lint` clean
- [x] Doc inventories cross-checked against `actionsForKind` / `ActionsForBulk`