### PR TITLE
feat(logs): live-log preview for container rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 |---|---|
 | `x` | Action menu (logs, exec, describe, edit, delete, scale, port-forward, etc.) |
 | `\` / `A` | Namespace selector / toggle all-namespaces |
-| `L` | Toggle live-log preview pane (right pane, streaming tail; pod resources only) |
+| `L` | Toggle live-log preview pane (right pane, streaming tail; pod and container rows) |
 | `Ctrl+L` | Open fullscreen log viewer |
 | `v` | Describe resource |
 | `D` / `X` | Delete / force delete |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -447,7 +447,7 @@ The fullscreen viewers (YAML, diff, describe, log, events) honor the shared `sea
 | `toggle_prefixes` | `p` | Toggle `[pod/name/container]` line prefixes (log viewer). |
 | `toggle_unified` | `u` | Toggle unified vs side-by-side layout (diff viewer). |
 | `toggle_preview` | `P` | Toggle the structured preview side panel (log viewer) / details↔YAML preview (explorer). |
-| `toggle_preview_logs` | `L` | Toggle the right-pane live-log preview for the selected pod (explorer; deeper levels only). |
+| `toggle_preview_logs` | `L` | Toggle the right-pane live-log preview for the selected pod or container (explorer; deeper levels only). |
 | `fullscreen` | `F` | Maximize/minimize: explorer middle column & dashboard, event timeline, error log. |
 | `sort_next` | `>` | Sort by next column |
 | `sort_prev` | `<` | Sort by previous column |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -141,7 +141,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `x` | Open action menu (bulk actions when items selected) | `action_menu` |
 | `\` | Open namespace selector | `namespace_selector` |
 | `A` | Toggle all-namespaces mode (also works inside the namespace selector — clears individual selections and enables all-ns) | `all_namespaces` |
-| `L` | Toggle live-log preview pane for selected pod (streaming tail in right pane; deeper levels only) | `toggle_preview_logs` |
+| `L` | Toggle live-log preview pane for selected pod or container (streaming tail in right pane; deeper levels only) | `toggle_preview_logs` |
 | `Ctrl+L` | Open fullscreen log viewer for selected resource | `logs` |
 | `e` | Secret/ConfigMap editor (inline key-value editing) | `secret_editor` |
 | `E` | Edit selected resource in $KUBE_EDITOR or $EDITOR | `edit` |

--- a/internal/app/logshared.go
+++ b/internal/app/logshared.go
@@ -10,20 +10,29 @@ import (
 	"slices"
 )
 
-// kubectlPodLogArgs builds the kubectl args to tail all containers of a single
-// pod. When follow is true the stream stays open (-f) with the flags needed to
-// survive init-container transitions (--max-log-requests, --ignore-errors);
-// when false it is a one-shot snapshot used for lazy history fetches. A tail of
-// 0 means "no backlog", a positive tail caps the backlog, and a negative tail
-// omits --tail entirely.
-func kubectlPodLogArgs(name, namespace, kctx string, follow bool, tail int) []string {
+// kubectlPodLogArgs builds the kubectl args to tail a single pod: all of its
+// containers when container is "", or just that container via -c. When follow
+// is true the stream stays open (-f) with the flags needed to survive
+// init-container transitions (--ignore-errors, plus --max-log-requests for the
+// multi-stream all-containers tail); when false it is a one-shot snapshot used
+// for lazy history fetches. A tail of 0 means "no backlog", a positive tail
+// caps the backlog, and a negative tail omits --tail entirely.
+func kubectlPodLogArgs(name, namespace, kctx string, follow bool, tail int, container string) []string {
 	args := []string{"logs"}
 	if follow {
 		args = append(args, "-f")
 	}
-	args = append(args, name, "-n", namespace, "--context", kctx, "--all-containers=true", "--prefix")
+	args = append(args, name, "-n", namespace, "--context", kctx)
+	if container != "" {
+		args = append(args, "-c", container)
+	} else {
+		args = append(args, "--all-containers=true", "--prefix")
+	}
 	if follow {
-		args = append(args, "--max-log-requests=20", "--ignore-errors")
+		if container == "" {
+			args = append(args, "--max-log-requests=20")
+		}
+		args = append(args, "--ignore-errors")
 	}
 	if tail >= 0 {
 		args = append(args, fmt.Sprintf("--tail=%d", tail))

--- a/internal/app/logshared_test.go
+++ b/internal/app/logshared_test.go
@@ -10,7 +10,7 @@ import (
 // needed to survive init-container transitions (-f, --max-log-requests,
 // --ignore-errors) plus the common all-containers/prefix/timestamps set.
 func TestKubectlPodLogArgs_Follow(t *testing.T) {
-	got := kubectlPodLogArgs("mypod", "myns", "myctx", true, 50)
+	got := kubectlPodLogArgs("mypod", "myns", "myctx", true, 50, "")
 	assert.Equal(t, []string{
 		"logs", "-f", "mypod",
 		"-n", "myns",
@@ -27,7 +27,7 @@ func TestKubectlPodLogArgs_Follow(t *testing.T) {
 // TestKubectlPodLogArgs_Snapshot asserts the one-shot variant (lazy history
 // fetch) omits -f and the follow-only flags but keeps --tail/--timestamps.
 func TestKubectlPodLogArgs_Snapshot(t *testing.T) {
-	got := kubectlPodLogArgs("mypod", "myns", "myctx", false, 200)
+	got := kubectlPodLogArgs("mypod", "myns", "myctx", false, 200, "")
 	assert.Equal(t, []string{
 		"logs", "mypod",
 		"-n", "myns",
@@ -39,9 +39,35 @@ func TestKubectlPodLogArgs_Snapshot(t *testing.T) {
 	}, got)
 }
 
+// TestKubectlPodLogArgs_Container asserts the single-container variant scopes
+// the stream with -c and drops the all-containers flags (--all-containers,
+// --prefix, --max-log-requests) that only make sense for multi-stream tails.
+func TestKubectlPodLogArgs_Container(t *testing.T) {
+	got := kubectlPodLogArgs("mypod", "myns", "myctx", true, 50, "sidecar")
+	assert.Equal(t, []string{
+		"logs", "-f", "mypod",
+		"-n", "myns",
+		"--context", "myctx",
+		"-c", "sidecar",
+		"--ignore-errors",
+		"--tail=50",
+		"--timestamps",
+	}, got)
+
+	snapshot := kubectlPodLogArgs("mypod", "myns", "myctx", false, 200, "sidecar")
+	assert.Equal(t, []string{
+		"logs", "mypod",
+		"-n", "myns",
+		"--context", "myctx",
+		"-c", "sidecar",
+		"--tail=200",
+		"--timestamps",
+	}, snapshot)
+}
+
 // TestKubectlPodLogArgs_NoTail asserts a negative tail omits the --tail flag.
 func TestKubectlPodLogArgs_NoTail(t *testing.T) {
-	got := kubectlPodLogArgs("p", "n", "c", false, -1)
+	got := kubectlPodLogArgs("p", "n", "c", false, -1, "")
 	assert.NotContains(t, got, "--tail=-1")
 	for _, a := range got {
 		assert.NotContains(t, a, "--tail", "no --tail flag when tail < 0")

--- a/internal/app/previewlog.go
+++ b/internal/app/previewlog.go
@@ -184,7 +184,7 @@ func (m Model) startPreviewLogStream(ref podRef, reconnect bool) (Model, tea.Cmd
 		m.previewLog.historyTail = initialTail
 	}
 
-	args := kubectlPodLogArgs(ref.name, ref.namespace, m.kubectlContext(ref.context), true, tail)
+	args := kubectlPodLogArgs(ref.name, ref.namespace, m.kubectlContext(ref.context), true, tail, ref.container)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.previewLog.cancel = cancel
@@ -400,21 +400,37 @@ func (m Model) maybeRestartOrCancelPreviewLog() (Model, tea.Cmd) {
 	return m.maybeRestartPreviewLog(ref)
 }
 
-// previewLogPodLabel returns "namespace/name" for the currently-selected pod,
-// or "" when no pod resolves (so RenderLogPreview shows its placeholder).
+// previewLogPodLabel returns "namespace/name" for the currently-selected pod
+// ("namespace/name/container" for a container stream), or "" when no pod
+// resolves (so RenderLogPreview shows its placeholder).
 func (m Model) previewLogPodLabel() string {
 	ref, ok := m.selectedPodForLogPreview()
 	if !ok {
 		return ""
 	}
-	return ref.namespace + "/" + ref.name
+	label := ref.namespace + "/" + ref.name
+	if ref.container != "" {
+		label += "/" + ref.container
+	}
+	return label
 }
 
-// podRef identifies a single pod for the live-log preview stream.
-type podRef struct{ context, namespace, name string }
+// podRef identifies a single pod — or one container of it — for the live-log
+// preview stream. An empty container means "all containers" (the whole-pod
+// stream).
+type podRef struct{ context, namespace, name, container string }
 
-// key returns the cache/dedup key for this pod ref ("ctx/ns/name").
-func (r podRef) key() string { return r.context + "/" + r.namespace + "/" + r.name }
+// key returns the cache/dedup key for this ref ("ctx/ns/name", with a
+// "/container" suffix for single-container streams so a container switch is
+// seen as a stream change). Kubernetes name validation forbids "/" in
+// namespace, pod, and container names, so the separator is unambiguous.
+func (r podRef) key() string {
+	k := r.context + "/" + r.namespace + "/" + r.name
+	if r.container != "" {
+		k += "/" + r.container
+	}
+	return k
+}
 
 // cachePreviewLog saves the current preview buffer under its podKey so it can
 // be restored when the user returns to the same pod. A copy of the slice is
@@ -552,14 +568,22 @@ func (m Model) previewLogViewportHeight() int {
 
 // selectedPodForLogPreview returns the pod to tail when the current selection
 // resolves to exactly one pod (a Pod row at LevelResources, or a Pod selected
-// after drilling into a parent at LevelOwned). Returns ok=false for multi-pod
-// parents and non-pod resources.
+// after drilling into a parent at LevelOwned) or one container of a pod (a
+// Container row at LevelContainers — the parent pod comes from nav.OwnedName,
+// mirroring buildActionCtx). Returns ok=false for multi-pod parents and
+// non-pod resources.
 func (m Model) selectedPodForLogPreview() (podRef, bool) {
 	sel := m.selectedMiddleItem()
 	if sel == nil {
 		return podRef{}, false
 	}
-	if sel.Kind != "Pod" {
+	name, container := sel.Name, ""
+	if sel.Kind == "Container" {
+		if m.nav.OwnedName == "" {
+			return podRef{}, false
+		}
+		name, container = m.nav.OwnedName, sel.Name
+	} else if sel.Kind != "Pod" {
 		return podRef{}, false
 	}
 	// Mirror the namespace resolution from buildActionCtx.
@@ -573,7 +597,8 @@ func (m Model) selectedPodForLogPreview() (podRef, bool) {
 	return podRef{
 		context:   m.effectiveContext(),
 		namespace: ns,
-		name:      sel.Name,
+		name:      name,
+		container: container,
 	}, true
 }
 
@@ -592,7 +617,7 @@ func (m Model) fetchOlderPreviewLogs(ref podRef, tail int) tea.Cmd {
 	kubeconfigPaths := m.client.KubeconfigPathForContext(ref.context)
 	podKey := ref.key()
 
-	args := kubectlPodLogArgs(ref.name, ref.namespace, m.kubectlContext(ref.context), false, tail)
+	args := kubectlPodLogArgs(ref.name, ref.namespace, m.kubectlContext(ref.context), false, tail, ref.container)
 
 	return func() tea.Msg {
 		cmd := exec.Command(kubectlPath, args...) //nolint:gosec

--- a/internal/app/previewlog_test.go
+++ b/internal/app/previewlog_test.go
@@ -24,14 +24,14 @@ func TestPreviewCacheRestoreOnReturn(t *testing.T) {
 
 	// Enter pod A (fresh start — no cache).
 	m = withSelectedPod(t, m, "ns", "pod-a")
-	m, _ = m.enterPreviewLogPod(podRef{"test-ctx", "ns", "pod-a"})
+	m, _ = m.enterPreviewLogPod(podRef{context: "test-ctx", namespace: "ns", name: "pod-a"})
 
 	// Simulate some lines arriving.
 	m.previewLog.lines = []string{"line-1", "line-2", "line-3"}
 
 	// Navigate to pod B — A's buffer should be cached.
 	m = withSelectedPod(t, m, "ns", "pod-b")
-	m, _ = m.enterPreviewLogPod(podRef{"test-ctx", "ns", "pod-b"})
+	m, _ = m.enterPreviewLogPod(podRef{context: "test-ctx", namespace: "ns", name: "pod-b"})
 
 	keyA := "test-ctx/ns/pod-a"
 	assert.Contains(t, m.previewLogCache, keyA, "pod-a buffer must be cached on leave")
@@ -39,7 +39,7 @@ func TestPreviewCacheRestoreOnReturn(t *testing.T) {
 
 	// Return to pod A — buffer must be restored.
 	m = withSelectedPod(t, m, "ns", "pod-a")
-	m, _ = m.enterPreviewLogPod(podRef{"test-ctx", "ns", "pod-a"})
+	m, _ = m.enterPreviewLogPod(podRef{context: "test-ctx", namespace: "ns", name: "pod-a"})
 
 	assert.Equal(t, "test-ctx/ns/pod-a", m.previewLog.podKey, "podKey must be pod-a after restore")
 	assert.Equal(t, []string{"line-1", "line-2", "line-3"}, m.previewLog.lines,
@@ -56,7 +56,7 @@ func TestPreviewCacheToggleOffOnSamePod(t *testing.T) {
 	m = withSelectedPod(t, m, "ns", "pod-a")
 
 	// Enter pod A.
-	m, _ = m.enterPreviewLogPod(podRef{"test-ctx", "ns", "pod-a"})
+	m, _ = m.enterPreviewLogPod(podRef{context: "test-ctx", namespace: "ns", name: "pod-a"})
 	m.previewLog.lines = []string{"a", "b", "c"}
 
 	// Toggle off: cache then cancel.
@@ -67,7 +67,7 @@ func TestPreviewCacheToggleOffOnSamePod(t *testing.T) {
 	assert.Contains(t, m.previewLogCache, "test-ctx/ns/pod-a", "buffer must be cached on disable")
 
 	// Toggle on again: restore from cache.
-	m, _ = m.enterPreviewLogPod(podRef{"test-ctx", "ns", "pod-a"})
+	m, _ = m.enterPreviewLogPod(podRef{context: "test-ctx", namespace: "ns", name: "pod-a"})
 	assert.Equal(t, []string{"a", "b", "c"}, m.previewLog.lines,
 		"re-enabling must restore from cache")
 	assert.Equal(t, "test-ctx/ns/pod-a", m.previewLog.podKey)
@@ -88,7 +88,7 @@ func TestPreviewCacheLRUEvicts(t *testing.T) {
 		// Set current pod lines before switching away so cachePreviewLog has content.
 		m.previewLog.podKey = "test-ctx/ns/" + podName
 		m.previewLog.lines = []string{"line-from-" + podName}
-		m, _ = m.enterPreviewLogPod(podRef{"test-ctx", "ns", fmt.Sprintf("pod-%d", i+1)})
+		m, _ = m.enterPreviewLogPod(podRef{context: "test-ctx", namespace: "ns", name: fmt.Sprintf("pod-%d", i+1)})
 	}
 
 	assert.LessOrEqual(t, len(m.previewLogCache), previewLogCacheMax,
@@ -364,6 +364,19 @@ func withSelectedResource(_ *testing.T, m Model, kind, ns, name string) Model {
 	return m
 }
 
+// withSelectedContainer positions the model at LevelContainers inside pod
+// (ns/podName) with the cursor on a single Container row, mirroring what
+// navigateChildResource does when drilling into a Pod.
+func withSelectedContainer(_ *testing.T, m Model, ns, podName, container string) Model {
+	m.nav.Level = model.LevelContainers
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", Namespaced: true}
+	m.nav.Namespace = ns
+	m.nav.OwnedName = podName
+	m.middleItems = []model.Item{{Name: container, Kind: "Container", Status: "Running"}}
+	m.setCursor(0)
+	return m
+}
+
 func TestUpdatePreviewLogLineAppendsForCurrentStream(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m.previewLog.readerInFlight = &atomic.Bool{}
@@ -437,7 +450,7 @@ func TestStartPreviewLogStreamReplacesPrevious(t *testing.T) {
 	m.previewLog.cancel = func() { cancelled = true }
 	m.previewLog.podKey = "ctx/ns/old"
 
-	m, _ = m.startPreviewLogStream(podRef{"ctx", "ns", "new"}, false)
+	m, _ = m.startPreviewLogStream(podRef{context: "ctx", namespace: "ns", name: "new"}, false)
 	assert.True(t, cancelled, "switching pods must cancel the previous stream")
 	assert.Equal(t, "ctx/ns/new", m.previewLog.podKey)
 }
@@ -456,7 +469,7 @@ func TestPreviewReconnectPreservesBufferAndCounter(t *testing.T) {
 	m.previewLog.fromBottom = 2
 	m.previewLog.podKey = "ctx/ns/pod-1"
 
-	m, _ = m.startPreviewLogStream(podRef{"ctx", "ns", "pod-1"}, true)
+	m, _ = m.startPreviewLogStream(podRef{context: "ctx", namespace: "ns", name: "pod-1"}, true)
 
 	assert.True(t, cancelled, "reconnect must cancel the previous kubectl stream")
 	assert.Equal(t, []string{"a", "b"}, m.previewLog.lines, "reconnect must preserve existing lines")
@@ -478,7 +491,7 @@ func TestPreviewSwitchClearsBuffer(t *testing.T) {
 	m.previewLog.fromBottom = 3
 	m.previewLog.podKey = "ctx/ns/pod-1"
 
-	m, _ = m.startPreviewLogStream(podRef{"ctx", "ns", "pod-2"}, false)
+	m, _ = m.startPreviewLogStream(podRef{context: "ctx", namespace: "ns", name: "pod-2"}, false)
 
 	assert.Empty(t, m.previewLog.lines, "pod switch must clear the buffer")
 	assert.Equal(t, 0, m.previewLog.autoReconnectAttempt, "pod switch must reset attempt counter")
@@ -527,6 +540,40 @@ func TestSelectedPodForLogPreview(t *testing.T) {
 		_, ok := m.selectedPodForLogPreview()
 		assert.False(t, ok)
 	})
+	t.Run("container row resolves to its pod plus container", func(t *testing.T) {
+		m := baseModelWithFakeClient()
+		m = withSelectedContainer(t, m, "ns", "pod-1", "sidecar")
+		ref, ok := m.selectedPodForLogPreview()
+		assert.True(t, ok)
+		assert.Equal(t, "pod-1", ref.name, "pod name comes from nav.OwnedName")
+		assert.Equal(t, "ns", ref.namespace)
+		assert.Equal(t, "sidecar", ref.container)
+	})
+	t.Run("container row without owned pod does not resolve", func(t *testing.T) {
+		m := baseModelWithFakeClient()
+		m = withSelectedContainer(t, m, "ns", "", "sidecar")
+		_, ok := m.selectedPodForLogPreview()
+		assert.False(t, ok)
+	})
+}
+
+// Two containers of the same pod must stream and cache independently: the
+// podRef key embeds the container so a container switch restarts the stream.
+func TestPodRefKeyDistinguishesContainers(t *testing.T) {
+	pod := podRef{context: "ctx", namespace: "ns", name: "pod-1"}
+	app := podRef{context: "ctx", namespace: "ns", name: "pod-1", container: "app"}
+	sidecar := podRef{context: "ctx", namespace: "ns", name: "pod-1", container: "sidecar"}
+
+	assert.Equal(t, "ctx/ns/pod-1", pod.key(), "whole-pod key keeps its historical shape")
+	assert.NotEqual(t, app.key(), sidecar.key())
+	assert.NotEqual(t, pod.key(), app.key())
+}
+
+// The pane title shows which container is being tailed.
+func TestPreviewLogPodLabelIncludesContainer(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m = withSelectedContainer(t, m, "ns", "pod-1", "app")
+	assert.Equal(t, "ns/pod-1/app", m.previewLogPodLabel())
 }
 
 func TestToggleLogPreviewMutualExclusivity(t *testing.T) {
@@ -564,7 +611,7 @@ func TestPreviewLogSwitchesOnlyOnPodChange(t *testing.T) {
 		m := baseModelWithFakeClient()
 		m.fullLogPreview = true
 		m.previewLog.podKey = "ctx/ns/pod-1"
-		m2, cmd := m.maybeRestartPreviewLog(podRef{"ctx", "ns", "pod-1"})
+		m2, cmd := m.maybeRestartPreviewLog(podRef{context: "ctx", namespace: "ns", name: "pod-1"})
 		assert.Equal(t, "ctx/ns/pod-1", m2.previewLog.podKey, "same pod must not change podKey")
 		assert.Nil(t, cmd, "same pod must return nil cmd (no-op)")
 	})
@@ -574,7 +621,7 @@ func TestPreviewLogSwitchesOnlyOnPodChange(t *testing.T) {
 		m.previewLog.readerInFlight = &atomic.Bool{}
 		m.fullLogPreview = true
 		m.previewLog.podKey = "ctx/ns/pod-1"
-		m2, _ := m.maybeRestartPreviewLog(podRef{"ctx", "ns", "pod-2"})
+		m2, _ := m.maybeRestartPreviewLog(podRef{context: "ctx", namespace: "ns", name: "pod-2"})
 		assert.Equal(t, "ctx/ns/pod-2", m2.previewLog.podKey, "different pod must update podKey")
 	})
 }

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -90,7 +90,7 @@ func helpSections() []helpSection {
 				{kb.NamespaceSelector, "Select namespace (space: include, tab: exclude, A: all-namespaces, R: refresh)"},
 				{kb.AllNamespaces, "Toggle all-namespaces mode"},
 				{kb.ActionMenu, "Action menu: l=tail logs (last 10 lines + follow), L=full logs, exec, debug, debug pod, describe, edit, delete, scale, port-forward, events, startup analysis, crash investigator, traffic capture, RBAC permissions"},
-				{kb.TogglePreviewLogs, "Toggle live-log preview pane for selected pod (right pane, streaming tail)"},
+				{kb.TogglePreviewLogs, "Toggle live-log preview pane for selected pod or container (right pane, streaming tail)"},
 				{kb.Logs, "Open fullscreen log viewer for selected resource"},
 				{kb.Describe, "Describe selected resource"},
 				{kb.Edit, "Edit selected resource in $KUBE_EDITOR or $EDITOR"},


### PR DESCRIPTION
## Summary

- The `shift+L` right-pane live-log preview only resolved Pod rows; on a Container row at `LevelContainers` the pane stayed blank (fullscreen logs already supported containers). Container rows now resolve too: the parent pod comes from `nav.OwnedName` (mirroring `buildActionCtx`) and the stream is scoped with `kubectl logs -c <container>` instead of `--all-containers --prefix` (dropping `--max-log-requests`, which only applies to multi-stream tails).
- `podRef` carries the container and includes it in the stream/cache key, so switching containers restarts the stream and each container keeps its own LRU buffer entry; lazy history fetches are scoped the same way. The pane title shows `ns/pod/container`.
- Help text, README hotkey table, `docs/keybindings.md`, and `docs/config-reference.md` updated from "selected pod" to "pod or container".

## Test plan

- [x] `kubectlPodLogArgs` single-container variant (follow + snapshot arg shapes)
- [x] `selectedPodForLogPreview` container subtests (resolves via OwnedName; no OwnedName → no resolve)
- [x] `podRef.key()` distinguishes containers of the same pod; whole-pod keys keep their historical shape
- [x] pane label includes the container
- [x] `go build`, `go vet`, `go test -race ./...`, `make lint` all clean
- [x] go-reviewer pass: 0 CRITICAL/HIGH (MEDIUM notes informational)