### PR TITLE
fix(preview): stop column flicker by carrying enriched columns into preview refetches

### DIFF
--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -130,6 +130,15 @@ func (m *Model) setMiddleItems(items []model.Item) {
 // This prevents blinking during watch mode refreshes while metrics load async.
 // Only carries over if actual usage data exists (CPU/MEM have real values).
 func (m *Model) carryOverMetricsColumns(newItems []model.Item) {
+	carryOverMetricsColumnsFrom(m.middleItems, newItems)
+}
+
+// carryOverMetricsColumnsFrom is the source-explicit core of
+// carryOverMetricsColumns. The right-pane list preview carries from its own
+// previous items / the drill-in cache instead of middleItems (issue #408:
+// preview fetches return unenriched items, so without the carry-over the
+// preview's column set flips against the drilled list on every refetch).
+func carryOverMetricsColumnsFrom(oldItems, newItems []model.Item) {
 	metricsKeys := map[string]bool{
 		"CPU": true, "CPU/R": true, "CPU/L": true,
 		"MEM": true, "MEM/R": true, "MEM/L": true,
@@ -143,7 +152,7 @@ func (m *Model) carryOverMetricsColumns(newItems []model.Item) {
 	// the metrics columns flicker out and back in on each refresh.
 	type itemKey struct{ ns, name string }
 	oldMetrics := make(map[itemKey][]model.KeyValue)
-	for _, item := range m.middleItems {
+	for _, item := range oldItems {
 		var cols []model.KeyValue
 		for _, kv := range item.Columns {
 			if metricsKeys[kv.Key] {
@@ -195,13 +204,20 @@ func (m *Model) carryOverMetricsColumns(newItems []model.Item) {
 //
 // Same reasoning as carryOverMetricsColumns above.
 func (m *Model) carryOverServiceEndpointColumns(newItems []model.Item) {
+	carryOverServiceEndpointColumnsFrom(m.middleItems, newItems)
+}
+
+// carryOverServiceEndpointColumnsFrom is the source-explicit core of
+// carryOverServiceEndpointColumns, shared with the right-pane list preview
+// (see carryOverMetricsColumnsFrom).
+func carryOverServiceEndpointColumnsFrom(oldItems, newItems []model.Item) {
 	endpointKeys := map[string]bool{
 		"Backing Endpoints": true,
 		"Endpoints":         true,
 	}
 	type itemKey struct{ ns, name string }
 	old := make(map[itemKey][]model.KeyValue)
-	for _, item := range m.middleItems {
+	for _, item := range oldItems {
 		var cols []model.KeyValue
 		for _, kv := range item.Columns {
 			if endpointKeys[kv.Key] {

--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -150,7 +150,9 @@ func carryOverMetricsColumnsFrom(oldItems, newItems []model.Item) {
 	// when metrics-server returned nothing. The previous hasUsage gate
 	// dropped the carryover whenever every value was empty/zero, which made
 	// the metrics columns flicker out and back in on each refresh.
-	type itemKey struct{ ns, name string }
+	// The key includes the cluster: in union mode the same namespace+name can
+	// exist in several clusters and must not share carried columns.
+	type itemKey struct{ cluster, ns, name string }
 	oldMetrics := make(map[itemKey][]model.KeyValue)
 	for _, item := range oldItems {
 		var cols []model.KeyValue
@@ -160,7 +162,7 @@ func carryOverMetricsColumnsFrom(oldItems, newItems []model.Item) {
 			}
 		}
 		if len(cols) > 0 {
-			oldMetrics[itemKey{item.Namespace, item.Name}] = cols
+			oldMetrics[itemKey{item.ClusterName, item.Namespace, item.Name}] = cols
 		}
 	}
 	if len(oldMetrics) == 0 {
@@ -170,7 +172,7 @@ func carryOverMetricsColumnsFrom(oldItems, newItems []model.Item) {
 	// the raw request/limit columns (CPU Req, CPU Lim, Mem Req, Mem Lim) so
 	// that podMetricsEnrichedMsg can still read them to compute percentages.
 	for i := range newItems {
-		key := itemKey{newItems[i].Namespace, newItems[i].Name}
+		key := itemKey{newItems[i].ClusterName, newItems[i].Namespace, newItems[i].Name}
 		cols, ok := oldMetrics[key]
 		if !ok {
 			continue
@@ -215,7 +217,8 @@ func carryOverServiceEndpointColumnsFrom(oldItems, newItems []model.Item) {
 		"Backing Endpoints": true,
 		"Endpoints":         true,
 	}
-	type itemKey struct{ ns, name string }
+	// Cluster-qualified key: see carryOverMetricsColumnsFrom.
+	type itemKey struct{ cluster, ns, name string }
 	old := make(map[itemKey][]model.KeyValue)
 	for _, item := range oldItems {
 		var cols []model.KeyValue
@@ -225,14 +228,14 @@ func carryOverServiceEndpointColumnsFrom(oldItems, newItems []model.Item) {
 			}
 		}
 		if len(cols) > 0 {
-			old[itemKey{item.Namespace, item.Name}] = cols
+			old[itemKey{item.ClusterName, item.Namespace, item.Name}] = cols
 		}
 	}
 	if len(old) == 0 {
 		return
 	}
 	for i := range newItems {
-		key := itemKey{newItems[i].Namespace, newItems[i].Name}
+		key := itemKey{newItems[i].ClusterName, newItems[i].Namespace, newItems[i].Name}
 		cols, ok := old[key]
 		if !ok {
 			continue

--- a/internal/app/cursor_carryover_union_test.go
+++ b/internal/app/cursor_carryover_union_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Union mode: identical namespace+name can exist in multiple clusters, so the
+// carry-over lookups must key by cluster too — otherwise one cluster's carried
+// columns overwrite another's (CodeRabbit review on PR #422).
+
+func TestCarryOverMetricsColumnsFrom_UnionClustersDontCollide(t *testing.T) {
+	oldItems := []model.Item{
+		{
+			Name: "pod-a", Namespace: "ns-1", ClusterName: "cluster-1",
+			Columns: []model.KeyValue{{Key: "CPU", Value: "100m"}},
+		},
+		{
+			Name: "pod-a", Namespace: "ns-1", ClusterName: "cluster-2",
+			Columns: []model.KeyValue{{Key: "CPU", Value: "900m"}},
+		},
+	}
+	newItems := []model.Item{
+		{Name: "pod-a", Namespace: "ns-1", ClusterName: "cluster-1"},
+		{Name: "pod-a", Namespace: "ns-1", ClusterName: "cluster-2"},
+	}
+	carryOverMetricsColumnsFrom(oldItems, newItems)
+
+	assert.Equal(t, []model.KeyValue{{Key: "CPU", Value: "100m"}}, newItems[0].Columns,
+		"cluster-1 row must keep cluster-1 metrics")
+	assert.Equal(t, []model.KeyValue{{Key: "CPU", Value: "900m"}}, newItems[1].Columns,
+		"cluster-2 row must keep cluster-2 metrics")
+}
+
+func TestCarryOverServiceEndpointColumnsFrom_UnionClustersDontCollide(t *testing.T) {
+	oldItems := []model.Item{
+		{
+			Name: "svc", Namespace: "ns-1", ClusterName: "cluster-1",
+			Columns: []model.KeyValue{{Key: "Backing Endpoints", Value: "2"}},
+		},
+		{
+			Name: "svc", Namespace: "ns-1", ClusterName: "cluster-2",
+			Columns: []model.KeyValue{{Key: "Backing Endpoints", Value: "7"}},
+		},
+	}
+	newItems := []model.Item{
+		{Name: "svc", Namespace: "ns-1", ClusterName: "cluster-1"},
+		{Name: "svc", Namespace: "ns-1", ClusterName: "cluster-2"},
+	}
+	carryOverServiceEndpointColumnsFrom(oldItems, newItems)
+
+	assert.Equal(t, []model.KeyValue{{Key: "Backing Endpoints", Value: "2"}}, newItems[0].Columns,
+		"cluster-1 row must keep cluster-1 endpoints")
+	assert.Equal(t, []model.KeyValue{{Key: "Backing Endpoints", Value: "7"}}, newItems[1].Columns,
+		"cluster-2 row must keep cluster-2 endpoints")
+}

--- a/internal/app/preview_carryover_test.go
+++ b/internal/app/preview_carryover_test.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Issue #408 follow-up: preview refetches return unenriched items (no
+// CPU/MEM metrics, no Service endpoint rollup), while the drilled list's
+// items are enriched asynchronously. Without carrying the enriched columns
+// over, every hover refetch (the rt-level watch tick drops the preview
+// fingerprint each interval) flips the auto-detected column set — columns
+// appear and disappear in the preview.
+
+func columnsByKey(item model.Item) map[string]string {
+	out := make(map[string]string, len(item.Columns))
+	for _, kv := range item.Columns {
+		out[kv.Key] = kv.Value
+	}
+	return out
+}
+
+func enrichedPodItems() []model.Item {
+	return []model.Item{
+		{Name: "web-0", Namespace: "default", Kind: "Pod", Status: "Running", Columns: []model.KeyValue{
+			{Key: "CPU", Value: "12m"},
+			{Key: "CPU/R", Value: "12%"},
+			{Key: "CPU/L", Value: "6%"},
+			{Key: "MEM", Value: "30Mi"},
+			{Key: "MEM/R", Value: "15%"},
+			{Key: "MEM/L", Value: "7%"},
+			{Key: "Node", Value: "n1"},
+		}},
+		{Name: "web-1", Namespace: "default", Kind: "Pod", Status: "Running", Columns: []model.KeyValue{
+			{Key: "CPU", Value: "7m"},
+			{Key: "CPU/R", Value: "7%"},
+			{Key: "CPU/L", Value: "3%"},
+			{Key: "MEM", Value: "22Mi"},
+			{Key: "MEM/R", Value: "11%"},
+			{Key: "MEM/L", Value: "5%"},
+			{Key: "Node", Value: "n2"},
+		}},
+	}
+}
+
+func unenrichedPodItems() []model.Item {
+	return []model.Item{
+		{Name: "web-0", Namespace: "default", Kind: "Pod", Status: "Running", Columns: []model.KeyValue{
+			{Key: "Node", Value: "n1"},
+		}},
+		{Name: "web-1", Namespace: "default", Kind: "Pod", Status: "Running", Columns: []model.KeyValue{
+			{Key: "Node", Value: "n2"},
+		}},
+	}
+}
+
+func TestPreviewCarriesMetricsColumnsFromDrillCache(t *testing.T) {
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.itemCache["test-ctx/pods"] = enrichedPodItems()
+
+	res, _ := m.Update(resourcesLoadedMsg{items: unenrichedPodItems(), forPreview: true, rt: previewPodsRT()})
+	rm := res.(Model)
+
+	if len(rm.rightItems) != 2 {
+		t.Fatalf("rightItems = %d items, want 2", len(rm.rightItems))
+	}
+	cols := columnsByKey(rm.rightItems[0])
+	if cols["CPU"] != "12m" || cols["MEM"] != "30Mi" {
+		t.Fatalf("metrics columns not carried over from the drill-in cache: CPU=%q MEM=%q", cols["CPU"], cols["MEM"])
+	}
+	if cols["Node"] != "n1" {
+		t.Fatalf("non-metrics column lost in carry-over: Node=%q", cols["Node"])
+	}
+	// The cache prime must keep the enrichment too — overwriting the
+	// drilled list's enriched cache with unenriched preview items made the
+	// next drill-in flash the same surprise columns. The prime writes a
+	// fresh slice (the handler copies msg.items), so asserting on its
+	// contents genuinely exercises the primed entry, not the pre-Update one.
+	primed := rm.itemCache["test-ctx/pods"]
+	if len(primed) != 2 {
+		t.Fatalf("primed cache entry = %d items, want 2", len(primed))
+	}
+	if pc := columnsByKey(primed[0]); pc["CPU"] != "12m" {
+		t.Fatalf("primed cache lost metrics columns: CPU=%q", pc["CPU"])
+	}
+}
+
+func TestPreviewCarriesNodeMetricsColumnsFromDrillCache(t *testing.T) {
+	nodeRT := model.ResourceTypeEntry{Kind: "Node", Resource: "nodes", APIVersion: "v1"}
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.itemCache["test-ctx/nodes"] = []model.Item{
+		{Name: "n1", Kind: "Node", Columns: []model.KeyValue{
+			{Key: "CPU", Value: "1200m"},
+			{Key: "CPU%", Value: "30%"},
+			{Key: "MEM", Value: "4Gi"},
+			{Key: "MEM%", Value: "50%"},
+		}},
+	}
+
+	fresh := []model.Item{{Name: "n1", Kind: "Node", Columns: []model.KeyValue{
+		{Key: "Roles", Value: "control-plane"},
+	}}}
+	res, _ := m.Update(resourcesLoadedMsg{items: fresh, forPreview: true, rt: nodeRT})
+	rm := res.(Model)
+
+	cols := columnsByKey(rm.rightItems[0])
+	if cols["CPU"] != "1200m" || cols["MEM%"] != "50%" {
+		t.Fatalf("node metrics not carried over: CPU=%q MEM%%=%q", cols["CPU"], cols["MEM%"])
+	}
+	if cols["Roles"] != "control-plane" {
+		t.Fatalf("non-metrics column lost: Roles=%q", cols["Roles"])
+	}
+}
+
+func TestPreviewCarriesMetricsColumnsFromCurrentRightItems(t *testing.T) {
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.rightItems = enrichedPodItems() // currently shown preview, no cache entry
+
+	res, _ := m.Update(resourcesLoadedMsg{items: unenrichedPodItems(), forPreview: true, rt: previewPodsRT()})
+	rm := res.(Model)
+
+	cols := columnsByKey(rm.rightItems[0])
+	if cols["CPU"] != "12m" || cols["MEM/L"] != "7%" {
+		t.Fatalf("metrics columns not carried over from previous rightItems: CPU=%q MEM/L=%q", cols["CPU"], cols["MEM/L"])
+	}
+}
+
+func TestPreviewCarriesServiceEndpointColumns(t *testing.T) {
+	svcRT := model.ResourceTypeEntry{Kind: "Service", Resource: "services", APIVersion: "v1", Namespaced: true}
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.itemCache["test-ctx/services"] = []model.Item{
+		{Name: "api", Namespace: "default", Kind: "Service", Columns: []model.KeyValue{
+			{Key: "Type", Value: "ClusterIP"},
+			{Key: "Backing Endpoints", Value: "3/3"},
+			{Key: "Endpoints", Value: "10.0.0.1:8080"},
+		}},
+	}
+
+	fresh := []model.Item{
+		{Name: "api", Namespace: "default", Kind: "Service", Columns: []model.KeyValue{
+			{Key: "Type", Value: "ClusterIP"},
+		}},
+	}
+	res, _ := m.Update(resourcesLoadedMsg{items: fresh, forPreview: true, rt: svcRT})
+	rm := res.(Model)
+
+	cols := columnsByKey(rm.rightItems[0])
+	if cols["Backing Endpoints"] != "3/3" {
+		t.Fatalf("endpoint rollup not carried over: %q", cols["Backing Endpoints"])
+	}
+}
+
+func TestPreviewCarryoverSkipsKindMismatchRightItems(t *testing.T) {
+	m := basePush80v2Model()
+	m.nav.Level = model.LevelResourceTypes
+	// Previous hover showed Nodes (different kind) — their metrics must not
+	// leak into a pods preview that matches on ns+name by accident.
+	m.rightItems = []model.Item{
+		{Name: "web-0", Namespace: "default", Kind: "Node", Columns: []model.KeyValue{
+			{Key: "CPU", Value: "999m"},
+		}},
+	}
+
+	res, _ := m.Update(resourcesLoadedMsg{items: unenrichedPodItems(), forPreview: true, rt: previewPodsRT()})
+	rm := res.(Model)
+
+	cols := columnsByKey(rm.rightItems[0])
+	if got, ok := cols["CPU"]; ok {
+		t.Fatalf("metrics carried over from a different kind's preview: CPU=%q", got)
+	}
+}

--- a/internal/app/update_resources_loaded_preview.go
+++ b/internal/app/update_resources_loaded_preview.go
@@ -19,6 +19,29 @@ func (m Model) updateResourcesLoadedPreview(msg resourcesLoadedMsg) Model {
 	// Sort before the cache priming below so the drill-in shortcut serves
 	// the same order the preview showed.
 	m.sortPreviewItems(msg.items, msg.rt)
+	// Anti-flap carry-over, mirroring updateResourcesLoadedMain: preview
+	// fetches return unenriched items (no CPU/MEM metrics, no Service
+	// endpoint rollup), while the drilled list enriches them async. The
+	// rt-level watch tick drops the preview fingerprint every interval, so
+	// each hover refetch would otherwise flip the auto-detected column set
+	// — columns appear and disappear in the preview (#408 follow-up).
+	// Carry from the drill-in cache (which the drilled list's metrics
+	// ticks keep enriched) and fall back to the currently shown preview.
+	// Runs before the cache prime below so the prime keeps the enrichment
+	// instead of clobbering the drilled list's enriched cache entry.
+	if msg.rt.Kind == "Pod" || msg.rt.Kind == "Node" || msg.rt.Kind == "Service" {
+		prev := m.itemCache[m.nav.Context+"/"+msg.rt.Resource]
+		if len(prev) == 0 && len(m.rightItems) > 0 && m.rightItems[0].Kind == msg.rt.Kind {
+			prev = m.rightItems
+		}
+		if len(prev) > 0 && prev[0].Kind == msg.rt.Kind {
+			if msg.rt.Kind == "Service" {
+				carryOverServiceEndpointColumnsFrom(prev, msg.items)
+			} else {
+				carryOverMetricsColumnsFrom(prev, msg.items)
+			}
+		}
+	}
 	// Prime itemCache under the drill-in navKey so loadResources can serve
 	// the list instantly and skip a redundant fetch when the user drills
 	// in or re-hovers this rt later. Only do this when msg.rt carries a


### PR DESCRIPTION
Fixes the latest comment on #408: "The sort order seems stable now but the columns are not - several surprise columns display in the preview and then after a moment disappear."

## Root cause

Preview fetches return unenriched items — no CPU/MEM metrics columns (the drilled list merges those asynchronously via the pod/node list-metrics ticks) and no Service endpoint rollup. Two consequences:

- The rt-level watch tick drops the preview cache fingerprint every interval, so each hover refetch replaced enriched items with unenriched ones. With the metrics columns gone, the auto-detect width budget admits other extras (NODE, QoS, IP, ...), and they vanish again when an enriched payload comes back — the "surprise columns" flicker.
- The preview cache prime (added in #410) overwrote the drilled list's enriched `itemCache` entry with unenriched data, so the next drill-in flashed the same way.

## Fix

Mirror the main list's existing anti-flash mechanism in the preview handler:

- Extract `carryOverMetricsColumnsFrom` / `carryOverServiceEndpointColumnsFrom` — source-explicit cores of the existing `middleItems`-based helpers.
- In `updateResourcesLoadedPreview`, carry enriched columns from the drill-in cache (fallback: the currently shown preview items of the same kind) into fresh Pod/Node/Service preview loads, before the cache prime so the prime keeps the enrichment instead of clobbering it.

## Test plan

- [x] Carry-over from the drill-in cache (Pod, Node) and from current rightItems (Pod)
- [x] Service endpoint rollup carry-over
- [x] Cache prime retains enrichment (no clobber)
- [x] Kind-mismatch guard (Node metrics never leak into a Pod preview)
- [x] `go test -race`, `go vet`, `golangci-lint` (0 issues), `gofumpt` clean