### PR TITLE
fix: action menu hotkey order, overlay badge background, tree-view descriptions

### DIFF
--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -504,16 +504,54 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 			}
 		}
 
-		// Recursive explain output carries no per-field descriptions, so the
-		// parser stores the path in Description (shown in the right column).
-		// Keep that in sync after re-anchoring relative paths at fieldPath.
 		fields := parseRecursiveExplainForSearch(string(output), "")
 		if fieldPath != "" {
 			for i := range fields {
 				fields[i].Path = fieldPath + "." + fields[i].Path
-				fields[i].Description = fields[i].Path
 			}
 		}
 		return explainTreeLoadedMsg{fields: fields, path: fieldPath}
+	})
+}
+
+// execKubectlExplainTreeDesc fetches the per-field descriptions for one
+// schema level of the API Explorer tree (a plain kubectl explain of
+// parentPath, the same call the flat view makes per level). Recursive
+// explain output carries no descriptions, so tree mode merges these in
+// lazily as the cursor visits each level.
+func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath string) tea.Cmd {
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		return func() tea.Msg {
+			return explainTreeDescMsg{resource: resource, parent: parentPath, err: fmt.Errorf("kubectl not found: %w", err)}
+		}
+	}
+
+	kctx := m.effectiveContext()
+	kubeconfigPaths := m.client.KubeconfigPathForContext(kctx)
+
+	target := resource
+	if parentPath != "" {
+		target = resource + "." + parentPath
+	}
+
+	return m.trackBgTask(scheduler.KindSubprocess, "Explain (descriptions): "+target, kctx, func() tea.Msg {
+		args := []string{"explain", target, "--context", m.kubectlContext(kctx)}
+		if apiVersion != "" {
+			args = append(args, "--api-version", apiVersion)
+		}
+		cmd := exec.Command(kubectlPath, args...)
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
+		logExecCmd("Running kubectl command", cmd)
+		output, cmdErr := cmd.CombinedOutput()
+		if cmdErr != nil {
+			return explainTreeDescMsg{
+				resource: resource,
+				parent:   parentPath,
+				err:      fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
+			}
+		}
+		_, fields := parseExplainOutput(string(output), parentPath)
+		return explainTreeDescMsg{resource: resource, parent: parentPath, fields: fields}
 	})
 }

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -520,14 +520,18 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 // explain output carries no descriptions, so tree mode merges these in
 // lazily as the cursor visits each level.
 func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath string) tea.Cmd {
+	kctx := m.effectiveContext()
+	ident := explainTreeDescMsg{resource: resource, apiVersion: apiVersion, kctx: kctx, parent: parentPath}
+
 	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil {
 		return func() tea.Msg {
-			return explainTreeDescMsg{resource: resource, parent: parentPath, err: fmt.Errorf("kubectl not found: %w", err)}
+			msg := ident
+			msg.err = fmt.Errorf("kubectl not found: %w", err)
+			return msg
 		}
 	}
 
-	kctx := m.effectiveContext()
 	kubeconfigPaths := m.client.KubeconfigPathForContext(kctx)
 
 	target := resource
@@ -544,14 +548,12 @@ func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath strin
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
+		msg := ident
 		if cmdErr != nil {
-			return explainTreeDescMsg{
-				resource: resource,
-				parent:   parentPath,
-				err:      fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
-			}
+			msg.err = fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output)))
+			return msg
 		}
-		_, fields := parseExplainOutput(string(output), parentPath)
-		return explainTreeDescMsg{resource: resource, parent: parentPath, fields: fields}
+		_, msg.fields = parseExplainOutput(string(output), parentPath)
+		return msg
 	})
 }

--- a/internal/app/explain_parser.go
+++ b/internal/app/explain_parser.go
@@ -300,10 +300,9 @@ func parseRecursiveExplainForSearch(output, query string) []model.ExplainField {
 		// When query is empty, return all fields (for namespace-selector-style browsing).
 		if lowerQuery == "" || ui.MatchLine(fieldName, query) {
 			results = append(results, model.ExplainField{
-				Name:        fieldName,
-				Type:        fieldType,
-				Path:        fullPath,
-				Description: fullPath,
+				Name: fieldName,
+				Type: fieldType,
+				Path: fullPath,
 			})
 		}
 	}

--- a/internal/app/explain_tree.go
+++ b/internal/app/explain_tree.go
@@ -23,6 +23,17 @@ type explainTreeLoadedMsg struct {
 	err    error
 }
 
+// explainTreeDescMsg carries the per-field descriptions of one schema level
+// (a plain kubectl explain of parent), merged into the tree rows under it.
+// resource guards against results arriving after the explorer moved to a
+// different resource type.
+type explainTreeDescMsg struct {
+	resource string
+	parent   string
+	fields   []model.ExplainField
+	err      error
+}
+
 // explainTreeState holds the API Explorer's tree-mode state, embedded in
 // Model.
 type explainTreeState struct {
@@ -32,6 +43,13 @@ type explainTreeState struct {
 	explainTreeCollapsed map[string]struct{}  // folded subtree roots, keyed by schema path
 	explainTreeWanted    bool                 // sticky: re-enter tree mode after every level load
 	explainFlatLevel     explainLevel         // flat level stashed while tree mode is on
+
+	// Recursive explain output carries no per-field descriptions, so tree
+	// mode lazily describes one schema level at a time (a plain kubectl
+	// explain of the cursor row's parent path) and caches which levels are
+	// done / in flight for the life of the tree.
+	explainTreeDescFetched  map[string]struct{} // levels whose descriptions are merged (or failed)
+	explainTreeDescInflight map[string]struct{} // levels with a fetch currently in flight
 }
 
 // toggleExplainTree flips the API Explorer between the flat field list and
@@ -79,6 +97,8 @@ func (m *Model) resetExplainTree() {
 	m.explainTreeAll = nil
 	m.explainTreeCollapsed = nil
 	m.explainFlatLevel = explainLevel{}
+	m.explainTreeDescFetched = nil
+	m.explainTreeDescInflight = nil
 }
 
 // updateExplainTreeLoaded swaps the recursive field tree into the active
@@ -109,6 +129,11 @@ func (m Model) updateExplainTreeLoaded(msg explainTreeLoadedMsg) (tea.Model, tea
 	if !m.explainTree && m.explainCursor >= 0 && m.explainCursor < len(m.explainFields) {
 		selPath = m.explainFields[m.explainCursor].Path
 	}
+	// The tree's depth-0 rows are the same fields the flat level showed —
+	// carry their descriptions over and mark the level as described.
+	seedExplainDescriptions(msg.fields, m.explainFields)
+	m.explainTreeDescFetched = map[string]struct{}{m.explainPath: {}}
+	m.explainTreeDescInflight = nil
 	m.explainFlatLevel = explainLevel{fields: m.explainFields, cursor: m.explainCursor, scroll: m.explainScroll}
 	m.explainTree = true
 	m.explainTreeAll = msg.fields
@@ -117,6 +142,96 @@ func (m Model) updateExplainTreeLoaded(msg explainTreeLoadedMsg) (tea.Model, tea
 	m.explainScroll = 0
 	m.applyExplainTreeVisible(selPath)
 	return m, nil
+}
+
+// seedExplainDescriptions copies non-empty descriptions from src onto the
+// dst fields with the same schema path.
+func seedExplainDescriptions(dst, src []model.ExplainField) {
+	descByPath := make(map[string]string, len(src))
+	for _, f := range src {
+		if f.Description != "" {
+			descByPath[f.Path] = f.Description
+		}
+	}
+	if len(descByPath) == 0 {
+		return
+	}
+	for i := range dst {
+		if d, ok := descByPath[dst[i].Path]; ok {
+			dst[i].Description = d
+		}
+	}
+}
+
+// updateExplainTreeDescLoaded merges an arrived description batch into the
+// tree rows under msg.parent (both the full tree and the visible list) and
+// marks the level described. Failed fetches mark the level described too —
+// retrying on every cursor move would spawn a kubectl process per keypress;
+// the cache resets with the next tree load.
+func (m Model) updateExplainTreeDescLoaded(msg explainTreeDescMsg) tea.Model {
+	delete(m.explainTreeDescInflight, msg.parent)
+	if !m.explainTree || msg.resource != m.explainResource {
+		return m
+	}
+	if m.explainTreeDescFetched == nil {
+		m.explainTreeDescFetched = make(map[string]struct{})
+	}
+	m.explainTreeDescFetched[msg.parent] = struct{}{}
+	if msg.err != nil || len(msg.fields) == 0 {
+		return m
+	}
+	seedExplainDescriptions(m.explainTreeAll, msg.fields)
+	seedExplainDescriptions(m.explainFields, msg.fields)
+	return m
+}
+
+// maybeFetchExplainTreeDesc returns a command fetching the descriptions for
+// the cursor row's schema level when tree mode hasn't loaded them yet, and
+// remembers the fetch as in flight. Nil outside tree mode or when the level
+// is already described / loading.
+func (m *Model) maybeFetchExplainTreeDesc() tea.Cmd {
+	if !m.explainTree || m.explainCursor < 0 || m.explainCursor >= len(m.explainFields) {
+		return nil
+	}
+	parent := explainParentPath(m.explainFields[m.explainCursor].Path)
+	if _, ok := m.explainTreeDescFetched[parent]; ok {
+		return nil
+	}
+	if _, ok := m.explainTreeDescInflight[parent]; ok {
+		return nil
+	}
+	if m.explainTreeDescInflight == nil {
+		m.explainTreeDescInflight = make(map[string]struct{})
+	}
+	m.explainTreeDescInflight[parent] = struct{}{}
+	return m.execKubectlExplainTreeDesc(m.explainResource, m.explainAPIVersion, parent)
+}
+
+// withExplainTreeDescFetch chains a tree-description fetch for the cursor
+// row's level onto a key handler's result when one is needed.
+func withExplainTreeDescFetch(mdl tea.Model, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	m, ok := mdl.(Model)
+	if !ok {
+		return mdl, cmd
+	}
+	fetch := m.maybeFetchExplainTreeDesc()
+	switch {
+	case fetch == nil:
+		return m, cmd
+	case cmd == nil:
+		return m, fetch
+	default:
+		return m, tea.Batch(cmd, fetch)
+	}
+}
+
+// explainParentPath returns the schema path one level above path ("" at the
+// resource root).
+func explainParentPath(path string) string {
+	if idx := strings.LastIndex(path, "."); idx >= 0 {
+		return path[:idx]
+	}
+	return ""
 }
 
 // applyExplainTreeVisible recomputes the visible tree (explainFields +

--- a/internal/app/explain_tree.go
+++ b/internal/app/explain_tree.go
@@ -25,13 +25,16 @@ type explainTreeLoadedMsg struct {
 
 // explainTreeDescMsg carries the per-field descriptions of one schema level
 // (a plain kubectl explain of parent), merged into the tree rows under it.
-// resource guards against results arriving after the explorer moved to a
-// different resource type.
+// resource, apiVersion, and kctx identify the request so results arriving
+// after the explorer moved to a different resource type, API version, or
+// cluster context are dropped instead of merged into the wrong tree.
 type explainTreeDescMsg struct {
-	resource string
-	parent   string
-	fields   []model.ExplainField
-	err      error
+	resource   string
+	apiVersion string
+	kctx       string
+	parent     string
+	fields     []model.ExplainField
+	err        error
 }
 
 // explainTreeState holds the API Explorer's tree-mode state, embedded in
@@ -170,7 +173,8 @@ func seedExplainDescriptions(dst, src []model.ExplainField) {
 // the cache resets with the next tree load.
 func (m Model) updateExplainTreeDescLoaded(msg explainTreeDescMsg) tea.Model {
 	delete(m.explainTreeDescInflight, msg.parent)
-	if !m.explainTree || msg.resource != m.explainResource {
+	if !m.explainTree || msg.resource != m.explainResource ||
+		msg.apiVersion != m.explainAPIVersion || msg.kctx != m.effectiveContext() {
 		return m
 	}
 	if m.explainTreeDescFetched == nil {

--- a/internal/app/explain_tree_desc_test.go
+++ b/internal/app/explain_tree_desc_test.go
@@ -88,8 +88,10 @@ func TestExplainTreeDesc_LoadedMergesByPath(t *testing.T) {
 	m = mdl.(Model)
 
 	mdl = m.updateExplainTreeDescLoaded(explainTreeDescMsg{
-		resource: "deployments",
-		parent:   "spec.template",
+		resource:   "deployments",
+		apiVersion: m.explainAPIVersion,
+		kctx:       m.effectiveContext(),
+		parent:     "spec.template",
 		fields: []model.ExplainField{
 			{Name: "spec", Path: "spec.template.spec", Description: "Specification of the desired behavior of the pod."},
 		},
@@ -111,21 +113,28 @@ func TestExplainTreeDesc_LoadedMergesByPath(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
-// TestExplainTreeDesc_StaleResourceIgnored: a batch for a different resource
-// (the user left and reopened the explorer) must not merge.
-func TestExplainTreeDesc_StaleResourceIgnored(t *testing.T) {
+// TestExplainTreeDesc_StaleIdentityIgnored: a batch whose request identity
+// (resource, API version, or kube context) no longer matches the explorer
+// session (the user left and reopened it elsewhere) must not merge.
+func TestExplainTreeDesc_StaleIdentityIgnored(t *testing.T) {
 	m := explainTreeDescModel(t)
-	mdl := m.updateExplainTreeDescLoaded(explainTreeDescMsg{
-		resource: "pods",
-		parent:   "spec.template",
-		fields: []model.ExplainField{
-			{Name: "spec", Path: "spec.template.spec", Description: "wrong resource"},
-		},
-	})
-	m = mdl.(Model)
-	assert.Empty(t, m.explainFields[2].Description)
-	_, fetched := m.explainTreeDescFetched["spec.template"]
-	assert.False(t, fetched)
+	stale := []explainTreeDescMsg{
+		{resource: "pods", apiVersion: m.explainAPIVersion, kctx: m.effectiveContext()},
+		{resource: "deployments", apiVersion: "apps/v1beta1", kctx: m.effectiveContext()},
+		{resource: "deployments", apiVersion: m.explainAPIVersion, kctx: "other-cluster"},
+	}
+	for _, msg := range stale {
+		msg.parent = "spec.template"
+		msg.fields = []model.ExplainField{
+			{Name: "spec", Path: "spec.template.spec", Description: "stale batch"},
+		}
+		mdl := m.updateExplainTreeDescLoaded(msg)
+		m = mdl.(Model)
+		assert.Empty(t, m.explainFields[2].Description,
+			"stale batch %+v must not merge", msg)
+		_, fetched := m.explainTreeDescFetched["spec.template"]
+		assert.False(t, fetched, "stale batch %+v must not mark the level described", msg)
+	}
 }
 
 // TestExplainTreeDesc_ErrorMarksLevelDescribed: a failed fetch must not
@@ -137,9 +146,11 @@ func TestExplainTreeDesc_ErrorMarksLevelDescribed(t *testing.T) {
 	m = mdl.(Model)
 
 	mdl = m.updateExplainTreeDescLoaded(explainTreeDescMsg{
-		resource: "deployments",
-		parent:   "spec.template",
-		err:      assert.AnError,
+		resource:   "deployments",
+		apiVersion: m.explainAPIVersion,
+		kctx:       m.effectiveContext(),
+		parent:     "spec.template",
+		err:        assert.AnError,
 	})
 	m = mdl.(Model)
 	assert.Empty(t, m.explainTreeDescInflight)

--- a/internal/app/explain_tree_desc_test.go
+++ b/internal/app/explain_tree_desc_test.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// explainTreeDescModel builds a tree-mode model whose flat level carried
+// per-field descriptions (as every flat kubectl explain load does).
+func explainTreeDescModel(t *testing.T) Model {
+	t.Helper()
+	m := explainTreeBaseModel()
+	m.explainFields[0].Description = "Number of desired pods."
+	m.explainFields[1].Description = "Template describes the pods that will be created."
+	mdl, _ := m.updateExplainTreeLoaded(sampleTreeMsg())
+	rm, ok := mdl.(Model)
+	require.True(t, ok)
+	require.True(t, rm.explainTree)
+	return rm
+}
+
+// TestExplainTreeDesc_SeedsFromFlatLevel: the depth-0 tree rows are the same
+// fields the flat view just showed — their descriptions must carry over into
+// tree mode without any extra fetch.
+func TestExplainTreeDesc_SeedsFromFlatLevel(t *testing.T) {
+	m := explainTreeDescModel(t)
+	assert.Equal(t, "Number of desired pods.", m.explainFields[0].Description)
+	assert.Equal(t, "Template describes the pods that will be created.", m.explainFields[1].Description)
+	// The tree root's level is fully described — no fetch needed for it.
+	_, fetched := m.explainTreeDescFetched["spec"]
+	assert.True(t, fetched, "the flat level's path must be marked as described")
+}
+
+// TestExplainTreeDesc_NoPathAsDescription: tree rows must not carry their
+// schema path as a fake description (the old stopgap the right pane showed).
+func TestExplainTreeDesc_NoPathAsDescription(t *testing.T) {
+	m := explainTreeDescModel(t)
+	for _, f := range m.explainFields {
+		assert.NotEqual(t, f.Path, f.Description,
+			"field %q must not use its path as description", f.Name)
+	}
+}
+
+// TestExplainTreeDesc_CursorMoveFetchesUnknownLevel: moving the cursor onto a
+// row whose level has not been described yet dispatches exactly one fetch for
+// that level and remembers it as in flight.
+func TestExplainTreeDesc_CursorMoveFetchesUnknownLevel(t *testing.T) {
+	m := explainTreeDescModel(t)
+	require.Equal(t, 1, m.explainCursor) // on "spec.template" (depth 0, described)
+
+	// j → "spec.template.spec": its level ("spec.template") is unknown.
+	mdl, cmd := m.handleExplainKey(key("j"))
+	m = mdl.(Model)
+	require.Equal(t, "spec.template.spec", m.explainFields[m.explainCursor].Path)
+	assert.NotNil(t, cmd, "moving onto an undescribed level must fetch its descriptions")
+	_, inflight := m.explainTreeDescInflight["spec.template"]
+	assert.True(t, inflight)
+
+	// k back, then j again: the level is in flight — no duplicate fetch.
+	mdl, _ = m.handleExplainKey(key("k"))
+	m = mdl.(Model)
+	mdl, cmd = m.handleExplainKey(key("j"))
+	m = mdl.(Model)
+	assert.Nil(t, cmd, "an in-flight level must not be fetched twice")
+}
+
+// TestExplainTreeDesc_CursorMoveOnDescribedLevelNoFetch: rows whose level is
+// already described never trigger a fetch.
+func TestExplainTreeDesc_CursorMoveOnDescribedLevelNoFetch(t *testing.T) {
+	m := explainTreeDescModel(t)
+	m.explainCursor = 1
+	mdl, cmd := m.handleExplainKey(key("k")) // onto "spec.replicas" (depth 0)
+	m = mdl.(Model)
+	assert.Nil(t, cmd)
+	assert.Empty(t, m.explainTreeDescInflight)
+}
+
+// TestExplainTreeDesc_LoadedMergesByPath: an arriving description batch fills
+// the matching tree rows (visible list and full tree) and marks the level
+// described.
+func TestExplainTreeDesc_LoadedMergesByPath(t *testing.T) {
+	m := explainTreeDescModel(t)
+	mdl, _ := m.handleExplainKey(key("j")) // trigger fetch for "spec.template"
+	m = mdl.(Model)
+
+	mdl = m.updateExplainTreeDescLoaded(explainTreeDescMsg{
+		resource: "deployments",
+		parent:   "spec.template",
+		fields: []model.ExplainField{
+			{Name: "spec", Path: "spec.template.spec", Description: "Specification of the desired behavior of the pod."},
+		},
+	})
+	m = mdl.(Model)
+
+	assert.Equal(t, "Specification of the desired behavior of the pod.",
+		m.explainFields[2].Description)
+	assert.Equal(t, "Specification of the desired behavior of the pod.",
+		m.explainTreeAll[2].Description)
+	_, fetched := m.explainTreeDescFetched["spec.template"]
+	assert.True(t, fetched)
+	assert.Empty(t, m.explainTreeDescInflight)
+
+	// Revisiting the row fetches nothing.
+	m.explainCursor = 1
+	mdl, cmd := m.handleExplainKey(key("j"))
+	m = mdl.(Model)
+	assert.Nil(t, cmd)
+}
+
+// TestExplainTreeDesc_StaleResourceIgnored: a batch for a different resource
+// (the user left and reopened the explorer) must not merge.
+func TestExplainTreeDesc_StaleResourceIgnored(t *testing.T) {
+	m := explainTreeDescModel(t)
+	mdl := m.updateExplainTreeDescLoaded(explainTreeDescMsg{
+		resource: "pods",
+		parent:   "spec.template",
+		fields: []model.ExplainField{
+			{Name: "spec", Path: "spec.template.spec", Description: "wrong resource"},
+		},
+	})
+	m = mdl.(Model)
+	assert.Empty(t, m.explainFields[2].Description)
+	_, fetched := m.explainTreeDescFetched["spec.template"]
+	assert.False(t, fetched)
+}
+
+// TestExplainTreeDesc_ErrorMarksLevelDescribed: a failed fetch must not
+// retry-storm on every cursor move; the level is treated as described (it
+// resets with the next tree load).
+func TestExplainTreeDesc_ErrorMarksLevelDescribed(t *testing.T) {
+	m := explainTreeDescModel(t)
+	mdl, _ := m.handleExplainKey(key("j"))
+	m = mdl.(Model)
+
+	mdl = m.updateExplainTreeDescLoaded(explainTreeDescMsg{
+		resource: "deployments",
+		parent:   "spec.template",
+		err:      assert.AnError,
+	})
+	m = mdl.(Model)
+	assert.Empty(t, m.explainTreeDescInflight)
+
+	m.explainCursor = 1
+	mdl, cmd := m.handleExplainKey(key("j"))
+	m = mdl.(Model)
+	assert.Nil(t, cmd, "a failed level must not refetch on every cursor move")
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -365,7 +365,7 @@ func (m Model) updateActionResultMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case diffLoadedMsg:
 		mdl, cmd := m.updateDiffLoaded(msg)
 		return mdl, cmd, true
-	case explainLoadedMsg, explainRecursiveMsg, explainTreeLoadedMsg:
+	case explainLoadedMsg, explainRecursiveMsg, explainTreeLoadedMsg, explainTreeDescMsg:
 		return m.updateExplainMsg(msg)
 	}
 	return m, nil, false

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -102,10 +102,39 @@ func (m Model) openResourceActionMenu() Model {
 		}
 	}
 
+	sortActionMenuItems(items)
 	m.overlay = overlayAction
 	m.overlayItems = items
 	m.overlayCursor = 0
 	return m
+}
+
+// sortActionMenuItems orders action-menu items by their hotkey chip
+// (Item.Status) so the menu reads in the order of the shortcut letters:
+// case-insensitive alphabetical, lowercase before uppercase on a case tie,
+// keyless items last in their original order.
+func sortActionMenuItems(items []model.Item) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return compareActionMenuKeys(items[i].Status, items[j].Status) < 0
+	})
+}
+
+// compareActionMenuKeys compares two hotkey chips for sortActionMenuItems.
+func compareActionMenuKeys(a, b string) int {
+	switch {
+	case a == b:
+		return 0
+	case a == "":
+		return 1
+	case b == "":
+		return -1
+	}
+	la, lb := strings.ToLower(a), strings.ToLower(b)
+	if la != lb {
+		return strings.Compare(la, lb)
+	}
+	// Same letter, different case: lowercase ("l") sorts before uppercase ("L").
+	return strings.Compare(b, a)
 }
 
 // buildActionCtx creates an actionContext from the current selection, extracting

--- a/internal/app/update_actions_bulk.go
+++ b/internal/app/update_actions_bulk.go
@@ -69,6 +69,7 @@ func (m Model) openBulkSelectionMenu() Model {
 		})
 	}
 
+	sortActionMenuItems(items)
 	m.overlay = overlayAction
 	m.overlayItems = items
 	m.overlayCursor = 0

--- a/internal/app/update_actions_cluster_picker.go
+++ b/internal/app/update_actions_cluster_picker.go
@@ -26,6 +26,7 @@ func (m Model) openClusterPickerActionMenu() Model {
 	for _, a := range actions {
 		items = append(items, model.Item{Name: a.Label, Status: a.Key, Extra: a.Description})
 	}
+	sortActionMenuItems(items)
 	m.bulkMode = false
 	m.overlay = overlayAction
 	m.overlayItems = items

--- a/internal/app/update_actions_hidden.go
+++ b/internal/app/update_actions_hidden.go
@@ -72,6 +72,7 @@ func (m Model) openResourceTypeActionMenu() Model {
 		items = append(items, model.Item{Name: hideLabel, Extra: hideDesc, Status: hideMenuChip})
 	}
 
+	sortActionMenuItems(items)
 	m.overlay = overlayAction
 	m.overlayItems = items
 	m.overlayCursor = 0

--- a/internal/app/update_actions_hidden_test.go
+++ b/internal/app/update_actions_hidden_test.go
@@ -95,12 +95,13 @@ func TestOpenResourceTypeActionMenu_LabelReflectsState(t *testing.T) {
 	m := hiddenTestModel(t)
 	m.setCursor(cursorIndexOfItem(&m, "Gadgets"))
 
+	// Items sort by hotkey chip: hide ("h") precedes pin ("p").
 	menu := m.openResourceTypeActionMenu()
 	require.Len(t, menu.overlayItems, 2, "menu offers both Pin and Hide")
-	assert.Equal(t, actionLabelPinType, menu.overlayItems[0].Name)
-	assert.Equal(t, ui.ActiveKeybindings.PinGroup, menu.overlayItems[0].Status, "pin entry carries the pin key chip")
-	assert.Equal(t, actionLabelHideType, menu.overlayItems[1].Name)
-	assert.Equal(t, hideMenuChip, menu.overlayItems[1].Status, "hide entry carries a key chip")
+	assert.Equal(t, actionLabelHideType, menu.overlayItems[0].Name)
+	assert.Equal(t, hideMenuChip, menu.overlayItems[0].Status, "hide entry carries a key chip")
+	assert.Equal(t, actionLabelPinType, menu.overlayItems[1].Name)
+	assert.Equal(t, ui.ActiveKeybindings.PinGroup, menu.overlayItems[1].Status, "pin entry carries the pin key chip")
 
 	// Hide it, then reopen: the hide entry flips to Show.
 	defer func(orig bool) { model.ShowRareResources = orig }(model.ShowRareResources)
@@ -110,7 +111,7 @@ func TestOpenResourceTypeActionMenu_LabelReflectsState(t *testing.T) {
 	rm.setCursor(cursorIndexOfItem(&rm, "Gadgets"))
 	menu2 := rm.openResourceTypeActionMenu()
 	require.Len(t, menu2.overlayItems, 2)
-	assert.Equal(t, actionLabelShowType, menu2.overlayItems[1].Name)
+	assert.Equal(t, actionLabelShowType, menu2.overlayItems[0].Name)
 }
 
 // rareTestModel builds a model whose sidebar includes a rarely-used type
@@ -163,9 +164,10 @@ func TestOpenResourceTypeActionMenu_PinLabelReflectsState(t *testing.T) {
 	m.pinnedState = newPinnedState()
 	m.setCursor(cursorIndexOfItem(&m, "Gadgets"))
 
+	// Items sort by hotkey chip: pin ("p") lands after hide ("h").
 	menu := m.openResourceTypeActionMenu()
 	require.Len(t, menu.overlayItems, 2)
-	assert.Equal(t, actionLabelPinType, menu.overlayItems[0].Name)
+	assert.Equal(t, actionLabelPinType, menu.overlayItems[1].Name)
 
 	// Pin via the menu dispatch path, then reopen: the entry flips to Unpin.
 	res, _ := m.handleKeyPinGroup()
@@ -173,5 +175,5 @@ func TestOpenResourceTypeActionMenu_PinLabelReflectsState(t *testing.T) {
 	rm.setCursor(cursorIndexOfItem(&rm, "Gadgets"))
 	menu2 := rm.openResourceTypeActionMenu()
 	require.Len(t, menu2.overlayItems, 2)
-	assert.Equal(t, actionLabelUnpinType, menu2.overlayItems[0].Name)
+	assert.Equal(t, actionLabelUnpinType, menu2.overlayItems[1].Name)
 }

--- a/internal/app/update_actions_security_menu.go
+++ b/internal/app/update_actions_security_menu.go
@@ -105,6 +105,7 @@ func (m Model) openSecurityActionMenu() Model {
 		Status: "R",
 	})
 
+	sortActionMenuItems(items)
 	m.overlay = overlayAction
 	m.overlayItems = items
 	m.overlayCursor = 0

--- a/internal/app/update_actions_sort_test.go
+++ b/internal/app/update_actions_sort_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestSortActionMenuItems(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []model.Item
+		want  []string // expected Name order
+	}{
+		{
+			name: "case-insensitive alphabetical by key",
+			items: []model.Item{
+				{Name: "Exec", Status: "s"},
+				{Name: "Delete", Status: "D"},
+				{Name: "Attach", Status: "A"},
+			},
+			want: []string{"Attach", "Delete", "Exec"},
+		},
+		{
+			name: "same letter sorts lowercase before uppercase",
+			items: []model.Item{
+				{Name: "Logs", Status: "L"},
+				{Name: "Tail Logs", Status: "l"},
+			},
+			want: []string{"Tail Logs", "Logs"},
+		},
+		{
+			name: "empty keys sort last keeping their relative order",
+			items: []model.Item{
+				{Name: "Custom B", Status: ""},
+				{Name: "Exec", Status: "s"},
+				{Name: "Custom A", Status: ""},
+				{Name: "Attach", Status: "A"},
+			},
+			want: []string{"Attach", "Exec", "Custom B", "Custom A"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortActionMenuItems(tt.items)
+			got := make([]string, len(tt.items))
+			for i, it := range tt.items {
+				got[i] = it.Name
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// actionMenuKeysSorted asserts the overlay items are in hotkey order:
+// case-insensitive alphabetical, lowercase first on a case tie, empty last.
+func assertActionMenuSorted(t *testing.T, items []model.Item) {
+	t.Helper()
+	require.NotEmpty(t, items)
+	for i := 1; i < len(items); i++ {
+		prev, cur := items[i-1].Status, items[i].Status
+		assert.LessOrEqual(t, compareActionMenuKeys(prev, cur), 0,
+			"items[%d] key %q should not sort after items[%d] key %q", i-1, prev, i, cur)
+	}
+}
+
+func TestOpenResourceActionMenuSortedByHotkey(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", Namespaced: true}
+	m.middleItems = []model.Item{{Name: "pod-1", Kind: "Pod", Namespace: "default"}}
+	m.setCursor(0)
+	rm := m.openActionMenu()
+	assert.Equal(t, overlayAction, rm.overlay)
+	assertActionMenuSorted(t, rm.overlayItems)
+	// Pod menu: "Attach" (A) is the lowest hotkey, so it must lead.
+	assert.Equal(t, "Attach", rm.overlayItems[0].Name)
+}
+
+func TestOpenBulkSelectionMenuSortedByHotkey(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", Namespaced: true}
+	m.middleItems = []model.Item{
+		{Name: "pod-1", Kind: "Pod", Namespace: "default"},
+		{Name: "pod-2", Kind: "Pod", Namespace: "default"},
+	}
+	m.selectedItems[selectionKey(m.middleItems[0])] = true
+	m.selectedItems[selectionKey(m.middleItems[1])] = true
+	rm := m.openActionMenu()
+	assert.Equal(t, overlayAction, rm.overlay)
+	assert.True(t, rm.bulkMode)
+	assertActionMenuSorted(t, rm.overlayItems)
+}
+
+func TestOpenSecurityActionMenuSortedByHotkey(t *testing.T) {
+	m := basePush80Model()
+	m.securityIgnores = &SecurityIgnoreState{Contexts: map[string][]SecurityIgnoreRule{}}
+	m.middleItems = []model.Item{{
+		Name:  "finding-group",
+		Kind:  "__security_finding_group__",
+		Extra: "group-key",
+	}}
+	m.setCursor(0)
+	rm, ok := m.openSecurityActionMenuIfApplicable()
+	require.True(t, ok)
+	assert.Equal(t, overlayAction, rm.overlay)
+	assertActionMenuSorted(t, rm.overlayItems)
+}

--- a/internal/app/update_describe_msgs.go
+++ b/internal/app/update_describe_msgs.go
@@ -78,6 +78,8 @@ func (m Model) updateExplainMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case explainTreeLoadedMsg:
 		mdl, cmd := m.updateExplainTreeLoaded(msg)
 		return mdl, cmd, true
+	case explainTreeDescMsg:
+		return m.updateExplainTreeDescLoaded(msg), nil, true
 	}
 	return m, nil, false
 }

--- a/internal/app/update_explain.go
+++ b/internal/app/update_explain.go
@@ -223,8 +223,16 @@ func (m *Model) clampExplainScroll() {
 	m.explainScroll = ui.VimScrollOff(m.explainScroll, m.explainCursor, len(m.explainFields), m.explainVisibleLines(), ui.ConfigScrollOff, identity)
 }
 
-// handleExplainKey handles keyboard input in the explain view mode.
+// handleExplainKey handles keyboard input in the explain view mode. In tree
+// mode, every key dispatch is followed by a lazy fetch of the cursor row's
+// level descriptions when they are not loaded yet (see explain_tree.go).
 func (m Model) handleExplainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	mdl, cmd := m.handleExplainKeyDispatch(msg)
+	return withExplainTreeDescFetch(mdl, cmd)
+}
+
+// handleExplainKeyDispatch routes a key press to the explain view's handlers.
+func (m Model) handleExplainKeyDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	fieldCount := len(m.explainFields)
 	visibleLines := m.explainVisibleLines()
 
@@ -297,8 +305,15 @@ func (m Model) handleExplainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleExplainSearchKey handles keyboard input when search is active in the explain view.
+// handleExplainSearchKey handles keyboard input when search is active in the
+// explain view. Search jumps move the cursor, so tree mode chains the same
+// lazy description fetch as handleExplainKey.
 func (m Model) handleExplainSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	mdl, cmd := m.handleExplainSearchKeyDispatch(msg)
+	return withExplainTreeDescFetch(mdl, cmd)
+}
+
+func (m Model) handleExplainSearchKeyDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "enter":
 		m.explainSearchActive = false

--- a/internal/app/view_overlay_autosync_bg_test.go
+++ b/internal/app/view_overlay_autosync_bg_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// nakedSpaceAfterReset matches spaces directly after an SGR reset — cells
+// painted with the terminal default background instead of the theme surface.
+// See the matching guard in internal/ui/overlay_list_badge_bg_test.go.
+var nakedSpaceAfterReset = regexp.MustCompile(`\x1b\[0m +`)
+
+// TestRenderAutoSyncOverlay_NoBackgroundHoles regression-guards the reported
+// bug: with a theme applied, the gap between the AutoSync / Self-Heal / Prune
+// labels and the ON/OFF badges rendered with the terminal's default
+// background instead of the overlay's surface background.
+func TestRenderAutoSyncOverlay_NoBackgroundHoles(t *testing.T) {
+	origProfile := lipgloss.DefaultRenderer().ColorProfile()
+	origNoColor := ui.ConfigNoColor
+	origContrast := ui.ConfigMinContrastRatio
+	origTransparent := ui.ConfigTransparentBg
+	origTheme := ui.ActiveTheme
+	t.Cleanup(func() {
+		ui.ConfigNoColor = origNoColor
+		ui.ConfigMinContrastRatio = origContrast
+		ui.ConfigTransparentBg = origTransparent
+		ui.ApplyTheme(origTheme)
+		lipgloss.DefaultRenderer().SetColorProfile(origProfile)
+	})
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	ui.ConfigNoColor = false
+	ui.ConfigMinContrastRatio = 0
+	ui.ConfigTransparentBg = false
+	ui.ApplyTheme(ui.DefaultTheme())
+
+	m := basePush80Model()
+	m.autoSyncEnabled = true
+	m.autoSyncSelfHeal = false
+	m.autoSyncPrune = true
+	m.autoSyncCursor = 1
+
+	out := renderAutoSyncOverlay(m)
+	assert.NotRegexp(t, nakedSpaceAfterReset, out,
+		"the AutoSync overlay must not contain unstyled spaces after an SGR "+
+			"reset — label-to-badge gaps and badges must carry the surface bg")
+}

--- a/internal/app/view_overlay_lists.go
+++ b/internal/app/view_overlay_lists.go
@@ -346,9 +346,11 @@ func renderAutoSyncOverlay(m Model) string {
 	contentH := chromeRows + 3 + 2 // title chrome + 3 rows + blank + footer
 	innerW := max(boxW-4, 1)
 
-	onStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorSecondary)).Bold(true)
-	offStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorError))
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorDimmed))
+	// Badges carry the surface background — fg-only styles would punch
+	// through to the terminal background inside the themed overlay box.
+	onStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorSecondary)).Bold(true).Background(ui.SurfaceBg)
+	offStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorError)).Background(ui.SurfaceBg)
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorDimmed)).Background(ui.SurfaceBg)
 
 	badge := func(on, disabled bool) string {
 		switch {

--- a/internal/ui/explaintreeview.go
+++ b/internal/ui/explaintreeview.go
@@ -13,9 +13,9 @@ import (
 // three-column Miller layout, but the middle column shows the recursive field
 // tree of the current schema path with ASCII-art guides (issue #417). depths
 // holds each field's nesting depth relative to the tree root; folded marks
-// rows whose subtree is folded away (rendered with a trailing "›"). Recursive
-// kubectl explain output carries no per-field descriptions, so the right
-// column shows the selected field's name/type only.
+// rows whose subtree is folded away (rendered with a trailing "›"). The right
+// column shows the selected field's description, lazily loaded per schema
+// level by the app (recursive kubectl explain output carries none itself).
 func RenderExplainTreeView(fields []model.ExplainField, depths []int, folded []bool, cursor, scroll int, resourceDesc, title string, parentFields []model.ExplainField, parentCursor int, searchQuery, hintBar string, width, height int) string {
 	d := objectExplorerDims(width, height)
 	if len(depths) != len(fields) {

--- a/internal/ui/overlay_list.go
+++ b/internal/ui/overlay_list.go
@@ -205,15 +205,19 @@ func RenderOverlayList(items []OverlayListItem, cfg OverlayListConfig, innerW in
 			// (badge or scrollbar) that needs a stable left edge —
 			// padding rows without a reserve regresses the historical
 			// "non-cursor rows keep their short visible width" behaviour.
+			// The padding renders through OverlayDimStyle so it carries the
+			// theme's surface background — raw spaces would punch through to
+			// the terminal background between the row text and the badge /
+			// scrollbar column.
 			if hasOverflow || cfg.BadgeWidth > 0 {
 				if pad := itemWidth - lipgloss.Width(line); pad > 0 {
-					line += strings.Repeat(" ", pad)
+					line += OverlayDimStyle.Render(strings.Repeat(" ", pad))
 				}
 			}
 			row = line
 		}
 		if cfg.BadgeWidth > 0 {
-			row += " " + it.Badge
+			row += OverlayDimStyle.Render(" ") + it.Badge
 		}
 		if hasOverflow {
 			row += renderScrollbar(i-start, visible, len(items), start)

--- a/internal/ui/overlay_list_badge_bg_test.go
+++ b/internal/ui/overlay_list_badge_bg_test.go
@@ -1,0 +1,88 @@
+package ui
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+)
+
+// nakedSpaceAfterReset matches a run of spaces sitting directly after an SGR
+// reset — i.e. cells painted with the terminal's default background instead
+// of the theme's surface background. Any hit inside an overlay row is the
+// "background hole" bug: with a themed surface bg, the gap between the item
+// text and the badge (or scrollbar) flashes the terminal background.
+var nakedSpaceAfterReset = regexp.MustCompile(`\x1b\[0m +`)
+
+// applyBadgeBgTestTheme applies a theme with a known surface color so the
+// Overlay* styles carry a real background, restoring everything on cleanup.
+func applyBadgeBgTestTheme(t *testing.T) {
+	t.Helper()
+	origProfile := lipgloss.DefaultRenderer().ColorProfile()
+	origNoColor := ConfigNoColor
+	origContrast := ConfigMinContrastRatio
+	origTransparent := ConfigTransparentBg
+	origTheme := ActiveTheme
+	t.Cleanup(func() {
+		ConfigNoColor = origNoColor
+		ConfigMinContrastRatio = origContrast
+		ConfigTransparentBg = origTransparent
+		ApplyTheme(origTheme)
+		lipgloss.DefaultRenderer().SetColorProfile(origProfile)
+	})
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.TrueColor)
+	ConfigNoColor = false
+	ConfigMinContrastRatio = 0
+	ConfigTransparentBg = false
+	ApplyTheme(DefaultTheme())
+}
+
+// TestRenderOverlayList_BadgeGapKeepsSurfaceBackground regression-guards the
+// AutoSync overlay report: with a themed surface background, the padding
+// between a row's text and its badge column rendered as raw spaces, punching
+// through to the terminal's default background.
+func TestRenderOverlayList_BadgeGapKeepsSurfaceBackground(t *testing.T) {
+	applyBadgeBgTestTheme(t)
+
+	badge := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#00ff00")).
+		Background(SurfaceBg).
+		Render(" ON")
+	items := []OverlayListItem{
+		{Name: "AutoSync      ", Badge: badge},
+		{Name: "Self-Heal     ", Badge: badge},
+		{Name: "Prune         ", Badge: badge, Disabled: true},
+	}
+	out := RenderOverlayList(items, OverlayListConfig{
+		Title:      "Configure AutoSync",
+		Cursor:     0,
+		BadgeWidth: 3,
+		FooterHint: "space: toggle | enter: save | esc: cancel",
+	}, 42)
+
+	assert.NotRegexp(t, nakedSpaceAfterReset, out,
+		"no overlay row may contain unstyled spaces after an SGR reset — "+
+			"the badge-gap padding must carry the surface background")
+}
+
+// TestRenderOverlayList_ScrollbarGapKeepsSurfaceBackground covers the same
+// hole for overflowing lists without badges: the padding between short rows
+// and the scrollbar column must carry the surface background too.
+func TestRenderOverlayList_ScrollbarGapKeepsSurfaceBackground(t *testing.T) {
+	applyBadgeBgTestTheme(t)
+
+	items := make([]OverlayListItem, 10)
+	for i := range items {
+		items[i] = OverlayListItem{Name: "item"}
+	}
+	out := RenderOverlayList(items, OverlayListConfig{
+		Title:      "Scrolling",
+		Cursor:     0,
+		MaxVisible: 4,
+	}, 42)
+
+	assert.NotRegexp(t, nakedSpaceAfterReset, out,
+		"scrollbar-gap padding must carry the surface background")
+}


### PR DESCRIPTION
## Summary

Three TUI bug fixes, one commit each:

- **fix(actions)**: action menu items now sort by their hotkey chip — case-insensitive alphabetical, lowercase before uppercase on a case tie, keyless custom actions last. Applied to all five menu builders (resource, bulk, cluster picker, resource-type pin/hide, security).
- **fix(ui)**: with a theme applied, the gap between overlay row text and the badge column (Configure AutoSync's ON/OFF indicators) and the row-to-scrollbar gap rendered with the terminal's default background instead of the surface background. Gap padding and the badge separator now render through `OverlayDimStyle`; the AutoSync badge styles carry the surface background.
- **fix(explorer)**: the API Explorer tree view showed the schema *path* in the description pane instead of the field description the flat view shows. Depth-0 rows now inherit the flat level's descriptions; deeper levels are described lazily (one plain `kubectl explain` per level as the cursor visits it), merged by path and cached per tree with in-flight dedup and no per-keypress retry on errors.

## Test plan

- [x] 13 new tests: sort comparator + per-menu ordering, ANSI background regression guards (`\x1b[0m` + raw-space detection) for the overlay list and AutoSync overlay, tree description seeding / lazy fetch / merge / stale-resource / error paths
- [x] `go build ./...`, `go test -race ./...`, `golangci-lint run` (0 issues)
- [x] go-reviewer pass — no blocking findings