### PR TITLE
fix(logs): give each container a distinct prefix color in the log viewer

### DIFF
--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
@@ -490,9 +491,48 @@ var podPrefixColors = []string{
 	"#41a6b5", // dark cyan
 }
 
-// colorizePodPrefix replaces the "[pod/name/container] " prefix with a colorized
-// version. The color is deterministically assigned based on the pod name so the
-// same pod always gets the same color across the session.
+// podPrefixColorIdx remembers the palette slot assigned to each
+// "pod/name/container" prefix so a prefix keeps its color for the session.
+// Only the first len(podPrefixColors) distinct prefixes are recorded (each
+// entry claims a free slot), so the map is bounded at the palette size;
+// later prefixes fall back to their stable hash slot without caching.
+var (
+	podPrefixColorMu    sync.Mutex
+	podPrefixColorIdx   = map[string]int{}
+	podPrefixColorTaken = make([]bool, len(podPrefixColors))
+)
+
+// podPrefixColor picks the color for a "pod/name/container" prefix. The hash
+// of the full prefix (pod AND container) seeds the slot, then probing skips
+// slots already taken by other prefixes — so different containers of the
+// same pod never share a color until the palette is exhausted. Past
+// exhaustion the raw hash slot is used, which is still deterministic.
+func podPrefixColor(prefix string) string {
+	podPrefixColorMu.Lock()
+	defer podPrefixColorMu.Unlock()
+	if idx, ok := podPrefixColorIdx[prefix]; ok {
+		return podPrefixColors[idx]
+	}
+
+	var hash uint32
+	for _, c := range prefix {
+		hash = hash*31 + uint32(c)
+	}
+	start := int(hash % uint32(len(podPrefixColors)))
+	for i := range podPrefixColors {
+		cand := (start + i) % len(podPrefixColors)
+		if !podPrefixColorTaken[cand] {
+			podPrefixColorTaken[cand] = true
+			podPrefixColorIdx[prefix] = cand
+			return podPrefixColors[cand]
+		}
+	}
+	return podPrefixColors[start]
+}
+
+// colorizePodPrefix replaces the "[pod/name/container] " prefix with a
+// colorized version. Each distinct pod/container pair gets its own color
+// (see podPrefixColor), stable for the session.
 func colorizePodPrefix(line string) string {
 	if len(line) == 0 || line[0] != '[' {
 		return line
@@ -504,25 +544,7 @@ func colorizePodPrefix(line string) string {
 	prefix := line[1:closeBracket] // "pod/name/container"
 	rest := line[closeBracket+2:]
 
-	// Extract pod name for color hashing (between first and last slash).
-	podName := prefix
-	if _, after, ok := strings.Cut(prefix, "/"); ok {
-		afterFirst := after
-		if lastSlash := strings.LastIndex(afterFirst, "/"); lastSlash >= 0 {
-			podName = afterFirst[:lastSlash]
-		} else {
-			podName = afterFirst
-		}
-	}
-
-	// Simple hash to pick a deterministic color.
-	var hash uint32
-	for _, c := range podName {
-		hash = hash*31 + uint32(c)
-	}
-	color := podPrefixColors[hash%uint32(len(podPrefixColors))]
-	style := lipgloss.NewStyle().Foreground(ThemeColor(color))
-
+	style := lipgloss.NewStyle().Foreground(ThemeColor(podPrefixColor(prefix)))
 	return style.Render("["+prefix+"]") + " " + rest
 }
 

--- a/internal/ui/logviewer_render_test.go
+++ b/internal/ui/logviewer_render_test.go
@@ -1,9 +1,13 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -371,6 +375,14 @@ func TestRenderLogViewer(t *testing.T) {
 
 // --- colorizePodPrefix ---
 
+// resetPodPrefixColors clears the prefix-to-color assignments between tests.
+func resetPodPrefixColors() {
+	podPrefixColorMu.Lock()
+	defer podPrefixColorMu.Unlock()
+	podPrefixColorIdx = map[string]int{}
+	podPrefixColorTaken = make([]bool, len(podPrefixColors))
+}
+
 func TestColorizePodPrefix(t *testing.T) {
 	t.Run("preserves prefix and content", func(t *testing.T) {
 		line := "[pod/myapp-abc12/app] some log output"
@@ -391,6 +403,8 @@ func TestColorizePodPrefix(t *testing.T) {
 	})
 
 	t.Run("same pod gets same result", func(t *testing.T) {
+		resetPodPrefixColors()
+		t.Cleanup(resetPodPrefixColors)
 		line1 := "[pod/myapp-abc12/app] log 1"
 		line2 := "[pod/myapp-abc12/app] log 2"
 		r1 := colorizePodPrefix(line1)
@@ -409,17 +423,90 @@ func TestColorizePodPrefix(t *testing.T) {
 		assert.Equal(t, line, result)
 	})
 
-	t.Run("extracts pod name correctly for hashing", func(t *testing.T) {
-		// Two lines with same pod but different containers should get same color.
-		line1 := "[pod/myapp-abc12/app] log 1"
-		line2 := "[pod/myapp-abc12/sidecar] log 2"
-		r1 := colorizePodPrefix(line1)
-		r2 := colorizePodPrefix(line2)
-		// Both reference pod "myapp-abc12" so they should get same color styling.
-		// We can't directly compare ANSI codes in non-terminal tests,
-		// but verify both process correctly.
-		assert.Contains(t, r1, "pod/myapp-abc12/app")
-		assert.Contains(t, r2, "pod/myapp-abc12/sidecar")
+	t.Run("different containers in same pod get different colors", func(t *testing.T) {
+		origProfile := lipgloss.DefaultRenderer().ColorProfile()
+		t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(origProfile) })
+		lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+		resetPodPrefixColors()
+		t.Cleanup(resetPodPrefixColors)
+
+		r1 := colorizePodPrefix("[pod/myapp-abc12/app] log 1")
+		r2 := colorizePodPrefix("[pod/myapp-abc12/sidecar] log 2")
+		pre1, ok1 := strings.CutSuffix(r1, " log 1")
+		pre2, ok2 := strings.CutSuffix(r2, " log 2")
+		assert.True(t, ok1)
+		assert.True(t, ok2)
+		assert.NotEqual(t, pre1, pre2,
+			"containers app and sidecar of the same pod must get distinct colors")
+	})
+
+	t.Run("first palette-size prefixes all get distinct colors", func(t *testing.T) {
+		origProfile := lipgloss.DefaultRenderer().ColorProfile()
+		t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(origProfile) })
+		lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+		resetPodPrefixColors()
+		t.Cleanup(resetPodPrefixColors)
+
+		seen := map[string]string{}
+		for i := range podPrefixColors {
+			line := fmt.Sprintf("[pod/myapp-abc12/c%d] x", i)
+			r := colorizePodPrefix(line)
+			styled, ok := strings.CutSuffix(r, " x")
+			assert.True(t, ok)
+			// Compare only the ANSI escape prefix (styling), not the text.
+			color, _, _ := strings.Cut(styled, "[pod/")
+			for prev, prevColor := range seen {
+				assert.NotEqual(t, prevColor, color,
+					"prefix %q and c%d must not share a color", prev, i)
+			}
+			seen[line] = color
+		}
+	})
+
+	t.Run("prefix keeps its color once assigned", func(t *testing.T) {
+		origProfile := lipgloss.DefaultRenderer().ColorProfile()
+		t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(origProfile) })
+		lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+		resetPodPrefixColors()
+		t.Cleanup(resetPodPrefixColors)
+
+		first := colorizePodPrefix("[pod/myapp-abc12/app] x")
+		for i := range 20 {
+			colorizePodPrefix(fmt.Sprintf("[pod/other-%d/app] x", i))
+		}
+		again := colorizePodPrefix("[pod/myapp-abc12/app] x")
+		assert.Equal(t, first, again, "a prefix must keep its color for the session")
+	})
+
+	t.Run("palette exhaustion still colorizes without panic", func(t *testing.T) {
+		origProfile := lipgloss.DefaultRenderer().ColorProfile()
+		t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(origProfile) })
+		lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+		resetPodPrefixColors()
+		t.Cleanup(resetPodPrefixColors)
+
+		for i := range 3 * len(podPrefixColors) {
+			line := fmt.Sprintf("[pod/pod-%d/app] x", i)
+			r := colorizePodPrefix(line)
+			assert.Contains(t, r, fmt.Sprintf("pod/pod-%d/app", i))
+			// Deterministic: same prefix renders identically on repeat.
+			assert.Equal(t, r, colorizePodPrefix(line))
+		}
+	})
+
+	t.Run("concurrent calls are safe", func(t *testing.T) {
+		resetPodPrefixColors()
+		t.Cleanup(resetPodPrefixColors)
+
+		var wg sync.WaitGroup
+		for g := range 8 {
+			wg.Go(func() {
+				for i := range 50 {
+					colorizePodPrefix(fmt.Sprintf("[pod/pod-%d/c%d] x", i%20, g%3))
+				}
+			})
+		}
+		wg.Wait()
 	})
 
 	t.Run("no-color mode emits no ANSI escape codes", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Log prefix colors were hashed from the pod name only, so different containers of the same pod always got identical colors.
- Color is now keyed on the full `pod/name/container` prefix: the prefix hash seeds a palette slot and linear probing skips slots already taken, so the first 12 distinct pod/container pairs are guaranteed distinct colors (a bare hash over the full prefix would still collide 1-in-12).
- Assignments are stable for the session; past palette exhaustion new prefixes fall back to their deterministic hash slot. The assignment cache is mutex-guarded and naturally bounded at palette size.

## Test plan
- [x] New subtests: different containers in the same pod get different colors; first palette-size prefixes are all distinct; a prefix keeps its color once assigned; palette exhaustion stays deterministic without panic; concurrent-access stress test for `-race`
- [x] `go test ./... -race` passes
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)