### PR TITLE
fix(scheduler): wire unscheduled K8s reads through the task scheduler

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -186,10 +187,16 @@ func (m Model) loadPodsForAction() tea.Cmd {
 	ns := m.actionNamespace()
 	kind := m.actionCtx.kind
 	name := m.actionCtx.name
-	return func() tea.Msg {
-		items, err := m.client.GetOwnedResources(context.Background(), kctx, ns, kind, name)
-		return podSelectMsg{items: items, err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"List pods: "+kind+"/"+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			items, err := m.client.GetOwnedResources(ctx, kctx, ns, kind, name)
+			return podSelectMsg{items: items, err: err}
+		},
+	)
 }
 
 // loadPodsForLogAction fetches pods matching the parent resource's selector using kubectl.
@@ -259,16 +266,22 @@ func (m Model) loadContainersForAction() tea.Cmd {
 	kctx := m.actionCtx.context
 	ns := m.actionNamespace()
 	podName := m.actionCtx.name
-	return func() tea.Msg {
-		items, err := m.client.GetContainers(context.Background(), kctx, ns, podName)
-		// Reverse order for the selector: regular containers first (reversed),
-		// then init/sidecar containers (reversed), so the most relevant
-		// container is at the top.
-		for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
-			items[i], items[j] = items[j], items[i]
-		}
-		return containerSelectMsg{items: items, err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindContainers,
+		"List containers (action)",
+		bgtaskTarget(kctx, ns)+" / "+podName,
+		func(ctx context.Context) tea.Msg {
+			items, err := m.client.GetContainers(ctx, kctx, ns, podName)
+			// Reverse order for the selector: regular containers first (reversed),
+			// then init/sidecar containers (reversed), so the most relevant
+			// container is at the top.
+			for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+				items[i], items[j] = items[j], items[i]
+			}
+			return containerSelectMsg{items: items, err: err}
+		},
+	)
 }
 
 // loadContainersForLogFilter fetches the container list for the current pod in the log viewer.
@@ -277,17 +290,23 @@ func (m Model) loadContainersForLogFilter() tea.Cmd {
 	kctx := m.actionCtx.context
 	ns := m.actionNamespace()
 	podName := m.actionCtx.name
-	return func() tea.Msg {
-		items, err := m.client.GetContainers(context.Background(), kctx, ns, podName)
-		if err != nil {
-			return logContainersLoadedMsg{err: err}
-		}
-		var names []string
-		for _, item := range items {
-			names = append(names, item.Name)
-		}
-		return logContainersLoadedMsg{containers: names}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindContainers,
+		"List containers (log filter)",
+		bgtaskTarget(kctx, ns)+" / "+podName,
+		func(ctx context.Context) tea.Msg {
+			items, err := m.client.GetContainers(ctx, kctx, ns, podName)
+			if err != nil {
+				return logContainersLoadedMsg{err: err}
+			}
+			var names []string
+			for _, item := range items {
+				names = append(names, item.Name)
+			}
+			return logContainersLoadedMsg{containers: names}
+		},
+	)
 }
 
 // clearBeforeExec wraps cmd to clear the terminal screen before running it.

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -23,7 +23,7 @@ func (m Model) deleteResource() tea.Cmd {
 	rt := m.actionCtx.resourceType
 	name := m.actionCtx.name
 	logger.Info("Deleting resource", "resource", rt.Resource, "name", name, "namespace", ns, "context", ctx)
-	return m.trackBgTask(scheduler.KindMutation, fmt.Sprintf("Delete %s/%s", rt.Resource, name), bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, fmt.Sprintf("Delete %s/%s", rt.Resource, name), bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.DeleteResource(ctx, ns, rt, name)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -138,7 +138,7 @@ func (m Model) resizePVC(newSize string) tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logger.Info("Resizing PVC", "name", name, "newSize", newSize, "namespace", ns, "context", ctx)
-	return m.trackBgTask(scheduler.KindMutation, "Resize PVC: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Resize PVC: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.ResizePVC(ctx, ns, name, newSize)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -153,7 +153,7 @@ func (m Model) scaleResource(replicas int32) tea.Cmd {
 	name := m.actionCtx.name
 	kind := m.actionCtx.kind
 	logger.Info("Scaling resource", "kind", kind, "name", name, "replicas", replicas, "namespace", ns, "context", ctx)
-	return m.trackBgTask(scheduler.KindMutation, fmt.Sprintf("Scale %s/%s → %d", kind, name, replicas), bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, fmt.Sprintf("Scale %s/%s → %d", kind, name, replicas), bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.ScaleResource(ctx, ns, name, kind, replicas)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -183,8 +183,8 @@ func (m Model) rollbackDeployment(revision int64) tea.Cmd {
 	name := m.actionCtx.name
 	client := m.client
 
-	return m.trackBgTask(scheduler.KindMutation, fmt.Sprintf("Rollback Deployment: %s@%d", name, revision), bgtaskTarget(kctx, ns), func() tea.Msg {
-		err := client.RollbackDeployment(context.Background(), kctx, ns, name, revision)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, fmt.Sprintf("Rollback Deployment: %s@%d", name, revision), bgtaskTarget(kctx, ns), func(ctx context.Context) tea.Msg {
+		err := client.RollbackDeployment(ctx, kctx, ns, name, revision)
 		return rollbackDoneMsg{err: err}
 	})
 }
@@ -251,8 +251,8 @@ func (m Model) triggerCronJob() tea.Cmd {
 	kctx := m.actionCtx.context
 	client := m.client
 
-	return m.trackBgTask(scheduler.KindMutation, "Trigger CronJob: "+name, bgtaskTarget(kctx, ns), func() tea.Msg {
-		jobName, err := client.TriggerCronJob(context.Background(), kctx, ns, name)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Trigger CronJob: "+name, bgtaskTarget(kctx, ns), func(ctx context.Context) tea.Msg {
+		jobName, err := client.TriggerCronJob(ctx, kctx, ns, name)
 		return triggerCronJobMsg{jobName: jobName, err: err}
 	})
 }

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -34,16 +34,22 @@ func (m Model) detectExecPodOSCmd() tea.Cmd {
 	kctx := m.actionCtx.context
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
-	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		podOS, err := client.GetPodOS(ctx, kctx, ns, name)
-		if err != nil {
-			logger.Warn("Could not resolve pod OS for exec; defaulting to Linux shell", "pod", name, "error", err)
-			return execPodOSResolvedMsg{}
-		}
-		return execPodOSResolvedMsg{podOS: podOS}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"Detect pod OS: "+name,
+		bgtaskTarget(kctx, ns),
+		func(schedCtx context.Context) tea.Msg {
+			ctx, cancel := context.WithTimeout(schedCtx, 5*time.Second)
+			defer cancel()
+			podOS, err := client.GetPodOS(ctx, kctx, ns, name)
+			if err != nil {
+				logger.Warn("Could not resolve pod OS for exec; defaulting to Linux shell", "pod", name, "error", err)
+				return execPodOSResolvedMsg{}
+			}
+			return execPodOSResolvedMsg{podOS: podOS}
+		},
+	)
 }
 
 // updateExecPodOSResolved fires once the pre-exec pod-OS lookup completes. It

--- a/internal/app/commands_exec_test.go
+++ b/internal/app/commands_exec_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 	"github.com/stretchr/testify/assert"
@@ -298,6 +299,7 @@ func TestPush3ExecKubectlEditNoKubectl(t *testing.T) {
 
 func TestPush3DeleteResourceNoClient(t *testing.T) {
 	m := basePush80v3Model()
+	m.scheduler = scheduler.New(0)
 	m.actionCtx = actionContext{
 		name:         "pod-1",
 		namespace:    "default",
@@ -307,7 +309,7 @@ func TestPush3DeleteResourceNoClient(t *testing.T) {
 	cmd := m.deleteResource()
 	require.NotNil(t, cmd)
 	// Execute -- should try to delete via fake client.
-	msg := cmd()
+	msg := execScheduled(t, m, cmd)
 	amsg, ok := msg.(actionResultMsg)
 	require.True(t, ok)
 	// Fake client will fail since the pod doesn't exist.
@@ -493,7 +495,7 @@ func TestCovResizePVC(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-pvc", "default", "PersistentVolumeClaim", model.ResourceTypeEntry{})
 	cmd := m.resizePVC("10Gi")
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	// PVC doesn't exist in fake client.
 	assert.Error(t, result.err)
@@ -503,7 +505,7 @@ func TestCovScaleResource(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-deploy", "default", "Deployment", model.ResourceTypeEntry{})
 	cmd := m.scaleResource(3)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	// Deployment doesn't exist in fake client.
 	assert.Error(t, result.err)
@@ -522,7 +524,7 @@ func TestCovRollbackDeployment(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-deploy", "default", "Deployment", model.ResourceTypeEntry{})
 	cmd := m.rollbackDeployment(1)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(rollbackDoneMsg)
 	require.True(t, ok)
 	assert.Error(t, result.err)
@@ -532,7 +534,7 @@ func TestCovTriggerCronJob(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-cj", "default", "CronJob", model.ResourceTypeEntry{})
 	cmd := m.triggerCronJob()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(triggerCronJobMsg)
 	require.True(t, ok)
 	assert.Error(t, result.err)

--- a/internal/app/commands_gitops.go
+++ b/internal/app/commands_gitops.go
@@ -265,13 +265,21 @@ func (m Model) watchArgoWorkflow() tea.Cmd {
 	ctx := m.actionCtx.context
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
-	return m.trackBgTask(scheduler.KindResourceList, "Watch workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
-		content, _, err := m.client.GetWorkflowStatus(ctx, ns, name)
-		if err != nil {
-			return describeLoadedMsg{title: "Watch: " + name, err: err}
-		}
-		return describeLoadedMsg{title: "Watch: " + name, content: content}
-	})
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"Watch workflow: "+name,
+		bgtaskTarget(ctx, ns),
+		// GetWorkflowStatus takes the kube-context string, not a
+		// context.Context, so the scheduler ctx is unused here.
+		func(_ context.Context) tea.Msg {
+			content, _, err := m.client.GetWorkflowStatus(ctx, ns, name)
+			if err != nil {
+				return describeLoadedMsg{title: "Watch: " + name, err: err}
+			}
+			return describeLoadedMsg{title: "Watch: " + name, content: content}
+		},
+	)
 }
 
 // forceRefreshExternalSecret triggers a force sync on an ESO resource.
@@ -437,10 +445,16 @@ func (m Model) loadAutoSyncConfig() tea.Cmd {
 	name := sel.Name
 	client := m.client
 
-	return m.trackBgTask(scheduler.KindResourceList, "Autosync config: "+name, bgtaskTarget(kctx, ns), func() tea.Msg {
-		enabled, selfHeal, prune, err := client.GetAutoSyncConfig(context.Background(), kctx, ns, name)
-		return autoSyncLoadedMsg{enabled: enabled, selfHeal: selfHeal, prune: prune, err: err}
-	})
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"Autosync config: "+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			enabled, selfHeal, prune, err := client.GetAutoSyncConfig(ctx, kctx, ns, name)
+			return autoSyncLoadedMsg{enabled: enabled, selfHeal: selfHeal, prune: prune, err: err}
+		},
+	)
 }
 
 func (m Model) saveAutoSyncConfig() tea.Cmd {

--- a/internal/app/commands_gitops.go
+++ b/internal/app/commands_gitops.go
@@ -28,7 +28,7 @@ func (m Model) syncArgoApp(applyOnly bool) tea.Cmd {
 	if applyOnly {
 		label = "Sync ArgoApp (apply only)"
 	}
-	return m.trackBgTask(scheduler.KindMutation, label+": "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, label+": "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.SyncArgoApp(ctx, ns, name, applyOnly)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -46,7 +46,7 @@ func (m Model) refreshArgoApp() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("ArgoCD app refresh requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Refresh ArgoApp: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Refresh ArgoApp: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.RefreshArgoApp(ctx, ns, name)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -60,7 +60,7 @@ func (m Model) refreshArgoAppSet() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("ArgoCD ApplicationSet refresh requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Refresh ApplicationSet: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Refresh ApplicationSet: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.RefreshArgoAppSet(ctx, ns, name)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -81,7 +81,7 @@ func (m Model) reconcileFluxResource() tea.Cmd {
 		Resource: rt.Resource,
 	}
 	logGitOps("Flux reconcile requested", ctx, ns, name, "kind", rt.Kind)
-	return m.trackBgTask(scheduler.KindMutation, "Reconcile Flux: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Reconcile Flux: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.ReconcileFluxResource(ctx, ns, name, gvr)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -102,7 +102,7 @@ func (m Model) suspendFluxResource() tea.Cmd {
 		Resource: rt.Resource,
 	}
 	logGitOps("Flux suspend requested", ctx, ns, name, "kind", rt.Kind)
-	return m.trackBgTask(scheduler.KindMutation, "Suspend Flux: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Suspend Flux: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.SuspendFluxResource(ctx, ns, name, gvr)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -123,7 +123,7 @@ func (m Model) resumeFluxResource() tea.Cmd {
 		Resource: rt.Resource,
 	}
 	logGitOps("Flux resume requested", ctx, ns, name, "kind", rt.Kind)
-	return m.trackBgTask(scheduler.KindMutation, "Resume Flux: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Resume Flux: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.ResumeFluxResource(ctx, ns, name, gvr)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -139,7 +139,7 @@ func (m Model) forceRenewCertificate() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("cert-manager Certificate renewal requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Renew certificate: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Renew certificate: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		if err := m.client.ForceRenewCertificate(ctx, ns, name); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -154,7 +154,7 @@ func (m Model) suspendArgoWorkflow() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo Workflow suspend requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Suspend workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Suspend workflow: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		if err := m.client.SuspendArgoWorkflow(ctx, ns, name); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -167,7 +167,7 @@ func (m Model) resumeArgoWorkflow() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo Workflow resume requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Resume workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Resume workflow: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		if err := m.client.ResumeArgoWorkflow(ctx, ns, name); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -180,7 +180,7 @@ func (m Model) stopArgoWorkflow() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo Workflow stop requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Stop workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Stop workflow: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		if err := m.client.StopArgoWorkflow(ctx, ns, name); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -193,7 +193,7 @@ func (m Model) terminateArgoWorkflow() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo Workflow terminate requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Terminate workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Terminate workflow: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		if err := m.client.TerminateArgoWorkflow(ctx, ns, name); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -206,7 +206,7 @@ func (m Model) resubmitArgoWorkflow() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo Workflow resubmit requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Resubmit workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Resubmit workflow: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		newName, err := m.client.ResubmitArgoWorkflow(ctx, ns, name)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -220,7 +220,7 @@ func (m Model) submitWorkflowFromTemplate(clusterScope bool) tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo Workflow submit-from-template requested", ctx, ns, name, "clusterScope", clusterScope)
-	return m.trackBgTask(scheduler.KindMutation, "Submit workflow from template: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Submit workflow from template: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		newName, err := m.client.SubmitWorkflowFromTemplate(ctx, ns, name, clusterScope)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -234,7 +234,7 @@ func (m Model) suspendCronWorkflow() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo CronWorkflow suspend requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Suspend cron workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Suspend cron workflow: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		if err := m.client.SuspendCronWorkflow(ctx, ns, name); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -247,7 +247,7 @@ func (m Model) resumeCronWorkflow() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("Argo CronWorkflow resume requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Resume cron workflow: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Resume cron workflow: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		if err := m.client.ResumeCronWorkflow(ctx, ns, name); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -297,7 +297,7 @@ func (m Model) forceRefreshExternalSecret() tea.Cmd {
 		ns = ""
 	}
 	logGitOps("ExternalSecret force-refresh requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Refresh ExternalSecret: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Refresh ExternalSecret: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.ForceRefreshExternalSecret(ctx, ns, name, gvr)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -318,7 +318,7 @@ func (m Model) pauseKEDAResource() tea.Cmd {
 		Resource: rt.Resource,
 	}
 	logGitOps("KEDA pause requested", ctx, ns, name, "kind", rt.Kind)
-	return m.trackBgTask(scheduler.KindMutation, "Pause KEDA: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Pause KEDA: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.PauseKEDAResource(ctx, ns, name, gvr)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -339,7 +339,7 @@ func (m Model) unpauseKEDAResource() tea.Cmd {
 		Resource: rt.Resource,
 	}
 	logGitOps("KEDA unpause requested", ctx, ns, name, "kind", rt.Kind)
-	return m.trackBgTask(scheduler.KindMutation, "Unpause KEDA: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Unpause KEDA: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.UnpauseKEDAResource(ctx, ns, name, gvr)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -411,7 +411,7 @@ func (m Model) terminateArgoSync() tea.Cmd {
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logGitOps("ArgoCD sync termination requested", ctx, ns, name)
-	return m.trackBgTask(scheduler.KindMutation, "Terminate sync: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Terminate sync: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		err := m.client.TerminateArgoSync(ctx, ns, name)
 		if err != nil {
 			return actionResultMsg{err: err}
@@ -475,8 +475,8 @@ func (m Model) saveAutoSyncConfig() tea.Cmd {
 	client := m.client
 
 	logGitOps("ArgoCD autosync config save requested", kctx, ns, name, "enabled", enabled, "selfHeal", selfHeal, "prune", prune)
-	return m.trackBgTask(scheduler.KindMutation, "Save autosync config: "+name, bgtaskTarget(kctx, ns), func() tea.Msg {
-		err := client.UpdateAutoSyncConfig(context.Background(), kctx, ns, name, enabled, selfHeal, prune)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Save autosync config: "+name, bgtaskTarget(kctx, ns), func(ctx context.Context) tea.Msg {
+		err := client.UpdateAutoSyncConfig(ctx, kctx, ns, name, enabled, selfHeal, prune)
 		return autoSyncSavedMsg{err: err}
 	})
 }

--- a/internal/app/commands_gitops.go
+++ b/internal/app/commands_gitops.go
@@ -270,10 +270,8 @@ func (m Model) watchArgoWorkflow() tea.Cmd {
 		scheduler.KindResourceList,
 		"Watch workflow: "+name,
 		bgtaskTarget(ctx, ns),
-		// GetWorkflowStatus takes the kube-context string, not a
-		// context.Context, so the scheduler ctx is unused here.
-		func(_ context.Context) tea.Msg {
-			content, _, err := m.client.GetWorkflowStatus(ctx, ns, name)
+		func(schedCtx context.Context) tea.Msg {
+			content, _, err := m.client.GetWorkflowStatus(schedCtx, ctx, ns, name)
 			if err != nil {
 				return describeLoadedMsg{title: "Watch: " + name, err: err}
 			}

--- a/internal/app/commands_gitops_test.go
+++ b/internal/app/commands_gitops_test.go
@@ -58,7 +58,7 @@ func TestCovSyncArgoApp(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-app", "argocd", "Application", model.ResourceTypeEntry{})
 	cmd := m.syncArgoApp(false)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	// The fake clientset doesn't have ArgoCD CRDs so we expect an error.
 	result, ok := msg.(actionResultMsg)
 	require.True(t, ok)
@@ -69,7 +69,7 @@ func TestCovSyncArgoAppApplyOnly(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-app", "argocd", "Application", model.ResourceTypeEntry{})
 	cmd := m.syncArgoApp(true)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -78,7 +78,7 @@ func TestCovRefreshArgoApp(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-app", "argocd", "Application", model.ResourceTypeEntry{})
 	cmd := m.refreshArgoApp()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -87,7 +87,7 @@ func TestCovRefreshArgoAppSet(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-appset", "argocd", "ApplicationSet", model.ResourceTypeEntry{})
 	cmd := m.refreshArgoAppSet()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -101,7 +101,7 @@ func TestCovReconcileFluxResource(t *testing.T) {
 	}
 	m = withActionCtx(m, "my-ks", "flux-system", "Kustomization", rt)
 	cmd := m.reconcileFluxResource()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -115,7 +115,7 @@ func TestCovSuspendFluxResource(t *testing.T) {
 	}
 	m = withActionCtx(m, "my-ks", "flux-system", "Kustomization", rt)
 	cmd := m.suspendFluxResource()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -129,7 +129,7 @@ func TestCovResumeFluxResource(t *testing.T) {
 	}
 	m = withActionCtx(m, "my-ks", "flux-system", "Kustomization", rt)
 	cmd := m.resumeFluxResource()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -138,7 +138,7 @@ func TestCovForceRenewCertificate(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-cert", "default", "Certificate", model.ResourceTypeEntry{})
 	cmd := m.forceRenewCertificate()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -147,7 +147,7 @@ func TestCovSuspendArgoWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-wf", "argo", "Workflow", model.ResourceTypeEntry{})
 	cmd := m.suspendArgoWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -156,7 +156,7 @@ func TestCovResumeArgoWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-wf", "argo", "Workflow", model.ResourceTypeEntry{})
 	cmd := m.resumeArgoWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -165,7 +165,7 @@ func TestCovStopArgoWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-wf", "argo", "Workflow", model.ResourceTypeEntry{})
 	cmd := m.stopArgoWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -174,7 +174,7 @@ func TestCovTerminateArgoWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-wf", "argo", "Workflow", model.ResourceTypeEntry{})
 	cmd := m.terminateArgoWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -183,7 +183,7 @@ func TestCovResubmitArgoWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-wf", "argo", "Workflow", model.ResourceTypeEntry{})
 	cmd := m.resubmitArgoWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -192,7 +192,7 @@ func TestCovSubmitWorkflowFromTemplate(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-tmpl", "argo", "WorkflowTemplate", model.ResourceTypeEntry{})
 	cmd := m.submitWorkflowFromTemplate(false)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	// SubmitWorkflowFromTemplate creates a workflow via dynamic client; fake dynamic
 	// client without the GVR registered may succeed or fail depending on version.
@@ -207,7 +207,7 @@ func TestCovSubmitWorkflowFromTemplateClusterScope(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-tmpl", "argo", "ClusterWorkflowTemplate", model.ResourceTypeEntry{})
 	cmd := m.submitWorkflowFromTemplate(true)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	if result.err != nil {
 		assert.Error(t, result.err)
@@ -220,7 +220,7 @@ func TestCovSuspendCronWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-cwf", "argo", "CronWorkflow", model.ResourceTypeEntry{})
 	cmd := m.suspendCronWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -229,7 +229,7 @@ func TestCovResumeCronWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-cwf", "argo", "CronWorkflow", model.ResourceTypeEntry{})
 	cmd := m.resumeCronWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -255,7 +255,7 @@ func TestCovForceRefreshExternalSecret(t *testing.T) {
 	}
 	m = withActionCtx(m, "my-es", "default", "ExternalSecret", rt)
 	cmd := m.forceRefreshExternalSecret()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -270,7 +270,7 @@ func TestCovForceRefreshExternalSecretClusterScoped(t *testing.T) {
 	}
 	m = withActionCtx(m, "my-ces", "default", "ClusterExternalSecret", rt)
 	cmd := m.forceRefreshExternalSecret()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -284,7 +284,7 @@ func TestCovPauseKEDAResource(t *testing.T) {
 	}
 	m = withActionCtx(m, "my-so", "default", "ScaledObject", rt)
 	cmd := m.pauseKEDAResource()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -298,7 +298,7 @@ func TestCovUnpauseKEDAResource(t *testing.T) {
 	}
 	m = withActionCtx(m, "my-so", "default", "ScaledObject", rt)
 	cmd := m.unpauseKEDAResource()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -311,7 +311,7 @@ func TestCovBulkSyncArgoApps(t *testing.T) {
 		{Name: "app-2"},
 	}
 	cmd := m.bulkSyncArgoApps(false)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(bulkActionResultMsg)
 	require.True(t, ok)
 	// Both should fail since there are no ArgoCD CRDs.
@@ -327,7 +327,7 @@ func TestCovBulkRefreshArgoApps(t *testing.T) {
 		{Name: "app-2"},
 	}
 	cmd := m.bulkRefreshArgoApps()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(bulkActionResultMsg)
 	require.True(t, ok)
 	assert.Equal(t, 2, result.failed)
@@ -337,7 +337,7 @@ func TestCovTerminateArgoSync(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-app", "argocd", "Application", model.ResourceTypeEntry{})
 	cmd := m.terminateArgoSync()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result := msg.(actionResultMsg)
 	assert.Error(t, result.err)
 }
@@ -368,7 +368,7 @@ func TestCovSaveAutoSyncConfig(t *testing.T) {
 	m.autoSyncSelfHeal = true
 	m.autoSyncPrune = false
 	cmd := m.saveAutoSyncConfig()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(autoSyncSavedMsg)
 	require.True(t, ok)
 	assert.Error(t, result.err)

--- a/internal/app/commands_gitops_test.go
+++ b/internal/app/commands_gitops_test.go
@@ -238,7 +238,7 @@ func TestCovWatchArgoWorkflow(t *testing.T) {
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-wf", "argo", "Workflow", model.ResourceTypeEntry{})
 	cmd := m.watchArgoWorkflow()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(describeLoadedMsg)
 	require.True(t, ok)
 	assert.Error(t, result.err)
@@ -347,7 +347,7 @@ func TestCovLoadAutoSyncConfig(t *testing.T) {
 	item := model.Item{Name: "my-app", Namespace: "argocd"}
 	m = withMiddleItem(m, item)
 	cmd := m.loadAutoSyncConfig()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(autoSyncLoadedMsg)
 	require.True(t, ok)
 	assert.Error(t, result.err)

--- a/internal/app/commands_karpenter.go
+++ b/internal/app/commands_karpenter.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -49,7 +50,7 @@ func (m Model) disruptNodeClaim() tea.Cmd {
 	ctx := m.actionCtx.context
 	name := m.actionCtx.name
 	logger.Info("Karpenter NodeClaim disrupt requested", "context", ctx, "name", name)
-	return m.trackBgTask(scheduler.KindMutation, "Disrupt NodeClaim: "+name, ctx, func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Disrupt NodeClaim: "+name, ctx, func(_ context.Context) tea.Msg {
 		if err := m.client.DisruptNodeClaim(ctx, name); err != nil {
 			return actionResultMsg{err: err}
 		}

--- a/internal/app/commands_knative.go
+++ b/internal/app/commands_knative.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -34,7 +35,7 @@ func (m Model) activateKnativeRevision() tea.Cmd {
 	ns := m.actionCtx.namespace
 	name := m.actionCtx.name
 	logger.Info("Knative Revision activation requested", "context", ctx, "namespace", ns, "name", name)
-	return m.trackBgTask(scheduler.KindMutation, "Activate Revision: "+name, bgtaskTarget(ctx, ns), func() tea.Msg {
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Activate Revision: "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
 		parent, err := m.client.ActivateKnativeRevision(ctx, ns, name)
 		if err != nil {
 			return actionResultMsg{err: err}

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -557,7 +557,6 @@ func (m Model) loadDiff(rt model.ResourceTypeEntry, itemA, itemB model.Item) tea
 		}
 	}
 	kctx := m.nav.Context
-	reqCtx := m.reqCtx
 
 	resolveCtx := func(item model.Item) string {
 		if item.ClusterName != "" {
@@ -591,22 +590,28 @@ func (m Model) loadDiff(rt model.ResourceTypeEntry, itemA, itemB model.Item) tea
 		rightLabel = ctxB + "/" + rightLabel
 	}
 
-	return func() tea.Msg {
-		yamlA, errA := m.client.GetResourceYAML(reqCtx, ctxA, nsA, rt, nameA)
-		if errA != nil {
-			return diffLoadedMsg{err: fmt.Errorf("fetching %s: %w", nameA, errA)}
-		}
-		yamlB, errB := m.client.GetResourceYAML(reqCtx, ctxB, nsB, rt, nameB)
-		if errB != nil {
-			return diffLoadedMsg{err: fmt.Errorf("fetching %s: %w", nameB, errB)}
-		}
-		return diffLoadedMsg{
-			left:      yamlA,
-			right:     yamlB,
-			leftName:  leftLabel,
-			rightName: rightLabel,
-		}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindYAMLFetch,
+		"Diff: "+nameA+" vs "+nameB,
+		bgtaskTarget(kctx, nsA),
+		func(ctx context.Context) tea.Msg {
+			yamlA, errA := m.client.GetResourceYAML(ctx, ctxA, nsA, rt, nameA)
+			if errA != nil {
+				return diffLoadedMsg{err: fmt.Errorf("fetching %s: %w", nameA, errA)}
+			}
+			yamlB, errB := m.client.GetResourceYAML(ctx, ctxB, nsB, rt, nameB)
+			if errB != nil {
+				return diffLoadedMsg{err: fmt.Errorf("fetching %s: %w", nameB, errB)}
+			}
+			return diffLoadedMsg{
+				left:      yamlA,
+				right:     yamlB,
+				leftName:  leftLabel,
+				rightName: rightLabel,
+			}
+		},
+	)
 }
 
 // resolveNamespace returns the namespace to use for get/describe operations.
@@ -630,12 +635,17 @@ func (m Model) loadRevisions() tea.Cmd {
 	}
 	name := sel.Name
 	client := m.client
-	reqCtx := m.reqCtx
 
-	return func() tea.Msg {
-		revs, err := client.GetDeploymentRevisions(reqCtx, kctx, ns, name)
-		return revisionListMsg{revisions: revs, err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"Revisions: "+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			revs, err := client.GetDeploymentRevisions(ctx, kctx, ns, name)
+			return revisionListMsg{revisions: revs, err: err}
+		},
+	)
 }
 
 // bgtaskTarget formats a context+namespace pair for the :tasks overlay's

--- a/internal/app/commands_load_dataops.go
+++ b/internal/app/commands_load_dataops.go
@@ -55,10 +55,16 @@ func (m Model) saveSecretData() tea.Cmd {
 	maps.Copy(data, m.secretData.Data)
 	client := m.client
 
-	return func() tea.Msg {
-		err := client.UpdateSecretData(ctx, ns, name, data)
-		return secretSavedMsg{err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityCritical,
+		scheduler.KindMutation,
+		"Save secret: "+name,
+		bgtaskTarget(ctx, ns),
+		func(_ context.Context) tea.Msg {
+			err := client.UpdateSecretData(ctx, ns, name, data)
+			return secretSavedMsg{err: err}
+		},
+	)
 }
 
 // loadConfigMapData fetches configmap data for the configmap editor.
@@ -108,10 +114,16 @@ func (m Model) saveConfigMapData() tea.Cmd {
 	maps.Copy(data, m.configMapData.Data)
 	client := m.client
 
-	return func() tea.Msg {
-		err := client.UpdateConfigMapData(ctx, ns, name, data)
-		return configMapSavedMsg{err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityCritical,
+		scheduler.KindMutation,
+		"Save configmap: "+name,
+		bgtaskTarget(ctx, ns),
+		func(_ context.Context) tea.Msg {
+			err := client.UpdateConfigMapData(ctx, ns, name, data)
+			return configMapSavedMsg{err: err}
+		},
+	)
 }
 
 // loadLabelData fetches labels and annotations for the selected resource.
@@ -163,8 +175,14 @@ func (m Model) saveLabelData() tea.Cmd {
 	maps.Copy(annotations, m.labelData.Annotations)
 	client := m.client
 
-	return func() tea.Msg {
-		err := client.UpdateLabelAnnotationData(context.Background(), kctx, rt, ns, name, labels, annotations)
-		return labelSavedMsg{err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityCritical,
+		scheduler.KindMutation,
+		"Save labels: "+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			err := client.UpdateLabelAnnotationData(ctx, kctx, rt, ns, name, labels, annotations)
+			return labelSavedMsg{err: err}
+		},
+	)
 }

--- a/internal/app/commands_load_dataops.go
+++ b/internal/app/commands_load_dataops.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 )
 
 // loadSecretData fetches secret data for the secret editor.
@@ -21,12 +22,17 @@ func (m Model) loadSecretData() tea.Cmd {
 	}
 	name := sel.Name
 	client := m.client
-	reqCtx := m.reqCtx
 
-	return func() tea.Msg {
-		data, err := client.GetSecretData(reqCtx, kctx, ns, name)
-		return secretDataLoadedMsg{data: data, err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"Secret data: "+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			data, err := client.GetSecretData(ctx, kctx, ns, name)
+			return secretDataLoadedMsg{data: data, err: err}
+		},
+	)
 }
 
 // saveSecretData saves the modified secret data back to the cluster.
@@ -69,12 +75,17 @@ func (m Model) loadConfigMapData() tea.Cmd {
 	}
 	name := sel.Name
 	client := m.client
-	reqCtx := m.reqCtx
 
-	return func() tea.Msg {
-		data, err := client.GetConfigMapData(reqCtx, kctx, ns, name)
-		return configMapDataLoadedMsg{data: data, err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"ConfigMap data: "+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			data, err := client.GetConfigMapData(ctx, kctx, ns, name)
+			return configMapDataLoadedMsg{data: data, err: err}
+		},
+	)
 }
 
 // saveConfigMapData saves the modified configmap data back to the cluster.
@@ -117,12 +128,17 @@ func (m Model) loadLabelData() tea.Cmd {
 	name := sel.Name
 	rt := m.labelResourceType
 	client := m.client
-	reqCtx := m.reqCtx
 
-	return func() tea.Msg {
-		data, err := client.GetLabelAnnotationData(reqCtx, kctx, rt, ns, name)
-		return labelDataLoadedMsg{data: data, err: err}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceList,
+		"Labels: "+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			data, err := client.GetLabelAnnotationData(ctx, kctx, rt, ns, name)
+			return labelDataLoadedMsg{data: data, err: err}
+		},
+	)
 }
 
 // saveLabelData saves modified labels and annotations.

--- a/internal/app/commands_load_overlays.go
+++ b/internal/app/commands_load_overlays.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"context"
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -49,9 +51,14 @@ func (m Model) loadRightsizing() tea.Cmd {
 	}
 
 	client := m.client
-	reqCtx := m.reqCtx
-	return func() tea.Msg {
-		data, err := client.GetRightsizing(reqCtx, ctx.context, ctx.namespace, ctx.kind, ctx.name, strategy, headroom)
-		return rightsizingLoadedMsg{key: key, data: data, err: err, generation: gen}
-	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityLow,
+		scheduler.KindMetrics,
+		"Rightsizing: "+ctx.name,
+		bgtaskTarget(ctx.context, ctx.namespace),
+		func(reqCtx context.Context) tea.Msg {
+			data, err := client.GetRightsizing(reqCtx, ctx.context, ctx.namespace, ctx.kind, ctx.name, strategy, headroom)
+			return rightsizingLoadedMsg{key: key, data: data, err: err, generation: gen}
+		},
+	)
 }

--- a/internal/app/commands_load_scheduler_reads_test.go
+++ b/internal/app/commands_load_scheduler_reads_test.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newReadsSchedulerModel returns a baseFinalModel wired to a fresh, worker-less
+// scheduler. With workers stopped the submitted task stays queued, so a wired
+// loader can be observed synchronously via QueueLen — the same technique as
+// TestLoadResourcesRegistersTaskSynchronously.
+func newReadsSchedulerModel() Model {
+	m := baseFinalModel()
+	m.scheduler = scheduler.New(0)
+	m.scheduler.StopWorkers()
+	return m
+}
+
+// TestK8sReadsAreScheduled asserts every previously-unwired K8s read loader now
+// dispatches through scheduleK8sCall (which Submits synchronously while the Cmd
+// is built), rather than running in a raw closure that bypasses the worker pool,
+// priority lanes, coalescing, and gen-based cancellation.
+func TestK8sReadsAreScheduled(t *testing.T) {
+	t.Run("loadSecretData", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadSecretData())
+	})
+	t.Run("loadConfigMapData", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadConfigMapData())
+	})
+	t.Run("loadLabelData", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadLabelData())
+	})
+	t.Run("loadRevisions", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadRevisions())
+	})
+	t.Run("loadContainersForAction", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadContainersForAction())
+	})
+	t.Run("loadContainersForLogFilter", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadContainersForLogFilter())
+	})
+	t.Run("detectExecPodOSCmd", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.detectExecPodOSCmd())
+	})
+	t.Run("loadPodsForAction", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadPodsForAction())
+	})
+	t.Run("loadRightsizing", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadRightsizing())
+	})
+	t.Run("copyYAMLToClipboard", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.copyYAMLToClipboard())
+	})
+	t.Run("copyYAMLForScope", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		scope := []model.Item{{Name: "pod-1", Namespace: "default", Kind: "Pod"}}
+		assertSchedulesOne(t, m, m.copyYAMLForScope(scope))
+	})
+	t.Run("exportResourceToFile", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.exportResourceToFile())
+	})
+	t.Run("loadDiff", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		rt := model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", Namespaced: true}
+		itemA := model.Item{Name: "pod-1", Namespace: "default", Kind: "Pod"}
+		itemB := model.Item{Name: "pod-2", Namespace: "default", Kind: "Pod"}
+		assertSchedulesOne(t, m, m.loadDiff(rt, itemA, itemB))
+	})
+	t.Run("watchArgoWorkflow", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.watchArgoWorkflow())
+	})
+	t.Run("loadAutoSyncConfig", func(t *testing.T) {
+		m := newReadsSchedulerModel()
+		assertSchedulesOne(t, m, m.loadAutoSyncConfig())
+	})
+}
+
+// assertSchedulesOne fails unless cmd is non-nil and a task was Submitted
+// synchronously onto the model's scheduler (QueueLen == 1) at Cmd-construction
+// time — proof the loader routes through scheduleK8sCall, not a raw closure.
+func assertSchedulesOne(t *testing.T, m Model, cmd tea.Cmd) {
+	t.Helper()
+	require.NotNil(t, cmd, "loader returned nil cmd; preconditions not met")
+	assert.Equal(t, 1, m.scheduler.QueueLen(m.nav.Context),
+		"loader must Submit one task synchronously via scheduleK8sCall")
+}

--- a/internal/app/commands_load_scheduler_reads_test.go
+++ b/internal/app/commands_load_scheduler_reads_test.go
@@ -92,6 +92,72 @@ func TestK8sReadsAreScheduled(t *testing.T) {
 	})
 }
 
+// TestK8sMutationsAreScheduled asserts in-process write operations route through
+// scheduleK8sCall (KindMutation) instead of trackBgTask / raw closures, so they
+// share the bounded worker pool and Critical priority. Mutations NeverCoalesce,
+// so unlike reads there is no coalescing hazard. Subprocess mutations (kubectl /
+// helm) and bulk-loop mutations stay on trackBgTask and are not covered here.
+func TestK8sMutationsAreScheduled(t *testing.T) {
+	podRT := model.ResourceTypeEntry{Resource: "pods", Kind: "Pod", Namespaced: true}
+	deployRT := model.ResourceTypeEntry{Resource: "deployments", Kind: "Deployment", Namespaced: true}
+
+	t.Run("deleteResource", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "pod-1", "default", "Pod", podRT)
+		assertSchedulesOne(t, m, m.deleteResource())
+	})
+	t.Run("scaleResource", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "deploy-1", "default", "Deployment", deployRT)
+		assertSchedulesOne(t, m, m.scaleResource(3))
+	})
+	t.Run("resizePVC", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "pvc-1", "default", "PersistentVolumeClaim", model.ResourceTypeEntry{})
+		assertSchedulesOne(t, m, m.resizePVC("10Gi"))
+	})
+	t.Run("rollbackDeployment", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "deploy-1", "default", "Deployment", deployRT)
+		assertSchedulesOne(t, m, m.rollbackDeployment(1))
+	})
+	t.Run("triggerCronJob", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "cj-1", "default", "CronJob", model.ResourceTypeEntry{})
+		assertSchedulesOne(t, m, m.triggerCronJob())
+	})
+	t.Run("syncArgoApp", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "my-app", "argocd", "Application", model.ResourceTypeEntry{})
+		assertSchedulesOne(t, m, m.syncArgoApp(false))
+	})
+	t.Run("terminateArgoSync", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "my-app", "argocd", "Application", model.ResourceTypeEntry{})
+		assertSchedulesOne(t, m, m.terminateArgoSync())
+	})
+	t.Run("disruptNodeClaim", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "nc-1", "", "NodeClaim", model.ResourceTypeEntry{})
+		assertSchedulesOne(t, m, m.disruptNodeClaim())
+	})
+	t.Run("activateKnativeRevision", func(t *testing.T) {
+		m := withActionCtx(baseModelWithFakeClient(), "rev-1", "default", "Revision", model.ResourceTypeEntry{})
+		assertSchedulesOne(t, m, m.activateKnativeRevision())
+	})
+	t.Run("saveAutoSyncConfig", func(t *testing.T) {
+		m := withMiddleItem(baseModelWithFakeClient(), model.Item{Name: "my-app", Namespace: "argocd"})
+		assertSchedulesOne(t, m, m.saveAutoSyncConfig())
+	})
+	t.Run("saveSecretData", func(t *testing.T) {
+		m := withMiddleItem(baseModelWithFakeClient(), model.Item{Name: "my-secret", Namespace: "default"})
+		m.secretData = &model.SecretData{Data: map[string]string{"k": "v"}}
+		assertSchedulesOne(t, m, m.saveSecretData())
+	})
+	t.Run("saveConfigMapData", func(t *testing.T) {
+		m := withMiddleItem(baseModelWithFakeClient(), model.Item{Name: "my-cm", Namespace: "default"})
+		m.configMapData = &model.ConfigMapData{Data: map[string]string{"k": "v"}}
+		assertSchedulesOne(t, m, m.saveConfigMapData())
+	})
+	t.Run("saveLabelData", func(t *testing.T) {
+		m := withMiddleItem(baseModelWithFakeClient(), model.Item{Name: "pod-1", Namespace: "default"})
+		m.labelData = &model.LabelAnnotationData{Labels: map[string]string{"l": "v"}, Annotations: map[string]string{"a": "v"}}
+		assertSchedulesOne(t, m, m.saveLabelData())
+	})
+}
+
 // assertSchedulesOne fails unless cmd is non-nil and a task was Submitted
 // synchronously onto the model's scheduler (QueueLen == 1) at Cmd-construction
 // time — proof the loader routes through scheduleK8sCall, not a raw closure.

--- a/internal/app/commands_load_test.go
+++ b/internal/app/commands_load_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,7 @@ import (
 
 func TestCov80LoadContainersForLogFilter(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.actionCtx = actionContext{
 		context:   "test-ctx",
 		name:      "my-pod",
@@ -21,7 +23,7 @@ func TestCov80LoadContainersForLogFilter(t *testing.T) {
 	}
 	cmd := m.loadContainersForLogFilter()
 	require.NotNil(t, cmd)
-	msg := cmd()
+	msg := execScheduled(t, m, cmd)
 	lmsg, ok := msg.(logContainersLoadedMsg)
 	require.True(t, ok)
 	// Fake client returns empty containers, so err is set or containers is empty.
@@ -30,6 +32,7 @@ func TestCov80LoadContainersForLogFilter(t *testing.T) {
 
 func TestCov80LoadContainersForLogFilterNoPod(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.actionCtx = actionContext{
 		context:   "test-ctx",
 		name:      "nonexistent-pod",
@@ -37,7 +40,7 @@ func TestCov80LoadContainersForLogFilterNoPod(t *testing.T) {
 	}
 	cmd := m.loadContainersForLogFilter()
 	require.NotNil(t, cmd)
-	msg := cmd()
+	msg := execScheduled(t, m, cmd)
 	_, ok := msg.(logContainersLoadedMsg)
 	assert.True(t, ok)
 }
@@ -812,7 +815,7 @@ func TestCovLoadDiff(t *testing.T) {
 	itemA := model.Item{Name: "cm-1", Namespace: "default"}
 	itemB := model.Item{Name: "cm-2", Namespace: "default"}
 	cmd := m.loadDiff(rt, itemA, itemB)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(diffLoadedMsg)
 	require.True(t, ok)
 	assert.NoError(t, result.err)
@@ -832,7 +835,7 @@ func TestCovLoadDiffDifferentNamespaces(t *testing.T) {
 	itemA := model.Item{Name: "cm-1", Namespace: "ns-a"}
 	itemB := model.Item{Name: "cm-2", Namespace: "ns-b"}
 	cmd := m.loadDiff(rt, itemA, itemB)
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(diffLoadedMsg)
 	require.True(t, ok)
 	// Items don't exist so we expect an error.
@@ -971,7 +974,7 @@ func TestCovLoadSecretData(t *testing.T) {
 	m := baseModelWithFakeClient(secret)
 	m = withMiddleItem(m, model.Item{Name: "my-secret", Namespace: "default"})
 	cmd := m.loadSecretData()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(secretDataLoadedMsg)
 	require.True(t, ok)
 	assert.NoError(t, result.err)
@@ -1023,7 +1026,7 @@ func TestCovLoadConfigMapData(t *testing.T) {
 	m := baseModelWithFakeClient(cm)
 	m = withMiddleItem(m, model.Item{Name: "my-cm", Namespace: "default"})
 	cmd := m.loadConfigMapData()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(configMapDataLoadedMsg)
 	require.True(t, ok)
 	assert.NoError(t, result.err)

--- a/internal/app/commands_load_test.go
+++ b/internal/app/commands_load_test.go
@@ -997,7 +997,7 @@ func TestCovSaveSecretData(t *testing.T) {
 	m = withMiddleItem(m, model.Item{Name: "my-secret", Namespace: "default"})
 	m.secretData = &model.SecretData{Data: map[string]string{"key": "new"}}
 	cmd := m.saveSecretData()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(secretSavedMsg)
 	require.True(t, ok)
 	assert.NoError(t, result.err)
@@ -1049,7 +1049,7 @@ func TestCovSaveConfigMapData(t *testing.T) {
 	m = withMiddleItem(m, model.Item{Name: "my-cm", Namespace: "default"})
 	m.configMapData = &model.ConfigMapData{Data: map[string]string{"key": "new"}}
 	cmd := m.saveConfigMapData()
-	msg := execCmd(t, cmd)
+	msg := execScheduled(t, m, cmd)
 	result, ok := msg.(configMapSavedMsg)
 	require.True(t, ok)
 	assert.NoError(t, result.err)

--- a/internal/app/commands_yaml.go
+++ b/internal/app/commands_yaml.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -32,6 +33,12 @@ func writeSecureFile(path string, data []byte) error {
 }
 
 // copyYAMLToClipboard fetches the YAML for the selected resource and sends it for clipboard copy.
+//
+// Every fetch routes through scheduleK8sCall (KindYAMLFetch) so it shares the
+// bounded worker pool, priority lanes, and gen-based cancellation with the rest
+// of the K8s reads. The task names are deliberately distinct from the "YAML: …"
+// preview path so a copy never coalesces onto an in-flight preview fetch (which
+// would deliver the copy a nil result and silently drop it).
 func (m Model) copyYAMLToClipboard() tea.Cmd {
 	// Synthetic security items (e.g., __security_affected_resource__) have
 	// no YAML; short-circuit to avoid "unknown resource type" warnings.
@@ -40,6 +47,7 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 	}
 	kctx := m.effectiveContext()
 	ns := m.resolveNamespace()
+	target := bgtaskTarget(kctx, ns)
 
 	switch m.nav.Level {
 	case model.LevelResources:
@@ -66,19 +74,21 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 				}
 				targets[i] = fetchTarget{ns: itemNs, name: it.Name, ctx: itemCtx}
 			}
-			return func() tea.Msg {
-				docs := make([]string, 0, len(targets))
-				var failures []string
-				for _, t := range targets {
-					content, err := m.client.GetResourceYAML(context.Background(), t.ctx, t.ns, rt, t.name)
-					if err != nil {
-						failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
-						continue
+			return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+				fmt.Sprintf("Copy YAML (%d items)", len(targets)), target,
+				func(ctx context.Context) tea.Msg {
+					docs := make([]string, 0, len(targets))
+					var failures []string
+					for _, t := range targets {
+						content, err := m.client.GetResourceYAML(ctx, t.ctx, t.ns, rt, t.name)
+						if err != nil {
+							failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+							continue
+						}
+						docs = append(docs, strings.TrimRight(content, "\n"))
 					}
-					docs = append(docs, strings.TrimRight(content, "\n"))
-				}
-				return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
-			}
+					return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
+				})
 		}
 		sel := m.selectedMiddleItem()
 		if sel == nil {
@@ -93,10 +103,12 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 		if sel.ClusterName != "" {
 			itemCtx = sel.ClusterName
 		}
-		return func() tea.Msg {
-			content, err := m.client.GetResourceYAML(context.Background(), itemCtx, itemNs, rt, name)
-			return yamlClipboardMsg{content: content, count: 1, err: err}
-		}
+		return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+			"Copy YAML: "+name, target,
+			func(ctx context.Context) tea.Msg {
+				content, err := m.client.GetResourceYAML(ctx, itemCtx, itemNs, rt, name)
+				return yamlClipboardMsg{content: content, count: 1, err: err}
+			})
 	case model.LevelOwned:
 		// Bulk path mirrors LevelResources: gate on visible selection so a
 		// selection that's been filtered out of view falls through to the
@@ -124,30 +136,32 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 				}
 				targets[i] = t
 			}
-			return func() tea.Msg {
-				docs := make([]string, 0, len(targets))
-				var failures []string
-				for _, t := range targets {
-					var (
-						content string
-						err     error
-					)
-					switch {
-					case t.isPod:
-						content, err = m.client.GetPodYAML(context.Background(), kctx, t.ns, t.name)
-					case t.resolved:
-						content, err = m.client.GetResourceYAML(context.Background(), kctx, t.ns, t.rt, t.name)
-					default:
-						err = fmt.Errorf("unknown resource type: %s", t.kind)
+			return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+				fmt.Sprintf("Copy YAML (%d items)", len(targets)), target,
+				func(ctx context.Context) tea.Msg {
+					docs := make([]string, 0, len(targets))
+					var failures []string
+					for _, t := range targets {
+						var (
+							content string
+							err     error
+						)
+						switch {
+						case t.isPod:
+							content, err = m.client.GetPodYAML(ctx, kctx, t.ns, t.name)
+						case t.resolved:
+							content, err = m.client.GetResourceYAML(ctx, kctx, t.ns, t.rt, t.name)
+						default:
+							err = fmt.Errorf("unknown resource type: %s", t.kind)
+						}
+						if err != nil {
+							failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+							continue
+						}
+						docs = append(docs, strings.TrimRight(content, "\n"))
 					}
-					if err != nil {
-						failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
-						continue
-					}
-					docs = append(docs, strings.TrimRight(content, "\n"))
-				}
-				return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
-			}
+					return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
+				})
 		}
 		sel := m.selectedMiddleItem()
 		if sel == nil {
@@ -159,10 +173,12 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 			itemNs = sel.Namespace
 		}
 		if sel.Kind == "Pod" {
-			return func() tea.Msg {
-				content, err := m.client.GetPodYAML(context.Background(), kctx, itemNs, name)
-				return yamlClipboardMsg{content: content, count: 1, err: err}
-			}
+			return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+				"Copy YAML: "+name, target,
+				func(ctx context.Context) tea.Msg {
+					content, err := m.client.GetPodYAML(ctx, kctx, itemNs, name)
+					return yamlClipboardMsg{content: content, count: 1, err: err}
+				})
 		}
 		rt, ok := m.resolveOwnedResourceType(sel)
 		if !ok {
@@ -170,10 +186,12 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 				return yamlClipboardMsg{err: fmt.Errorf("unknown resource type: %s", sel.Kind)}
 			}
 		}
-		return func() tea.Msg {
-			content, err := m.client.GetResourceYAML(context.Background(), kctx, itemNs, rt, name)
-			return yamlClipboardMsg{content: content, count: 1, err: err}
-		}
+		return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+			"Copy YAML: "+name, target,
+			func(ctx context.Context) tea.Msg {
+				content, err := m.client.GetResourceYAML(ctx, kctx, itemNs, rt, name)
+				return yamlClipboardMsg{content: content, count: 1, err: err}
+			})
 	case model.LevelContainers:
 		podName := m.nav.OwnedName
 		// Bulk path: if the user has selected N containers in this Pod,
@@ -186,22 +204,26 @@ func (m Model) copyYAMLToClipboard() tea.Cmd {
 			for i, it := range items {
 				names[i] = it.Name
 			}
-			return func() tea.Msg {
-				content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
-				if err != nil {
-					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
-				}
-				out, err := ExtractContainerBlocksYAML(content, names)
-				if err != nil {
-					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
-				}
-				return yamlClipboardMsg{content: out, count: len(names)}
-			}
+			return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+				"Copy YAML: "+podName, target,
+				func(ctx context.Context) tea.Msg {
+					content, err := m.client.GetPodYAML(ctx, kctx, ns, podName)
+					if err != nil {
+						return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+					}
+					out, err := ExtractContainerBlocksYAML(content, names)
+					if err != nil {
+						return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+					}
+					return yamlClipboardMsg{content: out, count: len(names)}
+				})
 		}
-		return func() tea.Msg {
-			content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
-			return yamlClipboardMsg{content: content, count: 1, err: err}
-		}
+		return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+			"Copy YAML: "+podName, target,
+			func(ctx context.Context) tea.Msg {
+				content, err := m.client.GetPodYAML(ctx, kctx, ns, podName)
+				return yamlClipboardMsg{content: content, count: 1, err: err}
+			})
 	}
 	return nil
 }
@@ -228,6 +250,7 @@ func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 	}
 	kctx := m.nav.Context
 	ns := m.resolveNamespace()
+	target := bgtaskTarget(kctx, ns)
 
 	switch m.nav.Level {
 	case model.LevelResources:
@@ -243,19 +266,21 @@ func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 			}
 			targets[i] = fetchTarget{ns: itemNs, name: it.Name}
 		}
-		return func() tea.Msg {
-			docs := make([]string, 0, len(targets))
-			var failures []string
-			for _, t := range targets {
-				content, err := m.client.GetResourceYAML(context.Background(), kctx, t.ns, rt, t.name)
-				if err != nil {
-					failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
-					continue
+		return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+			fmt.Sprintf("Copy YAML (%d items)", len(targets)), target,
+			func(ctx context.Context) tea.Msg {
+				docs := make([]string, 0, len(targets))
+				var failures []string
+				for _, t := range targets {
+					content, err := m.client.GetResourceYAML(ctx, kctx, t.ns, rt, t.name)
+					if err != nil {
+						failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+						continue
+					}
+					docs = append(docs, strings.TrimRight(content, "\n"))
 				}
-				docs = append(docs, strings.TrimRight(content, "\n"))
-			}
-			return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
-		}
+				return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
+			})
 	case model.LevelOwned:
 		type fetchTarget struct {
 			ns, name string
@@ -276,47 +301,51 @@ func (m Model) copyYAMLForScope(scope []model.Item) tea.Cmd {
 			}
 			targets[i] = t
 		}
-		return func() tea.Msg {
-			docs := make([]string, 0, len(targets))
-			var failures []string
-			for _, t := range targets {
-				var (
-					content string
-					err     error
-				)
-				switch {
-				case t.isPod:
-					content, err = m.client.GetPodYAML(context.Background(), kctx, t.ns, t.name)
-				case t.resolved:
-					content, err = m.client.GetResourceYAML(context.Background(), kctx, t.ns, t.rt, t.name)
-				default:
-					err = fmt.Errorf("unknown resource type: %s", t.kind)
+		return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+			fmt.Sprintf("Copy YAML (%d items)", len(targets)), target,
+			func(ctx context.Context) tea.Msg {
+				docs := make([]string, 0, len(targets))
+				var failures []string
+				for _, t := range targets {
+					var (
+						content string
+						err     error
+					)
+					switch {
+					case t.isPod:
+						content, err = m.client.GetPodYAML(ctx, kctx, t.ns, t.name)
+					case t.resolved:
+						content, err = m.client.GetResourceYAML(ctx, kctx, t.ns, t.rt, t.name)
+					default:
+						err = fmt.Errorf("unknown resource type: %s", t.kind)
+					}
+					if err != nil {
+						failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
+						continue
+					}
+					docs = append(docs, strings.TrimRight(content, "\n"))
 				}
-				if err != nil {
-					failures = append(failures, fmt.Sprintf("%s/%s: %v", t.ns, t.name, err))
-					continue
-				}
-				docs = append(docs, strings.TrimRight(content, "\n"))
-			}
-			return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
-		}
+				return buildBulkYAMLClipboardMsg(docs, failures, len(targets))
+			})
 	case model.LevelContainers:
 		podName := m.nav.OwnedName
 		names := make([]string, len(scope))
 		for i, it := range scope {
 			names[i] = it.Name
 		}
-		return func() tea.Msg {
-			content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
-			if err != nil {
-				return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
-			}
-			out, err := ExtractContainerBlocksYAML(content, names)
-			if err != nil {
-				return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
-			}
-			return yamlClipboardMsg{content: out, count: len(names)}
-		}
+		return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+			"Copy YAML: "+podName, target,
+			func(ctx context.Context) tea.Msg {
+				content, err := m.client.GetPodYAML(ctx, kctx, ns, podName)
+				if err != nil {
+					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+				}
+				out, err := ExtractContainerBlocksYAML(content, names)
+				if err != nil {
+					return yamlClipboardMsg{err: fmt.Errorf("%s/%s: %w", ns, podName, err)}
+				}
+				return yamlClipboardMsg{content: out, count: len(names)}
+			})
 	}
 	return nil
 }
@@ -364,7 +393,8 @@ func (m Model) exportResourceToFile() tea.Cmd {
 	kctx := m.effectiveContext()
 	ns := m.resolveNamespace()
 
-	var fetchYAML func() (string, string, error) // returns (yaml, kindForFilename, error)
+	var fetchYAML func(ctx context.Context) (string, string, error) // returns (yaml, kindForFilename, error)
+	var exportName string
 
 	switch m.nav.Level {
 	case model.LevelResources:
@@ -374,6 +404,7 @@ func (m Model) exportResourceToFile() tea.Cmd {
 		}
 		rt := m.nav.ResourceType
 		name := sel.Name
+		exportName = name
 		itemNs := ns
 		if sel.Namespace != "" {
 			itemNs = sel.Namespace
@@ -383,8 +414,8 @@ func (m Model) exportResourceToFile() tea.Cmd {
 			itemCtx = sel.ClusterName
 		}
 		kind := strings.ToLower(rt.Kind)
-		fetchYAML = func() (string, string, error) {
-			content, err := m.client.GetResourceYAML(context.Background(), itemCtx, itemNs, rt, name)
+		fetchYAML = func(ctx context.Context) (string, string, error) {
+			content, err := m.client.GetResourceYAML(ctx, itemCtx, itemNs, rt, name)
 			return content, kind, err
 		}
 	case model.LevelOwned:
@@ -393,6 +424,7 @@ func (m Model) exportResourceToFile() tea.Cmd {
 			return nil
 		}
 		name := sel.Name
+		exportName = name
 		itemNs := ns
 		if sel.Namespace != "" {
 			itemNs = sel.Namespace
@@ -402,8 +434,8 @@ func (m Model) exportResourceToFile() tea.Cmd {
 			itemCtx = sel.ClusterName
 		}
 		if sel.Kind == "Pod" {
-			fetchYAML = func() (string, string, error) {
-				content, err := m.client.GetPodYAML(context.Background(), itemCtx, itemNs, name)
+			fetchYAML = func(ctx context.Context) (string, string, error) {
+				content, err := m.client.GetPodYAML(ctx, itemCtx, itemNs, name)
 				return content, "pod", err
 			}
 		} else {
@@ -414,49 +446,52 @@ func (m Model) exportResourceToFile() tea.Cmd {
 				}
 			}
 			kind := strings.ToLower(rt.Kind)
-			fetchYAML = func() (string, string, error) {
-				content, err := m.client.GetResourceYAML(context.Background(), itemCtx, itemNs, rt, name)
+			fetchYAML = func(ctx context.Context) (string, string, error) {
+				content, err := m.client.GetResourceYAML(ctx, itemCtx, itemNs, rt, name)
 				return content, kind, err
 			}
 		}
 	case model.LevelContainers:
 		podName := m.nav.OwnedName
-		fetchYAML = func() (string, string, error) {
-			content, err := m.client.GetPodYAML(context.Background(), kctx, ns, podName)
+		exportName = podName
+		fetchYAML = func(ctx context.Context) (string, string, error) {
+			content, err := m.client.GetPodYAML(ctx, kctx, ns, podName)
 			return content, "pod", err
 		}
 	default:
 		return nil
 	}
 
-	return func() tea.Msg {
-		yaml, kind, err := fetchYAML()
-		if err != nil {
-			return exportDoneMsg{err: fmt.Errorf("fetching resource: %w", err)}
-		}
-
-		// Build filename: <kind>_<name>.yaml
-		var name string
-		switch m.nav.Level {
-		case model.LevelContainers:
-			name = m.nav.OwnedName
-		default:
-			sel := m.selectedMiddleItem()
-			if sel != nil {
-				name = sel.Name
+	return m.scheduleK8sCall(scheduler.PriorityHigh, scheduler.KindYAMLFetch,
+		"Export YAML: "+exportName, bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			yaml, kind, err := fetchYAML(ctx)
+			if err != nil {
+				return exportDoneMsg{err: fmt.Errorf("fetching resource: %w", err)}
 			}
-		}
-		sanitized := strings.ReplaceAll(name, "/", "_")
-		filename := fmt.Sprintf("%s_%s.yaml", kind, sanitized)
 
-		if err := writeSecureFile(filename, []byte(yaml)); err != nil {
-			return exportDoneMsg{err: fmt.Errorf("writing file: %w", err)}
-		}
+			// Build filename: <kind>_<name>.yaml
+			var name string
+			switch m.nav.Level {
+			case model.LevelContainers:
+				name = m.nav.OwnedName
+			default:
+				sel := m.selectedMiddleItem()
+				if sel != nil {
+					name = sel.Name
+				}
+			}
+			sanitized := strings.ReplaceAll(name, "/", "_")
+			filename := fmt.Sprintf("%s_%s.yaml", kind, sanitized)
 
-		abs, _ := filepath.Abs(filename)
-		if abs == "" {
-			abs = filename
-		}
-		return exportDoneMsg{path: abs}
-	}
+			if err := writeSecureFile(filename, []byte(yaml)); err != nil {
+				return exportDoneMsg{err: fmt.Errorf("writing file: %w", err)}
+			}
+
+			abs, _ := filepath.Abs(filename)
+			if abs == "" {
+				abs = filename
+			}
+			return exportDoneMsg{path: abs}
+		})
 }

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -1833,12 +1833,13 @@ func TestCov80CopyYAMLLevelResources(t *testing.T) {
 
 func TestCov80CopyYAMLLevelOwnedPod(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.nav.Level = model.LevelOwned
 	m.middleItems = []model.Item{{Name: "pod-1", Kind: "Pod", Namespace: "default"}}
 	m.setCursor(0)
 	cmd := m.copyYAMLToClipboard()
 	require.NotNil(t, cmd)
-	ymsg, ok := cmd().(yamlClipboardMsg)
+	ymsg, ok := execScheduled(t, m, cmd).(yamlClipboardMsg)
 	require.True(t, ok)
 	assert.Equal(t, 1, ymsg.count, "single-item path must tag count=1")
 }
@@ -1867,13 +1868,14 @@ func TestCov80CopyYAMLLevelOwnedUnknownKind(t *testing.T) {
 
 func TestCov80CopyYAMLLevelContainers(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.nav.Level = model.LevelContainers
 	m.nav.OwnedName = "pod-1"
 	m.middleItems = []model.Item{{Name: "container-1"}}
 	m.setCursor(0)
 	cmd := m.copyYAMLToClipboard()
 	require.NotNil(t, cmd)
-	ymsg, ok := cmd().(yamlClipboardMsg)
+	ymsg, ok := execScheduled(t, m, cmd).(yamlClipboardMsg)
 	require.True(t, ok)
 	assert.Equal(t, 1, ymsg.count, "single-item path must tag count=1")
 }

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -1478,6 +1478,7 @@ func TestCov80LoadMetricsAtLevelOwned(t *testing.T) {
 
 func TestCov80SaveLabelDataWithSelection(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.labelData = &model.LabelAnnotationData{
 		Labels:      map[string]string{"env": "prod"},
 		Annotations: map[string]string{"note": "test"},
@@ -1486,7 +1487,7 @@ func TestCov80SaveLabelDataWithSelection(t *testing.T) {
 	m.setCursor(0)
 	cmd := m.saveLabelData()
 	require.NotNil(t, cmd)
-	msg := cmd()
+	msg := execScheduled(t, m, cmd)
 	_, ok := msg.(labelSavedMsg)
 	assert.True(t, ok)
 }

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -614,6 +614,19 @@ func execCmd(t *testing.T, cmd tea.Cmd) tea.Msg {
 	return cmd()
 }
 
+// execScheduled runs a cmd that was Submitted to m.scheduler via scheduleK8sCall.
+// Such a cmd blocks until a worker delivers its Future, so the model's scheduler
+// must have workers running. StartWorkers retroactively spawns pools for queues
+// created by an earlier synchronous Submit, so starting here (after the cmd is
+// built) is sufficient. Workers are stopped before returning to avoid leaks.
+func execScheduled(t *testing.T, m Model, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	require.NotNil(t, cmd)
+	m.scheduler.StartWorkers()
+	defer m.scheduler.StopWorkers()
+	return cmd()
+}
+
 func keyMsg(s string) tea.KeyMsg {
 	switch s {
 	case "esc":

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -895,13 +896,14 @@ func TestCopyYAMLSelectionFilteredOutFallsBack(t *testing.T) {
 // TestUpdateYamlClipboardCountAwareStatus/bulk against the receiver directly.
 func TestCopyYAMLBulkErrorWrapsNamespaceName(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.toggleSelection(m.middleItems[0]) // default/pod-1
 	m.toggleSelection(m.middleItems[1]) // ns-2/pod-2
 
 	cmd := m.copyYAMLToClipboard()
 	require.NotNil(t, cmd)
 
-	ymsg, ok := cmd().(yamlClipboardMsg)
+	ymsg, ok := execScheduled(t, m, cmd).(yamlClipboardMsg)
 	require.True(t, ok)
 	require.Error(t, ymsg.err, "fake client has no pods seeded; first fetch must fail")
 	assert.Contains(t, ymsg.err.Error(), "default/pod-1",
@@ -1027,6 +1029,7 @@ func TestUpdateYamlClipboardCountAwareStatus(t *testing.T) {
 // assertion pins down which branch ran.
 func TestCopyYAMLBulkLevelOwnedWrapsErrorWithNamespaceName(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.nav.Level = model.LevelOwned
 	m.toggleSelection(m.middleItems[0]) // default/pod-1
 	m.toggleSelection(m.middleItems[1]) // ns-2/pod-2
@@ -1034,7 +1037,7 @@ func TestCopyYAMLBulkLevelOwnedWrapsErrorWithNamespaceName(t *testing.T) {
 	cmd := m.copyYAMLToClipboard()
 	require.NotNil(t, cmd)
 
-	ymsg, ok := cmd().(yamlClipboardMsg)
+	ymsg, ok := execScheduled(t, m, cmd).(yamlClipboardMsg)
 	require.True(t, ok)
 	require.Error(t, ymsg.err, "fake client has no pods seeded; first fetch must fail")
 	assert.Contains(t, ymsg.err.Error(), "default/pod-1",
@@ -1074,6 +1077,7 @@ func TestCopyYAMLBulkLevelOwnedDispatcherShowsFetchingStatus(t *testing.T) {
 // confirms the bulk path was taken rather than the single-pod fallthrough.
 func TestCopyYAMLLevelContainersBulkSelection(t *testing.T) {
 	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
 	m.nav.Level = model.LevelContainers
 	m.nav.OwnedName = "pod-1"
 	m.middleItems = []model.Item{
@@ -1096,7 +1100,7 @@ func TestCopyYAMLLevelContainersBulkSelection(t *testing.T) {
 		"LevelContainers now supports bulk; dispatcher must show the fetching toast")
 	require.NotNil(t, cmd, "must still dispatch a bulk fetch")
 
-	ymsg, ok := cmd().(yamlClipboardMsg)
+	ymsg, ok := execScheduled(t, r, cmd).(yamlClipboardMsg)
 	require.True(t, ok)
 	require.Error(t, ymsg.err, "fake client has no pod seeded; Pod GET must fail")
 	assert.Contains(t, ymsg.err.Error(), "default/pod-1",

--- a/internal/k8s/client_fakeclient_extra_test.go
+++ b/internal/k8s/client_fakeclient_extra_test.go
@@ -556,7 +556,7 @@ func TestGetWorkflowStatus(t *testing.T) {
 	dc := newFakeDynClient(wf)
 	c := newFakeClient(nil, dc)
 
-	statusStr, running, err := c.GetWorkflowStatus("", "default", "my-wf")
+	statusStr, running, err := c.GetWorkflowStatus(context.Background(), "", "default", "my-wf")
 	require.NoError(t, err)
 	assert.Contains(t, statusStr, "Succeeded")
 	assert.False(t, running) // Succeeded is not running

--- a/internal/k8s/gitops_workflow.go
+++ b/internal/k8s/gitops_workflow.go
@@ -164,14 +164,14 @@ func (c *Client) SubmitWorkflowFromTemplate(contextName, namespace, templateName
 
 // GetWorkflowStatus fetches an Argo Workflow and returns a formatted status string
 // showing the phase and each node's name, type, phase, and duration.
-func (c *Client) GetWorkflowStatus(contextName, namespace, name string) (string, bool, error) {
+func (c *Client) GetWorkflowStatus(ctx context.Context, contextName, namespace, name string) (string, bool, error) {
 	dynClient, err := c.dynamicForContext(contextName)
 	if err != nil {
 		return "", false, err
 	}
 
 	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "workflows"}
-	wf, err := dynClient.Resource(gvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	wf, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return "", false, fmt.Errorf("getting workflow %s: %w", name, err)
 	}


### PR DESCRIPTION
## Summary

An audit of scheduler wiring found K8s operations dispatching their API calls in raw `tea.Cmd` closures (or via `trackBgTask`, which only drives the bgtask indicator) — bypassing the scheduler's bounded worker pool, priority lanes, coalescing, and gen-based cancellation. Every such closure is an unbounded, unprioritized goroutine competing with the pool.

This routes both **reads** and **in-process write mutations** through `scheduleK8sCall`. Two commits:

### 1. Reads → `scheduleK8sCall`

| Loader(s) | Kind / Priority | Notes |
|---|---|---|
| `copyYAMLToClipboard`, `copyYAMLForScope`, `exportResourceToFile`, `loadDiff` | `KindYAMLFetch` / High | Distinct `Copy/Export/Diff` task names so a copy never coalesces onto an in-flight `YAML:` preview fetch (which would deliver the copy a nil result and drop it). |
| `loadContainersForAction`, `loadContainersForLogFilter` | `KindContainers` / High | Per-consumer names — distinct result-msg types. |
| `loadSecretData`, `loadConfigMapData`, `loadLabelData`, `loadRevisions`, `loadPodsForAction`, `detectExecPodOSCmd` | `KindResourceList` / High | `detectExecPodOSCmd` keeps its 5s budget, derived from the scheduler ctx. |
| `loadRightsizing` | `KindMetrics` / Low | Heavy enrichment; yields to foreground. |
| `watchArgoWorkflow`, `loadAutoSyncConfig` | `KindResourceList` / High | Moved off `trackBgTask`. |

### 2. In-process write mutations → `scheduleK8sCall(PriorityCritical, KindMutation)`

30 single in-process client-go writes across gitops (Argo / Flux / cert-manager / KEDA / ExternalSecrets), `exec_misc` (delete / scale / resize / rollback / triggerCronJob), karpenter, knative, and the dataops saves (which were raw closures — not even tracked). `KindMutation` **NeverCoalesces** and is never gen-superseded, so there is no coalescing hazard; the only sentinel a mutation can hit is `ErrContextSwitched`. `:tasks` visibility is preserved (the worker calls `startWithPriority` for every submission).

## Deliberately kept on `trackBgTask` (with reason)

- **Subprocess mutations** (kubectl / helm shell-outs): `forceDeleteResource`, `removeFinalizers`, `restartResource` (rollout restart), node cordon/drain, `kubectlNodeCmdFromClaim`. Not in-process client-go calls; the scheduler ctx/30s budget don't fit.
- **Bulk-loop mutations** (N calls per task → 30s-clamp risk): `bulkSyncArgoApps`, `bulkRefreshArgoApps`, `bulkRemoveFinalizer`. `commands_bulk.go` keeps its `StartCancellable` + progress-`Total` pattern.
- **`cmdLoadOrphans`** — bespoke namespace-scoped `context.WithCancel` + inflight dedup; wiring would drop that cancellation trigger.
- **`loadCrashInvestigation`** — needs a 60s budget that `scheduleK8sCall` would clamp to the 30s default.
- **`loadContexts` / `ReloadKubeconfig`** — read in-memory / on-disk kubeconfig, not the cluster API.

## Why it matters

Off-scheduler K8s calls lose **bounded concurrency** (each was an unbounded goroutine), **priority** (reads yield to foreground; mutations run Critical), **coalescing** (reads dedup duplicate in-flight fetches), and **gen-based cancellation**. They also now appear in the `:tasks` overlay.

## Test plan

- [x] `TestK8sReadsAreScheduled` (15) + `TestK8sMutationsAreScheduled` (13) assert each op `Submit`s synchronously to the scheduler queue at Cmd-construction time. TDD: red against the raw closures / `trackBgTask`, green after wiring.
- [x] Existing roundtrip tests that execute these cmds use a new `execScheduled` helper that starts the worker pool (a worker-less scheduler would otherwise block); models lacking a scheduler get one injected locally.
- [x] `go test -race ./...` — all green, no hangs
- [x] `golangci-lint run` — 0 issues
- [x] `go build ./...`, gofmt/gofumpt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)