### PR TITLE
chore(test): adopt t.Context() in tests via usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usetesting
   settings:
     gocyclo:
       min-complexity: 30
@@ -46,6 +47,12 @@ linters:
             - max: 800
               skipComments: false
               skipBlankLines: false
+    usetesting:
+      # Prefer t.Context() over context.Background()/context.TODO() in tests
+      # (Go 1.24+). Only flagged where a *testing.T is in scope; helpers
+      # without a t keep context.Background().
+      context-background: true
+      context-todo: true
   exclusions:
     paths:
       - vendor

--- a/internal/app/commands_bulk_union_test.go
+++ b/internal/app/commands_bulk_union_test.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"bytes"
-	"context"
 	"log/slog"
 	"testing"
 
@@ -40,7 +39,7 @@ func TestBulkScaleResources_UnionRoutesPerItemCluster(t *testing.T) {
 	// happens when an unrelated Deployment object is in the fake clientset).
 	// What we care about is the routing log line emitted before the call.
 	m := baseModelWithFakeClient()
-	m.reqCtx = context.Background()
+	m.reqCtx = t.Context()
 	m.bulkItems = []model.Item{
 		{Name: "blue-app", Namespace: "ns1", ClusterName: "blue"},
 		{Name: "green-app", Namespace: "ns1", ClusterName: "green"},
@@ -70,7 +69,7 @@ func TestBatchPatchLabels_UnionRoutesPerItemCluster(t *testing.T) {
 	buf := captureLogger(t)
 
 	m := baseModelWithFakeClient()
-	m.reqCtx = context.Background()
+	m.reqCtx = t.Context()
 	m.bulkItems = []model.Item{
 		{Name: "pod-blue", Namespace: "ns1", ClusterName: "blue"},
 		{Name: "pod-green", Namespace: "ns1", ClusterName: "green"},

--- a/internal/app/commands_load_preview_secret_test.go
+++ b/internal/app/commands_load_preview_secret_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"sync"
 	"testing"
 
@@ -70,7 +69,7 @@ func baseSecretModel(t *testing.T) Model {
 		execMu:              &sync.Mutex{},
 		client:              k8s.NewTestClient(cs, dyn),
 		namespace:           "default",
-		reqCtx:              context.Background(),
+		reqCtx:              t.Context(),
 		scheduler:           scheduler.New(scheduler.DefaultThreshold),
 	}
 	m.middleItems = []model.Item{

--- a/internal/app/commands_load_scheduler_test.go
+++ b/internal/app/commands_load_scheduler_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"sync"
 	"testing"
 
@@ -36,7 +35,7 @@ func newLoadResourcesTestModel(t *testing.T) Model {
 		execMu:              &sync.Mutex{},
 		namespace:           "default",
 		scheduler:           scheduler.New(0),
-		reqCtx:              context.Background(),
+		reqCtx:              t.Context(),
 	}
 	m.client = k8s.NewTestClient(clientfake.NewClientset(), newFinalDynClient())
 	return m

--- a/internal/app/commands_localcluster_test.go
+++ b/internal/app/commands_localcluster_test.go
@@ -97,7 +97,7 @@ func TestCreateLocalClusterCmd_ReturnsMsg(t *testing.T) {
 		name: "kind", installed: true,
 		listFn: func(context.Context) ([]localcluster.Cluster, error) { return nil, nil },
 	}
-	cmd := createLocalClusterCmd(context.Background(), 7, prov, localcluster.CreateSpec{Name: "dev"})
+	cmd := createLocalClusterCmd(t.Context(), 7, prov, localcluster.CreateSpec{Name: "dev"})
 	msg := cmd().(localClusterCreatedMsg)
 	if msg.gen != 7 || msg.provider != "kind" || msg.name != "dev" {
 		t.Fatalf("msg = %+v", msg)
@@ -106,7 +106,7 @@ func TestCreateLocalClusterCmd_ReturnsMsg(t *testing.T) {
 
 func TestStartLocalClusterCmd(t *testing.T) {
 	prov := fakeProvider{name: "k3d", installed: true}
-	cmd := startLocalClusterCmd(context.Background(), 1, prov, "staging")
+	cmd := startLocalClusterCmd(t.Context(), 1, prov, "staging")
 	msg := cmd().(localClusterMutatedMsg)
 	if msg.gen != 1 || msg.verb != "started" {
 		t.Fatalf("msg = %+v, want gen=1 verb=started", msg)
@@ -115,7 +115,7 @@ func TestStartLocalClusterCmd(t *testing.T) {
 
 func TestStopLocalClusterCmd(t *testing.T) {
 	prov := fakeProvider{name: "k3d", installed: true}
-	cmd := stopLocalClusterCmd(context.Background(), 2, prov, "staging")
+	cmd := stopLocalClusterCmd(t.Context(), 2, prov, "staging")
 	msg := cmd().(localClusterMutatedMsg)
 	if msg.gen != 2 || msg.verb != "stopped" {
 		t.Fatalf("msg = %+v, want gen=2 verb=stopped", msg)
@@ -124,7 +124,7 @@ func TestStopLocalClusterCmd(t *testing.T) {
 
 func TestDeleteLocalClusterCmd(t *testing.T) {
 	prov := fakeProvider{name: "kind", installed: true}
-	cmd := deleteLocalClusterCmd(context.Background(), 3, prov, "dev")
+	cmd := deleteLocalClusterCmd(t.Context(), 3, prov, "dev")
 	msg := cmd().(localClusterMutatedMsg)
 	if msg.gen != 3 || msg.verb != "deleted" {
 		t.Fatalf("msg = %+v, want gen=3 verb=deleted", msg)

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -1294,7 +1294,7 @@ func TestMoveCursorBumpsRequestGenAndDiscardsStalePreview(t *testing.T) {
 
 func TestMoveCursorDoesNotCancelInFlightReqCtx(t *testing.T) {
 	m := basePush80Model()
-	m.reqCtx, m.reqCancel = context.WithCancel(context.Background())
+	m.reqCtx, m.reqCancel = context.WithCancel(t.Context())
 	oldCtx := m.reqCtx
 	m.setCursor(0)
 

--- a/internal/app/discovery_cache_cancel_test.go
+++ b/internal/app/discovery_cache_cancel_test.go
@@ -22,7 +22,7 @@ func TestLoadAllDiscoveryCaches_RespectsCancelledContext(t *testing.T) {
 		c.AddTestContext(name, "https://"+name+".example.local:6443")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel before the call so the loop exits on the first check
 
 	out := loadAllDiscoveryCaches(ctx, c)
@@ -43,7 +43,7 @@ func TestLoadAllDiscoveryCaches_BackgroundContextProcessesAll(t *testing.T) {
 		c.AddTestContext(contextName(i), "https://h.example.local:6443")
 	}
 
-	out := loadAllDiscoveryCaches(context.Background(), c)
+	out := loadAllDiscoveryCaches(t.Context(), c)
 	// No cache files on disk → empty result map; the test passes if the
 	// call returned without hanging.
 	_ = out

--- a/internal/app/discovery_cache_test.go
+++ b/internal/app/discovery_cache_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -154,7 +153,7 @@ func TestLoadAllDiscoveryCachesMapsContextsToHostFiles(t *testing.T) {
 	client.AddTestContext("beta", hostA) // same host as alpha
 	client.AddTestContext("gamma", hostB)
 
-	loaded := loadAllDiscoveryCaches(context.Background(), client)
+	loaded := loadAllDiscoveryCaches(t.Context(), client)
 	require.Len(t, loaded["alpha"], 1)
 	require.Len(t, loaded["beta"], 1)
 	require.Len(t, loaded["gamma"], 1)
@@ -174,7 +173,7 @@ func TestLoadAllDiscoveryCachesSkipsContextsWithUnresolvableHost(t *testing.T) {
 		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods"},
 	}))
 
-	loaded := loadAllDiscoveryCaches(context.Background(), client)
+	loaded := loadAllDiscoveryCaches(t.Context(), client)
 	require.NotNil(t, loaded["alpha"])
 	assert.NotContains(t, loaded, "test-ctx",
 		"the default test-ctx had no cached host file — must not show up here")
@@ -210,7 +209,7 @@ func TestDiscoveryCachePreloadHydratesDiscoveredResources(t *testing.T) {
 	// Run the preload Cmd that Init() would dispatch and feed the resulting
 	// message through the handler. This is the post-startup state the user
 	// observes once the cache lands.
-	cmd := discoveryCachePreloadCmd(context.Background(), client)
+	cmd := discoveryCachePreloadCmd(t.Context(), client)
 	require.NotNil(t, cmd)
 	msg := cmd()
 	loaded, ok := msg.(discoveryCacheLoadedMsg)

--- a/internal/app/tab_switch_refresh_test.go
+++ b/internal/app/tab_switch_refresh_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"sync"
 	"testing"
 
@@ -223,7 +222,7 @@ func newTabSwitchTestModel(t *testing.T, level model.Level) Model {
 		execMu:              &sync.Mutex{},
 		namespace:           "default",
 		scheduler:           scheduler.New(0),
-		reqCtx:              context.Background(),
+		reqCtx:              t.Context(),
 		mode:                modeExplorer,
 	}
 	m.scheduler.StartWorkers()

--- a/internal/app/watch_tick_e2e_test.go
+++ b/internal/app/watch_tick_e2e_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -67,7 +66,7 @@ func TestWatchTickRemovesDeletedPodFromList(t *testing.T) {
 		execMu:              &sync.Mutex{},
 		namespace:           "default",
 		scheduler:           scheduler.New(0),
-		reqCtx:              context.Background(),
+		reqCtx:              t.Context(),
 		watchMode:           true,
 	}
 	m.client = k8s.NewTestClient(clientfake.NewClientset(), dyn)
@@ -92,7 +91,7 @@ func TestWatchTickRemovesDeletedPodFromList(t *testing.T) {
 
 	// Pod terminates: remove it from the fake API.
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
-	if err := dyn.Resource(gvr).Namespace("default").Delete(context.Background(), "doomed-pod", metav1.DeleteOptions{}); err != nil {
+	if err := dyn.Resource(gvr).Namespace("default").Delete(t.Context(), "doomed-pod", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("fake delete failed: %v", err)
 	}
 
@@ -171,7 +170,7 @@ func TestWatchTickRefreshesPreviewAtLevelResourceTypes(t *testing.T) {
 		execMu:              &sync.Mutex{},
 		namespace:           "default",
 		scheduler:           scheduler.New(0),
-		reqCtx:              context.Background(),
+		reqCtx:              t.Context(),
 		watchMode:           true,
 	}
 	// middleItems must mirror BuildSidebarItems' output so updateResourceTypes

--- a/internal/k8s/capture_backend_kubeshark_test.go
+++ b/internal/k8s/capture_backend_kubeshark_test.go
@@ -17,7 +17,7 @@ func TestDetectKubeshark_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	dc := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 	c := newFakeClient(cs, dc)
-	info, err := c.DetectKubeshark(context.Background(), "test-ctx")
+	info, err := c.DetectKubeshark(t.Context(), "test-ctx")
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
@@ -36,7 +36,7 @@ func TestDetectKubeshark_Found(t *testing.T) {
 	cs := k8sfake.NewClientset(svc)
 	dc := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 	c := newFakeClient(cs, dc)
-	info, err := c.DetectKubeshark(context.Background(), "test-ctx")
+	info, err := c.DetectKubeshark(t.Context(), "test-ctx")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestDetectKubeshark_HonoursOverrideNamespace(t *testing.T) {
 	c := newFakeClient(cs, dc)
 	c.SetKubesharkNamespace("trafcap")
 
-	info, err := c.DetectKubeshark(context.Background(), "test-ctx")
+	info, err := c.DetectKubeshark(t.Context(), "test-ctx")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestWaitForKubesharkPort_Timeout(t *testing.T) {
 	mgr := NewPortForwardManager()
 	t.Cleanup(mgr.StopAll)
 	// No matching entry — must time out.
-	_, err := waitForKubesharkPort(context.Background(), mgr, 999, 50*time.Millisecond, 10*time.Millisecond)
+	_, err := waitForKubesharkPort(t.Context(), mgr, 999, 50*time.Millisecond, 10*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
@@ -114,7 +114,7 @@ func TestWaitForKubesharkPort_Timeout(t *testing.T) {
 func TestWaitForKubesharkPort_ContextCancel(t *testing.T) {
 	mgr := NewPortForwardManager()
 	t.Cleanup(mgr.StopAll)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	_, err := waitForKubesharkPort(ctx, mgr, 999, 5*time.Second, 10*time.Millisecond)
 	if !errors.Is(err, context.Canceled) {

--- a/internal/k8s/capture_test.go
+++ b/internal/k8s/capture_test.go
@@ -60,7 +60,7 @@ func TestCaptureManager_Start_PopulatesEntry(t *testing.T) {
 		return &fakeBackend{stream: bytes.NewReader(emptyPcapHeader())}, nil
 	})
 
-	id, err := m.Start(context.Background(), req, func(s PacketSummary) {})
+	id, err := m.Start(t.Context(), req, func(s PacketSummary) {})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestCaptureManager_FindByPod(t *testing.T) {
 		Backend: BackendKubectlDebug, Context: "ctx", Namespace: "ns", PodName: "pod1",
 		OutputDir: tmp,
 	}
-	id, err := m.Start(context.Background(), req, func(s PacketSummary) {})
+	id, err := m.Start(t.Context(), req, func(s PacketSummary) {})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestCaptureManager_Start_RefusesPreexistingPath(t *testing.T) {
 		Backend: BackendKubectlDebug, Context: "ctx", Namespace: "ns", PodName: "pod1",
 		OutputDir: tmp,
 	}
-	id1, err := m.Start(context.Background(), req, func(s PacketSummary) {})
+	id1, err := m.Start(t.Context(), req, func(s PacketSummary) {})
 	if err != nil {
 		t.Fatalf("first Start: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestCaptureManager_Entries_AtomicCountersRace(t *testing.T) {
 func TestCaptureManager_Start_KubesharkRejected(t *testing.T) {
 	m := NewCaptureManager()
 	req := CaptureRequest{Backend: BackendKubeshark, OutputDir: t.TempDir()}
-	_, err := m.Start(context.Background(), req, func(s PacketSummary) {})
+	_, err := m.Start(t.Context(), req, func(s PacketSummary) {})
 	if err == nil {
 		t.Error("Start should reject BackendKubeshark — kubeshark hand-off has separate code path")
 	}

--- a/internal/k8s/client_fakeclient_extra_test.go
+++ b/internal/k8s/client_fakeclient_extra_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"maps"
 	"testing"
 
@@ -234,7 +233,7 @@ func TestGetAutoSyncConfig_Enabled(t *testing.T) {
 	dc := newFakeDynClient(app)
 	c := newFakeClient(nil, dc)
 
-	enabled, selfHeal, prune, err := c.GetAutoSyncConfig(context.Background(), "", "argocd", "my-app")
+	enabled, selfHeal, prune, err := c.GetAutoSyncConfig(t.Context(), "", "argocd", "my-app")
 	require.NoError(t, err)
 	assert.True(t, enabled)
 	assert.True(t, selfHeal)
@@ -253,7 +252,7 @@ func TestGetAutoSyncConfig_Disabled(t *testing.T) {
 	dc := newFakeDynClient(app)
 	c := newFakeClient(nil, dc)
 
-	enabled, _, _, err := c.GetAutoSyncConfig(context.Background(), "", "argocd", "my-app")
+	enabled, _, _, err := c.GetAutoSyncConfig(t.Context(), "", "argocd", "my-app")
 	require.NoError(t, err)
 	assert.False(t, enabled)
 }
@@ -270,7 +269,7 @@ func TestUpdateAutoSyncConfig_Enable(t *testing.T) {
 	dc := newFakeDynClient(app)
 	c := newFakeClient(nil, dc)
 
-	err := c.UpdateAutoSyncConfig(context.Background(), "", "argocd", "my-app", true, true, false)
+	err := c.UpdateAutoSyncConfig(t.Context(), "", "argocd", "my-app", true, true, false)
 	require.NoError(t, err)
 }
 
@@ -290,7 +289,7 @@ func TestUpdateAutoSyncConfig_Disable(t *testing.T) {
 	dc := newFakeDynClient(app)
 	c := newFakeClient(nil, dc)
 
-	err := c.UpdateAutoSyncConfig(context.Background(), "", "argocd", "my-app", false, false, false)
+	err := c.UpdateAutoSyncConfig(t.Context(), "", "argocd", "my-app", false, false, false)
 	require.NoError(t, err)
 }
 
@@ -556,7 +555,7 @@ func TestGetWorkflowStatus(t *testing.T) {
 	dc := newFakeDynClient(wf)
 	c := newFakeClient(nil, dc)
 
-	statusStr, running, err := c.GetWorkflowStatus(context.Background(), "", "default", "my-wf")
+	statusStr, running, err := c.GetWorkflowStatus(t.Context(), "", "default", "my-wf")
 	require.NoError(t, err)
 	assert.Contains(t, statusStr, "Succeeded")
 	assert.False(t, running) // Succeeded is not running
@@ -616,7 +615,7 @@ func TestBuildDeploymentTree(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	root := &model.ResourceNode{Name: "deploy", Kind: "Deployment", Namespace: "default"}
-	err := c.buildDeploymentTree(context.Background(), dc, "default", "deploy", root)
+	err := c.buildDeploymentTree(t.Context(), dc, "default", "deploy", root)
 	require.NoError(t, err)
 	assert.Len(t, root.Children, 1)
 	assert.Equal(t, "ReplicaSet", root.Children[0].Kind)
@@ -643,7 +642,7 @@ func TestBuildPodOwnerTree(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	root := &model.ResourceNode{Name: "my-sts", Kind: "StatefulSet", Namespace: "default"}
-	err := c.buildPodOwnerTree(context.Background(), dc, "default", "StatefulSet", "my-sts", root)
+	err := c.buildPodOwnerTree(t.Context(), dc, "default", "StatefulSet", "my-sts", root)
 	require.NoError(t, err)
 	assert.Len(t, root.Children, 1)
 	assert.Equal(t, "Pod", root.Children[0].Kind)
@@ -666,7 +665,7 @@ func TestBuildCronJobTree(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	root := &model.ResourceNode{Name: "my-cron", Kind: "CronJob", Namespace: "default"}
-	err := c.buildCronJobTree(context.Background(), dc, "default", "my-cron", root)
+	err := c.buildCronJobTree(t.Context(), dc, "default", "my-cron", root)
 	require.NoError(t, err)
 	assert.Len(t, root.Children, 1)
 	assert.Equal(t, "Job", root.Children[0].Kind)
@@ -705,7 +704,7 @@ func TestGetPodsViaReplicaSets(t *testing.T) {
 	dc := newFakeDynClient(rs, pod)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getPodsViaReplicaSets(context.Background(), dc, "default", "deploy")
+	items, err := c.getPodsViaReplicaSets(t.Context(), dc, "default", "deploy")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 	assert.Equal(t, "deploy-abc-xyz", items[0].Name)
@@ -732,7 +731,7 @@ func TestGetPodsByOwner(t *testing.T) {
 	dc := newFakeDynClient(pod)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getPodsByOwner(context.Background(), dc, "default", "StatefulSet", "my-sts")
+	items, err := c.getPodsByOwner(t.Context(), dc, "default", "StatefulSet", "my-sts")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 }
@@ -753,7 +752,7 @@ func TestGetJobsByOwner(t *testing.T) {
 	dc := newFakeDynClient(job)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getJobsByOwner(context.Background(), dc, "default", "my-cron")
+	items, err := c.getJobsByOwner(t.Context(), dc, "default", "my-cron")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 }
@@ -790,7 +789,7 @@ func TestBuildGenericOwnerTree(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	root := &model.ResourceNode{Name: "my-cluster", Kind: "Cluster", Namespace: "default"}
-	err := c.buildGenericOwnerTree(context.Background(), dc, "default", "Cluster", "my-cluster", root)
+	err := c.buildGenericOwnerTree(t.Context(), dc, "default", "Cluster", "my-cluster", root)
 	require.NoError(t, err)
 	assert.Greater(t, len(root.Children), 0)
 }
@@ -853,7 +852,7 @@ func TestGetNetworkPolicyInfo(t *testing.T) {
 	dc := newFakeDynClient(np, pod)
 	c := newFakeClient(nil, dc)
 
-	info, err := c.GetNetworkPolicyInfo(context.Background(), "", "default", "my-np")
+	info, err := c.GetNetworkPolicyInfo(t.Context(), "", "default", "my-np")
 	require.NoError(t, err)
 	assert.Equal(t, "my-np", info.Name)
 	assert.Equal(t, map[string]string{"app": "web"}, info.PodSelector)
@@ -875,7 +874,7 @@ func TestGetNetworkPolicyInfo_NoSpec(t *testing.T) {
 	dc := newFakeDynClient(np)
 	c := newFakeClient(nil, dc)
 
-	info, err := c.GetNetworkPolicyInfo(context.Background(), "", "default", "empty-np")
+	info, err := c.GetNetworkPolicyInfo(t.Context(), "", "default", "empty-np")
 	require.NoError(t, err)
 	assert.Equal(t, "empty-np", info.Name)
 	assert.Nil(t, info.IngressRules)
@@ -923,7 +922,7 @@ func TestRollbackDeployment(t *testing.T) {
 	cs := k8sfake.NewClientset(dep, rs1, rs2)
 	c := newFakeClient(cs, nil)
 
-	err := c.RollbackDeployment(context.Background(), "", "default", "my-deploy", 1)
+	err := c.RollbackDeployment(t.Context(), "", "default", "my-deploy", 1)
 	require.NoError(t, err)
 }
 
@@ -934,7 +933,7 @@ func TestRollbackDeployment_RevisionNotFound(t *testing.T) {
 	cs := k8sfake.NewClientset(dep, rs)
 	c := newFakeClient(cs, nil)
 
-	err := c.RollbackDeployment(context.Background(), "", "default", "my-deploy", 99)
+	err := c.RollbackDeployment(t.Context(), "", "default", "my-deploy", 99)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "revision 99 not found")
 }
@@ -965,7 +964,7 @@ func TestGetFluxManagedResources(t *testing.T) {
 	dc := newFakeDynClient(ks)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getFluxManagedResources(context.Background(), dc, "flux-system", "my-ks")
+	items, err := c.getFluxManagedResources(t.Context(), dc, "flux-system", "my-ks")
 	require.NoError(t, err)
 	assert.Len(t, items, 5)
 	// Items should be sorted by Kind then Name.
@@ -1000,7 +999,7 @@ func TestGetFluxManagedResources_PreservesK8sNameForCrossNamespace(t *testing.T)
 	dc := newFakeDynClient(ks)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getFluxManagedResources(context.Background(), dc, "flux-system", "my-ks")
+	items, err := c.getFluxManagedResources(t.Context(), dc, "flux-system", "my-ks")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 
@@ -1034,7 +1033,7 @@ func TestGetFluxManagedResources_NoStatus(t *testing.T) {
 	dc := newFakeDynClient(ks)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getFluxManagedResources(context.Background(), dc, "flux-system", "my-ks")
+	items, err := c.getFluxManagedResources(t.Context(), dc, "flux-system", "my-ks")
 	require.NoError(t, err)
 	assert.Nil(t, items)
 }
@@ -1051,7 +1050,7 @@ func TestGetFluxManagedResources_NoInventory(t *testing.T) {
 	dc := newFakeDynClient(ks)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getFluxManagedResources(context.Background(), dc, "flux-system", "my-ks")
+	items, err := c.getFluxManagedResources(t.Context(), dc, "flux-system", "my-ks")
 	require.NoError(t, err)
 	assert.Nil(t, items)
 }
@@ -1072,7 +1071,7 @@ func TestGetFluxManagedResources_EmptyEntries(t *testing.T) {
 	dc := newFakeDynClient(ks)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getFluxManagedResources(context.Background(), dc, "flux-system", "my-ks")
+	items, err := c.getFluxManagedResources(t.Context(), dc, "flux-system", "my-ks")
 	require.NoError(t, err)
 	assert.Nil(t, items)
 }
@@ -1100,7 +1099,7 @@ func TestGetFluxManagedResources_IconMapping(t *testing.T) {
 	dc := newFakeDynClient(ks)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getFluxManagedResources(context.Background(), dc, "flux-system", "my-ks")
+	items, err := c.getFluxManagedResources(t.Context(), dc, "flux-system", "my-ks")
 	require.NoError(t, err)
 	assert.Len(t, items, 6)
 }
@@ -1133,7 +1132,7 @@ func TestGetArgoManagedResources_WithStatusResources(t *testing.T) {
 	dc := newFakeDynClient(app)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.getArgoManagedResources(context.Background(), dc, "", "argocd", "my-app")
+	items, err := c.getArgoManagedResources(t.Context(), dc, "", "argocd", "my-app")
 	require.NoError(t, err)
 	assert.Len(t, items, 2)
 	// First should have combined status.
@@ -1176,7 +1175,7 @@ func TestGetArgoManagedResources_FallbackToLabels(t *testing.T) {
 	dc := newFakeDynClient(app)
 	c := newFakeClient(cs, dc)
 
-	items, err := c.getArgoManagedResources(context.Background(), dc, "", "argocd", "my-app")
+	items, err := c.getArgoManagedResources(t.Context(), dc, "", "argocd", "my-app")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(items), 1)
 }
@@ -1201,7 +1200,7 @@ func TestBuildServiceTree(t *testing.T) {
 	c := newFakeClient(cs, nil)
 
 	root := &model.ResourceNode{Name: "my-svc", Kind: "Service", Namespace: "default"}
-	err := c.buildServiceTree(context.Background(), "", "default", "my-svc", root)
+	err := c.buildServiceTree(t.Context(), "", "default", "my-svc", root)
 	require.NoError(t, err)
 	assert.Len(t, root.Children, 1)
 	assert.Equal(t, "Pod", root.Children[0].Kind)
@@ -1230,7 +1229,7 @@ func TestGetPodsOnNode(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	// Note: the fake client returns ALL pods regardless of field selector.
-	items, err := c.getPodsOnNode(context.Background(), dc, "node-1")
+	items, err := c.getPodsOnNode(t.Context(), dc, "node-1")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(items), 1)
 }
@@ -1253,7 +1252,7 @@ func TestBuildNodeTree(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	root := &model.ResourceNode{Name: "node-1", Kind: "Node"}
-	err := c.buildNodeTree(context.Background(), dc, "node-1", root)
+	err := c.buildNodeTree(t.Context(), dc, "node-1", root)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(root.Children), 1)
 }
@@ -1290,7 +1289,7 @@ func TestWrapWithOwners(t *testing.T) {
 			{Name: "app", Kind: "Container", Namespace: "default"},
 		},
 	}
-	c.wrapWithOwners(context.Background(), dc, "default", "ReplicaSet", "deploy-abc", root)
+	c.wrapWithOwners(t.Context(), dc, "default", "ReplicaSet", "deploy-abc", root)
 
 	// After wrapping, the root should be the Deployment (topmost owner).
 	assert.Equal(t, "Deployment", root.Kind)
@@ -1305,7 +1304,7 @@ func TestWrapWithOwners_UnknownKind(t *testing.T) {
 	root := &model.ResourceNode{
 		Name: "pod-xyz", Kind: "Pod", Namespace: "default",
 	}
-	c.wrapWithOwners(context.Background(), dc, "default", "UnknownCRD", "some-resource", root)
+	c.wrapWithOwners(t.Context(), dc, "default", "UnknownCRD", "some-resource", root)
 	// Should still wrap even with unknown kind (adds single chain entry).
 	assert.Equal(t, "UnknownCRD", root.Kind)
 }
@@ -1318,7 +1317,7 @@ func TestWrapWithOwners_EmptyChain(t *testing.T) {
 		Name: "pod-xyz", Kind: "Pod", Namespace: "default",
 	}
 	// No owner references from an existing resource - should still process.
-	c.wrapWithOwners(context.Background(), dc, "default", "ReplicaSet", "nonexistent-rs", root)
+	c.wrapWithOwners(t.Context(), dc, "default", "ReplicaSet", "nonexistent-rs", root)
 	// Should wrap with the RS (even though it doesn't exist, it adds a chain entry).
 	assert.Equal(t, "ReplicaSet", root.Kind)
 }
@@ -1363,7 +1362,7 @@ func TestGetOwnedResources_Deployment(t *testing.T) {
 	dc := newFakeDynClient(rs, pod)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "Deployment", "my-deploy")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "Deployment", "my-deploy")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 	assert.Equal(t, "Pod", items[0].Kind)
@@ -1389,7 +1388,7 @@ func TestGetOwnedResources_StatefulSet(t *testing.T) {
 	dc := newFakeDynClient(pod)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "StatefulSet", "my-sts")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "StatefulSet", "my-sts")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 }
@@ -1411,7 +1410,7 @@ func TestGetOwnedResources_Node(t *testing.T) {
 	dc := newFakeDynClient(pod)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "", "Node", "node-1")
+	items, err := c.GetOwnedResources(t.Context(), "", "", "Node", "node-1")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(items), 1)
 }
@@ -1432,7 +1431,7 @@ func TestGetOwnedResources_Service(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(cs, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "Service", "my-svc")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "Service", "my-svc")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 }
@@ -1457,7 +1456,7 @@ func TestGetResourceTree_Deployment(t *testing.T) {
 	dc := newFakeDynClient(rs)
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "Deployment", "my-deploy")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "Deployment", "my-deploy")
 	require.NoError(t, err)
 	assert.Equal(t, "my-deploy", root.Name)
 }
@@ -1466,7 +1465,7 @@ func TestGetResourceTree_StatefulSet(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "StatefulSet", "my-sts")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "StatefulSet", "my-sts")
 	require.NoError(t, err)
 	assert.Equal(t, "my-sts", root.Name)
 }
@@ -1475,7 +1474,7 @@ func TestGetResourceTree_CronJob(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "CronJob", "my-cron")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "CronJob", "my-cron")
 	require.NoError(t, err)
 	assert.Equal(t, "my-cron", root.Name)
 }
@@ -1489,7 +1488,7 @@ func TestGetResourceTree_Service(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(cs, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "Service", "my-svc")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "Service", "my-svc")
 	require.NoError(t, err)
 	assert.Equal(t, "my-svc", root.Name)
 }
@@ -1498,7 +1497,7 @@ func TestGetResourceTree_Node(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "", "Node", "node-1")
+	root, err := c.GetResourceTree(t.Context(), "", "", "Node", "node-1")
 	require.NoError(t, err)
 	assert.Equal(t, "node-1", root.Name)
 }
@@ -1513,7 +1512,7 @@ func TestGetResourceTree_Pod(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(cs, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "Pod", "my-pod")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "Pod", "my-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "Running", root.Status)
 }
@@ -1522,7 +1521,7 @@ func TestGetResourceTree_ReplicaSet(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "ReplicaSet", "my-rs")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "ReplicaSet", "my-rs")
 	require.NoError(t, err)
 	assert.Equal(t, "my-rs", root.Name)
 }
@@ -1531,7 +1530,7 @@ func TestGetResourceTree_Job(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "Job", "my-job")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "Job", "my-job")
 	require.NoError(t, err)
 	assert.Equal(t, "my-job", root.Name)
 }
@@ -1540,7 +1539,7 @@ func TestGetResourceTree_DaemonSet(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "DaemonSet", "my-ds")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "DaemonSet", "my-ds")
 	require.NoError(t, err)
 	assert.Equal(t, "my-ds", root.Name)
 }
@@ -1567,7 +1566,7 @@ func TestGetOwnedResources_Kustomization(t *testing.T) {
 	dc := newFakeDynClient(ks)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "Kustomization", "my-ks")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "Kustomization", "my-ks")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 }
@@ -1591,7 +1590,7 @@ func TestGetOwnedResources_Job(t *testing.T) {
 	dc := newFakeDynClient(pod)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "Job", "my-job")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "Job", "my-job")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 }
@@ -1615,7 +1614,7 @@ func TestGetOwnedResources_DaemonSet(t *testing.T) {
 	dc := newFakeDynClient(pod)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "DaemonSet", "my-ds")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "DaemonSet", "my-ds")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 }
@@ -1640,7 +1639,7 @@ func TestGetOwnedResources_HelmRelease(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(cs, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "HelmRelease", "myrel")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "HelmRelease", "myrel")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(items), 1)
 }
@@ -1651,7 +1650,7 @@ func TestGetOwnedResources_HelmRelease(t *testing.T) {
 
 func TestFindAffectedPods_Empty(t *testing.T) {
 	dc := newFakeDynClient()
-	result := findAffectedPods(context.Background(), dc, "default", map[string]string{"app": "web"})
+	result := findAffectedPods(t.Context(), dc, "default", map[string]string{"app": "web"})
 	assert.Empty(t, result)
 }
 
@@ -1667,7 +1666,7 @@ func TestFindAffectedPods_WithPods(t *testing.T) {
 		},
 	}
 	dc := newFakeDynClient(pod)
-	result := findAffectedPods(context.Background(), dc, "default", nil)
+	result := findAffectedPods(t.Context(), dc, "default", nil)
 	assert.GreaterOrEqual(t, len(result), 1)
 }
 
@@ -1702,7 +1701,7 @@ func TestGetPodYAML(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	yamlStr, err := c.GetPodYAML(context.Background(), "", "default", "my-pod")
+	yamlStr, err := c.GetPodYAML(t.Context(), "", "default", "my-pod")
 	require.NoError(t, err)
 	assert.Contains(t, yamlStr, "kind: Pod")
 	assert.Contains(t, yamlStr, "name: my-pod")

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -45,7 +44,7 @@ func TestGetSecretData(t *testing.T) {
 	cs := k8sfake.NewClientset(secret)
 	c := newFakeClient(cs, nil)
 
-	result, err := c.GetSecretData(context.Background(), "", "default", "my-secret")
+	result, err := c.GetSecretData(t.Context(), "", "default", "my-secret")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"password", "username"}, result.Keys)
 	assert.Equal(t, "s3cret", result.Data["password"])
@@ -56,7 +55,7 @@ func TestGetSecretData_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, err := c.GetSecretData(context.Background(), "", "default", "missing")
+	_, err := c.GetSecretData(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting secret")
 }
@@ -77,7 +76,7 @@ func TestUpdateSecretData(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the update took effect.
-	updated, err := cs.CoreV1().Secrets("default").Get(context.Background(), "my-secret", metav1.GetOptions{})
+	updated, err := cs.CoreV1().Secrets("default").Get(t.Context(), "my-secret", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, []byte("new-value"), updated.Data["new-key"])
 	_, hasOld := updated.Data["old-key"]
@@ -106,7 +105,7 @@ func TestGetConfigMapData(t *testing.T) {
 	cs := k8sfake.NewClientset(cm)
 	c := newFakeClient(cs, nil)
 
-	result, err := c.GetConfigMapData(context.Background(), "", "default", "my-cm")
+	result, err := c.GetConfigMapData(t.Context(), "", "default", "my-cm")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"app.conf", "config.yaml"}, result.Keys)
 	assert.Equal(t, "key: value", result.Data["config.yaml"])
@@ -116,7 +115,7 @@ func TestGetConfigMapData_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, err := c.GetConfigMapData(context.Background(), "", "default", "missing")
+	_, err := c.GetConfigMapData(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting configmap")
 }
@@ -136,7 +135,7 @@ func TestUpdateConfigMapData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	updated, err := cs.CoreV1().ConfigMaps("default").Get(context.Background(), "my-cm", metav1.GetOptions{})
+	updated, err := cs.CoreV1().ConfigMaps("default").Get(t.Context(), "my-cm", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "data", updated.Data["new"])
 	_, hasOld := updated.Data["old"]
@@ -191,7 +190,7 @@ func TestGetPodResourceRequests(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	cpuReq, cpuLim, memReq, memLim, err := c.GetPodResourceRequests(context.Background(), "", "default", "my-pod")
+	cpuReq, cpuLim, memReq, memLim, err := c.GetPodResourceRequests(t.Context(), "", "default", "my-pod")
 	require.NoError(t, err)
 	assert.Equal(t, int64(150), cpuReq) // 100m + 50m
 	assert.Equal(t, int64(700), cpuLim) // 500m + 200m
@@ -209,7 +208,7 @@ func TestGetPodResourceRequests_NoResources(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	cpuReq, cpuLim, memReq, memLim, err := c.GetPodResourceRequests(context.Background(), "", "default", "bare-pod")
+	cpuReq, cpuLim, memReq, memLim, err := c.GetPodResourceRequests(t.Context(), "", "default", "bare-pod")
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), cpuReq)
 	assert.Equal(t, int64(0), cpuLim)
@@ -221,7 +220,7 @@ func TestGetPodResourceRequests_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, _, _, _, err := c.GetPodResourceRequests(context.Background(), "", "default", "missing")
+	_, _, _, _, err := c.GetPodResourceRequests(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting pod")
 }
@@ -248,12 +247,12 @@ func TestTriggerCronJob(t *testing.T) {
 	cs := k8sfake.NewClientset(cronJob)
 	c := newFakeClient(cs, nil)
 
-	jobName, err := c.TriggerCronJob(context.Background(), "", "default", "my-cron")
+	jobName, err := c.TriggerCronJob(t.Context(), "", "default", "my-cron")
 	require.NoError(t, err)
 	assert.Contains(t, jobName, "my-cron-manual-")
 
 	// Verify the job was created.
-	jobs, err := cs.BatchV1().Jobs("default").List(context.Background(), metav1.ListOptions{})
+	jobs, err := cs.BatchV1().Jobs("default").List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	assert.Len(t, jobs.Items, 1)
 	assert.Equal(t, "busybox", jobs.Items[0].Spec.Template.Spec.Containers[0].Image)
@@ -271,7 +270,7 @@ func TestTriggerCronJob_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, err := c.TriggerCronJob(context.Background(), "", "default", "missing")
+	_, err := c.TriggerCronJob(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting cronjob")
 }
@@ -304,7 +303,7 @@ func TestGetContainers(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetContainers(context.Background(), "", "default", "my-pod")
+	items, err := c.GetContainers(t.Context(), "", "default", "my-pod")
 	require.NoError(t, err)
 	assert.Len(t, items, 3)
 	// Init containers come first.
@@ -317,7 +316,7 @@ func TestGetContainers_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, err := c.GetContainers(context.Background(), "", "default", "missing")
+	_, err := c.GetContainers(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 }
 
@@ -350,7 +349,7 @@ func TestGetContainers_WithEphemeralContainers(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetContainers(context.Background(), "", "default", "my-pod")
+	items, err := c.GetContainers(t.Context(), "", "default", "my-pod")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 
@@ -386,7 +385,7 @@ func TestGetContainerPorts(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	ports, err := c.GetContainerPorts(context.Background(), "", "default", "my-pod")
+	ports, err := c.GetContainerPorts(t.Context(), "", "default", "my-pod")
 	require.NoError(t, err)
 	assert.Len(t, ports, 2)
 	assert.Equal(t, int32(8080), ports[0].ContainerPort)
@@ -408,7 +407,7 @@ func TestGetServicePorts(t *testing.T) {
 	cs := k8sfake.NewClientset(svc)
 	c := newFakeClient(cs, nil)
 
-	ports, err := c.GetServicePorts(context.Background(), "", "default", "my-svc")
+	ports, err := c.GetServicePorts(t.Context(), "", "default", "my-svc")
 	require.NoError(t, err)
 	assert.Len(t, ports, 2)
 	assert.Equal(t, int32(80), ports[0].ContainerPort)
@@ -439,7 +438,7 @@ func TestGetDeploymentPorts(t *testing.T) {
 	cs := k8sfake.NewClientset(dep)
 	c := newFakeClient(cs, nil)
 
-	ports, err := c.GetDeploymentPorts(context.Background(), "", "default", "my-deploy")
+	ports, err := c.GetDeploymentPorts(t.Context(), "", "default", "my-deploy")
 	require.NoError(t, err)
 	assert.Len(t, ports, 1)
 	assert.Equal(t, int32(8080), ports[0].ContainerPort)
@@ -470,7 +469,7 @@ func TestGetStatefulSetPorts(t *testing.T) {
 	cs := k8sfake.NewClientset(sts)
 	c := newFakeClient(cs, nil)
 
-	ports, err := c.GetStatefulSetPorts(context.Background(), "", "default", "my-sts")
+	ports, err := c.GetStatefulSetPorts(t.Context(), "", "default", "my-sts")
 	require.NoError(t, err)
 	assert.Len(t, ports, 1)
 	assert.Equal(t, int32(5432), ports[0].ContainerPort)
@@ -501,7 +500,7 @@ func TestGetDaemonSetPorts(t *testing.T) {
 	cs := k8sfake.NewClientset(ds)
 	c := newFakeClient(cs, nil)
 
-	ports, err := c.GetDaemonSetPorts(context.Background(), "", "default", "my-ds")
+	ports, err := c.GetDaemonSetPorts(t.Context(), "", "default", "my-ds")
 	require.NoError(t, err)
 	assert.Len(t, ports, 1)
 	assert.Equal(t, int32(9100), ports[0].ContainerPort)
@@ -521,7 +520,7 @@ func TestGetNamespaces(t *testing.T) {
 	cs := k8sfake.NewClientset(ns1, ns2)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetNamespaces(context.Background(), "")
+	items, err := c.GetNamespaces(t.Context(), "")
 	require.NoError(t, err)
 	assert.Len(t, items, 2)
 	// Should be sorted by name.
@@ -538,7 +537,7 @@ func TestListServiceAccounts(t *testing.T) {
 	cs := k8sfake.NewClientset(sa1, sa2)
 	c := newFakeClient(cs, nil)
 
-	names, err := c.ListServiceAccounts(context.Background(), "", "default")
+	names, err := c.ListServiceAccounts(t.Context(), "", "default")
 	require.NoError(t, err)
 	assert.Len(t, names, 2)
 	assert.Equal(t, "admin", names[0]) // sorted
@@ -551,7 +550,7 @@ func TestListServiceAccounts_AllNamespaces(t *testing.T) {
 	cs := k8sfake.NewClientset(sa1, sa2)
 	c := newFakeClient(cs, nil)
 
-	names, err := c.ListServiceAccounts(context.Background(), "", "")
+	names, err := c.ListServiceAccounts(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Len(t, names, 2)
 	// When namespace is empty, names include namespace prefix.
@@ -579,7 +578,7 @@ func TestListRBACSubjects(t *testing.T) {
 	cs := k8sfake.NewClientset(crb, rb)
 	c := newFakeClient(cs, nil)
 
-	subjects, err := c.ListRBACSubjects(context.Background(), "")
+	subjects, err := c.ListRBACSubjects(t.Context(), "")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(subjects), 4)
 	// Check ordering: Users first, then Groups, then ServiceAccounts.
@@ -667,7 +666,7 @@ func TestGetDeploymentRevisions(t *testing.T) {
 	cs := k8sfake.NewClientset(dep, rs1, rs2, rsOther)
 	c := newFakeClient(cs, nil)
 
-	revisions, err := c.GetDeploymentRevisions(context.Background(), "", "default", "my-deploy")
+	revisions, err := c.GetDeploymentRevisions(t.Context(), "", "default", "my-deploy")
 	require.NoError(t, err)
 	assert.Len(t, revisions, 2)
 	// Sorted by revision descending.
@@ -681,7 +680,7 @@ func TestGetDeploymentRevisions_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, err := c.GetDeploymentRevisions(context.Background(), "", "default", "missing")
+	_, err := c.GetDeploymentRevisions(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 }
 
@@ -761,7 +760,7 @@ func TestGetPodSelector_Deployment(t *testing.T) {
 	cs := k8sfake.NewClientset(dep)
 	c := newFakeClient(cs, nil)
 
-	sel, err := c.GetPodSelector(context.Background(), "", "default", "Deployment", "my-deploy")
+	sel, err := c.GetPodSelector(t.Context(), "", "default", "Deployment", "my-deploy")
 	require.NoError(t, err)
 	assert.Contains(t, sel, "app=test")
 	assert.Contains(t, sel, "env=prod")
@@ -781,7 +780,7 @@ func TestGetPodSelector_StatefulSet(t *testing.T) {
 	cs := k8sfake.NewClientset(sts)
 	c := newFakeClient(cs, nil)
 
-	sel, err := c.GetPodSelector(context.Background(), "", "default", "StatefulSet", "my-sts")
+	sel, err := c.GetPodSelector(t.Context(), "", "default", "StatefulSet", "my-sts")
 	require.NoError(t, err)
 	assert.Equal(t, "app=db", sel)
 }
@@ -800,7 +799,7 @@ func TestGetPodSelector_DaemonSet(t *testing.T) {
 	cs := k8sfake.NewClientset(ds)
 	c := newFakeClient(cs, nil)
 
-	sel, err := c.GetPodSelector(context.Background(), "", "default", "DaemonSet", "my-ds")
+	sel, err := c.GetPodSelector(t.Context(), "", "default", "DaemonSet", "my-ds")
 	require.NoError(t, err)
 	assert.Equal(t, "app=agent", sel)
 }
@@ -821,7 +820,7 @@ func TestGetPodSelector_Job(t *testing.T) {
 	cs := k8sfake.NewClientset(job)
 	c := newFakeClient(cs, nil)
 
-	sel, err := c.GetPodSelector(context.Background(), "", "default", "Job", "my-job")
+	sel, err := c.GetPodSelector(t.Context(), "", "default", "Job", "my-job")
 	require.NoError(t, err)
 	assert.Equal(t, "job-name=my-job", sel)
 }
@@ -837,7 +836,7 @@ func TestGetPodSelector_Service(t *testing.T) {
 	cs := k8sfake.NewClientset(svc)
 	c := newFakeClient(cs, nil)
 
-	sel, err := c.GetPodSelector(context.Background(), "", "default", "Service", "my-svc")
+	sel, err := c.GetPodSelector(t.Context(), "", "default", "Service", "my-svc")
 	require.NoError(t, err)
 	assert.Equal(t, "app=web", sel)
 }
@@ -846,7 +845,7 @@ func TestGetPodSelector_UnknownKind(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	sel, err := c.GetPodSelector(context.Background(), "", "default", "ConfigMap", "my-cm")
+	sel, err := c.GetPodSelector(t.Context(), "", "default", "ConfigMap", "my-cm")
 	require.NoError(t, err)
 	assert.Empty(t, sel)
 }
@@ -859,7 +858,7 @@ func TestGetPodSelector_NoSelector(t *testing.T) {
 	cs := k8sfake.NewClientset(svc)
 	c := newFakeClient(cs, nil)
 
-	sel, err := c.GetPodSelector(context.Background(), "", "default", "Service", "headless")
+	sel, err := c.GetPodSelector(t.Context(), "", "default", "Service", "headless")
 	require.NoError(t, err)
 	assert.Empty(t, sel)
 }
@@ -895,7 +894,7 @@ func TestGetHelmReleases(t *testing.T) {
 	cs := k8sfake.NewClientset(s1, s2, s3)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetHelmReleases(context.Background(), "", "default")
+	items, err := c.GetHelmReleases(t.Context(), "", "default")
 	require.NoError(t, err)
 	assert.Len(t, items, 2)
 	// Should find myapp (latest v2) and other (v1).
@@ -915,7 +914,7 @@ func TestGetHelmReleases_NoNamespace(t *testing.T) {
 	cs := k8sfake.NewClientset(s)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetHelmReleases(context.Background(), "", "")
+	items, err := c.GetHelmReleases(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 	assert.Equal(t, "prod", items[0].Namespace)
@@ -932,7 +931,7 @@ func TestGetHelmReleases_SkipsNoName(t *testing.T) {
 	cs := k8sfake.NewClientset(s)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetHelmReleases(context.Background(), "", "default")
+	items, err := c.GetHelmReleases(t.Context(), "", "default")
 	require.NoError(t, err)
 	assert.Len(t, items, 0)
 }
@@ -952,7 +951,7 @@ func TestGetHelmReleaseYAML(t *testing.T) {
 	cs := k8sfake.NewClientset(s)
 	c := newFakeClient(cs, nil)
 
-	yamlStr, err := c.GetHelmReleaseYAML(context.Background(), "", "default", "myapp")
+	yamlStr, err := c.GetHelmReleaseYAML(t.Context(), "", "default", "myapp")
 	require.NoError(t, err)
 	assert.Contains(t, yamlStr, "name: myapp")
 	assert.Contains(t, yamlStr, "status: deployed")
@@ -962,7 +961,7 @@ func TestGetHelmReleaseYAML_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, err := c.GetHelmReleaseYAML(context.Background(), "", "default", "missing")
+	_, err := c.GetHelmReleaseYAML(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no helm release found")
 }
@@ -989,7 +988,7 @@ func TestGetHelmReleaseYAML_PicksLatest(t *testing.T) {
 	cs := k8sfake.NewClientset(old, newer)
 	c := newFakeClient(cs, nil)
 
-	yamlStr, err := c.GetHelmReleaseYAML(context.Background(), "", "default", "myapp")
+	yamlStr, err := c.GetHelmReleaseYAML(t.Context(), "", "default", "myapp")
 	require.NoError(t, err)
 	assert.Contains(t, yamlStr, "version: \"2\"")
 }
@@ -1044,7 +1043,7 @@ func TestGetPodStartupAnalysis(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	info, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "my-pod")
+	info, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "my-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "my-pod", info.PodName)
 	assert.Equal(t, "default", info.Namespace)
@@ -1082,7 +1081,7 @@ func TestGetPodStartupAnalysis_PendingPod(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	info, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "pending-pod")
+	info, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "pending-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "pending-pod", info.PodName)
 	// Should have scheduling phase in-progress.
@@ -1138,7 +1137,7 @@ func TestGetPodStartupAnalysis_WithImagePullEvents(t *testing.T) {
 	cs := k8sfake.NewClientset(pod, pullingEvent, pulledEvent)
 	c := newFakeClient(cs, nil)
 
-	info, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "pull-pod")
+	info, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "pull-pod")
 	require.NoError(t, err)
 
 	var foundImagePull bool
@@ -1156,7 +1155,7 @@ func TestGetPodStartupAnalysis_NotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	_, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "missing")
+	_, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 }
 
@@ -1204,7 +1203,7 @@ func TestGetPodStartupAnalysis_InitContainerRunning(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	info, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "init-running-pod")
+	info, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "init-running-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "init-running-pod", info.PodName)
 	// Should have init container phases.
@@ -1262,7 +1261,7 @@ func TestGetPodStartupAnalysis_TerminatedContainer(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	info, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "terminated-pod")
+	info, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "terminated-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "terminated-pod", info.PodName)
 }
@@ -1300,7 +1299,7 @@ func TestGetPodStartupAnalysis_ContainersReadyNoReady(t *testing.T) {
 	cs := k8sfake.NewClientset(pod)
 	c := newFakeClient(cs, nil)
 
-	info, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "readiness-waiting")
+	info, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "readiness-waiting")
 	require.NoError(t, err)
 	// Should have readiness probes in-progress.
 	var foundReadiness bool
@@ -1344,7 +1343,7 @@ func TestGetPodStartupAnalysis_InProgressImagePull(t *testing.T) {
 	cs := k8sfake.NewClientset(pod, pullingEvent)
 	c := newFakeClient(cs, nil)
 
-	info, err := c.GetPodStartupAnalysis(context.Background(), "", "default", "pulling-pod")
+	info, err := c.GetPodStartupAnalysis(t.Context(), "", "default", "pulling-pod")
 	require.NoError(t, err)
 
 	var foundImagePull bool
@@ -1432,7 +1431,7 @@ func TestGetResources_EventsSortedByLastSeen(t *testing.T) {
 	dc := newFakeDynClient(eventA, eventB, eventC)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetResources(context.Background(), "", "default", model.ResourceTypeEntry{
+	items, err := c.GetResources(t.Context(), "", "default", model.ResourceTypeEntry{
 		Kind: "Event", APIGroup: "", APIVersion: "v1", Resource: "events", Namespaced: true,
 	})
 	require.NoError(t, err)
@@ -1462,7 +1461,7 @@ func TestDeleteResource_Namespaced(t *testing.T) {
 
 	// Verify it's gone.
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
-	_, err = dc.Resource(gvr).Namespace("default").Get(context.Background(), "my-cm", metav1.GetOptions{})
+	_, err = dc.Resource(gvr).Namespace("default").Get(t.Context(), "my-cm", metav1.GetOptions{})
 	require.Error(t, err)
 }
 
@@ -1526,7 +1525,7 @@ func TestGetResourceYAML_Namespaced(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	yamlStr, err := c.GetResourceYAML(context.Background(), "", "default", model.ResourceTypeEntry{
+	yamlStr, err := c.GetResourceYAML(t.Context(), "", "default", model.ResourceTypeEntry{
 		APIGroup: "", APIVersion: "v1", Resource: "configmaps", Namespaced: true,
 	}, "my-cm")
 	require.NoError(t, err)
@@ -1547,7 +1546,7 @@ func TestGetResourceYAML_ClusterScoped(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	yamlStr, err := c.GetResourceYAML(context.Background(), "", "", model.ResourceTypeEntry{
+	yamlStr, err := c.GetResourceYAML(t.Context(), "", "", model.ResourceTypeEntry{
 		APIGroup: "", APIVersion: "v1", Resource: "namespaces", Namespaced: false,
 	}, "my-ns")
 	require.NoError(t, err)
@@ -1565,7 +1564,7 @@ func TestGetResourceYAML_HelmVirtualType(t *testing.T) {
 	cs := k8sfake.NewClientset(s)
 	c := newFakeClient(cs, nil)
 
-	yamlStr, err := c.GetResourceYAML(context.Background(), "", "default", model.ResourceTypeEntry{
+	yamlStr, err := c.GetResourceYAML(t.Context(), "", "default", model.ResourceTypeEntry{
 		APIGroup: "_helm", Resource: "releases",
 	}, "myapp")
 	require.NoError(t, err)
@@ -1575,7 +1574,7 @@ func TestGetResourceYAML_HelmVirtualType(t *testing.T) {
 func TestGetResourceYAML_PortForwardVirtualType(t *testing.T) {
 	c := newFakeClient(nil, nil)
 
-	yamlStr, err := c.GetResourceYAML(context.Background(), "", "default", model.ResourceTypeEntry{
+	yamlStr, err := c.GetResourceYAML(t.Context(), "", "default", model.ResourceTypeEntry{
 		APIGroup: "_portforward",
 	}, "any")
 	require.NoError(t, err)
@@ -1606,7 +1605,7 @@ func TestGetLabelAnnotationData_Namespaced(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	result, err := c.GetLabelAnnotationData(context.Background(), "", model.ResourceTypeEntry{
+	result, err := c.GetLabelAnnotationData(t.Context(), "", model.ResourceTypeEntry{
 		APIGroup: "", APIVersion: "v1", Resource: "configmaps", Namespaced: true,
 	}, "default", "my-cm")
 	require.NoError(t, err)
@@ -1631,7 +1630,7 @@ func TestGetLabelAnnotationData_ClusterScoped(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	result, err := c.GetLabelAnnotationData(context.Background(), "", model.ResourceTypeEntry{
+	result, err := c.GetLabelAnnotationData(t.Context(), "", model.ResourceTypeEntry{
 		APIGroup: "", APIVersion: "v1", Resource: "namespaces", Namespaced: false,
 	}, "", "my-ns")
 	require.NoError(t, err)
@@ -1653,7 +1652,7 @@ func TestGetLabelAnnotationData_NoLabelsOrAnnotations(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	result, err := c.GetLabelAnnotationData(context.Background(), "", model.ResourceTypeEntry{
+	result, err := c.GetLabelAnnotationData(t.Context(), "", model.ResourceTypeEntry{
 		APIGroup: "", APIVersion: "v1", Resource: "configmaps", Namespaced: true,
 	}, "default", "bare-cm")
 	require.NoError(t, err)
@@ -1680,7 +1679,7 @@ func TestUpdateLabelAnnotationData_Namespaced(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	err := c.UpdateLabelAnnotationData(context.Background(), "", model.ResourceTypeEntry{
+	err := c.UpdateLabelAnnotationData(t.Context(), "", model.ResourceTypeEntry{
 		APIGroup: "", APIVersion: "v1", Resource: "configmaps", Namespaced: true,
 	}, "default", "my-cm",
 		map[string]string{"keep": "yes", "new-label": "added"},
@@ -1703,7 +1702,7 @@ func TestUpdateLabelAnnotationData_ClusterScoped(t *testing.T) {
 	dc := newFakeDynClient(obj)
 	c := newFakeClient(nil, dc)
 
-	err := c.UpdateLabelAnnotationData(context.Background(), "", model.ResourceTypeEntry{
+	err := c.UpdateLabelAnnotationData(t.Context(), "", model.ResourceTypeEntry{
 		APIGroup: "", APIVersion: "v1", Resource: "namespaces", Namespaced: false,
 	}, "", "my-ns",
 		map[string]string{"env": "new"},
@@ -1744,7 +1743,7 @@ func TestFindResourcesWithFinalizer(t *testing.T) {
 		{APIGroup: "", APIVersion: "v1", Resource: "configmaps", Kind: "ConfigMap", Namespaced: true},
 	}
 
-	results, err := c.FindResourcesWithFinalizer(context.Background(), "", "default", "finalizer", rts)
+	results, err := c.FindResourcesWithFinalizer(t.Context(), "", "default", "finalizer", rts)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "cm-with-finalizer", results[0].Name)
@@ -1760,7 +1759,7 @@ func TestFindResourcesWithFinalizer_SkipsVirtualTypes(t *testing.T) {
 		{APIGroup: "_portforward", Resource: "portforwards"},
 	}
 
-	results, err := c.FindResourcesWithFinalizer(context.Background(), "", "", "test", rts)
+	results, err := c.FindResourcesWithFinalizer(t.Context(), "", "", "test", rts)
 	require.NoError(t, err)
 	assert.Len(t, results, 0)
 }
@@ -1784,7 +1783,7 @@ func TestFindResourcesWithFinalizer_CaseInsensitive(t *testing.T) {
 		{APIGroup: "", APIVersion: "v1", Resource: "configmaps", Kind: "ConfigMap", Namespaced: true},
 	}
 
-	results, err := c.FindResourcesWithFinalizer(context.Background(), "", "default", "myfinalizer", rts)
+	results, err := c.FindResourcesWithFinalizer(t.Context(), "", "default", "myfinalizer", rts)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 }
@@ -1817,7 +1816,7 @@ func TestRemoveFinalizerFromResource(t *testing.T) {
 		Matched:    "remove.this/finalizer",
 	}
 
-	err := c.RemoveFinalizerFromResource(context.Background(), "", match)
+	err := c.RemoveFinalizerFromResource(t.Context(), "", match)
 	require.NoError(t, err)
 }
 
@@ -1845,7 +1844,7 @@ func TestRemoveFinalizerFromResource_ClusterScoped(t *testing.T) {
 		Matched:    "kubernetes",
 	}
 
-	err := c.RemoveFinalizerFromResource(context.Background(), "", match)
+	err := c.RemoveFinalizerFromResource(t.Context(), "", match)
 	require.NoError(t, err)
 }
 
@@ -1913,7 +1912,7 @@ func TestGetResourceEvents(t *testing.T) {
 	dc := newFakeDynClient(event1, event2, event3)
 	c := newFakeClient(nil, dc)
 
-	events, err := c.GetResourceEvents(context.Background(), "", "default", "my-deploy", "Deployment")
+	events, err := c.GetResourceEvents(t.Context(), "", "default", "my-deploy", "Deployment")
 	require.NoError(t, err)
 	assert.Len(t, events, 2)
 	// Most recent first.
@@ -1926,7 +1925,7 @@ func TestGetResourceEvents_NoEvents(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	events, err := c.GetResourceEvents(context.Background(), "", "default", "my-deploy", "Deployment")
+	events, err := c.GetResourceEvents(t.Context(), "", "default", "my-deploy", "Deployment")
 	require.NoError(t, err)
 	assert.Empty(t, events)
 }
@@ -1954,7 +1953,7 @@ func TestGetResourceEvents_EventTimeAndCreationFallback(t *testing.T) {
 	dc := newFakeDynClient(ev)
 	c := newFakeClient(nil, dc)
 
-	events, err := c.GetResourceEvents(context.Background(), "", "default", "my-pod", "Pod")
+	events, err := c.GetResourceEvents(t.Context(), "", "default", "my-pod", "Pod")
 	require.NoError(t, err)
 	assert.Len(t, events, 1)
 	// Should use eventTime.
@@ -1983,7 +1982,7 @@ func TestGetResourceEvents_ReportingComponentFallback(t *testing.T) {
 	dc := newFakeDynClient(ev)
 	c := newFakeClient(nil, dc)
 
-	events, err := c.GetResourceEvents(context.Background(), "", "default", "my-pod", "Pod")
+	events, err := c.GetResourceEvents(t.Context(), "", "default", "my-pod", "Pod")
 	require.NoError(t, err)
 	assert.Len(t, events, 1)
 	assert.Equal(t, "kubelet", events[0].Source)
@@ -2027,7 +2026,7 @@ func TestGetPodsUsingPVC(t *testing.T) {
 	dc := newFakeDynClient(pod1, pod2)
 	c := newFakeClient(nil, dc)
 
-	names, err := c.GetPodsUsingPVC(context.Background(), "", "default", "my-pvc")
+	names, err := c.GetPodsUsingPVC(t.Context(), "", "default", "my-pvc")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"pod-using-pvc"}, names)
 }
@@ -2036,7 +2035,7 @@ func TestGetPodsUsingPVC_NoPods(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	names, err := c.GetPodsUsingPVC(context.Background(), "", "default", "my-pvc")
+	names, err := c.GetPodsUsingPVC(t.Context(), "", "default", "my-pvc")
 	require.NoError(t, err)
 	assert.Empty(t, names)
 }
@@ -2084,7 +2083,7 @@ func TestGetOwnedResources_PersistentVolumeClaim(t *testing.T) {
 	dc := newFakeDynClient(mounting, unrelated)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "PersistentVolumeClaim", "target-pvc")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "PersistentVolumeClaim", "target-pvc")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	assert.Equal(t, "mounter", items[0].Name)
@@ -2109,7 +2108,7 @@ func TestPatchLabels_Namespaced(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
-	err := c.PatchLabels(context.Background(), "", "default", "my-cm", gvr, map[string]any{
+	err := c.PatchLabels(t.Context(), "", "default", "my-cm", gvr, map[string]any{
 		"env": "prod",
 	})
 	require.NoError(t, err)
@@ -2129,7 +2128,7 @@ func TestPatchLabels_ClusterScoped(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
-	err := c.PatchLabels(context.Background(), "", "", "my-ns", gvr, map[string]any{
+	err := c.PatchLabels(t.Context(), "", "", "my-ns", gvr, map[string]any{
 		"env": "prod",
 	})
 	require.NoError(t, err)
@@ -2152,7 +2151,7 @@ func TestPatchAnnotations_Namespaced(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
-	err := c.PatchAnnotations(context.Background(), "", "default", "my-cm", gvr, map[string]any{
+	err := c.PatchAnnotations(t.Context(), "", "default", "my-cm", gvr, map[string]any{
 		"note": "important",
 	})
 	require.NoError(t, err)
@@ -2172,7 +2171,7 @@ func TestPatchAnnotations_ClusterScoped(t *testing.T) {
 	c := newFakeClient(nil, dc)
 
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
-	err := c.PatchAnnotations(context.Background(), "", "", "my-ns", gvr, map[string]any{
+	err := c.PatchAnnotations(t.Context(), "", "", "my-ns", gvr, map[string]any{
 		"note": "important",
 	})
 	require.NoError(t, err)
@@ -2208,7 +2207,7 @@ func TestGetNamespaceQuotas(t *testing.T) {
 	dc := newFakeDynClient(quota)
 	c := newFakeClient(nil, dc)
 
-	quotas, err := c.GetNamespaceQuotas(context.Background(), "", "default")
+	quotas, err := c.GetNamespaceQuotas(t.Context(), "", "default")
 	require.NoError(t, err)
 	assert.Len(t, quotas, 1)
 	assert.Equal(t, "my-quota", quotas[0].Name)
@@ -2243,7 +2242,7 @@ func TestGetNamespaceQuotas_NoStatus(t *testing.T) {
 	dc := newFakeDynClient(quota)
 	c := newFakeClient(nil, dc)
 
-	quotas, err := c.GetNamespaceQuotas(context.Background(), "", "default")
+	quotas, err := c.GetNamespaceQuotas(t.Context(), "", "default")
 	require.NoError(t, err)
 	assert.Len(t, quotas, 1)
 	assert.Len(t, quotas[0].Resources, 1)
@@ -2267,7 +2266,7 @@ func TestGetNamespaceQuotas_AllNamespaces(t *testing.T) {
 	dc := newFakeDynClient(quota)
 	c := newFakeClient(nil, dc)
 
-	quotas, err := c.GetNamespaceQuotas(context.Background(), "", "")
+	quotas, err := c.GetNamespaceQuotas(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Len(t, quotas, 1)
 }
@@ -2278,7 +2277,7 @@ func TestGetPodMetrics_NotAvailable(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	_, err := c.GetPodMetrics(context.Background(), "", "default", "my-pod")
+	_, err := c.GetPodMetrics(t.Context(), "", "default", "my-pod")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "metrics API unavailable")
 }
@@ -2316,7 +2315,7 @@ func TestGetPodsForService(t *testing.T) {
 	cs := k8sfake.NewClientset(svc, pod)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getPodsForService(context.Background(), "", "default", "my-svc")
+	items, err := c.getPodsForService(t.Context(), "", "default", "my-svc")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 	assert.Equal(t, "web-pod", items[0].Name)
@@ -2332,7 +2331,7 @@ func TestGetPodsForService_NoSelector(t *testing.T) {
 	cs := k8sfake.NewClientset(svc)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getPodsForService(context.Background(), "", "default", "headless")
+	items, err := c.getPodsForService(t.Context(), "", "default", "headless")
 	require.NoError(t, err)
 	assert.Nil(t, items)
 }
@@ -2370,7 +2369,7 @@ func TestBuildPodTree_WithEphemeralContainers(t *testing.T) {
 	c := newFakeClient(cs, dc)
 
 	root := &model.ResourceNode{Name: "my-pod", Kind: "Pod", Namespace: "default"}
-	err := c.buildPodTree(context.Background(), "", "default", "my-pod", root)
+	err := c.buildPodTree(t.Context(), "", "default", "my-pod", root)
 	require.NoError(t, err)
 
 	// Exactly 2 container children: app + debugger. AutomountServiceAccountToken=false suppresses the SA ref.
@@ -2409,7 +2408,7 @@ func TestBuildPodTree(t *testing.T) {
 	c := newFakeClient(cs, dc)
 
 	root := &model.ResourceNode{Name: "my-pod", Kind: "Pod", Namespace: "default"}
-	err := c.buildPodTree(context.Background(), "", "default", "my-pod", root)
+	err := c.buildPodTree(t.Context(), "", "default", "my-pod", root)
 	require.NoError(t, err)
 	assert.Equal(t, "Running", root.Status)
 	// init + app containers, plus the default ServiceAccount ref attached by appendPodRefs.
@@ -2453,7 +2452,7 @@ func TestBuildPodTree_RefsMissingAndPresent(t *testing.T) {
 	c := newFakeClient(cs, dc)
 
 	root := &model.ResourceNode{Name: "my-pod", Kind: "Pod", Namespace: "default"}
-	err := c.buildPodTree(context.Background(), "", "default", "my-pod", root)
+	err := c.buildPodTree(t.Context(), "", "default", "my-pod", root)
 	require.NoError(t, err)
 
 	byName := map[string]*model.ResourceNode{}
@@ -2538,7 +2537,7 @@ func TestGetResourceTree_DeploymentRefsMissingAndPresent(t *testing.T) {
 	dc := newFakeDynClient(deploy, rs, pod, presentSecret)
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "Deployment", "myapp")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "Deployment", "myapp")
 	require.NoError(t, err)
 	require.NotNil(t, root)
 
@@ -2610,7 +2609,7 @@ func TestGetHelmManagedResources(t *testing.T) {
 	cs := k8sfake.NewClientset(dep, svc)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getHelmManagedResources(context.Background(), "", "default", "myapp")
+	items, err := c.getHelmManagedResources(t.Context(), "", "default", "myapp")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(items), 2)
 }
@@ -2621,7 +2620,7 @@ func TestGetOwnedResources_DefaultReturnsNil(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "ConfigMap", "my-cm")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "ConfigMap", "my-cm")
 	require.NoError(t, err)
 	assert.Nil(t, items)
 }
@@ -2651,7 +2650,7 @@ func TestGetOwnedResources_CronJob(t *testing.T) {
 	dc := newFakeDynClient(job)
 	c := newFakeClient(nil, dc)
 
-	items, err := c.GetOwnedResources(context.Background(), "", "default", "CronJob", "my-cron")
+	items, err := c.GetOwnedResources(t.Context(), "", "default", "CronJob", "my-cron")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 	assert.Equal(t, "my-cron-12345", items[0].Name)
@@ -2663,7 +2662,7 @@ func TestGetResourceTree_UnknownKind(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
 
-	root, err := c.GetResourceTree(context.Background(), "", "default", "ConfigMap", "my-cm")
+	root, err := c.GetResourceTree(t.Context(), "", "default", "ConfigMap", "my-cm")
 	require.NoError(t, err)
 	assert.Equal(t, "my-cm", root.Name)
 }

--- a/internal/k8s/client_podos_test.go
+++ b/internal/k8s/client_podos_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,7 @@ func TestGetPodOS_SpecOSName(t *testing.T) {
 	}
 	c := newFakeClient(k8sfake.NewClientset(pod), nil)
 
-	got, err := c.GetPodOS(context.Background(), "ctx", "default", "win-pod")
+	got, err := c.GetPodOS(t.Context(), "ctx", "default", "win-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "windows", got)
 }
@@ -33,7 +32,7 @@ func TestGetPodOS_NodeSelectorFallback(t *testing.T) {
 	}
 	c := newFakeClient(k8sfake.NewClientset(pod), nil)
 
-	got, err := c.GetPodOS(context.Background(), "ctx", "default", "win-pod")
+	got, err := c.GetPodOS(t.Context(), "ctx", "default", "win-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "windows", got)
 }
@@ -46,7 +45,7 @@ func TestGetPodOS_Linux(t *testing.T) {
 	}
 	c := newFakeClient(k8sfake.NewClientset(pod), nil)
 
-	got, err := c.GetPodOS(context.Background(), "ctx", "default", "linux-pod")
+	got, err := c.GetPodOS(t.Context(), "ctx", "default", "linux-pod")
 	require.NoError(t, err)
 	assert.Equal(t, "linux", got)
 }
@@ -59,13 +58,13 @@ func TestGetPodOS_Unknown(t *testing.T) {
 	}
 	c := newFakeClient(k8sfake.NewClientset(pod), nil)
 
-	got, err := c.GetPodOS(context.Background(), "ctx", "default", "plain-pod")
+	got, err := c.GetPodOS(t.Context(), "ctx", "default", "plain-pod")
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
 
 func TestGetPodOS_NotFound(t *testing.T) {
 	c := newFakeClient(k8sfake.NewClientset(), nil)
-	_, err := c.GetPodOS(context.Background(), "ctx", "default", "missing")
+	_, err := c.GetPodOS(t.Context(), "ctx", "default", "missing")
 	assert.Error(t, err)
 }

--- a/internal/k8s/client_rightsizing_pods_test.go
+++ b/internal/k8s/client_rightsizing_pods_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +16,7 @@ func TestResolvePodsForWorkload_PodSelf(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"},
 	})
 	c := NewTestClient(cs, nil)
-	pods, err := c.resolvePodsForWorkload(context.Background(), "test-ctx", "default", "Pod", "pod-a")
+	pods, err := c.resolvePodsForWorkload(t.Context(), "test-ctx", "default", "Pod", "pod-a")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"pod-a"}, pods)
 }
@@ -40,7 +39,7 @@ func TestResolvePodsForWorkload_DeploymentByLabels(t *testing.T) {
 	}
 	cs := fake.NewSimpleClientset(dep, pod1, pod2, other)
 	c := NewTestClient(cs, nil)
-	pods, err := c.resolvePodsForWorkload(context.Background(), "test-ctx", "default", "Deployment", "frontend")
+	pods, err := c.resolvePodsForWorkload(t.Context(), "test-ctx", "default", "Deployment", "frontend")
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"frontend-aaa", "frontend-bbb"}, pods, "backend pod with non-matching labels must be excluded")
 }
@@ -57,7 +56,7 @@ func TestResolvePodsForWorkload_StatefulSetByLabels(t *testing.T) {
 	}
 	cs := fake.NewSimpleClientset(ss, pod)
 	c := NewTestClient(cs, nil)
-	pods, err := c.resolvePodsForWorkload(context.Background(), "test-ctx", "default", "StatefulSet", "db")
+	pods, err := c.resolvePodsForWorkload(t.Context(), "test-ctx", "default", "StatefulSet", "db")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"db-0"}, pods)
 }
@@ -74,7 +73,7 @@ func TestResolvePodsForWorkload_DaemonSetByLabels(t *testing.T) {
 	}
 	cs := fake.NewSimpleClientset(ds, pod)
 	c := NewTestClient(cs, nil)
-	pods, err := c.resolvePodsForWorkload(context.Background(), "test-ctx", "default", "DaemonSet", "node-exporter")
+	pods, err := c.resolvePodsForWorkload(t.Context(), "test-ctx", "default", "DaemonSet", "node-exporter")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"node-exporter-x"}, pods)
 }
@@ -91,7 +90,7 @@ func TestResolvePodsForWorkload_JobByLabels(t *testing.T) {
 	}
 	cs := fake.NewSimpleClientset(job, pod)
 	c := NewTestClient(cs, nil)
-	pods, err := c.resolvePodsForWorkload(context.Background(), "test-ctx", "default", "Job", "report")
+	pods, err := c.resolvePodsForWorkload(t.Context(), "test-ctx", "default", "Job", "report")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"report-x"}, pods)
 }
@@ -114,7 +113,7 @@ func TestResolvePodsForWorkload_CronJobWalksJobs(t *testing.T) {
 	}
 	cs := fake.NewSimpleClientset(cj, job, pod)
 	c := NewTestClient(cs, nil)
-	pods, err := c.resolvePodsForWorkload(context.Background(), "test-ctx", "default", "CronJob", "report")
+	pods, err := c.resolvePodsForWorkload(t.Context(), "test-ctx", "default", "CronJob", "report")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"report-1-pod"}, pods)
 }
@@ -122,6 +121,6 @@ func TestResolvePodsForWorkload_CronJobWalksJobs(t *testing.T) {
 func TestResolvePodsForWorkload_UnsupportedKind(t *testing.T) {
 	cs := fake.NewSimpleClientset()
 	c := NewTestClient(cs, nil)
-	_, err := c.resolvePodsForWorkload(context.Background(), "test-ctx", "default", "Service", "x")
+	_, err := c.resolvePodsForWorkload(t.Context(), "test-ctx", "default", "Service", "x")
 	assert.Error(t, err, "kinds outside the in-scope set must error")
 }

--- a/internal/k8s/client_rightsizing_prom_test.go
+++ b/internal/k8s/client_rightsizing_prom_test.go
@@ -163,7 +163,7 @@ func TestGetRightsizing_PrometheusMax1D(t *testing.T) {
 	// Explicit 1.2 headroom keeps the legacy expected values stable
 	// (the new picker default is 1.25, so without this the snap math
 	// would land on different canonical values).
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromMax1D, 1.2)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromMax1D, 1.2)
 	require.NoError(t, err)
 	assert.Equal(t, model.StrategyPromMax1D, out.Strategy)
 	assert.Equal(t, "1d-max", out.Source)
@@ -190,7 +190,7 @@ func TestGetRightsizing_PrometheusAvg1D(t *testing.T) {
 	}
 	c := newPromTestClient(t, pods, dep, stub)
 
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromAvg1D, 1.2)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromAvg1D, 1.2)
 	require.NoError(t, err)
 	assert.Equal(t, model.StrategyPromAvg1D, out.Strategy)
 	assert.Equal(t, "1d", out.Window)
@@ -212,7 +212,7 @@ func TestGetRightsizing_PrometheusP957D(t *testing.T) {
 	}
 	c := newPromTestClient(t, pods, dep, stub)
 
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromP957D, 1.2)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromP957D, 1.2)
 	require.NoError(t, err)
 	assert.Equal(t, model.StrategyPromP957D, out.Strategy)
 	assert.Equal(t, "7d", out.Window)
@@ -231,7 +231,7 @@ func TestGetRightsizing_PrometheusQueryFailureLeavesSuggestionEmpty(t *testing.T
 	}
 	c := newPromTestClient(t, pods, dep, stub)
 
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromMax1D, model.DefaultRightsizingHeadroom)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromMax1D, model.DefaultRightsizingHeadroom)
 	require.NoError(t, err, "Prom failure must be soft — strategy still selected")
 	require.Len(t, out.Containers, 1)
 	assert.Empty(t, out.Containers[0].CPU.RecommendedRequest)

--- a/internal/k8s/client_rightsizing_test.go
+++ b/internal/k8s/client_rightsizing_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +42,7 @@ func TestGetRightsizing_PodCurrentSpecExtracted(t *testing.T) {
 	}
 	cs := fake.NewSimpleClientset(pod)
 	c := NewTestClient(cs, nil)
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Pod", "pod-a", model.StrategySnapshot, model.DefaultRightsizingHeadroom)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Pod", "pod-a", model.StrategySnapshot, model.DefaultRightsizingHeadroom)
 	assert.NoError(t, err)
 	assert.NotNil(t, out)
 	assert.Equal(t, "snapshot", out.Source, "snapshot strategy yields snapshot label")
@@ -63,7 +62,7 @@ func TestGetRightsizing_PodCurrentSpecExtracted(t *testing.T) {
 func TestGetRightsizing_UnsupportedKindErrors(t *testing.T) {
 	cs := fake.NewSimpleClientset()
 	c := NewTestClient(cs, nil)
-	_, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "ConfigMap", "x", model.StrategySnapshot, model.DefaultRightsizingHeadroom)
+	_, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "ConfigMap", "x", model.StrategySnapshot, model.DefaultRightsizingHeadroom)
 	assert.Error(t, err, "kinds outside in-scope set must error")
 }
 
@@ -144,7 +143,7 @@ func TestGetRightsizing_VPAMatchesPopulatesRecommendations(t *testing.T) {
 	// headroom = 1.0 keeps the VPA target verbatim so the existing
 	// expected values (60m, 300m, 200Mi, 400Mi) still hold. The non-1.0
 	// case is covered by TestGetRightsizing_VPAHeadroomMultipliesTarget.
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, 1.0)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, 1.0)
 	assert.NoError(t, err)
 	assert.Equal(t, "VPA", out.Source)
 	assert.Equal(t, model.StrategyVPA, out.Strategy)
@@ -187,7 +186,7 @@ func TestGetRightsizing_VPATargetMismatchFallsThrough(t *testing.T) {
 	// VPA dispatch (no recommendations layered) and falls through to the
 	// metrics-server "live Usage" reading. Source label reflects the
 	// requested strategy because it didn't escalate to a different one.
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, model.DefaultRightsizingHeadroom)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, model.DefaultRightsizingHeadroom)
 	assert.NoError(t, err)
 	assert.Equal(t, model.StrategyVPA, out.Strategy, "requested strategy is preserved")
 }
@@ -255,7 +254,7 @@ func TestGetRightsizing_MetricsFallbackMaxAggregation(t *testing.T) {
 	// Explicit 1.2 headroom keeps the legacy expected values stable
 	// (the new picker default is 1.25, so without this the snap math
 	// would land on different canonical values).
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, 1.2)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, 1.2)
 	assert.NoError(t, err)
 	assert.Equal(t, "snapshot", out.Source)
 	assert.Equal(t, model.StrategySnapshot, out.Strategy)
@@ -314,7 +313,7 @@ func TestGetRightsizing_MetricsWindowPlumbedThrough(t *testing.T) {
 	}
 	c := NewTestClient(cs, dyn)
 
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, model.DefaultRightsizingHeadroom)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, model.DefaultRightsizingHeadroom)
 	assert.NoError(t, err)
 	assert.Equal(t, "30s", out.Window, "metrics-server PodMetrics 'window' field should be plumbed to model.Rightsizing.Window")
 }
@@ -368,7 +367,7 @@ func TestGetRightsizing_HeadroomZeroDefaults(t *testing.T) {
 	}
 	c := NewTestClient(cs, dyn)
 
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, 0)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, 0)
 	assert.NoError(t, err)
 	require.Len(t, out.Containers, 1)
 	// 80m * 1.25 = 100m → snap up to 100m. (1.25 is the default headroom
@@ -420,7 +419,7 @@ func TestGetRightsizing_HeadroomCustomMultiplier(t *testing.T) {
 	}
 	c := NewTestClient(cs, dyn)
 
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, 1.5)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategySnapshot, 1.5)
 	assert.NoError(t, err)
 	require.Len(t, out.Containers, 1)
 	// 80m * 1.5 = 120m → snap up to 120m
@@ -466,7 +465,7 @@ func TestGetRightsizing_VPAHeadroomMultipliesTarget(t *testing.T) {
 	c := NewTestClient(cs, dyn)
 
 	// At headroom 1.5: cpu 60m × 1.5 = 90m; memory 200Mi × 1.5 = 300Mi
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, 1.5)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, 1.5)
 	assert.NoError(t, err)
 	require.Len(t, out.Containers, 1)
 	assert.Equal(t, "90m", out.Containers[0].CPU.RecommendedRequest, "VPA target × 1.5 headroom")
@@ -503,7 +502,7 @@ func TestGetRightsizing_VPAHeadroom1RawTarget(t *testing.T) {
 	}))
 	c := NewTestClient(cs, dyn)
 
-	out, err := c.GetRightsizing(context.Background(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, 1.0)
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Pod", "frontend-aaa", model.StrategyVPA, 1.0)
 	assert.NoError(t, err)
 	assert.Equal(t, "60m", out.Containers[0].CPU.RecommendedRequest, "headroom 1.0 returns raw VPA target")
 }
@@ -586,7 +585,7 @@ func TestAvailableRightsizingStrategies(t *testing.T) {
 			}, tc.vpaObj)
 			c := NewTestClient(cs, dyn)
 
-			got := c.AvailableRightsizingStrategies(context.Background(), "test-ctx", "default", "Pod", "frontend-aaa")
+			got := c.AvailableRightsizingStrategies(t.Context(), "test-ctx", "default", "Pod", "frontend-aaa")
 			assert.Equal(t, tc.want, got, tc.comment)
 		})
 	}

--- a/internal/k8s/client_secret_list_test.go
+++ b/internal/k8s/client_secret_list_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -111,7 +110,7 @@ func TestGetResources_SecretMetadataPath(t *testing.T) {
 	)
 	c := newClientWithMeta(mc, nil)
 
-	items, err := c.GetResources(context.Background(), "", "default", secretRT)
+	items, err := c.GetResources(t.Context(), "", "default", secretRT)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -136,7 +135,7 @@ func TestGetResources_SecretNoDataColumns(t *testing.T) {
 	)
 	c := newClientWithMeta(mc, nil)
 
-	items, err := c.GetResources(context.Background(), "", "ns1", secretRT)
+	items, err := c.GetResources(t.Context(), "", "ns1", secretRT)
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 
@@ -159,7 +158,7 @@ func TestGetResources_SecretDeletionTimestamp(t *testing.T) {
 	)
 	c := newClientWithMeta(mc, nil)
 
-	items, err := c.GetResources(context.Background(), "", "default", secretRT)
+	items, err := c.GetResources(t.Context(), "", "default", secretRT)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -185,7 +184,7 @@ func TestGetResources_SecretNamespacedPath_AllNamespaces(t *testing.T) {
 	c := newClientWithMeta(mc, nil)
 
 	// namespace="" means all namespaces for a namespaced resource.
-	items, err := c.GetResources(context.Background(), "", "", secretRT)
+	items, err := c.GetResources(t.Context(), "", "", secretRT)
 	require.NoError(t, err)
 	// Fake client returns all objects regardless of namespace filter when namespace is "".
 	assert.GreaterOrEqual(t, len(items), 2)
@@ -200,7 +199,7 @@ func TestGetResources_SecretClusterScoped(t *testing.T) {
 	)
 	c := newClientWithMeta(mc, nil)
 
-	items, err := c.GetResources(context.Background(), "", "", secretRTCluster)
+	items, err := c.GetResources(t.Context(), "", "", secretRTCluster)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	assert.Equal(t, "cluster-secret", items[0].Name)
@@ -217,7 +216,7 @@ func TestGetResources_SecretSortedAlphabetically(t *testing.T) {
 	)
 	c := newClientWithMeta(mc, nil)
 
-	items, err := c.GetResources(context.Background(), "", "default", secretRT)
+	items, err := c.GetResources(t.Context(), "", "default", secretRT)
 	require.NoError(t, err)
 	require.Len(t, items, 3)
 
@@ -236,7 +235,7 @@ func TestGetResources_SecretWithOwnerReferences(t *testing.T) {
 	)
 	c := newClientWithMeta(mc, nil)
 
-	items, err := c.GetResources(context.Background(), "", "default", secretRT)
+	items, err := c.GetResources(t.Context(), "", "default", secretRT)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -302,7 +301,7 @@ func TestGetResources_NonSecretUsesDynamicPath(t *testing.T) {
 		Namespaced: true,
 	}
 
-	items, err := c.GetResources(context.Background(), "", "default", podRT)
+	items, err := c.GetResources(t.Context(), "", "default", podRT)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -342,7 +341,7 @@ func TestGetResources_SecretLazyLoadingDisabledUsesDynamicPath(t *testing.T) {
 	c := NewTestClient(nil, dc) // lazy loading off by default
 	require.False(t, c.secretLazyLoading.Load(), "precondition: flag must default to false")
 
-	items, err := c.GetResources(context.Background(), "", "default", secretRT)
+	items, err := c.GetResources(t.Context(), "", "default", secretRT)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -374,7 +373,7 @@ func TestGetResources_SecretLazyLoadingEnabledUsesMetadataPath(t *testing.T) {
 
 	c := newClientWithMeta(mc, dc) // helper enables the flag
 
-	items, err := c.GetResources(context.Background(), "", "default", secretRT)
+	items, err := c.GetResources(t.Context(), "", "default", secretRT)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 

--- a/internal/k8s/client_service_endpoints_test.go
+++ b/internal/k8s/client_service_endpoints_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -54,7 +53,7 @@ func TestGetServiceEndpoints_AggregatesAcrossSlices(t *testing.T) {
 	cs := k8sfake.NewClientset(slice1, slice2)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.GetServiceEndpoints(context.Background(), "", "default", "my-svc")
+	out, err := c.GetServiceEndpoints(t.Context(), "", "default", "my-svc")
 	require.NoError(t, err)
 	require.NotNil(t, out)
 
@@ -74,7 +73,7 @@ func TestGetServiceEndpoints_NoSlicesReturnsEmpty(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	out, err := c.GetServiceEndpoints(context.Background(), "", "default", "lonely")
+	out, err := c.GetServiceEndpoints(t.Context(), "", "default", "lonely")
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, 0, out.Ready)
@@ -119,7 +118,7 @@ func TestGetServiceEndpoints_FilterIgnoresOtherServices(t *testing.T) {
 	cs := k8sfake.NewClientset(owned, other)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.GetServiceEndpoints(context.Background(), "", "default", "my-svc")
+	out, err := c.GetServiceEndpoints(t.Context(), "", "default", "my-svc")
 	require.NoError(t, err)
 	assert.Equal(t, 1, out.Ready)
 	assert.NotContains(t, out.Block, "10.99.99.99",
@@ -149,7 +148,7 @@ func TestGetServiceEndpoints_MissingConditionsTreatedAsReady(t *testing.T) {
 	cs := k8sfake.NewClientset(slice)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.GetServiceEndpoints(context.Background(), "", "default", "my-svc")
+	out, err := c.GetServiceEndpoints(t.Context(), "", "default", "my-svc")
 	require.NoError(t, err)
 	assert.Equal(t, 1, out.Ready, "missing conditions.ready counts as ready")
 	assert.Equal(t, 0, out.NotReady)

--- a/internal/k8s/client_union_test.go
+++ b/internal/k8s/client_union_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +42,7 @@ func TestGetResourcesUnion_FanOutStampingAndSort(t *testing.T) {
 
 	contexts := []string{"green", "blue"} // unsorted to prove secondary sort
 	items, err := c.GetResourcesUnion(
-		context.Background(),
+		t.Context(),
 		contexts,
 		"cloud-cd",
 		model.ResourceTypeEntry{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
@@ -92,7 +91,7 @@ func TestGetResourcesUnion_SortsSameNameClusterByNamespace(t *testing.T) {
 	c := newFakeClient(nil, dyn)
 
 	items, err := c.GetResourcesUnion(
-		context.Background(),
+		t.Context(),
 		[]string{"blue"},
 		"",
 		model.ResourceTypeEntry{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
@@ -109,7 +108,7 @@ func TestGetResourcesUnion_EmptyContextsList(t *testing.T) {
 	c := newFakeClient(nil, dyn)
 
 	items, err := c.GetResourcesUnion(
-		context.Background(),
+		t.Context(),
 		nil,
 		"cloud-cd",
 		model.ResourceTypeEntry{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
@@ -142,7 +141,7 @@ func TestGetResourcesUnion_UsesStandardGetResources(t *testing.T) {
 
 	// Single-context union: one cluster, one pod → one row with ClusterName stamped.
 	items, err := c.GetResourcesUnion(
-		context.Background(),
+		t.Context(),
 		[]string{"solo-cluster"},
 		"cloud-cd",
 		model.ResourceTypeEntry{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
@@ -154,7 +153,7 @@ func TestGetResourcesUnion_UsesStandardGetResources(t *testing.T) {
 	// And the non-union GetResources must NOT stamp ClusterName — that field
 	// is the union feature's contract. Verify the two code paths differ here.
 	plain, err := c.GetResources(
-		context.Background(),
+		t.Context(),
 		"solo-cluster",
 		"cloud-cd",
 		model.ResourceTypeEntry{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},

--- a/internal/k8s/crash_investigator_test.go
+++ b/internal/k8s/crash_investigator_test.go
@@ -43,7 +43,7 @@ func TestGetCrashInvestigation_PodSummary(t *testing.T) {
 		return "Name: crashy\nNamespace: default\n", nil
 	}
 
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "crashy")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "crashy")
 	require.NoError(t, err)
 	assert.Equal(t, "crashy", got.Pod.Name)
 	assert.Equal(t, "default", got.Pod.Namespace)
@@ -99,7 +99,7 @@ func TestGetCrashInvestigation_SingleContainerCLB(t *testing.T) {
 	c := newFakeClient(cs, nil)
 	c.describeOverride = func(_ context.Context, _, _, _ string) (string, error) { return "", nil }
 
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "p")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "p")
 	require.NoError(t, err)
 	require.Len(t, got.AppContainers, 1)
 	require.Empty(t, got.InitContainers)
@@ -151,7 +151,7 @@ func TestGetCrashInvestigation_InitContainerCLB(t *testing.T) {
 	c := newFakeClient(cs, nil)
 	c.describeOverride = func(_ context.Context, _, _, _ string) (string, error) { return "", nil }
 
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "p")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "p")
 	require.NoError(t, err)
 	require.Len(t, got.InitContainers, 1)
 	require.Len(t, got.AppContainers, 1)
@@ -190,7 +190,7 @@ func TestGetCrashInvestigation_MultiContainerOnlyOneFailing(t *testing.T) {
 	c := newFakeClient(cs, nil)
 	c.describeOverride = func(_ context.Context, _, _, _ string) (string, error) { return "", nil }
 
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "p")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "p")
 	require.NoError(t, err)
 	require.Len(t, got.AppContainers, 2)
 	assert.Equal(t, "app", got.AppContainers[0].Name)
@@ -218,7 +218,7 @@ func TestGetCrashInvestigation_HealthyPod(t *testing.T) {
 	c := newFakeClient(cs, nil)
 	c.describeOverride = func(_ context.Context, _, _, _ string) (string, error) { return "", nil }
 
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "p")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "p")
 	require.NoError(t, err)
 	assert.Len(t, got.AppContainers, 1)
 	assert.True(t, got.AppContainers[0].Ready)
@@ -247,7 +247,7 @@ func TestGetCrashInvestigation_LogsPopulated(t *testing.T) {
 
 	// fakeclient `GetLogs` returns "fake logs" by default; that's enough
 	// to assert both PreviousLog and CurrentLog are populated.
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "p")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "p")
 	require.NoError(t, err)
 	require.Len(t, got.AppContainers, 1)
 	cc := got.AppContainers[0]
@@ -288,7 +288,7 @@ func TestGetCrashInvestigation_EventsFiltered(t *testing.T) {
 	c := newFakeClient(cs, nil)
 	c.describeOverride = func(_ context.Context, _, _, _ string) (string, error) { return "", nil }
 
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "p")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "p")
 	require.NoError(t, err)
 	require.Len(t, got.Events, 2)
 	// Newest first.
@@ -299,7 +299,7 @@ func TestGetCrashInvestigation_EventsFiltered(t *testing.T) {
 func TestGetCrashInvestigation_PodNotFound(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
-	_, err := c.GetCrashInvestigation(context.Background(), "", "default", "missing")
+	_, err := c.GetCrashInvestigation(t.Context(), "", "default", "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -315,7 +315,7 @@ func TestGetCrashInvestigation_DescribeFailureNonFatal(t *testing.T) {
 		return "", fmt.Errorf("kubectl not in PATH")
 	}
 
-	got, err := c.GetCrashInvestigation(context.Background(), "", "default", "p")
+	got, err := c.GetCrashInvestigation(t.Context(), "", "default", "p")
 	require.NoError(t, err, "describe failure must not fail the whole call")
 	require.NotNil(t, got)
 	assert.Empty(t, got.Describe)

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -170,7 +169,7 @@ func TestDiscoverAPIResources_MergesPrinterColumns(t *testing.T) {
 
 	c := newFakeClient(cs, dc)
 
-	entries, err := c.DiscoverAPIResources(context.Background(), "")
+	entries, err := c.DiscoverAPIResources(t.Context(), "")
 	require.NoError(t, err)
 
 	// Pod has no printer columns (core resource, discovery API has no columns).
@@ -229,7 +228,7 @@ func TestDiscoverAPIResources_PartialGroupFailure(t *testing.T) {
 
 	c := newFakeClient(cs, dc)
 
-	entries, err := c.DiscoverAPIResources(context.Background(), "")
+	entries, err := c.DiscoverAPIResources(t.Context(), "")
 	// The ErrGroupDiscoveryFailed branch falls through and returns the
 	// successful subset with no error. If the reactor pathway above does
 	// not produce ErrGroupDiscoveryFailed (the fake may surface it as a

--- a/internal/k8s/gitops_argo_wave_test.go
+++ b/internal/k8s/gitops_argo_wave_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"math"
 	"testing"
 
@@ -326,7 +325,7 @@ func TestFetchWaveAnnotations_ReadsFromAnnotation(t *testing.T) {
 		// Resource with SyncStatus=Missing must be skipped, no fetch attempted.
 		{Group: "", Version: "v1", Kind: "Service", Namespace: "default", Name: "missing", SyncStatus: "Missing"},
 	}
-	got, err := c.fetchWaveAnnotations(context.Background(), "", in)
+	got, err := c.fetchWaveAnnotations(t.Context(), "", in)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 
@@ -358,7 +357,7 @@ func TestFetchWaveAnnotations_MissingAnnotationDefaultsToZero(t *testing.T) {
 	in := []SyncWaveResource{
 		{Group: "", Version: "v1", Kind: "ConfigMap", Namespace: "default", Name: "config"},
 	}
-	got, err := c.fetchWaveAnnotations(context.Background(), "", in)
+	got, err := c.fetchWaveAnnotations(t.Context(), "", in)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, 0, got[0].wave, "missing annotation must default to wave 0")
@@ -371,7 +370,7 @@ func TestFetchWaveAnnotations_PerResourceErrorIsNonFatal(t *testing.T) {
 	in := []SyncWaveResource{
 		{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: "default", Name: "ghost"},
 	}
-	got, err := c.fetchWaveAnnotations(context.Background(), "", in)
+	got, err := c.fetchWaveAnnotations(t.Context(), "", in)
 	require.NoError(t, err) // top-level call succeeds
 	require.Len(t, got, 1)
 	assert.Equal(t, unknownWave, got[0].wave)
@@ -396,7 +395,7 @@ func TestFetchWaveAnnotations_BadAnnotationLandsAtUnknown(t *testing.T) {
 	in := []SyncWaveResource{
 		{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: "default", Name: "api"},
 	}
-	got, _ := c.fetchWaveAnnotations(context.Background(), "", in)
+	got, _ := c.fetchWaveAnnotations(t.Context(), "", in)
 	require.Len(t, got, 1)
 	assert.Equal(t, unknownWave, got[0].wave)
 }
@@ -457,7 +456,7 @@ func TestGetSyncWaveTimelineSkeleton_FastPath(t *testing.T) {
 	dc := newFakeDynClient(app, deploy, cm)
 	c := newFakeClient(nil, dc)
 
-	tl, err := c.GetSyncWaveTimelineSkeleton(context.Background(), "", "argocd", "my-app")
+	tl, err := c.GetSyncWaveTimelineSkeleton(t.Context(), "", "argocd", "my-app")
 	require.NoError(t, err)
 	require.NotNil(t, tl)
 
@@ -498,7 +497,7 @@ func TestGetSyncWaveTimelineSkeleton_FastPath(t *testing.T) {
 func TestGetSyncWaveTimelineSkeleton_AppNotFound(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
-	_, err := c.GetSyncWaveTimelineSkeleton(context.Background(), "", "argocd", "ghost")
+	_, err := c.GetSyncWaveTimelineSkeleton(t.Context(), "", "argocd", "ghost")
 	require.Error(t, err)
 }
 
@@ -551,7 +550,7 @@ func TestGetSyncWaveTimeline_FullPath(t *testing.T) {
 	dc := newFakeDynClient(app, deploy, cm)
 	c := newFakeClient(nil, dc)
 
-	tl, err := c.GetSyncWaveTimeline(context.Background(), "", "argocd", "my-app")
+	tl, err := c.GetSyncWaveTimeline(t.Context(), "", "argocd", "my-app")
 	require.NoError(t, err)
 	require.NotNil(t, tl)
 
@@ -596,7 +595,7 @@ func TestGetSyncWaveTimeline_FullPath(t *testing.T) {
 func TestGetSyncWaveTimeline_AppNotFound(t *testing.T) {
 	dc := newFakeDynClient()
 	c := newFakeClient(nil, dc)
-	_, err := c.GetSyncWaveTimeline(context.Background(), "", "argocd", "ghost")
+	_, err := c.GetSyncWaveTimeline(t.Context(), "", "argocd", "ghost")
 	require.Error(t, err)
 }
 
@@ -610,7 +609,7 @@ func TestGetSyncWaveTimeline_EmptyApp(t *testing.T) {
 	}
 	dc := newFakeDynClient(app)
 	c := newFakeClient(nil, dc)
-	tl, err := c.GetSyncWaveTimeline(context.Background(), "", "argocd", "empty")
+	tl, err := c.GetSyncWaveTimeline(t.Context(), "", "argocd", "empty")
 	require.NoError(t, err)
 	assert.Equal(t, "empty", tl.AppName)
 	// Even when the Application has no status, the timeline must still

--- a/internal/k8s/helm_test.go
+++ b/internal/k8s/helm_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -71,7 +70,7 @@ func TestGetHelmReleases_PopulatesChartColumns(t *testing.T) {
 	cs := k8sfake.NewClientset(secret)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetHelmReleases(context.Background(), "", "default")
+	items, err := c.GetHelmReleases(t.Context(), "", "default")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -118,7 +117,7 @@ func TestGetHelmReleases_GracefulBlobFailure(t *testing.T) {
 	cs := k8sfake.NewClientset(secret)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetHelmReleases(context.Background(), "", "default")
+	items, err := c.GetHelmReleases(t.Context(), "", "default")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -146,7 +145,7 @@ func TestGetHelmReleases_StripsControlCharsFromDescription(t *testing.T) {
 	cs := k8sfake.NewClientset(secret)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetHelmReleases(context.Background(), "", "default")
+	items, err := c.GetHelmReleases(t.Context(), "", "default")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -255,7 +254,7 @@ func TestGetHelmManagedResources_ManifestPath(t *testing.T) {
 	cs := k8sfake.NewClientset(secret, liveDep)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getHelmManagedResources(context.Background(), "", "default", "cilium")
+	items, err := c.getHelmManagedResources(t.Context(), "", "default", "cilium")
 	require.NoError(t, err)
 
 	kinds := map[string]int{}
@@ -333,7 +332,7 @@ func TestGetHelmManagedResources_EmptyManifestFallsBackToLabels(t *testing.T) {
 	cs := k8sfake.NewClientset(secret, labelledDep)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getHelmManagedResources(context.Background(), "", "default", "legacy")
+	items, err := c.getHelmManagedResources(t.Context(), "", "default", "legacy")
 	require.NoError(t, err)
 	// Fallback path must still pick up the labelled Deployment.
 	var found bool
@@ -377,7 +376,7 @@ func TestGetHelmManagedResources_DecodeFailureFallsBack(t *testing.T) {
 	cs := k8sfake.NewClientset(brokenSecret, labelledSvc)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getHelmManagedResources(context.Background(), "", "default", "broken")
+	items, err := c.getHelmManagedResources(t.Context(), "", "default", "broken")
 	require.NoError(t, err)
 	// Expect label-based fallback to surface the labelled Service.
 	var found bool
@@ -417,7 +416,7 @@ metadata:
 	cs := k8sfake.NewClientset(oldSec, newSec)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getHelmManagedResources(context.Background(), "", "default", "stacked")
+	items, err := c.getHelmManagedResources(t.Context(), "", "default", "stacked")
 	require.NoError(t, err)
 
 	var names []string
@@ -502,7 +501,7 @@ func TestGetHelmReleases_LatestVersionWins(t *testing.T) {
 	cs := k8sfake.NewClientset(oldSecret, newSecret)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.GetHelmReleases(context.Background(), "", "default")
+	items, err := c.GetHelmReleases(t.Context(), "", "default")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
@@ -539,7 +538,7 @@ metadata:
 	cs := k8sfake.NewClientset(secret)
 	c := newFakeClient(cs, nil)
 
-	items, err := c.getHelmManagedResources(context.Background(), "", "default", "storage-bundle")
+	items, err := c.getHelmManagedResources(t.Context(), "", "default", "storage-bundle")
 	require.NoError(t, err)
 
 	var va *model.Item

--- a/internal/k8s/informer_cache_test.go
+++ b/internal/k8s/informer_cache_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"runtime"
 	"sync"
 	"testing"
@@ -75,7 +74,7 @@ func TestGetResources_InformerCache_NamespaceSwitchHitsCache(t *testing.T) {
 	t.Cleanup(c.Shutdown)
 
 	// First list — primes the informer (the underlying watch fires one LIST).
-	itemsAll, err := c.GetResources(context.Background(), "", "", podRT)
+	itemsAll, err := c.GetResources(t.Context(), "", "", podRT)
 	require.NoError(t, err)
 	require.Len(t, itemsAll, 3)
 
@@ -85,11 +84,11 @@ func TestGetResources_InformerCache_NamespaceSwitchHitsCache(t *testing.T) {
 	// Switch to team-a, then team-b, then back to all-namespaces. Each call
 	// is the moment the user pressed the namespace selector — under the
 	// pre-#86 code these would have round-tripped to the apiserver.
-	itemsA, err := c.GetResources(context.Background(), "", "team-a", podRT)
+	itemsA, err := c.GetResources(t.Context(), "", "team-a", podRT)
 	require.NoError(t, err)
-	itemsB, err := c.GetResources(context.Background(), "", "team-b", podRT)
+	itemsB, err := c.GetResources(t.Context(), "", "team-b", podRT)
 	require.NoError(t, err)
-	itemsAll2, err := c.GetResources(context.Background(), "", "", podRT)
+	itemsAll2, err := c.GetResources(t.Context(), "", "", podRT)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"api-1", "api-2"}, []string{itemsA[0].Name, itemsA[1].Name})
@@ -112,7 +111,7 @@ func TestGetResources_InformerCache_OffModeHitsApiserverEveryTime(t *testing.T) 
 	c.SetInformerCacheMode(InformerCacheOff)
 
 	for range 3 {
-		_, err := c.GetResources(context.Background(), "", "team-a", podRT)
+		_, err := c.GetResources(t.Context(), "", "team-a", podRT)
 		require.NoError(t, err)
 	}
 
@@ -135,7 +134,7 @@ func TestGetResources_InformerCache_PicksUpDeletes(t *testing.T) {
 	t.Cleanup(c.Shutdown)
 
 	// Warm the cache.
-	items, err := c.GetResources(context.Background(), "", "team-a", podRT)
+	items, err := c.GetResources(t.Context(), "", "team-a", podRT)
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 
@@ -143,11 +142,11 @@ func TestGetResources_InformerCache_PicksUpDeletes(t *testing.T) {
 	// asynchronously, so we poll the cached list until it converges instead
 	// of asserting on the very next call.
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
-	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(context.Background(), "api-2", metav1.DeleteOptions{}))
+	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(t.Context(), "api-2", metav1.DeleteOptions{}))
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		items, err = c.GetResources(context.Background(), "", "team-a", podRT)
+		items, err = c.GetResources(t.Context(), "", "team-a", podRT)
 		require.NoError(t, err)
 		if len(items) == 1 {
 			break
@@ -221,7 +220,7 @@ func TestInformerCache_ConcurrentStopAndDemoteNoPanic(t *testing.T) {
 		withTunedThresholds(c, 1, 5, 1)
 
 		// Warm up: promotes on first list (1 item >= promoteAt=1).
-		_, err := c.GetResources(context.Background(), "", "", podRT)
+		_, err := c.GetResources(t.Context(), "", "", podRT)
 		require.NoError(t, err, "iter %d", iter)
 		require.True(t, c.informers.isPromoted("", podGVR()), "iter %d", iter)
 
@@ -236,7 +235,7 @@ func TestInformerCache_ConcurrentStopAndDemoteNoPanic(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-barrier
-			_, _ = c.GetResources(context.Background(), "", "", podRT)
+			_, _ = c.GetResources(t.Context(), "", "", podRT)
 		}()
 		go func() {
 			defer wg.Done()
@@ -272,7 +271,7 @@ func TestInformerCache_WaitForSyncTimeoutFallsBack(t *testing.T) {
 	entry.synced = make(chan struct{})
 
 	start := time.Now()
-	err = waitForSync(context.Background(), entry, 10*time.Millisecond)
+	err = waitForSync(t.Context(), entry, 10*time.Millisecond)
 	elapsed := time.Since(start)
 
 	require.Error(t, err, "expected timeout error when sync never completes")
@@ -295,7 +294,7 @@ func TestInformerCache_StopWaitsForGoroutines(t *testing.T) {
 	c.SetInformerCacheMode(InformerCacheAlways)
 
 	// Force the informer to start by issuing a list.
-	_, err := c.GetResources(context.Background(), "", "", podRT)
+	_, err := c.GetResources(t.Context(), "", "", podRT)
 	require.NoError(t, err)
 	require.Greater(t, runtime.NumGoroutine(), baseline,
 		"expected new goroutines for inf.Run + sync watcher")
@@ -348,7 +347,7 @@ func TestGetResources_InformerCache_AutoPromote(t *testing.T) {
 
 	// First call: direct LIST against the apiserver (cache not yet warm).
 	// Result has 4 items, which crosses promoteAt.
-	_, err := c.GetResources(context.Background(), "", "", podRT)
+	_, err := c.GetResources(t.Context(), "", "", podRT)
 	require.NoError(t, err)
 	listsAfterFirst := listActionCount(dc.Actions())
 	require.Equal(t, 1, listsAfterFirst, "first auto-mode call should LIST the apiserver directly")
@@ -358,12 +357,12 @@ func TestGetResources_InformerCache_AutoPromote(t *testing.T) {
 	// Second call: routed through the informer. The informer's own initial
 	// LIST counts as one apiserver call; subsequent namespace switches do
 	// not. Wait briefly for the watch to populate before asserting items.
-	_, err = c.GetResources(context.Background(), "", "team-a", podRT)
+	_, err = c.GetResources(t.Context(), "", "team-a", podRT)
 	require.NoError(t, err)
 
 	// Third call (different namespace) — must not add another apiserver list.
 	listsBefore := listActionCount(dc.Actions())
-	_, err = c.GetResources(context.Background(), "", "team-b", podRT)
+	_, err = c.GetResources(t.Context(), "", "team-b", podRT)
 	require.NoError(t, err)
 	assert.Equal(t, listsBefore, listActionCount(dc.Actions()),
 		"after promotion, namespace switching should be served from the cache")
@@ -387,14 +386,14 @@ func TestGetResources_InformerCache_AutoDemote(t *testing.T) {
 	// is the minimum to exercise the consecutive-call counter.
 
 	// Warm up: first list promotes the GVR (2 items >= promoteAt=1).
-	_, err := c.GetResources(context.Background(), "", "", podRT)
+	_, err := c.GetResources(t.Context(), "", "", podRT)
 	require.NoError(t, err)
 	require.True(t, c.informers.isPromoted("", podGVR()), "expected promotion after first list")
 
 	// Three more cached lists, each below demoteBelow. The third must trip
 	// the demote: state flips back to direct and the watch is torn down.
 	for i := range 3 {
-		_, err := c.GetResources(context.Background(), "", "", podRT)
+		_, err := c.GetResources(t.Context(), "", "", podRT)
 		require.NoError(t, err, "cached list iteration %d", i)
 	}
 	assert.False(t, c.informers.isPromoted("", podGVR()),
@@ -403,7 +402,7 @@ func TestGetResources_InformerCache_AutoDemote(t *testing.T) {
 	// Verify the watch was actually closed by re-promoting and observing
 	// that a fresh informer was started — i.e. demote is not a no-op.
 	listsBefore := listActionCount(dc.Actions())
-	_, err = c.GetResources(context.Background(), "", "", podRT)
+	_, err = c.GetResources(t.Context(), "", "", podRT)
 	require.NoError(t, err)
 	listsAfter := listActionCount(dc.Actions())
 	assert.Greater(t, listsAfter, listsBefore,
@@ -441,13 +440,13 @@ func TestListItems_MemoizesPerItem(t *testing.T) {
 	// Warmup: starts the informer, walks indexer, runs build per item,
 	// stores memo. GetResources is deliberately not used here so we
 	// don't pre-populate the memo with the production build.
-	first, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	first, builds, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	require.Len(t, first, 2)
 	assert.Equal(t, 2, builds, "warmup builds every item once")
 	assert.Equal(t, 2, buildCalls)
 
-	second, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	second, builds, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	require.Len(t, second, 2)
 	assert.Equal(t, 0, builds,
@@ -476,13 +475,13 @@ func TestListItems_RebuildsOnlyChangedItems(t *testing.T) {
 	}
 
 	// Warmup: builds all 3.
-	_, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	_, builds, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	require.Equal(t, 3, builds)
 
 	// Mutate exactly one pod: the watch bumps its individual RV; the
 	// other two pods' resourceVersion stays unchanged.
-	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(context.Background(), "api-2", metav1.DeleteOptions{}))
+	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(t.Context(), "api-2", metav1.DeleteOptions{}))
 
 	// Poll until the indexer reflects the delete (watch is async).
 	// Once it has, the next listItems should return 2 items and have
@@ -490,7 +489,7 @@ func TestListItems_RebuildsOnlyChangedItems(t *testing.T) {
 	// memo entries.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		items, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+		items, builds, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 		require.NoError(t, err)
 		if len(items) == 2 {
 			assert.Equal(t, 0, builds,
@@ -524,7 +523,7 @@ func TestListItems_RebuildsUpdatedItem(t *testing.T) {
 		return model.Item{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 	}
 
-	_, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	_, _, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"api-1", "api-2"}, buildNames)
 	buildNames = buildNames[:0]
@@ -537,13 +536,13 @@ func TestListItems_RebuildsUpdatedItem(t *testing.T) {
 	meta := updated.Object["metadata"].(map[string]any)
 	meta["labels"] = map[string]any{"updated": "true"}
 	meta["resourceVersion"] = "2"
-	_, err = dc.Resource(gvr).Namespace("team-a").Update(context.Background(), updated, metav1.UpdateOptions{})
+	_, err = dc.Resource(gvr).Namespace("team-a").Update(t.Context(), updated, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		buildNames = buildNames[:0]
-		_, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+		_, builds, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 		require.NoError(t, err)
 		if builds == 1 && len(buildNames) == 1 && buildNames[0] == "api-2" {
 			return
@@ -601,12 +600,12 @@ func TestListItems_ClusterScopedResource(t *testing.T) {
 		return model.Item{Name: obj.GetName(), Kind: "Namespace"}
 	}
 
-	first, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	first, builds, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	require.Len(t, first, 2)
 	assert.Equal(t, 2, builds, "warmup builds every cluster-scoped item once")
 
-	second, builds, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	second, builds, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	require.Len(t, second, 2)
 	assert.Equal(t, 0, builds,
@@ -639,17 +638,17 @@ func TestApplyMemo_PrunesDeletedKeysOnAllNamespacesList(t *testing.T) {
 	}
 
 	// Warmup: memo gets both keys.
-	_, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	_, _, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	entry := c.informers.entries[""][gvr]
 	require.Contains(t, entry.memo, "team-a/api-1")
 	require.Contains(t, entry.memo, "team-a/api-2")
 
 	// Delete api-2 and wait for the watch to apply.
-	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(context.Background(), "api-2", metav1.DeleteOptions{}))
+	require.NoError(t, dc.Resource(gvr).Namespace("team-a").Delete(t.Context(), "api-2", metav1.DeleteOptions{}))
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		items, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+		items, _, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 		require.NoError(t, err)
 		if len(items) == 1 {
 			break
@@ -686,7 +685,7 @@ func TestApplyMemo_PerNamespaceListDoesNotPruneOtherNamespaces(t *testing.T) {
 	}
 
 	// Warmup: all-namespaces list seeds memo with all three pods.
-	_, _, err := c.informers.listItems(context.Background(), "", gvr, "", build)
+	_, _, err := c.informers.listItems(t.Context(), "", gvr, "", build)
 	require.NoError(t, err)
 	entry := c.informers.entries[""][gvr]
 	require.Contains(t, entry.memo, "team-a/api-1")
@@ -696,7 +695,7 @@ func TestApplyMemo_PerNamespaceListDoesNotPruneOtherNamespaces(t *testing.T) {
 	// Now list only team-a. Even though team-b/worker-1 is not in the
 	// returned objs, the prune logic must leave its memo entry alone —
 	// the team-a list isn't authoritative for team-b.
-	_, _, err = c.informers.listItems(context.Background(), "", gvr, "team-a", build)
+	_, _, err = c.informers.listItems(t.Context(), "", gvr, "team-a", build)
 	require.NoError(t, err)
 	assert.Contains(t, entry.memo, "team-a/api-1")
 	assert.Contains(t, entry.memo, "team-a/api-2")

--- a/internal/k8s/karpenter_test.go
+++ b/internal/k8s/karpenter_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,7 +103,7 @@ func TestDisruptNodeClaim(t *testing.T) {
 	require.NoError(t, c.DisruptNodeClaim("test-ctx", "doomed"))
 
 	// Verify the NodeClaim is gone from the fake API.
-	_, err := dyn.Resource(karpenterNodeClaimGVR).Get(context.Background(), "doomed", metav1.GetOptions{})
+	_, err := dyn.Resource(karpenterNodeClaimGVR).Get(t.Context(), "doomed", metav1.GetOptions{})
 	require.Error(t, err, "DisruptNodeClaim must delete the NodeClaim from the API")
 }
 

--- a/internal/k8s/knative_test.go
+++ b/internal/k8s/knative_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -52,7 +51,7 @@ func TestActivateKnativeRevision(t *testing.T) {
 	// Verify the Service's spec.traffic was replaced with a single
 	// 100% entry pointing at the activated Revision. JSON merge-patch
 	// treats arrays as atomic, which is the intended semantic.
-	got, err := dyn.Resource(knativeServiceGVR).Namespace("default").Get(context.Background(), "my-svc", metav1.GetOptions{})
+	got, err := dyn.Resource(knativeServiceGVR).Namespace("default").Get(t.Context(), "my-svc", metav1.GetOptions{})
 	require.NoError(t, err)
 	traffic, found, err := unstructured.NestedSlice(got.Object, "spec", "traffic")
 	require.NoError(t, err)

--- a/internal/k8s/localcluster/exec_test.go
+++ b/internal/k8s/localcluster/exec_test.go
@@ -54,7 +54,7 @@ func TestRealRunnerRun(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.cancelCtx {
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithCancel(ctx)
@@ -103,7 +103,7 @@ func TestFakeRunnerSubstitutes(t *testing.T) {
 	if _, err := f.LookPath("k3d"); err == nil {
 		t.Fatalf("expected error for k3d")
 	}
-	out, _, _, err := f.Run(context.Background(), "kind", "version")
+	out, _, _, err := f.Run(t.Context(), "kind", "version")
 	if err != nil {
 		t.Fatalf("Run returned unexpected error: %v", err)
 	}

--- a/internal/k8s/localcluster/k3d_test.go
+++ b/internal/k8s/localcluster/k3d_test.go
@@ -36,7 +36,7 @@ func TestK3dList_ParsesRunning(t *testing.T) {
 		},
 	}
 	p := newK3dProvider(fake)
-	got, err := p.List(context.Background())
+	got, err := p.List(t.Context())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestK3dList_ParsesStopped(t *testing.T) {
 		},
 	}
 	p := newK3dProvider(fake)
-	got, _ := p.List(context.Background())
+	got, _ := p.List(t.Context())
 	if len(got) != 1 || got[0].Status != ClusterStatusStopped {
 		t.Fatalf("got %+v", got)
 	}
@@ -71,7 +71,7 @@ func TestK3dList_EmptyArray(t *testing.T) {
 		},
 	}
 	p := newK3dProvider(fake)
-	got, err := p.List(context.Background())
+	got, err := p.List(t.Context())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestK3dList_MalformedJSONErrors(t *testing.T) {
 		},
 	}
 	p := newK3dProvider(fake)
-	_, err := p.List(context.Background())
+	_, err := p.List(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "k3d:") {
 		t.Fatalf("expected wrapped 'k3d:' parse error, got %v", err)
 	}
@@ -105,7 +105,7 @@ func TestK3dList_NonZeroExitErrors(t *testing.T) {
 		},
 	}
 	p := newK3dProvider(fake)
-	_, err := p.List(context.Background())
+	_, err := p.List(t.Context())
 	if err == nil {
 		t.Fatal("expected error on non-zero exit")
 	}
@@ -117,7 +117,7 @@ func TestK3dCreate_NameOnly(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newK3dProvider(fake)
-	if err := p.Create(context.Background(), CreateSpec{Name: "staging"}); err != nil {
+	if err := p.Create(t.Context(), CreateSpec{Name: "staging"}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
@@ -133,7 +133,7 @@ func TestK3dCreate_WithVersionAndAgents(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newK3dProvider(fake)
-	_ = p.Create(context.Background(), CreateSpec{Name: "x", K8sVersion: "v1.30.0", Nodes: 3})
+	_ = p.Create(t.Context(), CreateSpec{Name: "x", K8sVersion: "v1.30.0", Nodes: 3})
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
 	if !strings.Contains(got, "--image rancher/k3s:v1.30.0-k3s1") {
 		t.Fatalf("argv = %q, want --image rancher/k3s:v1.30.0-k3s1", got)
@@ -149,7 +149,7 @@ func TestK3dDelete(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newK3dProvider(fake)
-	if err := p.Delete(context.Background(), "staging"); err != nil {
+	if err := p.Delete(t.Context(), "staging"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 	if strings.Join(fake.CallsSnapshot()[0].Args, " ") != "cluster delete staging" {
@@ -167,10 +167,10 @@ func TestK3dStartStop(t *testing.T) {
 	if !ok {
 		t.Fatal("k3dProvider must satisfy LifecycleProvider")
 	}
-	if err := lp.Start(context.Background(), "staging"); err != nil {
+	if err := lp.Start(t.Context(), "staging"); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	if err := lp.Stop(context.Background(), "staging"); err != nil {
+	if err := lp.Stop(t.Context(), "staging"); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	calls := fake.CallsSnapshot()

--- a/internal/k8s/localcluster/kind_test.go
+++ b/internal/k8s/localcluster/kind_test.go
@@ -16,7 +16,7 @@ func TestKindList_Empty(t *testing.T) {
 		},
 	}
 	p := newKindProvider(fake)
-	got, err := p.List(context.Background())
+	got, err := p.List(t.Context())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestKindList_OneRunningCluster(t *testing.T) {
 		},
 	}
 	p := newKindProvider(fake)
-	got, err := p.List(context.Background())
+	got, err := p.List(t.Context())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestKindList_DockerMissingMarksUnknown(t *testing.T) {
 		},
 	}
 	p := newKindProvider(fake)
-	got, _ := p.List(context.Background())
+	got, _ := p.List(t.Context())
 	if len(got) != 1 || got[0].Status != ClusterStatusUnknown {
 		t.Fatalf("expected single cluster with unknown status, got %+v", got)
 	}
@@ -75,7 +75,7 @@ func TestKindList_KindCLIError(t *testing.T) {
 		},
 	}
 	p := newKindProvider(fake)
-	_, err := p.List(context.Background())
+	_, err := p.List(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "kind:") {
 		t.Fatalf("expected wrapped 'kind:' error, got %v", err)
 	}
@@ -92,7 +92,7 @@ func TestKindList_MultilineFiltered(t *testing.T) {
 		},
 	}
 	p := newKindProvider(fake)
-	got, _ := p.List(context.Background())
+	got, _ := p.List(t.Context())
 	if len(got) != 2 {
 		t.Fatalf("expected 2 clusters, got %d", len(got))
 	}
@@ -104,7 +104,7 @@ func TestKindCreate_BuildsArgvNameOnly(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newKindProvider(fake)
-	if err := p.Create(context.Background(), CreateSpec{Name: "dev"}); err != nil {
+	if err := p.Create(t.Context(), CreateSpec{Name: "dev"}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	calls := fake.CallsSnapshot()
@@ -124,7 +124,7 @@ func TestKindCreate_BuildsArgvWithVersion(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newKindProvider(fake)
-	_ = p.Create(context.Background(), CreateSpec{Name: "dev", K8sVersion: "v1.30.0"})
+	_ = p.Create(t.Context(), CreateSpec{Name: "dev", K8sVersion: "v1.30.0"})
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
 	want := "create cluster --name dev --image kindest/node:v1.30.0"
 	if got != want {
@@ -138,7 +138,7 @@ func TestKindCreate_BuildsArgvWithMultipleNodes(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newKindProvider(fake)
-	_ = p.Create(context.Background(), CreateSpec{Name: "dev", Nodes: 3})
+	_ = p.Create(t.Context(), CreateSpec{Name: "dev", Nodes: 3})
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
 	if !strings.Contains(got, "--config") {
 		t.Fatalf("argv = %q, want --config flag for multi-node", got)
@@ -153,7 +153,7 @@ func TestKindCreate_PropagatesError(t *testing.T) {
 		},
 	}
 	p := newKindProvider(fake)
-	err := p.Create(context.Background(), CreateSpec{Name: "dev"})
+	err := p.Create(t.Context(), CreateSpec{Name: "dev"})
 	if err == nil || !strings.Contains(err.Error(), "kind:") {
 		t.Fatalf("expected wrapped 'kind:' error, got %v", err)
 	}
@@ -165,7 +165,7 @@ func TestKindDelete_BuildsArgv(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newKindProvider(fake)
-	if err := p.Delete(context.Background(), "dev"); err != nil {
+	if err := p.Delete(t.Context(), "dev"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
@@ -203,7 +203,7 @@ func TestKindContainerStatusMapping(t *testing.T) {
 					return tc.dockerStdout, "", 0, nil
 				},
 			}
-			got := kindContainerStatus(context.Background(), fake, "dev")
+			got := kindContainerStatus(t.Context(), fake, "dev")
 			if got != tc.want {
 				t.Fatalf("status for %q = %v, want %v", tc.dockerStdout, got, tc.want)
 			}

--- a/internal/k8s/localcluster/localcluster_test.go
+++ b/internal/k8s/localcluster/localcluster_test.go
@@ -107,7 +107,7 @@ func TestInstalledDelegates(t *testing.T) {
 }
 
 func TestValidateConfigFile(t *testing.T) {
-	tmp, err := os.CreateTemp("", "lfk-validate-*.yaml")
+	tmp, err := os.CreateTemp(t.TempDir(), "lfk-validate-*.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/k8s/localcluster/minikube_test.go
+++ b/internal/k8s/localcluster/minikube_test.go
@@ -24,7 +24,7 @@ func TestMinikubeList_ParsesValid(t *testing.T) {
 		},
 	}
 	p := newMinikubeProvider(fake)
-	got, err := p.List(context.Background())
+	got, err := p.List(t.Context())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestMinikubeList_EmptyValid(t *testing.T) {
 		},
 	}
 	p := newMinikubeProvider(fake)
-	got, err := p.List(context.Background())
+	got, err := p.List(t.Context())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestMinikubeList_NonZeroExitErrors(t *testing.T) {
 		},
 	}
 	p := newMinikubeProvider(fake)
-	_, err := p.List(context.Background())
+	_, err := p.List(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "minikube:") {
 		t.Fatalf("expected wrapped 'minikube:' error, got %v", err)
 	}
@@ -79,7 +79,7 @@ func TestMinikubeList_BadJSON(t *testing.T) {
 		},
 	}
 	p := newMinikubeProvider(fake)
-	_, err := p.List(context.Background())
+	_, err := p.List(t.Context())
 	if err == nil {
 		t.Fatal("expected error on bad JSON")
 	}
@@ -114,7 +114,7 @@ func TestMinikubeCreate_RejectsConfigFile(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newMinikubeProvider(fake)
-	err := p.Create(context.Background(), CreateSpec{Name: "exp", ConfigFile: "/tmp/foo.yaml"})
+	err := p.Create(t.Context(), CreateSpec{Name: "exp", ConfigFile: "/tmp/foo.yaml"})
 	if err == nil || !strings.Contains(err.Error(), "config-file is not supported") {
 		t.Fatalf("expected ConfigFile-not-supported error, got %v", err)
 	}
@@ -129,7 +129,7 @@ func TestMinikubeCreate_NameOnly(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newMinikubeProvider(fake)
-	if err := p.Create(context.Background(), CreateSpec{Name: "exp"}); err != nil {
+	if err := p.Create(t.Context(), CreateSpec{Name: "exp"}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
@@ -149,7 +149,7 @@ func TestMinikubeCreate_AlwaysPassesNonInteractive(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newMinikubeProvider(fake)
-	_ = p.Create(context.Background(), CreateSpec{Name: "exp", K8sVersion: "v1.30.0", Nodes: 2})
+	_ = p.Create(t.Context(), CreateSpec{Name: "exp", K8sVersion: "v1.30.0", Nodes: 2})
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
 	if !strings.Contains(got, "--interactive=false") {
 		t.Fatalf("argv = %q, must contain --interactive=false", got)
@@ -162,7 +162,7 @@ func TestMinikubeCreate_WithVersionAndNodes(t *testing.T) {
 		RunFn:      func(context.Context, string, ...string) (string, string, int, error) { return "", "", 0, nil },
 	}
 	p := newMinikubeProvider(fake)
-	_ = p.Create(context.Background(), CreateSpec{Name: "x", K8sVersion: "v1.30.0", Nodes: 3})
+	_ = p.Create(t.Context(), CreateSpec{Name: "x", K8sVersion: "v1.30.0", Nodes: 3})
 	got := strings.Join(fake.CallsSnapshot()[0].Args, " ")
 	if !strings.Contains(got, "--kubernetes-version v1.30.0") {
 		t.Fatalf("argv = %q, want --kubernetes-version v1.30.0", got)
@@ -182,13 +182,13 @@ func TestMinikubeDeleteStartStop(t *testing.T) {
 	if !ok {
 		t.Fatal("minikubeProvider must satisfy LifecycleProvider")
 	}
-	if err := p.Delete(context.Background(), "exp"); err != nil {
+	if err := p.Delete(t.Context(), "exp"); err != nil {
 		t.Fatal(err)
 	}
-	if err := lp.Start(context.Background(), "exp"); err != nil {
+	if err := lp.Start(t.Context(), "exp"); err != nil {
 		t.Fatal(err)
 	}
-	if err := lp.Stop(context.Background(), "exp"); err != nil {
+	if err := lp.Stop(t.Context(), "exp"); err != nil {
 		t.Fatal(err)
 	}
 	wantArgs := []string{

--- a/internal/k8s/metrics_prometheus_pods_test.go
+++ b/internal/k8s/metrics_prometheus_pods_test.go
@@ -58,7 +58,7 @@ func TestGetAllPodMetricsFromPrometheus(t *testing.T) {
 			{"metric":{"namespace":"dev","pod":"web-1"},"value":[1700000000,"209715200"]}]}}`), nil
 	}
 
-	got, err := c.getAllPodMetricsFromPrometheus(context.Background(), "ctx", "dev")
+	got, err := c.getAllPodMetricsFromPrometheus(t.Context(), "ctx", "dev")
 	require.NoError(t, err)
 	require.Contains(t, got, "dev/web-1")
 	pm := got["dev/web-1"]
@@ -90,7 +90,7 @@ func TestGetAllPodMetrics_PrefersPrometheusWhenConfigured(t *testing.T) {
 		}},
 	}
 
-	got, err := c.GetAllPodMetrics(context.Background(), "ctx", "dev")
+	got, err := c.GetAllPodMetrics(t.Context(), "ctx", "dev")
 	require.NoError(t, err)
 	require.Contains(t, got, "dev/web-1")
 	assert.Equal(t, int64(100), got["dev/web-1"].CPU)

--- a/internal/k8s/netpol_cilium_test.go
+++ b/internal/k8s/netpol_cilium_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"maps"
 	"testing"
 
@@ -278,7 +277,7 @@ func TestGetCiliumNetworkPolicyInfo_SingleSpec(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	infos, err := c.GetCiliumNetworkPolicyInfo(context.Background(), "test-ctx", "default", "cnp-web", "CiliumNetworkPolicy")
+	infos, err := c.GetCiliumNetworkPolicyInfo(t.Context(), "test-ctx", "default", "cnp-web", "CiliumNetworkPolicy")
 	require.NoError(t, err)
 	require.Len(t, infos, 1)
 	assert.Equal(t, "CiliumNetworkPolicy", infos[0].Kind)
@@ -294,7 +293,7 @@ func TestGetCiliumNetworkPolicyInfo_Clusterwide(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	infos, err := c.GetCiliumNetworkPolicyInfo(context.Background(), "test-ctx", "", "ccnp-all", "CiliumClusterwideNetworkPolicy")
+	infos, err := c.GetCiliumNetworkPolicyInfo(t.Context(), "test-ctx", "", "ccnp-all", "CiliumClusterwideNetworkPolicy")
 	require.NoError(t, err)
 	require.Len(t, infos, 1)
 	assert.Equal(t, "CiliumClusterwideNetworkPolicy", infos[0].Kind)
@@ -312,7 +311,7 @@ func TestGetCiliumNetworkPolicyInfo_MultiSpec(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	infos, err := c.GetCiliumNetworkPolicyInfo(context.Background(), "test-ctx", "default", "multi", "CiliumNetworkPolicy")
+	infos, err := c.GetCiliumNetworkPolicyInfo(t.Context(), "test-ctx", "default", "multi", "CiliumNetworkPolicy")
 	require.NoError(t, err)
 	require.Len(t, infos, 2)
 }
@@ -321,7 +320,7 @@ func TestGetCiliumNetworkPolicyInfo_NotFound(t *testing.T) {
 	dyn := netpolMatchFakeDyn()
 	c := NewTestClient(nil, dyn)
 
-	_, err := c.GetCiliumNetworkPolicyInfo(context.Background(), "test-ctx", "default", "missing", "CiliumNetworkPolicy")
+	_, err := c.GetCiliumNetworkPolicyInfo(t.Context(), "test-ctx", "default", "missing", "CiliumNetworkPolicy")
 	require.Error(t, err)
 }
 

--- a/internal/k8s/netpol_matching_cilium_test.go
+++ b/internal/k8s/netpol_matching_cilium_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestGetNetworkPoliciesForPod_IncludesCiliumPolicies(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "cnp-web", info.Policies[0].Name)
@@ -72,7 +71,7 @@ func TestGetNetworkPoliciesForPod_ClusterwideMatchesByNamespaceLabel(t *testing.
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "ccnp-default-ns", info.Policies[0].Name)
@@ -88,7 +87,7 @@ func TestGetNetworkPoliciesForPod_CiliumNodePolicySkipped(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	assert.Empty(t, info.Policies, "node policies must not appear in the pod view")
 }
@@ -107,7 +106,7 @@ func TestGetNetworkPoliciesForPod_CiliumCRDAbsent(t *testing.T) {
 	})
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err, "missing Cilium CRDs must not fail the lookup")
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "std-policy", info.Policies[0].Name)
@@ -134,7 +133,7 @@ func TestGetNetworkPoliciesForPod_ClusterwideAffectedPodsSpanNamespaces(t *testi
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	// Clusterwide policies report affected pods across all namespaces, not
@@ -154,7 +153,7 @@ func TestGetNetworkPoliciesForService_IncludesClusterwide(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "web-svc")
+	info, err := c.GetNetworkPoliciesForService(t.Context(), "test-ctx", "default", "web-svc")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "ccnp-default", info.Policies[0].Name)
@@ -174,7 +173,7 @@ func TestGetNetworkPoliciesForService_IncludesCilium(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "web-svc")
+	info, err := c.GetNetworkPoliciesForService(t.Context(), "test-ctx", "default", "web-svc")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "cnp-canary", info.Policies[0].Name)

--- a/internal/k8s/netpol_matching_test.go
+++ b/internal/k8s/netpol_matching_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,7 +91,7 @@ func TestGetNetworkPoliciesForPod_MatchesByLabels(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	assert.Equal(t, "Pod", info.Kind)
 	assert.Equal(t, "web-1", info.Name)
@@ -114,7 +113,7 @@ func TestGetNetworkPoliciesForPod_EmptySelectorMatchesAll(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "default-deny", info.Policies[0].Name)
@@ -138,12 +137,12 @@ func TestGetNetworkPoliciesForPod_MatchExpressions(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "expr-policy", info.Policies[0].Name)
 
-	info, err = c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "api-1")
+	info, err = c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "api-1")
 	require.NoError(t, err)
 	assert.Empty(t, info.Policies)
 }
@@ -159,7 +158,7 @@ func TestGetNetworkPoliciesForPod_NoMatch(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	assert.Empty(t, info.Policies)
 }
@@ -180,7 +179,7 @@ func TestGetNetworkPoliciesForPod_SpecLessPolicy(t *testing.T) {
 	c := NewTestClient(nil, dyn)
 
 	// No spec means an absent podSelector, which selects all pods.
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 1)
 	assert.Equal(t, "spec-less", info.Policies[0].Name)
@@ -190,7 +189,7 @@ func TestGetNetworkPoliciesForPod_PodNotFound(t *testing.T) {
 	dyn := netpolMatchFakeDyn()
 	c := NewTestClient(nil, dyn)
 
-	_, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "missing")
+	_, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "missing")
 	require.Error(t, err)
 }
 
@@ -206,7 +205,7 @@ func TestGetNetworkPoliciesForPod_SortedByName(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForPod(context.Background(), "test-ctx", "default", "web-1")
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "default", "web-1")
 	require.NoError(t, err)
 	require.Len(t, info.Policies, 2)
 	assert.Equal(t, "aa-policy", info.Policies[0].Name)
@@ -234,7 +233,7 @@ func TestGetNetworkPoliciesForService_MatchesBackingPods(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "web-svc")
+	info, err := c.GetNetworkPoliciesForService(t.Context(), "test-ctx", "default", "web-svc")
 	require.NoError(t, err)
 	assert.Equal(t, "Service", info.Kind)
 	assert.Equal(t, "web-svc", info.Name)
@@ -250,7 +249,7 @@ func TestGetNetworkPoliciesForService_NoSelector(t *testing.T) {
 	)
 	c := NewTestClient(nil, dyn)
 
-	info, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "external-svc")
+	info, err := c.GetNetworkPoliciesForService(t.Context(), "test-ctx", "default", "external-svc")
 	require.NoError(t, err)
 	assert.True(t, info.NoSelector)
 	assert.Empty(t, info.Policies)
@@ -260,6 +259,6 @@ func TestGetNetworkPoliciesForService_ServiceNotFound(t *testing.T) {
 	dyn := netpolMatchFakeDyn()
 	c := NewTestClient(nil, dyn)
 
-	_, err := c.GetNetworkPoliciesForService(context.Background(), "test-ctx", "default", "missing")
+	_, err := c.GetNetworkPoliciesForService(t.Context(), "test-ctx", "default", "missing")
 	require.Error(t, err)
 }

--- a/internal/k8s/orphan_detector_test.go
+++ b/internal/k8s/orphan_detector_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -26,7 +25,7 @@ func TestDetectOrphans_EmptyCluster(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.NoError(t, err)
 	assert.Empty(t, report.Pods)
@@ -64,7 +63,7 @@ func TestDetectOrphans_PodNoOwner(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(objs...)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.NoError(t, err)
 	require.Len(t, report.Pods, 2)
@@ -108,7 +107,7 @@ func TestDetectOrphans_SecretExclusions(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(objs...)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.NoError(t, err)
 	require.Len(t, report.Secrets, 1, "expected only old-tls-cert to be flagged")
@@ -140,7 +139,7 @@ func TestDetectOrphans_ConfigMapExclusions(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(objs...)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.NoError(t, err)
 	require.Len(t, report.ConfigMaps, 1)
@@ -239,7 +238,7 @@ func TestDetectOrphans_ServiceNoEndpoints(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(objs...)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.NoError(t, err)
 	require.Len(t, report.Services, 1)
@@ -325,7 +324,7 @@ func TestDetectOrphans_WorkloadTemplatesPreventFalsePositives(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(objs...)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.NoError(t, err)
 
@@ -420,7 +419,7 @@ func TestDetectOrphans_PVC(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(objs...)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.NoError(t, err)
 	require.Len(t, report.PVCs, 3, "live-data and owned-by-sts should be excluded")
@@ -463,7 +462,7 @@ func TestDetectOrphans_HPA(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(deployment, live, stale)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 	require.NoError(t, err)
 	require.Len(t, report.HPAs, 1)
 	assert.Equal(t, "ghost-hpa", report.HPAs[0].Name)
@@ -511,7 +510,7 @@ func TestDetectOrphans_PDB_NetPolSelector(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset(cronJob, pdbMatches, pdbStale, netpolStale)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 	require.NoError(t, err)
 
 	// matches-cron should NOT be orphan (CronJob template label matches).
@@ -561,7 +560,7 @@ func TestDetectOrphans_RBAC(t *testing.T) {
 	)
 	c := newFakeClient(cs, nil)
 
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 	require.NoError(t, err)
 
 	roleNames := orphanNames(report.Roles)
@@ -598,7 +597,7 @@ func TestDetectOrphans_PartialDenial(t *testing.T) {
 	})
 
 	c := newFakeClient(cs, nil)
-	report, err := c.DetectOrphans(context.Background(), "", "")
+	report, err := c.DetectOrphans(t.Context(), "", "")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ingresses")

--- a/internal/k8s/packet_decoder_test.go
+++ b/internal/k8s/packet_decoder_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"sync/atomic"
@@ -140,7 +139,7 @@ func TestPacketDecoder_Run_CountsPacketsAndBytes(t *testing.T) {
 		byteCount:   &byt,
 		onPacket:    func(s PacketSummary) { got = append(got, s) },
 	}
-	if err := d.Run(context.Background(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
+	if err := d.Run(t.Context(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -223,7 +222,7 @@ func TestPacketDecoder_LinuxSLL_LinkTypeDispatch(t *testing.T) {
 		byteCount:   &byt,
 		onPacket:    func(s PacketSummary) { got = append(got, s) },
 	}
-	if err := d.Run(context.Background(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
+	if err := d.Run(t.Context(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -307,7 +306,7 @@ func TestPacketDecoder_LinuxSLL2_DecodesIPv4(t *testing.T) {
 		byteCount:   &byt,
 		onPacket:    func(s PacketSummary) { got = append(got, s) },
 	}
-	if err := d.Run(context.Background(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
+	if err := d.Run(t.Context(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -378,7 +377,7 @@ func TestPacketDecoder_LinuxSLL2_BigEndianMagic(t *testing.T) {
 		byteCount:   &byt,
 		onPacket:    func(s PacketSummary) { got = append(got, s) },
 	}
-	if err := d.Run(context.Background(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
+	if err := d.Run(t.Context(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("Run: %v", err)
 	}
 	if len(got) != 1 {
@@ -422,7 +421,7 @@ func TestPacketDecoder_Run_NilCountersDoNotPanic(t *testing.T) {
 		byteCount:   nil,
 		onPacket:    func(PacketSummary) {},
 	}
-	if err := d.Run(context.Background(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
+	if err := d.Run(t.Context(), &pcapBuf); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("Run: %v", err)
 	}
 }

--- a/internal/k8s/portforward_extra_test.go
+++ b/internal/k8s/portforward_extra_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPortForwardManagerEntries_WithEntries(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	mgr.mu.Lock()
@@ -58,7 +58,7 @@ func TestPortForwardManagerEntries_WithEntries(t *testing.T) {
 
 func TestPortForwardManagerActiveCount_MixedStatuses(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	mgr.mu.Lock()
@@ -76,7 +76,7 @@ func TestPortForwardManagerActiveCount_MixedStatuses(t *testing.T) {
 
 func TestPortForwardManagerActiveCount_AllStopped(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	mgr.mu.Lock()
@@ -93,7 +93,7 @@ func TestPortForwardManagerActiveCount_AllStopped(t *testing.T) {
 
 func TestPortForwardManagerStop_RunningEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	callbackCalled := false
 	mgr.SetUpdateCallback(func() {
@@ -120,7 +120,7 @@ func TestPortForwardManagerStop_RunningEntry(t *testing.T) {
 
 func TestPortForwardManagerStop_StartingEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -139,7 +139,7 @@ func TestPortForwardManagerStop_StartingEntry(t *testing.T) {
 
 func TestPortForwardManagerStop_AlreadyStopped(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -158,7 +158,7 @@ func TestPortForwardManagerStop_AlreadyStopped(t *testing.T) {
 
 func TestPortForwardManagerStop_FailedEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -184,7 +184,7 @@ func TestPortForwardManagerStop_NotFound(t *testing.T) {
 
 func TestPortForwardManagerStop_NoCallback(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	// No callback set.
 	mgr.mu.Lock()
@@ -201,7 +201,7 @@ func TestPortForwardManagerStop_NoCallback(t *testing.T) {
 
 func TestPortForwardManagerRemove_StoppedEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	callbackCalled := false
 	mgr.SetUpdateCallback(func() {
@@ -223,7 +223,7 @@ func TestPortForwardManagerRemove_StoppedEntry(t *testing.T) {
 
 func TestPortForwardManagerRemove_RunningEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -238,7 +238,7 @@ func TestPortForwardManagerRemove_RunningEntry(t *testing.T) {
 
 func TestPortForwardManagerRemove_StartingEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -252,7 +252,7 @@ func TestPortForwardManagerRemove_StartingEntry(t *testing.T) {
 
 func TestPortForwardManagerRemove_NoCallback(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -268,7 +268,7 @@ func TestPortForwardManagerRemove_NoCallback(t *testing.T) {
 
 func TestPortForwardManagerGetEntry_Found(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -310,7 +310,7 @@ func TestPortForwardManagerGetEntry_NotFound(t *testing.T) {
 
 func TestPortForwardManagerGetEntry_ReturnsCopy(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -329,9 +329,9 @@ func TestPortForwardManagerGetEntry_ReturnsCopy(t *testing.T) {
 
 func TestPortForwardManagerStopAll_MixedStatuses(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel1 := context.WithCancel(context.Background())
-	_, cancel2 := context.WithCancel(context.Background())
-	_, cancel3 := context.WithCancel(context.Background())
+	_, cancel1 := context.WithCancel(t.Context())
+	_, cancel2 := context.WithCancel(t.Context())
+	_, cancel3 := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -352,8 +352,8 @@ func TestPortForwardManagerStopAll_MixedStatuses(t *testing.T) {
 
 func TestPortForwardManagerStopAll_AllRunning(t *testing.T) {
 	mgr := NewPortForwardManager()
-	_, cancel1 := context.WithCancel(context.Background())
-	_, cancel2 := context.WithCancel(context.Background())
+	_, cancel1 := context.WithCancel(t.Context())
+	_, cancel2 := context.WithCancel(t.Context())
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{

--- a/internal/k8s/security_affected_ignore_test.go
+++ b/internal/k8s/security_affected_ignore_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +39,7 @@ func TestGetSecurityAffectedResources_HidesIgnoredWhenToggleOff(t *testing.T) {
 	c.SetIgnoreChecker(stubIgnoreChecker{resources: map[string]bool{"ns/Pod/api": true}})
 	c.SetShowIgnored(false)
 
-	items, err := c.GetSecurityAffectedResources(context.Background(), "kctx", "",
+	items, err := c.GetSecurityAffectedResources(t.Context(), "kctx", "",
 		model.ResourceTypeEntry{Kind: "__security_heuristic__"}, "privileged")
 	require.NoError(t, err)
 	require.Len(t, items, 1, "the ignored resource must be filtered out")
@@ -55,7 +54,7 @@ func TestGetSecurityAffectedResources_TagsIgnoredWhenToggleOn(t *testing.T) {
 	c.SetIgnoreChecker(stubIgnoreChecker{resources: map[string]bool{"ns/Pod/api": true}})
 	c.SetShowIgnored(true)
 
-	items, err := c.GetSecurityAffectedResources(context.Background(), "kctx", "",
+	items, err := c.GetSecurityAffectedResources(t.Context(), "kctx", "",
 		model.ResourceTypeEntry{Kind: "__security_heuristic__"}, "privileged")
 	require.NoError(t, err)
 	require.Len(t, items, 2, "both resources shown in show-ignored mode")

--- a/internal/k8s/security_cached_test.go
+++ b/internal/k8s/security_cached_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -48,7 +47,7 @@ func TestGetSecurityFindingsCached_ColdThenWarm(t *testing.T) {
 	assert.Equal(t, int32(0), src.FetchCalls.Load(), "cached getter must never trigger a scan")
 
 	// Warm the shared scan.
-	_, err = mgr.FetchAll(context.Background(), "kctx", "")
+	_, err = mgr.FetchAll(t.Context(), "kctx", "")
 	require.NoError(t, err)
 	require.Equal(t, int32(1), src.FetchCalls.Load())
 
@@ -70,7 +69,7 @@ func TestGetSecurityAffectedResourcesCached_ColdThenWarm(t *testing.T) {
 	assert.False(t, ok, "cold cache reports not-cached")
 	assert.Equal(t, int32(0), src.FetchCalls.Load())
 
-	_, err = mgr.FetchAll(context.Background(), "kctx", "")
+	_, err = mgr.FetchAll(t.Context(), "kctx", "")
 	require.NoError(t, err)
 
 	items, ok, err := c.GetSecurityAffectedResourcesCached("kctx", "", rt, "privileged")

--- a/internal/k8s/security_resource_test.go
+++ b/internal/k8s/security_resource_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -64,7 +63,7 @@ func webRefs() []security.ResourceRef {
 func TestGetSecurityFindingsForResource_FiltersByRefsAcrossSources(t *testing.T) {
 	c, _ := resourceFindingsClient()
 
-	items, err := c.GetSecurityFindingsForResource(context.Background(), "kctx", "", webRefs())
+	items, err := c.GetSecurityFindingsForResource(t.Context(), "kctx", "", webRefs())
 	require.NoError(t, err)
 	require.Len(t, items, 2, "only groups touching pod/web or deploy/web-deploy survive")
 
@@ -87,7 +86,7 @@ func TestGetSecurityFindingsForResource_FiltersByRefsAcrossSources(t *testing.T)
 func TestGetSecurityFindingsForResource_NoMatchingRefs(t *testing.T) {
 	c, _ := resourceFindingsClient()
 
-	items, err := c.GetSecurityFindingsForResource(context.Background(), "kctx", "",
+	items, err := c.GetSecurityFindingsForResource(t.Context(), "kctx", "",
 		[]security.ResourceRef{{Namespace: "ns", Kind: "Pod", Name: "absent"}})
 	require.NoError(t, err)
 	assert.Empty(t, items)
@@ -97,14 +96,14 @@ func TestGetSecurityFindingsForResource_AppliesIgnorePolicy(t *testing.T) {
 	c, _ := resourceFindingsClient()
 	c.SetIgnoreChecker(stubIgnoreChecker{groups: map[string]bool{"privileged": true}})
 
-	items, err := c.GetSecurityFindingsForResource(context.Background(), "kctx", "", webRefs())
+	items, err := c.GetSecurityFindingsForResource(t.Context(), "kctx", "", webRefs())
 	require.NoError(t, err)
 	require.Len(t, items, 1, "ignored group is hidden")
 	assert.Equal(t, "CVE-2024-1", items[0].Name)
 
 	// Show-ignored mode reveals the group tagged __ignored__.
 	c.SetShowIgnored(true)
-	items, err = c.GetSecurityFindingsForResource(context.Background(), "kctx", "", webRefs())
+	items, err = c.GetSecurityFindingsForResource(t.Context(), "kctx", "", webRefs())
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 	assert.Equal(t, "true", items[1].ColumnValue("__ignored__"))
@@ -120,7 +119,7 @@ func TestGetSecurityFindingsForResourceCached_ColdThenWarm(t *testing.T) {
 	assert.Nil(t, items)
 
 	// Warm the shared scan, then the cached getter serves synchronously.
-	_, err = mgr.FetchAll(context.Background(), "kctx", "")
+	_, err = mgr.FetchAll(t.Context(), "kctx", "")
 	require.NoError(t, err)
 	items, ok, err = c.GetSecurityFindingsForResourceCached("kctx", "", webRefs())
 	require.NoError(t, err)
@@ -130,7 +129,7 @@ func TestGetSecurityFindingsForResourceCached_ColdThenWarm(t *testing.T) {
 
 func TestGetSecurityFindingsForResource_NilManager(t *testing.T) {
 	c := &Client{}
-	items, err := c.GetSecurityFindingsForResource(context.Background(), "kctx", "", webRefs())
+	items, err := c.GetSecurityFindingsForResource(t.Context(), "kctx", "", webRefs())
 	require.NoError(t, err)
 	assert.Nil(t, items)
 

--- a/internal/k8s/security_test.go
+++ b/internal/k8s/security_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -85,7 +84,7 @@ func TestSourceNameFromKind(t *testing.T) {
 func TestGetSecurityFindingsNilManager(t *testing.T) {
 	c := &Client{}
 	items, err := c.getSecurityFindings(
-		context.Background(),
+		t.Context(),
 		"kctx", "",
 		model.ResourceTypeEntry{Kind: "__security_trivy-operator__"},
 	)
@@ -98,7 +97,7 @@ func TestGetSecurityFindingsUnknownKind(t *testing.T) {
 	c := &Client{}
 	c.SetSecurityManager(mgr)
 	_, err := c.getSecurityFindings(
-		context.Background(),
+		t.Context(),
 		"kctx", "",
 		model.ResourceTypeEntry{Kind: "not-a-security-kind"},
 	)
@@ -138,7 +137,7 @@ func TestGetSecurityFindingsFiltersBySource(t *testing.T) {
 	c.SetSecurityManager(mgr)
 
 	items, err := c.getSecurityFindings(
-		context.Background(),
+		t.Context(),
 		"kctx", "",
 		model.ResourceTypeEntry{Kind: "__security_trivy-operator__"},
 	)
@@ -176,7 +175,7 @@ func TestGetSecurityFindingsSortsBySeverity(t *testing.T) {
 	c.SetSecurityManager(mgr)
 
 	items, err := c.getSecurityFindings(
-		context.Background(),
+		t.Context(),
 		"other-context", "",
 		model.ResourceTypeEntry{Kind: "__security_trivy-operator__"},
 	)
@@ -213,7 +212,7 @@ func TestGetResourcesDispatchesSecurityAPIGroup(t *testing.T) {
 		APIGroup: model.SecurityVirtualAPIGroup,
 		Resource: "findings-trivy-operator",
 	}
-	items, err := c.GetResources(context.Background(), "kctx", "", rt)
+	items, err := c.GetResources(t.Context(), "kctx", "", rt)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	assert.Equal(t, "__security_finding_group__", items[0].Kind)
@@ -247,7 +246,7 @@ func TestGetSecurityAffectedResources(t *testing.T) {
 	rt := model.ResourceTypeEntry{Kind: "__security_heuristic__"}
 
 	items, err := c.GetSecurityAffectedResources(
-		context.Background(), "kctx", "", rt, "privileged",
+		t.Context(), "kctx", "", rt, "privileged",
 	)
 	require.NoError(t, err)
 	require.Len(t, items, 2)
@@ -277,7 +276,7 @@ func TestGetSecurityAffectedResourcesPropagatesSourceError(t *testing.T) {
 	rt := model.ResourceTypeEntry{Kind: "__security_heuristic__"}
 
 	items, err := c.GetSecurityAffectedResources(
-		context.Background(), "kctx", "", rt, "privileged",
+		t.Context(), "kctx", "", rt, "privileged",
 	)
 	require.Error(t, err)
 	assert.Nil(t, items)

--- a/internal/k8s/whocan_test.go
+++ b/internal/k8s/whocan_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"sort"
 	"strings"
 	"testing"
@@ -50,7 +49,7 @@ func TestWhoCan_ClusterRoleBindingMatch(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "get")
 	require.NoError(t, err)
 
 	got := sortSubjects(out)
@@ -81,7 +80,7 @@ func TestWhoCan_RoleBindingToClusterRoleMatch(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, rb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "delete")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "delete")
 	require.NoError(t, err)
 
 	got := sortSubjects(out)
@@ -108,7 +107,7 @@ func TestWhoCan_RoleBindingToRoleMatch(t *testing.T) {
 	cs := k8sfake.NewClientset(r, rb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods/log", "get")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods/log", "get")
 	require.NoError(t, err)
 	got := sortSubjects(out)
 	assert.Contains(t, strings.Join(got, "\n"), "User/operator@",
@@ -132,7 +131,7 @@ func TestWhoCan_VerbWildcard(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 	for _, v := range []string{"get", "delete", "patch", "create"} {
-		out, err := c.WhoCan(context.Background(), "", "", "", "pods", v)
+		out, err := c.WhoCan(t.Context(), "", "", "", "pods", v)
 		require.NoError(t, err, "verb %s", v)
 		assert.NotEmpty(t, out, "verb=%q with rule.Verbs=[*] must match", v)
 	}
@@ -153,7 +152,7 @@ func TestWhoCan_ResourceWildcard(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 	for _, r := range []string{"pods", "secrets", "configmaps"} {
-		out, err := c.WhoCan(context.Background(), "", "", "", r, "get")
+		out, err := c.WhoCan(t.Context(), "", "", "", r, "get")
 		require.NoError(t, err)
 		assert.NotEmpty(t, out, "resource=%q with rule.Resources=[*] must match", r)
 	}
@@ -174,7 +173,7 @@ func TestWhoCan_GroupWildcard(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "apps", "deployments", "get")
+	out, err := c.WhoCan(t.Context(), "", "", "apps", "deployments", "get")
 	require.NoError(t, err)
 	assert.NotEmpty(t, out, "group=apps with rule.APIGroups=[*] must match")
 }
@@ -208,7 +207,7 @@ func TestWhoCan_NamespaceScopeFiltersRoleBindingsButNotClusterBindings(t *testin
 	cs := k8sfake.NewClientset(cr, rbA, rbB, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "team-a", "", "pods", "list")
+	out, err := c.WhoCan(t.Context(), "", "team-a", "", "pods", "list")
 	require.NoError(t, err)
 	got := sortSubjects(out)
 	joined := strings.Join(got, "\n")
@@ -238,7 +237,7 @@ func TestWhoCan_AllNamespacesIncludesEveryRoleBinding(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, rbA, rbB)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "list")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "list")
 	require.NoError(t, err)
 	joined := strings.Join(sortSubjects(out), "\n")
 	assert.Contains(t, joined, "User/alice@", "all-namespaces (ns=\"\") includes team-a's RB")
@@ -251,7 +250,7 @@ func TestWhoCan_NoMatchReturnsEmpty(t *testing.T) {
 	cs := k8sfake.NewClientset()
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "delete")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "delete")
 	require.NoError(t, err)
 	assert.Empty(t, out, "empty cluster (no roles, no bindings) → no subjects")
 }
@@ -269,7 +268,7 @@ func TestWhoCan_BindingWithoutMatchingRuleIsSkipped(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "get")
 	require.NoError(t, err)
 	assert.Empty(t, out, "binding's rules don't grant pods/get → skip subject")
 }
@@ -294,7 +293,7 @@ func TestWhoCan_NonResourceURLRulesIgnored(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "get")
 	require.NoError(t, err)
 	assert.Empty(t, out, "nonResourceURLs rules don't grant resource permissions")
 }
@@ -322,7 +321,7 @@ func TestWhoCan_QueryVerbWildcardMatchesAnyVerbRule(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "*")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "*")
 	require.NoError(t, err)
 	assert.Len(t, out, 1, "alice has list/watch on pods → must appear under verb=*")
 	assert.Equal(t, "alice", out[0].Name)
@@ -355,7 +354,7 @@ func TestWhoCan_ResourceNamesRulesAreSkipped(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "get")
 	require.NoError(t, err)
 	assert.Empty(t, out, "ResourceNames-scoped rules must not be reported as generic pod access")
 }
@@ -390,7 +389,7 @@ func TestWhoCan_ResultsSortedByName(t *testing.T) {
 	cs := k8sfake.NewClientset(cr, crb)
 	c := newFakeClient(cs, nil)
 
-	out, err := c.WhoCan(context.Background(), "", "", "", "pods", "get")
+	out, err := c.WhoCan(t.Context(), "", "", "", "pods", "get")
 	require.NoError(t, err)
 
 	names := make([]string, len(out))

--- a/internal/profiling/memstats_test.go
+++ b/internal/profiling/memstats_test.go
@@ -57,7 +57,7 @@ func TestLogFields_KeysValuesAndOrder(t *testing.T) {
 }
 
 func TestStartMemStatsLogger_EmitsBaselineThenStops(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	var mu sync.Mutex
 	var count int

--- a/internal/security/advisor/advisor_test.go
+++ b/internal/security/advisor/advisor_test.go
@@ -1,7 +1,6 @@
 package advisor
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,16 +98,16 @@ func TestSourceMetadata(t *testing.T) {
 	s := NewWithClient(fake.NewSimpleClientset())
 	assert.Equal(t, "advisor", s.Name())
 	assert.Equal(t, []security.Category{security.CategoryReliability}, s.Categories())
-	ok, err := s.IsAvailable(context.Background(), "")
+	ok, err := s.IsAvailable(t.Context(), "")
 	require.NoError(t, err)
 	assert.True(t, ok)
 
 	none := New()
-	ok, err = none.IsAvailable(context.Background(), "")
+	ok, err = none.IsAvailable(t.Context(), "")
 	require.NoError(t, err)
 	assert.False(t, ok)
 
-	findings, err := none.Fetch(context.Background(), "", "")
+	findings, err := none.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }
@@ -122,7 +121,7 @@ func TestFetchNamespaceChecks(t *testing.T) {
 		&corev1.LimitRange{ObjectMeta: metav1.ObjectMeta{Namespace: "guarded", Name: "lr"}},
 	)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	got := checksFor(t, findings)
 
@@ -145,7 +144,7 @@ func TestFetchWorkloadChecks(t *testing.T) {
 		deployment("kube-system", "coredns", 1, nil, corev1.Container{Name: "c"}),
 	)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	got := checksFor(t, findings)
 
@@ -163,7 +162,7 @@ func TestFetchProbeAndRequestChecks(t *testing.T) {
 		deployment("prod", "lax", 1, nil, bare, hardened("good")),
 	)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 
 	var probeSummary, reqSummary string
@@ -193,7 +192,7 @@ func TestFetchPDBBlocksDrain(t *testing.T) {
 		pdb("healthy", web, new(intstr.FromInt32(1)), nil),
 	)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	got := checksFor(t, findings)
 
@@ -233,7 +232,7 @@ func TestFetchHPAChecks(t *testing.T) {
 		hpa("hpa-withreq", "withreq"),
 	)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	got := checksFor(t, findings)
 
@@ -264,7 +263,7 @@ func TestFetchBestEffortRBAC(t *testing.T) {
 	forbid("horizontalpodautoscalers")
 
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	got := checksFor(t, findings)
 
@@ -285,7 +284,7 @@ func TestFetchNilReplicasDefaultsToOne(t *testing.T) {
 	dep.Spec.Replicas = nil
 	client := fake.NewSimpleClientset(dep)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	got := checksFor(t, findings)
 	assert.True(t, got["prod/Deployment/implicit"]["single_replica"])
@@ -297,7 +296,7 @@ func TestFetchNamespaceFilter(t *testing.T) {
 		deployment("staging", "b", 1, nil, hardened("c")),
 	)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "prod")
+	findings, err := s.Fetch(t.Context(), "", "prod")
 	require.NoError(t, err)
 	for _, f := range findings {
 		assert.Equal(t, "prod", f.Resource.Namespace)

--- a/internal/security/advisor/checks_scaling_test.go
+++ b/internal/security/advisor/checks_scaling_test.go
@@ -1,7 +1,6 @@
 package advisor
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,7 +155,7 @@ func TestPDBVsHPAMinNoDuplicateFindings(t *testing.T) {
 		hpaScaled("prod", "hpa-a", "a", 1, 10, 5),
 		hpaScaled("prod", "hpa-b", "b", 1, 10, 5),
 	))
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	count := 0
 	for _, f := range findings {

--- a/internal/security/advisor/checks_tier1_test.go
+++ b/internal/security/advisor/checks_tier1_test.go
@@ -1,7 +1,6 @@
 package advisor
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +39,7 @@ func daemonSet(ns, name string, labels map[string]string, containers ...corev1.C
 func fetchChecks(t *testing.T, objs ...runtime.Object) map[string]map[string]bool {
 	t.Helper()
 	s := NewWithClient(fake.NewSimpleClientset(objs...))
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	return checksFor(t, findings)
 }
@@ -118,7 +117,7 @@ func TestEmptyDirNoSizeLimit(t *testing.T) {
 	}
 
 	s := NewWithClient(fake.NewSimpleClientset(unbounded, bounded))
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	got := checksFor(t, findings)
 	assert.True(t, got["prod/Deployment/unbounded"]["emptydir_no_sizelimit"])
@@ -223,7 +222,7 @@ func TestOrphanPDBRequiresWorkloadLists(t *testing.T) {
 	)
 	forbidList(client, "deployments")
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	// Assert on the raw findings, not a map lookup that is vacuously false
 	// for a mistyped key.

--- a/internal/security/falco/falco_test.go
+++ b/internal/security/falco/falco_test.go
@@ -1,7 +1,6 @@
 package falco
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,13 +23,13 @@ func TestSourceCategories(t *testing.T) {
 }
 
 func TestIsAvailableNilClient(t *testing.T) {
-	ok, err := New().IsAvailable(context.Background(), "ctx")
+	ok, err := New().IsAvailable(t.Context(), "ctx")
 	assert.False(t, ok)
 	assert.NoError(t, err)
 }
 
 func TestFetchNilClient(t *testing.T) {
-	findings, err := New().Fetch(context.Background(), "ctx", "")
+	findings, err := New().Fetch(t.Context(), "ctx", "")
 	assert.Nil(t, findings)
 	assert.NoError(t, err)
 }
@@ -210,11 +209,11 @@ func TestFetchWithFakeClient(t *testing.T) {
 	s := NewWithClient(client)
 
 	// IsAvailable: checks for pods with the falco label.
-	ok, err := s.IsAvailable(context.Background(), "ctx")
+	ok, err := s.IsAvailable(t.Context(), "ctx")
 	require.NoError(t, err)
 	assert.True(t, ok)
 
-	findings, err := s.Fetch(context.Background(), "ctx", "prod")
+	findings, err := s.Fetch(t.Context(), "ctx", "prod")
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(findings), 1)
 	assert.Equal(t, "Unexpected Outbound Connection", findings[0].Title)

--- a/internal/security/gatekeeper/gatekeeper_test.go
+++ b/internal/security/gatekeeper/gatekeeper_test.go
@@ -1,7 +1,6 @@
 package gatekeeper
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,7 +125,7 @@ func TestIsAvailableFallsBackToV1beta1(t *testing.T) {
 		})
 
 	s := NewWithClients(nil, dc)
-	ok, err := s.IsAvailable(context.Background(), "ctx")
+	ok, err := s.IsAvailable(t.Context(), "ctx")
 	require.NoError(t, err)
 	assert.True(t, ok, "v1 NotFound must fall back to v1beta1")
 }
@@ -142,7 +141,7 @@ func TestIsAvailableBothVersionsNotFound(t *testing.T) {
 		})
 
 	s := NewWithClients(nil, dc)
-	ok, err := s.IsAvailable(context.Background(), "ctx")
+	ok, err := s.IsAvailable(t.Context(), "ctx")
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
@@ -160,7 +159,7 @@ func TestDiscoverConstraintKindsNotFoundReturnsEmpty(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	clientset.Resources = []*metav1.APIResourceList{}
 
-	kinds, err := discoverConstraintKinds(context.Background(), clientset)
+	kinds, err := discoverConstraintKinds(t.Context(), clientset)
 	require.NoError(t, err, "NotFound must NOT propagate as an error")
 	assert.Empty(t, kinds)
 }

--- a/internal/security/heuristic/checks_configmap_test.go
+++ b/internal/security/heuristic/checks_configmap_test.go
@@ -1,7 +1,6 @@
 package heuristic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +47,7 @@ func TestConfigMapSecretKeysNeverLeaksValues(t *testing.T) {
 	s := NewWithClient(fake.NewSimpleClientset(
 		configMap("prod", "leaky", map[string]string{"DB_PASSWORD": "sup3r-s3cret-value"}),
 	))
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Contains(t, findings[0].Summary, "DB_PASSWORD")
@@ -65,7 +64,7 @@ func TestConfigMapSecretKeysHonorsPatterns(t *testing.T) {
 	})
 	s := NewWithClient(fake.NewSimpleClientset(cm))
 	s.SetSecretEnvPatterns([]string{"*_CONN_STR"}, []string{"LEGACY_*"})
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Contains(t, findings[0].Summary, "MY_CONN_STR")
@@ -77,7 +76,7 @@ func TestConfigMapListBestEffort(t *testing.T) {
 		configMap("prod", "leaky", map[string]string{"DB_PASSWORD": "x"}),
 	)
 	forbidList(client, "configmaps")
-	findings, err := NewWithClient(client).Fetch(context.Background(), "", "")
+	findings, err := NewWithClient(client).Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }

--- a/internal/security/heuristic/checks_namespace_test.go
+++ b/internal/security/heuristic/checks_namespace_test.go
@@ -1,7 +1,6 @@
 package heuristic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,7 @@ func netpol(ns, name string) *networkingv1.NetworkPolicy {
 
 func checksByResource(t *testing.T, s *Source) map[string]map[string]bool {
 	t.Helper()
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	out := map[string]map[string]bool{}
 	for _, f := range findings {
@@ -93,7 +92,7 @@ func TestNamespaceChecksBestEffort(t *testing.T) {
 	forbidList(client, "namespaces")
 	forbidList(client, "networkpolicies")
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	for _, f := range findings {
 		assert.NotEqual(t, "psa_labels_missing", f.Labels["check"])
@@ -103,7 +102,7 @@ func TestNamespaceChecksBestEffort(t *testing.T) {
 
 func TestNamespaceFindingCategory(t *testing.T) {
 	s := NewWithClient(fake.NewSimpleClientset(namespaceObj("prod", nil)))
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	require.NotEmpty(t, findings)
 	for _, f := range findings {

--- a/internal/security/heuristic/checks_refs_test.go
+++ b/internal/security/heuristic/checks_refs_test.go
@@ -1,7 +1,6 @@
 package heuristic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +27,7 @@ func refPod(ns, name string, spec corev1.PodSpec) *corev1.Pod {
 
 func missingRefFindings(t *testing.T, s *Source) map[string]security.Finding {
 	t.Helper()
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	out := map[string]security.Finding{}
 	for _, f := range findings {

--- a/internal/security/heuristic/checks_secret_test.go
+++ b/internal/security/heuristic/checks_secret_test.go
@@ -1,7 +1,6 @@
 package heuristic
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -75,7 +74,7 @@ func TestSecretChecks(t *testing.T) {
 
 	s := scanningSource(expired, expiring, healthy, garbage, legacy, opaque, ignored)
 	s.SetIgnoredNamespaces([]string{"ignored-ns"})
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 
 	bySecret := map[string]security.Finding{}
@@ -109,7 +108,7 @@ func TestSecretChecksDisabledByDefault(t *testing.T) {
 		listed = true
 		return false, nil, nil
 	})
-	findings, err := NewWithClient(client).Fetch(context.Background(), "", "")
+	findings, err := NewWithClient(client).Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	for _, f := range findings {
 		assert.NotEqual(t, "Secret", f.Resource.Kind)
@@ -138,7 +137,7 @@ func TestSecretListBestEffort(t *testing.T) {
 	forbidList(client, "secrets")
 	s := NewWithClient(client)
 	s.SetScanSecrets(true)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	var privileged bool
 	for _, f := range findings {
@@ -157,7 +156,7 @@ func TestSecretSummariesNeverLeakData(t *testing.T) {
 		Data:       map[string][]byte{"token": []byte("super-secret-token-bytes")},
 	}
 	s := scanningSource(legacy)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	require.NotEmpty(t, findings)
 	for _, f := range findings {

--- a/internal/security/heuristic/checks_service_test.go
+++ b/internal/security/heuristic/checks_service_test.go
@@ -1,7 +1,6 @@
 package heuristic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +31,7 @@ func TestSourceFetchServiceExternalIPs(t *testing.T) {
 	)
 	s := NewWithClient(client)
 	s.SetIgnoredNamespaces([]string{"ignored-ns"})
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 
 	byName := map[string]security.Finding{}
@@ -66,7 +65,7 @@ func TestSourceFetchServiceListBestEffort(t *testing.T) {
 	})
 
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	var privileged bool
 	for _, f := range findings {

--- a/internal/security/heuristic/fetch_test.go
+++ b/internal/security/heuristic/fetch_test.go
@@ -1,7 +1,6 @@
 package heuristic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +50,7 @@ func TestSourceFetch(t *testing.T) {
 	)
 
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 
 	badCount := 0
@@ -92,7 +91,7 @@ func TestSourceFetchNamespaceFilter(t *testing.T) {
 	)
 
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "prod")
+	findings, err := s.Fetch(t.Context(), "", "prod")
 	require.NoError(t, err)
 	for _, f := range findings {
 		assert.Equal(t, "prod", f.Resource.Namespace)
@@ -116,7 +115,7 @@ func TestSourceFetchSecretEnvPatterns(t *testing.T) {
 		},
 	}
 	secretEnvNames := func(s *Source) []string {
-		findings, err := s.Fetch(context.Background(), "", "")
+		findings, err := s.Fetch(t.Context(), "", "")
 		require.NoError(t, err)
 		var sums []string
 		for _, f := range findings {
@@ -144,7 +143,7 @@ func TestSourceFetchSecretEnvPatterns(t *testing.T) {
 
 func TestSourceFetchNilClient(t *testing.T) {
 	s := New()
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }
@@ -173,7 +172,7 @@ func TestSourceFetchScansInitAndEphemeralContainers(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset(pod)
 	s := NewWithClient(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 
 	containers := map[string]bool{}

--- a/internal/security/heuristic/heuristic_test.go
+++ b/internal/security/heuristic/heuristic_test.go
@@ -1,7 +1,6 @@
 package heuristic
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,14 +23,14 @@ func TestSourceMetadata(t *testing.T) {
 	s := NewWithClient(fake.NewSimpleClientset())
 	assert.Equal(t, "heuristic", s.Name())
 	assert.Equal(t, []security.Category{security.CategoryMisconfig, security.CategoryReliability}, s.Categories())
-	ok, err := s.IsAvailable(context.Background(), "")
+	ok, err := s.IsAvailable(t.Context(), "")
 	assert.NoError(t, err)
 	assert.True(t, ok, "heuristic source with a client is always available")
 }
 
 func TestSourceUnavailableWithoutClient(t *testing.T) {
 	s := New()
-	ok, err := s.IsAvailable(context.Background(), "")
+	ok, err := s.IsAvailable(t.Context(), "")
 	assert.NoError(t, err)
 	assert.False(t, ok, "heuristic with nil client reports unavailable")
 }

--- a/internal/security/manager_cached_test.go
+++ b/internal/security/manager_cached_test.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -21,7 +20,7 @@ func TestCachedFindings(t *testing.T) {
 	assert.False(t, ok, "cold cache before any fetch")
 	assert.Equal(t, int32(0), src.FetchCalls.Load(), "peek must not scan")
 
-	_, err := mgr.FetchAll(context.Background(), "kctx", "")
+	_, err := mgr.FetchAll(t.Context(), "kctx", "")
 	require.NoError(t, err)
 	require.Equal(t, int32(1), src.FetchCalls.Load())
 

--- a/internal/security/manager_test.go
+++ b/internal/security/manager_test.go
@@ -32,7 +32,7 @@ func TestManagerFetchAllCoalescesConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	for range n {
 		wg.Go(func() {
-			_, _ = m.FetchAll(context.Background(), "ctx", "")
+			_, _ = m.FetchAll(t.Context(), "ctx", "")
 		})
 	}
 	wg.Wait()
@@ -54,7 +54,7 @@ func TestManagerRegisterAndFetchAll(t *testing.T) {
 	m.Register(s1)
 	m.Register(s2)
 
-	res, err := m.FetchAll(context.Background(), "ctx", "")
+	res, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	assert.Len(t, res.Findings, 2)
 	assert.Empty(t, res.Errors)
@@ -70,7 +70,7 @@ func TestManagerFetchAllParallel(t *testing.T) {
 	m.Register(s2)
 
 	start := time.Now()
-	_, err := m.FetchAll(context.Background(), "ctx", "")
+	_, err := m.FetchAll(t.Context(), "ctx", "")
 	elapsed := time.Since(start)
 
 	require.NoError(t, err)
@@ -93,12 +93,12 @@ func TestManagerFetchAllWaiterRespectsContext(t *testing.T) {
 	})
 
 	// Kick off a scan that will be in flight for ~800ms.
-	go func() { _, _ = m.FetchAll(context.Background(), "ctx", "") }()
+	go func() { _, _ = m.FetchAll(t.Context(), "ctx", "") }()
 	time.Sleep(50 * time.Millisecond) // let the flight start
 
 	// A second caller for the same key with a short deadline must return when
 	// its own context expires, not block until the in-flight scan completes.
-	cctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	cctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	start := time.Now()
 	_, err := m.FetchAll(cctx, "ctx", "")
@@ -119,7 +119,7 @@ func TestManagerFetchAllPartialFailure(t *testing.T) {
 	m.Register(good)
 	m.Register(bad)
 
-	res, err := m.FetchAll(context.Background(), "ctx", "")
+	res, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err, "partial failures must not return error")
 	assert.Len(t, res.Findings, 1)
 	assert.Contains(t, res.Errors, "bad")
@@ -139,7 +139,7 @@ func TestManagerSkipsUnavailableSources(t *testing.T) {
 	m.Register(avail)
 	m.Register(gone)
 
-	res, err := m.FetchAll(context.Background(), "ctx", "")
+	res, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	assert.Len(t, res.Findings, 1)
 	assert.Equal(t, "ok", res.Findings[0].ID)
@@ -151,7 +151,7 @@ func TestManagerAnyAvailable(t *testing.T) {
 	m := NewManager()
 	m.Register(&FakeSource{NameStr: "a", Available: false})
 	m.Register(&FakeSource{NameStr: "b", Available: true})
-	ok, err := m.AnyAvailable(context.Background(), "ctx")
+	ok, err := m.AnyAvailable(t.Context(), "ctx")
 	require.NoError(t, err)
 	assert.True(t, ok)
 }
@@ -159,7 +159,7 @@ func TestManagerAnyAvailable(t *testing.T) {
 func TestManagerCancellation(t *testing.T) {
 	m := NewManager()
 	m.Register(&FakeSource{NameStr: "slow", Available: true, FetchDelay: 500 * time.Millisecond})
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel before call
 
 	start := time.Now()
@@ -176,7 +176,7 @@ func TestManagerAnyAvailableSkipsSourcesWithErrors(t *testing.T) {
 	m.Register(&FakeSource{NameStr: "broken", Available: false, AvailableErr: errors.New("probe failed")})
 	m.Register(&FakeSource{NameStr: "healthy", Available: true})
 
-	ok, err := m.AnyAvailable(context.Background(), "ctx")
+	ok, err := m.AnyAvailable(t.Context(), "ctx")
 	require.NoError(t, err)
 	assert.True(t, ok, "AnyAvailable must skip erroring sources and return true when another is healthy")
 }
@@ -190,9 +190,9 @@ func TestManagerCachedFetch(t *testing.T) {
 	}
 	m.Register(s)
 
-	_, err := m.FetchAll(context.Background(), "ctx", "")
+	_, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
-	_, err = m.FetchAll(context.Background(), "ctx", "")
+	_, err = m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), s.FetchCalls.Load(),
 		"second call within TTL should hit cache")
@@ -207,8 +207,8 @@ func TestManagerForceRefresh(t *testing.T) {
 	}
 	m.Register(s)
 
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
-	_, _ = m.Refresh(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
+	_, _ = m.Refresh(t.Context(), "ctx", "")
 	assert.Equal(t, int32(2), s.FetchCalls.Load(),
 		"Refresh must bypass the cache")
 }
@@ -222,8 +222,8 @@ func TestManagerInvalidateOnContextChange(t *testing.T) {
 	}
 	m.Register(s)
 
-	_, _ = m.FetchAll(context.Background(), "ctxA", "")
-	_, _ = m.FetchAll(context.Background(), "ctxB", "")
+	_, _ = m.FetchAll(t.Context(), "ctxA", "")
+	_, _ = m.FetchAll(t.Context(), "ctxB", "")
 	assert.Equal(t, int32(2), s.FetchCalls.Load(),
 		"different kubeCtx should bypass cache")
 }
@@ -234,8 +234,8 @@ func TestManagerAvailabilityCached(t *testing.T) {
 	s := &FakeSource{NameStr: "s", Available: true}
 	m.Register(s)
 
-	_, _ = m.AnyAvailable(context.Background(), "ctx")
-	_, _ = m.AnyAvailable(context.Background(), "ctx")
+	_, _ = m.AnyAvailable(t.Context(), "ctx")
+	_, _ = m.AnyAvailable(t.Context(), "ctx")
 	assert.Equal(t, int32(1), s.AvailCalls.Load(),
 		"availability should be cached within TTL")
 }
@@ -258,7 +258,7 @@ func TestFindingIndexCountsAndLookup(t *testing.T) {
 	}}
 	m.Register(s)
 
-	_, err := m.FetchAll(context.Background(), "ctx", "")
+	_, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 
 	idx := m.Index()
@@ -400,15 +400,15 @@ func TestManagerInvalidateClearsCache(t *testing.T) {
 	}
 	m.Register(s)
 
-	_, err := m.FetchAll(context.Background(), "ctx", "")
+	_, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), s.FetchCalls.Load())
 
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	assert.Equal(t, int32(1), s.FetchCalls.Load())
 
 	m.Invalidate()
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	assert.Equal(t, int32(2), s.FetchCalls.Load())
 }
 
@@ -425,7 +425,7 @@ func TestManagerInvalidateClearsIndex(t *testing.T) {
 		Findings: []Finding{{ID: "1", Source: "s", Severity: SeverityCritical, Resource: ref}},
 	})
 
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	require.Equal(t, 1, m.Index().For(ref).Total(), "index populated after FetchAll")
 
 	m.Invalidate()
@@ -445,11 +445,11 @@ func TestManagerCachesSuccessfulEmptyResults(t *testing.T) {
 	s := &FakeSource{NameStr: "s", Available: true} // zero findings on purpose
 	m.Register(s)
 
-	_, err := m.FetchAll(context.Background(), "ctx", "")
+	_, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	require.Equal(t, int32(1), s.FetchCalls.Load(), "first call hits the source")
 
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	assert.Equal(t, int32(1), s.FetchCalls.Load(), "second call must hit the cache, not the source")
 }
 
@@ -467,17 +467,17 @@ func TestManagerNegativeCacheOnAllErroredFetch(t *testing.T) {
 	bad := &FakeSource{NameStr: "bad", Available: true, FetchErr: errors.New("boom")}
 	m.Register(bad)
 
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	require.Equal(t, int32(1), bad.FetchCalls.Load())
 
 	// Within the error TTL, the result is served from cache.
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	assert.Equal(t, int32(1), bad.FetchCalls.Load(),
 		"all-errored fetch within errorTTL must hit the negative cache")
 
 	// After the error TTL, the next call re-fires.
 	time.Sleep(60 * time.Millisecond)
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	assert.Equal(t, int32(2), bad.FetchCalls.Load(),
 		"after errorTTL elapses the source must be re-probed")
 }
@@ -505,7 +505,7 @@ func TestManagerSetAvailabilityHintSkipsIsAvailableProbe(t *testing.T) {
 		"kubescape": false, // hint says NOT available — skip Fetch entirely
 	})
 
-	res, err := m.FetchAll(context.Background(), "ctx", "")
+	res, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	assert.Len(t, res.Findings, 1, "only available source's findings show")
 	assert.Equal(t, int32(0), available.AvailCalls.Load(),
@@ -537,7 +537,7 @@ func TestManagerFetchAllRespectsConcurrencyCap(t *testing.T) {
 	}
 
 	start := time.Now()
-	res, err := m.FetchAll(context.Background(), "ctx", "")
+	res, err := m.FetchAll(t.Context(), "ctx", "")
 	elapsed := time.Since(start)
 	require.NoError(t, err)
 	assert.Len(t, res.Sources, sourceCount, "every source must produce a status")
@@ -567,7 +567,7 @@ func TestManagerFetchAllUnboundedConcurrency(t *testing.T) {
 	}
 
 	start := time.Now()
-	_, err := m.FetchAll(context.Background(), "ctx", "")
+	_, err := m.FetchAll(t.Context(), "ctx", "")
 	elapsed := time.Since(start)
 	require.NoError(t, err)
 	// Fully parallel: elapsed ≈ delay + scheduler overhead.
@@ -586,7 +586,7 @@ func TestManagerFetchAllFallsBackToProbeWhenNoHint(t *testing.T) {
 	}
 	m.Register(s)
 
-	_, err := m.FetchAll(context.Background(), "ctx", "")
+	_, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), s.AvailCalls.Load(),
 		"no hint → IsAvailable must run as before")
@@ -604,7 +604,7 @@ func TestManagerUnavailableSourceReportsAvailableFalse(t *testing.T) {
 	notInstalled := &FakeSource{NameStr: "trivy", Available: false}
 	m.Register(notInstalled)
 
-	res, err := m.FetchAll(context.Background(), "ctx", "")
+	res, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	require.Len(t, res.Sources, 1)
 	assert.False(t, res.Sources[0].Available,
@@ -622,11 +622,11 @@ func TestManagerErroringSourceUsesNegativeCache(t *testing.T) {
 	bad := &FakeSource{NameStr: "s", Available: true, FetchErr: errors.New("boom")}
 	m.Register(bad)
 
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	require.Equal(t, int32(1), bad.FetchCalls.Load())
 
 	time.Sleep(60 * time.Millisecond)
-	_, _ = m.FetchAll(context.Background(), "ctx", "")
+	_, _ = m.FetchAll(t.Context(), "ctx", "")
 	assert.Equal(t, int32(2), bad.FetchCalls.Load(),
 		"errored source must re-fire after errorTTL")
 }
@@ -648,12 +648,12 @@ func TestManagerIgnoredNamespacesFilterDoesNotAliasCachedSlice(t *testing.T) {
 	}
 	m.Register(s)
 
-	res, err := m.FetchAll(context.Background(), "ctx", "")
+	res, err := m.FetchAll(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	require.Len(t, res.Findings, 1)
 	// Mutating the returned slice must not corrupt the cached one.
 	res.Findings = append(res.Findings, Finding{ID: "tamper"})
-	cached, _ := m.FetchAll(context.Background(), "ctx", "")
+	cached, _ := m.FetchAll(t.Context(), "ctx", "")
 	require.Len(t, cached.Findings, 1, "cache must be insulated from caller mutation")
 	assert.NotEqual(t, "tamper", cached.Findings[0].ID)
 }

--- a/internal/security/pagination_test.go
+++ b/internal/security/pagination_test.go
@@ -68,7 +68,7 @@ func TestListPaginatedAccumulatesPages(t *testing.T) {
 	const total = 753 // not a multiple of page size on purpose
 	f := &fakeLister{totalItems: total}
 
-	out, err := ListPaginated(context.Background(), f)
+	out, err := ListPaginated(t.Context(), f)
 	require.NoError(t, err)
 	assert.Len(t, out.Items, total)
 	// 753 / 200 page size = 4 pages (200, 200, 200, 153). pager's first
@@ -85,7 +85,7 @@ func TestListPaginatedAccumulatesPages(t *testing.T) {
 // List shape callers expect.
 func TestListPaginatedEmpty(t *testing.T) {
 	f := &fakeLister{totalItems: 0}
-	out, err := ListPaginated(context.Background(), f)
+	out, err := ListPaginated(t.Context(), f)
 	require.NoError(t, err)
 	assert.Empty(t, out.Items)
 	assert.Equal(t, 1, f.calls)
@@ -95,7 +95,7 @@ func TestListPaginatedEmpty(t *testing.T) {
 // still return all items and stop (no follow-up call).
 func TestListPaginatedSinglePage(t *testing.T) {
 	f := &fakeLister{totalItems: 50}
-	out, err := ListPaginated(context.Background(), f)
+	out, err := ListPaginated(t.Context(), f)
 	require.NoError(t, err)
 	assert.Len(t, out.Items, 50)
 	assert.Equal(t, 1, f.calls)
@@ -110,7 +110,7 @@ func TestListPaginatedPropagatesError(t *testing.T) {
 	wantErr := errors.New("connection lost")
 	f := &fakeLister{totalItems: 1000, failOnPage: 2, listErr: wantErr}
 
-	_, err := ListPaginated(context.Background(), f)
+	_, err := ListPaginated(t.Context(), f)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, wantErr)
 }
@@ -121,7 +121,7 @@ func TestListPaginatedPropagatesError(t *testing.T) {
 // the walker stops requesting more pages.
 func TestListPaginatedRespectsCancellation(t *testing.T) {
 	f := &fakeLister{totalItems: 10_000}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // already cancelled
 
 	_, err := ListPaginated(ctx, f)

--- a/internal/security/policyreport/policyreport_test.go
+++ b/internal/security/policyreport/policyreport_test.go
@@ -1,7 +1,6 @@
 package policyreport
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,14 +27,14 @@ func TestSourceCategories(t *testing.T) {
 
 func TestIsAvailableNilClient(t *testing.T) {
 	s := New()
-	ok, err := s.IsAvailable(context.Background(), "ctx")
+	ok, err := s.IsAvailable(t.Context(), "ctx")
 	assert.False(t, ok)
 	assert.NoError(t, err)
 }
 
 func TestFetchNilClient(t *testing.T) {
 	s := New()
-	findings, err := s.Fetch(context.Background(), "ctx", "")
+	findings, err := s.Fetch(t.Context(), "ctx", "")
 	assert.Nil(t, findings)
 	assert.NoError(t, err)
 }
@@ -238,11 +237,11 @@ func TestFetchWithFakeClient(t *testing.T) {
 
 	s := NewWithDynamic(dc)
 
-	ok, err := s.IsAvailable(context.Background(), "ctx")
+	ok, err := s.IsAvailable(t.Context(), "ctx")
 	require.NoError(t, err)
 	assert.True(t, ok)
 
-	findings, err := s.Fetch(context.Background(), "ctx", "")
+	findings, err := s.Fetch(t.Context(), "ctx", "")
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	assert.Equal(t, "check-ro-rootfs", findings[0].Title)

--- a/internal/security/rbac/rbac_test.go
+++ b/internal/security/rbac/rbac_test.go
@@ -1,7 +1,6 @@
 package rbac
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,7 +48,7 @@ func rule(verbs, apiGroups, resources []string) rbacv1.PolicyRule {
 func fetchChecks(t *testing.T, objs ...runtime.Object) map[string]map[string]bool {
 	t.Helper()
 	s := NewWithClient(fake.NewSimpleClientset(objs...))
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	out := map[string]map[string]bool{}
 	for _, f := range findings {
@@ -68,11 +67,11 @@ func TestSourceMetadata(t *testing.T) {
 	s := NewWithClient(fake.NewSimpleClientset())
 	assert.Equal(t, "rbac", s.Name())
 	assert.Equal(t, []security.Category{security.CategoryMisconfig}, s.Categories())
-	ok, err := s.IsAvailable(context.Background(), "")
+	ok, err := s.IsAvailable(t.Context(), "")
 	require.NoError(t, err)
 	assert.True(t, ok)
 
-	findings, err := New().Fetch(context.Background(), "", "")
+	findings, err := New().Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Empty(t, findings, "nil client fetches nothing")
 }
@@ -204,7 +203,7 @@ func TestForbiddenListsSkipDependentChecks(t *testing.T) {
 		client.PrependReactor("list", "clusterroles", func(k8stesting.Action) (bool, runtime.Object, error) {
 			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "clusterroles"}, "", nil)
 		})
-		findings, err := NewWithClient(client).Fetch(context.Background(), "", "")
+		findings, err := NewWithClient(client).Fetch(t.Context(), "", "")
 		require.NoError(t, err)
 		var masters bool
 		for _, f := range findings {
@@ -219,7 +218,7 @@ func TestForbiddenListsSkipDependentChecks(t *testing.T) {
 		client.PrependReactor("list", "clusterrolebindings", func(k8stesting.Action) (bool, runtime.Object, error) {
 			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "clusterrolebindings"}, "", nil)
 		})
-		findings, err := NewWithClient(client).Fetch(context.Background(), "", "")
+		findings, err := NewWithClient(client).Fetch(t.Context(), "", "")
 		require.NoError(t, err)
 		for _, f := range findings {
 			assert.NotEqual(t, "rbac_secrets_cluster_wide", f.Labels["check"],

--- a/internal/security/trivyop/trivyop_test.go
+++ b/internal/security/trivyop/trivyop_test.go
@@ -1,7 +1,6 @@
 package trivyop
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,7 +34,7 @@ func TestSourceMetadata(t *testing.T) {
 
 func TestIsAvailableNilClient(t *testing.T) {
 	s := New()
-	ok, err := s.IsAvailable(context.Background(), "")
+	ok, err := s.IsAvailable(t.Context(), "")
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
@@ -43,7 +42,7 @@ func TestIsAvailableNilClient(t *testing.T) {
 func TestIsAvailableCRDReachable(t *testing.T) {
 	client := newFakeDyn()
 	s := NewWithDynamic(client)
-	ok, err := s.IsAvailable(context.Background(), "")
+	ok, err := s.IsAvailable(t.Context(), "")
 	require.NoError(t, err)
 	assert.True(t, ok, "empty list still means the CRD is served")
 }
@@ -205,7 +204,7 @@ func TestFetchAggregatesBothCRDs(t *testing.T) {
 
 	client := newFakeDyn(vuln, audit)
 	s := NewWithDynamic(client)
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Len(t, findings, 2)
 
@@ -248,7 +247,7 @@ func TestFetchNamespaceFilter(t *testing.T) {
 
 	client := newFakeDyn(make("prod", "a"), make("staging", "b"))
 	s := NewWithDynamic(client)
-	findings, err := s.Fetch(context.Background(), "", "prod")
+	findings, err := s.Fetch(t.Context(), "", "prod")
 	require.NoError(t, err)
 	assert.Len(t, findings, 1)
 	assert.Equal(t, "prod", findings[0].Resource.Namespace)
@@ -256,7 +255,7 @@ func TestFetchNamespaceFilter(t *testing.T) {
 
 func TestFetchNilClient(t *testing.T) {
 	s := New()
-	findings, err := s.Fetch(context.Background(), "", "")
+	findings, err := s.Fetch(t.Context(), "", "")
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }


### PR DESCRIPTION
## Summary

Enable the `usetesting` linter and adopt `t.Context()` over `context.Background()`/`context.TODO()` in test bodies (Go 1.24+). Generalizes a CodeRabbit nitpick from #429 into a repo-wide standard.

`t.Context()` is cancelled when the test completes — giving automatic cancellation, better timeout integration, and goroutine-leak detection. Enabling the linter also **prevents regressions** (new `context.Background()` in test functions is now flagged).

## Scope

- **Config**: `usetesting` added to `.golangci.yml` with `context-background: true` + `context-todo: true`.
- **Autofix**: mechanical conversion across **63 test files**. The linter is scope-aware — it only rewrites sites where a `*testing.T` is in scope, so helpers without a `t` keep `context.Background()` (the idiomatic split). No production code changed.

## Cancellation-semantics review

`t.Context()` cancels at test end, so I manually reviewed the tests that assert on cancellation:

- `discovery_cache_cancel_test.go` (`RespectsCancelledContext`, `BackgroundContextProcessesAll`) — safe: one drives an explicit `WithCancel`+`cancel()` (parent context is irrelevant), the other passes synchronously and returns before test-end cancellation.
- `cursor_test.go` `TestMoveCursorDoesNotCancelInFlightReqCtx` — safe: `reqCtx` is derived via `WithCancel`; the parent stays live during the test body.

No `//nolint` needed.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` — green, plus `-count=2` on changed packages, no flakes (the key check for premature-cancellation)
- [x] `golangci-lint run` — 0 issues
- [x] gofmt clean; only `*_test.go` + `.golangci.yml` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)