### PR TITLE
fix(namespace): restore selection when leaving all-namespaces mode

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -170,14 +170,14 @@ type Model struct {
 	// Text input for type-to-confirm overlay (e.g., Force Finalize).
 	confirmTypeInput TextInput
 
-	// Namespace selection state (all-namespaces mode + multi-select).
-	allNamespaces       bool
-	selectedNamespaces  map[string]bool
-	nsSelectionNegated  bool // when true, selectedNamespaces is an EXCLUDE set
-	nsFilterMode        bool
-	nsSelectionModified bool   // tracks if Space was pressed in current ns overlay session
-	nsFilterEntryItem   string // namespace name selected when filter mode was entered; restored on Esc
-	nsOverlayContext    string // context the open namespace overlay lists; used by the in-overlay refresh (R)
+	// Namespace selection state. saved* stash the selection during all-namespaces mode so toggling off restores it.
+	allNamespaces                               bool
+	selectedNamespaces, savedSelectedNamespaces map[string]bool
+	nsSelectionNegated, savedNsSelectionNegated bool // nsSelectionNegated: EXCLUDE set
+	nsFilterMode                                bool
+	nsSelectionModified                         bool   // tracks if Space was pressed in current ns overlay session
+	nsFilterEntryItem                           string // namespace name selected when filter mode was entered; restored on Esc
+	nsOverlayContext                            string // context the open namespace overlay lists; used by the in-overlay refresh (R)
 
 	// Fullscreen toggles: middle = hides left and right columns; dashboard
 	// = renders the cluster dashboard full screen.

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -441,13 +441,18 @@ type TabState struct {
 	allNamespaces      bool
 	selectedNamespaces map[string]bool
 	nsSelectionNegated bool
-	sortColumnName     string // column name to sort by (e.g. "Name", "Age", "CPU")
-	sortAscending      bool
-	sortMemory         map[string]sortPref
-	filterText         string
-	watchMode          bool
-	objectExplorerLive bool
-	objectExplorerTree bool
+	// Stashed namespace selection while all-namespaces mode is active, so
+	// toggling the mode off restores the prior multi-select instead of
+	// resetting to the default namespace.
+	savedSelectedNamespaces map[string]bool
+	savedNsSelectionNegated bool
+	sortColumnName          string // column name to sort by (e.g. "Name", "Age", "CPU")
+	sortAscending           bool
+	sortMemory              map[string]sortPref
+	filterText              string
+	watchMode               bool
+	objectExplorerLive      bool
+	objectExplorerTree      bool
 	// readOnly blocks all mutating actions for this tab. Re-evaluated on
 	// context switch from CLI flag, per-context config, and global config.
 	readOnly               bool

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -430,6 +430,8 @@ func (m *Model) saveCurrentTab() {
 	t.allNamespaces = m.allNamespaces
 	t.selectedNamespaces = copyMapStringBool(m.selectedNamespaces)
 	t.nsSelectionNegated = m.nsSelectionNegated
+	t.savedSelectedNamespaces = copyMapStringBool(m.savedSelectedNamespaces)
+	t.savedNsSelectionNegated = m.savedNsSelectionNegated
 	t.sortColumnName = m.sortColumnName
 	t.sortAscending = m.sortAscending
 	t.filterText = m.filterText
@@ -555,6 +557,8 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.allNamespaces = t.allNamespaces
 	m.selectedNamespaces = copyMapStringBool(t.selectedNamespaces)
 	m.nsSelectionNegated = t.nsSelectionNegated
+	m.savedSelectedNamespaces = copyMapStringBool(t.savedSelectedNamespaces)
+	m.savedNsSelectionNegated = t.savedNsSelectionNegated
 	m.sortColumnName = t.sortColumnName
 	m.sortAscending = t.sortAscending
 	m.filterText = t.filterText
@@ -707,58 +711,60 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 // cloneCurrentTab creates a deep copy of the current model state as a new TabState.
 func (m *Model) cloneCurrentTab() TabState {
 	newTab := TabState{
-		nav:                    m.nav,
-		leftItems:              append([]model.Item(nil), m.leftItems...),
-		middleItems:            append([]model.Item(nil), m.middleItems...),
-		rightItems:             append([]model.Item(nil), m.rightItems...),
-		cursors:                m.cursors,
-		middleScroll:           ui.ActiveMiddleScroll,
-		leftScroll:             ui.ActiveLeftScroll,
-		cursorMemory:           copyMapStringInt(m.cursorMemory),
-		filterMemory:           copyMapStringSavedFilter(m.filterMemory),
-		sortMemory:             copyMapStringSortPref(m.sortMemory),
-		itemCache:              copyItemCache(m.itemCache),
-		cacheFingerprints:      copyMapStringString(m.cacheFingerprints),
-		yamlContent:            m.yamlView.content,
-		yamlCollapsed:          copyMapStringBool(m.yamlView.collapsed),
-		splitPreview:           m.splitPreview,
-		fullYAMLPreview:        m.fullYAMLPreview,
-		fullLogPreview:         m.fullLogPreview,
-		previewYAML:            m.previewYAML,
-		namespace:              m.namespace,
-		allNamespaces:          m.allNamespaces,
-		selectedNamespaces:     copyMapStringBool(m.selectedNamespaces),
-		nsSelectionNegated:     m.nsSelectionNegated,
-		sortColumnName:         m.sortColumnName,
-		sortAscending:          m.sortAscending,
-		filterText:             m.filterText,
-		watchMode:              m.watchMode,
-		objectExplorerLive:     m.objectExplorerLive,
-		objectExplorerTree:     m.objectExplorerTree,
-		readOnly:               m.readOnly,
-		requestGen:             m.requestGen,
-		selectedItems:          copyMapStringBool(m.selectedItems),
-		selectionAnchor:        m.selectionAnchor,
-		fullscreenMiddle:       m.fullscreenMiddle,
-		fullscreenDashboard:    m.fullscreenDashboard,
-		dashboardPreview:       m.dashboardPreview,
-		dashboardEventsPreview: m.dashboardEventsPreview,
-		monitoringPreview:      m.monitoringPreview,
-		metricsContent:         m.metricsContent,
-		previewEventsContent:   m.previewEventsContent,
-		metricsData:            m.metricsData,
-		metricsLoading:         m.metricsLoading,
-		previewEventsData:      append([]ui.EventTimelineEntry(nil), m.previewEventsData...),
-		warningEventsOnly:      m.warningEventsOnly,
-		eventGrouping:          m.eventGrouping,
-		expandedGroup:          m.expandedGroup,
-		allGroupsExpanded:      m.allGroupsExpanded,
-		logCursor:              m.logView.cursor,
-		logVisualMode:          false, // don't clone visual mode into new tabs
-		logVisualStart:         0,
-		logVisualType:          'V',
-		logVisualCol:           0,
-		logVisualCurCol:        0,
+		nav:                     m.nav,
+		leftItems:               append([]model.Item(nil), m.leftItems...),
+		middleItems:             append([]model.Item(nil), m.middleItems...),
+		rightItems:              append([]model.Item(nil), m.rightItems...),
+		cursors:                 m.cursors,
+		middleScroll:            ui.ActiveMiddleScroll,
+		leftScroll:              ui.ActiveLeftScroll,
+		cursorMemory:            copyMapStringInt(m.cursorMemory),
+		filterMemory:            copyMapStringSavedFilter(m.filterMemory),
+		sortMemory:              copyMapStringSortPref(m.sortMemory),
+		itemCache:               copyItemCache(m.itemCache),
+		cacheFingerprints:       copyMapStringString(m.cacheFingerprints),
+		yamlContent:             m.yamlView.content,
+		yamlCollapsed:           copyMapStringBool(m.yamlView.collapsed),
+		splitPreview:            m.splitPreview,
+		fullYAMLPreview:         m.fullYAMLPreview,
+		fullLogPreview:          m.fullLogPreview,
+		previewYAML:             m.previewYAML,
+		namespace:               m.namespace,
+		allNamespaces:           m.allNamespaces,
+		selectedNamespaces:      copyMapStringBool(m.selectedNamespaces),
+		nsSelectionNegated:      m.nsSelectionNegated,
+		savedSelectedNamespaces: copyMapStringBool(m.savedSelectedNamespaces),
+		savedNsSelectionNegated: m.savedNsSelectionNegated,
+		sortColumnName:          m.sortColumnName,
+		sortAscending:           m.sortAscending,
+		filterText:              m.filterText,
+		watchMode:               m.watchMode,
+		objectExplorerLive:      m.objectExplorerLive,
+		objectExplorerTree:      m.objectExplorerTree,
+		readOnly:                m.readOnly,
+		requestGen:              m.requestGen,
+		selectedItems:           copyMapStringBool(m.selectedItems),
+		selectionAnchor:         m.selectionAnchor,
+		fullscreenMiddle:        m.fullscreenMiddle,
+		fullscreenDashboard:     m.fullscreenDashboard,
+		dashboardPreview:        m.dashboardPreview,
+		dashboardEventsPreview:  m.dashboardEventsPreview,
+		monitoringPreview:       m.monitoringPreview,
+		metricsContent:          m.metricsContent,
+		previewEventsContent:    m.previewEventsContent,
+		metricsData:             m.metricsData,
+		metricsLoading:          m.metricsLoading,
+		previewEventsData:       append([]ui.EventTimelineEntry(nil), m.previewEventsData...),
+		warningEventsOnly:       m.warningEventsOnly,
+		eventGrouping:           m.eventGrouping,
+		expandedGroup:           m.expandedGroup,
+		allGroupsExpanded:       m.allGroupsExpanded,
+		logCursor:               m.logView.cursor,
+		logVisualMode:           false, // don't clone visual mode into new tabs
+		logVisualStart:          0,
+		logVisualType:           'V',
+		logVisualCol:            0,
+		logVisualCurCol:         0,
 	}
 	// New tabs inherit the active tab's security state because they
 	// start on the same cluster; navigateChildCluster will rebuild

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -238,9 +238,18 @@ func (m Model) handleExplorerActionKeyAllNamespaces() (tea.Model, tea.Cmd, bool)
 	}
 	m.allNamespaces = !m.allNamespaces
 	if m.allNamespaces {
+		// Stash the current selection so toggling back off restores it
+		// instead of resetting to the default namespace.
+		m.savedSelectedNamespaces = m.selectedNamespaces
+		m.savedNsSelectionNegated = m.nsSelectionNegated
 		m.selectedNamespaces = nil
+		m.nsSelectionNegated = false
 		m.setStatusMessage("All namespaces mode ON", false)
 	} else {
+		m.selectedNamespaces = m.savedSelectedNamespaces
+		m.nsSelectionNegated = m.savedNsSelectionNegated
+		m.savedSelectedNamespaces = nil
+		m.savedNsSelectionNegated = false
 		m.setStatusMessage("All namespaces mode OFF (ns: "+m.namespace+")", false)
 	}
 	m.cancelAndReset()

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -30,6 +30,75 @@ func TestActionKeyATogglesAllNamespaces(t *testing.T) {
 	assert.False(t, result.allNamespaces)
 }
 
+func TestActionKeyAllNamespacesRestoresPreviousSelection(t *testing.T) {
+	m := baseExplorerModel()
+	m.selectedNamespaces = map[string]bool{"alpha": true, "beta": true}
+	m.allNamespaces = false
+
+	// Toggle ON: selection stashed, all-namespaces enabled.
+	ret, _, handled := m.handleExplorerActionKey(runeKey('A'))
+	require.True(t, handled)
+	on := ret.(Model)
+	assert.True(t, on.allNamespaces)
+	assert.Empty(t, on.selectedNamespaces, "selection cleared while in all-namespaces mode")
+
+	// Toggle OFF: previous multi-select restored, not reset to default.
+	ret, _, handled = on.handleExplorerActionKey(runeKey('A'))
+	require.True(t, handled)
+	off := ret.(Model)
+	assert.False(t, off.allNamespaces)
+	assert.Equal(t, map[string]bool{"alpha": true, "beta": true}, off.selectedNamespaces)
+}
+
+func TestActionKeyAllNamespacesRestoresNegatedSelection(t *testing.T) {
+	m := baseExplorerModel()
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.nsSelectionNegated = true
+	m.allNamespaces = false
+
+	ret, _, _ := m.handleExplorerActionKey(runeKey('A'))
+	on := ret.(Model)
+	assert.True(t, on.allNamespaces)
+	assert.False(t, on.nsSelectionNegated, "negation flag cleared while in all-namespaces mode")
+
+	ret, _, _ = on.handleExplorerActionKey(runeKey('A'))
+	off := ret.(Model)
+	assert.True(t, off.nsSelectionNegated, "negation flag restored on toggle off")
+	assert.Equal(t, map[string]bool{"kube-system": true}, off.selectedNamespaces)
+}
+
+// TestActionKeyAllNamespacesSavedSelectionSurvivesTabSwitch proves the
+// stashed selection is per-tab: toggling all-namespaces ON, switching tabs
+// away and back, then toggling OFF must restore that tab's own selection.
+func TestActionKeyAllNamespacesSavedSelectionSurvivesTabSwitch(t *testing.T) {
+	m := baseExplorerModel()
+	m.tabs = []TabState{{}, {}}
+	m.activeTab = 0
+
+	// Tab 1: select two namespaces, then toggle all-namespaces ON.
+	m.selectedNamespaces = map[string]bool{"alpha": true, "beta": true}
+	ret, _, _ := m.handleExplorerActionKey(runeKey('A'))
+	m = ret.(Model)
+	require.True(t, m.allNamespaces)
+	require.Empty(t, m.selectedNamespaces)
+
+	// Switch to tab 2 and back to tab 1.
+	ret, _, _ = m.handleExplorerActionKeyNextTab()
+	m = ret.(Model)
+	require.Equal(t, 1, m.activeTab)
+	ret, _, _ = m.handleExplorerActionKeyPrevTab()
+	m = ret.(Model)
+	require.Equal(t, 0, m.activeTab)
+
+	// Tab 1 is still in all-namespaces mode; toggling OFF restores the
+	// selection that was stashed before the tab round-trip.
+	require.True(t, m.allNamespaces)
+	ret, _, _ = m.handleExplorerActionKey(runeKey('A'))
+	m = ret.(Model)
+	assert.False(t, m.allNamespaces)
+	assert.Equal(t, map[string]bool{"alpha": true, "beta": true}, m.selectedNamespaces)
+}
+
 func TestActionKeyAllNamespacesNoOpAtClusters(t *testing.T) {
 	m := baseExplorerModel()
 	m.nav.Level = model.LevelClusters


### PR DESCRIPTION
Fixes #433

## Problem

Selecting a few namespaces with `\`, toggling all-namespaces mode on with `Shift+A`, then toggling it back off reset the filter to the default namespace instead of restoring the prior selection.

## Root cause

`handleExplorerActionKeyAllNamespaces` set `selectedNamespaces = nil` when entering all-namespaces mode and never restored it on exit, so `effectiveNamespace()` fell back to the default namespace.

## Fix

- Stash `selectedNamespaces` (and the `nsSelectionNegated` exclude flag) on toggle ON; restore them on toggle OFF.
- Carry the stash per-tab through the tab snapshot/restore paths (`saveCurrentTab`, `loadTab`, `cloneCurrentTab`) so it survives tab switches.
- Grouped same-type struct fields to keep `app.go` at the 800-line cap.

## Tests

Added to `update_keys_actions_test.go`:
- `TestActionKeyAllNamespacesRestoresPreviousSelection` - multi-select round-trip
- `TestActionKeyAllNamespacesRestoresNegatedSelection` - negated (exclude) set round-trip
- `TestActionKeyAllNamespacesSavedSelectionSurvivesTabSwitch` - per-tab isolation across a tab switch (mutation-tested: fails without the `loadTab` wiring)

## Verification

- [x] `go build ./...`
- [x] `go test -race ./internal/app/`
- [x] full suite passes
- [x] `golangci-lint` - 0 issues
- [x] `app.go` at 800-line cap

