### PR TITLE
feat: force-delete and evict replicas for Longhorn nodes

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -971,6 +971,11 @@ The action menu (`x` key) shows context-specific actions based on the resource t
 ### Node Actions
 `c` Cordon, `u` Uncordon, `n` Drain, `t` Taint, `T` Untaint, `s` Shell, `v` Describe, `E` Edit, `b` Debug Pod, `V` Events
 
+### Longhorn Node Actions
+`e` Evict Replicas, `C` Cancel Eviction, `v` Describe, `E` Edit, `D` Delete, `X` Force Delete, `V` Events, `P` Permissions
+
+The Longhorn Nodes list shows a `REPLICAS` column with the count of replicas scheduled on each node. Force Delete disables scheduling, then deletes (the `validator.longhorn.io` webhook rejects deleting a still-schedulable node). Evict Replicas disables scheduling and sets `spec.evictionRequested`, so Longhorn rebuilds each replica on another node before removing it.
+
 ### Job Actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `b` Debug Pod, `V` Events
 

--- a/internal/app/commands_longhorn.go
+++ b/internal/app/commands_longhorn.go
@@ -16,13 +16,13 @@ import (
 // satisfies the webhook without removing replicas/engines (a node that still
 // holds data is rejected on purpose and the error is surfaced).
 func (m Model) forceDeleteLonghornNode() tea.Cmd {
-	ctx := m.actionCtx.context
+	kctx := m.actionCtx.context
 	ns := m.actionNamespace()
 	rt := m.actionCtx.resourceType
 	name := m.actionCtx.name
-	logger.Info("Force deleting Longhorn node", "name", name, "namespace", ns, "context", ctx)
-	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Force delete Longhorn node "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
-		if err := m.client.ForceDeleteLonghornNode(ctx, ns, rt, name); err != nil {
+	logger.Info("Force deleting Longhorn node", "name", name, "namespace", ns, "context", kctx)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Force delete Longhorn node "+name, bgtaskTarget(kctx, ns), func(ctx context.Context) tea.Msg {
+		if err := m.client.ForceDeleteLonghornNode(ctx, kctx, ns, rt, name); err != nil {
 			return actionResultMsg{err: err}
 		}
 		return actionResultMsg{message: fmt.Sprintf("Force deleted Longhorn node %s", name)}
@@ -34,7 +34,7 @@ func (m Model) forceDeleteLonghornNode() tea.Cmd {
 // disables scheduling; Longhorn rebuilds each replica on another node before
 // removing it here, so no data is lost.
 func (m Model) setLonghornNodeEviction(evict bool) tea.Cmd {
-	ctx := m.actionCtx.context
+	kctx := m.actionCtx.context
 	ns := m.actionNamespace()
 	rt := m.actionCtx.resourceType
 	name := m.actionCtx.name
@@ -46,9 +46,9 @@ func (m Model) setLonghornNodeEviction(evict bool) tea.Cmd {
 		doneMsg = fmt.Sprintf("Replica eviction cancelled for %s", name)
 	}
 
-	logger.Info("Setting Longhorn node eviction", "name", name, "evict", evict, "namespace", ns, "context", ctx)
-	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, taskName, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
-		if err := m.client.SetLonghornNodeEviction(ctx, ns, rt, name, evict); err != nil {
+	logger.Info("Setting Longhorn node eviction", "name", name, "evict", evict, "namespace", ns, "context", kctx)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, taskName, bgtaskTarget(kctx, ns), func(ctx context.Context) tea.Msg {
+		if err := m.client.SetLonghornNodeEviction(ctx, kctx, ns, rt, name, evict); err != nil {
 			return actionResultMsg{err: err}
 		}
 		return actionResultMsg{message: doneMsg}

--- a/internal/app/commands_longhorn.go
+++ b/internal/app/commands_longhorn.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// forceDeleteLonghornNode disables scheduling on the selected longhorn.io node
+// and then deletes it. The validating webhook (validator.longhorn.io) rejects
+// deletion of a still-schedulable node, so the plain delete path fails; this
+// satisfies the webhook without removing replicas/engines (a node that still
+// holds data is rejected on purpose and the error is surfaced).
+func (m Model) forceDeleteLonghornNode() tea.Cmd {
+	ctx := m.actionCtx.context
+	ns := m.actionNamespace()
+	rt := m.actionCtx.resourceType
+	name := m.actionCtx.name
+	logger.Info("Force deleting Longhorn node", "name", name, "namespace", ns, "context", ctx)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Force delete Longhorn node "+name, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
+		if err := m.client.ForceDeleteLonghornNode(ctx, ns, rt, name); err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: fmt.Sprintf("Force deleted Longhorn node %s", name)}
+	})
+}
+
+// setLonghornNodeEviction requests (evict=true) or cancels (evict=false)
+// replica eviction on the selected longhorn.io node. Requesting eviction also
+// disables scheduling; Longhorn rebuilds each replica on another node before
+// removing it here, so no data is lost.
+func (m Model) setLonghornNodeEviction(evict bool) tea.Cmd {
+	ctx := m.actionCtx.context
+	ns := m.actionNamespace()
+	rt := m.actionCtx.resourceType
+	name := m.actionCtx.name
+
+	taskName := "Evict replicas from Longhorn node " + name
+	doneMsg := fmt.Sprintf("Replica eviction requested for %s", name)
+	if !evict {
+		taskName = "Cancel eviction on Longhorn node " + name
+		doneMsg = fmt.Sprintf("Replica eviction cancelled for %s", name)
+	}
+
+	logger.Info("Setting Longhorn node eviction", "name", name, "evict", evict, "namespace", ns, "context", ctx)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, taskName, bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
+		if err := m.client.SetLonghornNodeEviction(ctx, ns, rt, name, evict); err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: doneMsg}
+	})
+}

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -71,6 +71,11 @@ var mutatingActions = map[string]bool{
 	"Suspend":       true,
 	"Resume":        true,
 
+	// Longhorn node mutations. Force Delete (above) disables scheduling then
+	// deletes; Evict Replicas / Cancel Eviction toggle spec.evictionRequested.
+	"Evict Replicas":  true,
+	"Cancel Eviction": true,
+
 	// Karpenter NodeClaim mutations. Disrupt removes the underlying
 	// node; Cordon / Uncordon / Drain Node operate on the node bound
 	// to the NodeClaim.

--- a/internal/app/readonly_union_closure_test.go
+++ b/internal/app/readonly_union_closure_test.go
@@ -92,6 +92,8 @@ func TestIsUnionAllowedActionForKind_ClosureOverMutatingActions(t *testing.T) {
 		"Cordon Node":          nil,
 		"Uncordon Node":        nil,
 		"Drain Node":           nil,
+		"Evict Replicas":       nil,
+		"Cancel Eviction":      nil,
 		"Activate":             nil,
 		"Edit Values":          nil,
 		"Upgrade":              nil,

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -53,6 +53,11 @@ func (m Model) openResourceActionMenu() Model {
 		actions = model.ActionsForCapture()
 	case m.nav.Level == model.LevelContainers:
 		actions = model.ActionsForContainer()
+	case model.IsLonghornNode(m.actionCtx.resourceType):
+		// longhorn.io nodes share Kind "Node" with core nodes; route to the
+		// dedicated menu (Evict Replicas / Force Delete) instead of the
+		// core-node kubectl verbs.
+		actions = model.ActionsForLonghornNode()
 	default:
 		actions = model.ActionsForKind(kind)
 	}
@@ -299,15 +304,18 @@ func (m Model) directActionForceDelete() (tea.Model, tea.Cmd) {
 	if isVirtualResourceKind(kind) {
 		return m, nil
 	}
-	if !model.IsForceDeleteableKind(kind) {
-		m.setStatusMessage("Force delete not available for "+kind, true)
-		return m, scheduleStatusClear()
-	}
 	sel := m.selectedMiddleItem()
 	if sel == nil {
 		return m, nil
 	}
 	m.actionCtx = m.buildActionCtx(sel, kind)
+	// longhorn.io nodes are not force-deleteable by kind ("Node" collides with
+	// core nodes) but support their own force-delete (disable scheduling, then
+	// delete past the validating webhook).
+	if !model.IsForceDeleteableKind(kind) && !model.IsLonghornNode(m.actionCtx.resourceType) {
+		m.setStatusMessage("Force delete not available for "+kind, true)
+		return m, scheduleStatusClear()
+	}
 	if m.isUnionSentinel() && !isUnionAllowedActionForKind(kind, "Force Delete") {
 		logger.Info("Blocked by union view", "action", "Force Delete", "kind", kind)
 		m.setStatusMessage("Force Delete is not available in union view", true)
@@ -496,6 +504,12 @@ func (m Model) executeActionCoreOps(actionLabel string) (tea.Model, tea.Cmd, boo
 		return mdl, cmd, true
 	case "Force Finalize":
 		mdl, cmd := m.executeActionForceFinalize()
+		return mdl, cmd, true
+	case "Evict Replicas":
+		mdl, cmd := m.executeActionEvictReplicas()
+		return mdl, cmd, true
+	case "Cancel Eviction":
+		mdl, cmd := m.executeActionCancelEviction()
 		return mdl, cmd, true
 	case "Cordon":
 		mdl, cmd := m.executeActionCordon()

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -203,8 +203,35 @@ func (m Model) executeActionEdit() (tea.Model, tea.Cmd) {
 // executeActionDelete handles the "Delete" action.
 func (m Model) executeActionDelete() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
 	m.confirmAction = m.actionCtx.name
+	// Clear any override left by a previous non-delete confirm so the simple
+	// confirm overlay falls back to its "Delete X?" wording.
+	m.confirmTitle = ""
+	m.confirmQuestion = ""
 	m.overlay = overlayConfirm
 	m.pendingAction = "Delete"
+	return m, nil
+}
+
+// executeActionEvictReplicas handles the "Evict Replicas" action on a
+// longhorn.io node. Eviction is data-safe (Longhorn rebuilds each replica on
+// another node before removing it here), so a simple y/n confirm is enough.
+func (m Model) executeActionEvictReplicas() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
+	m.confirmAction = m.actionCtx.name
+	m.confirmTitle = "Confirm Evict Replicas"
+	m.confirmQuestion = fmt.Sprintf("Evict all replicas from %s?", m.actionCtx.name)
+	m.overlay = overlayConfirm
+	m.pendingAction = "Evict Replicas"
+	return m, nil
+}
+
+// executeActionCancelEviction handles the "Cancel Eviction" action on a
+// longhorn.io node (clears spec.evictionRequested).
+func (m Model) executeActionCancelEviction() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
+	m.confirmAction = m.actionCtx.name
+	m.confirmTitle = "Confirm Cancel Eviction"
+	m.confirmQuestion = fmt.Sprintf("Cancel replica eviction on %s?", m.actionCtx.name)
+	m.overlay = overlayConfirm
+	m.pendingAction = "Cancel Eviction"
 	return m, nil
 }
 

--- a/internal/app/update_actions_longhorn_test.go
+++ b/internal/app/update_actions_longhorn_test.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+var longhornNodeResourceType = model.ResourceTypeEntry{
+	APIGroup: "longhorn.io", APIVersion: "v1beta2", Resource: "nodes", Kind: "Node", Namespaced: true,
+}
+
+func longhornNodeModel() Model {
+	return Model{
+		nav: model.NavigationState{
+			Level:        model.LevelResources,
+			ResourceType: longhornNodeResourceType,
+		},
+		middleItems: []model.Item{
+			{Name: "lh-node-1", Kind: "Node", Namespace: "longhorn-system"},
+		},
+		tabs:  []TabState{{}},
+		width: 80, height: 40,
+	}
+}
+
+// TestLonghornNode_ActionMenu_UsesDedicatedMenu verifies the action overlay for
+// a longhorn.io node offers the Longhorn verbs, not the core-node kubectl verbs.
+func TestLonghornNode_ActionMenu_UsesDedicatedMenu(t *testing.T) {
+	m := longhornNodeModel()
+	m = m.openResourceActionMenu()
+
+	labels := make([]string, 0, len(m.overlayItems))
+	for _, it := range m.overlayItems {
+		labels = append(labels, it.Name)
+	}
+	assert.Contains(t, labels, "Force Delete")
+	assert.Contains(t, labels, "Evict Replicas")
+	assert.Contains(t, labels, "Cancel Eviction")
+	assert.NotContains(t, labels, "Cordon")
+	assert.NotContains(t, labels, "Drain")
+}
+
+// TestLonghornNode_ForceDelete_RoutesToLonghornPath verifies the global
+// force-delete key is allowed for longhorn.io nodes (kind "Node" is not in
+// IsForceDeleteableKind) and opens the type-to-confirm overlay.
+func TestLonghornNode_ForceDelete_OpensTypeConfirm(t *testing.T) {
+	m := longhornNodeModel()
+	ret, _ := m.directActionForceDelete()
+	result := ret.(Model)
+	assert.Equal(t, overlayConfirmType, result.overlay)
+	assert.Equal(t, "Force Delete", result.pendingAction)
+	assert.Contains(t, result.confirmQuestion, "Force delete lh-node-1")
+}
+
+// TestCoreNode_ForceDelete_StillBlocked guards against the longhorn allowance
+// leaking onto core Kubernetes nodes (same Kind "Node").
+func TestCoreNode_ForceDelete_StillBlocked(t *testing.T) {
+	m := Model{
+		nav: model.NavigationState{
+			Level:        model.LevelResources,
+			ResourceType: model.ResourceTypeEntry{APIGroup: "", APIVersion: "v1", Resource: "nodes", Kind: "Node"},
+		},
+		middleItems: []model.Item{{Name: "worker-1", Kind: "Node"}},
+		tabs:        []TabState{{}},
+		width:       80, height: 40,
+	}
+	ret, cmd := m.directActionForceDelete()
+	result := ret.(Model)
+	assert.NotEqual(t, overlayConfirmType, result.overlay)
+	assert.Contains(t, result.statusMessage, "Force delete not available")
+	require.NotNil(t, cmd) // status-clear timer
+}
+
+// TestLonghornNode_EvictReplicas_OpensConfirm verifies the Evict Replicas
+// action opens the simple confirm with eviction-specific wording.
+func TestLonghornNode_EvictReplicas_OpensConfirm(t *testing.T) {
+	m := longhornNodeModel()
+	m.actionCtx = m.buildActionCtx(&m.middleItems[0], "Node")
+	ret, _ := m.executeActionEvictReplicas()
+	result := ret.(Model)
+	assert.Equal(t, overlayConfirm, result.overlay)
+	assert.Equal(t, "Evict Replicas", result.pendingAction)
+	assert.Equal(t, "Confirm Evict Replicas", result.confirmTitle)
+	assert.Contains(t, result.confirmQuestion, "Evict all replicas from lh-node-1")
+}
+
+// TestLonghornNode_CancelEviction_OpensConfirm verifies the Cancel Eviction
+// action opens the simple confirm with cancel wording.
+func TestLonghornNode_CancelEviction_OpensConfirm(t *testing.T) {
+	m := longhornNodeModel()
+	m.actionCtx = m.buildActionCtx(&m.middleItems[0], "Node")
+	ret, _ := m.executeActionCancelEviction()
+	result := ret.(Model)
+	assert.Equal(t, overlayConfirm, result.overlay)
+	assert.Equal(t, "Cancel Eviction", result.pendingAction)
+	assert.Equal(t, "Confirm Cancel Eviction", result.confirmTitle)
+}
+
+// TestConfirmOverlay_CancelClearsTitleOverride guards against the eviction
+// confirm's title/question bleeding into a later plain-delete confirm: after
+// cancelling Evict Replicas, the simple confirm must fall back to its default
+// "Delete X?" wording.
+func TestConfirmOverlay_CancelClearsTitleOverride(t *testing.T) {
+	m := longhornNodeModel()
+	m.actionCtx = m.buildActionCtx(&m.middleItems[0], "Node")
+	ret, _ := m.executeActionEvictReplicas()
+	m = ret.(Model)
+	require.Equal(t, "Confirm Evict Replicas", m.confirmTitle)
+
+	// Cancel the overlay.
+	ret, _ = m.handleConfirmOverlayKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = ret.(Model)
+	assert.Empty(t, m.confirmTitle, "title override must be cleared on cancel")
+	assert.Empty(t, m.confirmQuestion, "question override must be cleared on cancel")
+}
+
+// TestEvictReplicas_BlockedByReadOnly verifies the eviction actions are gated
+// by read-only mode (registered in mutatingActions).
+func TestEvictReplicas_BlockedByReadOnly(t *testing.T) {
+	assert.True(t, isMutatingAction("Evict Replicas"))
+	assert.True(t, isMutatingAction("Cancel Eviction"))
+}

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
 
 func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -27,6 +29,11 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		action := m.pendingAction
 		m.pendingAction = ""
 		m.confirmAction = ""
+		// Clear any title/question override (set by non-delete confirms such as
+		// Longhorn replica eviction) so the next overlayConfirm opener that
+		// relies on the default "Delete X?" wording is not shown stale text.
+		m.confirmTitle = ""
+		m.confirmQuestion = ""
 
 		ns := m.actionCtx.namespace
 		name := m.actionCtx.name
@@ -67,6 +74,15 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.execKubectlDrain()
 		}
 
+		switch action {
+		case "Evict Replicas":
+			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch %s.longhorn.io %s --type merge -p '{\"spec\":{\"allowScheduling\":false,\"evictionRequested\":true}}'%s --context %s", rt.Resource, name, nsArg, ctx))
+			return m, m.setLonghornNodeEviction(true)
+		case "Cancel Eviction":
+			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch %s.longhorn.io %s --type merge -p '{\"spec\":{\"evictionRequested\":false}}'%s --context %s", rt.Resource, name, nsArg, ctx))
+			return m, m.setLonghornNodeEviction(false)
+		}
+
 		// Regular delete.
 		if rt.APIGroup == "_helm" {
 			m.addLogEntry("DBG", fmt.Sprintf("$ helm uninstall %s -n %s --kube-context %s", name, ns, ctx))
@@ -77,6 +93,8 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "n", "N", "esc", "q":
 		m.overlay = overlayNone
 		m.confirmAction = ""
+		m.confirmTitle = ""
+		m.confirmQuestion = ""
 		m.pendingAction = ""
 		m.resetBulkAction()
 		return m, nil
@@ -147,6 +165,10 @@ func (m Model) handleConfirmTypeOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 				m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch %s %s --type merge -p '{\"metadata\":{\"finalizers\":null}}'%s --context %s", rt.Resource, name, nsArg, ctx))
 				return m, m.removeFinalizers()
 			case "Force Delete":
+				if model.IsLonghornNode(rt) {
+					m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch %s.longhorn.io %s --type merge -p '{\"spec\":{\"allowScheduling\":false}}'%s; kubectl delete %s.longhorn.io %s%s --context %s", rt.Resource, name, nsArg, rt.Resource, name, nsArg, ctx))
+					return m, m.forceDeleteLonghornNode()
+				}
 				m.addLogEntry("DBG", fmt.Sprintf("$ kubectl delete %s %s --grace-period=0 --force%s --context %s", rt.Resource, name, nsArg, ctx))
 				return m, m.forceDeleteResource()
 			case "Finalizer Remove":

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -147,17 +147,32 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 			InnerHeight: sh - 2,
 		}), sw, sh, true
 	case overlayConfirm:
+		// Default to the delete wording; non-delete confirm actions (e.g.
+		// Longhorn replica eviction) set confirmTitle/confirmQuestion to
+		// override it.
+		title := m.confirmTitle
+		if title == "" {
+			title = "Confirm Delete"
+		}
+		warning := m.confirmQuestion
+		if warning == "" {
+			warning = fmt.Sprintf("Delete %s?", m.confirmAction)
+		}
+		w := min(50, m.width-10)
 		return ui.RenderOverlayConfirm(ui.OverlayConfirmConfig{
-			Title:   "Confirm Delete",
-			Warning: fmt.Sprintf("Delete %s?", m.confirmAction),
-		}), min(50, m.width-10), min(8, m.height-6), true
+			Title:     title,
+			Warning:   warning,
+			WrapWidth: w - 4,
+		}), w, min(8, m.height-6), true
 	case overlayConfirmType:
+		w := min(55, m.width-10)
 		return ui.RenderOverlayConfirm(ui.OverlayConfirmConfig{
 			Title:     m.confirmTitle,
 			Warning:   m.confirmQuestion,
 			TypeToken: "DELETE",
 			Input:     m.confirmTypeInput.Value,
-		}), min(55, m.width-10), min(10, m.height-6), true
+			WrapWidth: w - 4,
+		}), w, min(10, m.height-6), true
 	case overlayScaleInput:
 		return ui.RenderOverlayInput(ui.OverlayInputConfig{
 			Title: "Scale Deployment",

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -1386,6 +1386,8 @@ func newFakeDynClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient 
 			{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}: "KustomizationList",
 			{Group: "helm.toolkit.fluxcd.io", Version: "v2beta1", Resource: "helmreleases"}:   "HelmReleaseList",
 			{Group: "cert-manager.io", Version: "v1", Resource: "certificates"}:               "CertificateList",
+			{Group: "longhorn.io", Version: "v1beta2", Resource: "nodes"}:                     "NodeList",
+			{Group: "longhorn.io", Version: "v1beta2", Resource: "replicas"}:                  "ReplicaList",
 		}, objects...)
 }
 

--- a/internal/k8s/client_longhorn.go
+++ b/internal/k8s/client_longhorn.go
@@ -1,0 +1,139 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// LonghornReplicaColumn is the header for the computed per-node replica-count
+// column added to the Longhorn Nodes list.
+const LonghornReplicaColumn = "REPLICAS"
+
+// withLonghornReplicaCounts appends a REPLICAS column to each Longhorn node
+// item with the number of longhorn.io/replicas scheduled on that node
+// (spec.nodeID == node name). It is a no-op for any other resource type.
+//
+// One extra LIST per refresh (not per node): replicas are listed once and
+// grouped by node. Best-effort — a failure leaves the column unset rather than
+// failing the whole node list, so the table still renders.
+func (c *Client) withLonghornReplicaCounts(ctx context.Context, contextName, namespace string, rt model.ResourceTypeEntry, items []model.Item) []model.Item {
+	if !model.IsLonghornNode(rt) || len(items) == 0 {
+		return items
+	}
+	counts, err := c.longhornReplicaCountsByNode(ctx, contextName, namespace, rt)
+	if err != nil {
+		logger.Warn("counting Longhorn replicas for node column", "context", contextName, "error", err)
+		return items
+	}
+	for i := range items {
+		items[i].Columns = append(items[i].Columns, model.KeyValue{
+			Key:   LonghornReplicaColumn,
+			Value: strconv.Itoa(counts[items[i].Name]),
+		})
+	}
+	return items
+}
+
+// longhornReplicaCountsByNode lists longhorn.io/replicas and returns a map of
+// node name -> replica count, keyed by each replica's spec.nodeID. The
+// replicas share the node's API group/version, so rt.APIVersion is reused
+// rather than hardcoding a Longhorn API version.
+func (c *Client) longhornReplicaCountsByNode(ctx context.Context, contextName, namespace string, rt model.ResourceTypeEntry) (map[string]int, error) {
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	gvr := schema.GroupVersionResource{Group: rt.APIGroup, Version: rt.APIVersion, Resource: "replicas"}
+	list, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing Longhorn replicas: %w", err)
+	}
+	counts := make(map[string]int, len(list.Items))
+	for i := range list.Items {
+		nodeID, _, _ := unstructured.NestedString(list.Items[i].Object, "spec", "nodeID")
+		if nodeID != "" {
+			counts[nodeID]++
+		}
+	}
+	return counts, nil
+}
+
+// ForceDeleteLonghornNode deletes a longhorn.io Node that the validating
+// webhook (validator.longhorn.io) would otherwise refuse to remove.
+//
+// The webhook rejects deletion of a node that is still schedulable
+// (spec.allowScheduling=true), so this disables scheduling first and then
+// deletes. It deliberately does NOT remove replicas or engines: the webhook
+// keeps rejecting a node that still holds data, and that error is surfaced to
+// the caller so data is never silently destroyed. Evict the node's replicas
+// first (SetLonghornNodeEviction) when it still holds data.
+//
+// The exact GroupVersionResource is used via the dynamic client rather than
+// shelling out to "kubectl delete nodes" because that resource name is
+// ambiguous between core nodes and longhorn.io nodes.
+//
+// The patch and delete are two separate calls: if the delete fails after the
+// patch succeeds, the node is left with allowScheduling=false. The error is
+// surfaced to the caller and a retry is safe (the patch is idempotent), but
+// re-enable scheduling manually if abandoning the delete.
+func (c *Client) ForceDeleteLonghornNode(contextName, namespace string, rt model.ResourceTypeEntry, name string) error {
+	logger.Info("Force deleting Longhorn node", "context", contextName, "namespace", namespace, "name", name)
+	res, err := c.longhornNodeResource(contextName, namespace, rt)
+	if err != nil {
+		return err
+	}
+
+	patch := []byte(`{"spec":{"allowScheduling":false}}`)
+	if _, err := res.Patch(context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("disabling scheduling on Longhorn node %s: %w", name, err)
+	}
+	if err := res.Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deleting Longhorn node %s: %w", name, err)
+	}
+	return nil
+}
+
+// SetLonghornNodeEviction toggles replica eviction on a longhorn.io Node.
+//
+// When evict is true it sets spec.evictionRequested=true and
+// spec.allowScheduling=false in one patch: Longhorn only evicts a node whose
+// scheduling is disabled, and then rebuilds each replica on another node
+// before removing it from this one (data-safe). When evict is false it clears
+// spec.evictionRequested, leaving scheduling untouched.
+func (c *Client) SetLonghornNodeEviction(contextName, namespace string, rt model.ResourceTypeEntry, name string, evict bool) error {
+	logger.Info("Setting Longhorn node eviction", "context", contextName, "namespace", namespace, "name", name, "evict", evict)
+	res, err := c.longhornNodeResource(contextName, namespace, rt)
+	if err != nil {
+		return err
+	}
+
+	patch := []byte(`{"spec":{"evictionRequested":false}}`)
+	if evict {
+		patch = []byte(`{"spec":{"allowScheduling":false,"evictionRequested":true}}`)
+	}
+	if _, err := res.Patch(context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("setting eviction=%t on Longhorn node %s: %w", evict, name, err)
+	}
+	return nil
+}
+
+// longhornNodeResource returns the namespaced dynamic resource interface for
+// the longhorn.io Node CRD in the given context.
+func (c *Client) longhornNodeResource(contextName, namespace string, rt model.ResourceTypeEntry) (dynamic.ResourceInterface, error) {
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	gvr := schema.GroupVersionResource{Group: rt.APIGroup, Version: rt.APIVersion, Resource: rt.Resource}
+	return dynClient.Resource(gvr).Namespace(namespace), nil
+}

--- a/internal/k8s/client_longhorn.go
+++ b/internal/k8s/client_longhorn.go
@@ -26,6 +26,10 @@ const LonghornReplicaColumn = "REPLICAS"
 // One extra LIST per refresh (not per node): replicas are listed once and
 // grouped by node. Best-effort — a failure leaves the column unset rather than
 // failing the whole node list, so the table still renders.
+//
+// Returns a new slice with per-item copies of Columns: the informer-cache path
+// reuses memoized model.Items across refreshes, so appending to the original
+// Columns slice would accumulate duplicate REPLICAS columns on unchanged rows.
 func (c *Client) withLonghornReplicaCounts(ctx context.Context, contextName, namespace string, rt model.ResourceTypeEntry, items []model.Item) []model.Item {
 	if !model.IsLonghornNode(rt) || len(items) == 0 {
 		return items
@@ -35,13 +39,14 @@ func (c *Client) withLonghornReplicaCounts(ctx context.Context, contextName, nam
 		logger.Warn("counting Longhorn replicas for node column", "context", contextName, "error", err)
 		return items
 	}
-	for i := range items {
-		items[i].Columns = append(items[i].Columns, model.KeyValue{
-			Key:   LonghornReplicaColumn,
-			Value: strconv.Itoa(counts[items[i].Name]),
-		})
+	out := make([]model.Item, len(items))
+	copy(out, items)
+	for i := range out {
+		col := model.KeyValue{Key: LonghornReplicaColumn, Value: strconv.Itoa(counts[out[i].Name])}
+		// Fresh Columns slice so memoized cache items are never mutated.
+		out[i].Columns = append(append([]model.KeyValue(nil), out[i].Columns...), col)
 	}
-	return items
+	return out
 }
 
 // longhornReplicaCountsByNode lists longhorn.io/replicas and returns a map of
@@ -86,7 +91,7 @@ func (c *Client) longhornReplicaCountsByNode(ctx context.Context, contextName, n
 // patch succeeds, the node is left with allowScheduling=false. The error is
 // surfaced to the caller and a retry is safe (the patch is idempotent), but
 // re-enable scheduling manually if abandoning the delete.
-func (c *Client) ForceDeleteLonghornNode(contextName, namespace string, rt model.ResourceTypeEntry, name string) error {
+func (c *Client) ForceDeleteLonghornNode(ctx context.Context, contextName, namespace string, rt model.ResourceTypeEntry, name string) error {
 	logger.Info("Force deleting Longhorn node", "context", contextName, "namespace", namespace, "name", name)
 	res, err := c.longhornNodeResource(contextName, namespace, rt)
 	if err != nil {
@@ -94,10 +99,10 @@ func (c *Client) ForceDeleteLonghornNode(contextName, namespace string, rt model
 	}
 
 	patch := []byte(`{"spec":{"allowScheduling":false}}`)
-	if _, err := res.Patch(context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+	if _, err := res.Patch(ctx, name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 		return fmt.Errorf("disabling scheduling on Longhorn node %s: %w", name, err)
 	}
-	if err := res.Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+	if err := res.Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("deleting Longhorn node %s: %w", name, err)
 	}
 	return nil
@@ -110,7 +115,7 @@ func (c *Client) ForceDeleteLonghornNode(contextName, namespace string, rt model
 // scheduling is disabled, and then rebuilds each replica on another node
 // before removing it from this one (data-safe). When evict is false it clears
 // spec.evictionRequested, leaving scheduling untouched.
-func (c *Client) SetLonghornNodeEviction(contextName, namespace string, rt model.ResourceTypeEntry, name string, evict bool) error {
+func (c *Client) SetLonghornNodeEviction(ctx context.Context, contextName, namespace string, rt model.ResourceTypeEntry, name string, evict bool) error {
 	logger.Info("Setting Longhorn node eviction", "context", contextName, "namespace", namespace, "name", name, "evict", evict)
 	res, err := c.longhornNodeResource(contextName, namespace, rt)
 	if err != nil {
@@ -121,7 +126,7 @@ func (c *Client) SetLonghornNodeEviction(contextName, namespace string, rt model
 	if evict {
 		patch = []byte(`{"spec":{"allowScheduling":false,"evictionRequested":true}}`)
 	}
-	if _, err := res.Patch(context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+	if _, err := res.Patch(ctx, name, k8stypes.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 		return fmt.Errorf("setting eviction=%t on Longhorn node %s: %w", evict, name, err)
 	}
 	return nil

--- a/internal/k8s/client_longhorn_test.go
+++ b/internal/k8s/client_longhorn_test.go
@@ -1,0 +1,151 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+var longhornNodeRT = model.ResourceTypeEntry{
+	APIGroup: "longhorn.io", APIVersion: "v1beta2", Resource: "nodes", Kind: "Node", Namespaced: true,
+}
+
+var longhornNodeGVR = schema.GroupVersionResource{Group: "longhorn.io", Version: "v1beta2", Resource: "nodes"}
+
+func newLonghornNode(name string, allowScheduling, evictionRequested bool) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "longhorn.io/v1beta2",
+			"kind":       "Node",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "longhorn-system",
+			},
+			"spec": map[string]any{
+				"allowScheduling":   allowScheduling,
+				"evictionRequested": evictionRequested,
+			},
+		},
+	}
+}
+
+func newLonghornReplica(name, nodeID string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "longhorn.io/v1beta2",
+			"kind":       "Replica",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "longhorn-system",
+			},
+			"spec": map[string]any{"nodeID": nodeID},
+		},
+	}
+}
+
+// TestGetResources_LonghornNode_ReplicaCountColumn verifies the Longhorn Nodes
+// list gets a REPLICAS column counting longhorn.io/replicas by spec.nodeID.
+func TestGetResources_LonghornNode_ReplicaCountColumn(t *testing.T) {
+	dc := newFakeDynClient(
+		newLonghornNode("node-a", true, false),
+		newLonghornNode("node-b", true, false),
+		newLonghornNode("node-c", true, false), // no replicas -> "0"
+		newLonghornReplica("r1", "node-a"),
+		newLonghornReplica("r2", "node-a"),
+		newLonghornReplica("r3", "node-b"),
+	)
+	c := newFakeClient(nil, dc)
+
+	items, err := c.GetResources(t.Context(), "", "longhorn-system", longhornNodeRT)
+	require.NoError(t, err)
+
+	got := map[string]string{}
+	for _, it := range items {
+		for _, kv := range it.Columns {
+			if kv.Key == "REPLICAS" {
+				got[it.Name] = kv.Value
+			}
+		}
+	}
+	assert.Equal(t, "2", got["node-a"])
+	assert.Equal(t, "1", got["node-b"])
+	assert.Equal(t, "0", got["node-c"])
+}
+
+// TestGetResources_NonLonghorn_NoReplicaColumn ensures the REPLICAS column is
+// scoped to Longhorn nodes and does not leak onto other resource types.
+func TestGetResources_NonLonghorn_NoReplicaColumn(t *testing.T) {
+	pod := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "p1", "namespace": "default"},
+	}}
+	dc := newFakeDynClient(pod)
+	c := newFakeClient(nil, dc)
+
+	rt := model.ResourceTypeEntry{APIGroup: "", APIVersion: "v1", Resource: "pods", Kind: "Pod", Namespaced: true}
+	items, err := c.GetResources(t.Context(), "", "default", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	for _, kv := range items[0].Columns {
+		assert.NotEqual(t, "REPLICAS", kv.Key)
+	}
+}
+
+// TestForceDeleteLonghornNode verifies the node is removed. Scheduling is
+// disabled first (the validating webhook rejects deletion of a still
+// schedulable node), then the node is deleted.
+func TestForceDeleteLonghornNode(t *testing.T) {
+	dc := newFakeDynClient(newLonghornNode("node1", true, false))
+	c := newFakeClient(nil, dc)
+
+	err := c.ForceDeleteLonghornNode("", "longhorn-system", longhornNodeRT, "node1")
+	require.NoError(t, err)
+
+	_, getErr := dc.Resource(longhornNodeGVR).Namespace("longhorn-system").
+		Get(t.Context(), "node1", metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(getErr), "node should be deleted, got %v", getErr)
+}
+
+// TestSetLonghornNodeEviction_Enable verifies that requesting eviction sets
+// both evictionRequested=true and allowScheduling=false (Longhorn refuses to
+// evict a node that is still schedulable).
+func TestSetLonghornNodeEviction_Enable(t *testing.T) {
+	dc := newFakeDynClient(newLonghornNode("node1", true, false))
+	c := newFakeClient(nil, dc)
+
+	err := c.SetLonghornNodeEviction("", "longhorn-system", longhornNodeRT, "node1", true)
+	require.NoError(t, err)
+
+	obj, getErr := dc.Resource(longhornNodeGVR).Namespace("longhorn-system").
+		Get(t.Context(), "node1", metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	evict, _, _ := unstructured.NestedBool(obj.Object, "spec", "evictionRequested")
+	sched, _, _ := unstructured.NestedBool(obj.Object, "spec", "allowScheduling")
+	assert.True(t, evict, "evictionRequested must be true")
+	assert.False(t, sched, "allowScheduling must be false during eviction")
+}
+
+// TestSetLonghornNodeEviction_Cancel verifies that cancelling eviction clears
+// evictionRequested without re-enabling scheduling.
+func TestSetLonghornNodeEviction_Cancel(t *testing.T) {
+	dc := newFakeDynClient(newLonghornNode("node1", false, true))
+	c := newFakeClient(nil, dc)
+
+	err := c.SetLonghornNodeEviction("", "longhorn-system", longhornNodeRT, "node1", false)
+	require.NoError(t, err)
+
+	obj, getErr := dc.Resource(longhornNodeGVR).Namespace("longhorn-system").
+		Get(t.Context(), "node1", metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	evict, _, _ := unstructured.NestedBool(obj.Object, "spec", "evictionRequested")
+	assert.False(t, evict, "evictionRequested must be false after cancel")
+}

--- a/internal/k8s/client_longhorn_test.go
+++ b/internal/k8s/client_longhorn_test.go
@@ -79,6 +79,30 @@ func TestGetResources_LonghornNode_ReplicaCountColumn(t *testing.T) {
 	assert.Equal(t, "0", got["node-c"])
 }
 
+// TestWithLonghornReplicaCounts_DoesNotMutateInput guards against the
+// informer-cache path accumulating duplicate REPLICAS columns: the function
+// must not mutate the (memoized) input items, and repeated calls must each
+// yield exactly one REPLICAS column.
+func TestWithLonghornReplicaCounts_DoesNotMutateInput(t *testing.T) {
+	dc := newFakeDynClient(newLonghornReplica("r1", "node-a"))
+	c := newFakeClient(nil, dc)
+	items := []model.Item{{Name: "node-a"}}
+
+	out1 := c.withLonghornReplicaCounts(t.Context(), "", "longhorn-system", longhornNodeRT, items)
+	out2 := c.withLonghornReplicaCounts(t.Context(), "", "longhorn-system", longhornNodeRT, items)
+
+	assert.Empty(t, items[0].Columns, "input items must not be mutated")
+	for _, out := range [][]model.Item{out1, out2} {
+		count := 0
+		for _, kv := range out[0].Columns {
+			if kv.Key == LonghornReplicaColumn {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "each call must produce exactly one REPLICAS column")
+	}
+}
+
 // TestGetResources_NonLonghorn_NoReplicaColumn ensures the REPLICAS column is
 // scoped to Longhorn nodes and does not leak onto other resource types.
 func TestGetResources_NonLonghorn_NoReplicaColumn(t *testing.T) {
@@ -105,7 +129,7 @@ func TestForceDeleteLonghornNode(t *testing.T) {
 	dc := newFakeDynClient(newLonghornNode("node1", true, false))
 	c := newFakeClient(nil, dc)
 
-	err := c.ForceDeleteLonghornNode("", "longhorn-system", longhornNodeRT, "node1")
+	err := c.ForceDeleteLonghornNode(t.Context(), "", "longhorn-system", longhornNodeRT, "node1")
 	require.NoError(t, err)
 
 	_, getErr := dc.Resource(longhornNodeGVR).Namespace("longhorn-system").
@@ -120,15 +144,19 @@ func TestSetLonghornNodeEviction_Enable(t *testing.T) {
 	dc := newFakeDynClient(newLonghornNode("node1", true, false))
 	c := newFakeClient(nil, dc)
 
-	err := c.SetLonghornNodeEviction("", "longhorn-system", longhornNodeRT, "node1", true)
+	err := c.SetLonghornNodeEviction(t.Context(), "", "longhorn-system", longhornNodeRT, "node1", true)
 	require.NoError(t, err)
 
 	obj, getErr := dc.Resource(longhornNodeGVR).Namespace("longhorn-system").
 		Get(t.Context(), "node1", metav1.GetOptions{})
 	require.NoError(t, getErr)
 
-	evict, _, _ := unstructured.NestedBool(obj.Object, "spec", "evictionRequested")
-	sched, _, _ := unstructured.NestedBool(obj.Object, "spec", "allowScheduling")
+	evict, evictFound, evictErr := unstructured.NestedBool(obj.Object, "spec", "evictionRequested")
+	sched, schedFound, schedErr := unstructured.NestedBool(obj.Object, "spec", "allowScheduling")
+	require.NoError(t, evictErr)
+	require.NoError(t, schedErr)
+	require.True(t, evictFound, "spec.evictionRequested should exist")
+	require.True(t, schedFound, "spec.allowScheduling should exist")
 	assert.True(t, evict, "evictionRequested must be true")
 	assert.False(t, sched, "allowScheduling must be false during eviction")
 }
@@ -139,13 +167,19 @@ func TestSetLonghornNodeEviction_Cancel(t *testing.T) {
 	dc := newFakeDynClient(newLonghornNode("node1", false, true))
 	c := newFakeClient(nil, dc)
 
-	err := c.SetLonghornNodeEviction("", "longhorn-system", longhornNodeRT, "node1", false)
+	err := c.SetLonghornNodeEviction(t.Context(), "", "longhorn-system", longhornNodeRT, "node1", false)
 	require.NoError(t, err)
 
 	obj, getErr := dc.Resource(longhornNodeGVR).Namespace("longhorn-system").
 		Get(t.Context(), "node1", metav1.GetOptions{})
 	require.NoError(t, getErr)
 
-	evict, _, _ := unstructured.NestedBool(obj.Object, "spec", "evictionRequested")
+	evict, evictFound, evictErr := unstructured.NestedBool(obj.Object, "spec", "evictionRequested")
+	sched, schedFound, schedErr := unstructured.NestedBool(obj.Object, "spec", "allowScheduling")
+	require.NoError(t, evictErr)
+	require.NoError(t, schedErr)
+	require.True(t, evictFound, "spec.evictionRequested should exist")
+	require.True(t, schedFound, "spec.allowScheduling should exist")
 	assert.False(t, evict, "evictionRequested must be false after cancel")
+	assert.False(t, sched, "allowScheduling must remain disabled after cancel")
 }

--- a/internal/k8s/client_resources.go
+++ b/internal/k8s/client_resources.go
@@ -78,7 +78,7 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 		if cerr == nil {
 			items = sortResourceItems(items, rt.Kind)
 			infs.observeCachedListSize(contextName, gvr, len(items))
-			return items, nil
+			return c.withLonghornReplicaCounts(ctx, contextName, namespace, rt, items), nil
 		}
 	}
 
@@ -112,7 +112,7 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	if mode == InformerCacheAuto && infs != nil {
 		infs.observeDirectListSize(contextName, gvr, len(items))
 	}
-	return sortResourceItems(items, rt.Kind), nil
+	return c.withLonghornReplicaCounts(ctx, contextName, namespace, rt, sortResourceItems(items, rt.Kind)), nil
 }
 
 // cacheEnabled reports whether the informer cache is wired up at all. False

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -550,6 +550,26 @@ func actionsForKnativeKind(kind string) ([]ActionMenuItem, bool) {
 	return nil, false
 }
 
+// ActionsForLonghornNode returns the action menu for longhorn.io Node CRDs.
+// Distinct from the core-node menu (Cordon / Drain / Taint / Shell are
+// kubectl node verbs that do not apply here): a longhorn.io node is managed
+// through its spec. Evict Replicas / Cancel Eviction toggle
+// spec.evictionRequested so Longhorn rebuilds replicas elsewhere before
+// removing them; Force Delete disables scheduling then deletes past the
+// validating webhook (which rejects deletion of a still-schedulable node).
+func ActionsForLonghornNode() []ActionMenuItem {
+	return []ActionMenuItem{
+		{Label: "Evict Replicas", Description: "Drain replicas off this node (rebuilds them elsewhere first)", Key: "e"},
+		{Label: "Cancel Eviction", Description: "Stop an in-progress replica eviction", Key: "C"},
+		{Label: "Describe", Description: "Describe resource", Key: "v"},
+		{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
+		{Label: "Delete", Description: "Delete this Longhorn node", Key: "D"},
+		{Label: "Force Delete", Description: "Force delete this Longhorn node (disable scheduling, then delete)", Key: "X"},
+		{Label: "Events", Description: "Show related events", Key: "V"},
+		{Label: "Permissions", Description: "Check RBAC permissions", Key: "P"},
+	}
+}
+
 // actionsDefault returns the generic action menu for unrecognized resource kinds.
 func actionsDefault() []ActionMenuItem {
 	return []ActionMenuItem{

--- a/internal/model/actions_longhorn_test.go
+++ b/internal/model/actions_longhorn_test.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsLonghornNode disambiguates the longhorn.io Node CRD from the core
+// Kubernetes Node, which share the Kind "Node". Force delete and replica
+// eviction must only apply to the longhorn.io variant.
+func TestIsLonghornNode(t *testing.T) {
+	tests := []struct {
+		name string
+		rt   ResourceTypeEntry
+		want bool
+	}{
+		{
+			name: "longhorn node",
+			rt:   ResourceTypeEntry{APIGroup: "longhorn.io", APIVersion: "v1beta2", Resource: "nodes", Kind: "Node"},
+			want: true,
+		},
+		{
+			name: "core node",
+			rt:   ResourceTypeEntry{APIGroup: "", APIVersion: "v1", Resource: "nodes", Kind: "Node"},
+			want: false,
+		},
+		{
+			name: "longhorn volume",
+			rt:   ResourceTypeEntry{APIGroup: "longhorn.io", APIVersion: "v1beta2", Resource: "volumes", Kind: "Volume"},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsLonghornNode(tc.rt))
+		})
+	}
+}
+
+// TestActionsForLonghornNode locks in the dedicated action menu for
+// longhorn.io nodes. It must offer the Longhorn-native verbs (Evict
+// Replicas / Cancel Eviction) and Force Delete (disable scheduling then
+// delete past the validating webhook), but NOT the core-node kubectl verbs
+// (Cordon / Drain / Taint / Shell) that do not apply to a longhorn.io node.
+func TestActionsForLonghornNode(t *testing.T) {
+	items := ActionsForLonghornNode()
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+
+	assert.Contains(t, labels, "Evict Replicas",
+		"Longhorn node must offer Evict Replicas (spec.evictionRequested=true)")
+	assert.Contains(t, labels, "Cancel Eviction",
+		"Longhorn node must offer Cancel Eviction (spec.evictionRequested=false)")
+	assert.Contains(t, labels, "Force Delete",
+		"Longhorn node must offer Force Delete (disable scheduling then delete)")
+	assert.Contains(t, labels, "Delete")
+	assert.Contains(t, labels, "Describe")
+	assert.Contains(t, labels, "Edit")
+	assert.Contains(t, labels, "Events")
+
+	// Core-node-only kubectl verbs do not apply to a longhorn.io node.
+	assert.NotContains(t, labels, "Cordon")
+	assert.NotContains(t, labels, "Drain")
+	assert.NotContains(t, labels, "Taint")
+	assert.NotContains(t, labels, "Shell")
+
+	// Force Delete stays on the canonical X hotkey (see TestForceDeleteHotkeyConsistency).
+	fd, ok := findAction(items, "Force Delete")
+	require.True(t, ok)
+	assert.Equal(t, "X", fd.Key)
+
+	// Hotkeys within the menu must be unique.
+	seen := map[string]string{}
+	for _, it := range items {
+		if it.Key == "" {
+			continue
+		}
+		if prev, dup := seen[it.Key]; dup {
+			t.Fatalf("hotkey %q reused by %q and %q", it.Key, prev, it.Label)
+		}
+		seen[it.Key] = it.Label
+	}
+}

--- a/internal/model/resource_lookup.go
+++ b/internal/model/resource_lookup.go
@@ -107,3 +107,11 @@ func IsForceDeleteableKind(kind string) bool {
 		return false
 	}
 }
+
+// IsLonghornNode reports whether rt is the longhorn.io Node CRD. The CRD's
+// Kind is "Node", which collides with the core Kubernetes Node, so callers
+// must disambiguate by API group rather than Kind alone. Force delete and
+// replica eviction apply only to the longhorn.io variant.
+func IsLonghornNode(rt ResourceTypeEntry) bool {
+	return rt.APIGroup == "longhorn.io" && rt.Resource == "nodes"
+}

--- a/internal/ui/overlay_confirm.go
+++ b/internal/ui/overlay_confirm.go
@@ -33,6 +33,50 @@ type OverlayConfirmConfig struct {
 	Centered    bool
 	InnerWidth  int
 	InnerHeight int
+
+	// WrapWidth, when > 0, word-wraps the Warning to this many columns
+	// before rendering. Without it, lipgloss wraps the styled line at the
+	// box edge and breaks on hyphens / mid-word, which shatters long
+	// resource names (e.g. dev-envs-autoscaled-cx43-...). Callers pass the
+	// box inner width.
+	WrapWidth int
+}
+
+// wrapConfirmText word-wraps text to width on whitespace boundaries so words
+// (and hyphenated resource names) stay intact. A single token longer than
+// width is hard-split into width-sized chunks so no line exceeds width and
+// lipgloss never re-wraps with its hyphen-breaking default. Confirm text is
+// ASCII, so byte length is a safe column proxy.
+func wrapConfirmText(text string, width int) []string {
+	if width <= 0 {
+		return []string{text}
+	}
+	var lines []string
+	cur := ""
+	flush := func() {
+		if cur != "" {
+			lines = append(lines, cur)
+			cur = ""
+		}
+	}
+	for word := range strings.FieldsSeq(text) {
+		for len(word) > width {
+			flush()
+			lines = append(lines, word[:width])
+			word = word[width:]
+		}
+		switch {
+		case cur == "":
+			cur = word
+		case len(cur)+1+len(word) <= width:
+			cur += " " + word
+		default:
+			flush()
+			cur = word
+		}
+	}
+	flush()
+	return lines
 }
 
 // RenderOverlayConfirm renders a confirm overlay per cfg.
@@ -50,7 +94,11 @@ func RenderOverlayConfirm(cfg OverlayConfirmConfig) string {
 	b.WriteString(OverlayTitleStyle.Render(cfg.Title))
 	b.WriteString("\n\n")
 	if cfg.Warning != "" {
-		b.WriteString(OverlayWarningStyle.Render(cfg.Warning))
+		warning := cfg.Warning
+		if cfg.WrapWidth > 0 {
+			warning = strings.Join(wrapConfirmText(warning, cfg.WrapWidth), "\n")
+		}
+		b.WriteString(OverlayWarningStyle.Render(warning))
 		b.WriteString("\n\n")
 	}
 	for i, line := range cfg.Body {

--- a/internal/ui/overlay_confirm.go
+++ b/internal/ui/overlay_confirm.go
@@ -42,11 +42,11 @@ type OverlayConfirmConfig struct {
 	WrapWidth int
 }
 
-// wrapConfirmText word-wraps text to width on whitespace boundaries so words
-// (and hyphenated resource names) stay intact. A single token longer than
-// width is hard-split into width-sized chunks so no line exceeds width and
-// lipgloss never re-wraps with its hyphen-breaking default. Confirm text is
-// ASCII, so byte length is a safe column proxy.
+// wrapConfirmText word-wraps text to width display columns on whitespace
+// boundaries so words (and hyphenated resource names) stay intact. A single
+// token wider than width is hard-split on rune boundaries so no line exceeds
+// width and lipgloss never re-wraps with its hyphen-breaking default. Widths
+// use lipgloss.Width so multibyte/wide characters are measured correctly.
 func wrapConfirmText(text string, width int) []string {
 	if width <= 0 {
 		return []string{text}
@@ -60,15 +60,16 @@ func wrapConfirmText(text string, width int) []string {
 		}
 	}
 	for word := range strings.FieldsSeq(text) {
-		for len(word) > width {
+		for lipgloss.Width(word) > width {
 			flush()
-			lines = append(lines, word[:width])
-			word = word[width:]
+			head, rest := splitAtWidth(word, width)
+			lines = append(lines, head)
+			word = rest
 		}
 		switch {
 		case cur == "":
 			cur = word
-		case len(cur)+1+len(word) <= width:
+		case lipgloss.Width(cur)+1+lipgloss.Width(word) <= width:
 			cur += " " + word
 		default:
 			flush()
@@ -77,6 +78,21 @@ func wrapConfirmText(text string, width int) []string {
 	}
 	flush()
 	return lines
+}
+
+// splitAtWidth returns the longest prefix of s whose display width is <= width
+// and the remainder, splitting on rune boundaries so multibyte characters are
+// never cut in half.
+func splitAtWidth(s string, width int) (string, string) {
+	w := 0
+	for i, r := range s {
+		rw := lipgloss.Width(string(r))
+		if w+rw > width {
+			return s[:i], s[i:]
+		}
+		w += rw
+	}
+	return s, ""
 }
 
 // RenderOverlayConfirm renders a confirm overlay per cfg.

--- a/internal/ui/overlay_confirm_wrap_test.go
+++ b/internal/ui/overlay_confirm_wrap_test.go
@@ -1,8 +1,11 @@
 package ui
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,7 +13,7 @@ func TestWrapConfirmText(t *testing.T) {
 	t.Run("keeps words and hyphenated names intact", func(t *testing.T) {
 		lines := wrapConfirmText("Evict all replicas from dev-envs-autoscaled-cx43-2496bed88dc5524c?", 46)
 		for _, ln := range lines {
-			assert.LessOrEqual(t, len(ln), 46, "line exceeds width: %q", ln)
+			assert.LessOrEqual(t, lipgloss.Width(ln), 46, "line exceeds width: %q", ln)
 		}
 		// The long name fits within 46 cols, so it must stay on one line
 		// (no hyphen shattering).
@@ -23,12 +26,22 @@ func TestWrapConfirmText(t *testing.T) {
 		long := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 30 chars
 		lines := wrapConfirmText(long, 10)
 		for _, ln := range lines {
-			assert.LessOrEqual(t, len(ln), 10)
+			assert.LessOrEqual(t, lipgloss.Width(ln), 10)
 		}
 		assert.Equal(t, []string{"aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"}, lines)
 	})
 
 	t.Run("zero width returns text unchanged", func(t *testing.T) {
 		assert.Equal(t, []string{"hello world"}, wrapConfirmText("hello world", 0))
+	})
+
+	t.Run("hard-splits multibyte token on rune boundaries", func(t *testing.T) {
+		token := strings.Repeat("α", 9) // 9 width-1 Greek runes
+		lines := wrapConfirmText(token, 4)
+		for _, ln := range lines {
+			assert.True(t, utf8.ValidString(ln), "split produced invalid UTF-8: %q", ln)
+			assert.LessOrEqual(t, lipgloss.Width(ln), 4)
+		}
+		assert.Equal(t, token, strings.Join(lines, ""), "split must not lose or corrupt runes")
 	})
 }

--- a/internal/ui/overlay_confirm_wrap_test.go
+++ b/internal/ui/overlay_confirm_wrap_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapConfirmText(t *testing.T) {
+	t.Run("keeps words and hyphenated names intact", func(t *testing.T) {
+		lines := wrapConfirmText("Evict all replicas from dev-envs-autoscaled-cx43-2496bed88dc5524c?", 46)
+		for _, ln := range lines {
+			assert.LessOrEqual(t, len(ln), 46, "line exceeds width: %q", ln)
+		}
+		// The long name fits within 46 cols, so it must stay on one line
+		// (no hyphen shattering).
+		assert.Contains(t, lines, "dev-envs-autoscaled-cx43-2496bed88dc5524c?")
+		// No word is split mid-character.
+		assert.NotContains(t, lines, "r")
+	})
+
+	t.Run("hard-splits a token longer than width", func(t *testing.T) {
+		long := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 30 chars
+		lines := wrapConfirmText(long, 10)
+		for _, ln := range lines {
+			assert.LessOrEqual(t, len(ln), 10)
+		}
+		assert.Equal(t, []string{"aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"}, lines)
+	})
+
+	t.Run("zero width returns text unchanged", func(t *testing.T) {
+		assert.Equal(t, []string{"hello world"}, wrapConfirmText("hello world", 0))
+	})
+}


### PR DESCRIPTION
## Summary

Adds Longhorn-aware node operations to the `longhorn.io/nodes` ("Longhorn Nodes") resource type.

**Why:** deleting a Longhorn node fails with `admission webhook "validator.longhorn.io" denied the request: could not delete node ... node schedulable true`. The webhook rejects the DELETE itself when the node is still schedulable — and `kubectl delete --grace-period=0 --force` / finalizer removal do **not** bypass validating webhooks. The only real fix is to make the node satisfy the webhook (disable scheduling), then delete.

## What's included

- **Force Delete** (`X`): patches `spec.allowScheduling=false`, then deletes via the dynamic client with the exact GVR (avoids the core-vs-longhorn `nodes` ambiguity). The webhook still protects nodes that hold data, surfacing a clear error instead of risking data loss.
- **Evict Replicas** (`e`) / **Cancel Eviction** (`C`): toggle `spec.evictionRequested` (+ disable scheduling). Longhorn rebuilds each replica elsewhere before removing it, so eviction is data-safe. Use this to drain a node before force-deleting.
- **REPLICAS column** on the Longhorn Nodes list: one extra LIST per refresh grouped by `spec.nodeID` (no N+1) — see at a glance whether a node still holds data.
- **Dedicated Longhorn-node action menu**: the list previously showed the core-node menu (Cordon/Drain/Taint) since both share Kind `"Node"`; detection is group-aware via `IsLonghornNode`.
- **Confirm-overlay wrapping fix**: word-wrap on whitespace (keeping hyphenated names intact), hard-split only over-long tokens, so long resource names no longer shatter mid-word. Also improves the plain Delete / Force Delete confirms.

## Typical workflow (orphaned autoscaled node)

Open Longhorn Nodes → check `REPLICAS` is `0` → `X` Force Delete. If `REPLICAS > 0`, `e` Evict Replicas first, wait for it to drain, then force delete.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run` (0 issues)
- [x] Unit tests: group-aware detection, dedicated menu, force-delete routing (and no leak onto core nodes), evict/cancel confirm flow, read-only gating, REPLICAS column counting by `spec.nodeID`, confirm-text wrapping
- [ ] Manual: force-delete a real stuck Longhorn node; evict replicas off a node with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)