### PR TITLE
feat: allow Ctrl+O (open in browser) for port forwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ All search and filter inputs support three modes, auto-detected from the query s
 - Teleport between levels with `0` / `1` / `2` (clusters / resource types / resources)
 - Sort by any column with `>` / `<`, flip direction with `=`, reset with `-`
 - Check firing Prometheus/Alertmanager alerts with `@` and namespace quotas with `Q`
-- Open an Ingress host in your browser with `Ctrl+O`
+- Open an Ingress host - or an active port-forward's localhost URL - in your browser with `Ctrl+O`
 - Save the selected resource manifest to a file with `W`
 - Spin up a throwaway kind/k3d/minikube cluster without leaving lfk: `Ctrl+N` at the cluster list
 - Capture a Pod's network traffic with `c` - live decode plus pcap export (kubectl-debug or kubeshark)

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -151,7 +151,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `X` | Force delete (Pod/Job only) | `force_delete` |
 | `S` | Scale resource (Deployment / StatefulSet / ReplicaSet) | `scale` |
 | `W` | Save resource to file / toggle warnings-only filter (Events view) | `save_resource` |
-| `Ctrl+O` | Open ingress host in browser | `open_browser` |
+| `Ctrl+O` | Open ingress host or port-forward localhost URL in browser | `open_browser` |
 | `i` | Edit labels/annotations | `label_editor` |
 | `a` | Create new resource from template (/ to search) | `create_template` |
 | `d` | Diff two selected resources | `diff` |

--- a/internal/app/update_actions_helm_misc_test.go
+++ b/internal/app/update_actions_helm_misc_test.go
@@ -8,6 +8,72 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestHandleExplorerActionKeyOpenBrowser covers the global ctrl+o keybinding
+// gate: it must open a browser for Ingress resources and port-forward entries,
+// and reject everything else.
+func TestHandleExplorerActionKeyOpenBrowser(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(m *Model)
+		wantErr bool
+		wantMsg string
+	}{
+		{
+			name: "ingress opens its precomputed URL",
+			setup: func(m *Model) {
+				m.nav.Level = model.LevelResources
+				m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Ingress"}
+				m.middleItems = []model.Item{{
+					Name:    "my-ingress",
+					Columns: []model.KeyValue{{Key: "__ingress_url", Value: "https://example.com"}},
+				}}
+			},
+			wantErr: false,
+			wantMsg: "Opening https://example.com",
+		},
+		{
+			name: "port forward opens its localhost URL",
+			setup: func(m *Model) {
+				m.nav.Level = model.LevelResources
+				m.nav.ResourceType = model.ResourceTypeEntry{Kind: "__port_forwards__"}
+				m.middleItems = []model.Item{{
+					Name:    "Pod/my-pod  8080:80",
+					Kind:    "__port_forward_entry__",
+					Columns: []model.KeyValue{{Key: "Local", Value: "8080"}},
+				}}
+			},
+			wantErr: false,
+			wantMsg: "Opening http://localhost:8080",
+		},
+		{
+			name: "unsupported kind is rejected",
+			setup: func(m *Model) {
+				m.nav.Level = model.LevelResources
+				m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod"}
+				m.middleItems = []model.Item{{Name: "my-pod", Kind: "Pod"}}
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := baseModelUpdate()
+			tc.setup(&m)
+
+			ret, cmd, handled := m.handleExplorerActionKeyOpenBrowser()
+			result := ret.(Model)
+
+			assert.True(t, handled)
+			assert.NotNil(t, cmd)
+			assert.True(t, result.hasStatusMessage())
+			assert.Equal(t, tc.wantErr, result.statusMessageErr)
+			if tc.wantMsg != "" {
+				assert.Equal(t, tc.wantMsg, result.statusMessage)
+			}
+		})
+	}
+}
+
 // TestRemoveSelectedPortForward covers the D / delete key path in the
 // __port_forwards__ browser. The action-menu "Remove" shares the same
 // manager call.

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -485,8 +485,8 @@ func (m Model) handleExplorerActionKeyJumpOwner() (tea.Model, tea.Cmd, bool) {
 
 func (m Model) handleExplorerActionKeyOpenBrowser() (tea.Model, tea.Cmd, bool) {
 	kind := m.selectedResourceKind()
-	if kind != "Ingress" {
-		m.setStatusMessage("Open in browser is only available for Ingress resources", true)
+	if kind != "Ingress" && kind != "__port_forwards__" && kind != "__port_forward_entry__" {
+		m.setStatusMessage("Open in browser is only available for Ingress resources and port forwards", true)
 		return m, scheduleStatusClear(), true
 	}
 	sel := m.selectedMiddleItem()


### PR DESCRIPTION
## Summary
- `Ctrl+O` (open in browser) now works on **port forwards**, not just Ingresses.
- The `executeActionOpenInBrowser` action already handled port-forward entries (opening `http://localhost:<local-port>`), and the port-forward action menu already exposed "Open in Browser". The only gap was the global `Ctrl+O` keybind handler (`handleExplorerActionKeyOpenBrowser`), which hard-rejected every kind except `Ingress`.
- Widened the gate to also accept `__port_forwards__` and `__port_forward_entry__`, and updated the rejection message.
- Updated keybinding docs (README, `docs/keybindings.md`).

## Test plan
- [x] `go build ./...`
- [x] New table-driven test `TestHandleExplorerActionKeyOpenBrowser` (Ingress opens URL, port-forward opens `http://localhost:8080`, unsupported kind rejected) — written RED-first, now green
- [x] `go test ./internal/app/ ./internal/ui/`
- [x] `go vet` + `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)