### PR TITLE
fix: show PriorityClass Value and Preemption Policy columns

### DIFF
--- a/internal/k8s/client_populate_ext.go
+++ b/internal/k8s/client_populate_ext.go
@@ -54,14 +54,19 @@ func populateResourceDetailsExt(ti *model.Item, obj map[string]any, kind string,
 		populateEndpointSlice(ti, obj)
 
 	case "PriorityClass":
-		if val, ok := spec["globalDefault"].(bool); ok && val {
+		// PriorityClass has no spec: value, globalDefault, and preemptionPolicy
+		// are top-level fields on the object.
+		if val, ok := obj["globalDefault"].(bool); ok && val {
 			ti.Name += " (default)"
 			ti.Status = "default"
 		}
-		if v, ok := spec["value"].(float64); ok {
+		switch v := obj["value"].(type) {
+		case int64:
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Value", Value: fmt.Sprintf("%d", v)})
+		case float64:
 			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Value", Value: fmt.Sprintf("%d", int64(v))})
 		}
-		if pp, ok := spec["preemptionPolicy"].(string); ok && pp != "" {
+		if pp, ok := obj["preemptionPolicy"].(string); ok && pp != "" {
 			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Preemption Policy", Value: pp})
 		}
 

--- a/internal/k8s/client_populate_ext_coverage_test.go
+++ b/internal/k8s/client_populate_ext_coverage_test.go
@@ -122,27 +122,22 @@ func TestPopulateExt_ServiceAccountCoverage(t *testing.T) {
 
 func TestPopulateExt_PriorityClassCoverage(t *testing.T) {
 	t.Run("default priority class", func(t *testing.T) {
+		// PriorityClass fields are top-level on the object, not under spec.
 		obj := map[string]any{
-			"spec": map[string]any{
-				"globalDefault": true,
-			},
+			"globalDefault": true,
 		}
 		ti := &model.Item{Name: "high-priority"}
-		spec := obj["spec"].(map[string]any)
-		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, spec)
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
 		assert.Equal(t, "high-priority (default)", ti.Name)
 		assert.Equal(t, "default", ti.Status)
 	})
 
 	t.Run("non-default priority class", func(t *testing.T) {
 		obj := map[string]any{
-			"spec": map[string]any{
-				"globalDefault": false,
-			},
+			"globalDefault": false,
 		}
 		ti := &model.Item{Name: "low-priority"}
-		spec := obj["spec"].(map[string]any)
-		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, spec)
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
 		assert.Equal(t, "low-priority", ti.Name)
 	})
 }

--- a/internal/k8s/client_populate_ext_test.go
+++ b/internal/k8s/client_populate_ext_test.go
@@ -963,13 +963,16 @@ func TestPopulateResourceDetailsExt_ServiceAccount(t *testing.T) {
 
 // --- populateResourceDetailsExt: PriorityClass ---
 
+// PriorityClass has no spec: value, globalDefault, and preemptionPolicy are
+// top-level fields on the object. These tests pass them via obj (matching real
+// Kubernetes), not the spec argument.
 func TestPopulateResourceDetailsExt_PriorityClass(t *testing.T) {
 	t.Run("default PriorityClass", func(t *testing.T) {
 		ti := &model.Item{Name: "high-priority"}
-		spec := map[string]any{
+		obj := map[string]any{
 			"globalDefault": true,
 		}
-		populateResourceDetailsExt(ti, map[string]any{}, "PriorityClass", nil, spec)
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
 
 		assert.Equal(t, "high-priority (default)", ti.Name)
 		assert.Equal(t, "default", ti.Status)
@@ -977,10 +980,10 @@ func TestPopulateResourceDetailsExt_PriorityClass(t *testing.T) {
 
 	t.Run("non-default PriorityClass", func(t *testing.T) {
 		ti := &model.Item{Name: "low-priority"}
-		spec := map[string]any{
+		obj := map[string]any{
 			"globalDefault": false,
 		}
-		populateResourceDetailsExt(ti, map[string]any{}, "PriorityClass", nil, spec)
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
 
 		assert.Equal(t, "low-priority", ti.Name)
 	})
@@ -1074,23 +1077,34 @@ func TestPopulateResourceDetailsExt_IngressClass_ControllerAndParameters(t *test
 func TestPopulateResourceDetailsExt_PriorityClass_ValueAndPreemption(t *testing.T) {
 	t.Run("value 1000 and preemption Never", func(t *testing.T) {
 		ti := &model.Item{Name: "high-priority"}
-		spec := map[string]any{
+		obj := map[string]any{
 			"value":            float64(1000),
 			"preemptionPolicy": "Never",
 		}
-		populateResourceDetailsExt(ti, map[string]any{}, "PriorityClass", nil, spec)
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
 
 		colMap := columnsToMap(ti.Columns)
 		assert.Equal(t, "1000", colMap["Value"])
 		assert.Equal(t, "Never", colMap["Preemption Policy"])
 	})
 
+	t.Run("value as int64 (unstructured numeric form)", func(t *testing.T) {
+		ti := &model.Item{Name: "high-priority"}
+		obj := map[string]any{
+			"value": int64(2000000000),
+		}
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
+
+		colMap := columnsToMap(ti.Columns)
+		assert.Equal(t, "2000000000", colMap["Value"])
+	})
+
 	t.Run("zero value emitted", func(t *testing.T) {
 		ti := &model.Item{Name: "zero-priority"}
-		spec := map[string]any{
+		obj := map[string]any{
 			"value": float64(0),
 		}
-		populateResourceDetailsExt(ti, map[string]any{}, "PriorityClass", nil, spec)
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
 
 		colMap := columnsToMap(ti.Columns)
 		assert.Equal(t, "0", colMap["Value"])
@@ -1098,11 +1112,11 @@ func TestPopulateResourceDetailsExt_PriorityClass_ValueAndPreemption(t *testing.
 
 	t.Run("empty preemption policy suppressed", func(t *testing.T) {
 		ti := &model.Item{Name: "some-priority"}
-		spec := map[string]any{
+		obj := map[string]any{
 			"value":            float64(500),
 			"preemptionPolicy": "",
 		}
-		populateResourceDetailsExt(ti, map[string]any{}, "PriorityClass", nil, spec)
+		populateResourceDetailsExt(ti, obj, "PriorityClass", nil, nil)
 
 		colMap := columnsToMap(ti.Columns)
 		_, found := colMap["Preemption Policy"]


### PR DESCRIPTION
## Summary
PriorityClass list rows never showed the **Value** or **Preemption Policy** columns, and the global-default marker was never applied.

Root cause: `populateResourceDetailsExt` read `value`, `globalDefault`, and `preemptionPolicy` from the `spec` argument. But PriorityClass has **no `spec`** — those are top-level fields on the object — so `obj["spec"]` is `nil` for a real PriorityClass and the columns were never populated. (Existing tests passed the data via `spec`, masking the bug.)

## Changes
- Read `value` / `globalDefault` / `preemptionPolicy` from `obj` (top level), handling both `int64` and `float64` numeric forms (unstructured objects can carry either).
- Updated the unit tests to use the real Kubernetes object shape (data in `obj`, not `spec`) and added an `int64` value case.

Both columns auto-detect into the list view: `Value` is present on every PriorityClass, and neither column is in any blocked list.

## Test plan
- [x] `go build ./...`
- [x] `TestPopulateResourceDetailsExt_PriorityClass*` and `TestPopulateExt_PriorityClassCoverage` updated RED-first, now green
- [x] `go test ./internal/k8s/ ./internal/ui/`
- [x] `go vet` + `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)