### PR TITLE
feat: Port Forward & Open action for Services (Ctrl+O)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ All search and filter inputs support three modes, auto-detected from the query s
 - Teleport between levels with `0` / `1` / `2` (clusters / resource types / resources)
 - Sort by any column with `>` / `<`, flip direction with `=`, reset with `-`
 - Check firing Prometheus/Alertmanager alerts with `@` and namespace quotas with `Q`
-- Open an Ingress host - or an active port-forward's localhost URL - in your browser with `Ctrl+O`
+- Open an Ingress host - or an active port-forward's localhost URL - in your browser with `Ctrl+O`; on a Service, `Ctrl+O` starts a port forward and opens it
 - Save the selected resource manifest to a file with `W`
 - Spin up a throwaway kind/k3d/minikube cluster without leaving lfk: `Ctrl+N` at the cluster list
 - Capture a Pod's network traffic with `c` - live decode plus pcap export (kubectl-debug or kubeshark)

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -151,14 +151,14 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `X` | Force delete (Pod/Job only) | `force_delete` |
 | `S` | Scale resource (Deployment / StatefulSet / ReplicaSet) | `scale` |
 | `W` | Save resource to file / toggle warnings-only filter (Events view) | `save_resource` |
-| `Ctrl+O` | Open ingress host or port-forward localhost URL in browser | `open_browser` |
+| `Ctrl+O` | Open in browser: ingress host, port-forward localhost URL, or (on a Service) start a port forward and open it | `open_browser` |
 | `i` | Edit labels/annotations | `label_editor` |
 | `a` | Create new resource from template (/ to search) | `create_template` |
 | `d` | Diff two selected resources | `diff` |
 
 Events list also groups duplicate events (same Type/Reason/Message/Object) by default; press `z` to toggle grouping.
 
-Port forwarding is available via the action menu (`x`) on Pod, Service, Deployment, StatefulSet, and DaemonSet resources. In the port-forward dialog, select an exposed port with `j`/`k`, or type a `local:remote` mapping (e.g. `8080:80`) to choose a specific local port — omit the local port (e.g. `:80`) for a random one. After creating a port forward, the view automatically navigates to the Port Forwards list and displays the resolved local port in the status bar. Active port forwards can be managed via the "Port Forwards" virtual resource in the Networking group; press `D` there to remove the selected forward.
+Port forwarding is available via the action menu (`x`) on Pod, Service, Deployment, StatefulSet, and DaemonSet resources. In the port-forward dialog, select an exposed port with `j`/`k`, or type a `local:remote` mapping (e.g. `8080:80`) to choose a specific local port — omit the local port (e.g. `:80`) for a random one. After creating a port forward, the view automatically navigates to the Port Forwards list and displays the resolved local port in the status bar. Active port forwards can be managed via the "Port Forwards" virtual resource in the Networking group; press `D` there to remove the selected forward. On a Service, `Ctrl+O` (or the "Port Forward & Open" action) starts a port forward and opens the resolved `http://localhost:<port>` in the browser once it is ready.
 
 Resource-specific actions (exec, scale, restart, secret editor, etc.) are available through the action menu (`x`).
 
@@ -960,7 +960,7 @@ The action menu (`x` key) shows context-specific actions based on the resource t
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
 ### Service Actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies affecting the service's backing pods), `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `O` Port Forward & Open (forward a port and open it in the browser), `c` Capture Traffic, `N` Network Policies (policies affecting the service's backing pods), `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
 
 ### Secret Actions
 `e` Secret Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -738,11 +738,11 @@ type Model struct {
 	captureOverlay captureOverlayState
 
 	// Port forward overlay state: discovered ports for the selected resource.
-	pfAvailablePorts []ui.PortInfo
-	pfPortCursor     int              // cursor in the available ports list (-1 = manual input)
-	pfLastCreatedID  int              // ID of the most recently created port forward (for showing resolved port)
-	pfLoggedErrors   map[int]struct{} // port forward IDs whose failures have been logged to errorLog
-
+	pfAvailablePorts          []ui.PortInfo
+	pfPortCursor              int              // cursor in the available ports list (-1 = manual input)
+	pfLastCreatedID           int              // ID of the most recently created port forward (for showing resolved port)
+	pfLoggedErrors            map[int]struct{} // port forward IDs whose failures have been logged to errorLog
+	pfOpenInBrowserAfterStart bool             // open localhost:<port> once the next forward resolves ("Port Forward & Open")
 	// Explain view state (API browser).
 	explainFields                []model.ExplainField
 	explainDesc                  string // resource/field-level description

--- a/internal/app/port_forward_open_test.go
+++ b/internal/app/port_forward_open_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConsumePortForwardBrowserOpen covers the helper that decides whether to
+// open the resolved localhost URL and clear the pending intent.
+func TestConsumePortForwardBrowserOpen(t *testing.T) {
+	t.Run("no pending intent is a no-op", func(t *testing.T) {
+		m := baseModelUpdate()
+		m.pfOpenInBrowserAfterStart = false
+		cmd := m.consumePortForwardBrowserOpen("8080")
+		assert.Nil(t, cmd)
+		assert.False(t, m.pfOpenInBrowserAfterStart)
+	})
+
+	t.Run("pending intent with unresolved port keeps the intent", func(t *testing.T) {
+		m := baseModelUpdate()
+		m.pfOpenInBrowserAfterStart = true
+		for _, port := range []string{"0", ""} {
+			cmd := m.consumePortForwardBrowserOpen(port)
+			assert.Nil(t, cmd)
+			assert.True(t, m.pfOpenInBrowserAfterStart, "intent must survive port %q", port)
+		}
+	})
+
+	t.Run("pending intent with resolved port opens and clears", func(t *testing.T) {
+		m := baseModelUpdate()
+		m.pfOpenInBrowserAfterStart = true
+		cmd := m.consumePortForwardBrowserOpen("8080")
+		assert.NotNil(t, cmd)
+		assert.False(t, m.pfOpenInBrowserAfterStart)
+		assert.Equal(t, "Opening http://localhost:8080", m.statusMessage)
+		assert.False(t, m.statusMessageErr)
+	})
+}
+
+// TestExecuteActionPortForwardAndOpen asserts the action sets the pending
+// browser-open intent before loading ports.
+func TestExecuteActionPortForwardAndOpen(t *testing.T) {
+	m := baseModelUpdate()
+	m.actionCtx = actionContext{kind: "Service", name: "web", namespace: "default", context: "test-ctx"}
+
+	ret, cmd := m.executeAction("Port Forward & Open")
+	result := ret.(Model)
+
+	assert.True(t, result.pfOpenInBrowserAfterStart)
+	assert.NotNil(t, cmd) // loadContainerPorts
+}
+
+// TestExecuteActionPortForwardAndOpen_ReadOnlyBlocked asserts the chained
+// action is gated by read-only mode and does not set the intent.
+func TestExecuteActionPortForwardAndOpen_ReadOnlyBlocked(t *testing.T) {
+	m := baseModelUpdate()
+	m.readOnly = true
+	m.actionCtx = actionContext{kind: "Service", name: "web", namespace: "default", context: "test-ctx"}
+
+	ret, _ := m.executeAction("Port Forward & Open")
+	result := ret.(Model)
+
+	assert.Equal(t, readOnlyBlockedMessage("Port Forward & Open"), result.statusMessage)
+	assert.True(t, result.statusMessageErr)
+	assert.False(t, result.pfOpenInBrowserAfterStart)
+}
+
+// TestPortForwardStarted_OpensWhenPortKnown covers the explicit-local-port path
+// where the browser opens immediately on start.
+func TestPortForwardStarted_OpensWhenPortKnown(t *testing.T) {
+	m := baseModelUpdate()
+	m.pfOpenInBrowserAfterStart = true
+
+	ret, cmd := m.updatePortForwardStarted(portForwardStartedMsg{id: 1, localPort: "8080", remotePort: "80"})
+	result := ret.(Model)
+
+	assert.False(t, result.pfOpenInBrowserAfterStart, "intent consumed once port is known")
+	assert.Equal(t, "Opening http://localhost:8080", result.statusMessage)
+	assert.NotNil(t, cmd)
+}
+
+// TestPortForwardStarted_DefersWhenPortRandom keeps the intent until the random
+// port resolves later.
+func TestPortForwardStarted_DefersWhenPortRandom(t *testing.T) {
+	m := baseModelUpdate()
+	m.pfOpenInBrowserAfterStart = true
+
+	ret, _ := m.updatePortForwardStarted(portForwardStartedMsg{id: 1, localPort: "0", remotePort: "80"})
+	result := ret.(Model)
+
+	assert.True(t, result.pfOpenInBrowserAfterStart, "intent survives until the port resolves")
+}
+
+// TestPortForwardStarted_ErrorClearsIntent ensures a failed start does not leak
+// the intent into an unrelated future forward.
+func TestPortForwardStarted_ErrorClearsIntent(t *testing.T) {
+	m := baseModelUpdate()
+	m.pfOpenInBrowserAfterStart = true
+
+	ret, _ := m.updatePortForwardStarted(portForwardStartedMsg{err: assertErr{}})
+	result := ret.(Model)
+
+	assert.False(t, result.pfOpenInBrowserAfterStart)
+}
+
+// TestHandleOpenBrowser_ServiceTriggersPortForwardOpen asserts Ctrl+O on a
+// Service routes through the chained action and sets the intent.
+func TestHandleOpenBrowser_ServiceTriggersPortForwardOpen(t *testing.T) {
+	m := baseModelUpdate()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Service", Resource: "services", Namespaced: true}
+	m.middleItems = []model.Item{{Name: "web", Namespace: "default", Kind: "Service"}}
+
+	ret, cmd, handled := m.handleExplorerActionKeyOpenBrowser()
+	result := ret.(Model)
+
+	assert.True(t, handled)
+	assert.NotNil(t, cmd)
+	assert.True(t, result.pfOpenInBrowserAfterStart)
+}
+
+// TestHandleOpenBrowser_ServiceReadOnlyBlocked asserts read-only mode blocks the
+// Service Ctrl+O path without setting the intent.
+func TestHandleOpenBrowser_ServiceReadOnlyBlocked(t *testing.T) {
+	m := baseModelUpdate()
+	m.readOnly = true
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Service", Resource: "services", Namespaced: true}
+	m.middleItems = []model.Item{{Name: "web", Namespace: "default", Kind: "Service"}}
+
+	ret, _, handled := m.handleExplorerActionKeyOpenBrowser()
+	result := ret.(Model)
+
+	assert.True(t, handled)
+	assert.False(t, result.pfOpenInBrowserAfterStart)
+	assert.Equal(t, readOnlyBlockedMessage("Port Forward & Open"), result.statusMessage)
+}
+
+// TestPortForwardOverlayCancelClearsIntent ensures escaping the overlay drops a
+// pending browser-open intent.
+func TestPortForwardOverlayCancelClearsIntent(t *testing.T) {
+	m := baseModelUpdate()
+	m.pfOpenInBrowserAfterStart = true
+	m.overlay = overlayPortForward
+
+	ret, _ := m.handlePortForwardOverlayKey(tea.KeyMsg{Type: tea.KeyEsc})
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNone, result.overlay)
+	assert.False(t, result.pfOpenInBrowserAfterStart)
+}
+
+// assertErr is a trivial error used to exercise the start-error path.
+type assertErr struct{}
+
+func (assertErr) Error() string { return "boom" }

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -34,6 +34,7 @@ var mutatingActions = map[string]bool{
 	"Debug Pod":            true,
 	"Debug Mount":          true,
 	"Port Forward":         true,
+	"Port Forward & Open":  true,
 	"Cordon":               true,
 	"Uncordon":             true,
 	"Drain":                true,
@@ -111,6 +112,8 @@ func isUnionAllowedActionForKind(kind, label string) bool {
 			return true
 		}
 		return false
+	case "Port Forward & Open":
+		return kind == "Service"
 	case "Restart":
 		return model.IsRestartableKind(kind)
 	default:

--- a/internal/app/readonly_union_closure_test.go
+++ b/internal/app/readonly_union_closure_test.go
@@ -41,6 +41,10 @@ func TestIsUnionAllowedActionForKind_ClosureOverMutatingActions(t *testing.T) {
 		// Allowed for the five kinds the action handler supports.
 		"Port Forward": {"Pod", "Service", "Deployment", "StatefulSet", "DaemonSet"},
 
+		// Port Forward & Open chains a port forward with a browser open;
+		// only Services expose it (Ctrl+O / action menu).
+		"Port Forward & Open": {"Service"},
+
 		// Everything below is hard-blocked at the union sentinel.
 		// These either need a single API target (Scale, Rollback,
 		// Edit) or are kind-specific operations (Cordon, Drain,

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -476,6 +476,10 @@ func (m Model) executeActionCoreK8s(actionLabel string) (tea.Model, tea.Cmd, boo
 	case "Port Forward":
 		mdl, cmd := m.executeActionPortForward()
 		return mdl, cmd, true
+	case "Port Forward & Open":
+		m.pfOpenInBrowserAfterStart = true
+		mdl, cmd := m.executeActionPortForward()
+		return mdl, cmd, true
 	case "Debug":
 		mdl, cmd := m.executeActionDebug()
 		return mdl, cmd, true

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -485,8 +485,18 @@ func (m Model) handleExplorerActionKeyJumpOwner() (tea.Model, tea.Cmd, bool) {
 
 func (m Model) handleExplorerActionKeyOpenBrowser() (tea.Model, tea.Cmd, bool) {
 	kind := m.selectedResourceKind()
-	if kind != "Ingress" && kind != "__port_forwards__" && kind != "__port_forward_entry__" {
-		m.setStatusMessage("Open in browser is only available for Ingress resources and port forwards", true)
+	// Ingresses and port forwards have a directly openable URL. A Service has
+	// none, so Ctrl+O instead starts a port forward and opens the resolved
+	// localhost URL once it is ready (the "Port Forward & Open" action, which
+	// is read-only gated in executeAction).
+	var action string
+	switch kind {
+	case "Ingress", "__port_forwards__", "__port_forward_entry__":
+		action = "Open in Browser"
+	case "Service":
+		action = "Port Forward & Open"
+	default:
+		m.setStatusMessage("Open in browser is only available for Ingress, Service, and port forwards", true)
 		return m, scheduleStatusClear(), true
 	}
 	sel := m.selectedMiddleItem()
@@ -494,7 +504,7 @@ func (m Model) handleExplorerActionKeyOpenBrowser() (tea.Model, tea.Cmd, bool) {
 		return m, nil, true
 	}
 	m.actionCtx = m.buildActionCtx(sel, kind)
-	ret, cmd := m.executeAction("Open in Browser")
+	ret, cmd := m.executeAction(action)
 	return ret, cmd, true
 }
 

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -337,6 +337,7 @@ func (m Model) handlePortForwardOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.portForwardInput.Clear()
 		m.pfAvailablePorts = nil
 		m.pfPortCursor = -1
+		m.pfOpenInBrowserAfterStart = false
 		return m, nil
 	case "j", "down":
 		if len(m.pfAvailablePorts) > 0 && m.pfPortCursor < len(m.pfAvailablePorts)-1 {
@@ -372,6 +373,7 @@ func (m Model) handlePortForwardOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 				// An empty local port (":80") is fine — kubectl picks one.
 				m.setStatusMessage("Port mapping needs a remote port (e.g., 8080:80)", true)
 				m.overlay = overlayNone
+				m.pfOpenInBrowserAfterStart = false
 				return m, scheduleStatusClear()
 			}
 			localPort = parts[0]
@@ -383,6 +385,7 @@ func (m Model) handlePortForwardOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		default:
 			m.setStatusMessage("Port mapping required (e.g., 8080:80)", true)
 			m.overlay = overlayNone
+			m.pfOpenInBrowserAfterStart = false
 			return m, scheduleStatusClear()
 		}
 		portMapping := localPort + ":" + remotePort

--- a/internal/app/update_portforward_msgs.go
+++ b/internal/app/update_portforward_msgs.go
@@ -40,6 +40,9 @@ func (m Model) updateContainerPortsLoaded(msg containerPortsLoadedMsg) Model {
 
 func (m Model) updatePortForwardStarted(msg portForwardStartedMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
+		// Don't carry an "open in browser" intent into a future, unrelated
+		// port forward when this one failed to start.
+		m.pfOpenInBrowserAfterStart = false
 		m.setErrorFromErr("Port forward failed: ", msg.err)
 		return m, scheduleStatusClear()
 	}
@@ -55,7 +58,28 @@ func (m Model) updatePortForwardStarted(msg portForwardStartedMsg) (tea.Model, t
 	m.navigateToPortForwards()
 	m.saveCurrentPortForwards()
 	cmds := []tea.Cmd{m.waitForPortForwardUpdate()}
+	// If the user asked to open the forward in the browser and the local port
+	// is already known, open it now. A random ("0") port is opened later by
+	// updatePortForwardUpdate once it resolves.
+	if openCmd := m.consumePortForwardBrowserOpen(msg.localPort); openCmd != nil {
+		cmds = append(cmds, openCmd)
+	}
 	return m, tea.Batch(cmds...)
+}
+
+// consumePortForwardBrowserOpen returns a command that opens
+// http://localhost:<localPort> in the browser when a "Port Forward & Open"
+// intent is pending and the local port is resolved (non-empty, non-"0"). It
+// clears the intent and updates the status message as a side effect. Returns
+// nil (leaving the intent set) when there is nothing to open yet.
+func (m *Model) consumePortForwardBrowserOpen(localPort string) tea.Cmd {
+	if !m.pfOpenInBrowserAfterStart || localPort == "" || localPort == "0" {
+		return nil
+	}
+	m.pfOpenInBrowserAfterStart = false
+	url := "http://localhost:" + localPort
+	m.setStatusMessage("Opening "+url, false)
+	return openInBrowser(url)
 }
 
 func (m Model) updatePortForwardStopped(msg portForwardStoppedMsg) (tea.Model, tea.Cmd) {
@@ -107,6 +131,13 @@ func (m Model) updatePortForwardUpdate(msg portForwardUpdateMsg) (tea.Model, tea
 				m.addLogEntry("INF", fmt.Sprintf("Port forward %d resolved: localhost:%s -> %s", e.ID, e.LocalPort, e.RemotePort))
 				m.pfLastCreatedID = 0
 				m.saveCurrentPortForwards()
+				// Open the resolved localhost URL in the browser if a
+				// "Port Forward & Open" intent is still pending (the port was
+				// random and only became known now). Overrides the status
+				// message set just above.
+				if openCmd := m.consumePortForwardBrowserOpen(e.LocalPort); openCmd != nil {
+					cmds = append(cmds, openCmd)
+				}
 				cmds = append(cmds, scheduleStatusClear())
 				break
 			}

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -119,6 +119,7 @@ func actionsForCoreKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Exec", Description: "Exec into pod behind service", Key: "s"},
 			{Label: "Attach", Description: "Attach to pod behind service", Key: "A"},
 			{Label: "Port Forward", Description: "Forward local port to service", Key: "p"},
+			{Label: "Port Forward & Open", Description: "Forward a local port and open it in the browser", Key: "O"},
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this service", Key: "D"},

--- a/internal/model/actions_port_forward_open_test.go
+++ b/internal/model/actions_port_forward_open_test.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPortForwardAndOpenActionPresentForService(t *testing.T) {
+	var found bool
+	for _, it := range ActionsForKind("Service") {
+		if it.Label == "Port Forward & Open" {
+			found = true
+			assert.Equal(t, "O", it.Key)
+			assert.NotEmpty(t, it.Description)
+			break
+		}
+	}
+	assert.True(t, found, "Service must offer the Port Forward & Open action item")
+}
+
+func TestPortForwardAndOpenActionAbsentForNonService(t *testing.T) {
+	for _, kind := range []string{"Pod", "Deployment", "StatefulSet", "DaemonSet", "Ingress"} {
+		t.Run(kind, func(t *testing.T) {
+			for _, it := range ActionsForKind(kind) {
+				assert.NotEqual(t, "Port Forward & Open", it.Label,
+					"%q must not offer the Port Forward & Open action item", kind)
+			}
+		})
+	}
+}

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -105,6 +105,7 @@ func helpSections() []helpSection {
 				{helpKeyDisplay(kb.PasteApply), "Apply resource from clipboard (kubectl apply)"},
 				{"", "Port forwarding: use action menu (" + kb.ActionMenu + ") on Pod/Service/Deployment/StatefulSet/DaemonSet"},
 				{"", "Auto-navigates to Port Forwards list after creation; shows resolved local port"},
+				{helpKeyDisplay(kb.OpenBrowser), "Open in browser: Ingress host, port-forward URL, or (Service) forward a port and open it"},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
A Service has no directly openable URL, so `Ctrl+O` did nothing useful on one. This adds a **"Port Forward & Open"** flow: start a port forward to the Service, then open `http://localhost:<local-port>` in the browser once the local port resolves.

Exposed two ways:
- New **"Port Forward & Open"** Service action-menu item (key `O`).
- **`Ctrl+O`** on a Service routes to the same chained action.

## How it works
- `pfOpenInBrowserAfterStart` intent flag on `Model`, set by the action and consumed when the port resolves — immediately on start for an explicit local port, or later in `updatePortForwardUpdate` for a random (`0`) port.
- `consumePortForwardBrowserOpen` centralizes the open-and-clear logic (opens only on a resolved, non-`0` port).
- Intent is cleared on start error and on overlay cancel / invalid input, so it never leaks into an unrelated future forward.
- Read-only gated (added to `mutatingActions`) and union-policy scoped to `Service`.

## Notes for reviewers
This PR is **stacked on `feat/open-browser-port-forwards` (#445)** because both touch `handleExplorerActionKeyOpenBrowser`. Base is set to that branch so the diff shows only the Service additions. Once #445 merges to `main`, I'll retarget this PR to `main`.

## Test plan
- [x] `go build ./...`
- [x] New tests: `internal/model/actions_port_forward_open_test.go` (action present/absent, key `O`), `internal/app/port_forward_open_test.go` (intent helper, dispatch, read-only block, start-known/deferred/error, Ctrl+O on Service, overlay-cancel cleanup) — TDD
- [x] `internal/app/readonly_union_closure_test.go` updated for the new union policy row
- [x] `go test ./...` (full suite)
- [x] `go vet` + `golangci-lint` clean; 800-line cap on `app.go` respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)