### PR TITLE
fix: scope to default namespace when toggling all-namespaces off with none set

### DIFF
--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -622,6 +622,16 @@ func (m Model) resolveNamespace() string {
 	return m.namespace
 }
 
+// defaultNamespaceForContext returns the namespace to scope to when none is
+// set: the active context's kubeconfig namespace when a client is available,
+// falling back to "default". Guards against a nil client (test models).
+func (m Model) defaultNamespaceForContext() string {
+	if m.client != nil {
+		return m.client.DefaultNamespace(m.nav.Context)
+	}
+	return "default"
+}
+
 // loadRevisions fetches the revision history for a deployment.
 func (m Model) loadRevisions() tea.Cmd {
 	sel := m.selectedMiddleItem()

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -258,7 +258,10 @@ func (m Model) handleExplorerActionKeyAllNamespaces() (tea.Model, tea.Cmd, bool)
 		if m.namespace == "" && len(m.selectedNamespaces) == 0 {
 			m.namespace = m.defaultNamespaceForContext()
 		}
-		m.setStatusMessage("All namespaces mode OFF (ns: "+m.namespace+")", false)
+		// Report the effective scope: a restored single selection lives in
+		// selectedNamespaces (not m.namespace), so building the hint from
+		// m.namespace alone could still show "(ns: )".
+		m.setStatusMessage("All namespaces mode OFF (ns: "+m.effectiveNamespace()+")", false)
 	}
 	m.cancelAndReset()
 	m.requestGen++

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -250,6 +250,14 @@ func (m Model) handleExplorerActionKeyAllNamespaces() (tea.Model, tea.Cmd, bool)
 		m.nsSelectionNegated = m.savedNsSelectionNegated
 		m.savedSelectedNamespaces = nil
 		m.savedNsSelectionNegated = false
+		// With no concrete namespace to return to (started in all-namespaces
+		// mode, or the namespace was cleared by a prior navigation) and no
+		// restored single selection, fall back to the default namespace.
+		// Otherwise effectiveNamespace returns "" and the fetch silently stays
+		// on every namespace, so the toggle looks like a no-op.
+		if m.namespace == "" && len(m.selectedNamespaces) == 0 {
+			m.namespace = m.defaultNamespaceForContext()
+		}
 		m.setStatusMessage("All namespaces mode OFF (ns: "+m.namespace+")", false)
 	}
 	m.cancelAndReset()

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -137,6 +137,9 @@ func TestActionKeyAllNamespacesOffKeepsRestoredSelection(t *testing.T) {
 	assert.False(t, off.allNamespaces)
 	assert.Equal(t, map[string]bool{"team-a": true}, off.selectedNamespaces)
 	assert.Empty(t, off.namespace, "single-namespace selection takes precedence; no default fallback needed")
+	// Status hint must reflect the restored selection, not the empty
+	// m.namespace (would otherwise read "(ns: )").
+	assert.Contains(t, off.statusMessage, "ns: team-a")
 }
 
 func TestActionKeyAllNamespacesNoOpAtClusters(t *testing.T) {

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -99,6 +99,46 @@ func TestActionKeyAllNamespacesSavedSelectionSurvivesTabSwitch(t *testing.T) {
 	assert.Equal(t, map[string]bool{"alpha": true, "beta": true}, m.selectedNamespaces)
 }
 
+// TestActionKeyAllNamespacesOffFallsBackToDefault covers the repro where the
+// app is in all-namespaces mode with no concrete namespace to return to
+// (m.namespace == "" and no saved selection): toggling OFF must scope to the
+// default namespace instead of silently staying on every namespace.
+func TestActionKeyAllNamespacesOffFallsBackToDefault(t *testing.T) {
+	m := baseExplorerModel()
+	m.allNamespaces = true
+	m.namespace = ""
+	m.selectedNamespaces = nil
+	m.savedSelectedNamespaces = nil
+
+	ret, _, handled := m.handleExplorerActionKey(runeKey('A'))
+	require.True(t, handled)
+	off := ret.(Model)
+
+	assert.False(t, off.allNamespaces)
+	assert.Equal(t, "default", off.namespace)
+	assert.Equal(t, "default", off.effectiveNamespace(), "must scope the fetch, not return empty (all namespaces)")
+	assert.Contains(t, off.statusMessage, "ns: default")
+}
+
+// TestActionKeyAllNamespacesOffKeepsRestoredSelection ensures the default
+// fallback does not clobber a restored single-namespace selection.
+func TestActionKeyAllNamespacesOffKeepsRestoredSelection(t *testing.T) {
+	m := baseExplorerModel()
+	m.selectedNamespaces = map[string]bool{"team-a": true}
+	m.namespace = ""
+	m.allNamespaces = false
+
+	// Toggle ON (stash), then OFF (restore).
+	ret, _, _ := m.handleExplorerActionKey(runeKey('A'))
+	on := ret.(Model)
+	ret, _, _ = on.handleExplorerActionKey(runeKey('A'))
+	off := ret.(Model)
+
+	assert.False(t, off.allNamespaces)
+	assert.Equal(t, map[string]bool{"team-a": true}, off.selectedNamespaces)
+	assert.Empty(t, off.namespace, "single-namespace selection takes precedence; no default fallback needed")
+}
+
 func TestActionKeyAllNamespacesNoOpAtClusters(t *testing.T) {
 	m := baseExplorerModel()
 	m.nav.Level = model.LevelClusters


### PR DESCRIPTION
## Summary
Pressing the all-namespaces key (`A` / `Shift+A`) to turn the mode **OFF** restored the previous namespace selection — but when there was none to return to (the app started in all-namespaces mode, or the namespace had been cleared by a prior navigation), `m.namespace` stayed empty. `effectiveNamespace()` then returns `""`, which the fetch treats as "all namespaces", so the toggle looked like a no-op and the status bar showed `(ns: )`:

```
All namespaces mode OFF (ns: )
All namespaces mode ON
```

## Fix
When toggling OFF with no concrete namespace and no restored single selection, fall back to the context's default namespace (kubeconfig namespace, or `"default"`). A restored single/multi-namespace selection still takes precedence, so existing behavior is unchanged.

Added `defaultNamespaceForContext` helper (nil-client safe for tests).

The namespace selector overlay (`\`) is unaffected: its `A` only turns the mode ON, and Enter always applies a concrete namespace or all-ns — so the empty-on-OFF path is unique to the explorer toggle.

## Test plan
- [x] `TestActionKeyAllNamespacesOffFallsBackToDefault` — reproduces the empty-namespace symptom, asserts fallback to `default` and non-empty `effectiveNamespace()` (TDD, RED first)
- [x] `TestActionKeyAllNamespacesOffKeepsRestoredSelection` — guards that a restored selection is not clobbered by the fallback
- [x] Existing all-namespaces toggle tests still pass
- [x] `go test ./internal/app/`, `go vet`, `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)