### PR TITLE
fix(logs): reconnect specific-container stream while it is waiting to start

### DIFF
--- a/internal/app/commands_logs.go
+++ b/internal/app/commands_logs.go
@@ -113,6 +113,10 @@ func (m *Model) startLogStream() tea.Cmd {
 	// On auto-reconnect, force --tail=0 so we only pick up new lines from
 	// the next container rather than re-pulling history we already have.
 	reconnecting := m.logView.reconnecting
+	if !reconnecting {
+		// Fresh open: clear any stale pending-start state from a prior stream.
+		m.logView.pendingContainerStart = false
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.logView.cancel = cancel

--- a/internal/app/logview.go
+++ b/internal/app/logview.go
@@ -55,6 +55,13 @@ type logViewState struct {
 	// Auto-reconnect for multi-container Pods.
 	autoReconnectAttempt int
 	reconnecting         bool
+	// pendingContainerStart is set while the stream keeps hitting a "waiting
+	// to start" (ContainerCreating / PodInitializing) error. It enables
+	// auto-reconnect for a specific-container stream — kubectl logs -c <name>
+	// exits immediately when the container hasn't started, so without it the
+	// viewer would be stuck on that error and never pick up logs once the
+	// container starts. Cleared as soon as real output arrives.
+	pendingContainerStart bool
 
 	// Container filter state.
 	containers         []string // available container names for current pod

--- a/internal/app/update_exec_log_msgs.go
+++ b/internal/app/update_exec_log_msgs.go
@@ -115,9 +115,22 @@ func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	// A line arrived — the stream is producing output, so any pending
-	// auto-reconnect backoff is no longer relevant.
+	// auto-reconnect backoff is no longer relevant. (Reset for transient
+	// "waiting to start" notices too, so a slow image pull keeps polling past
+	// the give-up cap instead of stalling.)
 	if m.logView.autoReconnectAttempt > 0 {
 		m.logView.autoReconnectAttempt = 0
+	}
+	if isKubectlTransientError(msg.line) {
+		// Container hasn't started yet. Flag the pending start so a
+		// specific-container stream reconnects when it ends, and show the
+		// notice only once — not one copy per reconnect poll.
+		if m.logView.pendingContainerStart {
+			return m, m.waitForLogLine()
+		}
+		m.logView.pendingContainerStart = true
+	} else {
+		m.logView.pendingContainerStart = false
 	}
 	m.appendRawLogLine(msg.line)
 	// Bound the live buffer so a long-running follow doesn't grow memory
@@ -174,12 +187,21 @@ func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 // scrolled away from the tail (logFollow=false) they're reading history,
 // not watching live — no point re-arming the stream on their behalf.
 func (m Model) shouldAutoReconnectLogs() bool {
-	return m.mode == modeLogs &&
-		m.logView.follow &&
-		!m.logView.isMulti &&
-		!m.logView.previous &&
-		m.actionCtx.kind == "Pod" &&
-		m.actionCtx.containerName == ""
+	if m.mode != modeLogs || !m.logView.follow || m.logView.isMulti ||
+		m.logView.previous || m.actionCtx.kind != "Pod" {
+		return false
+	}
+	if m.actionCtx.containerName == "" {
+		// All-containers single-Pod stream: kubectl exits on every
+		// init-container transition; reconnect to pick up the next one.
+		return true
+	}
+	// A specific container was selected. kubectl logs -c <name> exits
+	// immediately with a "waiting to start" error while the container is
+	// ContainerCreating/PodInitializing. Reconnect only while that pending
+	// state holds; once it has produced real output, a normal stream-end is
+	// terminal (the user opted into that one stream).
+	return m.logView.pendingContainerStart
 }
 
 // updateLogStreamRestart fires when a scheduled auto-reconnect is due. If

--- a/internal/app/update_logs_reconnect_test.go
+++ b/internal/app/update_logs_reconnect_test.go
@@ -80,6 +80,89 @@ func TestUpdateLogLine_DoneSpecificContainerStreamEnds(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
+// A specific container that is still ContainerCreating makes kubectl logs
+// -c <name> exit immediately with a "waiting to start" error. The viewer must
+// keep that container's stream alive via auto-reconnect so logs appear once
+// the container starts — otherwise it's stuck on the error forever.
+func TestUpdateLogLine_SpecificContainerWaitingToStartReconnects(t *testing.T) {
+	ch := make(chan string, 1)
+	transient := `error: container "external-dns" in pod "external-dns-5fccb74474-gj9sk" is waiting to start: ContainerCreating`
+	m := Model{
+		mode: modeLogs,
+		logView: logViewState{
+			ch:     ch,
+			follow: true,
+		},
+		tabs:              []TabState{{}},
+		logReaderInFlight: make(map[chan string]bool),
+		actionCtx: actionContext{
+			kind:          "Pod",
+			name:          "external-dns-5fccb74474-gj9sk",
+			containerName: "external-dns",
+		},
+	}
+
+	// The "waiting to start" notice arrives once and flags a pending start.
+	result, _ := m.Update(logLineMsg{line: transient, ch: ch})
+	m = result.(Model)
+	assert.True(t, m.logView.pendingContainerStart)
+	assert.Equal(t, []string{transient}, m.logView.rawLines, "notice shown once")
+
+	// The stream then ends (kubectl exited) — a reconnect must be scheduled
+	// even though a specific container was selected.
+	result, cmd := m.Update(logLineMsg{done: true, ch: ch})
+	m = result.(Model)
+	assert.NotNil(t, cmd, "specific-container stream waiting to start must reconnect")
+}
+
+// Across reconnect polls the same "waiting to start" notice must not be
+// appended repeatedly — show it once, not one copy per poll.
+func TestUpdateLogLine_SpecificContainerTransientDeduped(t *testing.T) {
+	ch := make(chan string, 1)
+	transient := `error: container "external-dns" in pod "p" is waiting to start: ContainerCreating`
+	m := Model{
+		mode: modeLogs,
+		logView: logViewState{
+			ch:                    ch,
+			follow:                true,
+			rawLines:              []string{transient},
+			pendingContainerStart: true,
+		},
+		tabs:              []TabState{{}},
+		logReaderInFlight: make(map[chan string]bool),
+		actionCtx:         actionContext{kind: "Pod", name: "p", containerName: "external-dns"},
+	}
+	result, cmd := m.Update(logLineMsg{line: transient, ch: ch})
+	m = result.(Model)
+	assert.Equal(t, []string{transient}, m.logView.rawLines, "duplicate notice suppressed")
+	assert.True(t, m.logView.pendingContainerStart)
+	assert.NotNil(t, cmd, "reader re-armed to keep draining")
+}
+
+// Once real output arrives the pending flag clears, and a subsequent
+// stream-end for that specific container no longer reconnects.
+func TestUpdateLogLine_SpecificContainerRealOutputClearsPending(t *testing.T) {
+	ch := make(chan string, 1)
+	m := Model{
+		mode: modeLogs,
+		logView: logViewState{
+			ch:                    ch,
+			follow:                true,
+			pendingContainerStart: true,
+		},
+		tabs:              []TabState{{}},
+		logReaderInFlight: make(map[chan string]bool),
+		actionCtx:         actionContext{kind: "Pod", name: "p", containerName: "external-dns"},
+	}
+	result, _ := m.Update(logLineMsg{line: "2026-06-17T10:00:00Z serving metrics on :7979", ch: ch})
+	m = result.(Model)
+	assert.False(t, m.logView.pendingContainerStart, "real output means the container started")
+
+	result, cmd := m.Update(logLineMsg{done: true, ch: ch})
+	m = result.(Model)
+	assert.Nil(t, cmd, "a started specific container that ends normally must not reconnect")
+}
+
 // Deployment/StatefulSet/etc. use --max-log-requests with a selector — a
 // single "done" doesn't reliably mean a container transition, so we don't
 // auto-reconnect. No sentinel marker is written either.


### PR DESCRIPTION
## Symptom
Viewing logs for a specific container that is still `ContainerCreating` shows only:

```
error: container "external-dns" in pod "external-dns-5fccb74474-gj9sk" is waiting to start: ContainerCreating
```

…and never recovers — once the container starts and produces logs, the viewer stays stuck on that error.

## Root cause
Following a single container runs `kubectl logs -f -c <name>` **without** `--ignore-errors` (that flag is only added in all-containers mode). While the container is `ContainerCreating`/`PodInitializing`, kubectl exits immediately with the "waiting to start" error. `shouldAutoReconnectLogs()` only reconnected when **no** specific container was selected (`containerName == ""`), so the specific-container stream ended and was never restarted.

## Fix
- Track `logView.pendingContainerStart`, set while the stream keeps hitting a transient "waiting to start" error and cleared as soon as real output arrives.
- Allow a specific-container stream to auto-reconnect **while that flag holds** (still gated on follow mode, single Pod, not `--previous`). Once it produces real output, a normal stream-end is terminal again.
- Show the "waiting to start" notice **once** instead of one copy per reconnect poll.
- The attempt counter resets on the transient notice, so a slow image pull keeps polling rather than hitting the give-up cap.
- Reset the flag on a fresh (non-reconnect) stream open.

## Test plan
- [x] New tests in `update_logs_reconnect_test.go`: waiting-to-start reconnects, duplicate notice deduped, real output clears pending + then no reconnect (TDD, RED first)
- [x] Existing reconnect tests still pass (all-containers, multi, previous, give-up cap, etc.)
- [x] `go test ./internal/app/`, `go vet`, `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)