### PR TITLE
feat: quick-filter to current item's namespace from selector (#455)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Clusters (kubeconfig contexts)
                     +-- Containers (for Pods)
 ```
 
-Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection — shows all except the marked namespaces, each prefixed with `!`), `A` to reset to all-namespaces mode, or `R` to refresh the list from the cluster.
+Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection — shows all except the marked namespaces, each prefixed with `!`), `A` to reset to all-namespaces mode, or `R` to refresh the list from the cluster. Press `.` to quick-filter straight to the namespace of the resource highlighted behind the overlay.
 
 ### Owner Resolution
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -139,7 +139,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | Key | Action | Config key |
 |---|---|---|
 | `x` | Open action menu (bulk actions when items selected) | `action_menu` |
-| `\` | Open namespace selector | `namespace_selector` |
+| `\` | Open namespace selector (then `.` to filter to current item's namespace) | `namespace_selector` |
 | `A` | Toggle all-namespaces mode (also works inside the namespace selector — clears individual selections and enables all-ns) | `all_namespaces` |
 | `L` | Toggle live-log preview pane for selected pod or container (streaming tail in right pane; deeper levels only) | `toggle_preview_logs` |
 | `Ctrl+L` | Open fullscreen log viewer for selected resource | `logs` |

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -121,6 +121,7 @@ func (m Model) overlayHintBarSelector() string {
 			{Key: "space", Desc: "select"},
 			{Key: "tab", Desc: "exclude"},
 			{Key: "A", Desc: "all"},
+			{Key: ".", Desc: "filter to selection"},
 			{Key: "enter", Desc: "apply"},
 			{Key: "/", Desc: "filter"},
 			{Key: "R", Desc: "refresh"},

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -121,7 +121,7 @@ func (m Model) overlayHintBarSelector() string {
 			{Key: "space", Desc: "select"},
 			{Key: "tab", Desc: "exclude"},
 			{Key: "A", Desc: "all"},
-			{Key: ".", Desc: "filter to selection"},
+			{Key: ".", Desc: "filter to item's ns"},
 			{Key: "enter", Desc: "apply"},
 			{Key: "/", Desc: "filter"},
 			{Key: "R", Desc: "refresh"},

--- a/internal/app/update_keys_namespace_selector_test.go
+++ b/internal/app/update_keys_namespace_selector_test.go
@@ -181,6 +181,70 @@ func TestHandleKeyNamespaceSelector_StaleCacheSchedulesBackgroundRefresh(t *test
 	assert.NotNil(t, cmd, "stale cache must schedule a silent refresh command")
 }
 
+// TestHandleNamespaceOverlay_QuickFilterToSelectedNamespace verifies the "."
+// quick filter (pressed while the namespace overlay is open) snaps the
+// namespace scope to the namespace of the resource highlighted in the
+// explorer behind the overlay, then closes.
+func TestHandleNamespaceOverlay_QuickFilterToSelectedNamespace(t *testing.T) {
+	m := nsSelectorModel()
+	m.allNamespaces = true
+	m.namespace = ""
+	m.middleItems = []model.Item{
+		{Name: "pod-a", Kind: "Pod", Namespace: "team-alpha"},
+		{Name: "pod-b", Kind: "Pod", Namespace: "team-beta"},
+	}
+	m.setCursor(1) // highlight pod-b in team-beta
+	m.overlay = overlayNamespace
+
+	ret, _ := m.handleNamespaceOverlayKey(runeKey('.'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNone, result.overlay, "quick filter must close the overlay")
+	assert.Equal(t, "team-beta", result.namespace)
+	assert.False(t, result.allNamespaces, "quick filter must leave all-namespaces mode")
+	assert.True(t, result.selectedNamespaces["team-beta"])
+	assert.Len(t, result.selectedNamespaces, 1)
+}
+
+// TestHandleNamespaceOverlay_QuickFilterNoNamespaceIsNoOp verifies the quick
+// filter is a safe no-op (overlay stays open, scope unchanged) when the
+// highlighted resource is cluster-scoped (empty Namespace).
+func TestHandleNamespaceOverlay_QuickFilterNoNamespaceIsNoOp(t *testing.T) {
+	m := nsSelectorModel()
+	m.allNamespaces = true
+	m.middleItems = []model.Item{
+		{Name: "node-1", Kind: "Node", Namespace: ""},
+	}
+	m.setCursor(0)
+	m.overlay = overlayNamespace
+
+	ret, _ := m.handleNamespaceOverlayKey(runeKey('.'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay, "no-op quick filter keeps the overlay open")
+	assert.True(t, result.allNamespaces, "scope must be unchanged")
+	assert.NotEmpty(t, result.statusMessage)
+	assert.True(t, result.statusMessageErr)
+}
+
+// TestHandleNamespaceOverlay_QuickFilterInertInUnionMode verifies the quick
+// filter does nothing in union mode, which enforces its own single-namespace
+// rules.
+func TestHandleNamespaceOverlay_QuickFilterInertInUnionMode(t *testing.T) {
+	m := nsSelectorModel()
+	m.unionMode = true
+	m.allNamespaces = true
+	m.middleItems = []model.Item{{Name: "pod-a", Kind: "Pod", Namespace: "team-alpha"}}
+	m.setCursor(0)
+	m.overlay = overlayNamespace
+
+	ret, _ := m.handleNamespaceOverlayKey(runeKey('.'))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay, "union mode must leave the overlay open")
+	assert.True(t, result.allNamespaces, "union mode quick filter must not change scope")
+}
+
 // TestHandleNamespaceOverlay_RefreshReloads verifies the in-overlay refresh
 // (R / kb.Refresh) re-fetches namespaces and keeps the overlay open.
 func TestHandleNamespaceOverlay_RefreshReloads(t *testing.T) {

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -43,6 +43,35 @@ func (m Model) rejectPendingUnionSetNamespaceMultiSelect() (tea.Model, tea.Cmd) 
 	return m, scheduleStatusClear()
 }
 
+// quickFilterToSelectedNamespace narrows the namespace scope to the namespace
+// of the resource highlighted in the explorer behind the namespace overlay,
+// then closes the overlay and refreshes the current level. Mirrors the single-
+// namespace branch of the Enter handler so the resulting scope is identical to
+// picking that namespace from the list by hand.
+func (m Model) quickFilterToSelectedNamespace() (tea.Model, tea.Cmd) {
+	sel := m.selectedMiddleItem()
+	if sel == nil || sel.Namespace == "" {
+		m.setStatusMessage("No namespaced resource selected to filter to", true)
+		return m, scheduleStatusClear()
+	}
+	ns := sel.Namespace
+	oldNs := m.namespace
+	m.selectedNamespaces = map[string]bool{ns: true}
+	m.namespace = ns
+	m.allNamespaces = false
+	m.nsSelectionNegated = false
+	m.nsSelectionModified = false
+	m.invalidateOrphanCacheForNamespace(m.nav.Context, oldNs)
+	m.overlayFilter.Clear()
+	m.nsFilterMode = false
+	m.overlay = overlayNone
+	m.saveCurrentSession()
+	m.cancelAndReset()
+	m.requestGen++
+	m.setStatusMessage("Filtered to namespace: "+ns, false)
+	return m, tea.Batch(m.refreshCurrentLevel(), scheduleStatusClear())
+}
+
 //nolint:gocyclo // switch-based key dispatch is inherently high-complexity
 func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	items := m.filteredOverlayItems()
@@ -182,6 +211,17 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.nsSelectionNegated = !m.nsSelectionNegated
 		m.nsSelectionModified = true
 		return m, nil
+
+	case ".":
+		// Quick filter to the namespace of the resource highlighted in the
+		// explorer behind the overlay (chord: "\\" to open, then "."). Inert
+		// in union mode / the union-set picker (single-namespace rules of
+		// their own) and when the overlay was opened from a parent overlay
+		// (the explorer selection is not the relevant subject there).
+		if m.pendingUnionSetName != "" || m.unionMode || m.previousOverlay != overlayNone {
+			return m, nil
+		}
+		return m.quickFilterToSelectedNamespace()
 
 	case ui.ActiveKeybindings.AllNamespaces:
 		if m.pendingUnionSetName != "" {

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -87,7 +87,7 @@ func helpSections() []helpSection {
 		{
 			title: "Actions",
 			bindings: []helpEntry{
-				{kb.NamespaceSelector, "Select namespace (space: include, tab: exclude, A: all-namespaces, R: refresh)"},
+				{kb.NamespaceSelector, "Select namespace (space: include, tab: exclude, A: all-namespaces, R: refresh, .: quick filter to current item's namespace)"},
 				{kb.AllNamespaces, "Toggle all-namespaces mode"},
 				{kb.ActionMenu, "Action menu: l=tail logs (last 10 lines + follow), L=full logs, T=Log Top aggregation, exec, debug, debug pod, describe, edit, delete, scale, port-forward, events, startup analysis, crash investigator, traffic capture, RBAC permissions"},
 				{kb.TogglePreviewLogs, "Toggle live-log preview pane for selected pod or container (right pane, streaming tail)"},


### PR DESCRIPTION
## Summary
Closes #455. Adds a quick way to scope the explorer to the namespace of the resource you're looking at, reachable from the namespace selector.

- `\` opens the namespace selector (unchanged; `\` again still closes it).
- **`.`** inside the selector filters straight to the namespace of the resource highlighted in the explorer behind the overlay, then closes and refreshes.

The chord is `\` then `.`. It reuses the existing single-namespace apply path, so the resulting scope is identical to picking that namespace from the list by hand — no new config key.

### Edge cases
- No-op (overlay stays open) in union mode, the union-set picker, and when the selector was opened from a parent overlay (RBAC/CanI).
- Status error when the highlighted row is cluster-scoped (no namespace).

## Changes
| File | Change |
|---|---|
| `internal/app/update_overlays_selectors.go` | `quickFilterToSelectedNamespace` helper + `.` case in `handleNamespaceNormalMode` |
| `internal/app/overlay_hintbar.go` | `. filter to selection` hint |
| `internal/ui/help_sections.go` | help text |
| `docs/keybindings.md`, `README.md` | document `\` then `.` |
| `internal/app/update_keys_namespace_selector_test.go` | 3 tests |

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/ ./internal/ui/` pass
- [x] `golangci-lint run` — 0 issues
- [x] Manual: open a multi-namespace pod list, `\` then `.` on a row, confirm scope narrows to that pod's namespace