### PR TITLE
chore(ci): skip CodeRabbit review on release-please PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+reviews:
+  auto_review:
+    # release-please bot PRs only bump the version and CHANGELOG. Skip CodeRabbit
+    # review and pre-merge checks on them (the auto-generated description never
+    # matches the PR template, which otherwise trips the Description check).
+    ignore_title_keywords:
+      - "chore(main): release"


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` that skips CodeRabbit review + pre-merge checks for release-please PRs (title contains `chore(main): release`).

## Why
Release-please PRs (e.g. #457) only bump the version and CHANGELOG. Their auto-generated description never matches the repo PR template, so CodeRabbit's **Description** pre-merge check posts a ⚠️ warning on every release PR. There is no code to review on these PRs, so skipping CodeRabbit on them is the clean fix.

Uses `reviews.auto_review.ignore_title_keywords` (case-insensitive title match), verified against the CodeRabbit v2 config schema.

## Notes
- Takes effect once merged to `main` (CodeRabbit reads config from the default branch).
- Normal PRs are unaffected — only titles containing `chore(main): release` are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)