### PR TITLE
fix(release): make Chocolatey publish best-effort

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,21 @@ jobs:
           sudo apt-get install -y --no-install-recommends mono-devel
           mkdir -p /opt/chocolatey
           wget -q -O - "https://github.com/chocolatey/choco/releases/download/${CHOCOLATEY_VERSION}/chocolatey.v${CHOCOLATEY_VERSION}.tar.gz" | tar -xz -C /opt/chocolatey
-          printf '#!/bin/bash\nmono /opt/chocolatey/choco.exe "$@"\n' | sudo tee /usr/local/bin/choco > /dev/null
+          # choco push is best-effort: when a release is still pending in the
+          # Chocolatey moderation queue, `choco push` exits non-zero even though
+          # the package was submitted. Wrap it so push failures warn but do not
+          # fail the release. `pack` and other subcommands still fail normally.
+          cat <<'WRAP' | sudo tee /usr/local/bin/choco > /dev/null
+          #!/bin/bash
+          if [ "$1" = "push" ]; then
+            mono /opt/chocolatey/choco.exe "$@" || {
+              echo "::warning::choco push failed (package may already be in the Chocolatey moderation queue); continuing."
+              exit 0
+            }
+          else
+            exec mono /opt/chocolatey/choco.exe "$@"
+          fi
+          WRAP
           sudo chmod +x /usr/local/bin/choco
           choco --version
 


### PR DESCRIPTION
## Summary
- Make the Chocolatey `choco push` step non-fatal so a stuck/pending Chocolatey moderation queue doesn't fail an otherwise-successful release.

## Problem
GoReleaser runs `choco push` inside the single "Run GoReleaser" step and has no per-publisher continue-on-error. When a release version is still pending in the **Chocolatey moderation queue**, `choco push` exits non-zero even though the package was submitted — failing the entire release (GitHub release, Docker, Homebrew, etc. all already succeeded). Putting `continue-on-error` on the whole step would mask *all* failures, which is unacceptable.

## Fix
Wrap the existing `choco` shim (already a mono wrapper on Linux runners) so that:
- `choco push` failure → emits a `::warning::` and exits 0 (best-effort).
- `choco pack` and every other subcommand → fail normally (genuine packaging/auth errors are NOT masked).

## Validation
- `release.yml` parses (yq); heredoc renders correctly inside the YAML block scalar.
- Simulated the generated wrapper: `push`→warn+exit 0, `pack`→exit 1, `--version`→pass-through.
- yamllint is not a CI/pre-commit gate in this repo; the change matches existing line-length conventions.

## Trade-off
Chocolatey push problems (including a bad API key) will now warn instead of fail. That's the intended best-effort behavior; the warning is visible in the run log.