### PR TITLE
feat: manual scaling for HorizontalPodAutoscalers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **ArgoCD integration**: Browse Applications, sync, terminate sync, refresh, view managed resources
 - **Argo Workflows integration**: Suspend/resume, stop/terminate, resubmit Workflows; submit from WorkflowTemplates; suspend/resume CronWorkflows
 - **Helm integration**: Browse releases, view managed resources, uninstall
+- **HPA scaling**: Press `S` on a HorizontalPodAutoscaler to edit its min/max replica bounds and scale its target workload (Deployment / StatefulSet / ReplicaSet) in one overlay
 - **KEDA integration**: Pause/unpause ScaledObjects and ScaledJobs
 - **External Secrets integration**: Force refresh ExternalSecrets, ClusterExternalSecrets, and PushSecrets
 - **CRD discovery**: Automatically discovers installed CRDs and groups them by API group

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -149,7 +149,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `v` | Describe selected resource | `describe` |
 | `D` | Delete resource (force delete Pod/Job if already deleting, force finalize others) | `delete` |
 | `X` | Force delete (Pod/Job only) | `force_delete` |
-| `S` | Scale resource (Deployment / StatefulSet / ReplicaSet) | `scale` |
+| `S` | Scale resource (Deployment / StatefulSet / ReplicaSet / HPA) | `scale` |
 | `W` | Save resource to file / toggle warnings-only filter (Events view) | `save_resource` |
 | `Ctrl+O` | Open in browser: ingress host, port-forward localhost URL, or (on a Service) start a port forward and open it | `open_browser` |
 | `i` | Edit labels/annotations | `label_editor` |
@@ -981,6 +981,11 @@ The action menu (`x` key) shows context-specific actions based on the resource t
 
 ### DaemonSet Actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
+
+### HorizontalPodAutoscaler Actions
+`S` Scale (edit min/max bounds & target replicas), `E` Edit, `D` Delete, `v` Describe, `b` Debug Pod, `V` Events
+
+The Scale overlay edits the HPA's `spec.minReplicas` / `spec.maxReplicas` (the HPA keeps autoscaling within the new range) and, optionally, scales the target workload directly. Fields prefill from the HPA's current values. `j`/`k` (or `↓`/`↑`) move between the three fields; `h`/`-` and `l`/`+` decrement/increment the active field; `←`/`→` move the cursor within the field; digits type a value directly. Target replica changes may be reverted by the HPA on its next reconcile. The same `h`/`-`/`l`/`+` steppers work in the workload Scale overlay.
 
 ### Service Actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `O` Port Forward & Open (forward a port and open it in the browser), `c` Capture Traffic, `N` Network Policies (policies affecting the service's backing pods), `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -103,6 +103,7 @@ category, and every entry maps to a constant in `app_types.go`.
 | Overlay                  | Default trigger                | Purpose                                            |
 | ------------------------ | ------------------------------ | -------------------------------------------------- |
 | `overlayScaleInput`      | `S` on workload                | Replica count input.                                |
+| `overlayHPAScale`        | `S` on HPA                     | HPA min/max bounds + target replica scale.          |
 | `overlayPortForward`     | `p` on Service / Pod           | Port-forward destination input.                     |
 | `overlaySecretEditor`    | `e` on Secret                  | Inline edit of decoded secret values.               |
 | `overlayConfigMapEditor` | `e` on ConfigMap               | Inline edit of CM keys.                             |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -153,7 +153,7 @@ type Model struct {
 
 	// Scale input state.
 	scaleInput TextInput
-
+	hpaScale   hpaScaleState // HPA scale overlay: min/max bounds + target replicas
 	// PVC resize: current size displayed in the overlay.
 	pvcCurrentSize string
 

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -44,6 +44,7 @@ const (
 	overlayConfirm     // y/n confirmation (regular delete, drain)
 	overlayConfirmType // requires typing "DELETE" to confirm (force delete, force finalize)
 	overlayScaleInput
+	overlayHPAScale // HPA min/max bounds + target replicas (action menu key S)
 	overlayPortForward
 	overlayContainerSelect
 	overlayPodSelect
@@ -403,6 +404,24 @@ type actionContext struct {
 	image         string // container image (for vuln scan at container level)
 	resourceType  model.ResourceTypeEntry
 	columns       []model.KeyValue // additional item columns (e.g., Node, IP) for custom action templates
+	raw           map[string]any   // full source object; used to prefill scale overlays from spec/status
+}
+
+// hpaScaleState backs the HPA scale overlay. The overlay edits the HPA's
+// own min/max bounds (patched on the HPA) and, separately, the replica count
+// of its scale target (a Deployment/StatefulSet/ReplicaSet — scaled directly,
+// which the HPA may revert on its next reconcile). orig* snapshots the
+// prefilled values so apply only issues a call for fields the user changed.
+type hpaScaleState struct {
+	min        TextInput
+	max        TextInput
+	target     TextInput
+	field      int // active row: 0=min, 1=max, 2=target
+	targetKind string
+	targetName string
+	origMin    string
+	origMax    string
+	origTarget string
 }
 
 // TabState holds per-tab navigation state so each tab is fully independent.

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -47,6 +47,14 @@ func (m Model) overlayHintBarDialog() string {
 		})
 	case overlayScaleInput:
 		return m.renderHints([]ui.HintEntry{
+			{Key: "h/l -/+", Desc: "−/＋"},
+			{Key: "Enter", Desc: "apply"},
+			{Key: "esc", Desc: "cancel"},
+		})
+	case overlayHPAScale:
+		return m.renderHints([]ui.HintEntry{
+			{Key: "j/k", Desc: "field"},
+			{Key: "h/l -/+", Desc: "−/＋"},
 			{Key: "Enter", Desc: "apply"},
 			{Key: "esc", Desc: "cancel"},
 		})

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -183,6 +183,9 @@ func (m *Model) buildActionCtx(sel *model.Item, kind string) actionContext {
 
 	// Store item columns for custom action template variable substitution.
 	ctx.columns = sel.Columns
+	// Retain the raw object so scale overlays can prefill from spec/status
+	// without depending on column key names.
+	ctx.raw = sel.Raw
 
 	return ctx
 }
@@ -338,7 +341,7 @@ func (m Model) directActionScale() (tea.Model, tea.Cmd) {
 	if isVirtualResourceKind(kind) {
 		return m, nil
 	}
-	if !model.IsScaleableKind(kind) {
+	if !model.IsScaleableKind(kind) && kind != "HorizontalPodAutoscaler" {
 		m.setStatusMessage("Scale not available for "+kind, true)
 		return m, scheduleStatusClear()
 	}

--- a/internal/app/update_actions_misc.go
+++ b/internal/app/update_actions_misc.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strconv"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -147,7 +148,16 @@ func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) executeActionScale() Model {
-	m.scaleInput.Clear()
+	if m.actionCtx.kind == "HorizontalPodAutoscaler" {
+		return m.openHPAScaleOverlay()
+	}
+	// Prefill with the workload's current desired replica count so the user
+	// can step from it rather than retype.
+	if v, ok := nestedInt(m.actionCtx.raw, "spec", "replicas"); ok {
+		m.scaleInput.Set(strconv.FormatInt(v, 10))
+	} else {
+		m.scaleInput.Clear()
+	}
 	m.overlay = overlayScaleInput
 	return m
 }

--- a/internal/app/update_hpa_scale.go
+++ b/internal/app/update_hpa_scale.go
@@ -1,0 +1,263 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// hpaScaleFieldCount is the number of editable rows in the HPA scale overlay
+// (min, max, target).
+const hpaScaleFieldCount = 3
+
+// active returns a pointer to the currently focused input row.
+func (s *hpaScaleState) active() *TextInput {
+	switch s.field {
+	case 1:
+		return &s.max
+	case 2:
+		return &s.target
+	default:
+		return &s.min
+	}
+}
+
+// floor returns the lowest legal value for the active field. minReplicas and
+// maxReplicas must be >= 1; the target workload may scale to 0.
+func (s *hpaScaleState) floor() int {
+	if s.field == 2 {
+		return 0
+	}
+	return 1
+}
+
+// nestedInt reads an integer at the given path, tolerating both the float64
+// and int64 forms unstructured objects can carry for the same JSON number.
+func nestedInt(obj map[string]any, fields ...string) (int64, bool) {
+	v, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil || !found {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	}
+	return 0, false
+}
+
+// openHPAScaleOverlay prefills the HPA scale overlay and opens it. Min/Max come
+// from the HPA spec; the target replica field is seeded from the HPA's desired
+// (falling back to current) replicas, and the scale target (Kind/Name) from
+// spec.scaleTargetRef. Values are read from the raw object, falling back to the
+// item's columns when the raw object is unavailable (synthetic items / tests).
+func (m Model) openHPAScaleOverlay() Model {
+	var minStr, maxStr, targetStr, kind, name string
+
+	if raw := m.actionCtx.raw; raw != nil {
+		if v, ok := nestedInt(raw, "spec", "minReplicas"); ok {
+			minStr = strconv.FormatInt(v, 10)
+		}
+		if v, ok := nestedInt(raw, "spec", "maxReplicas"); ok {
+			maxStr = strconv.FormatInt(v, 10)
+		}
+		if v, ok := nestedInt(raw, "status", "desiredReplicas"); ok {
+			targetStr = strconv.FormatInt(v, 10)
+		} else if v, ok := nestedInt(raw, "status", "currentReplicas"); ok {
+			targetStr = strconv.FormatInt(v, 10)
+		}
+		kind, _, _ = unstructured.NestedString(raw, "spec", "scaleTargetRef", "kind")
+		name, _, _ = unstructured.NestedString(raw, "spec", "scaleTargetRef", "name")
+	}
+
+	item := model.Item{Columns: m.actionCtx.columns}
+	if minStr == "" {
+		minStr = columnValue(item, "Min Replicas")
+	}
+	if maxStr == "" {
+		maxStr = columnValue(item, "Max Replicas")
+	}
+	if targetStr == "" {
+		if targetStr = columnValue(item, "Desired Replicas"); targetStr == "" {
+			targetStr = columnValue(item, "Current Replicas")
+		}
+	}
+	if kind == "" || name == "" {
+		if ref := columnValue(item, "Target"); ref != "" {
+			if k, n, ok := strings.Cut(ref, "/"); ok {
+				kind, name = k, n
+			}
+		}
+	}
+
+	st := hpaScaleState{targetKind: kind, targetName: name}
+	st.min.Set(minStr)
+	st.max.Set(maxStr)
+	st.target.Set(targetStr)
+	st.origMin, st.origMax, st.origTarget = minStr, maxStr, targetStr
+	m.hpaScale = st
+	m.overlay = overlayHPAScale
+	return m
+}
+
+func (m Model) handleHPAScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		m.overlay = overlayNone
+		m.hpaScale = hpaScaleState{}
+		return m, nil
+	case "ctrl+c":
+		return m.closeTabOrQuit()
+	case "j", "down":
+		m.hpaScale.field = (m.hpaScale.field + 1) % hpaScaleFieldCount
+		return m, nil
+	case "k", "up":
+		m.hpaScale.field = (m.hpaScale.field - 1 + hpaScaleFieldCount) % hpaScaleFieldCount
+		return m, nil
+	case "l", "+":
+		stepInput(m.hpaScale.active(), 1, m.hpaScale.floor())
+		return m, nil
+	case "h", "-":
+		stepInput(m.hpaScale.active(), -1, m.hpaScale.floor())
+		return m, nil
+	case "left":
+		m.hpaScale.active().Left()
+		return m, nil
+	case "right":
+		m.hpaScale.active().Right()
+		return m, nil
+	case "enter":
+		return m.applyHPAScaleOverlay()
+	case "backspace":
+		m.hpaScale.active().Backspace()
+		return m, nil
+	case "ctrl+w":
+		m.hpaScale.active().DeleteWord()
+		return m, nil
+	default:
+		key := msg.String()
+		if len(key) == 1 && key[0] >= '0' && key[0] <= '9' {
+			m.hpaScale.active().Insert(key)
+		}
+		return m, nil
+	}
+}
+
+// stepInput increments (or decrements) a numeric text input by delta, clamping
+// at floor. A non-numeric or empty value is treated as floor before stepping.
+func stepInput(t *TextInput, delta, floor int) {
+	n, err := strconv.Atoi(strings.TrimSpace(t.Value))
+	if err != nil {
+		n = floor
+	}
+	n += delta
+	if n < floor {
+		n = floor
+	}
+	t.Set(strconv.Itoa(n))
+}
+
+// applyHPAScaleOverlay validates the three inputs and dispatches the patch
+// (min/max on the HPA) and/or the target scale, for whichever fields changed.
+func (m Model) applyHPAScaleOverlay() (tea.Model, tea.Cmd) {
+	st := m.hpaScale
+	scaleMinMax := st.min.Value != st.origMin || st.max.Value != st.origMax
+	scaleTarget := st.target.Value != st.origTarget && st.targetName != ""
+
+	if !scaleMinMax && !scaleTarget {
+		m.overlay = overlayNone
+		m.hpaScale = hpaScaleState{}
+		m.setStatusMessage("No changes", false)
+		return m, scheduleStatusClear()
+	}
+
+	minR, maxR, targetR, err := parseHPAScaleInputs(st, scaleTarget)
+	if err != nil {
+		m.overlay = overlayNone
+		m.hpaScale = hpaScaleState{}
+		m.setStatusMessage(err.Error(), true)
+		return m, scheduleStatusClear()
+	}
+
+	// Belt-and-suspenders read-only gate: the dispatcher blocks "Scale"
+	// upstream, but a user who toggled RO on while this overlay was open
+	// could otherwise commit the change.
+	if m.actionTargetBlockedByReadOnly() {
+		m.overlay = overlayNone
+		m.hpaScale = hpaScaleState{}
+		m.setStatusMessage(readOnlyBlockedMessage("Scale"), true)
+		return m, scheduleStatusClear()
+	}
+
+	m.overlay = overlayNone
+	m.loading = true
+	m.hpaScale = hpaScaleState{}
+
+	var cmds []tea.Cmd
+	if scaleMinMax {
+		m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch hpa %s --type merge -p '{\"spec\":{\"minReplicas\":%d,\"maxReplicas\":%d}}' -n %s --context %s", m.actionCtx.name, minR, maxR, m.actionCtx.namespace, m.actionCtx.context))
+		cmds = append(cmds, m.patchHPAScale(minR, maxR))
+	}
+	if scaleTarget {
+		m.addLogEntry("DBG", fmt.Sprintf("$ kubectl scale %s %s --replicas=%d -n %s --context %s", strings.ToLower(st.targetKind), st.targetName, targetR, m.actionCtx.namespace, m.actionCtx.context))
+		cmds = append(cmds, m.scaleHPATarget(st.targetKind, st.targetName, targetR))
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// parseHPAScaleInputs validates and parses the overlay inputs. minReplicas must
+// be >= 1, maxReplicas >= minReplicas, and (when changed) target replicas >= 0.
+func parseHPAScaleInputs(st hpaScaleState, scaleTarget bool) (minR, maxR, targetR int32, err error) {
+	minV, errMin := strconv.ParseInt(strings.TrimSpace(st.min.Value), 10, 32)
+	maxV, errMax := strconv.ParseInt(strings.TrimSpace(st.max.Value), 10, 32)
+	if errMin != nil || errMax != nil || minV < 1 || maxV < 1 {
+		return 0, 0, 0, fmt.Errorf("invalid min/max replicas")
+	}
+	if maxV < minV {
+		return 0, 0, 0, fmt.Errorf("max replicas must be >= min replicas")
+	}
+	if scaleTarget {
+		tv, errT := strconv.ParseInt(strings.TrimSpace(st.target.Value), 10, 32)
+		if errT != nil || tv < 0 {
+			return 0, 0, 0, fmt.Errorf("invalid target replicas")
+		}
+		targetR = int32(tv)
+	}
+	return int32(minV), int32(maxV), targetR, nil
+}
+
+func (m Model) patchHPAScale(minR, maxR int32) tea.Cmd {
+	ctx := m.actionCtx.context
+	ns := m.actionNamespace()
+	name := m.actionCtx.name
+	rt := m.actionCtx.resourceType
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, fmt.Sprintf("Scale HPA %s → %d-%d", name, minR, maxR), bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
+		err := m.client.PatchHPAScale(ctx, ns, rt, name, minR, maxR)
+		if err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: fmt.Sprintf("Scaled HPA %s to %d-%d replicas", name, minR, maxR)}
+	})
+}
+
+func (m Model) scaleHPATarget(kind, name string, replicas int32) tea.Cmd {
+	ctx := m.actionCtx.context
+	ns := m.actionNamespace()
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, fmt.Sprintf("Scale %s/%s → %d", kind, name, replicas), bgtaskTarget(ctx, ns), func(_ context.Context) tea.Msg {
+		err := m.client.ScaleResource(ctx, ns, name, kind, replicas)
+		if err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: fmt.Sprintf("Scaled %s to %d replicas", name, replicas)}
+	})
+}

--- a/internal/app/update_hpa_scale.go
+++ b/internal/app/update_hpa_scale.go
@@ -110,6 +110,9 @@ func (m Model) openHPAScaleOverlay() Model {
 	return m
 }
 
+// handleHPAScaleOverlayKey routes a keypress in the HPA scale overlay: j/k move
+// between fields, h/- and l/+ step the active value, arrows move the cursor,
+// digits type, enter applies, esc cancels.
 func (m Model) handleHPAScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc", "q":
@@ -181,7 +184,7 @@ func (m Model) applyHPAScaleOverlay() (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 
-	minR, maxR, targetR, err := parseHPAScaleInputs(st, scaleTarget)
+	minR, maxR, targetR, err := parseHPAScaleInputs(st, scaleMinMax, scaleTarget)
 	if err != nil {
 		m.overlay = overlayNone
 		m.hpaScale = hpaScaleState{}
@@ -215,16 +218,22 @@ func (m Model) applyHPAScaleOverlay() (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
-// parseHPAScaleInputs validates and parses the overlay inputs. minReplicas must
-// be >= 1, maxReplicas >= minReplicas, and (when changed) target replicas >= 0.
-func parseHPAScaleInputs(st hpaScaleState, scaleTarget bool) (minR, maxR, targetR int32, err error) {
-	minV, errMin := strconv.ParseInt(strings.TrimSpace(st.min.Value), 10, 32)
-	maxV, errMax := strconv.ParseInt(strings.TrimSpace(st.max.Value), 10, 32)
-	if errMin != nil || errMax != nil || minV < 1 || maxV < 1 {
-		return 0, 0, 0, fmt.Errorf("invalid min/max replicas")
-	}
-	if maxV < minV {
-		return 0, 0, 0, fmt.Errorf("max replicas must be >= min replicas")
+// parseHPAScaleInputs validates and parses only the inputs that are actually
+// being applied. When scaleMinMax is set, minReplicas must be >= 1 and
+// maxReplicas >= minReplicas; when scaleTarget is set, target replicas >= 0.
+// Min/max are not validated for a target-only change (they may be unset when
+// prefill from the HPA spec was unavailable).
+func parseHPAScaleInputs(st hpaScaleState, scaleMinMax, scaleTarget bool) (minR, maxR, targetR int32, err error) {
+	if scaleMinMax {
+		minV, errMin := strconv.ParseInt(strings.TrimSpace(st.min.Value), 10, 32)
+		maxV, errMax := strconv.ParseInt(strings.TrimSpace(st.max.Value), 10, 32)
+		if errMin != nil || errMax != nil || minV < 1 || maxV < 1 {
+			return 0, 0, 0, fmt.Errorf("invalid min/max replicas")
+		}
+		if maxV < minV {
+			return 0, 0, 0, fmt.Errorf("max replicas must be >= min replicas")
+		}
+		minR, maxR = int32(minV), int32(maxV)
 	}
 	if scaleTarget {
 		tv, errT := strconv.ParseInt(strings.TrimSpace(st.target.Value), 10, 32)
@@ -233,9 +242,10 @@ func parseHPAScaleInputs(st hpaScaleState, scaleTarget bool) (minR, maxR, target
 		}
 		targetR = int32(tv)
 	}
-	return int32(minV), int32(maxV), targetR, nil
+	return minR, maxR, targetR, nil
 }
 
+// patchHPAScale returns a command that patches the selected HPA's min/max bounds.
 func (m Model) patchHPAScale(minR, maxR int32) tea.Cmd {
 	ctx := m.actionCtx.context
 	ns := m.actionNamespace()
@@ -250,6 +260,8 @@ func (m Model) patchHPAScale(minR, maxR int32) tea.Cmd {
 	})
 }
 
+// scaleHPATarget returns a command that scales the HPA's target workload to the
+// given replica count (reusing the generic ScaleResource path).
 func (m Model) scaleHPATarget(kind, name string, replicas int32) tea.Cmd {
 	ctx := m.actionCtx.context
 	ns := m.actionNamespace()

--- a/internal/app/update_hpa_scale_test.go
+++ b/internal/app/update_hpa_scale_test.go
@@ -1,0 +1,240 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func hpaActionCtxModel() Model {
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "web", "default", "HorizontalPodAutoscaler", model.ResourceTypeEntry{
+		APIGroup: "autoscaling", APIVersion: "v2", Resource: "horizontalpodautoscalers", Namespaced: true,
+	})
+	m.actionCtx.columns = []model.KeyValue{
+		{Key: "Target", Value: "Deployment/web"},
+		{Key: "Min Replicas", Value: "2"},
+		{Key: "Max Replicas", Value: "5"},
+		{Key: "Current Replicas", Value: "3"},
+		{Key: "Desired Replicas", Value: "4"},
+	}
+	return m
+}
+
+func TestExecuteActionScale_HPAOpensHPAOverlay(t *testing.T) {
+	m := hpaActionCtxModel()
+	m = m.executeActionScale()
+
+	assert.Equal(t, overlayHPAScale, m.overlay)
+	assert.Equal(t, "2", m.hpaScale.min.Value)
+	assert.Equal(t, "5", m.hpaScale.max.Value)
+	assert.Equal(t, "4", m.hpaScale.target.Value) // desired preferred over current
+	assert.Equal(t, "Deployment", m.hpaScale.targetKind)
+	assert.Equal(t, "web", m.hpaScale.targetName)
+	assert.Equal(t, "2", m.hpaScale.origMin)
+	assert.Equal(t, "5", m.hpaScale.origMax)
+	assert.Equal(t, "4", m.hpaScale.origTarget)
+}
+
+func TestExecuteActionScale_DeploymentUsesPlainOverlay(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "web", "default", "Deployment", model.ResourceTypeEntry{})
+	m = m.executeActionScale()
+	assert.Equal(t, overlayScaleInput, m.overlay)
+}
+
+func TestHPAScaleOverlay_FieldNavigation(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+
+	mdl, _ := m.handleHPAScaleOverlayKey(keyMsg("down")) // j/down = next field
+	m = mdl.(Model)
+	assert.Equal(t, 1, m.hpaScale.field)
+
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("j"))
+	m = mdl.(Model)
+	assert.Equal(t, 2, m.hpaScale.field)
+
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("down"))
+	m = mdl.(Model)
+	assert.Equal(t, 0, m.hpaScale.field) // wraps
+
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("k")) // k/up = prev field
+	m = mdl.(Model)
+	assert.Equal(t, 2, m.hpaScale.field) // wraps backwards
+}
+
+func TestHPAScaleOverlay_DigitsEditActiveField(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+	// Move to max field (j = next), clear it, type 9.
+	mdl, _ := m.handleHPAScaleOverlayKey(keyMsg("j"))
+	m = mdl.(Model)
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("backspace"))
+	m = mdl.(Model)
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("9"))
+	m = mdl.(Model)
+	assert.Equal(t, "9", m.hpaScale.max.Value)
+	assert.Equal(t, "2", m.hpaScale.min.Value) // min untouched
+}
+
+func TestHPAScaleOverlay_StepKeys(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay() // min=2, max=5, target=4
+
+	// l/right/+ increment the active (min) field.
+	mdl, _ := m.handleHPAScaleOverlayKey(keyMsg("l"))
+	m = mdl.(Model)
+	assert.Equal(t, "3", m.hpaScale.min.Value)
+
+	// h/left/- decrement.
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("h"))
+	m = mdl.(Model)
+	assert.Equal(t, "2", m.hpaScale.min.Value)
+
+	// min floors at 1.
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("-"))
+	m = mdl.(Model)
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("-"))
+	m = mdl.(Model)
+	assert.Equal(t, "1", m.hpaScale.min.Value)
+}
+
+func TestHPAScaleOverlay_TargetFloorsAtZero(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+	m.hpaScale.field = 2 // target
+	m.hpaScale.target.Set("1")
+	mdl, _ := m.handleHPAScaleOverlayKey(keyMsg("-"))
+	m = mdl.(Model)
+	mdl, _ = m.handleHPAScaleOverlayKey(keyMsg("-"))
+	m = mdl.(Model)
+	assert.Equal(t, "0", m.hpaScale.target.Value)
+}
+
+func TestOpenHPAScaleOverlay_PrefillsFromRaw(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "api", "default", "HorizontalPodAutoscaler", model.ResourceTypeEntry{
+		APIGroup: "autoscaling", APIVersion: "v2", Resource: "horizontalpodautoscalers", Namespaced: true,
+	})
+	m.actionCtx.raw = map[string]any{
+		"spec": map[string]any{
+			"minReplicas":    int64(3),
+			"maxReplicas":    int64(9),
+			"scaleTargetRef": map[string]any{"kind": "Deployment", "name": "api"},
+		},
+		"status": map[string]any{"desiredReplicas": int64(6)},
+	}
+	m = m.openHPAScaleOverlay()
+	assert.Equal(t, "3", m.hpaScale.min.Value)
+	assert.Equal(t, "9", m.hpaScale.max.Value)
+	assert.Equal(t, "6", m.hpaScale.target.Value)
+	assert.Equal(t, "Deployment", m.hpaScale.targetKind)
+	assert.Equal(t, "api", m.hpaScale.targetName)
+}
+
+func TestExecuteActionScale_WorkloadPrefillsReplicas(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "web", "default", "Deployment", model.ResourceTypeEntry{})
+	m.actionCtx.raw = map[string]any{"spec": map[string]any{"replicas": int64(4)}}
+	m = m.executeActionScale()
+	assert.Equal(t, overlayScaleInput, m.overlay)
+	assert.Equal(t, "4", m.scaleInput.Value)
+}
+
+func TestHPAScaleOverlay_EscCancels(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+	mdl, _ := m.handleHPAScaleOverlayKey(keyMsg("esc"))
+	m = mdl.(Model)
+	assert.Equal(t, overlayNone, m.overlay)
+	assert.Empty(t, m.hpaScale.min.Value)
+}
+
+func TestHPAScaleOverlay_NoChangeClosesWithoutCmd(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+	mdl, cmd := m.handleHPAScaleOverlayKey(keyMsg("enter"))
+	m = mdl.(Model)
+	assert.Equal(t, overlayNone, m.overlay)
+	require.NotNil(t, cmd) // scheduleStatusClear
+	assert.False(t, m.loading)
+}
+
+func TestHPAScaleOverlay_MaxLessThanMinRejected(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+	m.hpaScale.min.Set("5")
+	m.hpaScale.max.Set("2")
+	mdl, _ := m.handleHPAScaleOverlayKey(keyMsg("enter"))
+	m = mdl.(Model)
+	assert.Equal(t, overlayNone, m.overlay)
+	assert.False(t, m.loading) // not applied
+}
+
+func TestHPAScaleOverlay_ApplyMinMaxDispatches(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+	m.hpaScale.min.Set("3")
+	m.hpaScale.max.Set("10")
+	mdl, cmd := m.handleHPAScaleOverlayKey(keyMsg("enter"))
+	m = mdl.(Model)
+	assert.Equal(t, overlayNone, m.overlay)
+	assert.True(t, m.loading)
+	require.NotNil(t, cmd)
+}
+
+func TestParseHPAScaleInputs(t *testing.T) {
+	tests := []struct {
+		name        string
+		min, max    string
+		target      string
+		scaleTarget bool
+		wantErr     bool
+		wantMin     int32
+		wantMax     int32
+		wantTarget  int32
+	}{
+		{name: "valid min/max only", min: "2", max: "5", wantMin: 2, wantMax: 5},
+		{name: "valid with target", min: "1", max: "8", target: "4", scaleTarget: true, wantMin: 1, wantMax: 8, wantTarget: 4},
+		{name: "min zero rejected", min: "0", max: "5", wantErr: true},
+		{name: "max below min rejected", min: "5", max: "2", wantErr: true},
+		{name: "non-numeric rejected", min: "x", max: "5", wantErr: true},
+		{name: "negative target rejected", min: "1", max: "5", target: "-1", scaleTarget: true, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := hpaScaleState{}
+			st.min.Set(tt.min)
+			st.max.Set(tt.max)
+			st.target.Set(tt.target)
+			minR, maxR, targetR, err := parseHPAScaleInputs(st, tt.scaleTarget)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMin, minR)
+			assert.Equal(t, tt.wantMax, maxR)
+			assert.Equal(t, tt.wantTarget, targetR)
+		})
+	}
+}
+
+func TestHPAScaleOverlay_Renders(t *testing.T) {
+	m := hpaActionCtxModel().openHPAScaleOverlay()
+	content, _, _, ok := m.renderOverlayContent()
+	require.True(t, ok)
+	plain := stripANSI(content)
+	assert.Contains(t, plain, "Scale HPA")
+	assert.Contains(t, plain, "Min replicas")
+	assert.Contains(t, plain, "Max replicas")
+	assert.Contains(t, plain, "Target replicas")
+}
+
+func TestActionsForHPA_IncludesScale(t *testing.T) {
+	actions := model.ActionsForKind("HorizontalPodAutoscaler")
+	var found bool
+	for _, a := range actions {
+		if a.Label == "Scale" {
+			found = true
+			assert.Equal(t, "S", a.Key)
+		}
+	}
+	assert.True(t, found, "HPA action menu must include Scale")
+}

--- a/internal/app/update_hpa_scale_test.go
+++ b/internal/app/update_hpa_scale_test.go
@@ -184,18 +184,20 @@ func TestParseHPAScaleInputs(t *testing.T) {
 		name        string
 		min, max    string
 		target      string
+		scaleMinMax bool
 		scaleTarget bool
 		wantErr     bool
 		wantMin     int32
 		wantMax     int32
 		wantTarget  int32
 	}{
-		{name: "valid min/max only", min: "2", max: "5", wantMin: 2, wantMax: 5},
-		{name: "valid with target", min: "1", max: "8", target: "4", scaleTarget: true, wantMin: 1, wantMax: 8, wantTarget: 4},
-		{name: "min zero rejected", min: "0", max: "5", wantErr: true},
-		{name: "max below min rejected", min: "5", max: "2", wantErr: true},
-		{name: "non-numeric rejected", min: "x", max: "5", wantErr: true},
-		{name: "negative target rejected", min: "1", max: "5", target: "-1", scaleTarget: true, wantErr: true},
+		{name: "valid min/max only", min: "2", max: "5", scaleMinMax: true, wantMin: 2, wantMax: 5},
+		{name: "valid with target", min: "1", max: "8", target: "4", scaleMinMax: true, scaleTarget: true, wantMin: 1, wantMax: 8, wantTarget: 4},
+		{name: "target only ignores unset min/max", min: "", max: "", target: "3", scaleTarget: true, wantTarget: 3},
+		{name: "min zero rejected", min: "0", max: "5", scaleMinMax: true, wantErr: true},
+		{name: "max below min rejected", min: "5", max: "2", scaleMinMax: true, wantErr: true},
+		{name: "non-numeric rejected", min: "x", max: "5", scaleMinMax: true, wantErr: true},
+		{name: "negative target rejected", min: "1", max: "5", target: "-1", scaleMinMax: true, scaleTarget: true, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -203,7 +205,7 @@ func TestParseHPAScaleInputs(t *testing.T) {
 			st.min.Set(tt.min)
 			st.max.Set(tt.max)
 			st.target.Set(tt.target)
-			minR, maxR, targetR, err := parseHPAScaleInputs(st, tt.scaleTarget)
+			minR, maxR, targetR, err := parseHPAScaleInputs(st, tt.scaleMinMax, tt.scaleTarget)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -118,6 +118,9 @@ func (m Model) handleOverlayKeyPrimary(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool
 	case overlayScaleInput:
 		mdl, cmd := m.handleScaleOverlayKey(msg)
 		return mdl, cmd, true
+	case overlayHPAScale:
+		mdl, cmd := m.handleHPAScaleOverlayKey(msg)
+		return mdl, cmd, true
 	case overlayPVCResize:
 		mdl, cmd := m.handlePVCResizeOverlayKey(msg)
 		return mdl, cmd, true

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -243,6 +243,18 @@ func (m Model) handleScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		m.addLogEntry("DBG", fmt.Sprintf("$ kubectl scale %s %s --replicas=%d -n %s --context %s", strings.ToLower(m.actionCtx.kind), m.actionCtx.name, replicas, m.actionCtx.namespace, m.actionCtx.context))
 		return m, m.scaleResource(int32(replicas))
+	case "l", "+":
+		stepInput(&m.scaleInput, 1, 0)
+		return m, nil
+	case "h", "-":
+		stepInput(&m.scaleInput, -1, 0)
+		return m, nil
+	case "left":
+		m.scaleInput.Left()
+		return m, nil
+	case "right":
+		m.scaleInput.Right()
+		return m, nil
 	case "backspace":
 		if len(m.scaleInput.Value) > 0 {
 			m.scaleInput.Backspace()
@@ -250,18 +262,6 @@ func (m Model) handleScaleOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "ctrl+w":
 		m.scaleInput.DeleteWord()
-		return m, nil
-	case "ctrl+a":
-		m.scaleInput.Home()
-		return m, nil
-	case "ctrl+e":
-		m.scaleInput.End()
-		return m, nil
-	case "left":
-		m.scaleInput.Left()
-		return m, nil
-	case "right":
-		m.scaleInput.Right()
 		return m, nil
 	case "ctrl+c":
 		return m.closeTabOrQuit()

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -174,10 +174,23 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 			WrapWidth: w - 4,
 		}), w, min(10, m.height-6), true
 	case overlayScaleInput:
+		w := min(45, m.width-10)
 		return ui.RenderOverlayInput(ui.OverlayInputConfig{
 			Title: "Scale Deployment",
-			Rows:  []ui.OverlayInputRow{{Label: "Replicas: ", Input: m.scaleInput.Value}},
-		}), min(45, m.width-10), min(8, m.height-6), true
+			Width: w - 4,
+			Rows:  []ui.OverlayInputRow{{Label: "Replicas: ", Input: m.scaleInput.Value, ShowCursor: true, Cursor: m.scaleInput.Cursor}},
+		}), w, min(8, m.height-6), true
+	case overlayHPAScale:
+		w := min(56, m.width-10)
+		return ui.RenderOverlayInput(ui.OverlayInputConfig{
+			Title: "Scale HPA",
+			Width: w - 4,
+			Rows: []ui.OverlayInputRow{
+				{Label: "Min replicas:    ", Input: m.hpaScale.min.Value, ShowCursor: m.hpaScale.field == 0, Cursor: m.hpaScale.min.Cursor},
+				{Label: "Max replicas:    ", Input: m.hpaScale.max.Value, ShowCursor: m.hpaScale.field == 1, Cursor: m.hpaScale.max.Cursor},
+				{Label: "Target replicas: ", Input: m.hpaScale.target.Value, ShowCursor: m.hpaScale.field == 2, Cursor: m.hpaScale.target.Cursor},
+			},
+		}), w, min(11, m.height-6), true
 	case overlayPVCResize:
 		var hint string
 		if m.pvcCurrentSize != "" {
@@ -240,6 +253,7 @@ func (m Model) renderOverlayContentExtended() (string, int, int, bool) {
 					Label:      prompt + "\n  ",
 					Input:      m.batchLabelInput.Value,
 					ShowCursor: true,
+					Cursor:     m.batchLabelInput.Cursor,
 				},
 			},
 		})

--- a/internal/k8s/client_hpa_scale_test.go
+++ b/internal/k8s/client_hpa_scale_test.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+var hpaGVR = schema.GroupVersionResource{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"}
+
+func hpaResourceType() model.ResourceTypeEntry {
+	return model.ResourceTypeEntry{APIGroup: "autoscaling", APIVersion: "v2", Resource: "horizontalpodautoscalers", Namespaced: true}
+}
+
+func hpaUnstructured() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "autoscaling/v2",
+		"kind":       "HorizontalPodAutoscaler",
+		"metadata":   map[string]any{"name": "web", "namespace": "default"},
+		"spec": map[string]any{
+			"minReplicas":    int64(2),
+			"maxReplicas":    int64(5),
+			"scaleTargetRef": map[string]any{"kind": "Deployment", "name": "web"},
+		},
+	}}
+}
+
+func TestPatchHPAScale(t *testing.T) {
+	dc := newFakeDynClientWith(map[schema.GroupVersionResource]string{hpaGVR: "HorizontalPodAutoscalerList"}, hpaUnstructured())
+	c := newFakeClient(nil, dc)
+
+	err := c.PatchHPAScale("", "default", hpaResourceType(), "web", 3, 10)
+	require.NoError(t, err)
+
+	got, err := dc.Resource(hpaGVR).Namespace("default").Get(t.Context(), "web", metav1.GetOptions{})
+	require.NoError(t, err)
+	spec, ok := got.Object["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 3, spec["minReplicas"])
+	assert.EqualValues(t, 10, spec["maxReplicas"])
+}
+
+func TestPatchHPAScale_InvalidContext(t *testing.T) {
+	c := newTestClient(t)
+	err := c.PatchHPAScale("nonexistent-context", "default", hpaResourceType(), "web", 1, 3)
+	require.Error(t, err)
+}

--- a/internal/k8s/client_operations.go
+++ b/internal/k8s/client_operations.go
@@ -178,6 +178,27 @@ func (c *Client) ScaleResource(contextName, namespace, name, kind string, replic
 	return nil
 }
 
+// PatchHPAScale patches a HorizontalPodAutoscaler's spec.minReplicas and
+// spec.maxReplicas. rt carries the cluster's served HPA group/version so the
+// patch targets the right endpoint (autoscaling/v2 on modern clusters).
+func (c *Client) PatchHPAScale(contextName, namespace string, rt model.ResourceTypeEntry, name string, minReplicas, maxReplicas int32) error {
+	logger.Info("Scaling HPA", "context", contextName, "namespace", namespace, "name", name, "min", minReplicas, "max", maxReplicas)
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return err
+	}
+
+	gvr := schema.GroupVersionResource{Group: rt.APIGroup, Version: rt.APIVersion, Resource: rt.Resource}
+	patch := fmt.Appendf(nil, `{"spec":{"minReplicas":%d,"maxReplicas":%d}}`, minReplicas, maxReplicas)
+	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
+		context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("scaling HPA %s to min=%d max=%d: %w", name, minReplicas, maxReplicas, err)
+	}
+	return nil
+}
+
 // ResizePVC patches a PersistentVolumeClaim's spec.resources.requests.storage to the given size.
 func (c *Client) ResizePVC(contextName, namespace, name, newSize string) error {
 	logger.Info("Resizing PVC", "context", contextName, "namespace", namespace, "name", name, "size", newSize)

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -222,6 +222,7 @@ func actionsForWorkloadKind(kind string) ([]ActionMenuItem, bool) {
 		}, true
 	case "HorizontalPodAutoscaler":
 		return []ActionMenuItem{
+			{Label: "Scale", Description: "Edit min/max bounds & target replicas", Key: "S"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Delete", Description: "Delete this HPA", Key: "D"},
 			{Label: "Describe", Description: "Describe resource", Key: "v"},

--- a/internal/ui/overlay_input.go
+++ b/internal/ui/overlay_input.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // OverlayInputRow is one Label+Input pair inside an OverlayInput. Multiple
@@ -12,7 +14,8 @@ type OverlayInputRow struct {
 	Label       string
 	Input       string
 	Placeholder string // shown dim when Input is empty
-	ShowCursor  bool   // append a dim █ block after Input
+	ShowCursor  bool   // render a reverse-video cursor at Cursor
+	Cursor      int    // byte offset of the cursor within Input (used when ShowCursor)
 	ReadOnly    bool   // render the value but suppress cursor
 }
 
@@ -32,6 +35,11 @@ type OverlayInputConfig struct {
 	CandidateTitle  string
 	Candidates      []OverlayListItem
 	CandidateCursor int
+
+	// Width is the inner content width. When > 0, the active (ShowCursor)
+	// row is highlighted full-width — label and value on the selection
+	// background, matching the selected row in list overlays.
+	Width int
 
 	// One or more input rows. Each row renders "<Label><Input or Placeholder>"
 	// with optional trailing cursor.
@@ -72,21 +80,81 @@ func RenderOverlayInput(cfg OverlayInputConfig) string {
 	}
 
 	for i, row := range cfg.Rows {
-		b.WriteString(OverlayNormalStyle.Render(row.Label))
 		switch {
+		case row.ShowCursor && !row.ReadOnly && cfg.Width > 0:
+			// Highlight the whole active row (label + value) full-width,
+			// like the selected row in list overlays, with a visible cursor
+			// cell inside the highlight.
+			b.WriteString(renderActiveInputRow(row.Label, row.Input, row.Cursor, cfg.Width))
+		case row.ShowCursor && !row.ReadOnly:
+			// No width available: fall back to a reverse-video cursor cell
+			// at the cursor offset (e.g. the batch label overlay).
+			b.WriteString(OverlayNormalStyle.Render(row.Label))
+			b.WriteString(overlayInputCursor(row.Input, row.Cursor))
 		case row.Input == "" && row.Placeholder != "":
+			b.WriteString(OverlayNormalStyle.Render(row.Label))
 			b.WriteString(OverlayDimStyle.Render(row.Placeholder))
 		case row.Input == "":
+			b.WriteString(OverlayNormalStyle.Render(row.Label))
 			b.WriteString(OverlayDimStyle.Render("_"))
 		default:
-			b.WriteString(OverlayInputStyle.Render(row.Input))
-		}
-		if row.ShowCursor && !row.ReadOnly {
-			b.WriteString(OverlayDimStyle.Render("█"))
+			b.WriteString(OverlayNormalStyle.Render(row.Label))
+			b.WriteString(OverlayNormalStyle.Render(row.Input))
 		}
 		if i < len(cfg.Rows)-1 {
 			b.WriteString("\n")
 		}
 	}
 	return b.String()
+}
+
+// renderActiveInputRow renders the active row (label + value) on the selection
+// background, padded to width, with a visible cursor cell at the cursor offset.
+// The cursor cell reverses the selection colors so it stands out within the
+// highlighted row. A cursor at the end of the value yields a trailing cell.
+func renderActiveInputRow(label, value string, cursor, width int) string {
+	sel := OverlaySelectedStyle
+	cur := OverlaySelectedStyle.Reverse(true)
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor > len(value) {
+		cursor = len(value)
+	}
+
+	var b strings.Builder
+	b.WriteString(sel.Render(label))
+	used := lipgloss.Width(label) + lipgloss.Width(value)
+	if cursor == len(value) {
+		b.WriteString(sel.Render(value))
+		b.WriteString(cur.Render(" "))
+		used++ // trailing cursor cell
+	} else {
+		end := nextRuneEnd(value, cursor)
+		b.WriteString(sel.Render(value[:cursor]))
+		b.WriteString(cur.Render(value[cursor:end]))
+		b.WriteString(sel.Render(value[end:]))
+	}
+	if pad := width - used; pad > 0 {
+		b.WriteString(sel.Render(strings.Repeat(" ", pad)))
+	}
+	return b.String()
+}
+
+// overlayInputCursor renders s with a reverse-video cursor at the byte offset
+// cursor, for overlays that don't supply a Width (no full-row highlight).
+// A cursor at len(s) (or an empty input) yields a trailing cursor cell.
+func overlayInputCursor(s string, cursor int) string {
+	cursorStyle := OverlayNormalStyle.Reverse(true).Background(SurfaceBg)
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor > len(s) {
+		cursor = len(s)
+	}
+	if cursor == len(s) {
+		return OverlayNormalStyle.Render(s) + cursorStyle.Render(" ")
+	}
+	end := nextRuneEnd(s, cursor)
+	return OverlayNormalStyle.Render(s[:cursor]) + cursorStyle.Render(s[cursor:end]) + OverlayNormalStyle.Render(s[end:])
 }

--- a/internal/ui/overlay_input_test.go
+++ b/internal/ui/overlay_input_test.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,20 +70,41 @@ func TestRenderOverlayInput(t *testing.T) {
 		assert.Contains(t, out, "8080")
 	})
 
-	t.Run("ShowCursor appends a cursor block to the row", func(t *testing.T) {
+	t.Run("ShowCursor renders a reverse-video cursor cell at the cursor offset", func(t *testing.T) {
+		// With styling stripped in tests, a cursor at the end of the input
+		// surfaces as a trailing cursor cell (space) after the value.
 		out := RenderOverlayInput(OverlayInputConfig{
 			Title: "Add Labels",
-			Rows:  []OverlayInputRow{{Label: "key=value: ", Input: "app=foo", ShowCursor: true}},
+			Rows:  []OverlayInputRow{{Label: "key=value: ", Input: "app=foo", ShowCursor: true, Cursor: 7}},
 		})
-		assert.Contains(t, out, "█")
+		assert.Contains(t, out, "app=foo ")
 	})
 
-	t.Run("ShowCursor off omits cursor block", func(t *testing.T) {
+	t.Run("ShowCursor off renders no cursor cell", func(t *testing.T) {
 		out := RenderOverlayInput(OverlayInputConfig{
 			Title: "Scale",
 			Rows:  []OverlayInputRow{{Label: "Replicas: ", Input: "3", ShowCursor: false}},
 		})
 		assert.NotContains(t, out, "█")
+		assert.NotContains(t, out, "3 ")
+	})
+
+	t.Run("Width highlights the active row full-width", func(t *testing.T) {
+		out := RenderOverlayInput(OverlayInputConfig{
+			Title: "Scale",
+			Width: 30,
+			Rows:  []OverlayInputRow{{Label: "Replicas: ", Input: "3", ShowCursor: true}},
+		})
+		// The active row carries the label + value and is padded to Width
+		// (styles are stripped in tests, leaving the spacing).
+		var rowLine string
+		for line := range strings.SplitSeq(out, "\n") {
+			if strings.Contains(line, "Replicas: 3") {
+				rowLine = line
+			}
+		}
+		assert.NotEmpty(t, rowLine)
+		assert.GreaterOrEqual(t, lipgloss.Width(rowLine), 30)
 	})
 
 	t.Run("candidate list rendered with header and cursor", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds a **Scale** action (`S`) to the HorizontalPodAutoscaler action menu, opening a dedicated overlay.
- The overlay edits the HPA's `spec.minReplicas` / `spec.maxReplicas` (HPA keeps autoscaling within the new range) and, optionally, scales the target workload (Deployment / StatefulSet / ReplicaSet) directly.
- Fields prefill from the object's `spec`/`status` (`Item.Raw`), so values populate regardless of which display columns are configured.
- The workload Scale overlay also now prefills the current replica count.

## UX
- Active row is highlighted full-width (like list overlays) with a visible cursor cell.
- Keys: `j`/`k` move between fields, `h`/`-` and `l`/`+` step the active value, `←`/`→` move the cursor, digits type directly.
- Validation: `minReplicas >= 1`, `maxReplicas >= minReplicas`, target `>= 0`. Only changed fields are dispatched. Target changes may be reverted by the HPA on its next reconcile (noted in the menu description).

## Implementation
- `k8s`: `Client.PatchHPAScale` merge-patches min/max via the dynamic client using the resource's served group/version; target scaling reuses `ScaleResource`.
- Read-only mode and the existing `Scale` mutating-action gate are honored.
- New shared `OverlayInputConfig.Width` enables full-width active-row highlight in `RenderOverlayInput`; removed the underline from rendered input values.

## Tests
- `k8s`: `PatchHPAScale` against a fake dynamic client (+ invalid-context path).
- `app`: prefill from raw, field navigation, steppers + floor clamping, validation, dispatch, workload prefill, render.
- `ui`: full-width active-row highlight.
- Full gate green: `go vet`, `go test ./...` (with `-race` on changed packages), `golangci-lint` 0 issues.

## Docs
- README feature bullet, `docs/keybindings.md` (HPA actions + key scheme), `docs/views-and-overlays.md` (`overlayHPAScale`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)