### PR TITLE
feat: goto navigation (g-prefix chords) + which-key overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `J` / `K` | Scroll preview pane down/up |
 | `o` | Jump to owner/controller of selected resource |
 | `Backspace` | Jump back through teleport history (owner / port-forward / orphan / finding / mark jumps) |
-| `g`+`p/d/s/n/N/i/j/c/r/D/t/C/S/a` | Goto resource type: Pods / Deployments / Services / Nodes / Namespaces / Ingresses / Jobs / CronJobs / ReplicaSets / DaemonSets / StatefulSets / ConfigMaps / Secrets / ArgoCD Applications (press `g` for which-key popup) |
+| `g`+`p/d/s/n/N/i/j/c/r/D/t/C/S/h/v/V/b` | Goto resource type: Pods / Deployments / Services / Nodes / Namespaces / Ingresses / Jobs / CronJobs / ReplicaSets / DaemonSets / StatefulSets / ConfigMaps / Secrets / HPAs / PVCs / PVs / PDBs (press `g` for which-key popup; add CRDs like ArgoCD via `goto_targets`) |
 
 ### Views and Modes
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `J` / `K` | Scroll preview pane down/up |
 | `o` | Jump to owner/controller of selected resource |
 | `Backspace` | Jump back through teleport history (owner / port-forward / orphan / finding / mark jumps) |
+| `g`+`p/d/s/n/N/i/j/c/r/D/t/C/S/a` | Goto resource type: Pods / Deployments / Services / Nodes / Namespaces / Ingresses / Jobs / CronJobs / ReplicaSets / DaemonSets / StatefulSets / ConfigMaps / Secrets / ArgoCD Applications (press `g` for which-key popup) |
 
 ### Views and Modes
 

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -534,6 +534,12 @@ filter_presets:
 #     match:
 #       status: "OOMKilled"
 
+# ─── Extra Goto Chords ──────────────────────────────────────────────────────
+# Extra goto chords (g prefix). Key is the full chord; must start with jump_top.
+# goto_targets:
+#   gA: { kind: ApplicationSet, group: argoproj.io, name: AppSets }
+#   gx: { kind: Rollout, group: argoproj.io }
+
 # ─── Pinned CRD Groups ──────────────────────────────────────────────────────
 # Pin CRD API groups so they appear right after built-in categories
 # (Workloads, Networking, etc.) instead of being sorted alphabetically.

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -540,6 +540,10 @@ filter_presets:
 #   gA: { kind: ApplicationSet, group: argoproj.io, name: AppSets }
 #   gx: { kind: Rollout, group: argoproj.io }
 
+# ─── Which-Key Popup ─────────────────────────────────────────────────────────
+# which_key_enabled: true
+# which_key_delay_ms: 0
+
 # ─── Pinned CRD Groups ──────────────────────────────────────────────────────
 # Pin CRD API groups so they appear right after built-in categories
 # (Workloads, Networking, etc.) instead of being sorted alphabetically.

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -535,8 +535,10 @@ filter_presets:
 #       status: "OOMKilled"
 
 # ─── Extra Goto Chords ──────────────────────────────────────────────────────
-# Extra goto chords (g prefix). Key is the full chord; must start with jump_top.
+# Extra goto chords (g prefix), including CRDs. Key is the full chord; must
+# start with jump_top.
 # goto_targets:
+#   ga: { kind: Application, group: argoproj.io, name: ArgoCD Applications }
 #   gA: { kind: ApplicationSet, group: argoproj.io, name: AppSets }
 #   gx: { kind: Rollout, group: argoproj.io }
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -32,6 +32,7 @@ Prefer a local copy? Point `$schema` at a relative or absolute path instead of t
 | `abbreviations` | map[string]string | *(see Abbreviations section)* | Custom search abbreviation overrides/extensions. |
 | `custom_actions` | map[string]list | `{}` | User-defined actions per resource type. |
 | `filter_presets` | map[string]list | `{}` | User-defined quick filter presets per resource type. |
+| `goto_targets` | map | `{}` | Extra g-prefix goto chords. Key = full chord (e.g. `gA`); value = `{kind, group, name}`. Overrides built-ins on collision. |
 | `terminal` | string | `"pty"` | How exec/shell commands run: `"pty"` (embedded in TUI), `"exec"` (takes over terminal), or `"mux"` (opens in a new tmux/zellij window/pane; errors out if no multiplexer is detected). |
 | `pinned_groups` | list[string] | `[]` | CRD API groups to pin after built-in categories. Also manageable in-app with `p` key (stored per-context and per-union-set in `~/.local/state/lfk/pinned.yaml`). |
 | `union_sets` | map[string]object or list[object] | `[]` | Named multi-cluster groups that the `--union-set <name>` CLI flag expands. See [Union Sets](#union-sets). |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -33,6 +33,8 @@ Prefer a local copy? Point `$schema` at a relative or absolute path instead of t
 | `custom_actions` | map[string]list | `{}` | User-defined actions per resource type. |
 | `filter_presets` | map[string]list | `{}` | User-defined quick filter presets per resource type. |
 | `goto_targets` | map | `{}` | Extra g-prefix goto chords. Key = full chord (e.g. `gA`); value = `{kind, group, name}`. Overrides built-ins on collision. |
+| `which_key_enabled` | bool | `true` | Show the which-key popup while the `g` prefix is pending. |
+| `which_key_delay_ms` | int | `0` | Delay before the popup appears (ms, 0-2000). |
 | `terminal` | string | `"pty"` | How exec/shell commands run: `"pty"` (embedded in TUI), `"exec"` (takes over terminal), or `"mux"` (opens in a new tmux/zellij window/pane; errors out if no multiplexer is detected). |
 | `pinned_groups` | list[string] | `[]` | CRD API groups to pin after built-in categories. Also manageable in-app with `p` key (stored per-context and per-union-set in `~/.local/state/lfk/pinned.yaml`). |
 | `union_sets` | map[string]object or list[object] | `[]` | Named multi-cluster groups that the `--union-set <name>` CLI flag expands. See [Union Sets](#union-sets). |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -93,6 +93,18 @@
         "required": ["kind"]
       }
     },
+    "which_key_enabled": {
+      "type": "boolean",
+      "description": "Show the which-key popup while a chord prefix (g) is pending. Chords still work when false.",
+      "default": true
+    },
+    "which_key_delay_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2000,
+      "description": "Delay before the which-key popup appears, in milliseconds (0 = immediate).",
+      "default": 0
+    },
     "terminal": {
       "type": "string",
       "description": "How exec/shell commands run: \"pty\" (embedded in the TUI), \"exec\" (takes over the terminal), or \"mux\" (open in a new tmux/zellij window or pane).",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -79,6 +79,20 @@
         "items": { "$ref": "#/definitions/filterPreset" }
       }
     },
+    "goto_targets": {
+      "type": ["object", "null"],
+      "description": "User-defined g-prefix goto chords. Key is the full chord (e.g. \"gA\") and must start with the jump_top key.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "type": "string" },
+          "group": { "type": "string" },
+          "name": { "type": "string" }
+        },
+        "required": ["kind"]
+      }
+    },
     "terminal": {
       "type": "string",
       "description": "How exec/shell commands run: \"pty\" (embedded in the TUI), \"exec\" (takes over the terminal), or \"mux\" (open in a new tmux/zellij window or pane).",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -451,7 +451,10 @@
         "goto_statefulsets": { "type": "string" },
         "goto_configmaps": { "type": "string" },
         "goto_secrets": { "type": "string" },
-        "goto_argo_applications": { "type": "string" }
+        "goto_hpas": { "type": "string" },
+        "goto_pvcs": { "type": "string" },
+        "goto_pvs": { "type": "string" },
+        "goto_pdbs": { "type": "string" }
       }
     },
     "view": {

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -411,7 +411,21 @@
         "security_ignore_toggle": { "type": "string" },
         "security_badge_toggle": { "type": "string" },
         "toggle_preview_logs": { "type": "string" },
-        "log_top": { "type": "string" }
+        "log_top": { "type": "string" },
+        "goto_pods": { "type": "string" },
+        "goto_deployments": { "type": "string" },
+        "goto_services": { "type": "string" },
+        "goto_nodes": { "type": "string" },
+        "goto_namespaces": { "type": "string" },
+        "goto_ingresses": { "type": "string" },
+        "goto_jobs": { "type": "string" },
+        "goto_cronjobs": { "type": "string" },
+        "goto_replicasets": { "type": "string" },
+        "goto_daemonsets": { "type": "string" },
+        "goto_statefulsets": { "type": "string" },
+        "goto_configmaps": { "type": "string" },
+        "goto_secrets": { "type": "string" },
+        "goto_argo_applications": { "type": "string" }
       }
     },
     "view": {

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -43,9 +43,19 @@ Vim-style `g`-prefix chords that switch the active resource type while keeping t
 | `gt` | StatefulSets |
 | `gC` | ConfigMaps |
 | `gS` | Secrets |
-| `ga` | ArgoCD Applications |
+| `gh` | HorizontalPodAutoscalers |
+| `gv` | PersistentVolumeClaims |
+| `gV` | PersistentVolumes |
+| `gb` | PodDisruptionBudgets |
 
-Add custom chords via `goto_targets` in `~/.config/lfk/config.yaml`. All built-in chords are rebindable under `keybindings`.
+Add custom chords (including CRDs) via `goto_targets` in `~/.config/lfk/config.yaml`. For example, to jump to ArgoCD Applications with `ga`:
+
+```yaml
+goto_targets:
+  ga: { kind: Application, group: argoproj.io, name: ArgoCD Applications }
+```
+
+All built-in chords are rebindable under `keybindings`.
 
 ## Views and Tools
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -26,7 +26,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 
 ## Goto Navigation
 
-Vim-style `g`-prefix chords that switch the active resource type while keeping the current context and namespace filter. Press `g` to open the which-key popup (configurable via `which_key_enabled` and `which_key_delay_ms`).
+Vim-style `g`-prefix chords that switch the active resource type while keeping the current context and namespace filter. Press `g` to open the which-key popup (configurable via `which_key_enabled` and `which_key_delay_ms`); `esc` or any unmapped key closes it.
 
 | Key | Resource |
 |---|---|

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -24,6 +24,29 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `o` / `O` | `o` jumps to the owner/controller of the selected resource; `O` opens the Object Explorer for it |
 | `Backspace` | Jump back through teleport history (owner, port-forward, orphan, finding, and mark jumps push history; hierarchical `h`/`l` navigation does not) |
 
+## Goto Navigation
+
+Vim-style `g`-prefix chords that switch the active resource type while keeping the current context and namespace filter. Press `g` to open the which-key popup (configurable via `which_key_enabled` and `which_key_delay_ms`).
+
+| Key | Resource |
+|---|---|
+| `gp` | Pods |
+| `gd` | Deployments |
+| `gs` | Services |
+| `gn` | Nodes |
+| `gN` | Namespaces |
+| `gi` | Ingresses |
+| `gj` | Jobs |
+| `gc` | CronJobs |
+| `gr` | ReplicaSets |
+| `gD` | DaemonSets |
+| `gt` | StatefulSets |
+| `gC` | ConfigMaps |
+| `gS` | Secrets |
+| `ga` | ArgoCD Applications |
+
+Add custom chords via `goto_targets` in `~/.config/lfk/config.yaml`. All built-in chords are rebindable under `keybindings`.
+
 ## Views and Tools
 
 | Key | Action |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -193,11 +193,11 @@ type Model struct {
 	statusMessageExp time.Time // when message expires
 	statusMessageTip bool      // true when the message is a startup tip (dismiss on keypress)
 
-	// Pending target: when set, after resources load, find and select this item by name.
-	pendingTarget string
+	pendingTarget string // when set, resources load selects this item by name
 
-	// Vim-style 'gg' command: when true, the next 'g' press jumps to top.
-	pendingG bool
+	// pendingG: vim 'gg' -> next 'g' jumps to top; whichKeyShown: popup visible while armed.
+	pendingG      bool
+	whichKeyShown bool
 
 	// Vim text-object operator pending in visual mode ('i'/'a'); 0 = none.
 	pendingTextObject byte

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -203,6 +203,11 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 // updateEasterEggMsg handles easter egg tick/clear messages.
 func (m Model) updateEasterEggMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg.(type) {
+	case whichKeyTickMsg:
+		if m.pendingG {
+			m.whichKeyShown = true
+		}
+		return m, nil, true
 	case konamiClearMsg:
 		m = m.clearKonami()
 		return m, nil, true

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -17,8 +17,14 @@ func (m Model) handleExplorerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, scheduleKonamiClear()
 	}
 
-	if m.pendingG && msg.String() != kb.JumpTop {
-		m.pendingG = false
+	if m.pendingG {
+		if out, cmd, handled := m.handleGotoChord(msg); handled {
+			return out, cmd
+		}
+		if msg.String() != kb.JumpTop {
+			m.pendingG = false
+			m.whichKeyShown = false
+		}
 	}
 
 	if m.pendingMark {

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -276,7 +276,8 @@ func (m Model) handleExplorerJumpTop() (tea.Model, tea.Cmd) {
 		return m, m.loadPreview()
 	}
 	m.pendingG = true
-	return m, nil
+	mdl, cmd := m.armWhichKey()
+	return mdl, cmd
 }
 
 func (m Model) handleExplorerJumpBottom() (tea.Model, tea.Cmd) {

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -9,21 +9,17 @@ import (
 )
 
 func (m Model) handleExplorerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	kb := ui.ActiveKeybindings
-
 	wasKonami := m.konamiActive
 	m = m.checkKonami(msg)
 	if m.konamiActive && !wasKonami {
 		return m, scheduleKonamiClear()
 	}
 
+	// While the g prefix is armed, handleGotoChord consumes every key except a
+	// second "g" (which falls through to the gg jump-top handler below).
 	if m.pendingG {
 		if out, cmd, handled := m.handleGotoChord(msg); handled {
 			return out, cmd
-		}
-		if msg.String() != kb.JumpTop {
-			m.pendingG = false
-			m.whichKeyShown = false
 		}
 	}
 
@@ -270,6 +266,7 @@ func (m Model) handleExplorerJumpTop() (tea.Model, tea.Cmd) {
 	}
 	if m.pendingG {
 		m.pendingG = false
+		m.whichKeyShown = false
 		m.setCursor(0)
 		m.clampCursor()
 		m.syncExpandedGroup()

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -149,6 +149,10 @@ func (m Model) View() string {
 		view = m.renderErrorLogOverlay(view)
 	}
 
+	// Render which-key popup when g prefix is armed and delay has elapsed.
+	// Placed after regular overlays so a real overlay still wins.
+	view = m.renderWhichKey(view)
+
 	// Render help screen as an overlay on top of the explorer view.
 	// The status bar (bottom line) already renders the help search prompt,
 	// so size the overlay to leave the bottom line uncovered.

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -540,6 +540,7 @@ func (m Model) explorerHintEntries() []ui.HintEntry {
 	if len(m.jumpBackStack) > 0 {
 		hintEntries = append(hintEntries, ui.HintEntry{Key: kb.JumpBack, Desc: "jump back"})
 	}
+	hintEntries = append(hintEntries, ui.HintEntry{Key: ui.ActiveKeybindings.JumpTop, Desc: "goto"})
 	hintEntries = append(hintEntries,
 		ui.HintEntry{Key: kb.Help, Desc: "help"},
 		ui.HintEntry{Key: "q", Desc: "quit"},

--- a/internal/app/view_status_goto_test.go
+++ b/internal/app/view_status_goto_test.go
@@ -1,0 +1,16 @@
+package app
+
+import "testing"
+
+func TestExplorerHintEntries_IncludesGoto(t *testing.T) {
+	m := gotoTestModel()
+	found := false
+	for _, h := range m.explorerHintEntries() {
+		if h.Desc == "goto" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("explorer hint bar missing a goto hint")
+	}
+}

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -138,23 +140,23 @@ func (m *Model) normalizeGotoPanes() {
 	m.clearRight()
 }
 
-// handleGotoChord is called while the g prefix is armed (m.pendingG). It
-// consumes only registered goto chords; the second "g" and any unregistered
-// key are left to the existing dispatch (jump-top / passthrough), so no
-// current behavior regresses.
+// handleGotoChord is called while the g prefix is armed (m.pendingG). The
+// second "g" falls through to the gg jump-top handler. Every other key closes
+// the prefix and the popup (which-key semantics): a registered chord navigates,
+// and an unregistered key (e.g. gP) is swallowed as a silent noop rather than
+// falling through to the key's normal explorer action.
 func (m Model) handleGotoChord(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	key := msg.String()
 	if key == ui.ActiveKeybindings.JumpTop { // "g" -> belongs to gg jump-top
 		return m, nil, false
 	}
-	gt, ok := m.gotoTargetForChord("g" + key)
-	if !ok {
-		return m, nil, false
-	}
 	m.pendingG = false
 	m.whichKeyShown = false
-	out, cmd := m.gotoResourceType(gt.Kind, gt.Group)
-	return out, cmd, true
+	if gt, ok := m.gotoTargetForChord(ui.ActiveKeybindings.JumpTop + key); ok {
+		out, cmd := m.gotoResourceType(gt.Kind, gt.Group)
+		return out, cmd, true
+	}
+	return m, nil, true
 }
 
 // whichKeyTickMsg fires after which_key_delay_ms to reveal the popup.
@@ -176,25 +178,81 @@ func (m Model) armWhichKey() (Model, tea.Cmd) {
 	return m, tea.Tick(d, func(time.Time) tea.Msg { return whichKeyTickMsg{} })
 }
 
-// renderWhichKey draws the goto cheatsheet over background when the g prefix
-// is armed and visible. Returns background unchanged when hidden/disabled.
+// whichKeyCell is one continuation key and its label in the which-key panel.
+type whichKeyCell struct {
+	key  string // continuation after the prefix, e.g. "p" for "gp"
+	desc string
+}
+
+// whichKeyCells builds the sorted continuation entries for the g prefix: gg
+// (list top) plus every goto target, keyed by the part of the chord after the
+// prefix. Sorted alphanumerically like neovim's which-key.
+func (m Model) whichKeyCells() []whichKeyCell {
+	prefix := ui.ActiveKeybindings.JumpTop
+	targets := m.gotoTargets()
+	cells := make([]whichKeyCell, 0, len(targets)+1)
+	cells = append(cells, whichKeyCell{prefix, "list top"})
+	for _, gt := range targets {
+		cells = append(cells, whichKeyCell{strings.TrimPrefix(gt.Chord, prefix), gt.Label})
+	}
+	sort.SliceStable(cells, func(i, j int) bool {
+		li, lj := strings.ToLower(cells[i].key), strings.ToLower(cells[j].key)
+		if li != lj {
+			return li < lj
+		}
+		return cells[i].key < cells[j].key
+	})
+	return cells
+}
+
+// renderWhichKey draws the goto cheatsheet anchored to the bottom of the screen
+// when the g prefix is armed and visible, styled after neovim's which-key
+// "modern" preset: a compact full-width double-bordered panel of key/desc
+// columns. Returns background unchanged when hidden/disabled.
 func (m Model) renderWhichKey(background string) string {
 	if !m.pendingG || !m.whichKeyShown || !ui.ConfigWhichKeyEnabled {
 		return background
 	}
-	targets := m.gotoTargets()
-	if len(targets) == 0 {
+	cells := m.whichKeyCells()
+	if len(cells) == 0 {
 		return background
 	}
-	var b strings.Builder
-	b.WriteString("Goto\n\n")
-	fmt.Fprintf(&b, "  %-4s %s\n", ui.ActiveKeybindings.JumpTop+ui.ActiveKeybindings.JumpTop, "list top")
-	for _, gt := range targets {
-		fmt.Fprintf(&b, "  %-4s %s\n", gt.Chord, gt.Label)
+
+	// Column width is the widest "key desc" pair, floored at which-key's
+	// min column width of 5.
+	plain := make([]string, len(cells))
+	styled := make([]string, len(cells))
+	cellW := 5
+	for i, c := range cells {
+		plain[i] = c.key + " " + c.desc
+		styled[i] = ui.HelpKeyStyle.Render(c.key) + " " + ui.BarDimStyle.Render(c.desc)
+		cellW = max(cellW, lipgloss.Width(plain[i]))
 	}
-	content := strings.TrimRight(b.String(), "\n")
-	w := min(40, m.width-4)
-	content = ui.FillLinesBg(content, w, ui.SurfaceBg)
-	box := ui.OverlayStyle.Width(w).Render(content)
-	return ui.PlaceOverlay(m.width, m.height, box, ui.PadToHeight(background, m.height))
+
+	const gap = 1
+	inner := max(m.width-2, cellW) // 2 = double border sides
+	cols := max((inner+gap)/(cellW+gap), 1)
+	rows := (len(cells) + cols - 1) / cols
+
+	lines := make([]string, rows)
+	for r := range rows {
+		var parts []string
+		for c := range cols {
+			idx := c*rows + r // column-major: fill down each column first
+			if idx >= len(cells) {
+				continue
+			}
+			pad := max(cellW-lipgloss.Width(plain[idx]), 0)
+			parts = append(parts, styled[idx]+strings.Repeat(" ", pad))
+		}
+		lines[r] = strings.Join(parts, strings.Repeat(" ", gap))
+	}
+	content := ui.FillLinesBg(strings.Join(lines, "\n"), inner, ui.SurfaceBg)
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.DoubleBorder()).
+		BorderForeground(lipgloss.Color(ui.ColorPrimary)).
+		Width(inner).
+		Render(content)
+	return ui.PlaceOverlayBottom(m.width, m.height, box, ui.PadToHeight(background, m.height))
 }

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -218,6 +218,12 @@ func (m Model) renderWhichKey(background string) string {
 		return background
 	}
 
+	// Panel-local styles: foreground only, all on the theme base background so
+	// the panel matches the theme rather than carrying the status bar's grey
+	// surface. Keys use the help-key accent; descriptions use normal text.
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorSecondary)).Bold(true).Background(ui.BaseBg)
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorFile)).Background(ui.BaseBg)
+
 	// Column width is the widest "key desc" pair, floored at which-key's
 	// min column width of 5.
 	plain := make([]string, len(cells))
@@ -225,12 +231,14 @@ func (m Model) renderWhichKey(background string) string {
 	cellW := 5
 	for i, c := range cells {
 		plain[i] = c.key + " " + c.desc
-		styled[i] = ui.HelpKeyStyle.Render(c.key) + " " + ui.BarDimStyle.Render(c.desc)
+		styled[i] = keyStyle.Render(c.key) + " " + descStyle.Render(c.desc)
 		cellW = max(cellW, lipgloss.Width(plain[i]))
 	}
 
 	const gap = 1
-	inner := max(m.width-2, cellW) // 2 = double border sides
+	// Panel spans ~75% of the screen width, centered, with the double border
+	// inside that budget.
+	inner := max(m.width*3/4-2, cellW)
 	cols := max((inner+gap)/(cellW+gap), 1)
 	rows := (len(cells) + cols - 1) / cols
 
@@ -247,12 +255,15 @@ func (m Model) renderWhichKey(background string) string {
 		}
 		lines[r] = strings.Join(parts, strings.Repeat(" ", gap))
 	}
-	content := ui.FillLinesBg(strings.Join(lines, "\n"), inner, ui.SurfaceBg)
+	content := ui.FillLinesBg(strings.Join(lines, "\n"), inner, ui.BaseBg)
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.DoubleBorder()).
 		BorderForeground(lipgloss.Color(ui.ColorPrimary)).
+		Background(ui.BaseBg).
 		Width(inner).
 		Render(content)
-	return ui.PlaceOverlayBottom(m.width, m.height, box, ui.PadToHeight(background, m.height))
+	// marginBottom of 1 lifts the panel off the very bottom row, keeping the
+	// hint bar visible beneath it.
+	return ui.PlaceOverlayBottom(m.width, m.height, 1, box, ui.PadToHeight(background, m.height))
 }

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -1,0 +1,156 @@
+package app
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// gotoTarget is one g-prefix goto entry: a full chord and the resource type it
+// jumps to.
+type gotoTarget struct {
+	Chord string // full chord, e.g. "gp"
+	Kind  string
+	Group string // APIGroup; "" for core
+	Label string
+}
+
+// gotoTargets returns the active goto targets: built-ins from the keybinding
+// config, then user-defined goto_targets (Task 3) which override built-ins on
+// chord collision. Order is stable for rendering.
+func (m Model) gotoTargets() []gotoTarget {
+	kb := ui.ActiveKeybindings
+	base := []gotoTarget{
+		{kb.GotoPods, "Pod", "", "Pods"},
+		{kb.GotoDeployments, "Deployment", "apps", "Deployments"},
+		{kb.GotoServices, "Service", "", "Services"},
+		{kb.GotoNodes, "Node", "", "Nodes"},
+		{kb.GotoNamespaces, "Namespace", "", "Namespaces"},
+		{kb.GotoIngresses, "Ingress", "networking.k8s.io", "Ingresses"},
+		{kb.GotoJobs, "Job", "batch", "Jobs"},
+		{kb.GotoCronJobs, "CronJob", "batch", "CronJobs"},
+		{kb.GotoReplicaSets, "ReplicaSet", "apps", "ReplicaSets"},
+		{kb.GotoDaemonSets, "DaemonSet", "apps", "DaemonSets"},
+		{kb.GotoStatefulSets, "StatefulSet", "apps", "StatefulSets"},
+		{kb.GotoConfigMaps, "ConfigMap", "", "ConfigMaps"},
+		{kb.GotoSecrets, "Secret", "", "Secrets"},
+		{kb.GotoArgoApplications, "Application", "argoproj.io", "ArgoCD Applications"},
+	}
+	out := make([]gotoTarget, 0, len(base)+len(ui.ConfigGotoTargets))
+	idx := map[string]int{}
+	for _, gt := range base {
+		if gt.Chord == "" {
+			continue
+		}
+		idx[gt.Chord] = len(out)
+		out = append(out, gt)
+	}
+	// Custom targets override built-ins on chord collision. This loop is a
+	// no-op until Task 3 populates ui.ConfigGotoTargets.
+	for chord, ct := range ui.ConfigGotoTargets {
+		label := ct.Name
+		if label == "" {
+			label = ct.Kind
+		}
+		gt := gotoTarget{Chord: chord, Kind: ct.Kind, Group: ct.Group, Label: label}
+		if i, ok := idx[chord]; ok {
+			out[i] = gt
+			continue
+		}
+		idx[chord] = len(out)
+		out = append(out, gt)
+	}
+	return out
+}
+
+// gotoTargetForChord looks up a goto target by its full chord (e.g. "gp").
+func (m Model) gotoTargetForChord(chord string) (gotoTarget, bool) {
+	for _, gt := range m.gotoTargets() {
+		if gt.Chord == chord {
+			return gt, true
+		}
+	}
+	return gotoTarget{}, false
+}
+
+// gotoResourceType switches the current tab to the given resource type in the
+// active context, preserving the namespace filter. It mirrors the descend path
+// of navigateChildResourceType. Requires an active cluster/context.
+func (m Model) gotoResourceType(kind, apiGroup string) (tea.Model, tea.Cmd) {
+	if m.nav.Level == model.LevelClusters {
+		m.setStatusMessage("Select a cluster first", true)
+		return m, scheduleStatusClear()
+	}
+	discoveryCtx := m.nav.Context
+	if m.isUnionSentinel() && len(m.unionContexts) > 0 {
+		discoveryCtx = m.unionContexts[0]
+	}
+	rt, ok := model.FindResourceTypeByKindAndGroup(kind, apiGroup, m.discoveredResources[discoveryCtx])
+	if !ok {
+		m.setStatusMessage(fmt.Sprintf("%s not available in this cluster", kind), true)
+		return m, scheduleStatusClear()
+	}
+	m.saveCursor()
+	m.nav.ResourceType = rt
+	m.applyResourceTypeSortDefault(m.nav.ResourceType, m.nav.Context)
+	m.nav.Level = model.LevelResources
+	m.normalizeGotoPanes()
+	m.saveCurrentSession()
+	if cached, hit := m.itemCache[m.navKey()]; hit {
+		m.setMiddleItems(cached)
+		m.restoreCursor()
+	} else {
+		m.setMiddleItems(nil)
+		m.setCursor(0)
+	}
+	m.loading = true
+	return m, m.loadResources(false)
+}
+
+// normalizeGotoPanes rebuilds the left pane for a clean LevelResources view
+// regardless of the level the goto fired from. After this call, leftItems holds
+// the resource-types sidebar so that pressing h/left returns the user to the
+// correct types list rather than a stale resources or owned pane.
+func (m *Model) normalizeGotoPanes() {
+	discoveryCtx := m.nav.Context
+	if m.isUnionSentinel() && len(m.unionContexts) > 0 {
+		discoveryCtx = m.unionContexts[0]
+	}
+	// Build a fresh resource-types sidebar for the left pane. This is the
+	// same item set that navigateChildResourceType's pushLeft() would promote.
+	typesItems := model.BuildSidebarItems(m.discoveredResources[discoveryCtx])
+
+	// Retain only the deepest cluster-level history entry so that navigating
+	// back past LevelResources -> LevelResourceTypes -> LevelClusters still
+	// works correctly. The history at index 0 (if any) holds the cluster
+	// picker items; everything above it was intermediate pane state that the
+	// goto jumps over.
+	var clusterHistory [][]model.Item
+	if len(m.leftItemsHistory) > 0 {
+		clusterHistory = [][]model.Item{m.leftItemsHistory[0]}
+	}
+	m.leftItemsHistory = clusterHistory
+	m.leftItems = typesItems
+	m.clearRight()
+}
+
+// handleGotoChord is called while the g prefix is armed (m.pendingG). It
+// consumes only registered goto chords; the second "g" and any unregistered
+// key are left to the existing dispatch (jump-top / passthrough), so no
+// current behavior regresses.
+func (m Model) handleGotoChord(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	key := msg.String()
+	if key == ui.ActiveKeybindings.JumpTop { // "g" -> belongs to gg jump-top
+		return m, nil, false
+	}
+	gt, ok := m.gotoTargetForChord("g" + key)
+	if !ok {
+		return m, nil, false
+	}
+	m.pendingG = false
+	m.whichKeyShown = false
+	out, cmd := m.gotoResourceType(gt.Kind, gt.Group)
+	return out, cmd, true
+}

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -40,7 +40,10 @@ func (m Model) gotoTargets() []gotoTarget {
 		{kb.GotoStatefulSets, "StatefulSet", "apps", "StatefulSets"},
 		{kb.GotoConfigMaps, "ConfigMap", "", "ConfigMaps"},
 		{kb.GotoSecrets, "Secret", "", "Secrets"},
-		{kb.GotoArgoApplications, "Application", "argoproj.io", "ArgoCD Applications"},
+		{kb.GotoHPAs, "HorizontalPodAutoscaler", "autoscaling", "HPAs"},
+		{kb.GotoPVCs, "PersistentVolumeClaim", "", "PVCs"},
+		{kb.GotoPVs, "PersistentVolume", "", "PVs"},
+		{kb.GotoPDBs, "PodDisruptionBudget", "policy", "PDBs"},
 	}
 	out := make([]gotoTarget, 0, len(base)+len(ui.ConfigGotoTargets))
 	idx := map[string]int{}

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -210,39 +210,57 @@ func (m Model) whichKeyCells() []whichKeyCell {
 // terminal is too narrow to fit them.
 const (
 	whichKeyMaxCols = 4 // preferred column count
-	whichKeyColGap  = 3 // spaces between columns
+	whichKeyMinGap  = 3 // minimum spaces between columns
 )
 
-// whichKeyLayout describes a laid-out grid: the per-column widths, the row
-// count, and the total inner content width.
+// whichKeyLayout describes a laid-out grid: the per-column widths, the spacing
+// inserted between each pair of columns (length cols-1), the row count, and the
+// total inner content width.
 type whichKeyLayout struct {
 	colW  []int
+	gaps  []int
 	rows  int
 	inner int
 }
 
 // layoutWhichKey lays the cells into the largest column count (up to
 // whichKeyMaxCols) that fits maxInner, sizing each column to its own widest
-// entry (so the grid has no trailing right gap). Column-major fill: entries go
-// down each column.
-func layoutWhichKey(plain []string, maxInner int) whichKeyLayout {
+// entry. The columns are then spread to targetInner (bounded by maxInner) by
+// widening the inter-column gaps, so the grid fills the width without any
+// trailing gap past the last column. Column-major fill: entries go down each
+// column.
+func layoutWhichKey(plain []string, targetInner, maxInner int) whichKeyLayout {
 	cols := min(whichKeyMaxCols, len(plain))
 	for {
 		rows := (len(plain) + cols - 1) / cols
 		colW := make([]int, cols)
+		sumW := 0
 		for c := range cols {
 			for r := range rows {
 				if idx := c*rows + r; idx < len(plain) {
 					colW[c] = max(colW[c], lipgloss.Width(plain[idx]))
 				}
 			}
+			sumW += colW[c]
 		}
-		inner := whichKeyColGap * (cols - 1)
-		for _, w := range colW {
-			inner += w
+		if cols == 1 {
+			return whichKeyLayout{colW: colW, rows: rows, inner: sumW}
 		}
-		if cols == 1 || inner <= maxInner {
-			return whichKeyLayout{colW: colW, rows: rows, inner: inner}
+		minWidth := sumW + whichKeyMinGap*(cols-1)
+		if minWidth <= maxInner {
+			// Stretch toward targetInner (never below the minimal layout, never
+			// past the screen). The slack is shared across the gaps.
+			want := min(max(targetInner, minWidth), maxInner)
+			slack := want - sumW
+			base, rem := slack/(cols-1), slack%(cols-1)
+			gaps := make([]int, cols-1)
+			for i := range gaps {
+				gaps[i] = base
+				if i < rem {
+					gaps[i]++
+				}
+			}
+			return whichKeyLayout{colW: colW, gaps: gaps, rows: rows, inner: want}
 		}
 		cols--
 	}
@@ -275,28 +293,34 @@ func (m Model) renderWhichKey(background string) string {
 	}
 
 	const (
-		padV = 1 // rows of padding above and below
-		padH = 2 // columns of padding left and right
+		padV     = 1  // rows of padding above and below
+		padH     = 2  // columns of padding left and right
+		widthPct = 60 // panel spans this percent of the screen width
 	)
-	// Budget the natural grid against the screen, leaving room for padding and
-	// the border.
-	maxInner := max(m.width-2*padH-2, 1)
-	lay := layoutWhichKey(plain, maxInner)
+	// Target ~widthPct of the screen, but never wider than the screen leaves
+	// room for once padding and the border are accounted for.
+	chrome := 2*padH + 2
+	maxInner := max(m.width-chrome, 1)
+	targetInner := max(m.width*widthPct/100-chrome, 1)
+	lay := layoutWhichKey(plain, targetInner, maxInner)
 	cols := len(lay.colW)
 
 	body := make([]string, lay.rows)
 	for r := range lay.rows {
-		parts := make([]string, cols)
+		var sb strings.Builder
 		for c := range cols {
 			idx := c*lay.rows + r // column-major: fill down each column first
-			if idx >= len(cells) {
-				parts[c] = strings.Repeat(" ", lay.colW[c])
-				continue
+			if idx < len(cells) {
+				sb.WriteString(styled[idx])
+				sb.WriteString(strings.Repeat(" ", max(lay.colW[c]-lipgloss.Width(plain[idx]), 0)))
+			} else {
+				sb.WriteString(strings.Repeat(" ", lay.colW[c]))
 			}
-			pad := max(lay.colW[c]-lipgloss.Width(plain[idx]), 0)
-			parts[c] = styled[idx] + strings.Repeat(" ", pad)
+			if c < cols-1 {
+				sb.WriteString(strings.Repeat(" ", lay.gaps[c]))
+			}
 		}
-		body[r] = strings.Join(parts, strings.Repeat(" ", whichKeyColGap))
+		body[r] = sb.String()
 	}
 	content := ui.FillLinesBg(strings.Join(body, "\n"), lay.inner, ui.BaseBg)
 

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/janosmiko/lfk/internal/model"
@@ -153,4 +155,46 @@ func (m Model) handleGotoChord(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	m.whichKeyShown = false
 	out, cmd := m.gotoResourceType(gt.Kind, gt.Group)
 	return out, cmd, true
+}
+
+// whichKeyTickMsg fires after which_key_delay_ms to reveal the popup.
+type whichKeyTickMsg struct{}
+
+// armWhichKey is called when the g prefix arms. With no delay it shows the
+// popup immediately; otherwise it schedules a reveal tick.
+func (m Model) armWhichKey() (Model, tea.Cmd) {
+	if !ui.ConfigWhichKeyEnabled {
+		m.whichKeyShown = false
+		return m, nil
+	}
+	if ui.ConfigWhichKeyDelayMs <= 0 {
+		m.whichKeyShown = true
+		return m, nil
+	}
+	m.whichKeyShown = false
+	d := time.Duration(ui.ConfigWhichKeyDelayMs) * time.Millisecond
+	return m, tea.Tick(d, func(time.Time) tea.Msg { return whichKeyTickMsg{} })
+}
+
+// renderWhichKey draws the goto cheatsheet over background when the g prefix
+// is armed and visible. Returns background unchanged when hidden/disabled.
+func (m Model) renderWhichKey(background string) string {
+	if !m.pendingG || !m.whichKeyShown || !ui.ConfigWhichKeyEnabled {
+		return background
+	}
+	targets := m.gotoTargets()
+	if len(targets) == 0 {
+		return background
+	}
+	var b strings.Builder
+	b.WriteString("Goto\n\n")
+	fmt.Fprintf(&b, "  %-4s %s\n", ui.ActiveKeybindings.JumpTop+ui.ActiveKeybindings.JumpTop, "list top")
+	for _, gt := range targets {
+		fmt.Fprintf(&b, "  %-4s %s\n", gt.Chord, gt.Label)
+	}
+	content := strings.TrimRight(b.String(), "\n")
+	w := min(40, m.width-4)
+	content = ui.FillLinesBg(content, w, ui.SurfaceBg)
+	box := ui.OverlayStyle.Width(w).Render(content)
+	return ui.PlaceOverlay(m.width, m.height, box, ui.PadToHeight(background, m.height))
 }

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -236,34 +236,55 @@ func (m Model) renderWhichKey(background string) string {
 	}
 
 	const gap = 1
-	// Panel spans ~75% of the screen width, centered, with the double border
+	// Panel spans ~75% of the screen width, centered, with the rounded border
 	// inside that budget.
 	inner := max(m.width*3/4-2, cellW)
 	cols := max((inner+gap)/(cellW+gap), 1)
 	rows := (len(cells) + cols - 1) / cols
 
-	lines := make([]string, rows)
+	// Spread the columns across the full inner width instead of packing them
+	// left: each column is at least cellW wide, and the rounding remainder is
+	// absorbed by the leftmost columns.
+	avail := max(inner-gap*(cols-1), cols)
+	baseW, rem := avail/cols, avail%cols
+	colW := func(c int) int {
+		if c < rem {
+			return baseW + 1
+		}
+		return baseW
+	}
+
+	body := make([]string, rows)
 	for r := range rows {
-		var parts []string
+		parts := make([]string, cols)
 		for c := range cols {
 			idx := c*rows + r // column-major: fill down each column first
 			if idx >= len(cells) {
+				parts[c] = strings.Repeat(" ", colW(c))
 				continue
 			}
-			pad := max(cellW-lipgloss.Width(plain[idx]), 0)
-			parts = append(parts, styled[idx]+strings.Repeat(" ", pad))
+			pad := max(colW(c)-lipgloss.Width(plain[idx]), 0)
+			parts[c] = styled[idx] + strings.Repeat(" ", pad)
 		}
-		lines[r] = strings.Join(parts, strings.Repeat(" ", gap))
+		body[r] = strings.Join(parts, strings.Repeat(" ", gap))
 	}
+	// A blank leading row gives the first entries breathing room below the
+	// top border.
+	lines := append([]string{""}, body...)
 	content := ui.FillLinesBg(strings.Join(lines, "\n"), inner, ui.BaseBg)
 
 	box := lipgloss.NewStyle().
-		Border(lipgloss.DoubleBorder()).
+		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(ui.ColorPrimary)).
 		Background(ui.BaseBg).
 		Width(inner).
 		Render(content)
-	// marginBottom of 1 lifts the panel off the very bottom row, keeping the
-	// hint bar visible beneath it.
-	return ui.PlaceOverlayBottom(m.width, m.height, 1, box, ui.PadToHeight(background, m.height))
+
+	// Dim the screen behind the panel like the other overlays do, then lift
+	// the panel one row off the bottom so the hint bar stays visible.
+	bg := ui.PadToHeight(background, m.height)
+	if ui.ConfigDimOverlay {
+		bg = ui.DimBackground(bg, 1)
+	}
+	return ui.PlaceOverlayBottom(m.width, m.height, 1, box, bg)
 }

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -205,10 +205,53 @@ func (m Model) whichKeyCells() []whichKeyCell {
 	return cells
 }
 
-// renderWhichKey draws the goto cheatsheet anchored to the bottom of the screen
-// when the g prefix is armed and visible, styled after neovim's which-key
-// "modern" preset: a compact full-width double-bordered panel of key/desc
-// columns. Returns background unchanged when hidden/disabled.
+// which-key grid geometry. The grid grows vertically (more rows) as entries
+// are added, keeping a stable column count; the count drops only when the
+// terminal is too narrow to fit them.
+const (
+	whichKeyMaxCols = 4 // preferred column count
+	whichKeyColGap  = 3 // spaces between columns
+)
+
+// whichKeyLayout describes a laid-out grid: the per-column widths, the row
+// count, and the total inner content width.
+type whichKeyLayout struct {
+	colW  []int
+	rows  int
+	inner int
+}
+
+// layoutWhichKey lays the cells into the largest column count (up to
+// whichKeyMaxCols) that fits maxInner, sizing each column to its own widest
+// entry (so the grid has no trailing right gap). Column-major fill: entries go
+// down each column.
+func layoutWhichKey(plain []string, maxInner int) whichKeyLayout {
+	cols := min(whichKeyMaxCols, len(plain))
+	for {
+		rows := (len(plain) + cols - 1) / cols
+		colW := make([]int, cols)
+		for c := range cols {
+			for r := range rows {
+				if idx := c*rows + r; idx < len(plain) {
+					colW[c] = max(colW[c], lipgloss.Width(plain[idx]))
+				}
+			}
+		}
+		inner := whichKeyColGap * (cols - 1)
+		for _, w := range colW {
+			inner += w
+		}
+		if cols == 1 || inner <= maxInner {
+			return whichKeyLayout{colW: colW, rows: rows, inner: inner}
+		}
+		cols--
+	}
+}
+
+// renderWhichKey draws the goto cheatsheet near the bottom of the screen when
+// the g prefix is armed and visible, styled after neovim's which-key "modern"
+// preset: a rounded-border panel of key/desc columns with uniform padding over
+// a dimmed background. Returns background unchanged when hidden/disabled.
 func (m Model) renderWhichKey(background string) string {
 	if !m.pendingG || !m.whichKeyShown || !ui.ConfigWhichKeyEnabled {
 		return background
@@ -224,67 +267,51 @@ func (m Model) renderWhichKey(background string) string {
 	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorSecondary)).Bold(true).Background(ui.BaseBg)
 	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ui.ColorFile)).Background(ui.BaseBg)
 
-	// Column width is the widest "key desc" pair, floored at which-key's
-	// min column width of 5.
 	plain := make([]string, len(cells))
 	styled := make([]string, len(cells))
-	cellW := 5
 	for i, c := range cells {
 		plain[i] = c.key + " " + c.desc
 		styled[i] = keyStyle.Render(c.key) + " " + descStyle.Render(c.desc)
-		cellW = max(cellW, lipgloss.Width(plain[i]))
 	}
 
-	const gap = 1
-	// Panel spans ~75% of the screen width, centered, with the rounded border
-	// inside that budget.
-	inner := max(m.width*3/4-2, cellW)
-	cols := max((inner+gap)/(cellW+gap), 1)
-	rows := (len(cells) + cols - 1) / cols
+	const (
+		padV = 1 // rows of padding above and below
+		padH = 2 // columns of padding left and right
+	)
+	// Budget the natural grid against the screen, leaving room for padding and
+	// the border.
+	maxInner := max(m.width-2*padH-2, 1)
+	lay := layoutWhichKey(plain, maxInner)
+	cols := len(lay.colW)
 
-	// Spread the columns across the full inner width instead of packing them
-	// left: each column is at least cellW wide, and the rounding remainder is
-	// absorbed by the leftmost columns.
-	avail := max(inner-gap*(cols-1), cols)
-	baseW, rem := avail/cols, avail%cols
-	colW := func(c int) int {
-		if c < rem {
-			return baseW + 1
-		}
-		return baseW
-	}
-
-	body := make([]string, rows)
-	for r := range rows {
+	body := make([]string, lay.rows)
+	for r := range lay.rows {
 		parts := make([]string, cols)
 		for c := range cols {
-			idx := c*rows + r // column-major: fill down each column first
+			idx := c*lay.rows + r // column-major: fill down each column first
 			if idx >= len(cells) {
-				parts[c] = strings.Repeat(" ", colW(c))
+				parts[c] = strings.Repeat(" ", lay.colW[c])
 				continue
 			}
-			pad := max(colW(c)-lipgloss.Width(plain[idx]), 0)
+			pad := max(lay.colW[c]-lipgloss.Width(plain[idx]), 0)
 			parts[c] = styled[idx] + strings.Repeat(" ", pad)
 		}
-		body[r] = strings.Join(parts, strings.Repeat(" ", gap))
+		body[r] = strings.Join(parts, strings.Repeat(" ", whichKeyColGap))
 	}
-	// A blank leading row gives the first entries breathing room below the
-	// top border.
-	lines := append([]string{""}, body...)
-	content := ui.FillLinesBg(strings.Join(lines, "\n"), inner, ui.BaseBg)
+	content := ui.FillLinesBg(strings.Join(body, "\n"), lay.inner, ui.BaseBg)
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(ui.ColorPrimary)).
 		Background(ui.BaseBg).
-		Width(inner).
+		Padding(padV, padH).
 		Render(content)
 
-	// Dim the screen behind the panel like the other overlays do, then lift
-	// the panel one row off the bottom so the hint bar stays visible.
+	// Dim the screen behind the panel like the other overlays do, then lift the
+	// panel a few rows off the bottom.
 	bg := ui.PadToHeight(background, m.height)
 	if ui.ConfigDimOverlay {
 		bg = ui.DimBackground(bg, 1)
 	}
-	return ui.PlaceOverlayBottom(m.width, m.height, 1, box, bg)
+	return ui.PlaceOverlayBottom(m.width, m.height, 5, box, bg)
 }

--- a/internal/app/whichkey_render_test.go
+++ b/internal/app/whichkey_render_test.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func TestRenderWhichKey_ListsTargets(t *testing.T) {
+	ui.ActiveKeybindings = ui.DefaultKeybindings()
+	ui.ConfigWhichKeyEnabled = true
+	ui.ConfigWhichKeyDelayMs = 0
+	m := gotoTestModel()
+	m.pendingG = true
+	m.whichKeyShown = true
+	out := stripANSI(m.renderWhichKey(strings.Repeat("\n", m.height)))
+	if !strings.Contains(out, "Pods") || !strings.Contains(out, "gp") {
+		t.Fatalf("which-key popup missing goto targets:\n%s", out)
+	}
+}
+
+func TestRenderWhichKey_HiddenWhenDisabled(t *testing.T) {
+	ui.ConfigWhichKeyEnabled = false
+	m := gotoTestModel()
+	m.pendingG = true
+	m.whichKeyShown = true
+	bg := strings.Repeat("\n", m.height)
+	if got := m.renderWhichKey(bg); got != bg {
+		t.Fatal("popup must not render when which_key_enabled is false")
+	}
+}

--- a/internal/app/whichkey_render_test.go
+++ b/internal/app/whichkey_render_test.go
@@ -15,8 +15,35 @@ func TestRenderWhichKey_ListsTargets(t *testing.T) {
 	m.pendingG = true
 	m.whichKeyShown = true
 	out := stripANSI(m.renderWhichKey(strings.Repeat("\n", m.height)))
-	if !strings.Contains(out, "Pods") || !strings.Contains(out, "gp") {
-		t.Fatalf("which-key popup missing goto targets:\n%s", out)
+	for _, want := range []string{"Pods", "Deployments", "list top"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("which-key popup missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The modern preset anchors the panel to the bottom of the screen, so the
+// content must land in the lower rows, not centered or at the top.
+func TestRenderWhichKey_AnchoredToBottom(t *testing.T) {
+	ui.ActiveKeybindings = ui.DefaultKeybindings()
+	ui.ConfigWhichKeyEnabled = true
+	ui.ConfigWhichKeyDelayMs = 0
+	m := gotoTestModel()
+	m.pendingG = true
+	m.whichKeyShown = true
+	lines := strings.Split(stripANSI(m.renderWhichKey(strings.Repeat("\n", m.height))), "\n")
+	podsRow := -1
+	for i, l := range lines {
+		if strings.Contains(l, "Pods") {
+			podsRow = i
+			break
+		}
+	}
+	if podsRow < 0 {
+		t.Fatal("Pods not found in rendered panel")
+	}
+	if podsRow <= m.height/2 {
+		t.Fatalf("panel must be bottom-anchored; Pods at row %d of %d", podsRow, m.height)
 	}
 }
 

--- a/internal/app/whichkey_render_test.go
+++ b/internal/app/whichkey_render_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRenderWhichKey_ListsTargets(t *testing.T) {
+	restoreWhichKeyGlobals(t)
 	ui.ActiveKeybindings = ui.DefaultKeybindings()
 	ui.ConfigWhichKeyEnabled = true
 	ui.ConfigWhichKeyDelayMs = 0
@@ -25,6 +26,7 @@ func TestRenderWhichKey_ListsTargets(t *testing.T) {
 // The modern preset anchors the panel to the bottom of the screen, so the
 // content must land in the lower rows, not centered or at the top.
 func TestRenderWhichKey_AnchoredToBottom(t *testing.T) {
+	restoreWhichKeyGlobals(t)
 	ui.ActiveKeybindings = ui.DefaultKeybindings()
 	ui.ConfigWhichKeyEnabled = true
 	ui.ConfigWhichKeyDelayMs = 0
@@ -48,6 +50,7 @@ func TestRenderWhichKey_AnchoredToBottom(t *testing.T) {
 }
 
 func TestRenderWhichKey_HiddenWhenDisabled(t *testing.T) {
+	restoreWhichKeyGlobals(t)
 	ui.ConfigWhichKeyEnabled = false
 	m := gotoTestModel()
 	m.pendingG = true

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// restoreWhichKeyGlobals snapshots the package-global UI config the which-key
+// tests mutate and restores it after the test, so test order can't leak state.
+func restoreWhichKeyGlobals(t *testing.T) {
+	t.Helper()
+	kb := ui.ActiveKeybindings
+	enabled := ui.ConfigWhichKeyEnabled
+	delay := ui.ConfigWhichKeyDelayMs
+	dim := ui.ConfigDimOverlay
+	t.Cleanup(func() {
+		ui.ActiveKeybindings = kb
+		ui.ConfigWhichKeyEnabled = enabled
+		ui.ConfigWhichKeyDelayMs = delay
+		ui.ConfigDimOverlay = dim
+	})
+}
+
 // gotoTestModel returns an explorer model at LevelResourceTypes with a
 // discovered resource set containing Pods and Deployments for the active context.
 func gotoTestModel() Model {
@@ -83,6 +99,7 @@ func TestHandleGotoChord_GPassesThroughToJumpTop(t *testing.T) {
 // nothing happens — which-key semantics, no fall-through to the key's normal
 // explorer action.
 func TestHandleGotoChord_UnregisteredConsumesAndCloses(t *testing.T) {
+	restoreWhichKeyGlobals(t)
 	ui.ActiveKeybindings = ui.DefaultKeybindings()
 	m := gotoTestModel()
 	m.pendingG = true
@@ -111,6 +128,7 @@ func TestHandleGotoChord_UnregisteredConsumesAndCloses(t *testing.T) {
 // esc (and any non-g key) is swallowed while the prefix is armed: it closes
 // the popup as a noop instead of falling through to its normal explorer action.
 func TestHandleGotoChord_EscClosesPopup(t *testing.T) {
+	restoreWhichKeyGlobals(t)
 	ui.ActiveKeybindings = ui.DefaultKeybindings()
 	m := gotoTestModel()
 	m.pendingG = true
@@ -190,6 +208,7 @@ func TestLayoutWhichKey(t *testing.T) {
 }
 
 func TestGotoTargets_IncludesBuiltins(t *testing.T) {
+	restoreWhichKeyGlobals(t)
 	ui.ActiveKeybindings = ui.DefaultKeybindings()
 	m := gotoTestModel()
 	byChord := map[string]string{}
@@ -230,7 +249,7 @@ func TestGotoResourceType_LeftPaneIsResourceTypes(t *testing.T) {
 			kinds[item.Kind] = true
 		}
 	}
-	if !kinds["Pod"] && !kinds["Deployment"] {
+	if !kinds["Pod"] || !kinds["Deployment"] {
 		t.Fatalf("left pane does not hold resource-type items after goto; kinds=%v", kinds)
 	}
 }

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -147,28 +147,43 @@ func TestLayoutWhichKey(t *testing.T) {
 		return out
 	}
 
-	// Wide terminal, 15 entries -> 4 columns, ceil(15/4)=4 rows.
-	lay := layoutWhichKey(mk(15), 1000)
+	sumOf := func(xs []int) int {
+		s := 0
+		for _, x := range xs {
+			s += x
+		}
+		return s
+	}
+
+	// 15 entries -> 4 columns, ceil(15/4)=4 rows; stretched to the target width
+	// with the slack in the gaps and no trailing space past the last column
+	// (inner == sum(colW) + sum(gaps)).
+	lay := layoutWhichKey(mk(15), 100, 200)
 	if len(lay.colW) != 4 || lay.rows != 4 {
 		t.Fatalf("15 entries: want 4 cols / 4 rows, got %d cols / %d rows", len(lay.colW), lay.rows)
 	}
+	if lay.inner != 100 {
+		t.Fatalf("grid must stretch to target inner 100, got %d", lay.inner)
+	}
+	if sumOf(lay.colW)+sumOf(lay.gaps) != lay.inner {
+		t.Fatalf("no-trailing-gap invariant broken: cols=%v gaps=%v inner=%d", lay.colW, lay.gaps, lay.inner)
+	}
 
 	// Adding entries keeps 4 columns and grows rows (expand vertically).
-	lay2 := layoutWhichKey(mk(23), 1000)
+	lay2 := layoutWhichKey(mk(23), 100, 200)
 	if len(lay2.colW) != 4 || lay2.rows != 6 { // ceil(23/4)=6
 		t.Fatalf("23 entries: want 4 cols / 6 rows, got %d cols / %d rows", len(lay2.colW), lay2.rows)
 	}
 
-	// Each column is sized to its own widest entry (no global padding => no
-	// trailing right gap). 4 entries, 4 columns, 1 row each.
+	// Each column is sized to its own widest entry. 4 entries, 4 columns, 1 row.
 	wide := []string{"short", "a-very-long-entry", "short", "short"}
-	lay3 := layoutWhichKey(wide, 1000)
+	lay3 := layoutWhichKey(wide, 100, 200)
 	if lay3.colW[1] != len("a-very-long-entry") || lay3.colW[0] != len("short") {
 		t.Fatalf("per-column widths wrong: %v", lay3.colW)
 	}
 
 	// Narrow terminal reduces the column count to fit.
-	lay4 := layoutWhichKey(mk(15), 5)
+	lay4 := layoutWhichKey(mk(15), 5, 5)
 	if len(lay4.colW) >= 4 {
 		t.Fatalf("narrow width must reduce columns, got %d", len(lay4.colW))
 	}

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -79,6 +79,65 @@ func TestHandleGotoChord_GPassesThroughToJumpTop(t *testing.T) {
 	}
 }
 
+// An unregistered second key (e.g. gP) is swallowed: the popup closes and
+// nothing happens — which-key semantics, no fall-through to the key's normal
+// explorer action.
+func TestHandleGotoChord_UnregisteredConsumesAndCloses(t *testing.T) {
+	ui.ActiveKeybindings = ui.DefaultKeybindings()
+	m := gotoTestModel()
+	m.pendingG = true
+	m.whichKeyShown = true
+	out, cmd, handled := m.handleGotoChord(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
+	if !handled {
+		t.Fatal("unregistered second key must be consumed (handled=true)")
+	}
+	if cmd != nil {
+		t.Fatal("unregistered second key must be a noop (no command)")
+	}
+	rm := out.(Model)
+	if rm.pendingG || rm.whichKeyShown {
+		t.Fatal("unregistered second key must close the prefix and the popup")
+	}
+	// A real goto sets Level to LevelResources; an unregistered key must leave
+	// the nav level untouched (here: LevelResourceTypes).
+	if rm.nav.Level != model.LevelResourceTypes {
+		t.Fatalf("unregistered second key must not navigate; nav.Level = %v", rm.nav.Level)
+	}
+	if rm.statusMessageErr {
+		t.Fatal("unregistered second key must be silent (no error status)")
+	}
+}
+
+// esc (and any non-g key) is swallowed while the prefix is armed: it closes
+// the popup as a noop instead of falling through to its normal explorer action.
+func TestHandleGotoChord_EscClosesPopup(t *testing.T) {
+	ui.ActiveKeybindings = ui.DefaultKeybindings()
+	m := gotoTestModel()
+	m.pendingG = true
+	m.whichKeyShown = true
+	out, cmd, handled := m.handleGotoChord(tea.KeyMsg{Type: tea.KeyEsc})
+	if !handled || cmd != nil {
+		t.Fatal("esc must be consumed as a noop while the prefix is armed")
+	}
+	rm := out.(Model)
+	if rm.pendingG || rm.whichKeyShown {
+		t.Fatal("esc must close the prefix and the popup")
+	}
+}
+
+// Completing gg (jump to top) must clear whichKeyShown along with pendingG so
+// no stale visibility flag lingers.
+func TestExplorerJumpTop_GGClearsWhichKeyShown(t *testing.T) {
+	m := gotoTestModel()
+	m.pendingG = true
+	m.whichKeyShown = true
+	out, _ := m.handleExplorerJumpTop()
+	rm := out.(Model)
+	if rm.pendingG || rm.whichKeyShown {
+		t.Fatalf("gg must clear both pendingG and whichKeyShown; got pendingG=%v whichKeyShown=%v", rm.pendingG, rm.whichKeyShown)
+	}
+}
+
 func TestGotoTargets_IncludesBuiltins(t *testing.T) {
 	ui.ActiveKeybindings = ui.DefaultKeybindings()
 	m := gotoTestModel()

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -138,6 +138,42 @@ func TestExplorerJumpTop_GGClearsWhichKeyShown(t *testing.T) {
 	}
 }
 
+func TestLayoutWhichKey(t *testing.T) {
+	mk := func(n int) []string {
+		out := make([]string, n)
+		for i := range out {
+			out[i] = "x x" // width 3
+		}
+		return out
+	}
+
+	// Wide terminal, 15 entries -> 4 columns, ceil(15/4)=4 rows.
+	lay := layoutWhichKey(mk(15), 1000)
+	if len(lay.colW) != 4 || lay.rows != 4 {
+		t.Fatalf("15 entries: want 4 cols / 4 rows, got %d cols / %d rows", len(lay.colW), lay.rows)
+	}
+
+	// Adding entries keeps 4 columns and grows rows (expand vertically).
+	lay2 := layoutWhichKey(mk(23), 1000)
+	if len(lay2.colW) != 4 || lay2.rows != 6 { // ceil(23/4)=6
+		t.Fatalf("23 entries: want 4 cols / 6 rows, got %d cols / %d rows", len(lay2.colW), lay2.rows)
+	}
+
+	// Each column is sized to its own widest entry (no global padding => no
+	// trailing right gap). 4 entries, 4 columns, 1 row each.
+	wide := []string{"short", "a-very-long-entry", "short", "short"}
+	lay3 := layoutWhichKey(wide, 1000)
+	if lay3.colW[1] != len("a-very-long-entry") || lay3.colW[0] != len("short") {
+		t.Fatalf("per-column widths wrong: %v", lay3.colW)
+	}
+
+	// Narrow terminal reduces the column count to fit.
+	lay4 := layoutWhichKey(mk(15), 5)
+	if len(lay4.colW) >= 4 {
+		t.Fatalf("narrow width must reduce columns, got %d", len(lay4.colW))
+	}
+}
+
 func TestGotoTargets_IncludesBuiltins(t *testing.T) {
 	ui.ActiveKeybindings = ui.DefaultKeybindings()
 	m := gotoTestModel()

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// gotoTestModel returns an explorer model at LevelResourceTypes with a
+// discovered resource set containing Pods and Deployments for the active context.
+func gotoTestModel() Model {
+	m := basePush80Model()
+	m.nav.Context = "ctx"
+	m.nav.Level = model.LevelResourceTypes
+	m.discoveredResources = map[string][]model.ResourceTypeEntry{
+		"ctx": {
+			{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true},
+			{Kind: "Deployment", APIGroup: "apps", APIVersion: "v1", Resource: "deployments", Namespaced: true},
+		},
+	}
+	return m
+}
+
+func TestGotoResourceType_SwitchesType(t *testing.T) {
+	m := gotoTestModel()
+	out, _ := m.gotoResourceType("Pod", "")
+	rm := out.(Model)
+	if rm.nav.ResourceType.Kind != "Pod" {
+		t.Fatalf("nav.ResourceType.Kind = %q, want Pod", rm.nav.ResourceType.Kind)
+	}
+	if rm.nav.Level != model.LevelResources {
+		t.Fatalf("nav.Level = %v, want LevelResources", rm.nav.Level)
+	}
+}
+
+func TestGotoResourceType_NoContextErrors(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelClusters
+	out, _ := m.gotoResourceType("Pod", "")
+	rm := out.(Model)
+	if !rm.statusMessageErr {
+		t.Fatal("expected an error status when no cluster is selected")
+	}
+}
+
+func TestGotoResourceType_TypeNotServedErrors(t *testing.T) {
+	m := gotoTestModel()
+	out, _ := m.gotoResourceType("Application", "argoproj.io")
+	rm := out.(Model)
+	if !rm.statusMessageErr {
+		t.Fatal("expected an error status when the type is not discovered")
+	}
+}
+
+func TestHandleGotoChord_NavigatesOnMatch(t *testing.T) {
+	m := gotoTestModel()
+	m.pendingG = true
+	out, _, handled := m.handleGotoChord(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if !handled {
+		t.Fatal("gp should be handled as a goto chord")
+	}
+	rm := out.(Model)
+	if rm.nav.ResourceType.Kind != "Pod" {
+		t.Fatalf("gp did not navigate to Pods, got %q", rm.nav.ResourceType.Kind)
+	}
+	if rm.pendingG {
+		t.Fatal("pendingG should be cleared after a goto chord")
+	}
+}
+
+func TestHandleGotoChord_GPassesThroughToJumpTop(t *testing.T) {
+	m := gotoTestModel()
+	m.pendingG = true
+	_, _, handled := m.handleGotoChord(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	if handled {
+		t.Fatal("second g must NOT be consumed by goto; it belongs to jump-top")
+	}
+}
+
+func TestGotoTargets_IncludesBuiltins(t *testing.T) {
+	ui.ActiveKeybindings = ui.DefaultKeybindings()
+	m := gotoTestModel()
+	byChord := map[string]string{}
+	for _, gt := range m.gotoTargets() {
+		byChord[gt.Chord] = gt.Kind
+	}
+	if byChord["gp"] != "Pod" || byChord["gd"] != "Deployment" {
+		t.Fatalf("built-in goto targets missing: %+v", byChord)
+	}
+}
+
+// TestGotoResourceType_LeftPaneIsResourceTypes verifies that after a goto fired
+// from LevelResources, the left pane holds the resource-types sidebar so the
+// user can press h/left to return to the types list correctly.
+func TestGotoResourceType_LeftPaneIsResourceTypes(t *testing.T) {
+	m := gotoTestModel()
+	// Start at LevelResources (already at types level for gotoTestModel, but
+	// simulate being at resources level with leftItems = resource-types sidebar).
+	m.nav.Level = model.LevelResourceTypes
+	// Descend: push left so leftItems becomes the resource-types sidebar.
+	typesItems := model.BuildSidebarItems(m.discoveredResources["ctx"])
+	m.setMiddleItems(typesItems)
+	m.pushLeft()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1"}
+
+	// Now fire goto Deployment from LevelResources.
+	out, _ := m.gotoResourceType("Deployment", "apps")
+	rm := out.(Model)
+
+	if rm.nav.ResourceType.Kind != "Deployment" {
+		t.Fatalf("nav.ResourceType.Kind = %q, want Deployment", rm.nav.ResourceType.Kind)
+	}
+	// leftItems should be resource-types sidebar (contains Pod and Deployment items).
+	kinds := map[string]bool{}
+	for _, item := range rm.leftItems {
+		if item.Kind != "__collapsed_group__" {
+			kinds[item.Kind] = true
+		}
+	}
+	if !kinds["Pod"] && !kinds["Deployment"] {
+		t.Fatalf("left pane does not hold resource-type items after goto; kinds=%v", kinds)
+	}
+}

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -598,6 +598,12 @@ var ConfigMouse = true
 // mutating action is blocked unless overridden per-context.
 var ConfigReadOnly bool
 
+// ConfigWhichKeyEnabled toggles the which-key popup (chords work regardless).
+var ConfigWhichKeyEnabled = true
+
+// ConfigWhichKeyDelayMs delays the popup after a prefix is pressed (0..2000).
+var ConfigWhichKeyDelayMs = 0
+
 // ConfigShowRareTypes is the startup default for the "show rarely-used resource
 // types" toggle (the ToggleRare / H key). When true the sidebar surfaces the
 // rare and "Advanced" resource types from launch. The runtime H toggle

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -444,6 +444,7 @@ func applyConfigMaps(cfg configFile, abbr map[string]string) {
 			ConfigFilterPresets[strings.ToLower(k)] = v
 		}
 	}
+	applyGotoTargets(cfg)
 	if len(cfg.Clusters) > 0 {
 		ConfigClusterResourceColumns = make(map[string]map[string][]string, len(cfg.Clusters))
 		ConfigClusterReadOnly = make(map[string]bool, len(cfg.Clusters))

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -195,6 +195,7 @@ func applyConfigOptions(cfg configFile) {
 	if cfg.Scheduler != nil {
 		applySchedulerConfig(cfg.Scheduler)
 	}
+	applyWhichKey(cfg)
 	if os.Getenv("NO_COLOR") != "" {
 		// Per https://no-color.org, the presence of NO_COLOR (regardless of
 		// value) disables color. Env takes precedence over the config file

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -444,7 +444,6 @@ func applyConfigMaps(cfg configFile, abbr map[string]string) {
 			ConfigFilterPresets[strings.ToLower(k)] = v
 		}
 	}
-	applyGotoTargets(cfg)
 	if len(cfg.Clusters) > 0 {
 		ConfigClusterResourceColumns = make(map[string]map[string][]string, len(cfg.Clusters))
 		ConfigClusterReadOnly = make(map[string]bool, len(cfg.Clusters))

--- a/internal/ui/config_goto_targets.go
+++ b/internal/ui/config_goto_targets.go
@@ -9,8 +9,9 @@ type GotoTargetEntry struct {
 	Name  string `json:"name" yaml:"name"`
 }
 
-// ConfigGotoTargets is populated by applyGotoTargets (called from applyConfigMaps)
-// from the goto_targets config section. Keys are full chords (e.g. "gx").
+// ConfigGotoTargets is populated by applyGotoTargets (called from LoadConfig
+// after the keybindings merge) from the goto_targets config section. Keys are
+// full chords (e.g. "gx").
 // Invalid entries (wrong chord format or missing kind) are silently skipped.
 var ConfigGotoTargets map[string]GotoTargetEntry
 

--- a/internal/ui/config_goto_targets.go
+++ b/internal/ui/config_goto_targets.go
@@ -1,13 +1,33 @@
 package ui
 
+import "strings"
+
 // GotoTargetEntry is one user-defined goto target from the config file.
-// Task 3 populates ConfigGotoTargets; until then the map is always empty.
 type GotoTargetEntry struct {
 	Kind  string `json:"kind" yaml:"kind"`
 	Group string `json:"group" yaml:"group"`
 	Name  string `json:"name" yaml:"name"`
 }
 
-// ConfigGotoTargets is populated by applyConfigOptions (Task 3) from the
-// goto_targets config section. Keys are full chords (e.g. "gx").
+// ConfigGotoTargets is populated by applyGotoTargets (called from applyConfigMaps)
+// from the goto_targets config section. Keys are full chords (e.g. "gx").
+// Invalid entries (wrong chord format or missing kind) are silently skipped.
 var ConfigGotoTargets map[string]GotoTargetEntry
+
+// applyGotoTargets validates and loads goto_targets from cfg into ConfigGotoTargets.
+// A chord must be exactly 2 runes, start with the jump_top keybinding, and have
+// a non-empty kind; invalid entries are silently skipped.
+func applyGotoTargets(cfg configFile) {
+	if len(cfg.GotoTargets) == 0 {
+		return
+	}
+	valid := make(map[string]GotoTargetEntry, len(cfg.GotoTargets))
+	prefix := ActiveKeybindings.JumpTop
+	for chord, t := range cfg.GotoTargets {
+		if len([]rune(chord)) != 2 || !strings.HasPrefix(chord, prefix) || t.Kind == "" {
+			continue
+		}
+		valid[chord] = t
+	}
+	ConfigGotoTargets = valid
+}

--- a/internal/ui/config_goto_targets.go
+++ b/internal/ui/config_goto_targets.go
@@ -22,6 +22,9 @@ var ConfigGotoTargets map[string]GotoTargetEntry
 // kind; invalid entries are silently skipped.
 func applyGotoTargets(cfg configFile, jumpTopPrefix string) {
 	if len(cfg.GotoTargets) == 0 {
+		// Reset so a previous non-empty value does not survive a reload that
+		// removed goto_targets.
+		ConfigGotoTargets = nil
 		return
 	}
 	valid := make(map[string]GotoTargetEntry, len(cfg.GotoTargets))

--- a/internal/ui/config_goto_targets.go
+++ b/internal/ui/config_goto_targets.go
@@ -15,16 +15,17 @@ type GotoTargetEntry struct {
 var ConfigGotoTargets map[string]GotoTargetEntry
 
 // applyGotoTargets validates and loads goto_targets from cfg into ConfigGotoTargets.
-// A chord must be exactly 2 runes, start with the jump_top keybinding, and have
-// a non-empty kind; invalid entries are silently skipped.
-func applyGotoTargets(cfg configFile) {
+// jumpTopPrefix is the already-merged jump_top keybinding (pass kb.JumpTop from
+// LoadConfig so custom jump_top values are validated against the correct prefix).
+// A chord must be exactly 2 runes, start with jumpTopPrefix, and have a non-empty
+// kind; invalid entries are silently skipped.
+func applyGotoTargets(cfg configFile, jumpTopPrefix string) {
 	if len(cfg.GotoTargets) == 0 {
 		return
 	}
 	valid := make(map[string]GotoTargetEntry, len(cfg.GotoTargets))
-	prefix := ActiveKeybindings.JumpTop
 	for chord, t := range cfg.GotoTargets {
-		if len([]rune(chord)) != 2 || !strings.HasPrefix(chord, prefix) || t.Kind == "" {
+		if len([]rune(chord)) != 2 || !strings.HasPrefix(chord, jumpTopPrefix) || t.Kind == "" {
 			continue
 		}
 		valid[chord] = t

--- a/internal/ui/config_goto_targets.go
+++ b/internal/ui/config_goto_targets.go
@@ -1,0 +1,13 @@
+package ui
+
+// GotoTargetEntry is one user-defined goto target from the config file.
+// Task 3 populates ConfigGotoTargets; until then the map is always empty.
+type GotoTargetEntry struct {
+	Kind  string `json:"kind" yaml:"kind"`
+	Group string `json:"group" yaml:"group"`
+	Name  string `json:"name" yaml:"name"`
+}
+
+// ConfigGotoTargets is populated by applyConfigOptions (Task 3) from the
+// goto_targets config section. Keys are full chords (e.g. "gx").
+var ConfigGotoTargets map[string]GotoTargetEntry

--- a/internal/ui/config_goto_targets_test.go
+++ b/internal/ui/config_goto_targets_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_GotoTargets(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yaml := `goto_targets:
+  gA:
+    kind: ApplicationSet
+    group: argoproj.io
+    name: AppSets
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ConfigGotoTargets = nil
+	LoadConfig(path)
+	got, ok := ConfigGotoTargets["gA"]
+	if !ok {
+		t.Fatalf("goto_targets not wired; got %+v", ConfigGotoTargets)
+	}
+	if got.Kind != "ApplicationSet" || got.Group != "argoproj.io" || got.Name != "AppSets" {
+		t.Fatalf("goto_targets value wrong: %+v", got)
+	}
+}

--- a/internal/ui/config_goto_targets_test.go
+++ b/internal/ui/config_goto_targets_test.go
@@ -28,3 +28,121 @@ func TestLoadConfig_GotoTargets(t *testing.T) {
 		t.Fatalf("goto_targets value wrong: %+v", got)
 	}
 }
+
+// TestLoadConfig_GotoTargets_InvalidSkipped verifies that invalid goto_targets
+// entries are silently skipped while valid siblings are kept.
+func TestLoadConfig_GotoTargets_InvalidSkipped(t *testing.T) {
+	cases := []struct {
+		name        string
+		yamlBody    string
+		validChord  string // the one valid entry that must survive
+		validKind   string
+		rejectChord string // an invalid chord that must NOT appear
+	}{
+		{
+			name: "chord_too_short",
+			yamlBody: `goto_targets:
+  g:
+    kind: Pod
+  gA:
+    kind: ApplicationSet
+`,
+			validChord:  "gA",
+			validKind:   "ApplicationSet",
+			rejectChord: "g",
+		},
+		{
+			name: "chord_too_long",
+			yamlBody: `goto_targets:
+  gAA:
+    kind: Pod
+  gA:
+    kind: ApplicationSet
+`,
+			validChord:  "gA",
+			validKind:   "ApplicationSet",
+			rejectChord: "gAA",
+		},
+		{
+			name: "wrong_prefix",
+			yamlBody: `goto_targets:
+  xA:
+    kind: Pod
+  gA:
+    kind: ApplicationSet
+`,
+			validChord:  "gA",
+			validKind:   "ApplicationSet",
+			rejectChord: "xA",
+		},
+		{
+			name: "empty_kind",
+			yamlBody: `goto_targets:
+  gB:
+    kind: ""
+  gA:
+    kind: ApplicationSet
+`,
+			validChord:  "gA",
+			validKind:   "ApplicationSet",
+			rejectChord: "gB",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.yamlBody), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ConfigGotoTargets = nil
+			LoadConfig(path)
+
+			if _, bad := ConfigGotoTargets[tc.rejectChord]; bad {
+				t.Errorf("invalid chord %q should have been skipped, but was accepted", tc.rejectChord)
+			}
+			got, ok := ConfigGotoTargets[tc.validChord]
+			if !ok {
+				t.Fatalf("valid chord %q missing from ConfigGotoTargets; got %+v", tc.validChord, ConfigGotoTargets)
+			}
+			if got.Kind != tc.validKind {
+				t.Errorf("chord %q: want kind %q, got %q", tc.validChord, tc.validKind, got.Kind)
+			}
+		})
+	}
+}
+
+// TestLoadConfig_GotoTargets_CustomJumpTop is the regression test for the
+// keybinding-merge ordering bug: a custom jump_top prefix must be used when
+// validating goto_targets chords in the same config.
+func TestLoadConfig_GotoTargets_CustomJumpTop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	// Custom jump_top = "f"; chord "fA" should be valid; "gA" (old default) should not.
+	yaml := `keybindings:
+  jump_top: "f"
+goto_targets:
+  fA:
+    kind: ApplicationSet
+    group: argoproj.io
+  gA:
+    kind: Pod
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ConfigGotoTargets = nil
+	LoadConfig(path)
+
+	got, ok := ConfigGotoTargets["fA"]
+	if !ok {
+		t.Fatalf("chord fA (matching custom jump_top=f) should be valid; got %+v", ConfigGotoTargets)
+	}
+	if got.Kind != "ApplicationSet" {
+		t.Errorf("chord fA: want kind ApplicationSet, got %q", got.Kind)
+	}
+	if _, bad := ConfigGotoTargets["gA"]; bad {
+		t.Error("chord gA should have been rejected because jump_top was changed to f")
+	}
+}

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -153,20 +153,23 @@ type Keybindings struct {
 	// Goto navigation: vim-style g-prefix chords that switch the active
 	// resource type in the current context. Each holds the full chord
 	// (e.g. "gp"). Reserved: "gg" jumps to list top, "G" to list bottom.
-	GotoPods             string `json:"goto_pods" yaml:"goto_pods"`
-	GotoDeployments      string `json:"goto_deployments" yaml:"goto_deployments"`
-	GotoServices         string `json:"goto_services" yaml:"goto_services"`
-	GotoNodes            string `json:"goto_nodes" yaml:"goto_nodes"`
-	GotoNamespaces       string `json:"goto_namespaces" yaml:"goto_namespaces"`
-	GotoIngresses        string `json:"goto_ingresses" yaml:"goto_ingresses"`
-	GotoJobs             string `json:"goto_jobs" yaml:"goto_jobs"`
-	GotoCronJobs         string `json:"goto_cronjobs" yaml:"goto_cronjobs"`
-	GotoReplicaSets      string `json:"goto_replicasets" yaml:"goto_replicasets"`
-	GotoDaemonSets       string `json:"goto_daemonsets" yaml:"goto_daemonsets"`
-	GotoStatefulSets     string `json:"goto_statefulsets" yaml:"goto_statefulsets"`
-	GotoConfigMaps       string `json:"goto_configmaps" yaml:"goto_configmaps"`
-	GotoSecrets          string `json:"goto_secrets" yaml:"goto_secrets"`
-	GotoArgoApplications string `json:"goto_argo_applications" yaml:"goto_argo_applications"`
+	GotoPods         string `json:"goto_pods" yaml:"goto_pods"`
+	GotoDeployments  string `json:"goto_deployments" yaml:"goto_deployments"`
+	GotoServices     string `json:"goto_services" yaml:"goto_services"`
+	GotoNodes        string `json:"goto_nodes" yaml:"goto_nodes"`
+	GotoNamespaces   string `json:"goto_namespaces" yaml:"goto_namespaces"`
+	GotoIngresses    string `json:"goto_ingresses" yaml:"goto_ingresses"`
+	GotoJobs         string `json:"goto_jobs" yaml:"goto_jobs"`
+	GotoCronJobs     string `json:"goto_cronjobs" yaml:"goto_cronjobs"`
+	GotoReplicaSets  string `json:"goto_replicasets" yaml:"goto_replicasets"`
+	GotoDaemonSets   string `json:"goto_daemonsets" yaml:"goto_daemonsets"`
+	GotoStatefulSets string `json:"goto_statefulsets" yaml:"goto_statefulsets"`
+	GotoConfigMaps   string `json:"goto_configmaps" yaml:"goto_configmaps"`
+	GotoSecrets      string `json:"goto_secrets" yaml:"goto_secrets"`
+	GotoHPAs         string `json:"goto_hpas" yaml:"goto_hpas"`
+	GotoPVCs         string `json:"goto_pvcs" yaml:"goto_pvcs"`
+	GotoPVs          string `json:"goto_pvs" yaml:"goto_pvs"`
+	GotoPDBs         string `json:"goto_pdbs" yaml:"goto_pdbs"`
 }
 
 // DefaultKeybindings returns the default keybinding configuration.
@@ -264,7 +267,8 @@ func DefaultKeybindings() Keybindings {
 		GotoNodes: "gn", GotoNamespaces: "gN", GotoIngresses: "gi",
 		GotoJobs: "gj", GotoCronJobs: "gc", GotoReplicaSets: "gr",
 		GotoDaemonSets: "gD", GotoStatefulSets: "gt", GotoConfigMaps: "gC",
-		GotoSecrets: "gS", GotoArgoApplications: "ga",
+		GotoSecrets: "gS", GotoHPAs: "gh", GotoPVCs: "gv", GotoPVs: "gV",
+		GotoPDBs: "gb",
 	}
 }
 

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -149,6 +149,24 @@ type Keybindings struct {
 	// viewer over the lines already buffered. "T" is free in modeLogs
 	// (ThemeSelector's "T" only dispatches in explorer/error-log modes).
 	LogTop string `json:"log_top" yaml:"log_top"`
+
+	// Goto navigation: vim-style g-prefix chords that switch the active
+	// resource type in the current context. Each holds the full chord
+	// (e.g. "gp"). Reserved: "gg" jumps to list top, "G" to list bottom.
+	GotoPods             string `json:"goto_pods" yaml:"goto_pods"`
+	GotoDeployments      string `json:"goto_deployments" yaml:"goto_deployments"`
+	GotoServices         string `json:"goto_services" yaml:"goto_services"`
+	GotoNodes            string `json:"goto_nodes" yaml:"goto_nodes"`
+	GotoNamespaces       string `json:"goto_namespaces" yaml:"goto_namespaces"`
+	GotoIngresses        string `json:"goto_ingresses" yaml:"goto_ingresses"`
+	GotoJobs             string `json:"goto_jobs" yaml:"goto_jobs"`
+	GotoCronJobs         string `json:"goto_cronjobs" yaml:"goto_cronjobs"`
+	GotoReplicaSets      string `json:"goto_replicasets" yaml:"goto_replicasets"`
+	GotoDaemonSets       string `json:"goto_daemonsets" yaml:"goto_daemonsets"`
+	GotoStatefulSets     string `json:"goto_statefulsets" yaml:"goto_statefulsets"`
+	GotoConfigMaps       string `json:"goto_configmaps" yaml:"goto_configmaps"`
+	GotoSecrets          string `json:"goto_secrets" yaml:"goto_secrets"`
+	GotoArgoApplications string `json:"goto_argo_applications" yaml:"goto_argo_applications"`
 }
 
 // DefaultKeybindings returns the default keybinding configuration.
@@ -240,6 +258,13 @@ func DefaultKeybindings() Keybindings {
 
 		// Log Top from log viewer. "T" is free in modeLogs.
 		LogTop: "T",
+
+		// Goto navigation chords (g prefix).
+		GotoPods: "gp", GotoDeployments: "gd", GotoServices: "gs",
+		GotoNodes: "gn", GotoNamespaces: "gN", GotoIngresses: "gi",
+		GotoJobs: "gj", GotoCronJobs: "gc", GotoReplicaSets: "gr",
+		GotoDaemonSets: "gD", GotoStatefulSets: "gt", GotoConfigMaps: "gC",
+		GotoSecrets: "gS", GotoArgoApplications: "ga",
 	}
 }
 

--- a/internal/ui/config_keybindings_goto_test.go
+++ b/internal/ui/config_keybindings_goto_test.go
@@ -9,7 +9,8 @@ func TestDefaultKeybindings_GotoChords(t *testing.T) {
 		"GotoNodes": "gn", "GotoNamespaces": "gN", "GotoIngresses": "gi",
 		"GotoJobs": "gj", "GotoCronJobs": "gc", "GotoReplicaSets": "gr",
 		"GotoDaemonSets": "gD", "GotoStatefulSets": "gt", "GotoConfigMaps": "gC",
-		"GotoSecrets": "gS", "GotoArgoApplications": "ga",
+		"GotoSecrets": "gS", "GotoHPAs": "gh", "GotoPVCs": "gv", "GotoPVs": "gV",
+		"GotoPDBs": "gb",
 	}
 	got := map[string]string{
 		"GotoPods": kb.GotoPods, "GotoDeployments": kb.GotoDeployments,
@@ -18,7 +19,8 @@ func TestDefaultKeybindings_GotoChords(t *testing.T) {
 		"GotoJobs": kb.GotoJobs, "GotoCronJobs": kb.GotoCronJobs,
 		"GotoReplicaSets": kb.GotoReplicaSets, "GotoDaemonSets": kb.GotoDaemonSets,
 		"GotoStatefulSets": kb.GotoStatefulSets, "GotoConfigMaps": kb.GotoConfigMaps,
-		"GotoSecrets": kb.GotoSecrets, "GotoArgoApplications": kb.GotoArgoApplications,
+		"GotoSecrets": kb.GotoSecrets, "GotoHPAs": kb.GotoHPAs,
+		"GotoPVCs": kb.GotoPVCs, "GotoPVs": kb.GotoPVs, "GotoPDBs": kb.GotoPDBs,
 	}
 	for field, want := range cases {
 		if got[field] != want {

--- a/internal/ui/config_keybindings_goto_test.go
+++ b/internal/ui/config_keybindings_goto_test.go
@@ -1,0 +1,28 @@
+package ui
+
+import "testing"
+
+func TestDefaultKeybindings_GotoChords(t *testing.T) {
+	kb := DefaultKeybindings()
+	cases := map[string]string{
+		"GotoPods": "gp", "GotoDeployments": "gd", "GotoServices": "gs",
+		"GotoNodes": "gn", "GotoNamespaces": "gN", "GotoIngresses": "gi",
+		"GotoJobs": "gj", "GotoCronJobs": "gc", "GotoReplicaSets": "gr",
+		"GotoDaemonSets": "gD", "GotoStatefulSets": "gt", "GotoConfigMaps": "gC",
+		"GotoSecrets": "gS", "GotoArgoApplications": "ga",
+	}
+	got := map[string]string{
+		"GotoPods": kb.GotoPods, "GotoDeployments": kb.GotoDeployments,
+		"GotoServices": kb.GotoServices, "GotoNodes": kb.GotoNodes,
+		"GotoNamespaces": kb.GotoNamespaces, "GotoIngresses": kb.GotoIngresses,
+		"GotoJobs": kb.GotoJobs, "GotoCronJobs": kb.GotoCronJobs,
+		"GotoReplicaSets": kb.GotoReplicaSets, "GotoDaemonSets": kb.GotoDaemonSets,
+		"GotoStatefulSets": kb.GotoStatefulSets, "GotoConfigMaps": kb.GotoConfigMaps,
+		"GotoSecrets": kb.GotoSecrets, "GotoArgoApplications": kb.GotoArgoApplications,
+	}
+	for field, want := range cases {
+		if got[field] != want {
+			t.Errorf("%s = %q, want %q", field, got[field], want)
+		}
+	}
+}

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -234,6 +234,11 @@ type configFile struct {
 	// CLI --namespace overrides the per-set namespace; --union-context and
 	// --context are mutually exclusive with --union-set.
 	UnionSets UnionSetsConfig `json:"union_sets" yaml:"union_sets"`
+	// GotoTargets maps full g-prefix chords (e.g. "gA") to user-defined
+	// goto targets. Chords must start with the jump_top key and be exactly
+	// 2 runes. Kind is required; Group and Name are optional.
+	// User entries override built-ins on chord collision.
+	GotoTargets map[string]GotoTargetEntry `json:"goto_targets" yaml:"goto_targets"`
 }
 
 // UnionSetsConfig accepts both supported top-level shapes:

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -634,6 +634,7 @@ func LoadConfig(configOverride string) {
 	applyColorscheme(&theme, cfg)
 	mergeThemeOverrides(&theme, cfg.Theme)
 	MergeKeybindings(&kb, &cfg.Keybindings)
+	applyGotoTargets(cfg, kb.JumpTop)
 	applyConfigOptions(cfg)
 	applyConfigMaps(cfg, abbr)
 

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -239,6 +239,12 @@ type configFile struct {
 	// 2 runes. Kind is required; Group and Name are optional.
 	// User entries override built-ins on chord collision.
 	GotoTargets map[string]GotoTargetEntry `json:"goto_targets" yaml:"goto_targets"`
+	// WhichKeyEnabled controls whether the which-key popup appears while a
+	// chord prefix (g) is pending. Chords still work when false.
+	WhichKeyEnabled *bool `json:"which_key_enabled" yaml:"which_key_enabled"`
+	// WhichKeyDelayMs is the delay before the which-key popup appears after a
+	// prefix is pressed, in milliseconds. Clamped to [0, 2000].
+	WhichKeyDelayMs *int `json:"which_key_delay_ms" yaml:"which_key_delay_ms"`
 }
 
 // UnionSetsConfig accepts both supported top-level shapes:

--- a/internal/ui/config_whichkey.go
+++ b/internal/ui/config_whichkey.go
@@ -1,0 +1,11 @@
+package ui
+
+// applyWhichKey applies the which_key_enabled and which_key_delay_ms settings.
+func applyWhichKey(cfg configFile) {
+	if cfg.WhichKeyEnabled != nil {
+		ConfigWhichKeyEnabled = *cfg.WhichKeyEnabled
+	}
+	if cfg.WhichKeyDelayMs != nil {
+		ConfigWhichKeyDelayMs = max(0, min(*cfg.WhichKeyDelayMs, 2000))
+	}
+}

--- a/internal/ui/config_whichkey_test.go
+++ b/internal/ui/config_whichkey_test.go
@@ -1,0 +1,25 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_WhichKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yaml := "which_key_enabled: false\nwhich_key_delay_ms: 5000\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ConfigWhichKeyEnabled = true
+	ConfigWhichKeyDelayMs = 0
+	LoadConfig(path)
+	if ConfigWhichKeyEnabled {
+		t.Error("which_key_enabled=false not wired")
+	}
+	if ConfigWhichKeyDelayMs != 2000 {
+		t.Errorf("which_key_delay_ms = %d, want clamped to 2000", ConfigWhichKeyDelayMs)
+	}
+}

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -94,6 +94,9 @@ filter_presets:
       key: p
       match:
         status: Pending
+goto_targets:
+  gx:
+    kind: Deployment
 monitoring:
   _global:
     node_metrics: prometheus
@@ -277,6 +280,7 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	assert.Equal(t, "Ping", ConfigCustomActions["Pod"][0].Label)
 	require.Contains(t, ConfigFilterPresets, "pod", "filter_presets")
 	assert.Equal(t, "Pending", ConfigFilterPresets["pod"][0].Match.Status)
+	assert.Equal(t, "Deployment", ConfigGotoTargets["gx"].Kind, "goto_targets")
 
 	// Per-cluster overrides (clusters.<ctx>.*).
 	assert.True(t, ConfigClusterReadOnly["ctx1"], "clusters.read_only")
@@ -346,6 +350,7 @@ var wiringCoveredFields = map[string]string{
 	"scheduler":               "TestLoadConfig_AllSettingsWired",
 	"kubeconfig_dir":          "TestLoadConfig_AllSettingsWired",
 	"union_sets":              "TestLoadConfig_AllSettingsWired",
+	"goto_targets":            "TestLoadConfig_AllSettingsWired + TestLoadConfig_GotoTargets",
 }
 
 // TestConfigFile_EveryFieldHasWiringCoverage is a forcing function: it fails if
@@ -446,6 +451,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 	origClusterSecSources := ConfigClusterSecuritySources
 	origClusterQPS := ConfigClusterK8sClientQPS
 	origClusterBurst := ConfigClusterK8sClientBurst
+	origGotoTargets := ConfigGotoTargets
 
 	origMonitoring := model.ConfigMonitoring
 	origRSStrategy := model.ConfigDefaultRightsizingStrategy
@@ -529,6 +535,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 		ConfigClusterSecuritySources = origClusterSecSources
 		ConfigClusterK8sClientQPS = origClusterQPS
 		ConfigClusterK8sClientBurst = origClusterBurst
+		ConfigGotoTargets = origGotoTargets
 
 		model.ConfigMonitoring = origMonitoring
 		model.ConfigDefaultRightsizingStrategy = origRSStrategy

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -97,6 +97,8 @@ filter_presets:
 goto_targets:
   gx:
     kind: Deployment
+which_key_enabled: false
+which_key_delay_ms: 250
 monitoring:
   _global:
     node_metrics: prometheus
@@ -281,6 +283,8 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	require.Contains(t, ConfigFilterPresets, "pod", "filter_presets")
 	assert.Equal(t, "Pending", ConfigFilterPresets["pod"][0].Match.Status)
 	assert.Equal(t, "Deployment", ConfigGotoTargets["gx"].Kind, "goto_targets")
+	assert.False(t, ConfigWhichKeyEnabled, "which_key_enabled")
+	assert.Equal(t, 250, ConfigWhichKeyDelayMs, "which_key_delay_ms")
 
 	// Per-cluster overrides (clusters.<ctx>.*).
 	assert.True(t, ConfigClusterReadOnly["ctx1"], "clusters.read_only")
@@ -351,6 +355,8 @@ var wiringCoveredFields = map[string]string{
 	"kubeconfig_dir":          "TestLoadConfig_AllSettingsWired",
 	"union_sets":              "TestLoadConfig_AllSettingsWired",
 	"goto_targets":            "TestLoadConfig_AllSettingsWired + TestLoadConfig_GotoTargets",
+	"which_key_enabled":       "TestLoadConfig_AllSettingsWired + TestLoadConfig_WhichKey",
+	"which_key_delay_ms":      "TestLoadConfig_AllSettingsWired + TestLoadConfig_WhichKey",
 }
 
 // TestConfigFile_EveryFieldHasWiringCoverage is a forcing function: it fails if
@@ -452,6 +458,8 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 	origClusterQPS := ConfigClusterK8sClientQPS
 	origClusterBurst := ConfigClusterK8sClientBurst
 	origGotoTargets := ConfigGotoTargets
+	origWhichKeyEnabled := ConfigWhichKeyEnabled
+	origWhichKeyDelayMs := ConfigWhichKeyDelayMs
 
 	origMonitoring := model.ConfigMonitoring
 	origRSStrategy := model.ConfigDefaultRightsizingStrategy
@@ -536,6 +544,8 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 		ConfigClusterK8sClientQPS = origClusterQPS
 		ConfigClusterK8sClientBurst = origClusterBurst
 		ConfigGotoTargets = origGotoTargets
+		ConfigWhichKeyEnabled = origWhichKeyEnabled
+		ConfigWhichKeyDelayMs = origWhichKeyDelayMs
 
 		model.ConfigMonitoring = origMonitoring
 		model.ConfigDefaultRightsizingStrategy = origRSStrategy

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -6,6 +6,12 @@ package ui
 // pushing help.go past the repo's 800-line file cap.
 func helpSections() []helpSection {
 	kb := ActiveKeybindings
+	gotoChordList := kb.GotoPods + "/" + kb.GotoDeployments + "/" + kb.GotoServices + "/" +
+		kb.GotoNodes + "/" + kb.GotoNamespaces + "/" + kb.GotoIngresses + "/" +
+		kb.GotoJobs + "/" + kb.GotoCronJobs + "/" + kb.GotoReplicaSets + "/" +
+		kb.GotoDaemonSets + "/" + kb.GotoStatefulSets + "/" + kb.GotoConfigMaps + "/" +
+		kb.GotoSecrets + "/" + kb.GotoHPAs + "/" + kb.GotoPVCs + "/" +
+		kb.GotoPVs + "/" + kb.GotoPDBs
 	return []helpSection{
 		{
 			title: "Navigation",
@@ -16,7 +22,7 @@ func helpSections() []helpSection {
 				{kb.Up + " / Up", "Move up"},
 				{kb.JumpTop + kb.JumpTop + " / Home", "Jump to top"},
 				{kb.JumpBottom + " / End", "Jump to bottom"},
-				{kb.JumpTop + "+chord (gp/gd/gs/gn/gN/gi/gj/gc/gr/gD/gt/gC/gS/gh/gv/gV/gb)", "Goto resource type (press " + kb.JumpTop + " for which-key popup; add custom chords/CRDs via goto_targets)"},
+				{kb.JumpTop + "+chord (" + gotoChordList + ")", "Goto resource type (press " + kb.JumpTop + " for which-key popup; add custom chords/CRDs via goto_targets)"},
 				{helpKeyDisplay(kb.PageDown) + " / " + helpKeyDisplay(kb.PageUp) + " / Shift+↓ / Shift+↑", "Half-page scroll down / up"},
 				{helpKeyDisplay(kb.PageForward) + " / " + helpKeyDisplay(kb.PageBack) + " / PgDn / PgUp", "Full-page scroll down / up"},
 				{kb.Enter, "Open YAML view / navigate into"},

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -16,7 +16,7 @@ func helpSections() []helpSection {
 				{kb.Up + " / Up", "Move up"},
 				{kb.JumpTop + kb.JumpTop + " / Home", "Jump to top"},
 				{kb.JumpBottom + " / End", "Jump to bottom"},
-				{kb.JumpTop + "+chord (gp/gd/gs/gn/gN/gi/gj/gc/gr/gD/gt/gC/gS/ga)", "Goto resource type (press " + kb.JumpTop + " for which-key popup; add custom chords via goto_targets)"},
+				{kb.JumpTop + "+chord (gp/gd/gs/gn/gN/gi/gj/gc/gr/gD/gt/gC/gS/gh/gv/gV/gb)", "Goto resource type (press " + kb.JumpTop + " for which-key popup; add custom chords/CRDs via goto_targets)"},
 				{helpKeyDisplay(kb.PageDown) + " / " + helpKeyDisplay(kb.PageUp) + " / Shift+↓ / Shift+↑", "Half-page scroll down / up"},
 				{helpKeyDisplay(kb.PageForward) + " / " + helpKeyDisplay(kb.PageBack) + " / PgDn / PgUp", "Full-page scroll down / up"},
 				{kb.Enter, "Open YAML view / navigate into"},

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -16,6 +16,7 @@ func helpSections() []helpSection {
 				{kb.Up + " / Up", "Move up"},
 				{kb.JumpTop + kb.JumpTop + " / Home", "Jump to top"},
 				{kb.JumpBottom + " / End", "Jump to bottom"},
+				{kb.JumpTop + "+chord (gp/gd/gs/gn/gN/gi/gj/gc/gr/gD/gt/gC/gS/ga)", "Goto resource type (press " + kb.JumpTop + " for which-key popup; add custom chords via goto_targets)"},
 				{helpKeyDisplay(kb.PageDown) + " / " + helpKeyDisplay(kb.PageUp) + " / Shift+↓ / Shift+↑", "Half-page scroll down / up"},
 				{helpKeyDisplay(kb.PageForward) + " / " + helpKeyDisplay(kb.PageBack) + " / PgDn / PgUp", "Full-page scroll down / up"},
 				{kb.Enter, "Open YAML view / navigate into"},

--- a/internal/ui/overlay_bottom_test.go
+++ b/internal/ui/overlay_bottom_test.go
@@ -8,7 +8,7 @@ import (
 func TestPlaceOverlayBottom(t *testing.T) {
 	bg := strings.Repeat("background\n", 10)
 	overlay := "AAAA\nBBBB"
-	out := PlaceOverlayBottom(20, 10, overlay, bg)
+	out := PlaceOverlayBottom(20, 10, 0, overlay, bg)
 	lines := strings.Split(out, "\n")
 	if len(lines) != 10 {
 		t.Fatalf("expected 10 lines, got %d", len(lines))
@@ -19,5 +19,20 @@ func TestPlaceOverlayBottom(t *testing.T) {
 	}
 	if !strings.Contains(lines[0], "background") {
 		t.Fatalf("top rows must remain background:\n%s", out)
+	}
+}
+
+func TestPlaceOverlayBottom_Margin(t *testing.T) {
+	bg := strings.Repeat("background\n", 10)
+	overlay := "AAAA\nBBBB"
+	out := PlaceOverlayBottom(20, 10, 2, overlay, bg)
+	lines := strings.Split(out, "\n")
+	// With a 2-row bottom margin the overlay sits on rows 6 and 7, and the
+	// last two rows stay as background.
+	if !strings.Contains(lines[6], "AAAA") || !strings.Contains(lines[7], "BBBB") {
+		t.Fatalf("overlay not lifted by margin:\n%s", out)
+	}
+	if !strings.Contains(lines[9], "background") {
+		t.Fatalf("bottom margin rows must remain background:\n%s", out)
 	}
 }

--- a/internal/ui/overlay_bottom_test.go
+++ b/internal/ui/overlay_bottom_test.go
@@ -1,0 +1,23 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlaceOverlayBottom(t *testing.T) {
+	bg := strings.Repeat("background\n", 10)
+	overlay := "AAAA\nBBBB"
+	out := PlaceOverlayBottom(20, 10, overlay, bg)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 10 {
+		t.Fatalf("expected 10 lines, got %d", len(lines))
+	}
+	// Overlay occupies the last two rows; earlier rows stay as background.
+	if !strings.Contains(lines[8], "AAAA") || !strings.Contains(lines[9], "BBBB") {
+		t.Fatalf("overlay not anchored to bottom:\n%s", out)
+	}
+	if !strings.Contains(lines[0], "background") {
+		t.Fatalf("top rows must remain background:\n%s", out)
+	}
+}

--- a/internal/ui/overlay_diff.go
+++ b/internal/ui/overlay_diff.go
@@ -575,11 +575,11 @@ func padToWidth(s string, targetWidth int) string {
 	return s + strings.Repeat(" ", targetWidth-w)
 }
 
-// PlaceOverlayBottom anchors an overlay to the bottom edge of the background,
-// horizontally centered. Used for the which-key panel, which rises from the
-// bottom of the screen like neovim's which-key "modern" preset rather than
-// floating in the center.
-func PlaceOverlayBottom(width, height int, overlay, background string) string {
+// PlaceOverlayBottom anchors an overlay near the bottom edge of the background,
+// horizontally centered, leaving marginBottom rows below it. Used for the
+// which-key panel, which rises from the bottom of the screen like neovim's
+// which-key "modern" preset rather than floating in the center.
+func PlaceOverlayBottom(width, height, marginBottom int, overlay, background string) string {
 	bgLines := strings.Split(background, "\n")
 	for len(bgLines) < height {
 		bgLines = append(bgLines, "")
@@ -594,7 +594,7 @@ func PlaceOverlayBottom(width, height int, overlay, background string) string {
 		ovWidth = lipgloss.Width(ovLines[0])
 	}
 
-	startRow := max(height-len(ovLines), 0)
+	startRow := max(height-marginBottom-len(ovLines), 0)
 	startCol := max((width-ovWidth)/2, 0)
 
 	result := make([]string, len(bgLines))

--- a/internal/ui/overlay_diff.go
+++ b/internal/ui/overlay_diff.go
@@ -575,6 +575,49 @@ func padToWidth(s string, targetWidth int) string {
 	return s + strings.Repeat(" ", targetWidth-w)
 }
 
+// PlaceOverlayBottom anchors an overlay to the bottom edge of the background,
+// horizontally centered. Used for the which-key panel, which rises from the
+// bottom of the screen like neovim's which-key "modern" preset rather than
+// floating in the center.
+func PlaceOverlayBottom(width, height int, overlay, background string) string {
+	bgLines := strings.Split(background, "\n")
+	for len(bgLines) < height {
+		bgLines = append(bgLines, "")
+	}
+	if len(bgLines) > height {
+		bgLines = bgLines[:height]
+	}
+
+	ovLines := strings.Split(overlay, "\n")
+	ovWidth := 0
+	if len(ovLines) > 0 {
+		ovWidth = lipgloss.Width(ovLines[0])
+	}
+
+	startRow := max(height-len(ovLines), 0)
+	startCol := max((width-ovWidth)/2, 0)
+
+	result := make([]string, len(bgLines))
+	copy(result, bgLines)
+	for i, line := range result {
+		if lineW := lipgloss.Width(line); lineW < width {
+			result[i] = line + strings.Repeat(" ", width-lineW)
+		}
+	}
+
+	for i, ovLine := range ovLines {
+		row := startRow + i
+		if row < 0 || row >= len(result) {
+			continue
+		}
+		ovVisualWidth := lipgloss.Width(ovLine)
+		leftBg := ansi.Truncate(result[row], startCol, "")
+		rightBg := ansi.TruncateLeft(result[row], startCol+ovVisualWidth, "")
+		result[row] = leftBg + ovLine + rightBg
+	}
+	return strings.Join(result, "\n")
+}
+
 // PlaceOverlay centers an overlay on top of a background by building a full-screen
 // layer with the overlay content padded to the correct position.
 func PlaceOverlay(width, height int, overlay, background string) string {


### PR DESCRIPTION
## Summary

Adds vim-style **goto navigation** and a **which-key overlay** to the explorer.

- **`g`-prefix goto chords** switch the active resource type within the current context, preserving the namespace filter. Built on the existing `pendingG` state, so `gg` (list top) / `G` (list bottom) are preserved. A second `g` jumps to top; a registered chord navigates; any other key (e.g. `gP`, `esc`) closes the popup as a silent noop (which-key modality, no fall-through).
- **Which-key overlay** styled after neovim's `which-key` "modern" preset: a rounded-border panel near the bottom of the screen over a dimmed background, with content-tight columns that fill ~60% of the width, growing vertically as entries are added. Configurable via `which_key_enabled` (default true) and `which_key_delay_ms` (0–2000).
- **User-definable targets** via a `goto_targets` config map (chord → `{kind, group, name}`), including CRDs. Custom entries override built-ins on chord collision.

### Built-in goto chords

| Chord | Resource | Chord | Resource |
|---|---|---|---|
| `gp` | Pods | `gD` | DaemonSets |
| `gd` | Deployments | `gt` | StatefulSets |
| `gs` | Services | `gC` | ConfigMaps |
| `gn` | Nodes | `gS` | Secrets |
| `gN` | Namespaces | `gh` | HorizontalPodAutoscalers |
| `gi` | Ingresses | `gv` | PersistentVolumeClaims |
| `gj` | Jobs | `gV` | PersistentVolumes |
| `gc` | CronJobs | `gb` | PodDisruptionBudgets |
| `gr` | ReplicaSets | | |

CRDs (e.g. ArgoCD Applications) are added via `goto_targets` — documented as an example in `keybindings.md` / `config-example.yaml`.

### New config keys

| Key | Type | Default | Notes |
|---|---|---|---|
| `which_key_enabled` | bool | `true` | Show the popup while `g` is pending (chords still work when off). |
| `which_key_delay_ms` | int | `0` | Delay before the popup appears (0–2000ms). |
| `goto_targets` | map | `{}` | Custom `g`-prefix chords, including CRDs. |

All built-in chords are rebindable under `keybindings`.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (all packages)
- [x] `golangci-lint run` (0 issues)
- [x] Unit tests: chord dispatch (`gp` navigates, `gg` still jumps top, unmapped key consumed+closes, `esc` closes), goto navigation (type switch, no-context error, type-not-served error, left-pane normalization from any level), `goto_targets` config wiring + validation (chord shape, jump_top prefix, custom-prefix regression), `which_key_*` config wiring + clamp, which-key grid layout (4 columns, vertical growth, per-column widths, narrow-width fallback), bottom-anchored overlay placement, hint-bar entry.
- [ ] Manual: press `g` to open the popup; `gp`/`gd`/… jump to the resource type; `gg` jumps to list top; `which_key_enabled: false` hides the popup while chords still navigate; add a CRD via `goto_targets`.

## Docs

`docs/keybindings.md`, `README.md`, in-app help, `docs/config-reference.md`, `docs/config-example.yaml`, `docs/config.schema.json` updated together.
