### PR TITLE
feat: save and restore list filter in bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **Port forwarding** from the action menu (with local port setting and browser open); manage active forwards via the Networking group
 - **Network policy visualizer**: Visualize a NetworkPolicy's ingress/egress rules (`x` → `N` on a NetworkPolicy), or list every policy affecting a Pod or Service (`x` → "Network Policies" on the resource) — including which backing pods a policy covers. Supports CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy (entities, FQDNs, deny rules, L7 indicators) when the Cilium CRDs are installed. The dialog scrolls with the mouse wheel and is searchable (`/`, `n`/`N`)
 - **Clipboard support**: Copy resource name (`y`), open copy-as picker (`Y`: YAML / JSON / Table), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
-- **Bookmarks**: Save favorite resource paths for quick navigation
+- **Bookmarks**: Save favorite resource paths (including the active list filter) for quick navigation
 - **Orphan detection**: Press `Shift+Z` (or run bare `:orphans`) to open the cluster-wide orphan overview across 11 kinds — Pods, Secrets, ConfigMaps, Services, PVCs, HPAs, PDBs, NetworkPolicies, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings. Per-list filters are still available via the filter-preset overlay (`.`) on each kind, or jump straight to a filtered view with `:orphans <kind>` (e.g., `:orphans secrets`). A strict / lenient toggle (`s`) flips between "truly unused" and "currently idle but referenced by workload templates" (e.g. CronJob between firings). Auto-excludes Helm release Secrets, ServiceAccount tokens, owner-managed resources, and `kube-root-ca.crt`.
 - **Session persistence**: Remembers last context/namespace/resource across restarts
 
@@ -367,7 +367,7 @@ All search and filter inputs support three modes, auto-detected from the query s
 - Press `o` on a resource to jump to its owner (e.g. Pod -> Deployment), then `Backspace` to jump back
 - Typos are fine in search: `/~deplymnt` fuzzy-matches `deployments`
 - Multi-select with `Space` (range-select with `Ctrl+Space`), then bulk delete/scale/restart via `x`
-- Set a bookmark with `m<letter>`, jump back with `'<letter>` - lowercase slots are context-aware. Press tab to jump to the namespace
+- Set a bookmark with `m<letter>`, jump back with `'<letter>` - lowercase slots are context-aware. Press tab to jump to the namespace. An active list filter is saved with the bookmark and reapplied on jump (shown as `> /<filter>` in the slot name)
 - Press `.` for quick filter presets (e.g. only failing Pods); extend them per resource type in config
 - Decode Secret values in the preview with `Ctrl+S`, or edit them decoded with `e`
 - Copy the resource name with `y`; press `Y` to copy as YAML, JSON, or Table

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -220,7 +220,9 @@ When items are selected, press `x` to open the bulk action menu (delete, force d
 
 Vim-style named marks for quick navigation. A bookmark stores a resource
 path (context + namespace + resource type + optional resource name) under
-a single-character slot.
+a single-character slot. Any list filter active when the mark is set is
+saved with it and reapplied on jump; filtered slots show a `> /<filter>`
+suffix in their name.
 
 - **Context-aware** (`a-z` / `0-9`): remembers the kube context; jumping
   switches clusters.

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -159,6 +159,25 @@ func (m Model) resolveBookmarkTarget(bm model.Bookmark, loadSavedNamespace bool)
 	return target, "", true
 }
 
+// bookmarkNamespaceScope returns the namespace scope to persist on a bookmark:
+// a single primary namespace plus, for multi-select scopes, the full sorted
+// list. An empty primary with a nil list means "all namespaces".
+func (m Model) bookmarkNamespaceScope() (string, []string) {
+	switch {
+	case m.allNamespaces:
+		return "", nil
+	case len(m.selectedNamespaces) > 1:
+		nsList := make([]string, 0, len(m.selectedNamespaces))
+		for n := range m.selectedNamespaces {
+			nsList = append(nsList, n)
+		}
+		sort.Strings(nsList)
+		return nsList[0], nsList // primary namespace for backward compat display
+	default:
+		return m.namespace, nil
+	}
+}
+
 // bookmarkToSlot saves the current location as a named mark in the given slot.
 // Lowercase (a-z) and digit (0-9) slots create context-aware bookmarks that
 // remember the current kube context or named union set. Uppercase (A-Z)
@@ -247,27 +266,21 @@ func (m Model) bookmarkToSlot(slot string) (tea.Model, tea.Cmd) {
 	if m.nav.ResourceName != "" {
 		parts = append(parts, m.nav.ResourceName)
 	}
+	// Capture the live list filter so it's restored on jump. Only the
+	// resources level carries a meaningful list filter; record it in the
+	// display name so the slot is distinguishable from an unfiltered one.
+	bmFilter := m.filterText
+	bmFilterBroad := m.filterBroadMode
+	if bmFilter != "" {
+		parts = append(parts, "/"+bmFilter)
+	}
 	name := strings.Join(parts, " > ")
 
 	// Always capture the current namespace scope so it's available for
 	// an opt-in override at jump time (Tab in the bookmark overlay).
 	// Context-free slots still ignore it on a default jump — the slot
 	// case controls defaults, not persistence.
-	var ns string
-	var nsList []string
-	switch {
-	case m.allNamespaces:
-		ns = ""
-	case len(m.selectedNamespaces) > 1:
-		nsList = make([]string, 0, len(m.selectedNamespaces))
-		for n := range m.selectedNamespaces {
-			nsList = append(nsList, n)
-		}
-		sort.Strings(nsList)
-		ns = nsList[0] // primary namespace for backward compat display
-	default:
-		ns = m.namespace
-	}
+	ns, nsList := m.bookmarkNamespaceScope()
 
 	bmContext := ""
 	bmUnionSet := ""
@@ -288,6 +301,8 @@ func (m Model) bookmarkToSlot(slot string) (tea.Model, tea.Cmd) {
 		NsSelectionNegated: m.nsSelectionNegated,
 		ResourceType:       rt.ResourceRef(),
 		ResourceName:       m.nav.ResourceName,
+		Filter:             bmFilter,
+		FilterBroad:        bmFilterBroad,
 		Slot:               slot,
 	}
 
@@ -699,9 +714,15 @@ func (m Model) navigateToBookmark(bm model.Bookmark) (tea.Model, tea.Cmd) {
 	m.cancelAndReset()
 	m.requestGen++
 	m.loading = true
-	m.filterText = ""
+	// Restore the bookmark's saved list filter (empty for unfiltered slots).
+	// The filter applies once the resources finish loading; persist it in
+	// filterMemory too so navigating away and back keeps it.
+	m.filterText = bm.Filter
+	m.filterInput.Set(bm.Filter)
+	m.filterBroadMode = bm.FilterBroad
 	m.filterActive = false
 	m.searchActive = false
+	m.saveLevelFilter()
 
 	m.setStatusMessage("Jumped to: "+bm.Name, false)
 	cmds := []tea.Cmd{m.loadResources(false), scheduleStatusClear()}

--- a/internal/app/update_bookmarks_test.go
+++ b/internal/app/update_bookmarks_test.go
@@ -203,6 +203,54 @@ func TestBookmarkToSlot_ContextAwareFlag(t *testing.T) {
 	}
 }
 
+// TestBookmarkToSlot_CapturesFilter verifies that the live list filter is
+// persisted on the bookmark (text + broad mode) and surfaced in the display
+// name so a filtered slot is distinguishable from an unfiltered one.
+func TestBookmarkToSlot_CapturesFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
+	rt := podResourceType()
+
+	t.Run("filter captured with broad mode", func(t *testing.T) {
+		m := Model{
+			nav: model.NavigationState{
+				Level:        model.LevelResources,
+				Context:      "test",
+				ResourceType: rt,
+			},
+			namespace:       "default",
+			filterText:      "nginx",
+			filterBroadMode: true,
+			tabs:            []TabState{{}},
+		}
+
+		result, _ := m.bookmarkToSlot("a")
+		bm := result.(Model).bookmarks[0]
+		assert.Equal(t, "nginx", bm.Filter)
+		assert.True(t, bm.FilterBroad)
+		assert.Equal(t, "test > Pods > /nginx", bm.Name)
+	})
+
+	t.Run("no filter leaves fields empty and name clean", func(t *testing.T) {
+		m := Model{
+			nav: model.NavigationState{
+				Level:        model.LevelResources,
+				Context:      "test",
+				ResourceType: rt,
+			},
+			namespace: "default",
+			tabs:      []TabState{{}},
+		}
+
+		result, _ := m.bookmarkToSlot("a")
+		bm := result.(Model).bookmarks[0]
+		assert.Empty(t, bm.Filter)
+		assert.False(t, bm.FilterBroad)
+		assert.Equal(t, "test > Pods", bm.Name)
+	})
+}
+
 // --- bookmarkToSlot display name resolution ---
 
 // TestBookmarkToSlot_CRDNameIncludesResourceType covers the user-reported

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -389,7 +389,9 @@ type Bookmark struct {
 	NsSelectionNegated bool     `json:"ns_selection_negated,omitempty" yaml:"ns_selection_negated,omitempty"`
 	ResourceType       string   `json:"resource_type" yaml:"resource_type"` // resource ref string (group/version/resource)
 	ResourceName       string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
-	Slot               string   `json:"slot,omitempty" yaml:"slot,omitempty"` // single char key for vim-style named marks (a-z, A-Z, 0-9)
+	Filter             string   `json:"filter,omitempty" yaml:"filter,omitempty"`             // list filter text restored on jump
+	FilterBroad        bool     `json:"filter_broad,omitempty" yaml:"filter_broad,omitempty"` // whether the filter also matched column values (Tab broad mode)
+	Slot               string   `json:"slot,omitempty" yaml:"slot,omitempty"`                 // single char key for vim-style named marks (a-z, A-Z, 0-9)
 }
 
 // IsContextAware reports whether this bookmark is anchored to a specific

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -156,8 +156,8 @@ func helpSections() []helpSection {
 		{
 			title: "Bookmarks",
 			bindings: []helpEntry{
-				{kb.SetMark + "<a-z/0-9>", "Set context-aware mark (switches cluster on jump)"},
-				{kb.SetMark + "<A-Z>", "Set context-free mark (stays in current cluster on jump)"},
+				{kb.SetMark + "<a-z/0-9>", "Set context-aware mark (switches cluster on jump, saves active filter)"},
+				{kb.SetMark + "<A-Z>", "Set context-free mark (stays in current cluster on jump, saves active filter)"},
 				{kb.OpenMarks, "Open bookmarks list"},
 				{"a-z/A-Z/0-9", "Jump to named mark (in overlay)"},
 				{"j/k", "Navigate bookmarks (in overlay)"},


### PR DESCRIPTION
## Summary

A bookmark now captures the active list filter (text + broad mode) when set, and reapplies it on jump. Filtered slots show a "> /<filter>" suffix in their name to distinguish them from unfiltered ones.

Extracted bookmarkNamespaceScope() to keep bookmarkToSlot under the gocyclo limit.

## Type of change

- [x] feat: new user-facing feature
- [ ] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

<!-- e.g. Closes #123 -->

## Changes

<!-- Bullet list of the key changes. -->

- model/types.go: Add Filter and FilterBroad fields to Bookmark (both omitempty, backward-compatible).
- app/update_bookmarks.go: Capture the active filter when setting a mark, restore it on jump, and show a > /<filter> suffix in the slot name. Extracted bookmarkNamespaceScope() to stay under gocyclo limit.
- app/update_bookmarks_test.go: Add TestBookmarkToSlot_CapturesFilter (filtered + unfiltered cases).
- Docs: Update in-app help, README.md, and docs/keybindings.md.

## Testing

<!-- How did you verify this works? Include the cluster / terminal you tested against when relevant. -->

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

<!-- Optional. Include for UI changes. -->
