### PR TITLE
ci: restore advanced CodeQL setup with fork-PR scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,108 @@
+name: CodeQL
+
+# Advanced CodeQL setup. Replaces the GitHub-managed "default setup" so we can
+# also scan pull requests from forks: GitHub never runs default-setup code
+# scanning on fork PRs (their read-only token cannot upload results), which
+# leaves the ruleset's code_scanning rule unsatisfiable and the PR blocked.
+#
+# Trusted paths (push, schedule, same-repo PRs) run on the normal pull_request
+# event. Fork PRs are scanned only via pull_request_target AFTER a maintainer
+# applies the `safe-to-scan` label - the label is the human review gate, because
+# this path checks out and builds untrusted contributor code with a write token.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+    types: [labeled, synchronize]
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    # Run on: push/schedule; same-repo PRs (trusted, fork == false); or a fork
+    # PR freshly labeled `safe-to-scan` (pull_request_target, runs in base repo
+    # context so the token can upload results). Fork PRs on the plain
+    # pull_request event are skipped here - their token is read-only.
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'safe-to-scan' &&
+        github.event.pull_request.head.repo.full_name != github.repository)
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # pull_request_target checks out the base by default; explicitly take
+          # the PR head SHA so we analyze the contributor's actual code. Safe
+          # only because this path requires the maintainer-applied label.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  # New commits to a labeled fork PR drop the label so the contributor cannot
+  # slip unreviewed code into a scan; a maintainer must re-apply it after review.
+  revoke-on-push:
+    name: Revoke safe-to-scan on new commits
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'safe-to-scan')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove safe-to-scan label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'safe-to-scan',
+            }).catch(err => {
+              // Tolerate "label already gone" (404); surface anything else so a
+              // failed removal fails the job instead of silently leaving the gate open.
+              if (err.status !== 404) throw err;
+            })


### PR DESCRIPTION
## Summary

Re-enables the advanced CodeQL workflow (reverts #458's move to default setup) and adds a label-gated path so pull requests **from forks** can be scanned.

### Why
GitHub's CodeQL *default setup* never runs code scanning on fork PRs (their read-only token can't upload results). The `main` ruleset's `code_scanning` rule then has nothing to satisfy it, so every external fork PR (e.g. #470) is permanently `BLOCKED`. Advanced setup + `pull_request_target` is the only way to scan fork code, and it can't coexist with default setup — so default setup is now disabled.

### How it works
| Path | Trigger | Scanned |
|---|---|---|
| push to `main` / weekly cron | `push` / `schedule` | yes |
| same-repo PR | `pull_request` (write token) | yes |
| fork PR, no label | `pull_request` (read-only) | skipped |
| fork PR + maintainer adds `safe-to-scan` | `pull_request_target` (builds head SHA) | yes |
| new commit on a labeled fork PR | `synchronize` | label auto-removed, re-review required |

### Safety
- Fork code is only built after a maintainer applies `safe-to-scan` (label requires write access).
- `revoke-on-push` drops the label on every new commit so unreviewed code can't be scanned.
- Untrusted job runs with minimal token (`contents:read` + `security-events:write`); no secrets needed.
- All actions SHA-pinned; security-reviewed.
- Query suite: `security-and-quality` (matches the prior advanced setup).

### Notes
- A repo-admin bypass actor was added to the `main` ruleset as a safety valve.
- The `safe-to-scan` label was created.

## Testing
- [x] `actionlint` passes
- [ ] CodeQL advanced analysis runs green on this PR (verifies the upload path now that default setup is off)
