### PR TITLE
ci(codeql): opt in to fork-PR checkout for safe-to-scan path

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,10 @@ jobs:
           # the PR head SHA so we analyze the contributor's actual code. Safe
           # only because this path requires the maintainer-applied label.
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # checkout v7 refuses fork-PR checkout under pull_request_target unless
+          # opted in. The safe-to-scan label gate + minimal token + revoke-on-push
+          # are the safeguards; only enable it on that path, never on trusted runs.
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Set up Go
         if: matrix.language == 'go'


### PR DESCRIPTION
Follow-up to #471. `actions/checkout@v7` refuses to check out fork PR code under `pull_request_target` unless `allow-unsafe-pr-checkout: true` is set, so the `safe-to-scan` fork scan failed at checkout (seen on #470).

Enables the opt-in **only on the `pull_request_target` path** (`allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}`); push and same-repo PR runs stay strict. The label review gate, minimal token (`contents:read` + `security-events:write`), and `revoke-on-push` remain the safeguards against pwn-request abuse.

## Testing
- [x] `actionlint` passes