### PR TITLE
feat: restore active list filter and cursor across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **Clipboard support**: Copy resource name (`y`), open copy-as picker (`Y`: YAML / JSON / Table), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
 - **Bookmarks**: Save favorite resource paths (including the active list filter) for quick navigation
 - **Orphan detection**: Press `Shift+Z` (or run bare `:orphans`) to open the cluster-wide orphan overview across 11 kinds — Pods, Secrets, ConfigMaps, Services, PVCs, HPAs, PDBs, NetworkPolicies, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings. Per-list filters are still available via the filter-preset overlay (`.`) on each kind, or jump straight to a filtered view with `:orphans <kind>` (e.g., `:orphans secrets`). A strict / lenient toggle (`s`) flips between "truly unused" and "currently idle but referenced by workload templates" (e.g. CronJob between firings). Auto-excludes Helm release Secrets, ServiceAccount tokens, owner-managed resources, and `kube-root-ca.crt`.
-- **Session persistence**: Remembers last context/namespace/resource across restarts
+- **Session persistence**: Remembers last context/namespace/resource, the active list filter, and the highlighted row across restarts
 
 ### Integrations
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1054,7 +1054,7 @@ To regenerate themes from the latest ghostty source, run `make generate-themes`.
 
 ## Session Persistence
 
-The application automatically saves and restores the last visited context, namespace, and resource type across restarts. The session state is stored at `~/.local/state/lfk/session.yaml`.
+The application automatically saves and restores the last visited context, namespace, and resource type across restarts (per tab, including the active tab). It also restores the active list filter (including the `Tab` broad-match mode) and the highlighted row, so you reopen lfk on the same resource you were looking at. The session state is stored at `~/.local/state/lfk/session.yaml`.
 
 This is transparent and requires no configuration. To start fresh, delete the session file.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -194,6 +194,8 @@ type Model struct {
 	statusMessageTip bool      // true when the message is a startup tip (dismiss on keypress)
 
 	pendingTarget string // when set, resources load selects this item by name
+	// pendingTargetNamespace narrows pendingTarget to one ns (empty = name-only).
+	pendingTargetNamespace string
 
 	// pendingG: vim 'gg' -> next 'g' jumps to top; whichKeyShown: popup visible while armed.
 	pendingG      bool
@@ -450,33 +452,31 @@ type Model struct {
 
 	// Contexts whose discoveredResources entries have been refreshed
 	// (i.e. live-fetched) during this session. NewModel prefills
-	// discoveredResources from the on-disk discovery cache for instant
-	// first paint, so the bare presence of an entry no longer implies
-	// "fresh" — this flag is the source of truth for stale-while-revalidate
-	// gating in the lazy discovery triggers.
+	// discoveredResources from the on-disk discovery cache for instant first
+	// paint, so an entry's mere presence no longer implies "fresh" — this flag
+	// is the source of truth for stale-while-revalidate gating in lazy discovery.
 	discoveryRefreshedContexts map[string]bool
 
 	// bookmarkAwaitingDiscovery holds a bookmark whose target resource type
 	// can't be resolved yet because API discovery for the effective context
 	// hasn't completed (typical at session restore — the seed list resolves
-	// Pods/Deployments synchronously but CRDs like ArgoCD Applications are
-	// only known after the discovery round-trip lands). Set by
-	// navigateToBookmark, consumed by updateAPIResourceDiscovery, which
-	// replays the navigation once the matching context's entries arrive.
-	// Distinct from pendingBookmark (which gates save-overwrite confirmation).
+	// Pods/Deployments synchronously but CRDs like ArgoCD Applications are only
+	// known after the discovery round-trip lands). Set by navigateToBookmark,
+	// consumed by updateAPIResourceDiscovery, which replays the navigation once
+	// the matching context's entries arrive. Distinct from pendingBookmark
+	// (which gates save-overwrite confirmation).
 	bookmarkAwaitingDiscovery *model.Bookmark
-
 	// sessionResourceTypeAwaitingDiscovery captures the resource type ref a
-	// just-restored session wants to land on when the type wasn't yet known
-	// to the seed list (CRD-backed views like ArgoCD Application). The
-	// matching apiResourceDiscoveryMsg consumes it and navigates to the
-	// resource type so the user lands back on the view they quit from
-	// instead of being dumped at the resource types level.
+	// just-restored session wants to land on when the type wasn't yet known to
+	// the seed list (CRD-backed views like ArgoCD Application). The matching
+	// apiResourceDiscoveryMsg consumes it and navigates to the resource type so
+	// the user lands back on the view they quit from rather than the type level.
 	sessionResourceTypeAwaitingDiscovery string
-	// sessionResourceNameAwaitingDiscovery is the resource name to land on
-	// once the type-await above resolves. Mirrors pendingTarget but is only
-	// armed when the type itself was deferred.
+	// sessionResourceNameAwaitingDiscovery is the resource name to land on once
+	// the type-await above resolves; mirrors pendingTarget but only when deferred.
 	sessionResourceNameAwaitingDiscovery string
+	// pendingSessionList carries the saved filter + cursor through a deferred restore.
+	pendingSessionList pendingSessionListState
 
 	// Preview scroll offset for the right column.
 	previewScroll int

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -474,9 +474,13 @@ type TabState struct {
 	sortMemory              map[string]sortPref
 	filterText              string
 	filterBroadMode         bool
-	watchMode               bool
-	objectExplorerLive      bool
-	objectExplorerTree      bool
+	// Identity of the highlighted resource row, captured on save so session
+	// restore can reopen every tab (not just the active one) on the same item.
+	cursorName         string
+	cursorNamespace    string
+	watchMode          bool
+	objectExplorerLive bool
+	objectExplorerTree bool
 	// readOnly blocks all mutating actions for this tab. Re-evaluated on
 	// context switch from CLI flag, per-context config, and global config.
 	readOnly               bool

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -473,6 +473,7 @@ type TabState struct {
 	sortAscending           bool
 	sortMemory              map[string]sortPref
 	filterText              string
+	filterBroadMode         bool
 	watchMode               bool
 	objectExplorerLive      bool
 	objectExplorerTree      bool

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -160,12 +160,10 @@ func (m *Model) saveCurrentSession() {
 		if t.nav.ResourceName != "" {
 			st.ResourceName = t.nav.ResourceName
 		}
-		// Persist the list filter and highlighted row only when the tab sits on
-		// a resource list; a filter typed at the resource-types level is not
-		// meaningful once the session reopens directly into the resource view.
-		// saveCurrentTab captured the cursor identity for every tab (live for
-		// the active one, last-seen for the rest), so restore can reopen each
-		// tab on its own row.
+		// Persist filter + highlighted row only on a resource list; a filter from
+		// the resource-types level is meaningless once restore reopens into the
+		// list. saveCurrentTab already captured each tab's cursor, so every tab
+		// reopens on its own row.
 		if t.nav.Level == model.LevelResources {
 			st.Filter = t.filterText
 			st.FilterBroad = t.filterBroadMode

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -137,7 +137,7 @@ func (m *Model) saveCurrentSession() {
 		ActiveTab: m.activeTab,
 	}
 
-	for i, t := range m.tabs {
+	for _, t := range m.tabs {
 		st := SessionTab{
 			Context:       t.nav.Context,
 			AllNamespaces: t.allNamespaces,
@@ -160,21 +160,17 @@ func (m *Model) saveCurrentSession() {
 		if t.nav.ResourceName != "" {
 			st.ResourceName = t.nav.ResourceName
 		}
-		// Persist the list filter only when the tab is sitting on a resource
-		// list; a filter typed at the resource-types level is not meaningful
-		// once the session reopens directly into the resource view.
+		// Persist the list filter and highlighted row only when the tab sits on
+		// a resource list; a filter typed at the resource-types level is not
+		// meaningful once the session reopens directly into the resource view.
+		// saveCurrentTab captured the cursor identity for every tab (live for
+		// the active one, last-seen for the rest), so restore can reopen each
+		// tab on its own row.
 		if t.nav.Level == model.LevelResources {
 			st.Filter = t.filterText
 			st.FilterBroad = t.filterBroadMode
-			// The active tab's highlighted row lives in the live Model state
-			// (saveCurrentTab copied indices, not the item identity), so read
-			// it back from there to land the cursor on the same resource.
-			if i == m.activeTab {
-				if name, ns, _, _ := m.cursorItemKey(); name != "" {
-					st.CursorName = name
-					st.CursorNamespace = ns
-				}
-			}
+			st.CursorName = t.cursorName
+			st.CursorNamespace = t.cursorNamespace
 		}
 		s.Tabs = append(s.Tabs, st)
 	}

--- a/internal/app/session.go
+++ b/internal/app/session.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/paths"
 )
 
@@ -20,6 +21,11 @@ type SessionTab struct {
 	NsSelectionNegated bool     `json:"ns_selection_negated,omitempty" yaml:"ns_selection_negated,omitempty"`
 	ResourceType       string   `json:"resource_type,omitempty" yaml:"resource_type,omitempty"`
 	ResourceName       string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
+	// List view state at quit time, restored once the resource list reloads.
+	Filter          string `json:"filter,omitempty" yaml:"filter,omitempty"`
+	FilterBroad     bool   `json:"filter_broad,omitempty" yaml:"filter_broad,omitempty"`
+	CursorName      string `json:"cursor_name,omitempty" yaml:"cursor_name,omitempty"`
+	CursorNamespace string `json:"cursor_namespace,omitempty" yaml:"cursor_namespace,omitempty"`
 }
 
 // SessionState represents the persisted navigation state across restarts.
@@ -32,6 +38,13 @@ type SessionState struct {
 	NsSelectionNegated bool     `json:"ns_selection_negated,omitempty" yaml:"ns_selection_negated,omitempty"`
 	ResourceType       string   `json:"resource_type,omitempty" yaml:"resource_type,omitempty"` // group/version/resource ref string
 	ResourceName       string   `json:"resource_name,omitempty" yaml:"resource_name,omitempty"`
+
+	// List view state for the legacy single-tab shape; the multi-tab path
+	// carries these per SessionTab instead.
+	Filter          string `json:"filter,omitempty" yaml:"filter,omitempty"`
+	FilterBroad     bool   `json:"filter_broad,omitempty" yaml:"filter_broad,omitempty"`
+	CursorName      string `json:"cursor_name,omitempty" yaml:"cursor_name,omitempty"`
+	CursorNamespace string `json:"cursor_namespace,omitempty" yaml:"cursor_namespace,omitempty"`
 
 	// Multi-tab fields.
 	Tabs      []SessionTab `json:"tabs,omitempty" yaml:"tabs,omitempty"`
@@ -124,7 +137,7 @@ func (m *Model) saveCurrentSession() {
 		ActiveTab: m.activeTab,
 	}
 
-	for _, t := range m.tabs {
+	for i, t := range m.tabs {
 		st := SessionTab{
 			Context:       t.nav.Context,
 			AllNamespaces: t.allNamespaces,
@@ -146,6 +159,22 @@ func (m *Model) saveCurrentSession() {
 		}
 		if t.nav.ResourceName != "" {
 			st.ResourceName = t.nav.ResourceName
+		}
+		// Persist the list filter only when the tab is sitting on a resource
+		// list; a filter typed at the resource-types level is not meaningful
+		// once the session reopens directly into the resource view.
+		if t.nav.Level == model.LevelResources {
+			st.Filter = t.filterText
+			st.FilterBroad = t.filterBroadMode
+			// The active tab's highlighted row lives in the live Model state
+			// (saveCurrentTab copied indices, not the item identity), so read
+			// it back from there to land the cursor on the same resource.
+			if i == m.activeTab {
+				if name, ns, _, _ := m.cursorItemKey(); name != "" {
+					st.CursorName = name
+					st.CursorNamespace = ns
+				}
+			}
 		}
 		s.Tabs = append(s.Tabs, st)
 	}

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
 
 // --- sessionFilePath ---
@@ -71,4 +73,168 @@ func TestLoadSessionNoFile(t *testing.T) {
 
 	session := loadSession()
 	assert.Nil(t, session)
+}
+
+// --- filter + cursor persistence ---
+
+// The list filter and highlighted row must survive a quit/relaunch so the user
+// reopens lfk exactly where they left off.
+func TestSession_FilterAndCursorRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
+	in := SessionState{
+		Context: "ctx",
+		Tabs: []SessionTab{{
+			Context:         "ctx",
+			AllNamespaces:   true,
+			ResourceType:    "v1/pods",
+			Filter:          "web",
+			FilterBroad:     true,
+			CursorName:      "pod-2",
+			CursorNamespace: "ns-2",
+		}},
+	}
+	require.NoError(t, saveSession(in))
+
+	out := loadSession()
+	require.NotNil(t, out)
+	require.Len(t, out.Tabs, 1)
+	assert.Equal(t, "web", out.Tabs[0].Filter)
+	assert.True(t, out.Tabs[0].FilterBroad)
+	assert.Equal(t, "pod-2", out.Tabs[0].CursorName)
+	assert.Equal(t, "ns-2", out.Tabs[0].CursorNamespace)
+}
+
+// applySessionFilterAndCursor seeds the live filter, commits it to filterMemory
+// (so a drill-out/back keeps it), and arms the cursor target for the upcoming
+// resource load.
+func TestApplySessionFilterAndCursor(t *testing.T) {
+	t.Run("seeds filter and cursor target", func(t *testing.T) {
+		m := basePush80Model()
+		m.filterMemory = make(map[string]savedFilter)
+
+		m.applySessionFilterAndCursor("web", true, "pod-2", "ns-2")
+
+		assert.Equal(t, "web", m.filterText)
+		assert.Equal(t, "web", m.filterInput.Value)
+		assert.True(t, m.filterBroadMode)
+		assert.False(t, m.filterActive)
+		assert.Equal(t, "pod-2", m.pendingTarget)
+		assert.Equal(t, "ns-2", m.pendingTargetNamespace)
+
+		f, ok := m.filterMemory[m.navKey()]
+		require.True(t, ok, "committed filter must land in filterMemory")
+		assert.Equal(t, savedFilter{text: "web", broad: true}, f)
+	})
+
+	t.Run("empty filter clears memory and leaves cursor untargeted", func(t *testing.T) {
+		m := basePush80Model()
+		key := m.navKey()
+		m.filterMemory = map[string]savedFilter{key: {text: "stale", broad: true}}
+
+		m.applySessionFilterAndCursor("", false, "", "")
+
+		assert.Empty(t, m.filterText)
+		assert.False(t, m.filterBroadMode)
+		_, ok := m.filterMemory[key]
+		assert.False(t, ok, "empty filter must drop the stale memory entry")
+		assert.Empty(t, m.pendingTarget)
+		assert.Empty(t, m.pendingTargetNamespace)
+	})
+}
+
+// applyPendingSessionList only fires when armed (deferred behind CRD discovery)
+// and is otherwise a no-op.
+func TestApplyPendingSessionList(t *testing.T) {
+	t.Run("armed state applies then clears", func(t *testing.T) {
+		m := basePush80Model()
+		m.filterMemory = make(map[string]savedFilter)
+		m.pendingSessionList = pendingSessionListState{
+			armed:       true,
+			filter:      "db",
+			filterBroad: true,
+			cursorName:  "pod-3",
+			cursorNs:    "default",
+		}
+
+		m.applyPendingSessionList()
+
+		assert.Equal(t, "db", m.filterText)
+		assert.True(t, m.filterBroadMode)
+		assert.Equal(t, "pod-3", m.pendingTarget)
+		assert.Equal(t, "default", m.pendingTargetNamespace)
+		assert.False(t, m.pendingSessionList.armed, "armed state must be consumed")
+	})
+
+	t.Run("unarmed is a no-op", func(t *testing.T) {
+		m := basePush80Model()
+		m.filterText = "keep"
+		m.applyPendingSessionList()
+		assert.Equal(t, "keep", m.filterText)
+		assert.Empty(t, m.pendingTarget)
+	})
+}
+
+// sessionCursor folds a drilled-in ResourceName into the cursor target (name
+// only, since its namespace was never persisted) and otherwise uses the saved
+// cursor name/namespace.
+func TestSessionCursor(t *testing.T) {
+	t.Run("ResourceName wins, name only", func(t *testing.T) {
+		name, ns := sessionCursor(&SessionState{ResourceName: "my-app", CursorName: "other", CursorNamespace: "x"})
+		assert.Equal(t, "my-app", name)
+		assert.Empty(t, ns)
+	})
+
+	t.Run("falls back to cursor name and namespace", func(t *testing.T) {
+		name, ns := sessionCursor(&SessionState{CursorName: "pod-2", CursorNamespace: "ns-2"})
+		assert.Equal(t, "pod-2", name)
+		assert.Equal(t, "ns-2", ns)
+	})
+}
+
+// saveCurrentSession captures the active tab's filter and highlighted row when
+// it is sitting on a resource list.
+func TestSaveCurrentSession_CapturesFilterAndCursor(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
+	m := basePush80Model()
+	m.allNamespaces = true
+	m.filterText = "pod"
+	m.filterInput.Set("pod")
+	m.filterBroadMode = true
+	// Land the cursor on the second visible row (pod-2 / ns-2).
+	m.setCursor(1)
+
+	m.saveCurrentSession()
+
+	out := loadSession()
+	require.NotNil(t, out)
+	require.Len(t, out.Tabs, 1)
+	assert.Equal(t, "pod", out.Tabs[0].Filter)
+	assert.True(t, out.Tabs[0].FilterBroad)
+	assert.Equal(t, "pod-2", out.Tabs[0].CursorName)
+	assert.Equal(t, "ns-2", out.Tabs[0].CursorNamespace)
+}
+
+// A filter typed at the resource-types level is not a resource-list filter and
+// must not be persisted as one.
+func TestSaveCurrentSession_SkipsFilterAboveResourceLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
+	m := basePush80Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.tabs[0].nav.Level = model.LevelResourceTypes
+	m.filterText = "dep"
+	m.filterInput.Set("dep")
+
+	m.saveCurrentSession()
+
+	out := loadSession()
+	require.NotNil(t, out)
+	require.Len(t, out.Tabs, 1)
+	assert.Empty(t, out.Tabs[0].Filter)
+	assert.Empty(t, out.Tabs[0].CursorName)
 }

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -176,21 +176,60 @@ func TestApplyPendingSessionList(t *testing.T) {
 	})
 }
 
-// sessionCursor folds a drilled-in ResourceName into the cursor target (name
-// only, since its namespace was never persisted) and otherwise uses the saved
-// cursor name/namespace.
+// sessionCursor prefers the saved cursor name/namespace (which disambiguates
+// same-named rows across namespaces) and only falls back to a drilled-in
+// ResourceName for legacy sessions saved before the cursor fields existed.
 func TestSessionCursor(t *testing.T) {
-	t.Run("ResourceName wins, name only", func(t *testing.T) {
-		name, ns := sessionCursor(&SessionState{ResourceName: "my-app", CursorName: "other", CursorNamespace: "x"})
-		assert.Equal(t, "my-app", name)
-		assert.Empty(t, ns)
-	})
-
-	t.Run("falls back to cursor name and namespace", func(t *testing.T) {
-		name, ns := sessionCursor(&SessionState{CursorName: "pod-2", CursorNamespace: "ns-2"})
+	t.Run("cursor name wins and keeps its namespace", func(t *testing.T) {
+		name, ns := sessionCursor(&SessionState{ResourceName: "other", CursorName: "pod-2", CursorNamespace: "ns-2"})
 		assert.Equal(t, "pod-2", name)
 		assert.Equal(t, "ns-2", ns)
 	})
+
+	t.Run("falls back to ResourceName for legacy sessions", func(t *testing.T) {
+		name, ns := sessionCursor(&SessionState{ResourceName: "my-app"})
+		assert.Equal(t, "my-app", name)
+		assert.Empty(t, ns)
+	})
+}
+
+// restoreCursorAfterLoad lands on the pending target, and when that target is
+// gone (deleted, or hidden by a restored filter) falls back to the prior row
+// rather than leaving a stale pre-load index.
+func TestRestoreCursorAfterLoad(t *testing.T) {
+	t.Run("lands on the namespace-qualified pending target", func(t *testing.T) {
+		m := basePush80Model() // pod-1/default, pod-2/ns-2, pod-3/default
+		m.pendingTarget, m.pendingTargetNamespace = "pod-2", "ns-2"
+
+		m.restoreCursorAfterLoad("", "", "", "", "")
+
+		assert.Equal(t, 1, m.cursor())
+		assert.Empty(t, m.pendingTarget)
+		assert.Empty(t, m.pendingTargetNamespace)
+	})
+
+	t.Run("falls back to the prior row when the target is gone", func(t *testing.T) {
+		m := basePush80Model()
+		m.setCursor(0)
+		m.pendingTarget, m.pendingTargetNamespace = "ghost", "default"
+
+		m.restoreCursorAfterLoad("pod-3", "default", "", "Pod", "")
+
+		assert.Equal(t, 2, m.cursor(), "missing target must restore the prior row")
+		assert.Empty(t, m.pendingTarget)
+	})
+}
+
+// saveCurrentTab captures the highlighted row for every tab so an inactive tab
+// can be reopened on its own resource, not just the active one.
+func TestSaveCurrentTab_CapturesCursorIdentity(t *testing.T) {
+	m := basePush80Model()
+	m.setCursor(1) // pod-2 / ns-2
+
+	m.saveCurrentTab()
+
+	assert.Equal(t, "pod-2", m.tabs[0].cursorName)
+	assert.Equal(t, "ns-2", m.tabs[0].cursorNamespace)
 }
 
 // saveCurrentSession captures the active tab's filter and highlighted row when

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -434,6 +434,7 @@ func (m *Model) saveCurrentTab() {
 	t.sortColumnName = m.sortColumnName
 	t.sortAscending = m.sortAscending
 	t.filterText = m.filterText
+	t.filterBroadMode = m.filterBroadMode
 	t.watchMode = m.watchMode
 	t.objectExplorerLive = m.objectExplorerLive
 	t.objectExplorerTree = m.objectExplorerTree
@@ -513,8 +514,8 @@ func (m *Model) saveCurrentTab() {
 	m.saveLogTopToTab(t)
 	m.saveSecurityStateToTab(t)
 	// Cache the current preview buffer then cancel the stream so it does not
-	// outlive the tab. The fullLogPreview flag is persisted above, so the next
-	// loadTab will know to restart (and can restore from cache) if needed.
+	// outlive the tab. fullLogPreview is persisted above, so the next loadTab
+	// knows to restart (and can restore from cache) if needed.
 	m.cachePreviewLog()
 	m.cancelPreviewLogStream()
 }
@@ -564,6 +565,8 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.sortColumnName = t.sortColumnName
 	m.sortAscending = t.sortAscending
 	m.filterText = t.filterText
+	m.filterBroadMode = t.filterBroadMode
+	m.filterInput.Set(t.filterText)
 	m.watchMode = t.watchMode
 	m.objectExplorerLive = t.objectExplorerLive
 	m.objectExplorerTree = t.objectExplorerTree
@@ -576,8 +579,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.dashboardPreview = t.dashboardPreview
 	m.dashboardEventsPreview = t.dashboardEventsPreview
 	m.monitoringPreview = t.monitoringPreview
-	// Restore the right-pane footers so the new tab paints with its own
-	// metrics / events instead of leaking the previous tab's values.
+	// Restore the right-pane footers so the new tab paints its own metrics/events.
 	m.metricsContent = t.metricsContent
 	m.previewEventsContent = t.previewEventsContent
 	m.metricsData = t.metricsData
@@ -615,8 +617,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.logView.visualCol = t.logVisualCol
 	m.logView.visualCurCol = t.logVisualCurCol
 	m.logView.scrollOption = t.logScrollOption
-	// Rebuild the filtered view after all offset/follow fields are restored so
-	// clampLogOffsets operates on the correct follow flag and cursor position.
+	// Rebuild after offset/follow restore so clampLogOffsets sees correct state.
 	m.rebuildLogView()
 	m.logView.parentKind = t.logParentKind
 	m.logView.parentName = t.logParentName
@@ -658,10 +659,9 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.pendingTextObject = 0
 
 	// Re-annotate cluster picker rows with the current effective read-only
-	// state. The override map is per-Model (shared across tabs), but
-	// middleItems was captured per-tab — so a Ctrl+R toggle in another tab
-	// can leave this tab's [RO] markers stale until the next context
-	// reload. This brings them in sync immediately on tab switch.
+	// state. The override map is per-Model (shared across tabs), but middleItems
+	// was captured per-tab — so a Ctrl+R toggle in another tab can leave this
+	// tab's [RO] markers stale until the next context reload. Sync them now.
 	m.refreshContextReadOnlyMarkers()
 
 	// If this tab was restored from a session but never loaded, clear the

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -435,6 +435,7 @@ func (m *Model) saveCurrentTab() {
 	t.sortAscending = m.sortAscending
 	t.filterText = m.filterText
 	t.filterBroadMode = m.filterBroadMode
+	t.cursorName, t.cursorNamespace, _, _ = m.cursorItemKey()
 	t.watchMode = m.watchMode
 	t.objectExplorerLive = m.objectExplorerLive
 	t.objectExplorerTree = m.objectExplorerTree
@@ -664,17 +665,15 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	// tab's [RO] markers stale until the next context reload. Sync them now.
 	m.refreshContextReadOnlyMarkers()
 
-	// If this tab was restored from a session but never loaded, clear the
-	// flag, set up the navigation column structure, and return a command
-	// that fetches the tab's data.
+	// If this tab was restored from a session but never loaded, clear the flag,
+	// set up the navigation column structure, and return a fetch command.
 	if needsLoad {
 		m.tabs[idx].needsLoad = false
 		m.applyPinnedTypes()
 
-		// Rebuild security state for the restored context so the Security
-		// sidebar seeds from the on-disk cache. Live availability probing is
-		// lazy (maybeProbeSecurityOnFocus) — it runs when the user focuses
-		// the Security category, not eagerly on every tab/context restore.
+		// Rebuild security state for the restored context so the Security sidebar
+		// seeds from the on-disk cache. Live availability probing is lazy
+		// (maybeProbeSecurityOnFocus): on Security focus, not on every restore.
 		securitySeedCmd := m.refreshSecuritySources()
 
 		// Load contexts for the left column breadcrumb.
@@ -690,13 +689,14 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 
 		switch m.nav.Level {
 		case model.LevelResources:
-			// At resources level: left = resource types, history = [contexts].
+			// Resources level: left = resource types, history = [contexts].
 			m.leftItemsHistory = [][]model.Item{contexts}
 			m.leftItems = resourceTypes
 			m.setMiddleItems(nil)
 			m.clearRight()
 			m.setCursor(0)
 			m.loading = true
+			m.pendingTarget, m.pendingTargetNamespace = t.cursorName, t.cursorNamespace // quit-time row
 			return tea.Batch(securitySeedCmd, m.loadResources(false))
 		case model.LevelResourceTypes:
 			// At resource types level: left = contexts, middle = resource types.

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -6,6 +6,55 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// pendingSessionListState holds the list filter and cursor target a restored
+// session must reapply once its resource list reloads. It is only armed when
+// the descent to the resource list is deferred behind CRD discovery; the
+// immediate path applies the same values directly.
+type pendingSessionListState struct {
+	armed       bool
+	filter      string
+	filterBroad bool
+	cursorName  string
+	cursorNs    string
+}
+
+// sessionCursor resolves the row a restored session should land on. A drilled-in
+// ResourceName takes precedence and matches on name alone (its namespace was
+// never persisted); otherwise the captured cursor name/namespace is used.
+func sessionCursor(sess *SessionState) (name, ns string) {
+	if sess.ResourceName != "" {
+		return sess.ResourceName, ""
+	}
+	return sess.CursorName, sess.CursorNamespace
+}
+
+// applySessionFilterAndCursor seeds the list filter and cursor target so they
+// take effect when the resource list finishes loading. The filter is also
+// committed to filterMemory so navigating away and back keeps it.
+func (m *Model) applySessionFilterAndCursor(filter string, broad bool, cursorName, cursorNs string) {
+	m.filterText = filter
+	m.filterInput.Set(filter)
+	m.filterBroadMode = broad
+	m.filterActive = false
+	m.searchActive = false
+	m.saveLevelFilter()
+	if cursorName != "" {
+		m.pendingTarget = cursorName
+		m.pendingTargetNamespace = cursorNs
+	}
+}
+
+// applyPendingSessionList applies a deferred session list state (armed when a
+// CRD discovery roundtrip was needed) and clears it. No-op when nothing armed.
+func (m *Model) applyPendingSessionList() {
+	p := m.pendingSessionList
+	m.pendingSessionList = pendingSessionListState{}
+	if !p.armed {
+		return
+	}
+	m.applySessionFilterAndCursor(p.filter, p.filterBroad, p.cursorName, p.cursorNs)
+}
+
 func (m Model) restoreSession(contexts []model.Item) (tea.Model, tea.Cmd) {
 	sess := m.pendingSession
 	m.pendingSession = nil
@@ -112,6 +161,14 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 		if !ok && needsDiscovery {
 			m.sessionResourceTypeAwaitingDiscovery = sess.ResourceType
 			m.sessionResourceNameAwaitingDiscovery = sess.ResourceName
+			cursorName, cursorNs := sessionCursor(sess)
+			m.pendingSessionList = pendingSessionListState{
+				armed:       true,
+				filter:      sess.Filter,
+				filterBroad: sess.FilterBroad,
+				cursorName:  cursorName,
+				cursorNs:    cursorNs,
+			}
 		}
 		if ok {
 			rtRef := rt.ResourceRef()
@@ -132,9 +189,8 @@ func (m Model) restoreSingleTabSession(sess *SessionState, contexts []model.Item
 			m.setCursor(0)
 			m.loading = true
 
-			if sess.ResourceName != "" {
-				m.pendingTarget = sess.ResourceName
-			}
+			cursorName, cursorNs := sessionCursor(sess)
+			m.applySessionFilterAndCursor(sess.Filter, sess.FilterBroad, cursorName, cursorNs)
 
 			cmds = append(cmds, m.loadResources(false))
 			return m, tea.Batch(cmds...)
@@ -181,6 +237,10 @@ func (m Model) restoreMultiTabSession(sess *SessionState, contexts []model.Item)
 		NsSelectionNegated: activeSess.NsSelectionNegated,
 		ResourceType:       activeSess.ResourceType,
 		ResourceName:       activeSess.ResourceName,
+		Filter:             activeSess.Filter,
+		FilterBroad:        activeSess.FilterBroad,
+		CursorName:         activeSess.CursorName,
+		CursorNamespace:    activeSess.CursorNamespace,
 	}, contexts)
 }
 
@@ -230,6 +290,10 @@ func buildSessionTabState(st *SessionTab, discovered []model.ResourceTypeEntry) 
 			if st.ResourceName != "" {
 				tab.nav.ResourceName = st.ResourceName
 			}
+			// Carry the saved list filter so switching to this lazily-loaded
+			// tab reopens it filtered, matching the active tab's restore.
+			tab.filterText = st.Filter
+			tab.filterBroadMode = st.FilterBroad
 		} else {
 			tab.nav.Level = model.LevelResourceTypes
 		}

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -18,14 +18,15 @@ type pendingSessionListState struct {
 	cursorNs    string
 }
 
-// sessionCursor resolves the row a restored session should land on. A drilled-in
-// ResourceName takes precedence and matches on name alone (its namespace was
-// never persisted); otherwise the captured cursor name/namespace is used.
+// sessionCursor resolves the row a restored session should land on. The captured
+// cursor name/namespace is preferred (it disambiguates same-named rows across
+// namespaces); a drilled-in ResourceName is only a fallback for legacy sessions
+// saved before the cursor fields existed, and matches on name alone.
 func sessionCursor(sess *SessionState) (name, ns string) {
-	if sess.ResourceName != "" {
-		return sess.ResourceName, ""
+	if sess.CursorName != "" {
+		return sess.CursorName, sess.CursorNamespace
 	}
-	return sess.CursorName, sess.CursorNamespace
+	return sess.ResourceName, ""
 }
 
 // applySessionFilterAndCursor seeds the list filter and cursor target so they
@@ -290,10 +291,13 @@ func buildSessionTabState(st *SessionTab, discovered []model.ResourceTypeEntry) 
 			if st.ResourceName != "" {
 				tab.nav.ResourceName = st.ResourceName
 			}
-			// Carry the saved list filter so switching to this lazily-loaded
-			// tab reopens it filtered, matching the active tab's restore.
+			// Carry the saved list filter and cursor so switching to this
+			// lazily-loaded tab reopens it filtered and on the same row.
 			tab.filterText = st.Filter
 			tab.filterBroadMode = st.FilterBroad
+			tab.cursorName, tab.cursorNamespace = sessionCursor(&SessionState{
+				ResourceName: st.ResourceName, CursorName: st.CursorName, CursorNamespace: st.CursorNamespace,
+			})
 		} else {
 			tab.nav.Level = model.LevelResourceTypes
 		}

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -6,10 +6,8 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// pendingSessionListState holds the list filter and cursor target a restored
-// session must reapply once its resource list reloads. It is only armed when
-// the descent to the resource list is deferred behind CRD discovery; the
-// immediate path applies the same values directly.
+// pendingSessionListState carries a restored session's filter and cursor target
+// when the descent to the resource list is deferred behind CRD discovery.
 type pendingSessionListState struct {
 	armed       bool
 	filter      string
@@ -18,10 +16,8 @@ type pendingSessionListState struct {
 	cursorNs    string
 }
 
-// sessionCursor resolves the row a restored session should land on. The captured
-// cursor name/namespace is preferred (it disambiguates same-named rows across
-// namespaces); a drilled-in ResourceName is only a fallback for legacy sessions
-// saved before the cursor fields existed, and matches on name alone.
+// sessionCursor resolves the row a restored session lands on: the saved cursor
+// name/namespace, falling back to ResourceName for pre-cursor legacy sessions.
 func sessionCursor(sess *SessionState) (name, ns string) {
 	if sess.CursorName != "" {
 		return sess.CursorName, sess.CursorNamespace
@@ -29,9 +25,8 @@ func sessionCursor(sess *SessionState) (name, ns string) {
 	return sess.ResourceName, ""
 }
 
-// applySessionFilterAndCursor seeds the list filter and cursor target so they
-// take effect when the resource list finishes loading. The filter is also
-// committed to filterMemory so navigating away and back keeps it.
+// applySessionFilterAndCursor seeds the filter and cursor target for the next
+// resource load, committing the filter to filterMemory so drill-out/back keeps it.
 func (m *Model) applySessionFilterAndCursor(filter string, broad bool, cursorName, cursorNs string) {
 	m.filterText = filter
 	m.filterInput.Set(filter)
@@ -45,8 +40,8 @@ func (m *Model) applySessionFilterAndCursor(filter string, broad bool, cursorNam
 	}
 }
 
-// applyPendingSessionList applies a deferred session list state (armed when a
-// CRD discovery roundtrip was needed) and clears it. No-op when nothing armed.
+// applyPendingSessionList applies a deferred (CRD-discovery) session list state
+// and clears it; no-op when nothing is armed.
 func (m *Model) applyPendingSessionList() {
 	p := m.pendingSessionList
 	m.pendingSessionList = pendingSessionListState{}
@@ -291,8 +286,7 @@ func buildSessionTabState(st *SessionTab, discovered []model.ResourceTypeEntry) 
 			if st.ResourceName != "" {
 				tab.nav.ResourceName = st.ResourceName
 			}
-			// Carry the saved list filter and cursor so switching to this
-			// lazily-loaded tab reopens it filtered and on the same row.
+			// Carry filter + cursor so this lazy tab reopens filtered and on its row.
 			tab.filterText = st.Filter
 			tab.filterBroadMode = st.FilterBroad
 			tab.cursorName, tab.cursorNamespace = sessionCursor(&SessionState{

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -239,9 +239,13 @@ func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) (Model, t
 			m.clearRight()
 			m.setCursor(0)
 			m.loading = true
+			// Land on the saved resource (deferred ResourceName) by name, then
+			// layer on the saved list filter and any cursor target that rode
+			// through discovery on pendingSessionList.
 			if name != "" {
 				m.pendingTarget = name
 			}
+			m.applyPendingSessionList()
 			return m, m.loadResources(false)
 		}
 	}
@@ -355,6 +359,36 @@ func (m Model) updateResourcesLoaded(msg resourcesLoadedMsg) (tea.Model, tea.Cmd
 	return mdl, cmd
 }
 
+// restoreCursorAfterLoad places the cursor once a resource list has loaded.
+// A pending session/bookmark target wins (matched against the visible list so a
+// restored filter that hides rows doesn't throw off the index; an optional
+// namespace disambiguates same-named rows in all-namespaces views). Otherwise
+// the previously-highlighted row is restored, preferring an exact cluster match
+// in union mode where names recur across clusters.
+func (m *Model) restoreCursorAfterLoad(prevName, prevNs, prevExtra, prevKind, prevCluster string) {
+	if m.pendingTarget != "" {
+		target, targetNs := m.pendingTarget, m.pendingTargetNamespace
+		for i, item := range m.visibleMiddleItems() {
+			if item.Name == target && (targetNs == "" || item.Namespace == targetNs) {
+				m.setCursor(i)
+				break
+			}
+		}
+		m.pendingTarget = ""
+		m.pendingTargetNamespace = ""
+		return
+	}
+	if m.unionMode && prevCluster != "" {
+		for i, item := range m.visibleMiddleItems() {
+			if item.Name == prevName && item.Namespace == prevNs && item.ClusterName == prevCluster {
+				m.setCursor(i)
+				return
+			}
+		}
+	}
+	m.restoreCursorToItem(prevName, prevNs, prevExtra, prevKind)
+}
+
 func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea.Cmd) {
 	msg.items = m.filterLoadedItemsBySelectedNamespaces(msg.items)
 	if len(msg.items) == 0 {
@@ -426,31 +460,7 @@ func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea
 	m.applyWarningEventsFilter()
 	m.applyEventGrouping()
 	m.reapplyFilterPreset()
-	if m.pendingTarget != "" {
-		for i, item := range m.middleItems {
-			if item.Name == m.pendingTarget {
-				m.setCursor(i)
-				break
-			}
-		}
-		m.pendingTarget = ""
-	} else if m.unionMode && prevCluster != "" {
-		// In union mode, prefer the exact cluster match to avoid jumping to
-		// the first alphabetical cluster when names are shared across clusters.
-		restored := false
-		for i, item := range m.visibleMiddleItems() {
-			if item.Name == prevName && item.Namespace == prevNs && item.ClusterName == prevCluster {
-				m.setCursor(i)
-				restored = true
-				break
-			}
-		}
-		if !restored {
-			m.restoreCursorToItem(prevName, prevNs, prevExtra, prevKind)
-		}
-	} else {
-		m.restoreCursorToItem(prevName, prevNs, prevExtra, prevKind)
-	}
+	m.restoreCursorAfterLoad(prevName, prevNs, prevExtra, prevKind, prevCluster)
 	// If this load originated from a watch-mode refresh, propagate the
 	// suppress flag to the downstream preview/metrics cmds so they too
 	// stay off the title-bar indicator. Capture the prior flag so the

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -368,14 +368,17 @@ func (m Model) updateResourcesLoaded(msg resourcesLoadedMsg) (tea.Model, tea.Cmd
 func (m *Model) restoreCursorAfterLoad(prevName, prevNs, prevExtra, prevKind, prevCluster string) {
 	if m.pendingTarget != "" {
 		target, targetNs := m.pendingTarget, m.pendingTargetNamespace
+		m.pendingTarget = ""
+		m.pendingTargetNamespace = ""
 		for i, item := range m.visibleMiddleItems() {
 			if item.Name == target && (targetNs == "" || item.Namespace == targetNs) {
 				m.setCursor(i)
-				break
+				return
 			}
 		}
-		m.pendingTarget = ""
-		m.pendingTargetNamespace = ""
+		// Target gone (deleted, or hidden by a restored filter): fall back to
+		// the prior row / clamp instead of leaving a stale pre-load index.
+		m.restoreCursorToItem(prevName, prevNs, prevExtra, prevKind)
 		return
 	}
 	if m.unionMode && prevCluster != "" {

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -239,9 +239,8 @@ func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) (Model, t
 			m.clearRight()
 			m.setCursor(0)
 			m.loading = true
-			// Land on the saved resource (deferred ResourceName) by name, then
-			// layer on the saved list filter and any cursor target that rode
-			// through discovery on pendingSessionList.
+			// Land on the deferred ResourceName, then apply the filter/cursor
+			// that rode through discovery on pendingSessionList.
 			if name != "" {
 				m.pendingTarget = name
 			}
@@ -359,12 +358,9 @@ func (m Model) updateResourcesLoaded(msg resourcesLoadedMsg) (tea.Model, tea.Cmd
 	return mdl, cmd
 }
 
-// restoreCursorAfterLoad places the cursor once a resource list has loaded.
-// A pending session/bookmark target wins (matched against the visible list so a
-// restored filter that hides rows doesn't throw off the index; an optional
-// namespace disambiguates same-named rows in all-namespaces views). Otherwise
-// the previously-highlighted row is restored, preferring an exact cluster match
-// in union mode where names recur across clusters.
+// restoreCursorAfterLoad places the cursor once a list has loaded: a pending
+// target (matched against the visible list, namespace-disambiguated) wins, else
+// the prior row, preferring the exact cluster in union mode.
 func (m *Model) restoreCursorAfterLoad(prevName, prevNs, prevExtra, prevKind, prevCluster string) {
 	if m.pendingTarget != "" {
 		target, targetNs := m.pendingTarget, m.pendingTargetNamespace
@@ -376,8 +372,8 @@ func (m *Model) restoreCursorAfterLoad(prevName, prevNs, prevExtra, prevKind, pr
 				return
 			}
 		}
-		// Target gone (deleted, or hidden by a restored filter): fall back to
-		// the prior row / clamp instead of leaving a stale pre-load index.
+		// Target gone (deleted or hidden by the restored filter): fall back to
+		// the prior row instead of a stale pre-load index.
 		m.restoreCursorToItem(prevName, prevNs, prevExtra, prevKind)
 		return
 	}


### PR DESCRIPTION
## Summary

On quit, LFK already restores the context / namespace / resource type per tab. This PR extends restore to the active list filter and the highlighted row, so reopening lands on the exact resource you were looking at.

## Type of change

- [x] feat: new user-facing feature

## Changes

- Persist the active filter (text + `Tab` broad-match mode) and the cursor (name + namespace) per tab, only when the tab sits on a resource list.
- Reapply filter and cursor when the restore descends to the list (immediate path and after a deferred CRD discovery resolves).
- Match the cursor against the visible (filtered) list, disambiguated by namespace — also fixes a stale index when a filter hides rows.
- Persist `filterBroadMode` in `TabState` (now survives tab switches too).

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (only a pre-existing `prealloc` warning out of scope remains)
- [x] Manually verified against a real cluster

## Checklist

- [x] Commits follow conventional commit style
- [x] README / `docs/` updated when user-visible behavior or config changed