### PR TITLE
fix: handle discarded GetContexts errors in navigation

### DIFF
--- a/internal/app/jump_history.go
+++ b/internal/app/jump_history.go
@@ -148,7 +148,12 @@ func (m *Model) restoreNavSnapshot(snap navSnapshot) tea.Cmd {
 			ui.ActiveLeftScroll = 0
 			m.clearRight()
 			m.clearSelection()
-			contexts, _ := m.client.GetContexts()
+			// Repopulate the cluster picker. On error keep the fallback flow
+			// (empty list) but surface the read failure rather than dropping it.
+			contexts, err := m.client.GetContexts()
+			if err != nil {
+				m.setErrorFromErr("Failed to load contexts: ", err)
+			}
 			m.leftItems = nil
 			m.setMiddleItems(contexts)
 			m.cursors = [5]int{}

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -583,8 +583,13 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 		// (maybeProbeSecurityOnFocus): on Security focus, not on every restore.
 		securitySeedCmd := m.refreshSecuritySources()
 
-		// Load contexts for the left column breadcrumb.
-		contexts, _ := m.client.GetContexts()
+		// Load contexts for the left column breadcrumb. A failure is
+		// non-fatal here (the breadcrumb just degrades to empty), but
+		// surface it so the read error is not swallowed silently.
+		contexts, err := m.client.GetContexts()
+		if err != nil {
+			m.setErrorFromErr("Failed to load contexts: ", err)
+		}
 		resourceTypes := model.BuildSidebarItems(model.SeedResources())
 		discoveryCtx := m.nav.Context
 		if m.unionMode && m.nav.Context == UnionContextSentinel && len(m.unionContexts) > 0 {

--- a/internal/app/tabs_portforward.go
+++ b/internal/app/tabs_portforward.go
@@ -49,11 +49,18 @@ func (m *Model) portForwardItems() []model.Item {
 // navigateToPortForwards switches the view to the Port Forwards resource list.
 // If pfLastCreatedID is set, the cursor is placed on the matching entry.
 func (m *Model) navigateToPortForwards() {
+	// Build the correct left column state for LevelResources. Fetch the
+	// contexts before mutating any state so a failure aborts the teleport
+	// cleanly instead of leaving navigation half-updated.
+	contexts, err := m.client.GetContexts()
+	if err != nil {
+		m.setErrorFromErr("Failed to load contexts: ", err)
+		return
+	}
+
 	// Record the origin so jump_back can return here after this teleport.
 	m.pushJumpHistory()
 
-	// Build the correct left column state for LevelResources.
-	contexts, _ := m.client.GetContexts()
 	var resourceTypes []model.Item
 	discoveryCtx := m.nav.Context
 	if m.isUnionSentinel() && len(m.unionContexts) > 0 {


### PR DESCRIPTION
## Summary

Three navigation paths called `m.client.GetContexts()` and discarded the
error (`contexts, _ := ...`), so a failed kube-context read silently left
navigation state partially built. Flagged by CodeRabbit on #476; the lines
are pre-existing (one was relocated in #476). Fixed each site per its context,
in three focused commits.

## Changes

- **`loadTab` (`tabs.go`)** — breadcrumb rebuild is non-critical: keep loading
  the tab, but surface the error instead of swallowing it.
- **`navigateToPortForwards` (`tabs_portforward.go`)** — fetch contexts before
  any state mutation and abort the teleport with a surfaced error, so a failed
  read can't leave the view half-navigated (also avoids a stray jump-history entry).
- **`restoreNavSnapshot` (`jump_history.go`)** — in the "jump target no longer
  available" cluster fallback, keep the fallback flow but report a failed read
  rather than leaving an empty picker.

All three report via the existing `setErrorFromErr` (status bar + error log).

## Testing

- [x] `go build ./...`
- [x] `go test -race ./...` (23 packages)
- [x] `golangci-lint run` — 0 issues

No unit tests for the error path: `Model.client` is a concrete `*k8s.Client`
(not an interface), so injecting a failing `GetContexts` would require a wider
refactor. Happy-path behaviour is unchanged and remains covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)