### PR TITLE
fix: land cursor on jumped-to resource type after goto back-nav

### DIFF
--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -104,6 +104,7 @@ func (m Model) gotoResourceType(kind, apiGroup string) (tea.Model, tea.Cmd) {
 	m.applyResourceTypeSortDefault(m.nav.ResourceType, m.nav.Context)
 	m.nav.Level = model.LevelResources
 	m.normalizeGotoPanes()
+	m.primeTypesReturnCursor(rt)
 	m.saveCurrentSession()
 	if cached, hit := m.itemCache[m.navKey()]; hit {
 		m.setMiddleItems(cached)
@@ -141,6 +142,40 @@ func (m *Model) normalizeGotoPanes() {
 	m.leftItemsHistory = clusterHistory
 	m.leftItems = typesItems
 	m.clearRight()
+}
+
+// primeTypesReturnCursor records the parent (LevelResourceTypes) cursor so that
+// pressing h/left from the jumped-to resource list lands on the resource type we
+// jumped to. A goto never moves the types-list cursor onto the target the way a
+// manual descent does, so restoreCursor would otherwise recall a stale highlight.
+// The index is computed through the real collapse logic (visibleMiddleItems) on a
+// throwaway copy positioned at LevelResourceTypes, and the target's group is
+// expanded so the recorded index and the restored view agree. Must run after
+// normalizeGotoPanes (which populates leftItems) and after saveCursor.
+func (m *Model) primeTypesReturnCursor(rt model.ResourceTypeEntry) {
+	ref := rt.ResourceRef()
+	if ref == "" || ref == "//" {
+		return
+	}
+	// Expand the target's group so it renders as a real (non-collapsed) row.
+	for _, it := range m.leftItems {
+		if it.Extra == ref {
+			if it.Category != "" {
+				m.expandedGroup = it.Category
+			}
+			break
+		}
+	}
+	probe := *m
+	probe.nav.Level = model.LevelResourceTypes
+	probe.nav.ResourceType = model.ResourceTypeEntry{}
+	probe.middleItems = m.leftItems
+	probe.filterText = ""
+	idx := indexByExtra(probe.visibleMiddleItems(), ref)
+	if idx < 0 {
+		return
+	}
+	m.cursorMemory[probe.navKey()] = idx
 }
 
 // handleGotoChord is called while the g prefix is armed (m.pendingG). The

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -253,3 +253,39 @@ func TestGotoResourceType_LeftPaneIsResourceTypes(t *testing.T) {
 		t.Fatalf("left pane does not hold resource-type items after goto; kinds=%v", kinds)
 	}
 }
+
+// TestGotoResourceType_BackNavLandsOnJumpedType verifies that after jumping to a
+// resource type via goto (gv) and pressing h/left to go back, the cursor lands on
+// the resource type that was jumped to rather than a stale or default highlight.
+func TestGotoResourceType_BackNavLandsOnJumpedType(t *testing.T) {
+	m := gotoTestModel() // LevelResourceTypes, ctx with Pod + Deployment
+	// Seed the types list as the middle column with the cursor on the first
+	// item (Pods), simulating a real session before the jump.
+	typesItems := model.BuildSidebarItems(m.discoveredResources["ctx"])
+	m.setMiddleItems(typesItems)
+	m.setCursor(0)
+
+	// Jump to Deployment (gv -> Deployment).
+	out, _ := m.gotoResourceType("Deployment", "apps")
+	m = out.(Model)
+	if m.nav.Level != model.LevelResources {
+		t.Fatalf("nav.Level = %v, want LevelResources", m.nav.Level)
+	}
+
+	// Press h/left to return to the resource-types list.
+	out, _ = m.navigateParent()
+	rm := out.(Model)
+	if rm.nav.Level != model.LevelResourceTypes {
+		t.Fatalf("nav.Level = %v, want LevelResourceTypes after back-nav", rm.nav.Level)
+	}
+
+	visible := rm.visibleMiddleItems()
+	c := rm.cursor()
+	if c < 0 || c >= len(visible) {
+		t.Fatalf("cursor %d out of range (visible=%d)", c, len(visible))
+	}
+	want := model.ResourceTypeEntry{Kind: "Deployment", APIGroup: "apps", APIVersion: "v1", Resource: "deployments"}
+	if got := visible[c]; got.Extra != want.ResourceRef() {
+		t.Fatalf("cursor landed on %q (%s), want Deployment (%s)", got.Name, got.Extra, want.ResourceRef())
+	}
+}


### PR DESCRIPTION
## Summary

Jumping to a list resource type via goto (`gv` → e.g. PVCs) and then pressing `h`/left to go back left the cursor on a stale entry in the resource-types list instead of on the type that was jumped to.

**Root cause:** A manual descent (`navigateChildResourceType`) calls `saveCursor()` while the cursor sits on the target type, so `restoreCursor()` lands correctly on back-nav. A goto jump never moves the types-list cursor onto the target — it sets `nav.ResourceType` directly and rebuilds the left pane — so `cursorMemory[context]` still held a stale index, and `navigateParent` restored that wrong position.

**Fix:** New `primeTypesReturnCursor(rt)`, called right after `normalizeGotoPanes()` in `gotoResourceType`. It:
- expands the target's accordion group so the type renders as a real row,
- computes the target's index through the real `visibleMiddleItems()` collapse logic on a throwaway model copy positioned at `LevelResourceTypes` (no duplicated collapse logic),
- writes that index into `cursorMemory` under the types-level key.

On back-nav the existing `restoreCursor()` + `syncExpandedGroup()` now agree and land on the jumped-to type. No new persistent state, so no `tabs.go` cloning changes.

## Test plan

- [x] Added `TestGotoResourceType_BackNavLandsOnJumpedType` (red before fix, green after)
- [x] `go test ./internal/app/ -race` passes
- [x] `go build ./...` clean
- [x] `golangci-lint run ./internal/app/...` — 0 issues
- [x] `go vet` clean