### PR TITLE
feat: add quick filter presets for PersistentVolumes

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -507,7 +507,8 @@ custom_actions:
 #
 # Built-in presets vary by kind. Pod: Failing/Pending/Not Ready/Restarting/
 # High Restarts/Not Running. Deployment/StatefulSet/DaemonSet: Not Ready/
-# Failing/Not Running. Job: Failed/Not Running. PVC: Pending/Lost/Not Bound.
+# Failing/Not Running. Job: Failed/Not Running. PV: Available/Released/Failed/
+# Not Bound. PVC: Pending/Lost/Not Bound.
 # Universal presets (Old, Recent) are always shown. Your custom presets appear
 # after the built-ins.
 filter_presets:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -785,6 +785,7 @@ Press `.` on any resource list to see the presets available for that kind. The b
 | Pod | Failing (`f`), Pending (`p`), Not Ready (`n`), Restarting (`r`), High Restarts (`R`), **Not Running (`x`)** |
 | Deployment / StatefulSet / DaemonSet | Not Ready (`n`), Failing (`f`), **Not Running (`x`)** |
 | Job | Failed (`f`), **Not Running (`x`)** |
+| PersistentVolume | Available (`a`), Released (`r`), Failed (`f`), **Not Bound (`x`)** |
 | PersistentVolumeClaim | Pending (`p`), Lost (`l`), **Not Bound (`x`)** |
 | Node | Not Ready (`n`), Cordoned (`c`) |
 | Certificate / CertificateRequest | Not Ready (`n`), Expiring Soon (`e`) |

--- a/internal/app/filters.go
+++ b/internal/app/filters.go
@@ -98,6 +98,8 @@ func kindFilterPresets(kind string) []FilterPreset {
 		return argoFilterPresets()
 	case "HelmRelease", "Kustomization":
 		return fluxFilterPresets()
+	case "PersistentVolume":
+		return pvFilterPresets()
 	case "PersistentVolumeClaim":
 		return pvcFilterPresets()
 	case "Event":
@@ -295,6 +297,29 @@ func fluxFilterPresets() []FilterPreset {
 			MatchFn: func(item model.Item) bool {
 				s := strings.ToLower(item.Status)
 				return s != "ready" && s != "applied" && !strings.Contains(s, "suspended")
+			},
+		},
+	}
+}
+
+func pvFilterPresets() []FilterPreset {
+	return []FilterPreset{
+		{
+			Name: "Available", Description: "Unbound, ready to be claimed", Key: "a",
+			MatchFn: func(item model.Item) bool { return strings.EqualFold(item.Status, "available") },
+		},
+		{
+			Name: "Released", Description: "Claim deleted, awaiting reclaim", Key: "r",
+			MatchFn: func(item model.Item) bool { return strings.EqualFold(item.Status, "released") },
+		},
+		{
+			Name: "Failed", Description: "Reclaim failed", Key: "f",
+			MatchFn: func(item model.Item) bool { return strings.EqualFold(item.Status, "failed") },
+		},
+		{
+			Name: "Not Bound", Description: "Phase != Bound", Key: notRunningKey,
+			MatchFn: func(item model.Item) bool {
+				return item.Status != "" && !strings.EqualFold(item.Status, "Bound")
 			},
 		},
 	}

--- a/internal/app/filters_test.go
+++ b/internal/app/filters_test.go
@@ -87,6 +87,44 @@ func TestBuiltinFilterPresets_EventSpecific(t *testing.T) {
 	}
 }
 
+func TestBuiltinFilterPresets_PVSpecific(t *testing.T) {
+	presets := builtinFilterPresets("PersistentVolume")
+	names := presetNames(presets)
+
+	expected := []string{"Available", "Released", "Failed", "Not Bound"}
+	for _, name := range expected {
+		if !names[name] {
+			t.Errorf("PersistentVolume presets missing %q", name)
+		}
+	}
+}
+
+func TestCovFilterPresetsPVPhases(t *testing.T) {
+	presets := builtinFilterPresets("PersistentVolume")
+
+	available := findPreset(presets, "Available")
+	require.NotNil(t, available)
+	assert.True(t, available.MatchFn(model.Item{Status: "Available"}))
+	assert.False(t, available.MatchFn(model.Item{Status: "Bound"}))
+
+	released := findPreset(presets, "Released")
+	require.NotNil(t, released)
+	assert.True(t, released.MatchFn(model.Item{Status: "Released"}))
+	assert.False(t, released.MatchFn(model.Item{Status: "Bound"}))
+
+	failed := findPreset(presets, "Failed")
+	require.NotNil(t, failed)
+	assert.True(t, failed.MatchFn(model.Item{Status: "Failed"}))
+	assert.False(t, failed.MatchFn(model.Item{Status: "Available"}))
+
+	notBound := findPreset(presets, "Not Bound")
+	require.NotNil(t, notBound)
+	assert.True(t, notBound.MatchFn(model.Item{Status: "Available"}))
+	assert.True(t, notBound.MatchFn(model.Item{Status: "Released"}))
+	assert.False(t, notBound.MatchFn(model.Item{Status: "Bound"}))
+	assert.False(t, notBound.MatchFn(model.Item{Status: ""}))
+}
+
 func TestBuiltinFilterPresets_UnknownKind(t *testing.T) {
 	presets := builtinFilterPresets("SomeCustomCRD")
 	// Should only have universal presets.
@@ -99,7 +137,7 @@ func TestBuiltinFilterPresets_UniqueKeys(t *testing.T) {
 	kinds := []string{
 		"Pod", "Deployment", "Node", "Job", "CronJob", "Service",
 		"Certificate", "Application", "HelmRelease", "Kustomization",
-		"PersistentVolumeClaim", "Event", "StatefulSet", "DaemonSet",
+		"PersistentVolume", "PersistentVolumeClaim", "Event", "StatefulSet", "DaemonSet",
 	}
 
 	for _, kind := range kinds {


### PR DESCRIPTION
## Summary

PersistentVolume lists had no kind-specific quick filters (the `.` preset overlay) — they fell through to only the universal `Old`/`Recent` presets. PVCs already had presets (`Pending`/`Lost`/`Not Bound`); PVs did not.

Adds `pvFilterPresets()` with status-based presets, mirroring the PVC pattern and reusing the shared `x` "not healthy" mnemonic. PV `item.Status` carries the phase, so these match directly:

| Preset | Key | Matches |
|---|---|---|
| Available | `a` | phase == Available (unbound, ready to claim) |
| Released | `r` | phase == Released (claim deleted, awaiting reclaim) |
| Failed | `f` | phase == Failed (reclaim failed) |
| Not Bound | `x` | phase != Bound |

## Changes

- `internal/app/filters.go`: new `pvFilterPresets()`, wired into `kindFilterPresets` for `PersistentVolume`.
- Docs: built-in presets table in `docs/config-reference.md` and the enumeration comment in `docs/config-example.yaml`.

## Test plan

- [x] Added `TestBuiltinFilterPresets_PVSpecific` and `TestCovFilterPresetsPVPhases` (red before, green after)
- [x] Added `PersistentVolume` to the unique-keys guard test
- [x] `go test ./internal/app/ -race` passes
- [x] `go build ./...` clean
- [x] `golangci-lint run ./internal/app/...` — 0 issues
- [x] `go vet` clean