### PR TITLE
feat(ui): color printer-column values by status semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **Configurable table columns** (global, per-resource-type, and per-cluster)
 - **Column visibility toggle** overlay to show/hide and reorder columns at runtime (`,` key)
 - **Startup tips**: Random tips on startup to help discover features (configurable via `tips: false`)
-- **Status-aware coloring**: Running=green, Pending=yellow, Failed=red
+- **Status-aware coloring**: Running=green, Pending=yellow, Failed=red — also applied to CRD printer-column values: recognized status words (Active, Failed, Pending, ...) get their severity color, and True/False values follow the column's polarity (Established=False red, Failed=False green)
 - **Resource usage metrics**: CPU/MEM with color-coded bars in dashboard
 
 ## Installation

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -369,8 +369,44 @@ func resourceColumnStyle(key, val string) lipgloss.Style {
 			return StatusFailed // red: disabled
 		}
 	default:
+		return extraColumnValueStyle(key, val)
+	}
+}
+
+// extraColumnValueStyle colors low-cardinality printer/extra column values:
+// boolean values follow the column name's condition polarity (Established/False
+// is a problem, Failed/False is healthy), recognized status words reuse the
+// shared status severity colors. Everything else stays dim.
+func extraColumnValueStyle(key, val string) lipgloss.Style {
+	if canonical, ok := canonicalBoolStatus(val); ok {
+		// ALLCAPS headers would tokenize letter-by-letter in the polarity
+		// heuristic; lowercase them so "ESTABLISHED" matches like "Established".
+		if key == strings.ToUpper(key) {
+			key = strings.ToLower(key)
+		}
+		return ConditionStyle(key, canonical)
+	}
+	switch statusSeverity(val) {
+	case sevRunning, sevDone, sevProgressing, sevFailed:
+		return StatusStyle(val)
+	default:
 		return DimStyle
 	}
+}
+
+// canonicalBoolStatus normalizes boolean-ish column values to condition-status
+// casing. CRD printer columns of type boolean render lowercase ("true"), while
+// condition-backed JSONPath columns yield "True"/"False"/"Unknown".
+func canonicalBoolStatus(val string) (string, bool) {
+	switch {
+	case strings.EqualFold(val, "true"):
+		return "True", true
+	case strings.EqualFold(val, "false"):
+		return "False", true
+	case strings.EqualFold(val, "unknown"):
+		return "Unknown", true
+	}
+	return "", false
 }
 
 // severityColumnStyle returns the lipgloss.Style that paints the

--- a/internal/ui/explorer_format_test.go
+++ b/internal/ui/explorer_format_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -186,6 +187,62 @@ func TestResourceColumnStyle(t *testing.T) {
 			// Verify the style can render without panicking.
 			rendered := style.Render("test")
 			assert.NotEmpty(t, rendered)
+		})
+	}
+}
+
+// TestResourceColumnStyle_ValueBased covers issue #488: printer/extra columns
+// with low-cardinality values (State: Active/Inactive, Established: True/False)
+// are colored semantically instead of always rendering dim.
+func TestResourceColumnStyle_ValueBased(t *testing.T) {
+	origProfile := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() { lipgloss.DefaultRenderer().SetColorProfile(origProfile) })
+	lipgloss.DefaultRenderer().SetColorProfile(termenv.ANSI256)
+
+	fgKey := func(s lipgloss.Style) string {
+		fg := s.GetForeground()
+		r, g, b, a := fg.RGBA()
+		return fmt.Sprintf("%d:%d:%d:%d", r, g, b, a)
+	}
+	red := fgKey(StatusFailed)
+	green := fgKey(StatusRunning)
+	blue := fgKey(StatusProgressing)
+	dim := fgKey(DimStyle)
+
+	tests := []struct {
+		key  string
+		val  string
+		want string
+		desc string
+	}{
+		// Boolean-ish values follow the column name's polarity, like conditions.
+		{"Established", "True", green, "ready-polarity column, True = healthy"},
+		{"Established", "False", red, "ready-polarity column, False = problem"},
+		{"established", "true", green, "case-insensitive boolean"},
+		{"ESTABLISHED", "FALSE", red, "case-insensitive boolean"},
+		{"Failed", "True", red, "error-polarity column, True = problem"},
+		{"Failed", "False", green, "error-polarity column, False = healthy"},
+		{"Suspend", "True", blue, "info-polarity column, True = active"},
+		{"Suspend", "False", dim, "info-polarity column, False = neutral"},
+		{"Ready", "Unknown", dim, "unknown is neutral"},
+
+		// Word values reuse the status severity classification.
+		{"State", "Active", green, "known-good status word"},
+		{"State", "Established", green, "established = healthy"},
+		{"State", "Failed", red, "known-bad status word"},
+		{"State", "Pending", blue, "progressing status word"},
+		{"State", "Inactive", dim, "unclassified word stays dim"},
+
+		// Arbitrary values stay dim.
+		{"Node", "node-1", dim, "arbitrary text stays dim"},
+		{"Class", "default", dim, "literal default is not a status"},
+		{"Replicas", "3", dim, "numbers stay dim"},
+		{"Host", "", dim, "empty stays dim"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key+"/"+tt.val, func(t *testing.T) {
+			got := fgKey(resourceColumnStyle(tt.key, tt.val))
+			assert.Equal(t, tt.want, got, "%s=%q: %s", tt.key, tt.val, tt.desc)
 		})
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -453,7 +453,8 @@ func statusSeverity(status string) statusSev {
 	case "Running", "Active", "Bound", "Available", "Ready",
 		"Healthy", "Healthy/Synced", "Synced",
 		"Deployed",
-		"SecretSynced", "Created", "Updated", "Valid":
+		"SecretSynced", "Created", "Updated", "Valid",
+		"Established":
 		return sevRunning
 	case "Succeeded", "Completed",
 		"Superseded":

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -151,6 +151,16 @@ func TestConditionStyle(t *testing.T) {
 	}
 }
 
+// --- statusSeverity: Established ---
+
+// "Established" is the healthy terminal state of a CRD (Established: True
+// condition), so it must classify as running-green in the built-in Status
+// column and rank as healthy in status rollups.
+func TestStatusSeverity_Established(t *testing.T) {
+	assert.Equal(t, sevRunning, statusSeverity("Established"))
+	assert.Equal(t, StatusSeverityRank("Running"), StatusSeverityRank("Established"))
+}
+
 // --- FillLinesBg ---
 
 // TestFillLinesBgReestablishesBgAfterShortReset guards issue #293's recurrence


### PR DESCRIPTION
## Summary
- Printer/extra columns (CRD `additionalPrinterColumns`, custom JSONPath columns) previously always rendered dim. Their values are now colored semantically: boolean values follow the column name's condition polarity via the existing `ConditionStyle` heuristic (`Established=False` red, `Failed=False` green, info-polarity `True` blue), and recognized status words reuse the shared `statusSeverity` colors (`Active` green, `Pending` blue, `Failed` red). Unrecognized values stay dim, so arbitrary text/numeric columns are unaffected.
- The literal `Established` status (a CRD's `Established: True` condition surfaced as item status) now classifies as healthy in the built-in Status column and status rollups instead of falling into the unknown bucket.
- ALLCAPS column headers are normalized before the polarity lookup so `ESTABLISHED` matches like `Established`.

Design note: `Inactive` intentionally stays dim rather than getting a distinct color — for resources like Crossplane MRDs it is a normal state, not a failure, and in a k8s TUI colors carry health semantics. Active-green vs Inactive-dim still makes rows visually scannable, which is what the issue asks for.

Styling remains a pure function of column name + value, so the cached row renderer needs no fingerprint changes, and no-color/theme variants come free by reusing the existing `Status*` styles.

Closes #488

## Test plan
- [x] TDD: `TestResourceColumnStyle_ValueBased` (19 cases: polarity, case-insensitivity, ALLCAPS keys, neutral/arbitrary values) written first and observed failing
- [x] `TestStatusSeverity_Established` pins the built-in Status column / rollup rank change
- [x] `go build ./...`, `go test ./...` (one unrelated flaky `internal/k8s` port-forward test passes on rerun and on a clean tree), `go test -race` on `internal/ui` + `internal/app`, `golangci-lint`: all green