### PR TITLE
ci(codeql): sync analyze pin to 4.36.3 to match init

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: docker
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,6 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

Every CodeQL run has been failing since ~10:38Z today (on `main` and all open PRs) with:

\`\`\`
##[error]Loaded a configuration file for version '4.36.3', but running version '4.36.2'
CodeQL job status was configuration error.
\`\`\`

Dependabot bumped the CodeQL sub-actions in **separate** PRs and only two landed:

| Step | File | Version |
|---|---|---|
| \`codeql-action/init\` | codeql.yml | 4.36.3 (#496) |
| \`codeql-action/analyze\` | codeql.yml | **4.36.2** (left behind) |
| \`codeql-action/upload-sarif\` | scorecard.yml | 4.36.3 (#494) |

\`init\` writes a config stamped 4.36.3 that the older \`analyze\` (4.36.2) rejects. \`init\` and \`analyze\` must run the same version.

## Fix

1. Bump \`analyze\` to the same SHA as \`init\` (\`54f647b7…\` = v4.36.3) to unbreak CI.
2. Add a Dependabot \`groups\` rule so all \`github/codeql-action/*\` sub-actions bump together in one PR, preventing this split-version drift from recurring.

## Test plan

- [ ] CodeQL \`Analyze (go)\` and \`Analyze (actions)\` pass on this PR