### PR TITLE
feat: single-field copy picker (ctrl+y)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **Resource templates**: Create resources from 25+ built-in templates (`a`, `/` to search); includes a Custom Resource template as a starting point
 - **Port forwarding** from the action menu (with local port setting and browser open); manage active forwards via the Networking group
 - **Network policy visualizer**: Visualize a NetworkPolicy's ingress/egress rules (`x` → `N` on a NetworkPolicy), or list every policy affecting a Pod or Service (`x` → "Network Policies" on the resource) — including which backing pods a policy covers. Supports CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy (entities, FQDNs, deny rules, L7 indicators) when the Cilium CRDs are installed. The dialog scrolls with the mouse wheel and is searchable (`/`, `n`/`N`)
-- **Clipboard support**: Copy resource name (`y`), open copy-as picker (`Y`: YAML / JSON / Table), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
+- **Clipboard support**: Copy resource name (`y`), open copy-as picker (`Y`: YAML / JSON / Table), copy a single field via a filterable picker (`Ctrl+Y`: visible columns by default, `Tab` for all manifest fields — e.g. a node's external IP), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
 - **Bookmarks**: Save favorite resource paths (including the active list filter) for quick navigation
 - **Orphan detection**: Press `Shift+Z` (or run bare `:orphans`) to open the cluster-wide orphan overview across 11 kinds — Pods, Secrets, ConfigMaps, Services, PVCs, HPAs, PDBs, NetworkPolicies, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings. Per-list filters are still available via the filter-preset overlay (`.`) on each kind, or jump straight to a filtered view with `:orphans <kind>` (e.g., `:orphans secrets`). A strict / lenient toggle (`s`) flips between "truly unused" and "currently idle but referenced by workload templates" (e.g. CronJob between firings). Auto-excludes Helm release Secrets, ServiceAccount tokens, owner-managed resources, and `kube-root-ca.crt`.
 - **Session persistence**: Remembers last context/namespace/resource, the active list filter, and the highlighted row across restarts
@@ -300,6 +300,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `v` | Describe resource |
 | `D` / `X` | Delete / force delete |
 | `y` / `Y` | Copy name / open copy-as picker (YAML / JSON / Table) |
+| `Ctrl+Y` | Copy a single field (columns by default, `Tab` for all manifest fields; works with multi-selection) |
 | `Space` | Toggle multi-selection (bulk actions via `x`) |
 | `m<slot>` / `'<slot>` | Set / jump to bookmark (lowercase = context-aware, uppercase = context-free) |
 | `t` / `]` / `[` | New tab / next / previous |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -434,6 +434,7 @@
         "open_browser": { "type": "string" },
         "copy_name": { "type": "string" },
         "copy_yaml": { "type": "string" },
+        "copy_field": { "type": "string" },
         "paste_apply": { "type": "string" },
         "diff": { "type": "string" },
         "toggle_select": { "type": "string" },

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -201,9 +201,10 @@ Resource-specific actions (exec, scale, restart, secret editor, etc.) are availa
 |---|---|
 | `y` | Copy resource name to clipboard (with multi-selection: newline-joined names of all selected items) |
 | `Y` | Open copy-as picker (YAML / JSON / Table). YAML/JSON support multi-selection (multi-doc YAML joined with `---`, JSON array). Table is a kubectl-style aligned plain-text view of the displayed columns. At LevelClusters and LevelResourceTypes only Table is offered. At LevelContainers, YAML and JSON extract the container spec block from the Pod manifest. |
+| `Ctrl+Y` | Copy a single field. Opens instantly on the visible table columns (Name, Status, extras...) — `Enter` copies the cell value. `Tab` switches to the full manifest field list, where array elements are labeled semantically (`status.addresses[ExternalIP].address` for a node's external IP) so filtering `ExternalIP` finds the address row. With multi-selection the chosen column/field is extracted from every selected item, one value per line; labeled array elements resolve per manifest (not by index), and items missing the field are skipped. Remembers the last-copied entry per resource kind for the session and preselects it next time. |
 | `Ctrl+P` | Apply resource from clipboard (`kubectl apply`) |
 
-When items are multi-selected (`Space` / `Ctrl+Space` / `Ctrl+A`), `y` and `Y` operate on the selection rather than the cursor row — mirroring the precedence used by `D` (delete) and other bulk actions. `Y` is capped at 50 manifests per copy (client-go's default rate limiter serializes the per-item fetches).
+When items are multi-selected (`Space` / `Ctrl+Space` / `Ctrl+A`), `y`, `Y`, and `Ctrl+Y` operate on the selection rather than the cursor row — mirroring the precedence used by `D` (delete) and other bulk actions. `Y` and `Ctrl+Y` are capped at 50 manifests per copy (client-go's default rate limiter serializes the per-item fetches).
 
 ## Multi-Selection
 
@@ -1144,6 +1145,7 @@ keybindings:
   create_template: "a"   # Create from template
   copy_name: "y"         # Copy name
   copy_yaml: "Y"         # Open copy-as picker (YAML / JSON / Table)
+  copy_field: "ctrl+y"   # Copy a single manifest field (filterable picker)
   paste_apply: "ctrl+p"  # Apply from clipboard
   open_browser: "ctrl+o" # Open in browser
   diff: "d"              # Diff resources

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -112,18 +112,18 @@ type Model struct {
 	// Current view mode.
 	mode viewMode
 
-	overlay          overlayKind  // active overlay kind (see overlayKind enum)
-	overlayItems     []model.Item // full list (e.g., all namespaces)
-	overlayFilter    TextInput    // typed filter text
-	overlayCursor    int
-	copyFormatPicker copyFormatPickerState // Y-key copy-as picker — see openCopyFormatPicker
+	overlay             overlayKind  // active overlay kind (see overlayKind enum)
+	overlayItems        []model.Item // full list (e.g., all namespaces)
+	overlayFilter       TextInput    // typed filter text
+	overlayCursor       int
+	copyFormatPicker    copyFormatPickerState      // Y-key copy-as picker — see openCopyFormatPicker
+	copyFieldPicker     copyFieldPickerState       // ctrl+y field picker — see updateCopyFieldManifests
+	lastCopyFieldByKind map[string]copyFieldMemory // last entry copied per kind (ctrl+y preselect; session-only, all tabs)
 
-	// Namespace (not a navigation level; displayed in top-right).
-	namespace string
+	namespace string // current namespace (not a navigation level; displayed in top-right)
 
 	// Terminal dimensions.
-	width  int
-	height int
+	width, height int
 
 	// Error to display.
 	err error

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -85,6 +85,7 @@ const (
 	overlayLocalClusters      // local-cluster manager (Ctrl+N at LevelClusters)
 	overlayTrafficCapture     // per-pod live packet capture (action menu key c)
 	overlayCopyFormat         // Y-key copy-as picker (YAML / JSON / Table)
+	overlayCopyField          // ctrl+y single-field copy picker
 	overlayShuttingDown       // non-interactive "graceful shutdown in progress" notice
 	overlayObjectExplorerFind // recursive key search over the object (r key)
 	overlayLogTopGroupBy      // multi-select group-by field picker for Log Top

--- a/internal/app/copy_field_dispatch_test.go
+++ b/internal/app/copy_field_dispatch_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func TestDefaultKeybindings_CopyFieldIsCtrlY(t *testing.T) {
+	assert.Equal(t, "ctrl+y", ui.DefaultKeybindings().CopyField)
+}
+
+func TestHandleExplorerActionKeyCopyField_NoItemsIsNoOp(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.middleItems = nil
+	mdl, cmd, handled := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	assert.True(t, handled)
+	assert.Nil(t, cmd)
+	assert.False(t, res.copyFieldPicker.active)
+}
+
+func TestHandleExplorerActionKeyCopyField_BulkCapDegradesToColumnsOnly(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.middleItems = make([]model.Item, maxBulkYAMLCopy+1)
+	m.selectedItems = map[string]bool{}
+	for i := range m.middleItems {
+		m.middleItems[i].Name = string(rune('a' + i%26))
+		m.middleItems[i].Namespace = "ns" + string(rune('0'+i/26))
+		m.selectedItems[selectionKey(m.middleItems[i])] = true
+	}
+	mdl, cmd, handled := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	assert.True(t, handled)
+	assert.Nil(t, cmd, "no manifest fetch above the cap")
+	require.True(t, res.copyFieldPicker.active, "columns mode still works for any count")
+	assert.True(t, res.copyFieldPicker.fieldsLoaded)
+	assert.Contains(t, res.copyFieldPicker.fieldsErr, "Max")
+}
+
+func TestHandleExplorerActionKeyCopyField_DispatchesBackgroundFetch(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Node"}
+	m.middleItems = []model.Item{{Name: "worker-1"}}
+	m.setCursor(0)
+	mdl, cmd, handled := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	assert.True(t, handled)
+	require.NotNil(t, cmd, "a fetch command is dispatched")
+	assert.True(t, res.copyFieldPicker.active, "picker opens without waiting for the fetch")
+	assert.Equal(t, "Node", res.copyFieldPicker.kind)
+}
+
+func TestWrapYAMLCmdForCopyField_ParsesDocs(t *testing.T) {
+	inner := func() tea.Msg {
+		return yamlClipboardMsg{content: "kind: Node\nmetadata:\n  name: a\n---\nkind: Node\nmetadata:\n  name: b\n", count: 2}
+	}
+	msg := wrapYAMLCmdForCopyField(inner, 2, 7)()
+	fm, ok := msg.(copyFieldManifestsMsg)
+	require.True(t, ok)
+	assert.Len(t, fm.docs, 2)
+	assert.Equal(t, 2, fm.requested)
+	assert.Equal(t, 7, fm.seq)
+	assert.NoError(t, fm.err)
+}
+
+func TestWrapYAMLCmdForCopyField_PassesThroughErrors(t *testing.T) {
+	inner := func() tea.Msg {
+		return yamlClipboardMsg{err: errors.New("rbac denied")}
+	}
+	msg := wrapYAMLCmdForCopyField(inner, 1, 1)()
+	fm, ok := msg.(copyFieldManifestsMsg)
+	require.True(t, ok)
+	assert.Empty(t, fm.docs)
+	assert.Error(t, fm.err)
+}
+
+func TestWrapYAMLCmdForCopyField_NonClipboardMsgPassesThrough(t *testing.T) {
+	inner := func() tea.Msg { return nil }
+	msg := wrapYAMLCmdForCopyField(inner, 1, 1)()
+	assert.Nil(t, msg)
+}

--- a/internal/app/copy_field_flatten.go
+++ b/internal/app/copy_field_flatten.go
@@ -1,0 +1,291 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// maxCopyFieldEntries caps the flattened field list so a pathological
+// object cannot produce an unbounded row list (mirrors
+// model.DefaultObjectTreeRowLimit).
+const maxCopyFieldEntries = 10000
+
+// copyFieldSeg is one segment of a field path. Map segments carry the
+// key; array segments carry "[i]" plus — when the element is a map
+// with a unique discriminator (name/id/key/type/step, per
+// model.ObjectElementLabel) — the selector that identifies the element
+// semantically, so extraction can resolve it per manifest instead of
+// by position.
+type copyFieldSeg struct {
+	key    string // map key, or "[i]" for array elements
+	selKey string // discriminator key ("type", "name", ...) when uniquely labeled
+	selVal string // discriminator value ("ExternalIP", ...) when uniquely labeled
+}
+
+// copyFieldEntry is one selectable row of the ctrl+y picker: either a
+// visible table column (column != "") or a leaf field of the fetched
+// manifest, with its display path (array elements labeled
+// semantically: status.addresses[ExternalIP]) and current value.
+type copyFieldEntry struct {
+	column  string // table column key — set only for columns-mode rows
+	path    []copyFieldSeg
+	display string
+	value   string
+}
+
+// flattenCopyFields lists every leaf field of a parsed manifest in
+// pre-order (sorted map keys, array indices in order). Non-leaf nodes
+// are omitted — the picker copies values, not subtrees — and the
+// metadata.managedFields block is dropped as noise. Returns nil for a
+// scalar or nil root.
+func flattenCopyFields(root any) []copyFieldEntry {
+	if _, ok := root.(map[string]any); !ok {
+		return nil
+	}
+	var out []copyFieldEntry
+	var walk func(v any, path []copyFieldSeg)
+	walk = func(v any, path []copyFieldSeg) {
+		if len(out) >= maxCopyFieldEntries {
+			return
+		}
+		switch t := v.(type) {
+		case map[string]any:
+			if len(t) == 0 {
+				out = append(out, newCopyFieldEntry(path, v))
+				return
+			}
+			keys := make([]string, 0, len(t))
+			for k := range t {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				if k == "managedFields" && len(path) == 1 && path[0].key == "metadata" {
+					continue
+				}
+				walk(t[k], append(path, copyFieldSeg{key: k}))
+			}
+		case []any:
+			if len(t) == 0 {
+				out = append(out, newCopyFieldEntry(path, v))
+				return
+			}
+			labels := uniqueElementSelectors(t)
+			for i, e := range t {
+				seg := copyFieldSeg{key: "[" + strconv.Itoa(i) + "]"}
+				if sel, ok := labels[i]; ok {
+					seg.selKey, seg.selVal = sel.key, sel.val
+				}
+				walk(e, append(path, seg))
+			}
+		default:
+			out = append(out, newCopyFieldEntry(path, v))
+		}
+	}
+	walk(root, nil)
+	return out
+}
+
+// newCopyFieldEntry builds an entry for the leaf at path, copying the
+// shared path slice (walk reuses its backing array between siblings).
+func newCopyFieldEntry(path []copyFieldSeg, v any) copyFieldEntry {
+	p := make([]copyFieldSeg, len(path))
+	copy(p, path)
+	return copyFieldEntry{
+		path:    p,
+		display: formatCopyFieldPath(p),
+		value:   copyFieldDisplayValue(copyFieldValueString(v)),
+	}
+}
+
+type elementSelector struct{ key, val string }
+
+// uniqueElementSelectors returns, per array index, the discriminator
+// selector labeling that element — only for labels that are unique
+// within the array. Ambiguous labels (two InternalIP addresses) keep
+// their numeric index so a selection can never silently pick the
+// wrong element.
+func uniqueElementSelectors(arr []any) map[int]elementSelector {
+	counts := make(map[string]int, len(arr))
+	sels := make(map[int]elementSelector, len(arr))
+	for i, e := range arr {
+		k, v := model.ObjectElementLabel(e)
+		if v == "" {
+			continue
+		}
+		counts[k+"\x00"+v]++
+		sels[i] = elementSelector{key: k, val: v}
+	}
+	for i, s := range sels {
+		if counts[s.key+"\x00"+s.val] != 1 {
+			delete(sels, i)
+		}
+	}
+	return sels
+}
+
+// formatCopyFieldPath renders a path as a readable dotted string,
+// labeling selector-bearing array segments semantically:
+// status.addresses[ExternalIP].address. Follows the
+// model.FormatObjectPath joining convention (no dot before "[").
+// Labels are display-sanitized — a hostile discriminator value must
+// not inject control bytes into the rendered row.
+func formatCopyFieldPath(path []copyFieldSeg) string {
+	var b strings.Builder
+	for _, s := range path {
+		seg := s.key
+		if s.selVal != "" {
+			seg = "[" + copyFieldDisplayValue(s.selVal) + "]"
+		}
+		if strings.HasPrefix(seg, "[") {
+			b.WriteString(seg)
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString(".")
+		}
+		b.WriteString(seg)
+	}
+	return b.String()
+}
+
+// resolveCopyFieldPath walks doc along path. Selector-bearing array
+// segments resolve by discriminator match when exactly one element in
+// this doc carries the label — so the same semantic field is found
+// even when array order differs between manifests — falling back to
+// the numeric index otherwise.
+func resolveCopyFieldPath(doc any, path []copyFieldSeg) (any, bool) {
+	cur := doc
+	for _, seg := range path {
+		switch t := cur.(type) {
+		case map[string]any:
+			v, ok := t[seg.key]
+			if !ok {
+				return nil, false
+			}
+			cur = v
+		case []any:
+			idx, ok := resolveArrayIndex(t, seg)
+			if !ok {
+				return nil, false
+			}
+			cur = t[idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// resolveArrayIndex picks the element a path segment refers to within
+// arr: unique selector match first, numeric index fallback.
+func resolveArrayIndex(arr []any, seg copyFieldSeg) (int, bool) {
+	if seg.selKey != "" {
+		match, n := -1, 0
+		for i, e := range arr {
+			if m, ok := e.(map[string]any); ok && copyFieldValueString(m[seg.selKey]) == seg.selVal {
+				match, n = i, n+1
+			}
+		}
+		if n == 1 {
+			return match, true
+		}
+	}
+	if !strings.HasPrefix(seg.key, "[") || !strings.HasSuffix(seg.key, "]") {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(seg.key[1 : len(seg.key)-1])
+	if err != nil || idx < 0 || idx >= len(arr) {
+		return 0, false
+	}
+	return idx, true
+}
+
+// copyFieldValueString renders a leaf value for the clipboard: strings
+// verbatim, everything else (numbers, bools, empty containers) via
+// YAML scalar notation so what lands on the clipboard matches what the
+// manifest shows.
+func copyFieldValueString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case nil:
+		return "null"
+	default:
+		b, err := yaml.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return strings.TrimRight(string(b), "\n")
+	}
+}
+
+// copyFieldDisplayValue flattens a value for the picker's one-line
+// description column: control bytes (newlines in certs, tabs, ANSI
+// escapes in hostile manifest data) become spaces so they cannot break
+// the overlay layout or escape-inject the terminal. Only the display
+// is sanitized — the clipboard payload keeps the raw value.
+func copyFieldDisplayValue(s string) string {
+	clean := func(r rune) bool { return r >= 0x20 && r != 0x7f }
+	if strings.IndexFunc(s, func(r rune) bool { return !clean(r) }) == -1 {
+		return s
+	}
+	return strings.Map(func(r rune) rune {
+		if clean(r) {
+			return r
+		}
+		return ' '
+	}, s)
+}
+
+// buildCopyFieldPayload extracts the field at path from every doc and
+// newline-joins the values in doc order. Docs missing the path are
+// skipped (counted in missing) so one divergent manifest doesn't turn
+// a bulk copy into an error.
+func buildCopyFieldPayload(docs []any, path []copyFieldSeg) (payload string, found, missing int) {
+	values := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		v, ok := resolveCopyFieldPath(doc, path)
+		if !ok {
+			missing++
+			continue
+		}
+		values = append(values, copyFieldValueString(v))
+	}
+	return strings.Join(values, "\n"), len(values), missing
+}
+
+// parseManifestDocs splits a multi-document YAML payload (joined with
+// "\n---\n" by the bulk fetch paths) and parses each document.
+// Unparsable documents are dropped — the picker degrades to the docs
+// that did parse, mirroring the bulk fetch's partial-failure behavior.
+// maxDocs > 0 stops parsing after that many documents; the fetch never
+// legitimately returns more docs than were requested, so the cap
+// bounds the work a pathological payload full of "---" lines can cause.
+func parseManifestDocs(content string, maxDocs int) []any {
+	parts := strings.Split(content, "\n---\n")
+	docs := make([]any, 0, len(parts))
+	for _, p := range parts {
+		if maxDocs > 0 && len(docs) >= maxDocs {
+			break
+		}
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		var doc any
+		if err := yaml.Unmarshal([]byte(p), &doc); err != nil {
+			continue
+		}
+		if doc == nil {
+			continue
+		}
+		docs = append(docs, doc)
+	}
+	return docs
+}

--- a/internal/app/copy_field_flatten.go
+++ b/internal/app/copy_field_flatten.go
@@ -94,12 +94,14 @@ func flattenCopyFields(root any) []copyFieldEntry {
 
 // newCopyFieldEntry builds an entry for the leaf at path, copying the
 // shared path slice (walk reuses its backing array between siblings).
+// The whole display path is sanitized — map keys and selector labels
+// both come from the manifest and could carry control bytes.
 func newCopyFieldEntry(path []copyFieldSeg, v any) copyFieldEntry {
 	p := make([]copyFieldSeg, len(path))
 	copy(p, path)
 	return copyFieldEntry{
 		path:    p,
-		display: formatCopyFieldPath(p),
+		display: copyFieldDisplayValue(formatCopyFieldPath(p)),
 		value:   copyFieldDisplayValue(copyFieldValueString(v)),
 	}
 }
@@ -134,14 +136,13 @@ func uniqueElementSelectors(arr []any) map[int]elementSelector {
 // labeling selector-bearing array segments semantically:
 // status.addresses[ExternalIP].address. Follows the
 // model.FormatObjectPath joining convention (no dot before "[").
-// Labels are display-sanitized — a hostile discriminator value must
-// not inject control bytes into the rendered row.
+// Sanitization of the whole path happens in newCopyFieldEntry.
 func formatCopyFieldPath(path []copyFieldSeg) string {
 	var b strings.Builder
 	for _, s := range path {
 		seg := s.key
 		if s.selVal != "" {
-			seg = "[" + copyFieldDisplayValue(s.selVal) + "]"
+			seg = "[" + s.selVal + "]"
 		}
 		if strings.HasPrefix(seg, "[") {
 			b.WriteString(seg)

--- a/internal/app/copy_field_flatten_test.go
+++ b/internal/app/copy_field_flatten_test.go
@@ -131,6 +131,22 @@ func TestFlattenCopyFields_HostileLabelSanitizedInDisplay(t *testing.T) {
 	}
 }
 
+func TestFlattenCopyFields_HostileMapKeySanitizedInDisplay(t *testing.T) {
+	doc := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				"evil\x1b[31mkey\ttab": "v",
+			},
+		},
+	}
+	entries := flattenCopyFields(doc)
+	require.NotEmpty(t, entries)
+	for _, e := range entries {
+		assert.NotContains(t, e.display, "\x1b", "map keys are sanitized before display")
+		assert.NotContains(t, e.display, "\t")
+	}
+}
+
 func TestBuildCopyFieldPayload_PreservesRawValue(t *testing.T) {
 	doc := map[string]any{"data": map[string]any{"crt": "line1\nline2"}}
 	entries := flattenCopyFields(doc)

--- a/internal/app/copy_field_flatten_test.go
+++ b/internal/app/copy_field_flatten_test.go
@@ -1,0 +1,201 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nodeManifestDoc is a trimmed Node-shaped document used across the
+// flattener tests: nested maps, an array of address objects, and a
+// managedFields block that must be excluded.
+func nodeManifestDoc() map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Node",
+		"metadata": map[string]any{
+			"name": "worker-1",
+			"labels": map[string]any{
+				"kubernetes.io/hostname": "worker-1",
+			},
+			"managedFields": []any{
+				map[string]any{"manager": "kubelet"},
+			},
+		},
+		"status": map[string]any{
+			"addresses": []any{
+				map[string]any{"type": "InternalIP", "address": "10.0.0.5"},
+				map[string]any{"type": "ExternalIP", "address": "34.1.2.3"},
+			},
+			"nodeInfo": map[string]any{
+				"kubeletVersion": "v1.31.0",
+			},
+		},
+	}
+}
+
+func findCopyFieldEntry(entries []copyFieldEntry, display string) *copyFieldEntry {
+	for i := range entries {
+		if entries[i].display == display {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+func TestFlattenCopyFields_SemanticArrayLabels(t *testing.T) {
+	entries := flattenCopyFields(nodeManifestDoc())
+
+	// Array elements with a unique discriminator are labeled by it, so
+	// filtering "ExternalIP" surfaces the address row by path.
+	ext := findCopyFieldEntry(entries, "status.addresses[ExternalIP].address")
+	require.NotNil(t, ext, "external IP leaf must be listed under a semantic label")
+	assert.Equal(t, "34.1.2.3", ext.value)
+
+	name := findCopyFieldEntry(entries, "metadata.name")
+	require.NotNil(t, name)
+	assert.Equal(t, "worker-1", name.value)
+
+	// Dotted map keys must stay a single segment (k8s label keys contain dots).
+	label := findCopyFieldEntry(entries, "metadata.labels.kubernetes.io/hostname")
+	require.NotNil(t, label)
+}
+
+func TestFlattenCopyFields_DuplicateLabelsFallBackToIndex(t *testing.T) {
+	doc := map[string]any{
+		"status": map[string]any{
+			"addresses": []any{
+				map[string]any{"type": "InternalIP", "address": "10.0.0.5"},
+				map[string]any{"type": "InternalIP", "address": "10.0.0.6"},
+			},
+		},
+	}
+	entries := flattenCopyFields(doc)
+	assert.NotNil(t, findCopyFieldEntry(entries, "status.addresses[0].address"),
+		"ambiguous labels keep index paths")
+	assert.NotNil(t, findCopyFieldEntry(entries, "status.addresses[1].address"))
+	assert.Nil(t, findCopyFieldEntry(entries, "status.addresses[InternalIP].address"))
+}
+
+func TestFlattenCopyFields_LeavesOnlyAndManagedFieldsSkipped(t *testing.T) {
+	entries := flattenCopyFields(nodeManifestDoc())
+	for _, e := range entries {
+		assert.NotEqual(t, "status", e.display, "non-leaf nodes are not listed")
+		assert.NotContains(t, e.display, "managedFields", "metadata.managedFields is noise")
+	}
+}
+
+func TestFlattenCopyFields_NonMapRootReturnsNil(t *testing.T) {
+	assert.Nil(t, flattenCopyFields(nil))
+	assert.Nil(t, flattenCopyFields("scalar"))
+}
+
+func TestCopyFieldValueString_Scalars(t *testing.T) {
+	assert.Equal(t, "34.1.2.3", copyFieldValueString("34.1.2.3"))
+	assert.Equal(t, "3", copyFieldValueString(float64(3)))
+	assert.Equal(t, "true", copyFieldValueString(true))
+	assert.Equal(t, "null", copyFieldValueString(nil))
+}
+
+func TestFlattenCopyFields_DisplayValueIsSingleLineAndControlFree(t *testing.T) {
+	doc := map[string]any{
+		"data": map[string]any{
+			"tls.crt": "-----BEGIN CERT-----\nline2\nline3\n-----END CERT-----",
+			"evil":    "a\x1b[31mred\x1b[0m\tb",
+		},
+	}
+	entries := flattenCopyFields(doc)
+
+	crt := findCopyFieldEntry(entries, "data.tls.crt")
+	require.NotNil(t, crt)
+	assert.NotContains(t, crt.value, "\n", "display value must be one line")
+
+	evil := findCopyFieldEntry(entries, "data.evil")
+	require.NotNil(t, evil)
+	assert.NotContains(t, evil.value, "\x1b", "escape bytes must not reach the renderer")
+	assert.NotContains(t, evil.value, "\t")
+}
+
+func TestFlattenCopyFields_HostileLabelSanitizedInDisplay(t *testing.T) {
+	doc := map[string]any{
+		"spec": map[string]any{
+			"items": []any{
+				map[string]any{"name": "ok\x1b[31mred", "v": "1"},
+			},
+		},
+	}
+	entries := flattenCopyFields(doc)
+	for _, e := range entries {
+		assert.NotContains(t, e.display, "\x1b", "labels are sanitized before display")
+	}
+}
+
+func TestBuildCopyFieldPayload_PreservesRawValue(t *testing.T) {
+	doc := map[string]any{"data": map[string]any{"crt": "line1\nline2"}}
+	entries := flattenCopyFields(doc)
+	e := findCopyFieldEntry(entries, "data.crt")
+	require.NotNil(t, e)
+	payload, found, missing := buildCopyFieldPayload([]any{doc}, e.path)
+	assert.Equal(t, "line1\nline2", payload, "clipboard keeps the raw value")
+	assert.Equal(t, 1, found)
+	assert.Equal(t, 0, missing)
+}
+
+func TestBuildCopyFieldPayload_LabelResolvesAcrossReorderedDocs(t *testing.T) {
+	docA := nodeManifestDoc() // ExternalIP at index 1
+	docB := map[string]any{   // ExternalIP at index 0 — order flipped
+		"status": map[string]any{
+			"addresses": []any{
+				map[string]any{"type": "ExternalIP", "address": "49.12.73.237"},
+				map[string]any{"type": "InternalIP", "address": "10.0.0.6"},
+			},
+		},
+	}
+	entries := flattenCopyFields(docA)
+	e := findCopyFieldEntry(entries, "status.addresses[ExternalIP].address")
+	require.NotNil(t, e)
+
+	payload, found, missing := buildCopyFieldPayload([]any{docA, docB}, e.path)
+	assert.Equal(t, "34.1.2.3\n49.12.73.237", payload,
+		"the labeled element is resolved per doc, not by index")
+	assert.Equal(t, 2, found)
+	assert.Equal(t, 0, missing)
+}
+
+func TestBuildCopyFieldPayload_MultiDocSkipsMissing(t *testing.T) {
+	docA := nodeManifestDoc()
+	docC := map[string]any{"kind": "Node"} // path missing entirely
+
+	entries := flattenCopyFields(docA)
+	e := findCopyFieldEntry(entries, "status.addresses[ExternalIP].address")
+	require.NotNil(t, e)
+
+	payload, found, missing := buildCopyFieldPayload([]any{docA, docC}, e.path)
+	assert.Equal(t, "34.1.2.3", payload)
+	assert.Equal(t, 1, found)
+	assert.Equal(t, 1, missing)
+}
+
+func TestParseManifestDocs_MultiDoc(t *testing.T) {
+	content := "kind: Node\nmetadata:\n  name: a\n---\nkind: Node\nmetadata:\n  name: b\n"
+	docs := parseManifestDocs(content, 0)
+	require.Len(t, docs, 2)
+	first, ok := docs[0].(map[string]any)
+	require.True(t, ok)
+	md, ok := first["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "a", md["name"])
+}
+
+func TestParseManifestDocs_SkipsUnparsableDoc(t *testing.T) {
+	content := "kind: Node\n---\n\t: not yaml {{{\n---\nkind: Pod\n"
+	docs := parseManifestDocs(content, 0)
+	require.Len(t, docs, 2, "bad doc dropped, good docs kept")
+}
+
+func TestParseManifestDocs_CapsAtMaxDocs(t *testing.T) {
+	content := "kind: A\n---\nkind: B\n---\nkind: C\n"
+	docs := parseManifestDocs(content, 2)
+	require.Len(t, docs, 2, "parsing stops at the requested doc count")
+}

--- a/internal/app/copy_field_hintbar_test.go
+++ b/internal/app/copy_field_hintbar_test.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverlayHintBar_CopyFieldPickerActive(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	assert.Equal(t, overlayCopyField, m.overlay)
+	hints := m.overlayHintBarSelector()
+	assert.NotEmpty(t, hints, "selector hint bar must render for the field picker overlay")
+	for _, frag := range []string{"filter", "navigate", "copy value", "close"} {
+		assert.Contains(t, hints, frag, "field picker hint bar must contain %q", frag)
+	}
+}

--- a/internal/app/copy_field_picker.go
+++ b/internal/app/copy_field_picker.go
@@ -1,0 +1,364 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// copyFieldMode selects which entry list the ctrl+y picker shows.
+type copyFieldMode int
+
+const (
+	copyFieldModeColumns copyFieldMode = iota // visible table columns (instant, no fetch)
+	copyFieldModeFields                       // every manifest leaf field (needs the fetch)
+)
+
+// copyFieldMemory records the last-copied entry for a kind so the next
+// ctrl+y preselects it (session-only).
+type copyFieldMemory struct {
+	mode    copyFieldMode
+	display string
+}
+
+// copyFieldPickerState is the ctrl+y field picker. It opens instantly
+// in columns mode on the scope snapshot; the manifest fetch runs in the
+// background and fills fieldEntries/docs for the tab-toggled fields
+// mode. entries are flattened from docs[0] only — the first item
+// defines the field list, the rest just contribute values.
+type copyFieldPickerState struct {
+	active       bool
+	mode         copyFieldMode
+	cursor       int
+	scroll       int
+	filter       string
+	filterActive bool
+
+	columnEntries []copyFieldEntry
+	fieldEntries  []copyFieldEntry
+	visible       []copyFieldEntry // current mode's entries matching filter (recomputeCopyFieldVisible)
+
+	fieldsLoaded bool   // manifest fetch finished (successfully or not)
+	fieldsErr    string // why fields mode is empty ("" when fine)
+
+	docs      []any        // parsed manifests, fetch order
+	scope     []model.Item // selection snapshot for column extraction
+	kind      string       // memory key
+	requested int          // scope size, for status messaging
+	seq       int          // fetch sequence — stale copyFieldManifestsMsg are dropped
+}
+
+// handleExplorerActionKeyCopyField opens the ctrl+y picker immediately
+// in columns mode on the scope snapshot (same precedence as Y) and
+// kicks off the manifest fetch in the background for the tab-toggled
+// fields mode. Over-cap or level-unsupported fetches degrade to
+// columns-only with the reason surfaced when the user presses tab.
+func (m Model) handleExplorerActionKeyCopyField() (tea.Model, tea.Cmd, bool) {
+	scope := m.copyFormatPickerScope()
+	if len(scope) == 0 {
+		return m, nil, true
+	}
+	kind := scope[0].Kind
+	if kind == "" {
+		kind = m.nav.ResourceType.Kind
+	}
+
+	var fetchCmd tea.Cmd
+	fieldsErr := ""
+	if len(scope) > maxBulkYAMLCopy {
+		fieldsErr = fmt.Sprintf("Max %d items for field copy", maxBulkYAMLCopy)
+	} else if fetchCmd = m.copyYAMLForScope(scope); fetchCmd == nil {
+		fieldsErr = "Fields are not available at this level"
+	}
+
+	seq := m.copyFieldPicker.seq + 1
+	m.copyFieldPicker = copyFieldPickerState{
+		active:        true,
+		mode:          copyFieldModeColumns,
+		columnEntries: buildCopyFieldColumnEntries(m.nav.Level, scope),
+		fieldsLoaded:  fetchCmd == nil,
+		fieldsErr:     fieldsErr,
+		scope:         scope,
+		kind:          kind,
+		requested:     len(scope),
+		seq:           seq,
+	}
+	m.recomputeCopyFieldVisible()
+	m.copyFieldPickerPreselect()
+	m.previousOverlay = m.overlay
+	m.overlay = overlayCopyField
+	if fetchCmd == nil {
+		return m, nil, true
+	}
+	return m, wrapYAMLCmdForCopyField(fetchCmd, len(scope), seq), true
+}
+
+// buildCopyFieldColumnEntries lists the visible table columns of the
+// scope as picker rows: the column header as the path, the first
+// item's cell as the value. Reuses the Y-table column set so the rows
+// match what the explorer displays.
+func buildCopyFieldColumnEntries(level model.Level, scope []model.Item) []copyFieldEntry {
+	cols := copyTableColumnsForLevel(level, scope)
+	entries := make([]copyFieldEntry, 0, len(cols))
+	for _, c := range cols {
+		entries = append(entries, copyFieldEntry{
+			column:  c,
+			display: ui.ColumnHeaderLabel(c),
+			value:   copyFieldDisplayValue(copyTableCellValue(&scope[0], c)),
+		})
+	}
+	return entries
+}
+
+// copyFieldManifestsMsg carries the parsed manifests for the field
+// picker's fields mode. err is non-nil when the underlying bulk fetch
+// failed (entirely or partially — docs holds whatever did parse).
+type copyFieldManifestsMsg struct {
+	docs      []any
+	requested int
+	seq       int
+	err       error
+}
+
+// wrapYAMLCmdForCopyField converts the yamlClipboardMsg produced by a
+// copyYAMLForScope cmd into a copyFieldManifestsMsg, parsing the
+// multi-doc payload off the UI loop. Non-yamlClipboardMsg results
+// (e.g. a coalesced fetch's nil) pass through unchanged.
+func wrapYAMLCmdForCopyField(cmd tea.Cmd, requested, seq int) tea.Cmd {
+	return func() tea.Msg {
+		msg := cmd()
+		yc, ok := msg.(yamlClipboardMsg)
+		if !ok {
+			return msg
+		}
+		return copyFieldManifestsMsg{
+			docs:      parseManifestDocs(yc.content, requested),
+			requested: requested,
+			seq:       seq,
+			err:       yc.err,
+		}
+	}
+}
+
+// updateCopyFieldManifests fills the picker's fields mode from a
+// completed background fetch. Messages for a closed picker or a stale
+// fetch (the user closed and reopened meanwhile) are dropped.
+func (m Model) updateCopyFieldManifests(msg copyFieldManifestsMsg) (tea.Model, tea.Cmd) {
+	p := &m.copyFieldPicker
+	if !p.active || msg.seq != p.seq {
+		return m, nil
+	}
+	p.fieldsLoaded = true
+	if len(msg.docs) == 0 {
+		reason := "no manifests fetched"
+		if msg.err != nil {
+			reason = msg.err.Error()
+		}
+		p.fieldsErr = reason
+		return m, nil
+	}
+	p.docs = msg.docs
+	p.fieldEntries = flattenCopyFields(msg.docs[0])
+	if len(p.fieldEntries) == 0 {
+		p.fieldsErr = "No fields found"
+	}
+	if p.kind == "" {
+		p.kind = manifestKind(msg.docs[0])
+	}
+	if p.mode == copyFieldModeFields {
+		m.recomputeCopyFieldVisible()
+		m.copyFieldPickerPreselect()
+	}
+	if msg.err != nil {
+		m.setStatusMessage("Copy field: "+msg.err.Error(), true)
+		return m, scheduleStatusClear()
+	}
+	return m, nil
+}
+
+// toggleCopyFieldMode flips columns <-> fields, resetting filter and
+// cursor — the two lists share nothing, so a carried-over filter would
+// just confuse.
+func (m *Model) toggleCopyFieldMode() {
+	p := &m.copyFieldPicker
+	if p.mode == copyFieldModeColumns {
+		p.mode = copyFieldModeFields
+	} else {
+		p.mode = copyFieldModeColumns
+	}
+	p.filter = ""
+	p.filterActive = false
+	p.cursor = 0
+	p.scroll = 0
+	m.recomputeCopyFieldVisible()
+	m.copyFieldPickerPreselect()
+}
+
+// manifestKind returns the manifest's kind field, or "" when absent.
+func manifestKind(doc any) string {
+	obj, ok := doc.(map[string]any)
+	if !ok {
+		return ""
+	}
+	kind, _ := obj["kind"].(string)
+	return kind
+}
+
+// copyFieldPickerCurrentEntries returns the active mode's full list.
+func (m Model) copyFieldPickerCurrentEntries() []copyFieldEntry {
+	if m.copyFieldPicker.mode == copyFieldModeColumns {
+		return m.copyFieldPicker.columnEntries
+	}
+	return m.copyFieldPicker.fieldEntries
+}
+
+// copyFieldPickerPreselect moves the cursor onto the entry last copied
+// for this kind (session memory) when it belongs to the active mode.
+// No-op otherwise.
+func (m *Model) copyFieldPickerPreselect() {
+	remembered, ok := m.lastCopyFieldByKind[m.copyFieldPicker.kind]
+	if !ok || remembered.mode != m.copyFieldPicker.mode {
+		return
+	}
+	for i, e := range m.copyFieldPicker.visible {
+		if e.display == remembered.display {
+			m.copyFieldPicker.cursor = i
+			m.clampCopyFieldScroll()
+			return
+		}
+	}
+}
+
+// closeCopyFieldPicker clears picker state and restores the prior
+// overlay. Idempotent. The fetch sequence counter survives the reset
+// so an in-flight fetch from this picker can never be mistaken for the
+// next one's.
+func (m *Model) closeCopyFieldPicker() {
+	m.copyFieldPicker = copyFieldPickerState{seq: m.copyFieldPicker.seq}
+	if m.overlay == overlayCopyField {
+		m.overlay = m.previousOverlay
+		m.previousOverlay = overlayNone
+	}
+}
+
+// recomputeCopyFieldVisible refreshes the filtered entry list for the
+// active mode. Matching is case-insensitive over both the path and the
+// value — so "ExternalIP" matches status.addresses[ExternalIP].address
+// by path, and "34.1" matches it by value. Called only when the
+// filter, mode, or entries change, so per-keystroke navigation never
+// re-scans a large manifest (mirrors objectexplorer_find's
+// recomputeFind).
+func (m *Model) recomputeCopyFieldVisible() {
+	p := &m.copyFieldPicker
+	entries := m.copyFieldPickerCurrentEntries()
+	f := strings.ToLower(p.filter)
+	if f == "" {
+		p.visible = entries
+		return
+	}
+	out := make([]copyFieldEntry, 0, len(entries))
+	for _, e := range entries {
+		if strings.Contains(strings.ToLower(e.display), f) ||
+			strings.Contains(strings.ToLower(e.value), f) {
+			out = append(out, e)
+		}
+	}
+	p.visible = out
+}
+
+// visibleCopyFieldEntries returns the cached filtered entry list.
+func (m Model) visibleCopyFieldEntries() []copyFieldEntry {
+	return m.copyFieldPicker.visible
+}
+
+// applyCopyFieldPicker copies the cursor row's value — from every item
+// in the scope (columns mode) or every fetched manifest (fields mode),
+// newline-joined in scope order — then closes the picker and records
+// the entry as this kind's last copied.
+func (m Model) applyCopyFieldPicker() (tea.Model, tea.Cmd) {
+	if !m.copyFieldPicker.active {
+		return m, nil
+	}
+	vis := m.visibleCopyFieldEntries()
+	if m.copyFieldPicker.cursor < 0 || m.copyFieldPicker.cursor >= len(vis) {
+		return m, nil
+	}
+	entry := vis[m.copyFieldPicker.cursor]
+	mode := m.copyFieldPicker.mode
+	kind := m.copyFieldPicker.kind
+
+	var payload string
+	var found, missing int
+	if entry.column != "" {
+		payload, found, missing = buildCopyFieldColumnPayload(m.copyFieldPicker.scope, entry.column)
+	} else {
+		payload, found, missing = buildCopyFieldPayload(m.copyFieldPicker.docs, entry.path)
+	}
+	m.closeCopyFieldPicker()
+
+	if found == 0 {
+		m.setStatusMessage("Copy field: no value for "+entry.display, true)
+		return m, scheduleStatusClear()
+	}
+	if m.lastCopyFieldByKind == nil {
+		m.lastCopyFieldByKind = make(map[string]copyFieldMemory)
+	}
+	m.lastCopyFieldByKind[kind] = copyFieldMemory{mode: mode, display: entry.display}
+
+	status := "Copied " + entry.display
+	if found > 1 || missing > 0 {
+		status = fmt.Sprintf("Copied %d values for %s", found, entry.display)
+		if missing > 0 {
+			status += fmt.Sprintf(" (%d missing)", missing)
+		}
+	}
+	m.setStatusMessage(status, false)
+	return m, tea.Batch(copyToSystemClipboard(payload), scheduleStatusClear())
+}
+
+// buildCopyFieldColumnPayload extracts a column's cell from every scope
+// item, newline-joined. Empty cells (and the "<none>" placeholder the
+// table renderer uses) count as missing rather than emitting blanks.
+func buildCopyFieldColumnPayload(scope []model.Item, column string) (payload string, found, missing int) {
+	values := make([]string, 0, len(scope))
+	for i := range scope {
+		v := copyTableCellValue(&scope[i], column)
+		if v == "" || v == "<none>" {
+			missing++
+			continue
+		}
+		values = append(values, v)
+	}
+	return strings.Join(values, "\n"), len(values), missing
+}
+
+// copyFieldOverlayDims returns the picker box width, height, and
+// visible row count. Shared by the renderer and scroll clamp so the
+// scrollbar and cursor stay in sync (same shape as findOverlayDims).
+func (m Model) copyFieldOverlayDims() (w, h, maxVisible int) {
+	w = min(m.width-6, max(m.width*70/100, 64))
+	h = min(m.height-4, max(m.height*70/100, 12))
+	maxVisible = max(h-8, 1) // title + subtitle + filter(2) + footer(2) + borders
+	return w, h, maxVisible
+}
+
+// clampCopyFieldScroll keeps the cursor within the visible window.
+func (m *Model) clampCopyFieldScroll() {
+	p := &m.copyFieldPicker
+	_, _, visible := m.copyFieldOverlayDims()
+	n := len(m.visibleCopyFieldEntries())
+	p.cursor = max(0, min(p.cursor, n-1))
+	if p.cursor < p.scroll {
+		p.scroll = p.cursor
+	}
+	if p.cursor >= p.scroll+visible {
+		p.scroll = p.cursor - visible + 1
+	}
+	if p.scroll < 0 {
+		p.scroll = 0
+	}
+}

--- a/internal/app/copy_field_picker.go
+++ b/internal/app/copy_field_picker.go
@@ -346,19 +346,12 @@ func (m Model) copyFieldOverlayDims() (w, h, maxVisible int) {
 	return w, h, maxVisible
 }
 
-// clampCopyFieldScroll keeps the cursor within the visible window.
+// clampCopyFieldScroll keeps the cursor within the visible window via
+// the shared vim-style scrolloff viewport.
 func (m *Model) clampCopyFieldScroll() {
 	p := &m.copyFieldPicker
 	_, _, visible := m.copyFieldOverlayDims()
 	n := len(m.visibleCopyFieldEntries())
 	p.cursor = max(0, min(p.cursor, n-1))
-	if p.cursor < p.scroll {
-		p.scroll = p.cursor
-	}
-	if p.cursor >= p.scroll+visible {
-		p.scroll = p.cursor - visible + 1
-	}
-	if p.scroll < 0 {
-		p.scroll = 0
-	}
+	overlayListScroll(&p.scroll, p.cursor, n, visible)
 }

--- a/internal/app/copy_field_picker.go
+++ b/internal/app/copy_field_picker.go
@@ -293,7 +293,7 @@ func (m Model) applyCopyFieldPicker() (tea.Model, tea.Cmd) {
 
 	var payload string
 	var found, missing int
-	if entry.column != "" {
+	if mode == copyFieldModeColumns {
 		payload, found, missing = buildCopyFieldColumnPayload(m.copyFieldPicker.scope, entry.column)
 	} else {
 		payload, found, missing = buildCopyFieldPayload(m.copyFieldPicker.docs, entry.path)

--- a/internal/app/copy_field_picker_keys.go
+++ b/internal/app/copy_field_picker_keys.go
@@ -60,10 +60,14 @@ func (m Model) handleCopyFieldPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		p.cursor = 0
 	case "G", "end":
 		p.cursor = max(n-1, 0)
-	case "ctrl+d", "pgdown", "shift+down":
+	case "ctrl+d":
 		p.cursor = min(p.cursor+visible/2, max(n-1, 0))
-	case "ctrl+u", "pgup", "shift+up":
+	case "ctrl+u":
 		p.cursor = max(p.cursor-visible/2, 0)
+	case "ctrl+f", "pgdown", "shift+down":
+		p.cursor = min(p.cursor+visible, max(n-1, 0))
+	case "ctrl+b", "pgup", "shift+up":
+		p.cursor = max(p.cursor-visible, 0)
 	}
 	m.clampCopyFieldScroll()
 	return m, nil
@@ -83,9 +87,7 @@ func (m Model) handleCopyFieldPickerFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cm
 		// Keep the filter, leave typing mode so j/k navigate the results.
 		p.filterActive = false
 	case "backspace":
-		if p.filter != "" {
-			p.filter = p.filter[:len(p.filter)-1]
-		}
+		p.filter = trimLastRune(p.filter)
 		p.cursor = 0
 		p.scroll = 0
 		m.recomputeCopyFieldVisible()

--- a/internal/app/copy_field_picker_keys.go
+++ b/internal/app/copy_field_picker_keys.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// copyFieldPickerHints is the field picker's bottom hint bar
+// (rendered by overlayHintBarSelector; kept here to co-locate the
+// feature and keep overlay_hintbar.go under the file-length cap).
+func copyFieldPickerHints() []ui.HintEntry {
+	return []ui.HintEntry{
+		{Key: "tab", Desc: "columns/fields"},
+		{Key: "/", Desc: "filter"},
+		{Key: "j/k", Desc: "navigate"},
+		{Key: "enter", Desc: "copy value"},
+		{Key: "esc", Desc: "close"},
+	}
+}
+
+// handleCopyFieldPickerKey routes key events to the ctrl+y field
+// picker, delegating to the filter-input sub-handler when the filter is
+// focused (same split as the Object Explorer's find overlay).
+func (m Model) handleCopyFieldPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.copyFieldPicker.filterActive {
+		return m.handleCopyFieldPickerFilterKey(msg)
+	}
+	p := &m.copyFieldPicker
+	n := len(m.visibleCopyFieldEntries())
+	_, _, visible := m.copyFieldOverlayDims()
+	switch msg.String() {
+	case "esc", "q":
+		if p.filter != "" {
+			p.filter = ""
+			p.cursor = 0
+			p.scroll = 0
+			m.recomputeCopyFieldVisible()
+			m.clampCopyFieldScroll()
+			return m, nil
+		}
+		m.closeCopyFieldPicker()
+		return m, nil
+	case "enter":
+		return m.applyCopyFieldPicker()
+	case "tab":
+		m.toggleCopyFieldMode()
+		return m, nil
+	case "/":
+		p.filterActive = true
+	case "j", "down", "ctrl+n":
+		if p.cursor < n-1 {
+			p.cursor++
+		}
+	case "k", "up", "ctrl+p":
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case "g", "home":
+		p.cursor = 0
+	case "G", "end":
+		p.cursor = max(n-1, 0)
+	case "ctrl+d", "pgdown", "shift+down":
+		p.cursor = min(p.cursor+visible/2, max(n-1, 0))
+	case "ctrl+u", "pgup", "shift+up":
+		p.cursor = max(p.cursor-visible/2, 0)
+	}
+	m.clampCopyFieldScroll()
+	return m, nil
+}
+
+// handleCopyFieldPickerFilterKey handles typing in the picker's filter input.
+func (m Model) handleCopyFieldPickerFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	p := &m.copyFieldPicker
+	switch msg.String() {
+	case "esc":
+		p.filterActive = false
+		p.filter = ""
+		p.cursor = 0
+		p.scroll = 0
+		m.recomputeCopyFieldVisible()
+	case "enter":
+		// Keep the filter, leave typing mode so j/k navigate the results.
+		p.filterActive = false
+	case "backspace":
+		if p.filter != "" {
+			p.filter = p.filter[:len(p.filter)-1]
+		}
+		p.cursor = 0
+		p.scroll = 0
+		m.recomputeCopyFieldVisible()
+	default:
+		if msg.Type == tea.KeyRunes {
+			p.filter += string(msg.Runes)
+			p.cursor = 0
+			p.scroll = 0
+			m.recomputeCopyFieldVisible()
+		}
+	}
+	m.clampCopyFieldScroll()
+	return m, nil
+}

--- a/internal/app/copy_field_picker_test.go
+++ b/internal/app/copy_field_picker_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -234,6 +235,44 @@ func TestCopyFieldPicker_TabResetsFilter(t *testing.T) {
 	m.recomputeCopyFieldVisible()
 	m = tabToFields(t, m)
 	assert.Equal(t, "", m.copyFieldPicker.filter, "filter does not carry across modes")
+}
+
+func TestCopyFieldPickerFilter_BackspaceIsRuneSafe(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	mdl, _ := m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = mdl.(Model)
+	mdl, _ = m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("naïve")})
+	m = mdl.(Model)
+	mdl, _ = m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = mdl.(Model)
+	assert.Equal(t, "naïv", m.copyFieldPicker.filter, "backspace removes one rune, not one byte")
+	mdl, _ = m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = mdl.(Model)
+	assert.Equal(t, "naï", m.copyFieldPicker.filter, "multibyte rune removed intact")
+}
+
+func TestRenderOverlayCopyField_LongRowsStayWithinWidth(t *testing.T) {
+	m := copyFieldTestModel(t)
+	doc := map[string]any{
+		"kind": "Node",
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				strings.Repeat("k", 200): strings.Repeat("v", 500),
+			},
+		},
+	}
+	mdl, _, _ := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	mdl, _ = res.updateCopyFieldManifests(copyFieldManifestsMsg{docs: []any{doc}, requested: 1, seq: res.copyFieldPicker.seq})
+	res = mdl.(Model)
+	res = tabToFields(t, res)
+
+	content, w, _ := res.renderOverlayCopyField()
+	innerW := w - 4
+	for line := range strings.SplitSeq(stripANSI(content), "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(line), innerW+2,
+			"no row may exceed the overlay content width")
+	}
 }
 
 func TestRenderOverlayCopyField_ColumnsAndFieldsSubtitles(t *testing.T) {

--- a/internal/app/copy_field_picker_test.go
+++ b/internal/app/copy_field_picker_test.go
@@ -1,0 +1,270 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// copyFieldTestModel returns a model at LevelResources with one node row.
+func copyFieldTestModel(t *testing.T) Model {
+	t.Helper()
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Node"}
+	m.middleItems = []model.Item{{Name: "worker-1", Status: "Ready"}}
+	m.setCursor(0)
+	return m
+}
+
+// copyFieldOpenPicker opens the picker via the ctrl+y handler (columns
+// mode) and injects the manifest fetch result so fields mode is ready.
+func copyFieldOpenPicker(t *testing.T, m Model) Model {
+	t.Helper()
+	docs := []any{nodeManifestDoc()}
+	mdl, _, handled := m.handleExplorerActionKeyCopyField()
+	require.True(t, handled)
+	res, ok := mdl.(Model)
+	require.True(t, ok)
+	mdl, _ = res.updateCopyFieldManifests(copyFieldManifestsMsg{
+		docs: docs, requested: len(docs), seq: res.copyFieldPicker.seq,
+	})
+	res, ok = mdl.(Model)
+	require.True(t, ok)
+	return res
+}
+
+// tabToFields switches the picker into fields mode.
+func tabToFields(t *testing.T, m Model) Model {
+	t.Helper()
+	mdl, _ := m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyTab})
+	res, ok := mdl.(Model)
+	require.True(t, ok)
+	require.Equal(t, copyFieldModeFields, res.copyFieldPicker.mode)
+	return res
+}
+
+func TestCopyFieldPicker_OpensInstantlyInColumnsMode(t *testing.T) {
+	m := copyFieldTestModel(t)
+	mdl, cmd, handled := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	require.True(t, handled)
+	assert.NotNil(t, cmd, "background manifest fetch dispatched")
+	assert.Equal(t, overlayCopyField, res.overlay)
+	require.True(t, res.copyFieldPicker.active)
+	assert.Equal(t, copyFieldModeColumns, res.copyFieldPicker.mode)
+	assert.False(t, res.copyFieldPicker.fieldsLoaded)
+
+	// Columns are available immediately, before any fetch completes.
+	vis := res.visibleCopyFieldEntries()
+	require.NotEmpty(t, vis)
+	name := findCopyFieldEntry(vis, "NAME")
+	require.NotNil(t, name)
+	assert.Equal(t, "worker-1", name.value)
+}
+
+func TestCopyFieldPicker_TabTogglesToSemanticFields(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	m = tabToFields(t, m)
+
+	vis := m.visibleCopyFieldEntries()
+	assert.NotNil(t, findCopyFieldEntry(vis, "status.addresses[ExternalIP].address"))
+
+	// Tab back returns to columns.
+	mdl, _ := m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyTab})
+	m = mdl.(Model)
+	assert.Equal(t, copyFieldModeColumns, m.copyFieldPicker.mode)
+	assert.NotNil(t, findCopyFieldEntry(m.visibleCopyFieldEntries(), "NAME"))
+}
+
+func TestCopyFieldPicker_ExternalIPFilterFindsAddressRow(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	m = tabToFields(t, m)
+
+	m.copyFieldPicker.filter = "externalip"
+	m.recomputeCopyFieldVisible()
+	vis := m.visibleCopyFieldEntries()
+	require.NotEmpty(t, vis)
+	assert.NotNil(t, findCopyFieldEntry(vis, "status.addresses[ExternalIP].address"),
+		"the address row is reachable via the semantic label, not just the type row")
+}
+
+func TestUpdateCopyFieldManifests_DroppedWhenPickerClosed(t *testing.T) {
+	m := copyFieldTestModel(t)
+	mdl, _, _ := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	seq := res.copyFieldPicker.seq
+	res.closeCopyFieldPicker()
+
+	mdl, _ = res.updateCopyFieldManifests(copyFieldManifestsMsg{docs: []any{nodeManifestDoc()}, seq: seq})
+	res = mdl.(Model)
+	assert.False(t, res.copyFieldPicker.active, "stale fetch must not reopen the picker")
+	assert.NotEqual(t, overlayCopyField, res.overlay)
+}
+
+func TestUpdateCopyFieldManifests_StaleSeqDropped(t *testing.T) {
+	m := copyFieldTestModel(t)
+	mdl, _, _ := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	staleSeq := res.copyFieldPicker.seq
+	res.closeCopyFieldPicker()
+	mdl, _, _ = res.handleExplorerActionKeyCopyField() // reopen — new seq
+	res = mdl.(Model)
+
+	mdl, _ = res.updateCopyFieldManifests(copyFieldManifestsMsg{docs: []any{nodeManifestDoc()}, seq: staleSeq})
+	res = mdl.(Model)
+	assert.False(t, res.copyFieldPicker.fieldsLoaded, "old fetch must not fill the new picker")
+}
+
+func TestUpdateCopyFieldManifests_FetchErrorSurfacesOnFieldsMode(t *testing.T) {
+	m := copyFieldTestModel(t)
+	mdl, _, _ := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	mdl, _ = res.updateCopyFieldManifests(copyFieldManifestsMsg{
+		err: errors.New("rbac denied"), seq: res.copyFieldPicker.seq,
+	})
+	res = mdl.(Model)
+	assert.True(t, res.copyFieldPicker.active, "columns mode stays usable")
+	assert.True(t, res.copyFieldPicker.fieldsLoaded)
+	assert.Contains(t, res.copyFieldPicker.fieldsErr, "rbac denied")
+}
+
+func TestApplyCopyFieldPicker_ColumnValue(t *testing.T) {
+	m := copyFieldTestModel(t)
+	m.middleItems = []model.Item{
+		{Name: "worker-1", Status: "Ready"},
+		{Name: "worker-2", Status: "NotReady"},
+	}
+	m.selectedItems = map[string]bool{
+		selectionKey(m.middleItems[0]): true,
+		selectionKey(m.middleItems[1]): true,
+	}
+	mdl, _, _ := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+
+	res.copyFieldPicker.filter = "status"
+	res.recomputeCopyFieldVisible()
+	res.copyFieldPicker.cursor = 0
+	mdl, cmd := res.applyCopyFieldPicker()
+	res = mdl.(Model)
+
+	assert.NotNil(t, cmd)
+	assert.Contains(t, res.statusMessage, "2 values")
+	assert.Equal(t, copyFieldMemory{mode: copyFieldModeColumns, display: "STATUS"},
+		res.lastCopyFieldByKind["Node"])
+}
+
+func TestApplyCopyFieldPicker_FieldValueRemembersPerKind(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	m = tabToFields(t, m)
+
+	m.copyFieldPicker.filter = "34.1.2.3"
+	m.recomputeCopyFieldVisible()
+	m.copyFieldPicker.cursor = 0
+	mdl, cmd := m.applyCopyFieldPicker()
+	res := mdl.(Model)
+
+	assert.NotNil(t, cmd)
+	assert.False(t, res.copyFieldPicker.active)
+	assert.Equal(t, overlayNone, res.overlay)
+	assert.Contains(t, res.statusMessage, "status.addresses[ExternalIP].address")
+	assert.Equal(t,
+		copyFieldMemory{mode: copyFieldModeFields, display: "status.addresses[ExternalIP].address"},
+		res.lastCopyFieldByKind["Node"])
+}
+
+func TestCopyFieldPicker_PreselectsRememberedFieldAfterTab(t *testing.T) {
+	m := copyFieldTestModel(t)
+	m.lastCopyFieldByKind = map[string]copyFieldMemory{
+		"Node": {mode: copyFieldModeFields, display: "status.addresses[ExternalIP].address"},
+	}
+	m = copyFieldOpenPicker(t, m)
+	assert.Equal(t, copyFieldModeColumns, m.copyFieldPicker.mode, "always opens on columns")
+	m = tabToFields(t, m)
+
+	vis := m.visibleCopyFieldEntries()
+	require.NotEmpty(t, vis)
+	require.Less(t, m.copyFieldPicker.cursor, len(vis))
+	assert.Equal(t, "status.addresses[ExternalIP].address", vis[m.copyFieldPicker.cursor].display)
+}
+
+func TestCopyFieldPickerKeys_FilterTypingAndEscape(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	m = tabToFields(t, m)
+
+	mdl, _ := m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = mdl.(Model)
+	assert.True(t, m.copyFieldPicker.filterActive)
+
+	mdl, _ = m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("kubelet")})
+	m = mdl.(Model)
+	assert.Equal(t, "kubelet", m.copyFieldPicker.filter)
+	for _, e := range m.visibleCopyFieldEntries() {
+		assert.True(t, strings.Contains(strings.ToLower(e.display), "kubelet") ||
+			strings.Contains(strings.ToLower(e.value), "kubelet"))
+	}
+
+	// Enter leaves filter-typing mode but keeps the filter.
+	mdl, _ = m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = mdl.(Model)
+	assert.False(t, m.copyFieldPicker.filterActive)
+	assert.Equal(t, "kubelet", m.copyFieldPicker.filter)
+
+	// Esc with a filter set clears it; second esc closes.
+	mdl, _ = m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = mdl.(Model)
+	assert.Equal(t, "", m.copyFieldPicker.filter)
+	assert.True(t, m.copyFieldPicker.active)
+
+	mdl, _ = m.handleCopyFieldPickerKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = mdl.(Model)
+	assert.False(t, m.copyFieldPicker.active)
+	assert.Equal(t, overlayNone, m.overlay)
+}
+
+func TestCopyFieldPicker_TabResetsFilter(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	m.copyFieldPicker.filter = "name"
+	m.recomputeCopyFieldVisible()
+	m = tabToFields(t, m)
+	assert.Equal(t, "", m.copyFieldPicker.filter, "filter does not carry across modes")
+}
+
+func TestRenderOverlayCopyField_ColumnsAndFieldsSubtitles(t *testing.T) {
+	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
+	content, w, h := m.renderOverlayCopyField()
+	require.NotEmpty(t, content)
+	assert.Positive(t, w)
+	assert.Positive(t, h)
+	plain := stripANSI(content)
+	assert.Contains(t, plain, "Copy field")
+	assert.Contains(t, plain, "columns (tab: all fields)")
+	assert.Contains(t, plain, "worker-1")
+
+	m = tabToFields(t, m)
+	plain = stripANSI(mustRenderCopyField(t, m))
+	assert.Contains(t, plain, "all fields (tab: columns)")
+	assert.Contains(t, plain, "metadata.name")
+}
+
+func TestRenderOverlayCopyField_LoadingState(t *testing.T) {
+	m := copyFieldTestModel(t)
+	mdl, _, _ := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+	res = tabToFields(t, res) // fetch has not landed yet
+	plain := stripANSI(mustRenderCopyField(t, res))
+	assert.Contains(t, plain, "Loading fields...")
+}
+
+func mustRenderCopyField(t *testing.T, m Model) string {
+	t.Helper()
+	content, _, _ := m.renderOverlayCopyField()
+	require.NotEmpty(t, content)
+	return content
+}

--- a/internal/app/copy_field_picker_test.go
+++ b/internal/app/copy_field_picker_test.go
@@ -161,6 +161,30 @@ func TestApplyCopyFieldPicker_ColumnValue(t *testing.T) {
 		res.lastCopyFieldByKind["Node"])
 }
 
+func TestApplyCopyFieldPicker_ColumnValuePartialMissIsCounted(t *testing.T) {
+	m := copyFieldTestModel(t)
+	m.middleItems = []model.Item{
+		{Name: "worker-1", Status: "Ready"},
+		{Name: "worker-2"}, // no Status — must be skipped and counted
+	}
+	m.selectedItems = map[string]bool{
+		selectionKey(m.middleItems[0]): true,
+		selectionKey(m.middleItems[1]): true,
+	}
+	mdl, _, _ := m.handleExplorerActionKeyCopyField()
+	res := mdl.(Model)
+
+	res.copyFieldPicker.filter = "status"
+	res.recomputeCopyFieldVisible()
+	res.copyFieldPicker.cursor = 0
+	mdl, cmd := res.applyCopyFieldPicker()
+	res = mdl.(Model)
+
+	assert.NotNil(t, cmd)
+	assert.Contains(t, res.statusMessage, "1 values")
+	assert.Contains(t, res.statusMessage, "1 missing")
+}
+
 func TestApplyCopyFieldPicker_FieldValueRemembersPerKind(t *testing.T) {
 	m := copyFieldOpenPicker(t, copyFieldTestModel(t))
 	m = tabToFields(t, m)

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -148,6 +148,8 @@ func (m Model) overlayHintBarSelector() string {
 			{Key: "enter", Desc: "apply"},
 			{Key: "esc", Desc: "cancel"},
 		})
+	case overlayCopyField:
+		return m.renderHints(copyFieldPickerHints())
 	case overlayPortForward:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "j/k", Desc: "select port"},

--- a/internal/app/runeutil.go
+++ b/internal/app/runeutil.go
@@ -1,0 +1,11 @@
+package app
+
+// trimLastRune drops the final rune (multibyte-safe backspace for
+// hand-rolled text inputs).
+func trimLastRune(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	return string(r[:len(r)-1])
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -327,6 +327,9 @@ func (m Model) updateActionResultMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case yamlClipboardMsg:
 		mdl, cmd := m.updateYamlClipboard(msg)
 		return mdl, cmd, true
+	case copyFieldManifestsMsg:
+		mdl, cmd := m.updateCopyFieldManifests(msg)
+		return mdl, cmd, true
 	case rbacCheckMsg:
 		mdl, cmd := m.updateRbacCheck(msg)
 		return mdl, cmd, true

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -90,6 +90,8 @@ func (m Model) handleExplorerToolKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 		return m.handleExplorerActionKeyCopyName()
 	case kb.CopyYAML:
 		return m.handleExplorerActionKeyCopyYAML()
+	case kb.CopyField:
+		return m.handleExplorerActionKeyCopyField()
 	case kb.PasteApply:
 		if m.readOnly {
 			m.setStatusMessage(readOnlyBlockedMessage("Paste & Apply"), true)

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -95,6 +95,8 @@ func (m Model) isOverlayToggleKey(key string) bool {
 		return key == kb.LocalClusterManager
 	case overlayCopyFormat:
 		return key == kb.CopyYAML
+	case overlayCopyField:
+		return key == kb.CopyField
 	}
 	return false
 }
@@ -256,6 +258,9 @@ func (m Model) handleOverlayKeySecondary(msg tea.KeyMsg) (tea.Model, tea.Cmd, bo
 		return mdl, cmd, true
 	case overlayCopyFormat:
 		mdl, cmd := m.handleCopyFormatPickerKey(msg)
+		return mdl, cmd, true
+	case overlayCopyField:
+		mdl, cmd := m.handleCopyFieldPickerKey(msg)
 		return mdl, cmd, true
 	}
 	return m, nil, false

--- a/internal/app/view_overlay_copy_field.go
+++ b/internal/app/view_overlay_copy_field.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// renderOverlayCopyField paints the ctrl+y copy picker: the visible
+// table columns by default, or — after tab — every leaf field of the
+// fetched manifest, each as a filterable row with the current value in
+// the description column. Returns empty content + zero dims when the
+// picker isn't active so the view-dispatch fallback fires.
+func (m Model) renderOverlayCopyField() (string, int, int) {
+	if !m.copyFieldPicker.active {
+		return "", 0, 0
+	}
+	p := m.copyFieldPicker
+	w, h, maxVisible := m.copyFieldOverlayDims()
+
+	// RenderOverlayList pads short rows but never truncates long ones, so
+	// cap path and value to the inner width — a multi-KB ConfigMap value
+	// must not overflow the row and desync the scrollbar column.
+	innerW := max(w-4, 1)
+	vis := m.visibleCopyFieldEntries()
+	items := make([]ui.OverlayListItem, len(vis))
+	for i, e := range vis {
+		items[i] = ui.OverlayListItem{
+			Name:        ui.Truncate(e.display, innerW),
+			Description: ui.Truncate(e.value, innerW),
+		}
+	}
+	cfg := ui.OverlayListConfig{
+		Title:           "Copy field",
+		Subtitle:        copyFieldSubtitle(p),
+		Cursor:          p.cursor,
+		Filterable:      true,
+		Filter:          p.filter,
+		FilterActive:    p.filterActive,
+		ShowDescription: true,
+		Scroll:          p.scroll,
+		MaxVisible:      maxVisible,
+		EmptyMessage:    copyFieldEmptyMessage(p),
+		Height:          h - 2,
+	}
+	return ui.RenderOverlayList(items, cfg, innerW), w, h
+}
+
+// copyFieldSubtitle names the kind, item count, and active mode with
+// the tab target — "Node — columns (tab: all fields)".
+func copyFieldSubtitle(p copyFieldPickerState) string {
+	mode := "columns (tab: all fields)"
+	if p.mode == copyFieldModeFields {
+		mode = "all fields (tab: columns)"
+	}
+	subject := p.kind
+	if p.requested > 1 {
+		subject = fmt.Sprintf("%s — %d items", p.kind, p.requested)
+	}
+	if subject == "" {
+		return mode
+	}
+	return subject + " — " + mode
+}
+
+// copyFieldEmptyMessage explains an empty list: fields still loading,
+// fields unavailable (with the reason), or just no filter matches.
+func copyFieldEmptyMessage(p copyFieldPickerState) string {
+	if p.mode == copyFieldModeFields {
+		if !p.fieldsLoaded {
+			return "Loading fields..."
+		}
+		if p.fieldsErr != "" && len(p.fieldEntries) == 0 {
+			return p.fieldsErr
+		}
+	}
+	return "No matching fields"
+}

--- a/internal/app/view_overlay_copy_field.go
+++ b/internal/app/view_overlay_copy_field.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -18,16 +20,21 @@ func (m Model) renderOverlayCopyField() (string, int, int) {
 	p := m.copyFieldPicker
 	w, h, maxVisible := m.copyFieldOverlayDims()
 
-	// RenderOverlayList pads short rows but never truncates long ones, so
-	// cap path and value to the inner width — a multi-KB ConfigMap value
-	// must not overflow the row and desync the scrollbar column.
+	// RenderOverlayList pads short rows but never truncates long ones,
+	// and it joins Name + "  " + Description on one line — so the two
+	// share a row budget. Long paths cap at 60% of the width; the value
+	// gets whatever the (possibly shorter) path leaves over. A multi-KB
+	// ConfigMap value must not overflow the row and desync the
+	// scrollbar column.
 	innerW := max(w-4, 1)
 	vis := m.visibleCopyFieldEntries()
 	items := make([]ui.OverlayListItem, len(vis))
 	for i, e := range vis {
+		name := ui.Truncate(e.display, max(innerW*3/5, 1))
+		descW := innerW - lipgloss.Width(name) - 2
 		items[i] = ui.OverlayListItem{
-			Name:        ui.Truncate(e.display, innerW),
-			Description: ui.Truncate(e.value, innerW),
+			Name:        name,
+			Description: ui.Truncate(e.value, max(descW, 0)),
 		}
 	}
 	cfg := ui.OverlayListConfig{

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -317,6 +317,9 @@ func (m Model) renderOverlayContentExtended() (string, int, int, bool) {
 	case overlayCopyFormat:
 		c, w, h := m.renderOverlayCopyFormat()
 		return c, w, h, true
+	case overlayCopyField:
+		c, w, h := m.renderOverlayCopyField()
+		return c, w, h, true
 	case overlayLogTopGroupBy:
 		c, w, h := m.renderLogTopGroupByOverlay()
 		return c, w, h, true

--- a/internal/model/objecttree.go
+++ b/internal/model/objecttree.go
@@ -87,16 +87,8 @@ func ObjectElementLabel(v any) (key, val string) {
 // elementName returns a friendly label for an array element that is a map,
 // using the first of objectNameKeys that resolves to a non-empty scalar.
 func elementName(v any) string {
-	m, ok := v.(map[string]any)
-	if !ok {
-		return ""
-	}
-	for _, k := range objectNameKeys {
-		if s := scalarString(m[k]); s != "" {
-			return s
-		}
-	}
-	return ""
+	_, val := ObjectElementLabel(v)
+	return val
 }
 
 // ObjectFieldHasChildren reports whether v is a non-empty map or array (i.e.

--- a/internal/model/objecttree.go
+++ b/internal/model/objecttree.go
@@ -67,6 +67,23 @@ func objectFieldFor(key string, v any) ObjectField {
 	}
 }
 
+// ObjectElementLabel returns the discriminator key/value labeling an
+// array element that is a map — the first of objectNameKeys resolving
+// to a non-empty scalar (e.g. "type"/"ExternalIP" for a node address).
+// Both returns are empty when no discriminator applies.
+func ObjectElementLabel(v any) (key, val string) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return "", ""
+	}
+	for _, k := range objectNameKeys {
+		if s := scalarString(m[k]); s != "" {
+			return k, s
+		}
+	}
+	return "", ""
+}
+
 // elementName returns a friendly label for an array element that is a map,
 // using the first of objectNameKeys that resolves to a non-empty scalar.
 func elementName(v any) string {

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -88,6 +88,7 @@ type Keybindings struct {
 	OpenBrowser       string `json:"open_browser" yaml:"open_browser"`
 	CopyName          string `json:"copy_name" yaml:"copy_name"`
 	CopyYAML          string `json:"copy_yaml" yaml:"copy_yaml"`
+	CopyField         string `json:"copy_field" yaml:"copy_field"`
 	PasteApply        string `json:"paste_apply" yaml:"paste_apply"`
 	Diff              string `json:"diff" yaml:"diff"`
 
@@ -211,6 +212,7 @@ func DefaultKeybindings() Keybindings {
 		Exec: "s", Edit: "E", Describe: "v", Delete: "D",
 		ForceDelete: "X", Scale: "S",
 		OpenBrowser: "ctrl+o", CopyName: "y", CopyYAML: "Y",
+		CopyField:  "ctrl+y",
 		PasteApply: "ctrl+p", Diff: "d",
 
 		// Multi-selection

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -109,6 +109,7 @@ func helpSections() []helpSection {
 				{kb.SaveResource, "Save resource to file / toggle warnings-only (Events)"},
 				{kb.CopyName, "Copy resource name to clipboard"},
 				{helpKeyDisplay(kb.CopyYAML), "Open copy-as picker (YAML / JSON / Table)"},
+				{helpKeyDisplay(kb.CopyField), "Copy a single field: visible columns by default, Tab for all manifest fields (multi-selection: one value per line)"},
 				{helpKeyDisplay(kb.PasteApply), "Apply resource from clipboard (kubectl apply)"},
 				{"", "Port forwarding: use action menu (" + kb.ActionMenu + ") on Pod/Service/Deployment/StatefulSet/DaemonSet"},
 				{"", "Auto-navigates to Port Forwards list after creation; shows resolved local port"},


### PR DESCRIPTION
## Summary

Adds a `Ctrl+Y` copy picker to the browser view for copying a single field of the selected resource(s) — e.g. a node's external IP — without hand-digging through YAML.

- **Columns mode (default)**: opens instantly on the visible table columns; Enter copies the cell value.
- **Fields mode (Tab)**: full manifest field list fetched in the background. Array elements are labeled by their discriminator — `status.addresses[ExternalIP].address` — so filtering `ExternalIP` surfaces the address row, not just the `type` row. Filter matches paths and values.
- **Multi-selection**: copies one value per line across all selected items; labeled array elements resolve per manifest (not by index), items missing the field are skipped and counted.
- **Session memory**: remembers the last-copied entry per resource kind and mode, preselecting it on reopen.
- Rebindable via a new `copy_field` keybinding (default `ctrl+y`).

Safety: overlay display values are control-byte sanitized (multiline certs / ANSI escapes in hostile manifests can't break the layout or escape-inject the terminal); the clipboard always gets the raw value. Fetches are capped at 50 items (columns mode keeps working above the cap), manifest parsing is bounded, and a fetch-sequence guard drops stale results.

## Test plan

- [x] TDD unit tests: flattener (semantic labels, duplicate-label index fallback, managedFields skip, sanitization), payload extraction (raw values, per-doc label resolution, missing-field counting), doc parsing caps
- [x] TUI tests: instant columns open, tab toggle, ExternalIP filter scenario, loading state, stale-fetch guard, per-kind memory preselect, filter typing/escape, hint bar
- [x] Keybinding/schema sync tests (`copy_field` in config schema)
- [x] `go test -race ./...`, `golangci-lint` (0 issues), `go build`
- [x] go-reviewer + security-reviewer passes; MEDIUM/LOW findings addressed (filter caching, row truncation, parse cap)
- [x] Manual: `ctrl+y` on a node → tab → filter `externalip` → Enter copies the external IP