### PR TITLE
refactor: build the copy-as shortcut hint from the formats

### DIFF
--- a/internal/app/copy_format_picker_keys.go
+++ b/internal/app/copy_format_picker_keys.go
@@ -1,21 +1,32 @@
 package app
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// copyFormatPickerHints is the copy-as picker's bottom hint bar
-// (kept here to co-locate the feature and keep overlay_hintbar.go
-// under the file-length cap).
-func copyFormatPickerHints() []ui.HintEntry {
-	return []ui.HintEntry{
-		{Key: "j/k", Desc: "navigate"},
-		{Key: "y/J/t", Desc: "shortcut"},
-		{Key: "enter", Desc: "apply"},
-		{Key: "esc", Desc: "cancel"},
+// copyFormatPickerHints is the copy-as picker's bottom hint bar (kept
+// here to co-locate the feature and keep overlay_hintbar.go under the
+// file-length cap). The shortcut chip is built from the open picker's
+// actual formats so it cannot drift from the ShortcutKey dispatch.
+func (m Model) copyFormatPickerHints() []ui.HintEntry {
+	keys := make([]string, 0, len(m.copyFormatPicker.formats))
+	for _, f := range m.copyFormatPicker.formats {
+		if k := f.ShortcutKey(); k != "" {
+			keys = append(keys, k)
+		}
 	}
+	hints := []ui.HintEntry{{Key: "j/k", Desc: "navigate"}}
+	if len(keys) > 0 {
+		hints = append(hints, ui.HintEntry{Key: strings.Join(keys, "/"), Desc: "shortcut"})
+	}
+	return append(hints,
+		ui.HintEntry{Key: "enter", Desc: "apply"},
+		ui.HintEntry{Key: "esc", Desc: "cancel"},
+	)
 }
 
 // handleCopyFormatPickerKey routes key events to the active copy-as

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -142,7 +142,7 @@ func (m Model) overlayHintBarSelector() string {
 			{Key: "esc", Desc: "close"},
 		})
 	case overlayCopyFormat:
-		return m.renderHints(copyFormatPickerHints())
+		return m.renderHints(m.copyFormatPickerHints())
 	case overlayCopyField:
 		return m.renderHints(copyFieldPickerHints())
 	case overlayTaintEditor:


### PR DESCRIPTION
## Summary

Follow-up to #501 (this commit was pushed to the branch minutes after the squash-merge, so it missed the train).

The copy-as picker's hint bar showed a hardcoded `y/J/t` shortcut chip while the key dispatch resolves shortcuts dynamically from each format's `ShortcutKey()` — the hint could silently drift if a format's shortcut changed or a new format was added (flagged by CodeRabbit on #501). The chip is now built from the open picker's actual format list.

## Test plan

- [x] Existing copy-format picker + hint bar tests pass
- [x] `go build`, `golangci-lint` (0 issues)
- [ ] Manual: `Y` on a resource → hint bar shows the shortcut chip matching the listed formats