### PR TITLE
fix: overlay list rows wrap and desync the scrollbar on overlong values

### DIFF
--- a/internal/ui/overlay_list.go
+++ b/internal/ui/overlay_list.go
@@ -207,16 +207,22 @@ func RenderOverlayList(items []OverlayListItem, cfg OverlayListConfig, innerW in
 			// so they stay readable against the box. CursorHighlightWidth
 			// caps the highlight short of the item area; the remainder pads
 			// with the surface background so the badge column stays put.
+			// Text is truncated to the highlight width — anything longer
+			// would wrap inside the Width(hlW) block, pushing every row
+			// below out of sync with the scrollbar column.
 			hlW := itemWidth
 			if cfg.CursorHighlightWidth > 0 && cfg.CursorHighlightWidth < itemWidth {
 				hlW = cfg.CursorHighlightWidth
 			}
-			row = OverlaySelectedStyle.Width(hlW).Render(itemPlainLine(it, cfg, hasActive))
+			row = OverlaySelectedStyle.Width(hlW).Render(Truncate(itemPlainLine(it, cfg, hasActive), hlW))
 			if pad := itemWidth - lipgloss.Width(row); pad > 0 {
 				row += OverlayDimStyle.Render(strings.Repeat(" ", pad))
 			}
 		} else {
-			line := OverlayNormalStyle.Render(itemStyledLine(it, cfg, hasActive))
+			// Truncated to the item area for the same reason as the cursor
+			// row: the component owns the no-wider-than-innerW invariant;
+			// callers only best-effort their Name/Description budgets.
+			line := OverlayNormalStyle.Render(Truncate(itemStyledLine(it, cfg, hasActive), itemWidth))
 			// Only pad non-cursor rows when there's a trailing column
 			// (badge or scrollbar) that needs a stable left edge —
 			// padding rows without a reserve regresses the historical

--- a/internal/ui/overlay_list_test.go
+++ b/internal/ui/overlay_list_test.go
@@ -388,3 +388,64 @@ func TestRenderOverlayList(t *testing.T) {
 		assert.Contains(t, out, "Stale")
 	})
 }
+
+// --- row width invariant ---
+
+// Rows must never exceed innerW, no matter how long a caller-supplied
+// Name/Description is — an overlong row wraps inside the overlay box,
+// shifting every row below it and desyncing the per-row scrollbar
+// (observed with multi-KB annotation values in the copy-field picker).
+func TestRenderOverlayList_RowsNeverExceedInnerWidth(t *testing.T) {
+	long := strings.Repeat("x", 300)
+	mk := func(n int) []OverlayListItem {
+		items := make([]OverlayListItem, n)
+		for i := range items {
+			items[i] = OverlayListItem{Name: long, Description: long}
+		}
+		return items
+	}
+	const innerW = 80
+
+	t.Run("overflowing list with scrollbar", func(t *testing.T) {
+		cfg := OverlayListConfig{
+			Title:           "T",
+			Cursor:          2,
+			ShowDescription: true,
+			MaxVisible:      5,
+		}
+		out := RenderOverlayList(mk(20), cfg, innerW)
+		for i, line := range strings.Split(out, "\n") {
+			require.LessOrEqualf(t, lipgloss.Width(line), innerW,
+				"line %d wider than innerW", i)
+		}
+	})
+
+	t.Run("short list without scrollbar", func(t *testing.T) {
+		cfg := OverlayListConfig{Cursor: 0, ShowDescription: true}
+		out := RenderOverlayList(mk(3), cfg, innerW)
+		for i, line := range strings.Split(out, "\n") {
+			require.LessOrEqualf(t, lipgloss.Width(line), innerW,
+				"line %d wider than innerW", i)
+		}
+	})
+
+	t.Run("cursor row with badge and multiselect", func(t *testing.T) {
+		items := mk(12)
+		for i := range items {
+			items[i].Selected = i%2 == 0
+			items[i].Badge = "##"
+		}
+		cfg := OverlayListConfig{
+			Cursor:          4,
+			MultiSelect:     true,
+			ShowDescription: true,
+			MaxVisible:      6,
+			BadgeWidth:      2,
+		}
+		out := RenderOverlayList(items, cfg, innerW)
+		for i, line := range strings.Split(out, "\n") {
+			require.LessOrEqualf(t, lipgloss.Width(line), innerW,
+				"line %d wider than innerW", i)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

In the copy-field picker (#500), a field with a very long value — e.g. a k3s `node-args` annotation — rendered a row wider than the overlay's content area. `RenderOverlayList` reserves a scrollbar column when the list overflows but never truncated rows, so the row wrapped onto a second physical line and every row below lost alignment with the per-row scrollbar glyphs.

The fix enforces the width invariant inside the shared component: non-cursor rows truncate (ANSI-aware, `~` suffix) to the item area (inner width minus badge/scrollbar reserves), and the cursor row truncates to its highlight width — text longer than that wrapped inside the lipgloss `Width` block. Callers' Name/Description budgets remain best-effort layout; the component now guarantees no row can break the box. The clipboard payload is unaffected — full values are still copied intact.

This also fixes the same latent overflow in the Object Explorer find overlay, which passes untruncated value previews.

## Type of change

- [x] fix: bug fix
- [x] test: add or update tests

## Related issue

None — reported directly with a screenshot of the copy-field picker on a k3s node (`metadata.annotations.k3s.io/node-args` wrapping and desyncing the scrollbar).

## Changes

- `internal/ui/overlay_list.go`: truncate non-cursor rows to the item area and the cursor row to its highlight width before styling; document the component-owned width invariant
- `internal/ui/overlay_list_test.go`: add `TestRenderOverlayList_RowsNeverExceedInnerWidth` covering an overflowing list with scrollbar, a short list without one, and a cursor row with badge + multi-select columns

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (full suite with `-race`)
- [x] `golangci-lint run` passes (0 issues)
- [ ] Manually verified against a real cluster: ctrl+y on the node from the report → the `node-args` row truncates with `~`, scrollbar stays aligned

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed (n/a — rendering bug fix, no behavior/config surface)
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (n/a)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch (not `main`)

## Screenshots / recordings

Before (from the report): the `metadata.annotations.k3s.io/node-args` row wraps onto a second line and the rows below shift against the scrollbar. After: the row renders truncated with a `~` at the box edge and all rows stay aligned.