### PR TITLE
fix(namespace): keep selector open on first Enter over a sole filtered result

### DIFF
--- a/internal/app/negative_namespace_test.go
+++ b/internal/app/negative_namespace_test.go
@@ -473,7 +473,7 @@ func TestNamespaceOverlayEnterCommitsExcludeSet(t *testing.T) {
 	assert.False(t, result.allNamespaces)
 }
 
-// --- filter-accept single-result apply clears a restored exclude scope ---
+// --- committing a single filtered namespace clears a restored exclude scope ---
 
 func TestNamespaceOverlayFilterAcceptSingleResultClearsNegation(t *testing.T) {
 	m := newNamespaceOverlayModel()
@@ -484,11 +484,15 @@ func TestNamespaceOverlayFilterAcceptSingleResultClearsNegation(t *testing.T) {
 	m.nsFilterMode = true
 	m.overlayFilter.Value = "kube-system"
 
+	// First Enter accepts the filter and keeps the overlay open; the second
+	// Enter (normal mode) commits the single cursored namespace.
 	ret, _ := m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter))
+	m = ret.(Model)
+	ret, _ = m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter))
 	result := ret.(Model)
 
 	assert.False(t, result.nsSelectionNegated,
-		"applying a single filtered namespace must clear the restored negation")
+		"committing a single filtered namespace must clear the restored negation")
 	assert.True(t, result.selectedNamespaces["kube-system"],
 		"the filtered namespace must be committed as an include selection")
 	assert.False(t, result.allNamespaces)

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -379,34 +379,12 @@ func (m Model) handleNamespaceFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
-		// When the filter narrows to a single result and the user hasn't
-		// been multi-selecting with Space, Enter is unambiguous: apply
-		// that result and close. Without this, the user has to press
-		// Enter twice (once to leave filter mode, once to commit) on a
-		// list that has only one row — the second Enter is busy work.
-		if !m.nsSelectionModified {
-			items := m.filteredOverlayItems()
-			if len(items) == 1 {
-				oldNs := m.namespace
-				m.nsSelectionNegated = false
-				if items[0].Status == "all" {
-					m.selectedNamespaces = nil
-					m.allNamespaces = true
-				} else {
-					ns := items[0].Name
-					m.selectedNamespaces = map[string]bool{ns: true}
-					m.namespace = ns
-					m.allNamespaces = false
-				}
-				m.invalidateOrphanCacheForNamespace(m.nav.Context, oldNs)
-				m.overlay = overlayNone
-				m.overlayFilter.Clear()
-				m.saveCurrentSession()
-				m.cancelAndReset()
-				m.requestGen++
-				return m, m.refreshCurrentLevel()
-			}
-		}
+		// Enter here only leaves filter-typing mode and keeps the overlay
+		// open (cursor on the first — often only — filtered row). It never
+		// auto-applies a single result: that would prevent building a
+		// multi-namespace scope. The user commits from normal mode with a
+		// second Enter (apply the cursor's namespace) or adds more with
+		// Space first. The retained filter keeps the narrowed row visible.
 		return m, nil
 	case filterClose:
 		// Ctrl+C in filter mode closes the overlay, not the tab —

--- a/internal/app/update_overlays_selectors_extra_test.go
+++ b/internal/app/update_overlays_selectors_extra_test.go
@@ -13,6 +13,59 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// The namespace filter's first Enter must NOT auto-apply a single filtered
+// result: it accepts the filter and keeps the overlay open so the user can add
+// more namespaces with Space (build a multi-namespace scope).
+func TestNamespaceOverlayFilterEnterKeepsOverlayOpen(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.nsFilterMode = true
+	m.overlayFilter.Value = "kube-system" // narrows to a single result
+
+	ret, _ := m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter))
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNamespace, result.overlay, "overlay stays open on first Enter")
+	assert.False(t, result.nsFilterMode, "filter-typing mode is left")
+	assert.Nil(t, result.selectedNamespaces, "single result is not auto-applied")
+	assert.False(t, result.allNamespaces)
+}
+
+// After the first Enter keeps the overlay open, Space adds the filtered
+// namespace to the selection and a second Enter applies it.
+func TestNamespaceOverlayFilterEnterThenSpaceThenEnterApplies(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.nsFilterMode = true
+	m.overlayFilter.Value = "kube-system"
+
+	ret, _ := m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter)) // accept filter, keep open
+	m = ret.(Model)
+	ret, _ = m.handleNamespaceOverlayKey(specialKey(tea.KeySpace)) // add to selection
+	m = ret.(Model)
+	assert.True(t, m.selectedNamespaces["kube-system"])
+
+	ret, _ = m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter)) // apply and close
+	result := ret.(Model)
+	assert.Equal(t, overlayNone, result.overlay, "second Enter applies and closes")
+	assert.True(t, result.selectedNamespaces["kube-system"])
+}
+
+// A plain second Enter (no Space) on the single filtered result applies it as
+// the sole namespace and closes.
+func TestNamespaceOverlayFilterEnterTwiceAppliesSingle(t *testing.T) {
+	m := newNamespaceOverlayModel()
+	m.nsFilterMode = true
+	m.overlayFilter.Value = "kube-system"
+
+	ret, _ := m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter)) // accept filter, keep open
+	m = ret.(Model)
+	ret, _ = m.handleNamespaceOverlayKey(specialKey(tea.KeyEnter)) // apply single
+	result := ret.(Model)
+
+	assert.Equal(t, overlayNone, result.overlay)
+	assert.True(t, result.selectedNamespaces["kube-system"])
+	assert.False(t, result.allNamespaces)
+}
+
 // --- handleNamespaceOverlayKey: normal mode ---
 
 func TestNamespaceOverlayEscClosesWithNoFilter(t *testing.T) {
@@ -256,7 +309,7 @@ func TestNamespaceFilterModeEnterCommits(t *testing.T) {
 // Filter narrows the list to a single concrete namespace: Enter must apply
 // it and close the overlay so the user does not have to press Enter again
 // on a one-row list.
-func TestNamespaceFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
+func TestNamespaceFilterModeEnterOnSoleResultKeepsOpen(t *testing.T) {
 	items := []model.Item{
 		{Name: "All Namespaces", Status: "all"},
 		{Name: "default"},
@@ -274,12 +327,13 @@ func TestNamespaceFilterModeEnterAutoSelectsSoleResult(t *testing.T) {
 	}
 	ret, cmd := m.handleNamespaceFilterMode(specialKey(tea.KeyEnter))
 	result := ret.(Model)
+	// First Enter only leaves filter mode; the sole result is NOT applied so
+	// the user can still add more namespaces with Space.
 	assert.False(t, result.nsFilterMode)
-	assert.Equal(t, overlayNone, result.overlay)
-	assert.Equal(t, "kube-system", result.namespace)
-	assert.True(t, result.selectedNamespaces["kube-system"])
-	assert.False(t, result.allNamespaces)
-	assert.NotNil(t, cmd)
+	assert.Equal(t, overlayNamespace, result.overlay, "overlay stays open")
+	assert.Nil(t, result.selectedNamespaces, "sole result is not auto-applied")
+	assert.True(t, result.allNamespaces, "prior scope is untouched until a namespace is committed")
+	assert.Nil(t, cmd)
 }
 
 // Two filtered results: Enter must keep the legacy behavior — exit filter


### PR DESCRIPTION
## Summary

The namespace selector auto-applied and closed as soon as the filter narrowed to a **single** row (when the user hadn't Space-toggled anything). That made it impossible to build a **multi-namespace** scope by filtering — the first Enter committed the sole result before you could add a second namespace.

This removes that auto-apply shortcut. **Enter in filter-typing mode now only leaves filter mode and keeps the overlay open**, cursor on the (sole) filtered row. From there:

- **Space** adds it to the selection → filter again (`/`) for the next namespace → Space → …, or
- a **second Enter** commits the cursored namespace as the sole selection (the normal-mode Enter path, which also clears any restored exclude/negation).

This matches the requested flow: *"on first enter it should keep the filtering to make it possible to add a namespace with space and enter; but if I only press enter again, it filters to that namespace only."*

The union-set single-result apply is untouched (union sets take exactly one namespace).

## Test plan

- [x] New: first Enter keeps overlay open and does not auto-apply
- [x] New: first Enter → Space → second Enter applies the multi-select
- [x] New: first Enter → second Enter (no Space) commits the sole namespace
- [x] Updated the two tests that asserted the old auto-select; exclude/negation clearing now verified on the committing Enter
- [x] `go build`, `go test -race ./internal/app/`, `golangci-lint` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)