### PR TITLE
chore(security): bump Go to 1.26.5 (fixes GO-2026-5856 in crypto/tls)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/janosmiko/lfk
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
## Summary

CI's govulncheck fails on `GO-2026-5856`, a `crypto/tls` vulnerability present in **go1.26.4** and fixed in **go1.26.5**. It's reachable through the Kubernetes client's TLS transport (`internal/k8s/auth_tagging.go` round-tripper, packet decoder, etc.), so govulncheck flags it as a called vulnerability.

Bump the `go` directive in `go.mod` to `1.26.5`. All CI jobs use `setup-go` with `go-version-file: go.mod`, so this makes them install the patched toolchain.

## Verification

- `go build ./...` — clean (toolchain auto-upgraded to go1.26.5)
- `govulncheck ./...` — **No vulnerabilities found** (was 1)
- `go vet` / `go test ./internal/app/` — green

No code changes; toolchain bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)