### PR TITLE
fix(node): humanize node Mem Alloc (6895736Ki → 6.6Gi)

### DIFF
--- a/internal/k8s/client_populate_kinds.go
+++ b/internal/k8s/client_populate_kinds.go
@@ -2,8 +2,11 @@ package k8s
 
 import (
 	"encoding/base64"
+	"fmt"
 	"sort"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
@@ -84,7 +87,7 @@ func populateNodeStatus(ti *model.Item, status map[string]any) {
 			ti.Columns = append(ti.Columns, model.KeyValue{Key: "CPU Alloc", Value: cpu})
 		}
 		if mem, ok := alloc["memory"].(string); ok {
-			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Mem Alloc", Value: mem})
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Mem Alloc", Value: humanizeMemory(mem)})
 		}
 		if pods, ok := alloc["pods"].(string); ok {
 			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pods Alloc", Value: pods})
@@ -215,5 +218,31 @@ func populateSecretDetails(ti *model.Item, obj map[string]any) {
 	}
 	if sType, ok := obj["type"].(string); ok {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Type", Value: sType})
+	}
+}
+
+// humanizeMemory converts a Kubernetes memory quantity to a compact Gi/Mi form
+// for display. The kubelet reports node allocatable/capacity memory in Ki
+// (e.g. "6895736Ki"), which is unreadable in a list — this renders it as
+// "6.6Gi". Falls back to the original string if it can't be parsed. Mirrors
+// ui.FormatMemory, which the k8s layer cannot import (layering).
+func humanizeMemory(s string) string {
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return s
+	}
+	b := q.Value()
+	switch {
+	case b >= 1024*1024*1024:
+		// Keep one decimal for fractional values (6.6Gi) but drop it for whole
+		// ones (8Gi, not 8.0Gi).
+		gi := strings.TrimSuffix(fmt.Sprintf("%.1f", float64(b)/(1024*1024*1024)), ".0")
+		return gi + "Gi"
+	case b >= 1024*1024:
+		return fmt.Sprintf("%.0fMi", float64(b)/(1024*1024))
+	case b >= 1024:
+		return fmt.Sprintf("%.0fKi", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%dB", b)
 	}
 }

--- a/internal/k8s/client_populate_kinds_test.go
+++ b/internal/k8s/client_populate_kinds_test.go
@@ -1,0 +1,29 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHumanizeMemory(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"6895736Ki", "6.6Gi"}, // node allocatable as the kubelet reports it
+		{"128Mi", "128Mi"},
+		{"1Gi", "1Gi"}, // whole values drop the .0
+		{"8Gi", "8Gi"},
+		{"1024Ki", "1Mi"},
+		{"512Ki", "512Ki"},
+		{"512", "512B"},
+		{"not-a-quantity", "not-a-quantity"}, // unparseable falls back unchanged
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, humanizeMemory(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The node view showed **Mem Alloc** as the raw Kubernetes quantity the kubelet reports — `status.allocatable.memory` comes back in `Ki` (e.g. `6895736Ki`), which is unreadable in a list.

Now it's rendered in `Gi`/`Mi`: `6895736Ki` → **`6.6Gi`**. Whole values drop the trailing `.0` (so `8Gi`, not `8.0Gi`).

## Why a new helper

`ui.FormatMemory` already does byte→Gi/Mi, but the population code lives in `internal/k8s`, which can't import `internal/ui` (layering). So this adds a small `humanizeMemory(quantityString)` in the k8s layer that parses with `resource.ParseQuantity` and falls back to the original string if unparseable.

Sorting is unaffected — the numeric column sorter already understands `Gi`/`Mi`/`Ki` suffixes (including decimals like `6.6Gi`).

## Test plan

- [x] `TestHumanizeMemory` covers `6895736Ki→6.6Gi`, whole-value stripping (`8Gi`), `Mi`/`Ki`/`B` tiers, and unparseable passthrough
- [x] Existing node-detail tests still pass (whole-Gi inputs round-trip cleanly)
- [x] `go test ./internal/k8s/`, `golangci-lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)