### PR TITLE
feat(tabs): move active tab left/right

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `Space` | Toggle multi-selection (bulk actions via `x`) |
 | `m<slot>` / `'<slot>` | Set / jump to bookmark (lowercase = context-aware, uppercase = context-free) |
 | `t` / `]` / `[` | New tab / next / previous |
+| `}` / `{` | Move current tab right / left |
 
 All views (YAML, logs, describe, diff, exec) use vim-style navigation (`j`/`k`, `gg`/`G`, `Ctrl+D`/`Ctrl+U`, `/` search, `v`/`V` visual selection). See [docs/keybindings.md](docs/keybindings.md) for the full reference.
 

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -410,6 +410,8 @@ keybindings:
   security_ignore_toggle: "i" # Show/hide ignored security findings (default: i; security view only — shadows the Label Editor there)
   session_manager: "C" # Open the session manager overlay: save/switch/delete named workspace sessions (default: C)
   security_badge_toggle: "B" # Show/hide the per-resource SEC severity badge (default: B)
+  move_tab_left: "{" # Move the current tab one slot left (default: { = shift+[)
+  move_tab_right: "}" # Move the current tab one slot right (default: } = shift+])
 
 # ─── Search Abbreviations ─────────────────────────────────────────────────────
 # Short names for resource types used in search/filter.

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -449,6 +449,8 @@
         "new_tab": { "type": "string" },
         "next_tab": { "type": "string" },
         "prev_tab": { "type": "string" },
+        "move_tab_left": { "type": "string" },
+        "move_tab_right": { "type": "string" },
         "set_mark": { "type": "string" },
         "open_marks": { "type": "string" },
         "terminal_toggle": { "type": "string" },

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -863,6 +863,8 @@ Invalid config values are dropped at startup with a warning in the error log.
 | `t` | New tab (clone current view) |
 | `]` | Next tab |
 | `[` | Previous tab |
+| `}` | Move current tab right (shift+]) |
+| `{` | Move current tab left (shift+[) |
 
 ## Read-Only Mode
 
@@ -1179,6 +1181,8 @@ keybindings:
   new_tab: "t"           # New tab
   next_tab: "]"          # Next tab
   prev_tab: "["          # Previous tab
+  move_tab_left: "{"     # Move current tab left
+  move_tab_right: "}"    # Move current tab right
 
   # Bookmarks
   set_mark: "m"          # Set mark

--- a/internal/app/status_clear.go
+++ b/internal/app/status_clear.go
@@ -40,7 +40,7 @@ func (m Model) clearStatusOnNavigationKey(msg tea.KeyMsg) Model {
 		kb.LevelCluster, kb.LevelTypes, kb.LevelResources,
 		kb.JumpBack, kb.JumpOwner,
 		kb.NextMatch, kb.PrevMatch,
-		kb.NextTab, kb.PrevTab, kb.NewTab:
+		kb.NextTab, kb.PrevTab, kb.NewTab, kb.MoveTabLeft, kb.MoveTabRight:
 		m.clearTransientStatus()
 	}
 	return m

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -628,6 +628,32 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	return nil
 }
 
+// moveActiveTab reorders the active tab one slot in the given direction
+// (-1 = left, +1 = right) and keeps it active at its new index. It is a
+// no-op (returns false) when there are fewer than two tabs or the tab is
+// already at the edge — the order does not wrap.
+//
+// This is a pure reorder that does NOT switch tabs: the active tab's live
+// state stays in the Model, only its slot and m.activeTab move. So it must
+// not call saveCurrentTab — that cancels the live preview-log stream (for a
+// real switch loadTab restarts it, but a move never reloads), which would
+// silently kill the tail. The active tab's snapshot in m.tabs is left stale
+// and is refreshed by the next real switch's saveCurrentTab before it is
+// ever loaded; the neighbor's snapshot is already current and just changes
+// index.
+func (m *Model) moveActiveTab(direction int) bool {
+	if len(m.tabs) <= 1 {
+		return false
+	}
+	target := m.activeTab + direction
+	if target < 0 || target >= len(m.tabs) {
+		return false
+	}
+	m.tabs[m.activeTab], m.tabs[target] = m.tabs[target], m.tabs[m.activeTab]
+	m.activeTab = target
+	return true
+}
+
 // cloneCurrentTab creates a deep copy of the current model state as a new TabState.
 func (m *Model) cloneCurrentTab() TabState {
 	newTab := TabState{

--- a/internal/app/tabs_move_test.go
+++ b/internal/app/tabs_move_test.go
@@ -98,6 +98,37 @@ func TestActionKeyBraceMoveTabAtEdgeStillHandled(t *testing.T) {
 	assert.True(t, handled)
 }
 
+// TestTabSwitchKeyBraceMovesTabInFullscreenViewer covers the second dispatch
+// path: in a fullscreen viewer (not explorer/exec) the brace keys route through
+// handleTabSwitchKey, which is gated off in explorer/exec by inputActive.
+func TestTabSwitchKeyBraceMovesTabInFullscreenViewer(t *testing.T) {
+	m := threeTabModel(0) // active = prod
+	m.mode = modeYAML     // fullscreen viewer
+
+	mdl, _, handled := m.handleTabSwitchKey(runeKey('}'))
+	require.True(t, handled)
+	right := mdl.(Model)
+	assert.Equal(t, 1, right.activeTab)
+	assert.Equal(t, []string{"staging", "prod", "dev"}, tabContexts(right))
+
+	mdl, _, handled = right.handleTabSwitchKey(runeKey('{'))
+	require.True(t, handled)
+	left := mdl.(Model)
+	assert.Equal(t, 0, left.activeTab)
+	assert.Equal(t, []string{"prod", "staging", "dev"}, tabContexts(left))
+}
+
+// TestTabSwitchKeyBraceMoveTabAtEdgeFallsThrough verifies the fullscreen path
+// does NOT claim the key on a no-op move (matching NextTab/PrevTab), so the
+// brace can still reach a viewer that might bind it.
+func TestTabSwitchKeyBraceMoveTabAtEdgeFallsThrough(t *testing.T) {
+	m := threeTabModel(2) // active = dev (rightmost)
+	m.mode = modeYAML
+
+	_, _, handled := m.handleTabSwitchKey(runeKey('}'))
+	assert.False(t, handled, "no-op move must fall through in the fullscreen path")
+}
+
 // TestMoveActiveTab_KeepsPreviewLogStream is a regression guard: a move is not a
 // tab switch, so it must not cancel the live preview-log stream (which is never
 // restarted afterward). moveActiveTab must avoid saveCurrentTab's

--- a/internal/app/tabs_move_test.go
+++ b/internal/app/tabs_move_test.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// tabContexts returns the per-tab context names in slice order so a reorder is
+// easy to assert against. threeTabModel seeds prod / staging / dev.
+func tabContexts(m Model) []string {
+	out := make([]string, len(m.tabs))
+	for i, t := range m.tabs {
+		out[i] = t.nav.Context
+	}
+	return out
+}
+
+func TestMoveActiveTab_Right(t *testing.T) {
+	m := threeTabModel(0) // active = prod
+
+	moved := m.moveActiveTab(+1)
+
+	require.True(t, moved)
+	assert.Equal(t, 1, m.activeTab, "active tab follows the move")
+	assert.Equal(t, []string{"staging", "prod", "dev"}, tabContexts(m))
+}
+
+func TestMoveActiveTab_Left(t *testing.T) {
+	m := threeTabModel(2) // active = dev
+
+	moved := m.moveActiveTab(-1)
+
+	require.True(t, moved)
+	assert.Equal(t, 1, m.activeTab)
+	assert.Equal(t, []string{"prod", "dev", "staging"}, tabContexts(m))
+}
+
+func TestMoveActiveTab_RightAtEdgeIsNoOp(t *testing.T) {
+	m := threeTabModel(2) // active = dev (rightmost)
+
+	moved := m.moveActiveTab(+1)
+
+	assert.False(t, moved, "rightmost tab cannot move further right (no wrap)")
+	assert.Equal(t, 2, m.activeTab)
+	assert.Equal(t, []string{"prod", "staging", "dev"}, tabContexts(m))
+}
+
+func TestMoveActiveTab_LeftAtEdgeIsNoOp(t *testing.T) {
+	m := threeTabModel(0) // active = prod (leftmost)
+
+	moved := m.moveActiveTab(-1)
+
+	assert.False(t, moved, "leftmost tab cannot move further left (no wrap)")
+	assert.Equal(t, 0, m.activeTab)
+	assert.Equal(t, []string{"prod", "staging", "dev"}, tabContexts(m))
+}
+
+func TestMoveActiveTab_SingleTabIsNoOp(t *testing.T) {
+	m := baseExplorerModel()
+	m.tabs = []TabState{{nav: model.NavigationState{Context: "only"}}}
+	m.activeTab = 0
+
+	assert.False(t, m.moveActiveTab(+1))
+	assert.False(t, m.moveActiveTab(-1))
+	assert.Equal(t, 0, m.activeTab)
+}
+
+// TestActionKeyBraceMovesTab drives the reorder through the explorer key
+// dispatcher (the path used in explorer/exec mode) with the default brace
+// bindings.
+func TestActionKeyBraceMovesTab(t *testing.T) {
+	m := threeTabModel(0) // active = prod
+
+	ret, _, handled := m.handleExplorerActionKey(runeKey('}'))
+	require.True(t, handled)
+	right := ret.(Model)
+	assert.Equal(t, 1, right.activeTab)
+	assert.Equal(t, []string{"staging", "prod", "dev"}, tabContexts(right))
+	assert.Contains(t, right.statusMessage, "Tab moved to position 2")
+
+	ret, _, handled = right.handleExplorerActionKey(runeKey('{'))
+	require.True(t, handled)
+	left := ret.(Model)
+	assert.Equal(t, 0, left.activeTab)
+	assert.Equal(t, []string{"prod", "staging", "dev"}, tabContexts(left))
+}
+
+// TestActionKeyBraceMoveTabAtEdgeStillHandled verifies the brace is swallowed
+// even when the move is a no-op, so it never leaks to another handler.
+func TestActionKeyBraceMoveTabAtEdgeStillHandled(t *testing.T) {
+	m := threeTabModel(2) // active = dev (rightmost)
+
+	_, _, handled := m.handleExplorerActionKey(runeKey('}'))
+	assert.True(t, handled)
+}
+
+// TestMoveActiveTab_KeepsPreviewLogStream is a regression guard: a move is not a
+// tab switch, so it must not cancel the live preview-log stream (which is never
+// restarted afterward). moveActiveTab must avoid saveCurrentTab's
+// cancelPreviewLogStream side effect.
+func TestMoveActiveTab_KeepsPreviewLogStream(t *testing.T) {
+	m := threeTabModel(0)
+	cancelled := false
+	m.previewLog.podKey = "ns/pod-a/"
+	m.previewLog.lines = []string{"line-1", "line-2"}
+	m.previewLog.cancel = func() { cancelled = true }
+
+	require.True(t, m.moveActiveTab(+1))
+
+	assert.False(t, cancelled, "move must not cancel the preview-log goroutine")
+	assert.Equal(t, "ns/pod-a/", m.previewLog.podKey, "preview stream identity preserved")
+	assert.Equal(t, []string{"line-1", "line-2"}, m.previewLog.lines, "preview buffer preserved")
+}

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -111,6 +111,16 @@ func (m Model) handleTabSwitchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 			m, logCmd := m.maybeRestartOrCancelPreviewLog()
 			return m, tea.Batch(m.postTabSwitchCmd(), logCmd), true
 		}
+	case kb.MoveTabLeft:
+		if m.moveActiveTab(-1) {
+			m.setStatusMessage(fmt.Sprintf("Tab moved to position %d", m.activeTab+1), false)
+			return m, scheduleStatusClear(), true
+		}
+	case kb.MoveTabRight:
+		if m.moveActiveTab(+1) {
+			m.setStatusMessage(fmt.Sprintf("Tab moved to position %d", m.activeTab+1), false)
+			return m, scheduleStatusClear(), true
+		}
 	case kb.NewTab:
 		if m.mode == modeKubetris && m.kubetrisGame != nil && !m.kubetrisGame.paused {
 			m.kubetrisGame.paused = true

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -108,6 +108,10 @@ func (m Model) handleExplorerToolKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 		return m.handleExplorerActionKeyNextTab()
 	case kb.PrevTab:
 		return m.handleExplorerActionKeyPrevTab()
+	case kb.MoveTabLeft:
+		return m.handleExplorerActionKeyMoveTab(-1)
+	case kb.MoveTabRight:
+		return m.handleExplorerActionKeyMoveTab(+1)
 	case kb.CreateTemplate:
 		return m.handleExplorerActionKeyCreateTemplate()
 	case kb.SecretEditor:
@@ -598,54 +602,6 @@ func (m Model) handleExplorerActionKeyCopyYAML() (tea.Model, tea.Cmd, bool) {
 	}
 	m.openCopyFormatPicker()
 	return m, nil, true
-}
-
-func (m Model) handleExplorerActionKeyNewTab() (tea.Model, tea.Cmd, bool) {
-	if m.unionMode {
-		m.setStatusMessage("New tab is not available in union view", true)
-		return m, scheduleStatusClear(), true
-	}
-	if len(m.tabs) >= 9 {
-		m.setStatusMessage("Max 9 tabs", true)
-		return m, scheduleStatusClear(), true
-	}
-	m.saveCurrentTab()
-	insertAt := m.activeTab + 1
-	newTab := m.cloneCurrentTab()
-	m.tabs = append(m.tabs[:insertAt], append([]TabState{newTab}, m.tabs[insertAt:]...)...)
-	m.activeTab = insertAt
-	m.setStatusMessage(fmt.Sprintf("Tab %d created", m.activeTab+1), false)
-	return m, scheduleStatusClear(), true
-}
-
-func (m Model) handleExplorerActionKeyNextTab() (tea.Model, tea.Cmd, bool) {
-	if len(m.tabs) <= 1 {
-		return m, nil, true
-	}
-	m.saveCurrentTab()
-	next := (m.activeTab + 1) % len(m.tabs)
-	if cmd := m.loadTab(next); cmd != nil {
-		return m, cmd, true
-	}
-	if m.mode == modeExec && m.execPTY != nil {
-		return m, m.scheduleExecTick(), true
-	}
-	return m, m.loadPreview(), true
-}
-
-func (m Model) handleExplorerActionKeyPrevTab() (tea.Model, tea.Cmd, bool) {
-	if len(m.tabs) <= 1 {
-		return m, nil, true
-	}
-	m.saveCurrentTab()
-	prev := (m.activeTab - 1 + len(m.tabs)) % len(m.tabs)
-	if cmd := m.loadTab(prev); cmd != nil {
-		return m, cmd, true
-	}
-	if m.mode == modeExec && m.execPTY != nil {
-		return m, m.scheduleExecTick(), true
-	}
-	return m, m.loadPreview(), true
 }
 
 func (m Model) handleExplorerActionKeyCreateTemplate() (tea.Model, tea.Cmd, bool) {

--- a/internal/app/update_keys_actions_tabs.go
+++ b/internal/app/update_keys_actions_tabs.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Tab action-key handlers (new / next / prev / move), dispatched from
+// handleExplorerActionKey in explorer and exec modes.
+
+func (m Model) handleExplorerActionKeyNewTab() (tea.Model, tea.Cmd, bool) {
+	if m.unionMode {
+		m.setStatusMessage("New tab is not available in union view", true)
+		return m, scheduleStatusClear(), true
+	}
+	if len(m.tabs) >= 9 {
+		m.setStatusMessage("Max 9 tabs", true)
+		return m, scheduleStatusClear(), true
+	}
+	m.saveCurrentTab()
+	insertAt := m.activeTab + 1
+	newTab := m.cloneCurrentTab()
+	m.tabs = append(m.tabs[:insertAt], append([]TabState{newTab}, m.tabs[insertAt:]...)...)
+	m.activeTab = insertAt
+	m.setStatusMessage(fmt.Sprintf("Tab %d created", m.activeTab+1), false)
+	return m, scheduleStatusClear(), true
+}
+
+func (m Model) handleExplorerActionKeyNextTab() (tea.Model, tea.Cmd, bool) {
+	if len(m.tabs) <= 1 {
+		return m, nil, true
+	}
+	m.saveCurrentTab()
+	next := (m.activeTab + 1) % len(m.tabs)
+	if cmd := m.loadTab(next); cmd != nil {
+		return m, cmd, true
+	}
+	if m.mode == modeExec && m.execPTY != nil {
+		return m, m.scheduleExecTick(), true
+	}
+	return m, m.loadPreview(), true
+}
+
+func (m Model) handleExplorerActionKeyPrevTab() (tea.Model, tea.Cmd, bool) {
+	if len(m.tabs) <= 1 {
+		return m, nil, true
+	}
+	m.saveCurrentTab()
+	prev := (m.activeTab - 1 + len(m.tabs)) % len(m.tabs)
+	if cmd := m.loadTab(prev); cmd != nil {
+		return m, cmd, true
+	}
+	if m.mode == modeExec && m.execPTY != nil {
+		return m, m.scheduleExecTick(), true
+	}
+	return m, m.loadPreview(), true
+}
+
+// handleExplorerActionKeyMoveTab reorders the active tab one slot in the given
+// direction (-1 = left, +1 = right). A no-op at the edges or with a single tab
+// still claims the key so the brace doesn't leak to another handler.
+func (m Model) handleExplorerActionKeyMoveTab(direction int) (tea.Model, tea.Cmd, bool) {
+	if m.moveActiveTab(direction) {
+		m.setStatusMessage(fmt.Sprintf("Tab moved to position %d", m.activeTab+1), false)
+		return m, scheduleStatusClear(), true
+	}
+	return m, nil, true
+}

--- a/internal/app/update_overlays_errorlog.go
+++ b/internal/app/update_overlays_errorlog.go
@@ -42,7 +42,7 @@ func (m Model) errorLogForwardGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd, boo
 	}
 	kb := ui.ActiveKeybindings
 	switch msg.String() {
-	case kb.NewTab, kb.NextTab, kb.PrevTab:
+	case kb.NewTab, kb.NextTab, kb.PrevTab, kb.MoveTabLeft, kb.MoveTabRight:
 		if mdl, cmd, ok := m.handleExplorerActionKey(msg); ok {
 			return mdl, cmd, true
 		}

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -99,9 +99,11 @@ type Keybindings struct {
 	SelectAll    string `json:"select_all" yaml:"select_all"`
 
 	// Tabs
-	NewTab  string `json:"new_tab" yaml:"new_tab"`
-	NextTab string `json:"next_tab" yaml:"next_tab"`
-	PrevTab string `json:"prev_tab" yaml:"prev_tab"`
+	NewTab       string `json:"new_tab" yaml:"new_tab"`
+	NextTab      string `json:"next_tab" yaml:"next_tab"`
+	PrevTab      string `json:"prev_tab" yaml:"prev_tab"`
+	MoveTabLeft  string `json:"move_tab_left" yaml:"move_tab_left"`
+	MoveTabRight string `json:"move_tab_right" yaml:"move_tab_right"`
 
 	// Bookmarks
 	SetMark   string `json:"set_mark" yaml:"set_mark"`
@@ -220,8 +222,10 @@ func DefaultKeybindings() Keybindings {
 		// Multi-selection
 		ToggleSelect: " ", SelectRange: "ctrl+@", SelectAll: "ctrl+a",
 
-		// Tabs
+		// Tabs. Move keys mirror the switch keys: "}" (shift+]) moves the
+		// active tab one slot right, "{" (shift+[) one slot left.
 		NewTab: "t", NextTab: "]", PrevTab: "[",
+		MoveTabLeft: "{", MoveTabRight: "}",
 
 		// Bookmarks
 		SetMark: "m", OpenMarks: "'",

--- a/internal/ui/config_test.go
+++ b/internal/ui/config_test.go
@@ -20,6 +20,11 @@ func TestDefaultKeybindings_CriticalDefaults(t *testing.T) {
 	assert.Equal(t, " ", kb.ToggleSelect)
 	assert.Equal(t, "t", kb.NewTab)
 	assert.Equal(t, "m", kb.SetMark)
+	// Move-tab keys mirror the switch keys (shift+] / shift+[).
+	assert.Equal(t, "]", kb.NextTab)
+	assert.Equal(t, "[", kb.PrevTab)
+	assert.Equal(t, "}", kb.MoveTabRight)
+	assert.Equal(t, "{", kb.MoveTabLeft)
 }
 
 func TestMergeKeybindings_OverridesNonEmpty(t *testing.T) {

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -550,6 +550,8 @@ func helpSections() []helpSection {
 				{kb.NewTab, "New tab (clone current)"},
 				{kb.PrevTab, "Previous tab"},
 				{kb.NextTab, "Next tab"},
+				{kb.MoveTabLeft, "Move tab left"},
+				{kb.MoveTabRight, "Move tab right"},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Adds the ability to reorder the active tab, requested in the internal todo ("Implement move tab to left or right").

- New configurable keybindings: `move_tab_left` (default `{` = shift+[) and `move_tab_right` (default `}` = shift+]), mirroring the `[` / `]` switch keys.
- `moveActiveTab` does a pure slice reorder — no wrap, no-op at the edges and with a single tab — and keeps the same tab active at its new index.
- It deliberately does **not** call `saveCurrentTab`: a move is not a tab switch, so cancelling (and never restarting) the live preview-log stream would silently kill the tail. The active tab stays live in the `Model`; its snapshot is refreshed by the next real switch.
- Wired into both dispatch paths (fullscreen viewers via `handleTabSwitchKey`, explorer/exec via `handleExplorerActionKey`), the status-clear nav-key list, and the error-log overlay forward list.
- Tab action-key helpers extracted to `update_keys_actions_tabs.go` to keep `update_keys_actions.go` under the 800-line cap.
- Config schema, in-app help, `docs/keybindings.md`, `docs/config-example.yaml`, and README updated.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race ./internal/app/ ./internal/ui/`
- [x] `golangci-lint run` — 0 issues
- New tests: `moveActiveTab` (right / left / both edges / single tab), brace-key dispatch, edge-still-handled, and a regression guard that a move does not cancel the preview-log stream; UI default-keybinding assertions.