### PR TITLE
fix(sessions): show live tab count for the active session

### DIFF
--- a/internal/app/update_overlays_sessions.go
+++ b/internal/app/update_overlays_sessions.go
@@ -100,9 +100,18 @@ type sessionRow struct {
 // openSessionsOverlay loads the saved sessions and opens the picker overlay.
 func (m Model) openSessionsOverlay() (tea.Model, tea.Cmd) {
 	m.sessionsList = listNamedSessions()
-	m.defaultSessionTabs = 0
-	if s := loadSession(); s != nil {
-		m.defaultSessionTabs = len(s.Tabs)
+	// The default workspace's row shows the live tab count when it is the
+	// active session: new tabs are not persisted to session.yaml until a
+	// navigation/quit, so the on-disk count would be stale. When a named
+	// session is active instead, the default is dormant, so its last-saved
+	// session.yaml count is the best available.
+	if m.activeSession == "" {
+		m.defaultSessionTabs = len(m.tabs)
+	} else {
+		m.defaultSessionTabs = 0
+		if s := loadSession(); s != nil {
+			m.defaultSessionTabs = len(s.Tabs)
+		}
 	}
 	m.sessionsFilter.Clear()
 	m.sessionsFilterMode = false
@@ -119,7 +128,13 @@ func (m Model) sessionRows() []sessionRow {
 	rows := make([]sessionRow, 0, len(m.sessionsList)+1)
 	rows = append(rows, sessionRow{label: defaultSessionLabel, tabs: m.defaultSessionTabs, isDefault: true})
 	for _, s := range m.sessionsList {
-		rows = append(rows, sessionRow{name: s.Name, label: s.Name, tabs: len(s.State.Tabs), savedAt: s.SavedAt})
+		// The active named session's live tabs supersede its persisted count
+		// (same staleness as the default row), mirroring openSessionsOverlay.
+		tabs := len(s.State.Tabs)
+		if s.Name == m.activeSession {
+			tabs = len(m.tabs)
+		}
+		rows = append(rows, sessionRow{name: s.Name, label: s.Name, tabs: tabs, savedAt: s.SavedAt})
 	}
 	if m.sessionsFilter.Value == "" {
 		return rows

--- a/internal/app/update_overlays_sessions_test.go
+++ b/internal/app/update_overlays_sessions_test.go
@@ -99,6 +99,63 @@ func TestSessionsOverlayShowsDefaultRow(t *testing.T) {
 	assert.Contains(t, stripANSI(renderSessionsOverlay(rm)), "default")
 }
 
+// TestSessionsOverlayDefaultRowShowsLiveTabCount guards the reported bug: on the
+// default session, opening new tabs (which do not persist session.yaml) must
+// still show the live tab count, not the stale on-disk count.
+func TestSessionsOverlayDefaultRowShowsLiveTabCount(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// session.yaml on disk holds a single tab (the last persisted state).
+	require.NoError(t, saveSession(SessionState{Tabs: []SessionTab{{Context: "a"}}}))
+
+	m := basePush80Model() // activeSession == "" (default)
+	m.tabs = []TabState{{}, {}, {}}
+	m.activeTab = 0
+
+	ret, _ := m.openSessionsOverlay()
+	rm := ret.(Model)
+
+	rows := rm.sessionRows()
+	require.NotEmpty(t, rows)
+	assert.True(t, rows[0].isDefault)
+	assert.Equal(t, 3, rows[0].tabs, "default row shows live tab count, not the stale disk count")
+	assert.Contains(t, stripANSI(renderSessionsOverlay(rm)), "3 tabs")
+}
+
+// TestSessionsOverlayActiveNamedRowShowsLiveTabCount extends the fix to a named
+// session that is currently active: its row reflects the live tabs, while a
+// non-active named session keeps its persisted count.
+func TestSessionsOverlayActiveNamedRowShowsLiveTabCount(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	require.NoError(t, saveNamedSession(NamedSession{
+		Name: "work", SavedAt: time.Now(),
+		State: SessionState{Tabs: []SessionTab{{Context: "a"}, {Context: "b"}}},
+	}))
+	require.NoError(t, saveNamedSession(NamedSession{
+		Name: "other", SavedAt: time.Now(),
+		State: SessionState{Tabs: []SessionTab{{Context: "x"}}},
+	}))
+
+	m := basePush80Model()
+	m.activeSession = "work"
+	m.tabs = []TabState{{}, {}, {}, {}} // 4 live tabs
+	m.activeTab = 0
+
+	ret, _ := m.openSessionsOverlay()
+	rm := ret.(Model)
+
+	var work, other sessionRow
+	for _, r := range rm.sessionRows() {
+		switch r.name {
+		case "work":
+			work = r
+		case "other":
+			other = r
+		}
+	}
+	assert.Equal(t, 4, work.tabs, "active named session shows live tab count")
+	assert.Equal(t, 1, other.tabs, "inactive named session keeps its persisted count")
+}
+
 func TestSessionsOverlayEnterSwitches(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	require.NoError(t, saveNamedSession(NamedSession{


### PR DESCRIPTION
## Summary

Fixes a stale tab count in the session manager overlay for the currently-active workspace.

**Root cause:** the default row's count was read from the persisted `session.yaml` via `loadSession()`, but creating a tab does not persist the session — only `saveCurrentTab` (an in-memory snapshot) runs, never `saveCurrentSession` (the disk write). So the on-disk count lagged behind the live tabs:

- 3 tabs open, disk still at 1 → overlay showed "default 1 tabs"
- reopen with 3, open 2 more (5 live), disk still at 3 → showed "default 3 tabs"

**Fix:** use the live `len(m.tabs)` for whichever session is currently active — the default row when `activeSession` is empty, otherwise the matching named row. Dormant (non-active) sessions keep their persisted count, which is correct.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race ./internal/app/`
- [x] `golangci-lint run` — 0 issues
- New tests (TDD, red → green): default row shows live count when active vs stale disk count; active named session shows live count while an inactive one keeps its persisted count.