### PR TITLE
fix(nix): bump Go override to 1.26.5 to match go.mod

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are welcome! Here is how to get started.
 
 ## Prerequisites
 
-- Go 1.26.4 or later
+- Go 1.26.5 or later
 - Access to a Kubernetes cluster (for testing)
 - `kubectl` configured and working
 - `golangci-lint`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 RUN apk add --no-cache git
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,14 +18,14 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
 
-        # go.mod requires 1.26.4 (security). nixpkgs/master currently ships
-        # go_1_26 = 1.26.2; override the source to the official 1.26.4 tarball
+        # go.mod requires 1.26.5 (security). nixpkgs/master currently ships an
+        # older go_1_26; override the source to the official 1.26.5 tarball
         # until nixpkgs catches up, then delete this block.
-        go_1_26_4 = pkgs.go_1_26.overrideAttrs (_: rec {
-          version = "1.26.4";
+        go_1_26_5 = pkgs.go_1_26.overrideAttrs (_: rec {
+          version = "1.26.5";
           src = pkgs.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+            hash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
           };
         });
 
@@ -40,7 +40,7 @@
       in
       {
         packages = {
-          default = (pkgs.buildGoModule.override { go = go_1_26_4; }) {
+          default = (pkgs.buildGoModule.override { go = go_1_26_5; }) {
             pname = "lfk";
             inherit version;
 


### PR DESCRIPTION
## Summary

`make refresh-vendor-hash` was failing with `could not extract vendorHash from nix build output`.

Root cause: commit 8f472fa6 (`chore(security): bump Go to 1.26.5`) bumped `go.mod` to require Go 1.26.5, but `flake.nix` still pinned the Go toolchain override to **1.26.4**. Nix builds with `GOTOOLCHAIN=local`, so Go could not auto-fetch a newer toolchain and the go-modules derivation died in `buildPhase`:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

Because the build failed before any hash mismatch, there was no `got: sha256-...` line for the Makefile target to parse — hence the misleading "could not extract vendorHash" error.

## Changes

- Bump the Go source override in `flake.nix` from 1.26.4 to 1.26.5 (source tarball hash `sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=`).
- `vendorHash` is unchanged (`sha256-WYx/...`) — only the Go version moved, no dependencies changed.

## Test plan

- [x] `make refresh-vendor-hash` completes and reports the (unchanged) vendorHash
- [x] `nix build .#default` succeeds (exit 0)