### PR TITLE
feat(namespace): jump to previous namespace (g\)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are welcome! Here is how to get started.
 
 ## Prerequisites
 
-- Go 1.26.4 or later
+- Go 1.26.5 or later
 - Access to a Kubernetes cluster (for testing)
 - `kubectl` configured and working
 - `golangci-lint`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 RUN apk add --no-cache git
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 |---|---|
 | `x` | Action menu (logs, exec, describe, edit, delete, scale, port-forward, etc.) |
 | `\` / `A` | Namespace selector / toggle all-namespaces |
+| `g\` | Jump to previous namespace (swap back and forth) |
 | `L` | Toggle live-log preview pane (right pane, streaming tail; pod and container rows) |
 | `Ctrl+L` | Open fullscreen log viewer |
 | `v` | Describe resource |

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -412,6 +412,7 @@ keybindings:
   security_badge_toggle: "B" # Show/hide the per-resource SEC severity badge (default: B)
   move_tab_left: "{" # Move the current tab one slot left (default: { = shift+[)
   move_tab_right: "}" # Move the current tab one slot right (default: } = shift+])
+  previous_namespace: "g\\" # Jump to previous namespace, swapping the scope back and forth (default: g\)
 
 # ─── Search Abbreviations ─────────────────────────────────────────────────────
 # Short names for resource types used in search/filter.

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -478,7 +478,8 @@
         "goto_hpas": { "type": "string" },
         "goto_pvcs": { "type": "string" },
         "goto_pvs": { "type": "string" },
-        "goto_pdbs": { "type": "string" }
+        "goto_pdbs": { "type": "string" },
+        "previous_namespace": { "type": "string" }
       }
     },
     "view": {

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -55,6 +55,8 @@ goto_targets:
   ga: { kind: Application, group: argoproj.io, name: ArgoCD Applications }
 ```
 
+The `g` popup also lists `g\`, which jumps to the previous namespace (swaps the scope back and forth).
+
 All built-in chords are rebindable under `keybindings`.
 
 ## Views and Tools
@@ -175,6 +177,7 @@ Search supports abbreviated resource type names (e.g., `pvc`, `hpa`, `deploy`).
 | `x` | Open action menu (bulk actions when items selected) | `action_menu` |
 | `\` | Open namespace selector (then `.` to filter to current item's namespace) | `namespace_selector` |
 | `A` | Toggle all-namespaces mode (also works inside the namespace selector — clears individual selections and enables all-ns) | `all_namespaces` |
+| `g\` | Jump to previous namespace (swaps the scope back and forth) | `previous_namespace` |
 | `L` | Toggle live-log preview pane for selected pod or container (streaming tail in right pane; deeper levels only) | `toggle_preview_logs` |
 | `Ctrl+L` | Open fullscreen log viewer for selected resource | `logs` |
 | `e` | Secret/ConfigMap editor (inline key-value editing) | `secret_editor` |

--- a/flake.nix
+++ b/flake.nix
@@ -18,14 +18,14 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
 
-        # go.mod requires 1.26.4 (security). nixpkgs/master currently ships
-        # go_1_26 = 1.26.2; override the source to the official 1.26.4 tarball
+        # go.mod requires 1.26.5 (security). nixpkgs/master currently ships an
+        # older go_1_26; override the source to the official 1.26.5 tarball
         # until nixpkgs catches up, then delete this block.
-        go_1_26_4 = pkgs.go_1_26.overrideAttrs (_: rec {
-          version = "1.26.4";
+        go_1_26_5 = pkgs.go_1_26.overrideAttrs (_: rec {
+          version = "1.26.5";
           src = pkgs.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+            hash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
           };
         });
 
@@ -40,7 +40,7 @@
       in
       {
         packages = {
-          default = (pkgs.buildGoModule.override { go = go_1_26_4; }) {
+          default = (pkgs.buildGoModule.override { go = go_1_26_5; }) {
             pname = "lfk";
             inherit version;
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -176,9 +176,9 @@ type Model struct {
 	selectedNamespaces, savedSelectedNamespaces map[string]bool
 	nsSelectionNegated, savedNsSelectionNegated bool     // nsSelectionNegated: EXCLUDE set
 	nsFilterMode, nsSelectionModified           bool     // nsSelectionModified: Space pressed in current ns overlay session
-	nsFilterEntryItem                           string   // namespace name selected when filter mode was entered; restored on Esc
-	nsOverlayContext                            string   // context the open namespace overlay lists; used by the in-overlay refresh (R)
+	nsFilterEntryItem, nsOverlayContext         string   // filter-entry ns (restored on Esc); context the open overlay lists (in-overlay R refresh)
 	previousNsScope                             *nsScope // scope before the last change; g\ swaps back to it (per-tab)
+	nsOverlayEntryScope                         *nsScope // scope when the ns overlay opened; the pre-edit "previous" recorded on commit
 
 	// Fullscreen toggles: middle = hides left and right columns; dashboard
 	// = renders the cluster dashboard full screen.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -174,11 +174,11 @@ type Model struct {
 	// Namespace selection state. saved* stash the selection during all-namespaces mode so toggling off restores it.
 	allNamespaces                               bool
 	selectedNamespaces, savedSelectedNamespaces map[string]bool
-	nsSelectionNegated, savedNsSelectionNegated bool // nsSelectionNegated: EXCLUDE set
-	nsFilterMode                                bool
-	nsSelectionModified                         bool   // tracks if Space was pressed in current ns overlay session
-	nsFilterEntryItem                           string // namespace name selected when filter mode was entered; restored on Esc
-	nsOverlayContext                            string // context the open namespace overlay lists; used by the in-overlay refresh (R)
+	nsSelectionNegated, savedNsSelectionNegated bool     // nsSelectionNegated: EXCLUDE set
+	nsFilterMode, nsSelectionModified           bool     // nsSelectionModified: Space pressed in current ns overlay session
+	nsFilterEntryItem                           string   // namespace name selected when filter mode was entered; restored on Esc
+	nsOverlayContext                            string   // context the open namespace overlay lists; used by the in-overlay refresh (R)
+	previousNsScope                             *nsScope // scope before the last change; g\ swaps back to it (per-tab)
 
 	// Fullscreen toggles: middle = hides left and right columns; dashboard
 	// = renders the cluster dashboard full screen.

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -472,11 +472,13 @@ type TabState struct {
 	// resetting to the default namespace.
 	savedSelectedNamespaces map[string]bool
 	savedNsSelectionNegated bool
-	sortColumnName          string // column name to sort by (e.g. "Name", "Age", "CPU")
-	sortAscending           bool
-	sortMemory              map[string]sortPref
-	filterText              string
-	filterBroadMode         bool
+	// previousNsScope is this tab's jump-to-previous-namespace target.
+	previousNsScope *nsScope
+	sortColumnName  string // column name to sort by (e.g. "Name", "Age", "CPU")
+	sortAscending   bool
+	sortMemory      map[string]sortPref
+	filterText      string
+	filterBroadMode bool
 	// Identity of the highlighted resource row, captured on save so session
 	// restore can reopen every tab (not just the active one) on the same item.
 	cursorName         string

--- a/internal/app/namespace_history.go
+++ b/internal/app/namespace_history.go
@@ -1,0 +1,105 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// nsScope is a snapshot of the full namespace selection, so a jump can restore
+// it as one unit. It holds the four fields that together decide the effective
+// scope: a single namespace, all-namespaces mode, the multi-select set, and
+// whether that set is an exclude list.
+type nsScope struct {
+	namespace          string
+	allNamespaces      bool
+	selectedNamespaces map[string]bool
+	nsSelectionNegated bool
+}
+
+// captureNamespaceScope snapshots the current namespace selection.
+func (m Model) captureNamespaceScope() nsScope {
+	return nsScope{
+		namespace:          m.namespace,
+		allNamespaces:      m.allNamespaces,
+		selectedNamespaces: copyMapStringBool(m.selectedNamespaces),
+		nsSelectionNegated: m.nsSelectionNegated,
+	}
+}
+
+// equal reports whether two scopes select the same namespaces.
+func (s nsScope) equal(o nsScope) bool {
+	if s.namespace != o.namespace || s.allNamespaces != o.allNamespaces || s.nsSelectionNegated != o.nsSelectionNegated {
+		return false
+	}
+	if len(s.selectedNamespaces) != len(o.selectedNamespaces) {
+		return false
+	}
+	for k := range s.selectedNamespaces {
+		if !o.selectedNamespaces[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// clone deep-copies a scope so per-tab snapshots never alias the live map.
+func (s *nsScope) clone() *nsScope {
+	if s == nil {
+		return nil
+	}
+	c := *s
+	c.selectedNamespaces = copyMapStringBool(s.selectedNamespaces)
+	return &c
+}
+
+// applyNamespaceScope restores a snapshot onto the model.
+func (m *Model) applyNamespaceScope(s nsScope) {
+	m.namespace = s.namespace
+	m.allNamespaces = s.allNamespaces
+	m.selectedNamespaces = copyMapStringBool(s.selectedNamespaces)
+	m.nsSelectionNegated = s.nsSelectionNegated
+}
+
+// recordPreviousNamespace stores before as the previous scope, but only when
+// the selection actually changed, so a later jump-to-previous returns to the
+// last distinct scope rather than a no-op re-selection.
+func (m *Model) recordPreviousNamespace(before nsScope) {
+	if before.equal(m.captureNamespaceScope()) {
+		return
+	}
+	m.previousNsScope = before.clone()
+}
+
+// jumpToPreviousNamespace swaps the current namespace scope with the previously
+// recorded one. The swap means repeated presses toggle between the two scopes,
+// like a vim alternate buffer. Reports an error when there is no previous scope
+// or the current level/mode forbids changing the namespace.
+func (m Model) jumpToPreviousNamespace() (tea.Model, tea.Cmd) {
+	if m.nav.Level == model.LevelClusters {
+		m.setStatusMessage("Namespace selection requires a selected context", true)
+		return m, scheduleStatusClear()
+	}
+	if m.unionMode {
+		m.setStatusMessage("Union mode supports exactly one namespace", true)
+		return m, scheduleStatusClear()
+	}
+	if m.previousNsScope == nil {
+		m.setStatusMessage("No previous namespace to jump to", true)
+		return m, scheduleStatusClear()
+	}
+	oldNs := m.namespace
+	current := m.captureNamespaceScope()
+	m.applyNamespaceScope(*m.previousNsScope)
+	m.previousNsScope = current.clone()
+	// The all-namespaces stash belongs to the scope we just left; drop it so a
+	// later A-toggle doesn't restore a selection that no longer applies.
+	m.savedSelectedNamespaces = nil
+	m.savedNsSelectionNegated = false
+	m.nsSelectionModified = false
+	m.invalidateOrphanCacheForNamespace(m.nav.Context, oldNs)
+	m.saveCurrentSession()
+	m.cancelAndReset()
+	m.requestGen++
+	m.setStatusMessage("Namespace: "+m.buildNsLabelText(), false)
+	return m, tea.Batch(m.refreshCurrentLevel(), scheduleStatusClear())
+}

--- a/internal/app/namespace_history.go
+++ b/internal/app/namespace_history.go
@@ -60,6 +60,17 @@ func (m *Model) applyNamespaceScope(s nsScope) {
 	m.nsSelectionNegated = s.nsSelectionNegated
 }
 
+// namespaceOverlayEntryScope returns the scope captured when the namespace
+// overlay opened. It falls back to the current scope if no snapshot exists
+// (e.g. a commit path that never went through openNamespaceSelectorForContext),
+// so recordPreviousNamespace still gets a sane baseline.
+func (m Model) namespaceOverlayEntryScope() nsScope {
+	if m.nsOverlayEntryScope != nil {
+		return *m.nsOverlayEntryScope
+	}
+	return m.captureNamespaceScope()
+}
+
 // recordPreviousNamespace stores before as the previous scope, but only when
 // the selection actually changed, so a later jump-to-previous returns to the
 // last distinct scope rather than a no-op re-selection.

--- a/internal/app/namespace_history_test.go
+++ b/internal/app/namespace_history_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -88,6 +89,44 @@ func TestJumpToPreviousNamespace_NoPrevious(t *testing.T) {
 	got := out.(Model)
 	assert.Equal(t, "default", got.namespace, "no-op when nothing recorded")
 	assert.True(t, got.statusMessageErr, "reports an error message")
+}
+
+// TestNamespaceOverlayEntryScope_FallsBackToCurrent verifies the helper
+// returns the live scope when no overlay snapshot has been taken.
+func TestNamespaceOverlayEntryScope_FallsBackToCurrent(t *testing.T) {
+	m := newTestModel()
+	m.namespace = "default"
+	m.nsOverlayEntryScope = nil
+	assert.Equal(t, "default", m.namespaceOverlayEntryScope().namespace)
+
+	m.nsOverlayEntryScope = &nsScope{namespace: "kube-system"}
+	assert.Equal(t, "kube-system", m.namespaceOverlayEntryScope().namespace)
+}
+
+// TestOverlayCommit_RecordsPreOverlayScopeAfterSpaceEdit is the regression
+// guard for the CodeRabbit finding: Space mutates the live selection during
+// the overlay session, so the "previous" scope must come from the snapshot
+// taken when the overlay opened — not a capture at Enter time (which would
+// see the already-edited state and record nothing).
+func TestOverlayCommit_RecordsPreOverlayScopeAfterSpaceEdit(t *testing.T) {
+	m := newTestModel()
+	m.overlay = overlayNamespace
+	m.namespace = "default"
+	m.selectedNamespaces = map[string]bool{"default": true}
+	// Snapshot taken on open (pre-edit).
+	m.nsOverlayEntryScope = &nsScope{namespace: "default", selectedNamespaces: map[string]bool{"default": true}}
+	// Simulate a Space toggle having already mutated the live selection.
+	m.nsSelectionModified = true
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+
+	out, _ := m.handleNamespaceOverlayKey(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := out.(Model)
+
+	if assert.NotNil(t, rm.previousNsScope, "commit after a Space edit must record the pre-overlay scope") {
+		assert.Equal(t, "default", rm.previousNsScope.namespace)
+		assert.Equal(t, map[string]bool{"default": true}, rm.previousNsScope.selectedNamespaces)
+	}
+	assert.Equal(t, "kube-system", rm.namespace, "commit still applies the edited selection")
 }
 
 func TestJumpToPreviousNamespace_BlockedAtClusters(t *testing.T) {

--- a/internal/app/namespace_history_test.go
+++ b/internal/app/namespace_history_test.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNsScopeEqual(t *testing.T) {
+	base := nsScope{namespace: "a", selectedNamespaces: map[string]bool{"a": true}}
+	tests := []struct {
+		name string
+		a, b nsScope
+		want bool
+	}{
+		{"identical single", base, nsScope{namespace: "a", selectedNamespaces: map[string]bool{"a": true}}, true},
+		{"different namespace", base, nsScope{namespace: "b", selectedNamespaces: map[string]bool{"a": true}}, false},
+		{"different set size", base, nsScope{namespace: "a", selectedNamespaces: map[string]bool{"a": true, "b": true}}, false},
+		{"different set member", base, nsScope{namespace: "a", selectedNamespaces: map[string]bool{"b": true}}, false},
+		{"all-ns differs", nsScope{allNamespaces: true}, nsScope{allNamespaces: false}, false},
+		{"negated differs", nsScope{nsSelectionNegated: true}, nsScope{nsSelectionNegated: false}, false},
+		{"both empty", nsScope{}, nsScope{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.a.equal(tt.b))
+		})
+	}
+}
+
+func TestNsScopeCloneIsDeep(t *testing.T) {
+	orig := &nsScope{namespace: "a", selectedNamespaces: map[string]bool{"a": true}}
+	c := orig.clone()
+	c.selectedNamespaces["b"] = true
+	assert.NotContains(t, orig.selectedNamespaces, "b", "clone must not alias the source map")
+	assert.Nil(t, (*nsScope)(nil).clone(), "nil clone stays nil")
+}
+
+func TestRecordPreviousNamespace_OnlyOnChange(t *testing.T) {
+	m := newTestModel()
+	m.namespace = "default"
+	m.selectedNamespaces = map[string]bool{"default": true}
+
+	// No change: previous stays nil.
+	before := m.captureNamespaceScope()
+	m.recordPreviousNamespace(before)
+	assert.Nil(t, m.previousNsScope, "unchanged scope must not record a previous")
+
+	// Change: previous captures the old scope.
+	before = m.captureNamespaceScope()
+	m.namespace = "kube-system"
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.recordPreviousNamespace(before)
+	if assert.NotNil(t, m.previousNsScope) {
+		assert.Equal(t, "default", m.previousNsScope.namespace)
+	}
+}
+
+func TestJumpToPreviousNamespace_Swaps(t *testing.T) {
+	m := newTestModel()
+	m.nav.Level = model.LevelResources
+	m.namespace = "kube-system"
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.previousNsScope = &nsScope{namespace: "default", selectedNamespaces: map[string]bool{"default": true}}
+
+	out, _ := m.jumpToPreviousNamespace()
+	got := out.(Model)
+	assert.Equal(t, "default", got.namespace, "jump lands on the previous namespace")
+	assert.Equal(t, map[string]bool{"default": true}, got.selectedNamespaces)
+	// The scope we left becomes the new previous, so a second jump returns.
+	if assert.NotNil(t, got.previousNsScope) {
+		assert.Equal(t, "kube-system", got.previousNsScope.namespace)
+	}
+
+	out2, _ := got.jumpToPreviousNamespace()
+	got2 := out2.(Model)
+	assert.Equal(t, "kube-system", got2.namespace, "second jump swaps back")
+}
+
+func TestJumpToPreviousNamespace_NoPrevious(t *testing.T) {
+	m := newTestModel()
+	m.nav.Level = model.LevelResources
+	m.namespace = "default"
+	m.previousNsScope = nil
+
+	out, _ := m.jumpToPreviousNamespace()
+	got := out.(Model)
+	assert.Equal(t, "default", got.namespace, "no-op when nothing recorded")
+	assert.True(t, got.statusMessageErr, "reports an error message")
+}
+
+func TestJumpToPreviousNamespace_BlockedAtClusters(t *testing.T) {
+	m := newTestModel()
+	m.nav.Level = model.LevelClusters
+	m.previousNsScope = &nsScope{namespace: "default"}
+
+	out, _ := m.jumpToPreviousNamespace()
+	got := out.(Model)
+	assert.Equal(t, "", got.namespace, "namespace unchanged at cluster level")
+	assert.NotNil(t, got.previousNsScope, "previous scope preserved")
+}

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -336,6 +336,7 @@ func (m *Model) saveCurrentTab() {
 	t.nsSelectionNegated = m.nsSelectionNegated
 	t.savedSelectedNamespaces = copyMapStringBool(m.savedSelectedNamespaces)
 	t.savedNsSelectionNegated = m.savedNsSelectionNegated
+	t.previousNsScope = m.previousNsScope.clone()
 	t.sortColumnName = m.sortColumnName
 	t.sortAscending = m.sortAscending
 	t.filterText = m.filterText
@@ -469,6 +470,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.nsSelectionNegated = t.nsSelectionNegated
 	m.savedSelectedNamespaces = copyMapStringBool(t.savedSelectedNamespaces)
 	m.savedNsSelectionNegated = t.savedNsSelectionNegated
+	m.previousNsScope = t.previousNsScope.clone()
 	m.sortColumnName = t.sortColumnName
 	m.sortAscending = t.sortAscending
 	m.filterText = t.filterText
@@ -681,6 +683,7 @@ func (m *Model) cloneCurrentTab() TabState {
 		nsSelectionNegated:      m.nsSelectionNegated,
 		savedSelectedNamespaces: copyMapStringBool(m.savedSelectedNamespaces),
 		savedNsSelectionNegated: m.savedNsSelectionNegated,
+		previousNsScope:         m.previousNsScope.clone(),
 		sortColumnName:          m.sortColumnName,
 		sortAscending:           m.sortAscending,
 		filterText:              m.filterText,

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -379,6 +379,12 @@ func (m Model) openNamespaceSelectorForContext(contextName string) (tea.Model, t
 	m.overlayFilter.Clear()
 	ui.ResetOverlayNsScroll()
 	m.nsSelectionModified = false
+	// Snapshot the scope now, before Space/Tab/A editing mutates the live
+	// selection during the session. Commit (Enter) and the in-overlay quick
+	// filter (.) record THIS as the jump-to-previous target, not the
+	// mid-edit state a fresh capture would see.
+	entryScope := m.captureNamespaceScope()
+	m.nsOverlayEntryScope = &entryScope
 	// Remember which context this overlay lists so the in-overlay refresh
 	// (R) re-fetches the right namespaces even when activeContext() would
 	// resolve differently (e.g. the union-set namespace picker, which opens

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -242,6 +242,7 @@ func (m Model) handleExplorerActionKeyAllNamespaces() (tea.Model, tea.Cmd, bool)
 		m.setStatusMessage("Union mode supports exactly one namespace", true)
 		return m, scheduleStatusClear(), true
 	}
+	beforeScope := m.captureNamespaceScope()
 	m.allNamespaces = !m.allNamespaces
 	if m.allNamespaces {
 		// Stash the current selection so toggling back off restores it
@@ -269,6 +270,7 @@ func (m Model) handleExplorerActionKeyAllNamespaces() (tea.Model, tea.Cmd, bool)
 		// m.namespace alone could still show "(ns: )".
 		m.setStatusMessage("All namespaces mode OFF (ns: "+m.effectiveNamespace()+")", false)
 	}
+	m.recordPreviousNamespace(beforeScope)
 	m.cancelAndReset()
 	m.requestGen++
 	return m, tea.Batch(m.refreshCurrentLevel(), scheduleStatusClear()), true

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -56,7 +56,9 @@ func (m Model) quickFilterToSelectedNamespace() (tea.Model, tea.Cmd) {
 	}
 	ns := sel.Namespace
 	oldNs := m.namespace
-	beforeScope := m.captureNamespaceScope()
+	// Fired from inside the overlay (chord "\" then "."), so use the
+	// pre-overlay snapshot rather than the possibly Space-edited live scope.
+	beforeScope := m.namespaceOverlayEntryScope()
 	m.selectedNamespaces = map[string]bool{ns: true}
 	m.namespace = ns
 	m.allNamespaces = false
@@ -111,7 +113,9 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Apply selection and close.
 		oldNs := m.namespace
-		beforeScope := m.captureNamespaceScope()
+		// The pre-overlay scope, snapshotted on open — Space/Tab already
+		// mutated the live selection, so a fresh capture here would miss it.
+		beforeScope := m.namespaceOverlayEntryScope()
 		switch {
 		case m.nsSelectionModified && len(m.selectedNamespaces) > 0:
 			// User explicitly toggled selections with Space in this session.

--- a/internal/app/update_overlays_selectors.go
+++ b/internal/app/update_overlays_selectors.go
@@ -56,11 +56,13 @@ func (m Model) quickFilterToSelectedNamespace() (tea.Model, tea.Cmd) {
 	}
 	ns := sel.Namespace
 	oldNs := m.namespace
+	beforeScope := m.captureNamespaceScope()
 	m.selectedNamespaces = map[string]bool{ns: true}
 	m.namespace = ns
 	m.allNamespaces = false
 	m.nsSelectionNegated = false
 	m.nsSelectionModified = false
+	m.recordPreviousNamespace(beforeScope)
 	m.invalidateOrphanCacheForNamespace(m.nav.Context, oldNs)
 	m.overlayFilter.Clear()
 	m.nsFilterMode = false
@@ -109,6 +111,7 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Apply selection and close.
 		oldNs := m.namespace
+		beforeScope := m.captureNamespaceScope()
 		switch {
 		case m.nsSelectionModified && len(m.selectedNamespaces) > 0:
 			// User explicitly toggled selections with Space in this session.
@@ -131,6 +134,7 @@ func (m Model) handleNamespaceNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.allNamespaces = true
 			m.nsSelectionNegated = false
 		}
+		m.recordPreviousNamespace(beforeScope)
 		m.invalidateOrphanCacheForNamespace(m.nav.Context, oldNs)
 		m.overlayFilter.Clear()
 		m.nsFilterMode = false

--- a/internal/app/whichkey.go
+++ b/internal/app/whichkey.go
@@ -190,7 +190,12 @@ func (m Model) handleGotoChord(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	}
 	m.pendingG = false
 	m.whichKeyShown = false
-	if gt, ok := m.gotoTargetForChord(ui.ActiveKeybindings.JumpTop + key); ok {
+	chord := ui.ActiveKeybindings.JumpTop + key
+	if pn := ui.ActiveKeybindings.PreviousNamespace; pn != "" && chord == pn {
+		out, cmd := m.jumpToPreviousNamespace()
+		return out, cmd, true
+	}
+	if gt, ok := m.gotoTargetForChord(chord); ok {
 		out, cmd := m.gotoResourceType(gt.Kind, gt.Group)
 		return out, cmd, true
 	}
@@ -228,10 +233,13 @@ type whichKeyCell struct {
 func (m Model) whichKeyCells() []whichKeyCell {
 	prefix := ui.ActiveKeybindings.JumpTop
 	targets := m.gotoTargets()
-	cells := make([]whichKeyCell, 0, len(targets)+1)
+	cells := make([]whichKeyCell, 0, len(targets)+2)
 	cells = append(cells, whichKeyCell{prefix, "list top"})
 	for _, gt := range targets {
 		cells = append(cells, whichKeyCell{strings.TrimPrefix(gt.Chord, prefix), gt.Label})
+	}
+	if pn := ui.ActiveKeybindings.PreviousNamespace; pn != "" {
+		cells = append(cells, whichKeyCell{strings.TrimPrefix(pn, prefix), "Previous namespace"})
 	}
 	sort.SliceStable(cells, func(i, j int) bool {
 		li, lj := strings.ToLower(cells[i].key), strings.ToLower(cells[j].key)

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -86,6 +86,25 @@ func TestHandleGotoChord_NavigatesOnMatch(t *testing.T) {
 	}
 }
 
+func TestHandleGotoChord_PreviousNamespace(t *testing.T) {
+	restoreWhichKeyGlobals(t)
+	ui.ActiveKeybindings = ui.DefaultKeybindings()
+	m := gotoTestModel()
+	m.nav.Level = model.LevelResources
+	m.namespace = "kube-system"
+	m.selectedNamespaces = map[string]bool{"kube-system": true}
+	m.previousNsScope = &nsScope{namespace: "default", selectedNamespaces: map[string]bool{"default": true}}
+	m.pendingG = true
+	out, _, handled := m.handleGotoChord(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\\'}})
+	if !handled {
+		t.Fatal(`g\ should be handled`)
+	}
+	rm := out.(Model)
+	if rm.namespace != "default" {
+		t.Fatalf(`g\ did not jump to previous namespace, got %q`, rm.namespace)
+	}
+}
+
 func TestHandleGotoChord_GPassesThroughToJumpTop(t *testing.T) {
 	m := gotoTestModel()
 	m.pendingG = true

--- a/internal/app/whichkey_test.go
+++ b/internal/app/whichkey_test.go
@@ -103,6 +103,31 @@ func TestHandleGotoChord_PreviousNamespace(t *testing.T) {
 	if rm.namespace != "default" {
 		t.Fatalf(`g\ did not jump to previous namespace, got %q`, rm.namespace)
 	}
+	if !rm.selectedNamespaces["default"] || rm.selectedNamespaces["kube-system"] {
+		t.Fatalf("selectedNamespaces not swapped to previous scope: %v", rm.selectedNamespaces)
+	}
+}
+
+// With PreviousNamespace unbound, g\ is not a previous-namespace jump and
+// falls through to the goto-chord lookup (no such target -> consumed as an
+// unmapped chord, namespace untouched).
+func TestHandleGotoChord_PreviousNamespaceUnbound(t *testing.T) {
+	restoreWhichKeyGlobals(t)
+	kb := ui.DefaultKeybindings()
+	kb.PreviousNamespace = ""
+	ui.ActiveKeybindings = kb
+	m := gotoTestModel()
+	m.nav.Level = model.LevelResources
+	m.namespace = "kube-system"
+	m.previousNsScope = &nsScope{namespace: "default"}
+	m.pendingG = true
+	out, _, handled := m.handleGotoChord(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\\'}})
+	if !handled {
+		t.Fatal(`g\ should still be consumed as an unmapped chord`)
+	}
+	if rm := out.(Model); rm.namespace != "kube-system" {
+		t.Fatalf("unbound g\\ must not jump; namespace changed to %q", rm.namespace)
+	}
 }
 
 func TestHandleGotoChord_GPassesThroughToJumpTop(t *testing.T) {

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -174,6 +174,11 @@ type Keybindings struct {
 	GotoPVCs         string `json:"goto_pvcs" yaml:"goto_pvcs"`
 	GotoPVs          string `json:"goto_pvs" yaml:"goto_pvs"`
 	GotoPDBs         string `json:"goto_pdbs" yaml:"goto_pdbs"`
+
+	// PreviousNamespace is a g-prefix chord that swaps the namespace scope with
+	// the one in effect before the last change (toggle back and forth). Holds
+	// the full chord (e.g. "g\\").
+	PreviousNamespace string `json:"previous_namespace" yaml:"previous_namespace"`
 }
 
 // DefaultKeybindings returns the default keybinding configuration.
@@ -277,6 +282,10 @@ func DefaultKeybindings() Keybindings {
 		GotoDaemonSets: "gD", GotoStatefulSets: "gt", GotoConfigMaps: "gC",
 		GotoSecrets: "gS", GotoHPAs: "gh", GotoPVCs: "gv", GotoPVs: "gV",
 		GotoPDBs: "gb",
+
+		// Jump to previous namespace (g-prefix chord, sits next to the "\\"
+		// namespace selector).
+		PreviousNamespace: "g\\",
 	}
 }
 

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -97,6 +97,7 @@ func helpSections() []helpSection {
 			bindings: []helpEntry{
 				{kb.NamespaceSelector, "Select namespace (space: include, tab: exclude, A: all-namespaces, R: refresh, .: quick filter to current item's namespace)"},
 				{kb.AllNamespaces, "Toggle all-namespaces mode"},
+				{kb.PreviousNamespace, "Jump to previous namespace (swap back and forth)"},
 				{kb.ActionMenu, "Action menu: l=tail logs (last 10 lines + follow), L=full logs, T=Log Top aggregation, exec, debug, debug pod, describe, edit, delete, scale, port-forward, events, startup analysis, crash investigator, traffic capture, RBAC permissions"},
 				{kb.TogglePreviewLogs, "Toggle live-log preview pane for selected pod or container (right pane, streaming tail)"},
 				{kb.Logs, "Open fullscreen log viewer for selected resource"},


### PR DESCRIPTION
## Summary

Adds a "jump to previous namespace" hotkey: the `g\` chord swaps the current namespace scope with the one in effect before the last change. Repeated presses toggle back and forth between two namespaces (vim alternate-buffer / `cd -` semantics).

## Behavior

- `g\` (g-prefix chord, sits next to the `\` namespace selector) — jump to previous namespace.
- Toggle/swap: after jumping, the scope you left becomes the new "previous", so pressing `g\` again returns you.
- Reports `No previous namespace to jump to` when nothing has been recorded yet; inert at the cluster-picker level and in union mode.

## Implementation

- `nsScope` snapshots the full namespace selection as a unit: single namespace, all-namespaces mode, the multi-select set, and its exclude flag.
- The previous scope is captured before each interactive namespace change and recorded only when the scope actually changes:
  - namespace selector overlay `Enter`
  - in-overlay quick-filter (`.`)
  - all-namespaces toggle (`A`)
- Per-tab state: cloned through tab save/restore/new-tab so one tab's previous scope never leaks into another.
- Surfaces in the `g` which-key popup, the Actions help section, and the bookmark/explorer hint bar.
- Configurable via `keybindings.previous_namespace` (default `g\`).

## Tests

- `nsScope.equal` / `clone` (deep-copy) unit tests.
- `recordPreviousNamespace` only records on a real change.
- `jumpToPreviousNamespace` swaps, toggles back, no-ops with error when empty, and is blocked at cluster level.
- `handleGotoChord` routes `g\` to the jump.

## Verification

- `go build ./...`
- `go test ./internal/app/ ./internal/ui/ -race` — green
- `golangci-lint run` — 0 issues (app.go kept at the 800-line cap)
- schema/keybinding sync guards pass
