### PR TITLE
feat(bookmarks): load saved namespace by default, show it in the overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ All search and filter inputs support three modes, auto-detected from the query s
 - Press `o` on a resource to jump to its owner (e.g. Pod -> Deployment), then `Backspace` to jump back
 - Typos are fine in search: `/~deplymnt` fuzzy-matches `deployments`
 - Multi-select with `Space` (range-select with `Ctrl+Space`), then bulk delete/scale/restart via `x`
-- Set a bookmark with `m<letter>`, jump back with `'<letter>` - lowercase slots are context-aware. Press tab to jump to the namespace. An active list filter is saved with the bookmark and reapplied on jump (shown as `> /<filter>` in the slot name)
+- Set a bookmark with `m<letter>`, jump back with `'<letter>` - lowercase slots are context-aware. Each bookmark shows its saved namespace in the overlay and the jump applies it by default; press Tab to opt out and keep the current scope. An active list filter is saved with the bookmark and reapplied on jump (shown as `> /<filter>` in the slot name)
 - Press `.` for quick filter presets (e.g. only failing Pods); extend them per resource type in config
 - Decode Secret values in the preview with `Ctrl+S`, or edit them decoded with `e`
 - Copy the resource name with `y`; press `Y` to copy as YAML, JSON, or Table

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -242,13 +242,13 @@ suffix in their name.
 | `j` / `k` | Bookmark overlay | Navigate bookmarks |
 | `/` | Bookmark overlay | Filter bookmarks by name |
 | `Enter` | Bookmark overlay | Jump to selected bookmark |
-| `Tab` | Bookmark overlay | Toggle `[LOAD NAMESPACE]` — apply the bookmark's saved namespace scope on the next jump |
+| `Tab` | Bookmark overlay | Toggle `[KEEP CURRENT NS]` — opt out of loading the bookmark's saved namespace on the next jump |
 | `Ctrl+X` | Bookmark overlay | Delete selected bookmark (with confirmation) |
 | `Alt+X` | Bookmark overlay | Delete all bookmarks (with confirmation) |
 
-> Namespace on jump: by default the tab's current namespace is kept. Press
-> `Tab` in the overlay to arm `[LOAD NAMESPACE]`; the saved namespace is
-> then applied on the next jump and the flag is cleared on close.
+> Namespace on jump: each bookmark shows its saved namespace scope, and by
+> default the jump applies it. Press `Tab` to opt out (`[KEEP CURRENT NS]`)
+> and keep the tab's current scope instead; the flag resets on close.
 
 ## Help View
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -406,14 +406,11 @@ type Model struct {
 	bookmarks          []model.Bookmark
 	bookmarkFilter     TextInput           // filter text (f mode) for bookmark overlay
 	bookmarkSearchMode bookmarkOverlayMode // current interaction mode for bookmark overlay
-	// bookmarkLoadNamespace, when true, instructs the next jump issued
-	// from the bookmark overlay to apply the bookmark's saved namespace
-	// scope. By default bookmark jumps ignore the saved namespace and
-	// keep the tab's current scope (slot case only controls context
-	// switching, not namespace handling). Toggled by Tab inside the
-	// overlay and shown as a `[LOAD NAMESPACE]` chip in the title.
-	// Reset on overlay close and consumed after each jump so it never
-	// leaks between opens.
+	// bookmarkLoadNamespace controls whether the next jump from the bookmark
+	// overlay replays the bookmark's saved namespace scope. Loading is the
+	// default (seeded on open); Tab opts out to keep the tab's current scope,
+	// surfaced by a `[KEEP CURRENT NS]` title chip. Reset to the default on
+	// overlay close and consumed after each jump so it never leaks between opens.
 	bookmarkLoadNamespace bool
 	sessionsOverlayState
 	// Template overlay state.

--- a/internal/app/bookmark_namespace_test.go
+++ b/internal/app/bookmark_namespace_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHandleKeyOpenMarks_DefaultsToLoadNamespace verifies the bookmark
+// overlay opens with load-namespace ON, so a plain Enter/slot jump replays
+// the bookmark's saved scope without any Tab press.
+func TestHandleKeyOpenMarks_DefaultsToLoadNamespace(t *testing.T) {
+	m := baseFinalModel()
+	m.bookmarkLoadNamespace = false // simulate a stale prior value
+
+	rm := m.handleKeyOpenMarks()
+
+	assert.Equal(t, overlayBookmarks, rm.overlay)
+	assert.True(t, rm.bookmarkLoadNamespace, "open must default to loading the saved namespace")
+}
+
+func TestBookmarkNamespaceLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		bm   model.Bookmark
+		want string
+	}{
+		{"unscoped is all namespaces", model.Bookmark{}, "all namespaces"},
+		{"single namespace field", model.Bookmark{Namespace: "prod"}, "prod"},
+		{"single via list", model.Bookmark{Namespaces: []string{"prod"}}, "prod"},
+		{"multi sorted", model.Bookmark{Namespaces: []string{"web", "api"}}, "api,web"},
+		{"negated set", model.Bookmark{Namespaces: []string{"kube-system"}, NsSelectionNegated: true}, "!kube-system"},
+		{"capped at three", model.Bookmark{Namespaces: []string{"a", "b", "c", "d", "e"}}, "a,b,c +2 more"},
+		{"capped negated", model.Bookmark{Namespaces: []string{"a", "b", "c", "d"}, NsSelectionNegated: true}, "!a,!b,!c +1 more excl"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bookmarkNamespaceLabel(tt.bm))
+		})
+	}
+}
+
+// TestRenderBookmarkOverlay_ShowsNamespace verifies each bookmark row
+// carries its saved namespace, and the opt-out chip appears only when the
+// user has toggled loading off.
+func TestRenderBookmarkOverlay_ShowsNamespace(t *testing.T) {
+	m := baseFinalModel()
+	m.overlay = overlayBookmarks
+	m.bookmarkLoadNamespace = true
+	m.bookmarks = []model.Bookmark{
+		{Slot: "p", Name: "prod pods", Namespace: "production"},
+		{Slot: "a", Name: "all", Namespace: ""},
+	}
+
+	view := stripANSI(renderBookmarkOverlay(m))
+	assert.Contains(t, view, "ns: production")
+	assert.Contains(t, view, "ns: all namespaces")
+	assert.NotContains(t, view, "KEEP CURRENT NS", "no chip while loading (the default)")
+
+	m.bookmarkLoadNamespace = false
+	optedOut := stripANSI(renderBookmarkOverlay(m))
+	assert.Contains(t, optedOut, "KEEP CURRENT NS", "chip shows when the user opts out")
+}
+
+// sanity: label helper never panics on a nil Namespaces slice.
+func TestBookmarkNamespaceLabel_NilSlice(t *testing.T) {
+	assert.Equal(t, "all namespaces", bookmarkNamespaceLabel(model.Bookmark{Namespaces: nil}))
+	assert.False(t, strings.Contains(bookmarkNamespaceLabel(model.Bookmark{Namespace: "x"}), "more"))
+}

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -301,7 +301,7 @@ func (m Model) executeBuiltinCommand(input string) (tea.Model, tea.Cmd) {
 		m.overlay = overlayBookmarks
 		m.bookmarkSearchMode = bookmarkModeNormal
 		m.bookmarkFilter.Clear()
-		m.bookmarkLoadNamespace = false
+		m.bookmarkLoadNamespace = true
 		return m, nil
 
 	case "orphans":

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -427,10 +427,9 @@ func (m Model) overlayHintBarBookmarks() string {
 			{Key: "Esc/n", Desc: "cancel"},
 		})
 	default:
-		// tab desc flips with state: "load ns" when the user can arm
-		// the flag, "don't load" when it's already armed. That keeps
-		// the hint readable as the verb for the action Tab will
-		// perform next, matching what they see in the title chip.
+		// tab desc names the action Tab will perform next: loading is the
+		// default, so it reads "don't load ns" until the user opts out, then
+		// "load ns". Matches the title chip the user sees.
 		tabDesc := "load ns"
 		if m.bookmarkLoadNamespace {
 			tabDesc = "don't load ns"

--- a/internal/app/update_bookmarks.go
+++ b/internal/app/update_bookmarks.go
@@ -461,13 +461,13 @@ func (m Model) handleBookmarkNormalMode(msg tea.KeyMsg, filtered []model.Bookmar
 		m.overlay = overlayNone
 		m.bookmarkFilter.Clear()
 		m.bookmarkSearchMode = bookmarkModeNormal
-		// Discard any pending "load namespace" flag so the next open
-		// starts from the default (don't load).
-		m.bookmarkLoadNamespace = false
+		// Reset the flag; the next open re-seeds it to the default (load).
+		m.bookmarkLoadNamespace = true
 		return m, nil
 	case "tab":
-		// Arm the "load saved namespace" flag for the next jump. The
-		// title bar picks this up via the [LOAD NAMESPACE] chip so
+		// Toggle whether the jump replays the bookmark's saved namespace.
+		// Loading is the default; Tab opts out to keep the current scope.
+		// The title bar shows a [KEEP CURRENT NS] chip while opted out so
 		// the user sees what Enter / slot-key will do.
 		m.bookmarkLoadNamespace = !m.bookmarkLoadNamespace
 		return m, nil

--- a/internal/app/update_bookmarks_navigate.go
+++ b/internal/app/update_bookmarks_navigate.go
@@ -42,8 +42,9 @@ func (m *Model) applyBookmarkContextSwitch(target bookmarkTarget) {
 	}
 }
 
-// applyBookmarkNamespace replays the bookmark's saved namespace selection
-// only when the user explicitly requested it via Tab in the overlay.
+// applyBookmarkNamespace replays the bookmark's saved namespace selection.
+// This is the default; the user opts out per-jump with Tab in the overlay
+// (which clears m.bookmarkLoadNamespace to keep the current scope).
 // Consumes m.bookmarkLoadNamespace immediately so the flag can't leak
 // into the next overlay open. Skips namespace replay for union-set
 // targets — those carry their own namespace in the target record.

--- a/internal/app/update_bookmarks_test.go
+++ b/internal/app/update_bookmarks_test.go
@@ -1198,35 +1198,37 @@ func TestNavigateToBookmark_ContextAwareWithLoadAppliesSavedNamespace(t *testing
 		"Tab-armed jumps must apply the saved namespace for context-aware bookmarks too")
 }
 
-// TestBookmarkOverlay_TabTogglesLoadNamespace verifies that Tab
-// pressed in the bookmark overlay flips the "load namespace" chip,
-// so the next jump (Enter or slot key) applies the saved namespace.
+// TestBookmarkOverlay_TabTogglesLoadNamespace verifies that Tab pressed
+// in the bookmark overlay flips the load-namespace flag. Loading is the
+// default (as set on open), so the first Tab opts out (keep current scope)
+// and the second re-enables loading.
 func TestBookmarkOverlay_TabTogglesLoadNamespace(t *testing.T) {
 	m := baseFinalModel()
 	m.overlay = overlayBookmarks
 	m.bookmarks = []model.Bookmark{{Slot: "a", Name: "x"}}
+	m.bookmarkLoadNamespace = true // matches the open default
 
 	result, _ := m.handleBookmarkOverlayKey(tea.KeyMsg{Type: tea.KeyTab})
 	rm := result.(Model)
-	assert.True(t, rm.bookmarkLoadNamespace, "first Tab must arm the load flag")
+	assert.False(t, rm.bookmarkLoadNamespace, "first Tab must opt out of loading")
 
 	result, _ = rm.handleBookmarkOverlayKey(tea.KeyMsg{Type: tea.KeyTab})
 	rm = result.(Model)
-	assert.False(t, rm.bookmarkLoadNamespace, "second Tab must disarm the flag")
+	assert.True(t, rm.bookmarkLoadNamespace, "second Tab must re-enable loading")
 }
 
-// TestBookmarkOverlay_EscapeResetsLoadNamespace verifies that closing
-// the overlay without jumping discards any pending Tab arming, so
-// reopening the overlay presents a clean default state.
+// TestBookmarkOverlay_EscapeResetsLoadNamespace verifies that closing the
+// overlay resets the flag to the default (load) so an opt-out via Tab does
+// not leak into the next open.
 func TestBookmarkOverlay_EscapeResetsLoadNamespace(t *testing.T) {
 	m := baseFinalModel()
 	m.overlay = overlayBookmarks
-	m.bookmarkLoadNamespace = true
+	m.bookmarkLoadNamespace = false
 
 	result, _ := m.handleBookmarkOverlayKey(tea.KeyMsg{Type: tea.KeyEsc})
 	rm := result.(Model)
-	assert.False(t, rm.bookmarkLoadNamespace,
-		"closing the overlay must reset the flag so it doesn't leak into the next open")
+	assert.True(t, rm.bookmarkLoadNamespace,
+		"closing the overlay must reset the flag to the load default")
 }
 
 func TestNavigateToBookmark_LocalResourceNotFound(t *testing.T) {

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -497,9 +497,9 @@ func (m Model) handleKeyOpenMarks() Model {
 	m.overlay = overlayBookmarks
 	m.overlayCursor = 0
 	m.bookmarkFilter.Clear()
-	// Every open starts with "don't load namespace"; a prior
-	// session's Tab toggle must not leak in.
-	m.bookmarkLoadNamespace = false
+	// Every open starts with "load saved namespace" (the default); Tab
+	// opts out to keep the current scope. A prior open's toggle must not leak in.
+	m.bookmarkLoadNamespace = true
 	return m
 }
 

--- a/internal/app/view_overlay_lists.go
+++ b/internal/app/view_overlay_lists.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -121,31 +122,65 @@ func renderCanISubjectOverlay(m Model, innerW int) string {
 	}, innerW)
 }
 
-// renderBookmarkOverlay maps the bookmark picker onto OverlayList. The
-// "[LOAD NAMESPACE]" chip embeds in the title as raw styled text; the
-// per-row "<key>: <name>" slot prefix collapses into Status="[k]" + Name.
+// renderBookmarkOverlay maps the bookmark picker onto OverlayList. Each row
+// shows the bookmark's saved namespace scope as a dim "ns: <scope>" suffix.
+// The jump replays that scope by default; Tab opts out, surfaced by the
+// "[KEEP CURRENT NS]" title chip.
 func renderBookmarkOverlay(m Model) string {
 	const w = 90
 	title := "Bookmarks"
-	if m.bookmarkLoadNamespace {
-		title += "   " + ui.HelpKeyStyle.Render("[LOAD NAMESPACE]")
+	if !m.bookmarkLoadNamespace {
+		title += "   " + ui.HelpKeyStyle.Render("[KEEP CURRENT NS]")
 	}
 	var bookmarks []ui.OverlayListItem
 	for _, bm := range m.bookmarks {
 		if m.bookmarkFilter.Value != "" && !ui.MatchLine(bm.Name, m.bookmarkFilter.Value) {
 			continue
 		}
-		bookmarks = append(bookmarks, ui.OverlayListItem{Key: bm.Slot, Name: bm.Name})
+		bookmarks = append(bookmarks, ui.OverlayListItem{
+			Key:         bm.Slot,
+			Name:        bm.Name,
+			Description: "ns: " + bookmarkNamespaceLabel(bm),
+		})
 	}
 	return ui.RenderOverlayList(bookmarks, ui.OverlayListConfig{
-		Title:        title,
-		Cursor:       m.overlayCursor,
-		Filterable:   true,
-		Filter:       m.bookmarkFilter.Value,
-		FilterActive: m.bookmarkSearchMode == bookmarkModeFilter,
-		ShowKey:      true,
-		EmptyMessage: "No bookmarks yet — press m<key> in the explorer to set a mark",
+		Title:           title,
+		Cursor:          m.overlayCursor,
+		Filterable:      true,
+		Filter:          m.bookmarkFilter.Value,
+		FilterActive:    m.bookmarkSearchMode == bookmarkModeFilter,
+		ShowKey:         true,
+		ShowDescription: true,
+		EmptyMessage:    "No bookmarks yet — press m<key> in the explorer to set a mark",
 	}, min(w, m.width-10)-4)
+}
+
+// bookmarkNamespaceLabel formats a bookmark's saved namespace scope for the
+// overlay: "all namespaces" when unscoped, a single name, or a comma list
+// (prefixed "!" when the set is an exclude filter, capped at 3 + "+N more").
+func bookmarkNamespaceLabel(bm model.Bookmark) string {
+	names := bm.Namespaces
+	if len(names) == 0 && bm.Namespace != "" {
+		names = []string{bm.Namespace}
+	}
+	if len(names) == 0 {
+		return "all namespaces"
+	}
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	if bm.NsSelectionNegated {
+		for i, ns := range sorted {
+			sorted[i] = "!" + ns
+		}
+	}
+	if len(sorted) > 3 {
+		more := "more"
+		if bm.NsSelectionNegated {
+			more = "more excl"
+		}
+		return fmt.Sprintf("%s +%d %s", strings.Join(sorted[:3], ","), len(sorted)-3, more)
+	}
+	return strings.Join(sorted, ",")
 }
 
 // renderSessionsOverlay maps the named-session picker onto OverlayList.


### PR DESCRIPTION
## Summary

Two bookmark-overlay improvements:

1. **Load the saved namespace by default.** Previously a bookmark jump kept the tab's current namespace and only replayed the bookmark's saved scope when the user pressed `Tab` to opt in. Now the jump applies the saved namespace by default; `Tab` opts out to keep the current scope.
2. **Show each bookmark's namespace in the overlay.** Every row now carries a dim `ns: <scope>` suffix so you can see where a jump will land before pressing.

## Behavior

- Overlay opens with load-namespace ON (seeded in `handleKeyOpenMarks` and the `:bookmarks` command).
- `Tab` toggles it; opting out shows a `[KEEP CURRENT NS]` title chip (replaces the old `[LOAD NAMESPACE]` chip). The hint-bar `tab` verb flips accordingly.
- Per-row namespace label: single name, sorted comma list, exclude sets prefixed `!`, capped at 3 + `+N more`, or `all namespaces` when unscoped.
- The per-jump consume and close-reset now target the new default.

## Tests

- `handleKeyOpenMarks` defaults to loading.
- `bookmarkNamespaceLabel` table (all-ns / single / multi / negated / capped).
- Overlay render shows `ns: production` / `ns: all namespaces` and the chip only when opted out.
- Updated the existing Tab-toggle and Escape-reset tests for the inverted default.

## Verification

- `go build ./...`
- `go test ./internal/app/ ./internal/ui/ -race` — green
- `golangci-lint run` — 0 issues (app.go now 797 lines)
