### PR TITLE
fix(tabs): isolate quick filter presets per tab

### DIFF
--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -479,6 +479,12 @@ type TabState struct {
 	sortMemory      map[string]sortPref
 	filterText      string
 	filterBroadMode bool
+	// Quick filter preset applied to this tab, and the pre-filter middle list
+	// captured when it was applied. Per-tab so a preset set on one tab does not
+	// leak onto siblings (the next data load would otherwise re-apply it and
+	// hide non-matching rows).
+	activeFilterPreset    *FilterPreset
+	unfilteredMiddleItems []model.Item
 	// Identity of the highlighted resource row, captured on save so session
 	// restore can reopen every tab (not just the active one) on the same item.
 	cursorName         string

--- a/internal/app/tab_filter_preset_isolation_test.go
+++ b/internal/app/tab_filter_preset_isolation_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// A quick filter preset applied on one tab must stay on that tab. Before the
+// fix activeFilterPreset / unfilteredMiddleItems were loose Model fields not
+// captured per-tab, so switching to a sibling tab left the preset in place and
+// the next data load re-applied it (reapplyFilterPreset), silently hiding rows
+// that don't match — e.g. every Job vanishing under a "Failing pods" preset.
+func TestTabSwitchDoesNotLeakActiveFilterPreset(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "ctx"
+	// Two tabs: tab 0 is the current (Pods) tab, tab 1 is an untouched sibling.
+	m.tabs = []TabState{{}, {}}
+	m.activeTab = 0
+
+	full := []model.Item{
+		{Name: "pod-a", Kind: "Pod"},
+		{Name: "pod-b", Kind: "Pod"},
+	}
+	filtered := []model.Item{{Name: "pod-b", Kind: "Pod"}}
+	m.setMiddleItems(filtered)
+	m.unfilteredMiddleItems = full
+	m.activeFilterPreset = &FilterPreset{Name: "Failing"}
+
+	// Switch to the sibling tab, which never had a preset applied.
+	m.saveCurrentTab()
+	m.loadTab(1)
+
+	assert.Nil(t, m.activeFilterPreset,
+		"switching to a tab with no preset must clear the active preset")
+	assert.Nil(t, m.unfilteredMiddleItems,
+		"switching tabs must drop the previous tab's unfiltered snapshot")
+}
+
+// The preset must survive a round-trip: switching away and back restores the
+// tab's own active preset and its pre-filter snapshot.
+func TestTabSwitchRestoresActiveFilterPreset(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "ctx"
+	m.tabs = []TabState{{}, {}}
+	m.activeTab = 0
+
+	full := []model.Item{
+		{Name: "pod-a", Kind: "Pod"},
+		{Name: "pod-b", Kind: "Pod"},
+	}
+	filtered := []model.Item{{Name: "pod-b", Kind: "Pod"}}
+	m.setMiddleItems(filtered)
+	m.unfilteredMiddleItems = full
+	m.activeFilterPreset = &FilterPreset{Name: "Failing"}
+
+	m.saveCurrentTab()
+	m.loadTab(1)
+	// Back to tab 0.
+	m.saveCurrentTab()
+	m.loadTab(0)
+
+	if assert.NotNil(t, m.activeFilterPreset,
+		"returning to a tab with a preset must restore it") {
+		assert.Equal(t, "Failing", m.activeFilterPreset.Name)
+	}
+	assert.Equal(t, full, m.unfilteredMiddleItems,
+		"returning to a filtered tab must restore its unfiltered snapshot")
+}
+
+// A newly opened tab starts with no active preset even when cloned from a tab
+// that has one applied.
+func TestCloneCurrentTabStartsWithNoFilterPreset(t *testing.T) {
+	m := baseModelCov()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "ctx"
+	m.activeFilterPreset = &FilterPreset{Name: "Failing"}
+	m.unfilteredMiddleItems = []model.Item{{Name: "pod-a", Kind: "Pod"}}
+
+	clone := m.cloneCurrentTab()
+
+	assert.Nil(t, clone.activeFilterPreset,
+		"a cloned tab must start with no active filter preset")
+	assert.Nil(t, clone.unfilteredMiddleItems,
+		"a cloned tab must start with no unfiltered snapshot")
+}

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -341,6 +341,8 @@ func (m *Model) saveCurrentTab() {
 	t.sortAscending = m.sortAscending
 	t.filterText = m.filterText
 	t.filterBroadMode = m.filterBroadMode
+	t.activeFilterPreset = m.activeFilterPreset
+	t.unfilteredMiddleItems = append([]model.Item(nil), m.unfilteredMiddleItems...)
 	t.cursorName, t.cursorNamespace, _, _ = m.cursorItemKey()
 	t.watchMode = m.watchMode
 	t.objectExplorerLive = m.objectExplorerLive
@@ -476,6 +478,8 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.filterText = t.filterText
 	m.filterBroadMode = t.filterBroadMode
 	m.filterInput.Set(t.filterText)
+	m.activeFilterPreset = t.activeFilterPreset
+	m.unfilteredMiddleItems = append([]model.Item(nil), t.unfilteredMiddleItems...)
 	m.watchMode = t.watchMode
 	m.objectExplorerLive = t.objectExplorerLive
 	m.objectExplorerTree = t.objectExplorerTree


### PR DESCRIPTION
## Problem

A quick filter preset applied on one tab leaked onto every other tab. Selecting the "Failing pods" preset and switching to a different tab (e.g. Jobs) made those rows disappear, because the preset was re-applied to the sibling tab's data.

## Root cause

`activeFilterPreset` and `unfilteredMiddleItems` were loose `Model` fields, not captured per-tab. When switching tabs, the preset pointer stayed live, and the incoming tab's next data load ran `reapplyFilterPreset()` (`update_resources_loaded.go`), re-filtering its rows against the previous tab's preset.

This is the "loose Model fields leak across tabs" pattern the project's `CLAUDE.md` warns about.

## Fix

Make the preset per-tab state:

- Add `activeFilterPreset` / `unfilteredMiddleItems` to `TabState`.
- Snapshot them in `saveCurrentTab`, restore in `loadTab` (nil when the target tab has no preset, so switching to a clean tab clears it).
- `cloneCurrentTab` leaves them nil, so a newly opened tab starts with no active filter.

No session-serialization impact: sessions use the separate `SessionTab` struct, which never marshals the preset's `MatchFn`. The active preset stays session-transient, as before.

## Test plan

- [x] New TDD tests (`tab_filter_preset_isolation_test.go`): leak-on-switch, restore-on-return, clone-starts-clean — red before, green after
- [x] `go test -race ./internal/app/` passes
- [x] `go vet` + `golangci-lint` clean
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)