### PR TITLE
feat(nodes): show node uptime from Prometheus in the nodes list

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **Startup tips**: Random tips on startup to help discover features (configurable via `tips: false`)
 - **Status-aware coloring**: Running=green, Pending=yellow, Failed=red — also applied to CRD printer-column values: recognized status words (Active, Failed, Pending, ...) get their severity color, and True/False values follow the column's polarity (Established=False red, Failed=False green)
 - **Resource usage metrics**: CPU/MEM with color-coded bars in dashboard
+- **Node uptime column**: time since each node last booted, to spot restarts. Requires Prometheus as the monitoring source and node_exporter (the Kubernetes API does not expose boot time)
 
 ## Installation
 

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -256,6 +256,8 @@ monitoring:
 #     services: ["alertmanager-main"]
 #     port: "9093"
 #   node_metrics: prometheus  # "prometheus" or "metrics-api" (default: auto-detect)
+#                             # "prometheus" also enables the nodes-list Uptime
+#                             # column, which needs node_exporter installed.
 # _global:
 #   prometheus:
 #     namespaces: ["monitoring", "observability"]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -254,6 +254,21 @@ Each monitoring entry accepts the following top-level fields:
 | `alertmanager` | object | *(auto-discovery)* | Alertmanager endpoint configuration. See endpoint fields below. |
 | `node_metrics` | string | *(auto-detect)* | Metrics source for node **and pod** usage: `"prometheus"` (use Prometheus queries), `"metrics-api"` (use metrics.k8s.io API). When empty, uses Prometheus if a prometheus endpoint is configured, otherwise metrics-api. Either way the other source is tried as a fallback, so pod metrics resolve on clusters served only by Prometheus. |
 
+### Node Uptime Column
+
+The nodes list shows an `Uptime` column (how long since each node last booted)
+when Prometheus is the configured monitoring source — that is, a `prometheus`
+endpoint is set, or `node_metrics: prometheus`.
+
+| Requirement | Detail |
+|---|---|
+| Source | node_exporter's `node_boot_time_seconds` metric, queried via Prometheus |
+| Needs | node_exporter, not just Prometheus (e.g. kube-prometheus-stack ships both) |
+| Kubernetes API | Does not expose node boot time, so there is no fallback source |
+
+Clusters without node_exporter never show the column. A node missing from the
+query result shows `n/a`, as does every node if Prometheus stops responding.
+
 ### Monitoring Endpoint Fields
 
 Each endpoint (`prometheus` and `alertmanager`) accepts:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -258,7 +258,10 @@ Each monitoring entry accepts the following top-level fields:
 
 The nodes list shows an `Uptime` column (how long since each node last booted)
 when Prometheus is the configured monitoring source — that is, a `prometheus`
-endpoint is set, or `node_metrics: prometheus`.
+endpoint is set, or `node_metrics: prometheus`. One of the two is required;
+the column stays hidden on clusters with no monitoring config. With
+`node_metrics: prometheus` and no `prometheus` block, the endpoint itself is
+auto-discovered from the well-known namespaces and services listed below.
 
 | Requirement | Detail |
 |---|---|

--- a/internal/app/commands_load_metrics.go
+++ b/internal/app/commands_load_metrics.go
@@ -218,3 +218,31 @@ func (m Model) loadNodeMetricsForList() tea.Cmd {
 		},
 	)
 }
+
+// loadNodeUptimeForList fetches Prometheus node uptimes and returns them to
+// enrich the middle pane items with an Uptime column. A nil/empty result is
+// not an error: it means Prometheus isn't the configured monitoring source.
+func (m Model) loadNodeUptimeForList() tea.Cmd {
+	// See loadPodMetricsForList: skip at the union sentinel.
+	if m.isUnionSentinel() {
+		return nil
+	}
+	kctx := m.nav.Context
+	gen := m.requestGen
+	client := m.client
+	return m.scheduleK8sCall(
+		scheduler.PriorityLow,
+		scheduler.KindMetrics,
+		"Node uptime",
+		bgtaskTarget(kctx, ""),
+		func(ctx context.Context) tea.Msg {
+			uptimes, err := client.GetNodeUptimes(ctx, kctx)
+			if err != nil {
+				logger.WarnOnce("node-uptime-list-load", kctx,
+					"node uptime list load failed", "context", kctx, "error", logger.Redact(err.Error()))
+				return nodeUptimeEnrichedMsg{gen: gen}
+			}
+			return nodeUptimeEnrichedMsg{uptimes: uptimes, gen: gen}
+		},
+	)
+}

--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -142,7 +142,7 @@ func carryOverMetricsColumnsFrom(oldItems, newItems []model.Item) {
 	metricsKeys := map[string]bool{
 		"CPU": true, "CPU/R": true, "CPU/L": true,
 		"MEM": true, "MEM/R": true, "MEM/L": true,
-		"CPU%": true, "MEM%": true,
+		"CPU%": true, "MEM%": true, "Uptime": true,
 	}
 	// Build lookup from old items. Carry over whatever metrics columns the
 	// item already had so the column set stays visually stable across watch

--- a/internal/app/cursor_test.go
+++ b/internal/app/cursor_test.go
@@ -714,6 +714,33 @@ func TestCarryOverMetricsColumns(t *testing.T) {
 		m.carryOverMetricsColumns(newItems)
 		assert.Len(t, newItems[0].Columns, 1)
 	})
+
+	t.Run("Uptime survives a watch-tick refresh", func(t *testing.T) {
+		m := Model{
+			middleItems: []model.Item{
+				{
+					Name: "node-a",
+					Columns: []model.KeyValue{
+						{Key: "Uptime", Value: "3h"},
+					},
+				},
+			},
+		}
+		newItems := []model.Item{
+			{
+				Name:    "node-a",
+				Columns: []model.KeyValue{{Key: "Role", Value: "worker"}},
+			},
+		}
+		m.carryOverMetricsColumns(newItems)
+		var got string
+		for _, kv := range newItems[0].Columns {
+			if kv.Key == "Uptime" {
+				got = kv.Value
+			}
+		}
+		assert.Equal(t, "3h", got, "Uptime column must carry over across watch ticks")
+	})
 }
 
 // --- filteredOverlayItems ---

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -325,6 +325,16 @@ type nodeMetricsEnrichedMsg struct {
 	gen     uint64
 }
 
+// nodeUptimeEnrichedMsg carries Prometheus node uptimes to enrich the middle
+// pane items. uptimes separates name-keyed from address-keyed (IP/hostname)
+// results (see k8s.GetNodeUptimes) since node_exporter series aren't
+// reliably keyed by node name, and a name/address collision must not
+// silently overwrite either node's uptime.
+type nodeUptimeEnrichedMsg struct {
+	uptimes k8s.NodeUptimes
+	gen     uint64
+}
+
 // secretDataLoadedMsg carries the fetched secret data.
 type secretDataLoadedMsg struct {
 	data *model.SecretData

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"math"
 	"net/netip"
 	"sort"
 	"strconv"
@@ -162,20 +163,23 @@ var columnValueCmp = map[string]valueCmpFunc{
 	"Cluster IP":   compareIPCmp,
 	"Pod IP":       compareIPCmp,
 	"External IPs": compareIPCmp,
+	"Uptime":       compareUptimeCmp,
 }
 
-// metricsMissingLastColumns are the metrics columns whose cells render as
-// "n/a" when metrics-server has no data for the row. Rows missing such a value
-// must sort to the bottom regardless of sort direction (see sortMiddleItems).
+// metricsMissingLastColumns are columns whose cells can render as an "n/a"
+// placeholder — metrics-server data missing (CPU/MEM family) or unknown
+// Uptime. Rows with such a value must sort to the bottom regardless of
+// sort direction (see sortMiddleItems).
 var metricsMissingLastColumns = map[string]bool{
 	"CPU": true, "MEM": true,
 	"CPU%": true, "MEM%": true,
 	"CPU/R": true, "CPU/L": true, "MEM/R": true, "MEM/L": true,
+	"Uptime": true,
 }
 
-// metricValueMissing reports whether item's value for colName is a metrics-less
-// "n/a" placeholder that should always sort last. Returns false for non-metrics
-// columns, so only the CPU/MEM family gets the always-last treatment.
+// metricValueMissing reports whether item's value for colName is an "n/a"
+// placeholder that should always sort last. Returns false for columns not
+// in metricsMissingLastColumns.
 func metricValueMissing(colName string, item model.Item) bool {
 	if !metricsMissingLastColumns[colName] {
 		return false
@@ -461,6 +465,66 @@ func compareDurationCmp(a, b string) int {
 		return cmpInt64(int64(da), int64(db))
 	}
 	return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+}
+
+// ageDurationUnits maps formatAge's single-char suffixes to their
+// nanosecond multiplier. Days = 24h, years = 365d, matching formatAge's
+// own arithmetic.
+var ageDurationUnits = map[byte]time.Duration{
+	's': time.Second,
+	'm': time.Minute,
+	'h': time.Hour,
+	'd': 24 * time.Hour,
+	'y': 365 * 24 * time.Hour,
+}
+
+// parseAgeDuration parses the single-unit duration strings emitted by
+// k8s.formatAge (e.g. "45s", "5d", "2y") — never a combined form like
+// "5d3h". time.ParseDuration only understands ns/us/ms/s/m/h, so it can't
+// parse formatAge's "d"/"y" suffixes; this is a dedicated parser instead
+// of reusing compareDurationCmp.
+func parseAgeDuration(s string) (time.Duration, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	mult, known := ageDurationUnits[s[len(s)-1]]
+	if !known {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s[:len(s)-1], 10, 64)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	// This backs the "Uptime" column comparator for any resource whose
+	// columnValueCmp key matches, including CRD additionalPrinterColumns
+	// values from the cluster — so n*mult must be checked for int64
+	// nanosecond overflow rather than trusted, or the multiplication wraps
+	// into a negative duration and silently inverts sort order.
+	if n > int64(math.MaxInt64)/int64(mult) {
+		return 0, false
+	}
+	return time.Duration(n) * mult, true
+}
+
+// compareUptimeCmp compares two Uptime column values (formatAge output) by
+// real duration, so "10d" sorts after "9h" instead of before it lexically.
+// "n/a" (and any other unparseable value) sorts after real values so
+// unknown-uptime rows land at the bottom in ascending order, mirroring
+// comparePercentCmp.
+func compareUptimeCmp(a, b string) int {
+	da, okA := parseAgeDuration(a)
+	db, okB := parseAgeDuration(b)
+	switch {
+	case okA && okB:
+		return cmpInt64(int64(da), int64(db))
+	case okA:
+		return -1
+	case okB:
+		return 1
+	default:
+		return strings.Compare(strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b)))
+	}
 }
 
 // compareREVCmp compares REV column values numerically (decimal). Falls back

--- a/internal/app/tabs_compare_test.go
+++ b/internal/app/tabs_compare_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
@@ -205,4 +206,69 @@ func TestCompareResourceValuesCmp_SortOrder(t *testing.T) {
 
 func itemWithCol(key, val string) model.Item {
 	return model.Item{Columns: []model.KeyValue{{Key: key, Value: val}}}
+}
+
+func TestParseAgeDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want time.Duration
+		ok   bool
+	}{
+		{"seconds", "45s", 45 * time.Second, true},
+		{"minutes", "12m", 12 * time.Minute, true},
+		{"hours", "3h", 3 * time.Hour, true},
+		{"days", "5d", 5 * 24 * time.Hour, true},
+		{"years", "2y", 2 * 365 * 24 * time.Hour, true},
+		{"n/a rejected", "n/a", 0, false},
+		{"empty rejected", "", 0, false},
+		{"combined form rejected", "5d3h", 0, false},
+		{"unknown unit rejected", "5x", 0, false},
+		{"non-numeric rejected", "abc", 0, false},
+		{"negative rejected", "-3h", 0, false},
+		{"surrounding whitespace tolerated", " 7d ", 7 * 24 * time.Hour, true},
+		{"zero duration accepted", "0s", 0, true},
+		{"large but representable years accepted", "292y", 292 * 365 * 24 * time.Hour, true},
+		{"years overflow rejected", "999999999999y", 0, false},
+		{"days overflow rejected", "999999999999d", 0, false},
+		{"seconds overflow rejected", "9223372036854775807s", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseAgeDuration(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("parseAgeDuration(%q) ok = %v, want %v", tt.in, ok, tt.ok)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("parseAgeDuration(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			if got < 0 {
+				t.Fatalf("parseAgeDuration(%q) returned negative duration %v", tt.in, got)
+			}
+		})
+	}
+}
+
+func TestCompareUptimeCmp(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"9h before 10d by real duration, not lexically", "9h", "10d", -1},
+		{"10d after 9h", "10d", "9h", 1},
+		{"45s before 12m", "45s", "12m", -1},
+		{"equal values", "5d", "5d", 0},
+		{"n/a sorts after real value", "n/a", "5d", 1},
+		{"real value before n/a", "5d", "n/a", -1},
+		{"n/a equals n/a", "n/a", "n/a", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareUptimeCmp(tt.a, tt.b)
+			if (got < 0) != (tt.want < 0) || (got > 0) != (tt.want > 0) {
+				t.Errorf("compareUptimeCmp(%q, %q) = %d, want sign of %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/app/tabs_test.go
+++ b/internal/app/tabs_test.go
@@ -207,6 +207,53 @@ func TestSortMiddleItemsCPU_NaAlwaysLast(t *testing.T) {
 	})
 }
 
+func TestSortMiddleItemsUptime_NaAlwaysLast(t *testing.T) {
+	ui.ActiveSortableColumns = []string{"Name", "Uptime"}
+	defer func() { ui.ActiveSortableColumns = nil }()
+
+	mkItem := func(name, uptime string) model.Item {
+		return model.Item{Name: name, Columns: []model.KeyValue{{Key: "Uptime", Value: uptime}}}
+	}
+	seed := func() []model.Item {
+		return []model.Item{
+			mkItem("none1", "n/a"),
+			mkItem("short", "12m"),
+			mkItem("long", "10d"),
+			mkItem("none2", "n/a"),
+			mkItem("mid", "9h"),
+		}
+	}
+	names := func(items []model.Item) []string {
+		out := make([]string, len(items))
+		for i, it := range items {
+			out[i] = it.Name
+		}
+		return out
+	}
+
+	// "10d" must sort after "9h" by real duration, not lexically (lexical
+	// order would put "10d" before "9h" since '1' < '9').
+	t.Run("ascending sorts by real duration, n/a last", func(t *testing.T) {
+		m := Model{
+			nav:            model.NavigationState{Level: model.LevelResources},
+			sortColumnName: "Uptime", sortAscending: true,
+			middleItems: seed(),
+		}
+		m.sortMiddleItems()
+		assert.Equal(t, []string{"short", "mid", "long", "none1", "none2"}, names(m.middleItems))
+	})
+
+	t.Run("descending sorts by real duration, n/a still last", func(t *testing.T) {
+		m := Model{
+			nav:            model.NavigationState{Level: model.LevelResources},
+			sortColumnName: "Uptime", sortAscending: false,
+			middleItems: seed(),
+		}
+		m.sortMiddleItems()
+		assert.Equal(t, []string{"long", "mid", "short", "none1", "none2"}, names(m.middleItems))
+	})
+}
+
 func TestSortMiddleItemsByAge(t *testing.T) {
 	ui.ActiveSortableColumns = []string{"Name", "Age", "Status"}
 	defer func() { ui.ActiveSortableColumns = nil }()

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -184,6 +184,9 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case nodeMetricsEnrichedMsg:
 		mdl := m.updateNodeMetricsEnriched(msg)
 		return mdl, nil, true
+	case nodeUptimeEnrichedMsg:
+		mdl := m.updateNodeUptimeEnriched(msg)
+		return mdl, nil, true
 	case dashboardPartialMsg:
 		mdl, cmd := m.handleDashboardPartial(msg)
 		return mdl, cmd, true

--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -591,3 +591,117 @@ func (m Model) updateNodeMetricsEnriched(msg nodeMetricsEnrichedMsg) Model {
 	m.itemCache[m.navKey()] = m.middleItems
 	return m
 }
+
+// lookupNodeUptime resolves a node item's uptime from a Prometheus result
+// split into name-keyed and address-keyed results (see k8s.GetNodeUptimes).
+// The two keyspaces are checked separately -- a node named the same string
+// as another node's IP/hostname must resolve to its own uptime, not
+// whichever one happened to land in a shared map. node_exporter's
+// "instance" label is an IP:port, not a node name, so the name lookup alone
+// misses most clusters -- fall back to the item's InternalIP, then
+// Hostname, columns.
+func lookupNodeUptime(item model.Item, uptimes k8s.NodeUptimes) (time.Duration, bool) {
+	if d, ok := uptimes.ByName[item.Name]; ok {
+		return d, true
+	}
+	for _, key := range []string{"InternalIP", "Hostname"} {
+		for _, kv := range item.Columns {
+			if kv.Key != key {
+				continue
+			}
+			if d, ok := uptimes.ByAddr[kv.Value]; ok {
+				return d, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// updateNodeUptimeEnriched injects an "Uptime" column into each node item
+// once a Prometheus fetch resolves. msg.uptimes follows a three-way rule:
+//
+//   - Non-empty: write the formatted value for every matched node, "n/a" for
+//     every unmatched one (node_exporter simply doesn't cover every node).
+//   - Empty, and no item carries an "Uptime" column yet: a no-op. This means
+//     Prometheus isn't the configured monitoring source, node_exporter isn't
+//     installed, or the query has never once succeeded -- writing "n/a"
+//     placeholders here would permanently pin an UPTIME column onto every
+//     nodes list on every cluster that doesn't run node_exporter.
+//   - Empty, but an item already carries an "Uptime" column (from an earlier
+//     successful tick, possibly carried over by carryOverMetricsColumnsFrom):
+//     degrade that column to "n/a" in place. Otherwise a transient Prometheus
+//     outage leaves the last-known value on screen forever with no
+//     indication it has gone stale.
+func (m Model) updateNodeUptimeEnriched(msg nodeUptimeEnrichedMsg) Model {
+	if msg.gen != m.requestGen {
+		return m // stale response
+	}
+	empty := msg.uptimes.Empty()
+	if empty && !anyItemHasUptimeColumn(m.middleItems) {
+		return m
+	}
+	m.middleItemsRev++
+	for i := range m.middleItems {
+		item := &m.middleItems[i]
+		if empty {
+			if uptimeColumnIndex(item.Columns) >= 0 {
+				setUptimeColumn(item, "n/a")
+			}
+			continue
+		}
+		var value string
+		if d, ok := lookupNodeUptime(*item, msg.uptimes); ok {
+			value = k8s.FormatAge(d)
+		} else {
+			value = "n/a"
+		}
+		setUptimeColumn(item, value)
+	}
+	m.itemCache[m.navKey()] = m.middleItems
+	return m
+}
+
+// anyItemHasUptimeColumn reports whether any item already carries an
+// "Uptime" column, distinguishing "Prometheus never had data" (true no-op)
+// from "Prometheus had data and just stopped answering" (degrade to n/a).
+func anyItemHasUptimeColumn(items []model.Item) bool {
+	for _, item := range items {
+		if uptimeColumnIndex(item.Columns) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// uptimeColumnIndex returns the index of item's "Uptime" column, or -1.
+func uptimeColumnIndex(cols []model.KeyValue) int {
+	for i, kv := range cols {
+		if kv.Key == "Uptime" {
+			return i
+		}
+	}
+	return -1
+}
+
+// setUptimeColumn writes value into item's existing "Uptime" column, or
+// prepends a new one if absent. An existing column must never be moved:
+// carryOverMetricsColumnsFrom and updateNodeMetricsEnriched both prepend
+// their columns on every tick, and this handler moving Uptime to the end
+// instead made its row flap between two positions every refresh.
+// Insertion also prepends so a first-seen Uptime column lands in the same
+// spot regardless of which of the two enrichment messages arrives first.
+//
+// The Columns slice is replaced rather than written through: cloneCurrentTab
+// shallow-copies Item values, so a tab snapshot shares this backing array.
+func setUptimeColumn(item *model.Item, value string) {
+	if idx := uptimeColumnIndex(item.Columns); idx >= 0 {
+		newCols := append([]model.KeyValue(nil), item.Columns...)
+		newCols[idx].Value = value
+		item.Columns = newCols
+		return
+	}
+	newCols := make([]model.KeyValue, 0, len(item.Columns)+1)
+	newCols = append(newCols, model.KeyValue{Key: "Uptime", Value: value})
+	newCols = append(newCols, item.Columns...)
+	item.Columns = newCols
+}

--- a/internal/app/update_msg_extra_test.go
+++ b/internal/app/update_msg_extra_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
@@ -1857,6 +1858,379 @@ func TestUpdateNodeMetricsEnrichedStaleGen(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
+// --- lookupNodeUptime ---
+
+func TestLookupNodeUptime(t *testing.T) {
+	uptimes := k8s.NodeUptimes{
+		ByName: map[string]time.Duration{"node-a": 5 * time.Minute},
+		ByAddr: map[string]time.Duration{
+			"10.0.1.5":     10 * time.Minute,
+			"node-c.local": 15 * time.Minute,
+		},
+	}
+
+	t.Run("hit by name", func(t *testing.T) {
+		item := model.Item{Name: "node-a"}
+		d, ok := lookupNodeUptime(item, uptimes)
+		assert.True(t, ok)
+		assert.Equal(t, 5*time.Minute, d)
+	})
+
+	t.Run("miss on name but hit on InternalIP", func(t *testing.T) {
+		item := model.Item{
+			Name:    "node-b",
+			Columns: []model.KeyValue{{Key: "InternalIP", Value: "10.0.1.5"}},
+		}
+		d, ok := lookupNodeUptime(item, uptimes)
+		assert.True(t, ok)
+		assert.Equal(t, 10*time.Minute, d)
+	})
+
+	t.Run("miss on name and InternalIP but hit on Hostname", func(t *testing.T) {
+		item := model.Item{
+			Name: "node-c",
+			Columns: []model.KeyValue{
+				{Key: "InternalIP", Value: "10.0.9.9"},
+				{Key: "Hostname", Value: "node-c.local"},
+			},
+		}
+		d, ok := lookupNodeUptime(item, uptimes)
+		assert.True(t, ok)
+		assert.Equal(t, 15*time.Minute, d)
+	})
+
+	t.Run("total miss returns ok=false", func(t *testing.T) {
+		item := model.Item{
+			Name:    "node-z",
+			Columns: []model.KeyValue{{Key: "InternalIP", Value: "10.0.0.0"}},
+		}
+		_, ok := lookupNodeUptime(item, uptimes)
+		assert.False(t, ok)
+	})
+
+	t.Run("empty result returns ok=false", func(t *testing.T) {
+		item := model.Item{Name: "node-a"}
+		_, ok := lookupNodeUptime(item, k8s.NodeUptimes{})
+		assert.False(t, ok)
+	})
+}
+
+// TestLookupNodeUptimeNameAndAddrCollisionResolvesIndependently is the
+// regression guard for defect #4: a flat single-map keyspace let a node
+// literally named the same string as another node's InternalIP silently
+// collide, so one of the two would show the wrong uptime. Splitting into
+// ByName/ByAddr must resolve each node to its own value.
+func TestLookupNodeUptimeNameAndAddrCollisionResolvesIndependently(t *testing.T) {
+	uptimes := k8s.NodeUptimes{
+		ByName: map[string]time.Duration{"10.0.1.5": 100 * time.Minute}, // a node literally named "10.0.1.5"
+		ByAddr: map[string]time.Duration{"10.0.1.5": 5 * time.Minute},   // a different node whose InternalIP is 10.0.1.5
+	}
+
+	nodeNamedByIP := model.Item{Name: "10.0.1.5"}
+	d, ok := lookupNodeUptime(nodeNamedByIP, uptimes)
+	require.True(t, ok)
+	assert.Equal(t, 100*time.Minute, d, "must resolve via ByName, not the colliding ByAddr entry")
+
+	otherNode := model.Item{
+		Name:    "node-b",
+		Columns: []model.KeyValue{{Key: "InternalIP", Value: "10.0.1.5"}},
+	}
+	d, ok = lookupNodeUptime(otherNode, uptimes)
+	require.True(t, ok)
+	assert.Equal(t, 5*time.Minute, d, "must resolve via ByAddr for the node whose IP equals another node's name")
+}
+
+// --- nodeUptimeEnrichedMsg ---
+
+func TestUpdateNodeUptimeEnrichedStaleGen(t *testing.T) {
+	m := baseModel()
+	m.requestGen = 10
+	m.middleItems = []model.Item{{Name: "node-a"}}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": 5 * time.Minute}},
+		gen:     5,
+	})
+	rm := result.(Model)
+	for _, kv := range rm.middleItems[0].Columns {
+		assert.NotEqual(t, "Uptime", kv.Key, "stale gen must not mutate columns")
+	}
+}
+
+// TestUpdateNodeUptimeEnrichedEmptyMapAddsNoColumn is the key regression
+// guard: an empty uptimes map means Prometheus isn't configured (or
+// node_exporter isn't installed, or the query transiently failed) -- not
+// that every node genuinely has zero uptime data. Writing "n/a" placeholders
+// here would permanently pin an UPTIME column onto every nodes list on every
+// cluster that doesn't run node_exporter.
+func TestUpdateNodeUptimeEnrichedEmptyMapAddsNoColumn(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{Name: "node-a"}, {Name: "node-b"}}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{gen: 0})
+	rm := result.(Model)
+	for _, item := range rm.middleItems {
+		for _, kv := range item.Columns {
+			assert.NotEqual(t, "Uptime", kv.Key, "empty uptimes map must not add an Uptime column")
+		}
+	}
+}
+
+func TestUpdateNodeUptimeEnrichedMatchedAndUnmatched(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{Name: "node-a"}, {Name: "node-b"}}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": 90 * time.Minute}},
+		gen:     0,
+	})
+	rm := result.(Model)
+
+	got := func(item model.Item) (string, bool) {
+		for _, kv := range item.Columns {
+			if kv.Key == "Uptime" {
+				return kv.Value, true
+			}
+		}
+		return "", false
+	}
+
+	valA, okA := got(rm.middleItems[0])
+	require.True(t, okA)
+	assert.Equal(t, k8s.FormatAge(90*time.Minute), valA)
+
+	valB, okB := got(rm.middleItems[1])
+	require.True(t, okB)
+	assert.Equal(t, "n/a", valB)
+}
+
+func TestUpdateNodeUptimeEnrichedMatchedByInternalIP(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{
+		Name:    "node-a",
+		Columns: []model.KeyValue{{Key: "InternalIP", Value: "10.0.1.5"}},
+	}}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByAddr: map[string]time.Duration{"10.0.1.5": 45 * time.Minute}},
+		gen:     0,
+	})
+	rm := result.(Model)
+
+	var val string
+	for _, kv := range rm.middleItems[0].Columns {
+		if kv.Key == "Uptime" {
+			val = kv.Value
+		}
+	}
+	assert.Equal(t, k8s.FormatAge(45*time.Minute), val)
+}
+
+func TestUpdateNodeUptimeEnrichedTwiceDoesNotDuplicate(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{Name: "node-a"}}
+
+	msg := nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": 5 * time.Minute}},
+		gen:     0,
+	}
+	result, _ := m.Update(msg)
+	result, _ = result.(Model).Update(msg)
+	rm := result.(Model)
+
+	count := 0
+	for _, kv := range rm.middleItems[0].Columns {
+		if kv.Key == "Uptime" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+// TestUpdateNodeUptimeEnrichedPreservesExistingIndex is the regression guard
+// for defect #1 (row-flapping): an existing "Uptime" column must be updated
+// in place, never moved, or its position in the detail pane oscillates
+// between carryOverMetricsColumnsFrom's prepend and this handler's position.
+func TestUpdateNodeUptimeEnrichedPreservesExistingIndex(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{
+		Name: "node-a",
+		Columns: []model.KeyValue{
+			{Key: "Foo", Value: "x"},
+			{Key: "Uptime", Value: "1h0m0s"},
+			{Key: "Bar", Value: "y"},
+		},
+	}}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": 2 * time.Hour}},
+		gen:     0,
+	})
+	rm := result.(Model)
+
+	cols := rm.middleItems[0].Columns
+	require.Len(t, cols, 3)
+	assert.Equal(t, "Foo", cols[0].Key)
+	assert.Equal(t, "Uptime", cols[1].Key, "Uptime must keep its original index")
+	assert.Equal(t, k8s.FormatAge(2*time.Hour), cols[1].Value)
+	assert.Equal(t, "Bar", cols[2].Key)
+}
+
+// TestUpdateNodeUptimeEnrichedStableAcrossCarryOverTicks simulates two watch
+// ticks (carryOverMetricsColumnsFrom then the enrichment handler, twice) and
+// asserts the column key order never changes. The flap this defect fixes
+// alternated the UPTIME row between its carried-over (prepended) position
+// and a moved (appended) position on every tick.
+func TestUpdateNodeUptimeEnrichedStableAcrossCarryOverTicks(t *testing.T) {
+	m := baseModel()
+	// Seed a steady state where "Uptime" is already established (from a
+	// prior successful tick), matching the reported symptom: the flap was
+	// observed on an already-populated nodes list, not on the very first
+	// tick before an Uptime column ever existed.
+	m.middleItems = []model.Item{{
+		Name:    "node-a",
+		Columns: []model.KeyValue{{Key: "Uptime", Value: "1h0m0s"}, {Key: "Other", Value: "x"}},
+	}}
+
+	keysOf := func(cols []model.KeyValue) []string {
+		keys := make([]string, len(cols))
+		for i, kv := range cols {
+			keys[i] = kv.Key
+		}
+		return keys
+	}
+
+	var afterCarryOver, afterHandler [2][]string
+	for tick := range 2 {
+		fresh := []model.Item{{Name: "node-a", Columns: []model.KeyValue{{Key: "Other", Value: "x"}}}}
+		carryOverMetricsColumnsFrom(m.middleItems, fresh)
+		afterCarryOver[tick] = keysOf(fresh[0].Columns)
+
+		m.middleItems = fresh
+		result, _ := m.Update(nodeUptimeEnrichedMsg{
+			uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": time.Duration(tick+1) * time.Hour}},
+			gen:     0,
+		})
+		m = result.(Model)
+		afterHandler[tick] = keysOf(m.middleItems[0].Columns)
+	}
+
+	want := []string{"Uptime", "Other"}
+	assert.Equal(t, want, afterCarryOver[0], "carryOver must place Uptime at the same index every tick")
+	assert.Equal(t, want, afterHandler[0], "handler must not move the column carryOver just placed")
+	assert.Equal(t, want, afterCarryOver[1], "carryOver position must be stable across ticks")
+	assert.Equal(t, want, afterHandler[1], "handler position must be stable across ticks")
+}
+
+// TestUpdateNodeUptimeEnrichedOrderIndependentFromMetrics asserts running
+// updateNodeMetricsEnriched then updateNodeUptimeEnriched produces the same
+// column key order as running them in the reverse order -- the two async
+// messages can land in either order and must not disagree about where
+// "Uptime" sits relative to the CPU/MEM block.
+func TestUpdateNodeUptimeEnrichedOrderIndependentFromMetrics(t *testing.T) {
+	established := []model.KeyValue{
+		{Key: "CPU", Value: "100m"},
+		{Key: "CPU%", Value: "10%"},
+		{Key: "MEM", Value: "1Gi"},
+		{Key: "MEM%", Value: "20%"},
+		{Key: "Uptime", Value: "1h0m0s"},
+		{Key: "Other", Value: "x"},
+	}
+	newCols := func() []model.KeyValue {
+		cols := make([]model.KeyValue, len(established))
+		copy(cols, established)
+		return cols
+	}
+	keysOf := func(cols []model.KeyValue) []string {
+		keys := make([]string, len(cols))
+		for i, kv := range cols {
+			keys[i] = kv.Key
+		}
+		return keys
+	}
+
+	metricsMsg := nodeMetricsEnrichedMsg{
+		metrics: map[string]model.PodMetrics{"node-a": {CPU: 500, Memory: 2 * 1024 * 1024 * 1024}},
+		gen:     0,
+	}
+	uptimeMsg := nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": 3 * time.Hour}},
+		gen:     0,
+	}
+
+	mA := baseModel()
+	mA.middleItems = []model.Item{{Name: "node-a", Columns: newCols()}}
+	rA, _ := mA.Update(metricsMsg)
+	rA, _ = rA.(Model).Update(uptimeMsg)
+	orderA := keysOf(rA.(Model).middleItems[0].Columns)
+
+	mB := baseModel()
+	mB.middleItems = []model.Item{{Name: "node-a", Columns: newCols()}}
+	rB, _ := mB.Update(uptimeMsg)
+	rB, _ = rB.(Model).Update(metricsMsg)
+	orderB := keysOf(rB.(Model).middleItems[0].Columns)
+
+	wantOrder := keysOf(established)
+	assert.Equal(t, wantOrder, orderA, "metrics-then-uptime must not reorder columns")
+	assert.Equal(t, wantOrder, orderB, "uptime-then-metrics must not reorder columns")
+	assert.Equal(t, orderA, orderB, "arrival order must not affect final column order")
+}
+
+// TestUpdateNodeUptimeEnrichedEmptyMapDegradesExistingColumnToNA is the
+// regression guard for defect #2: once Prometheus stops answering (an empty
+// uptimes map), a node that already carries a live "Uptime" value must have
+// it degrade to "n/a" rather than freeze forever. A node that never had an
+// Uptime column must still not get one invented (see
+// TestUpdateNodeUptimeEnrichedEmptyMapAddsNoColumn).
+func TestUpdateNodeUptimeEnrichedEmptyMapDegradesExistingColumnToNA(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{
+		{Name: "node-a", Columns: []model.KeyValue{{Key: "Uptime", Value: "2h0m0s"}}},
+		{Name: "node-b", Columns: []model.KeyValue{{Key: "Foo", Value: "bar"}}},
+	}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{gen: 0})
+	rm := result.(Model)
+
+	require.Len(t, rm.middleItems[0].Columns, 1)
+	assert.Equal(t, "Uptime", rm.middleItems[0].Columns[0].Key, "position must not move")
+	assert.Equal(t, "n/a", rm.middleItems[0].Columns[0].Value, "stale value must degrade to n/a")
+
+	for _, kv := range rm.middleItems[1].Columns {
+		assert.NotEqual(t, "Uptime", kv.Key, "a node that never had Uptime must not get one invented")
+	}
+}
+
+// TestUpdateNodeUptimeEnrichedFreezePreventedAcrossTicks runs a realistic
+// tick sequence -- a successful fetch, a watch-tick carryOver, then a failed
+// (empty-map) fetch -- and asserts the column reads "n/a" afterward instead
+// of freezing on the last live value forever.
+func TestUpdateNodeUptimeEnrichedFreezePreventedAcrossTicks(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{Name: "node-a"}}
+
+	// Tick 1: Prometheus answers.
+	result, _ := m.Update(nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": 2 * time.Hour}},
+		gen:     0,
+	})
+	m = result.(Model)
+	liveValue := m.middleItems[0].Columns[0].Value
+	require.Equal(t, k8s.FormatAge(2*time.Hour), liveValue)
+
+	// Tick 2: list refresh carries the live value onto the fresh items,
+	// then the fetch fails (empty map).
+	fresh := []model.Item{{Name: "node-a"}}
+	carryOverMetricsColumnsFrom(m.middleItems, fresh)
+	m.middleItems = fresh
+	require.Equal(t, liveValue, m.middleItems[0].Columns[0].Value, "carryOver should have preserved the live value going into the failed tick")
+
+	result, _ = m.Update(nodeUptimeEnrichedMsg{gen: 0})
+	rm := result.(Model)
+
+	assert.Equal(t, "n/a", rm.middleItems[0].Columns[0].Value, "must degrade to n/a, not freeze on the stale live value")
+}
+
 // --- podLogSelectMsg ---
 
 func TestUpdatePodLogSelectError(t *testing.T) {
@@ -2043,4 +2417,21 @@ func TestUpdateWindowSizeMsgWithMultipleTabs(t *testing.T) {
 	assert.Equal(t, 100, mdl.width)
 	assert.Equal(t, 30, mdl.height)
 	assert.Nil(t, cmd)
+}
+
+// setUptimeColumn must replace the Columns slice, not write through it:
+// cloneCurrentTab shallow-copies Item values, so a tab snapshot shares the
+// backing array and would otherwise see another tab's uptime writes.
+func TestSetUptimeColumnDoesNotMutateSharedBackingArray(t *testing.T) {
+	item := model.Item{Name: "node-1", Columns: []model.KeyValue{
+		{Key: "Uptime", Value: "5d"},
+		{Key: "InternalIP", Value: "10.0.1.5"},
+	}}
+	snapshot := item // shallow copy, shares the Columns backing array
+
+	setUptimeColumn(&item, "n/a")
+
+	assert.Equal(t, "n/a", item.Columns[0].Value, "target item updated")
+	assert.Equal(t, "5d", snapshot.Columns[0].Value, "snapshot must not be mutated")
+	assert.Equal(t, "Uptime", item.Columns[0].Key, "position preserved")
 }

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -486,7 +486,7 @@ func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea
 	case "Pod":
 		cmds = append(cmds, m.loadPodMetricsForList())
 	case "Node":
-		cmds = append(cmds, m.loadNodeMetricsForList())
+		cmds = append(cmds, m.loadNodeMetricsForList(), m.loadNodeUptimeForList())
 	}
 	m.suppressBgtasks = savedSuppress
 	m.syncObjectExplorerLive()

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -479,6 +479,17 @@ func (c *Client) getNodeMetricsFromPrometheus(contextName string) (map[string]mo
 // queryPrometheusNodeMetric runs a PromQL instant query via Kubernetes service proxy
 // and returns a map of node name -> float64 value.
 func (c *Client) queryPrometheusNodeMetric(ctx context.Context, contextName string, cs kubernetes.Interface, namespaces, services []string, port, query string) (map[string]float64, error) {
+	return queryPrometheusMetric(ctx, contextName, cs, namespaces, services, port, query, parsePrometheusNodeResponse)
+}
+
+// queryPrometheusMetric runs a PromQL instant query via Kubernetes service proxy
+// and parses the response with the caller-supplied parser. A free function
+// (rather than a method) so it can be generic over the parsed result type T --
+// callers needing a different shape (e.g. node uptime, which splits into
+// name-keyed and address-keyed maps) reuse the same service-discovery and
+// promSvcCache logic instead of duplicating it.
+func queryPrometheusMetric[T any](ctx context.Context, contextName string, cs kubernetes.Interface, namespaces, services []string, port, query string, parse func([]byte) (T, error)) (T, error) {
+	var zero T
 	params := map[string]string{"query": query}
 
 	// Check cache for a known working namespace+service. Keyed by contextName
@@ -490,9 +501,9 @@ func (c *Client) queryPrometheusNodeMetric(ctx context.Context, contextName stri
 		result := cs.CoreV1().Services(entry.namespace).ProxyGet("http", entry.service, port, "/api/v1/query", params)
 		data, err := result.DoRaw(ctx)
 		if err == nil {
-			nodeMap, err := parsePrometheusNodeResponse(data)
+			parsed, err := parse(data)
 			if err == nil {
-				return nodeMap, nil
+				return parsed, nil
 			}
 		}
 		// Cache entry stale, remove and fall through to discovery.
@@ -509,20 +520,20 @@ func (c *Client) queryPrometheusNodeMetric(ctx context.Context, contextName stri
 				continue
 			}
 
-			nodeMap, err := parsePrometheusNodeResponse(data)
+			parsed, err := parse(data)
 			if err != nil {
 				lastErr = err
 				continue
 			}
 			promSvcCache.Store(contextName, promSvcEntry{namespace: ns, service: svc})
-			return nodeMap, nil
+			return parsed, nil
 		}
 	}
 
 	if lastErr != nil {
-		return nil, lastErr
+		return zero, lastErr
 	}
-	return nil, fmt.Errorf("no prometheus service found")
+	return zero, fmt.Errorf("no prometheus service found")
 }
 
 // parsePrometheusVector parses a Prometheus /api/v1/query instant-vector

--- a/internal/k8s/metrics_prometheus_nodes.go
+++ b/internal/k8s/metrics_prometheus_nodes.go
@@ -1,0 +1,181 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// nodeUptimeQueryEnabled reports whether Prometheus is the configured
+// monitoring source for contextName. On a metrics-server-only cluster there
+// is no Prometheus service to find, and an unconditional fetch would re-run
+// the full namespace x service discovery sweep on every watch tick.
+func nodeUptimeQueryEnabled(contextName string) bool {
+	nodeMetrics, hasPrometheus := resolveNodeMetricsConfig(contextName)
+	return nodeMetrics == "prometheus" || hasPrometheus
+}
+
+// nodeUptimeNameKeys returns the Kubernetes-node-name label values a
+// node_exporter series carries. Kept separate from nodeUptimeAddrKeys (see
+// NodeUptimes) so a node named the same string as another node's IP or OS
+// hostname can't collide in a single keyspace.
+func nodeUptimeNameKeys(labels map[string]string) []string {
+	var keys []string
+	for _, label := range []string{"node", "kubernetes_node"} {
+		if v := labels[label]; v != "" {
+			keys = append(keys, v)
+		}
+	}
+	return keys
+}
+
+// nodeUptimeAddrKeys returns the IP/hostname label values a node_exporter
+// series carries. node_exporter series don't reliably carry a "node" label,
+// and their "instance" label is a host:port ("10.0.1.5:9100"), never a
+// Kubernetes node name.
+func nodeUptimeAddrKeys(labels map[string]string) []string {
+	var keys []string
+	for _, label := range []string{"nodename", "host"} {
+		if v := labels[label]; v != "" {
+			keys = append(keys, v)
+		}
+	}
+	if instance := labels["instance"]; instance != "" {
+		keys = append(keys, stripInstancePort(instance))
+	}
+	return keys
+}
+
+// stripInstancePort trims the ":<port>" suffix off a node_exporter "instance"
+// label (e.g. "10.0.1.5:9100" -> "10.0.1.5", "[::1]:9100" -> "::1"). Falls
+// back to the raw value when it carries no port.
+func stripInstancePort(instance string) string {
+	host, _, err := net.SplitHostPort(instance)
+	if err != nil {
+		return instance
+	}
+	return host
+}
+
+// nodeUptimeSeconds is the float64-seconds counterpart to NodeUptimes,
+// produced by parseNodeUptimeVector before GetNodeUptimes converts each
+// value to a time.Duration.
+type nodeUptimeSeconds struct {
+	byName map[string]float64
+	byAddr map[string]float64
+}
+
+// parseNodeUptimeVector parses a `time() - node_boot_time_seconds` instant-
+// vector response into name-keyed and address-keyed seconds (see
+// nodeUptimeNameKeys / nodeUptimeAddrKeys). The two keyspaces are kept
+// separate so a node's name colliding with another node's IP/hostname can't
+// silently overwrite either value. Samples with an unparseable, negative,
+// NaN, or infinite value are skipped -- a negative/NaN/Inf uptime is
+// nonsense and would come from clock skew or a malformed sample.
+func parseNodeUptimeVector(data []byte) (nodeUptimeSeconds, error) {
+	var resp prometheusQueryResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nodeUptimeSeconds{}, fmt.Errorf("parsing prometheus response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nodeUptimeSeconds{}, fmt.Errorf("prometheus query returned status: %s", resp.Status)
+	}
+
+	result := nodeUptimeSeconds{
+		byName: make(map[string]float64, len(resp.Data.Result)),
+		byAddr: make(map[string]float64, len(resp.Data.Result)),
+	}
+	for _, r := range resp.Data.Result {
+		if len(r.Value) < 2 {
+			continue
+		}
+		var valStr string
+		if err := json.Unmarshal(r.Value[1], &valStr); err != nil {
+			continue
+		}
+		val, err := strconv.ParseFloat(valStr, 64)
+		// NaN and +Inf both pass a plain "val < 0" check (IEEE-754), and
+		// would otherwise render as "0s" (just rebooted) or a ~292y uptime --
+		// both actively misleading. -Inf is already caught by val < 0.
+		if err != nil || val < 0 || math.IsNaN(val) || math.IsInf(val, 0) {
+			continue
+		}
+
+		for _, key := range nodeUptimeNameKeys(r.Metric) {
+			result.byName[key] = val
+		}
+		for _, key := range nodeUptimeAddrKeys(r.Metric) {
+			result.byAddr[key] = val
+		}
+	}
+	return result, nil
+}
+
+// NodeUptimes separates node uptimes keyed by Kubernetes node name (ByName)
+// from those keyed by node IP or OS hostname (ByAddr). node_exporter series
+// don't reliably carry a Kubernetes node name, so callers commonly need to
+// fall back to an IP/hostname column (see lookupNodeUptime in the app
+// package) -- but folding both into one flat map let one node's name
+// collide with another node's IP/hostname, silently overwriting one node's
+// uptime with another's.
+type NodeUptimes struct {
+	ByName map[string]time.Duration
+	ByAddr map[string]time.Duration
+}
+
+// Empty reports whether neither map holds any data: Prometheus isn't the
+// configured monitoring source, node_exporter isn't installed, or the query
+// has never once succeeded.
+func (n NodeUptimes) Empty() bool {
+	return len(n.ByName) == 0 && len(n.ByAddr) == 0
+}
+
+// GetNodeUptimes queries Prometheus for how long each node has been
+// running, keyed separately by node name and by node IP/hostname (see
+// NodeUptimes). Returns a zero-value NodeUptimes (Empty() == true) with a
+// nil error when Prometheus isn't the configured monitoring source -- uptime
+// is simply unavailable on a metrics-server-only cluster, not an error.
+func (c *Client) GetNodeUptimes(ctx context.Context, contextName string) (NodeUptimes, error) {
+	if !nodeUptimeQueryEnabled(contextName) {
+		return NodeUptimes{}, nil
+	}
+
+	clientset, err := c.clientsetForContext(contextName)
+	if err != nil {
+		return NodeUptimes{}, fmt.Errorf("failed to get clientset: %w", err)
+	}
+
+	promNs, promSvc, promPort, _, _, _ := resolveMonitoringEndpoints(contextName)
+
+	// Bounded like the sibling node CPU/mem queries, so a hung proxy can't
+	// block the caller forever.
+	qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// Subtracted server-side so the result is independent of clock skew
+	// between this machine and the cluster.
+	const query = `time() - node_boot_time_seconds`
+	seconds, err := queryPrometheusMetric(qctx, contextName, clientset, promNs, promSvc, promPort, query, parseNodeUptimeVector)
+	if err != nil {
+		logger.Debug("Prometheus node uptime query failed", "context", contextName, "error", err)
+		return NodeUptimes{}, fmt.Errorf("prometheus node uptime query failed: %w", err)
+	}
+
+	result := NodeUptimes{
+		ByName: make(map[string]time.Duration, len(seconds.byName)),
+		ByAddr: make(map[string]time.Duration, len(seconds.byAddr)),
+	}
+	for key, s := range seconds.byName {
+		result.ByName[key] = time.Duration(s * float64(time.Second))
+	}
+	for key, s := range seconds.byAddr {
+		result.ByAddr[key] = time.Duration(s * float64(time.Second))
+	}
+	return result, nil
+}

--- a/internal/k8s/metrics_prometheus_nodes_test.go
+++ b/internal/k8s/metrics_prometheus_nodes_test.go
@@ -1,0 +1,333 @@
+package k8s
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// --- parseNodeUptimeVector ---
+
+func TestParseNodeUptimeVector(t *testing.T) {
+	t.Run("node label lands in byName", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"node-1"},"value":[1700000000,"3600"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{"node-1": 3600}, result.byName)
+		assert.Empty(t, result.byAddr)
+	})
+
+	t.Run("instance host:port strips port and lands in byAddr", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"instance":"10.0.1.5:9100"},"value":[1700000000,"120"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{"10.0.1.5": 120}, result.byAddr)
+		assert.Empty(t, result.byName)
+	})
+
+	t.Run("instance IPv6 host:port strips port", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"instance":"[::1]:9100"},"value":[1700000000,"42"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{"::1": 42}, result.byAddr)
+	})
+
+	t.Run("instance without port kept verbatim", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"instance":"worker-1"},"value":[1700000000,"55"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{"worker-1": 55}, result.byAddr)
+	})
+
+	t.Run("both node and instance labels populate both maps with the same value", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"node-1","instance":"10.0.1.5:9100"},"value":[1700000000,"99"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{"node-1": 99}, result.byName)
+		assert.Equal(t, map[string]float64{"10.0.1.5": 99}, result.byAddr)
+	})
+
+	t.Run("kubernetes_node fallback label lands in byName", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"kubernetes_node":"alt-node"},"value":[1700000000,"10"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{"alt-node": 10}, result.byName)
+		assert.Empty(t, result.byAddr)
+	})
+
+	for _, label := range []string{"nodename", "host"} {
+		t.Run(label+" fallback label lands in byAddr, not byName", func(t *testing.T) {
+			data := `{"status":"success","data":{"resultType":"vector","result":[
+				{"metric":{"` + label + `":"alt-node"},"value":[1700000000,"10"]}
+			]}}`
+			result, err := parseNodeUptimeVector([]byte(data))
+			require.NoError(t, err)
+			assert.Equal(t, map[string]float64{"alt-node": 10}, result.byAddr)
+			assert.Empty(t, result.byName)
+		})
+	}
+
+	// Regression guard for defect #4: a node's name colliding with another
+	// node's stripped instance address must not overwrite either value --
+	// each keyspace stays independent.
+	t.Run("node name colliding with another series' instance address stays independent", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"10.0.1.5"},"value":[1700000000,"100"]},
+			{"metric":{"instance":"10.0.1.5:9100"},"value":[1700000000,"9999"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{"10.0.1.5": 100}, result.byName)
+		assert.Equal(t, map[string]float64{"10.0.1.5": 9999}, result.byAddr)
+	})
+
+	t.Run("empty label values are skipped", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"","instance":""},"value":[1700000000,"10"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Empty(t, result.byName)
+		assert.Empty(t, result.byAddr)
+	})
+
+	t.Run("unparseable sample value is skipped", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"node-1"},"value":[1700000000,"not-a-number"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Empty(t, result.byName)
+	})
+
+	t.Run("negative value is skipped", func(t *testing.T) {
+		data := `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"node-1"},"value":[1700000000,"-5"]}
+		]}}`
+		result, err := parseNodeUptimeVector([]byte(data))
+		require.NoError(t, err)
+		assert.Empty(t, result.byName)
+	})
+
+	for _, val := range []string{"NaN", "+Inf", "Inf", "-Inf"} {
+		t.Run(val+" value is skipped", func(t *testing.T) {
+			data := `{"status":"success","data":{"resultType":"vector","result":[
+				{"metric":{"node":"node-1"},"value":[1700000000,"` + val + `"]}
+			]}}`
+			result, err := parseNodeUptimeVector([]byte(data))
+			require.NoError(t, err)
+			assert.Empty(t, result.byName, "%s must be skipped, not rendered as a bogus uptime", val)
+		})
+	}
+
+	t.Run("non-success status returns error", func(t *testing.T) {
+		data := `{"status":"error","errorType":"bad_data","error":"invalid query"}`
+		_, err := parseNodeUptimeVector([]byte(data))
+		assert.Error(t, err)
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		_, err := parseNodeUptimeVector([]byte(`{not-valid-json`))
+		assert.Error(t, err)
+	})
+}
+
+// --- nodeUptimeQueryEnabled ---
+
+func TestNodeUptimeQueryEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  map[string]model.MonitoringConfig
+		ctx  string
+		want bool
+	}{
+		{
+			name: "nil config",
+			cfg:  nil,
+			ctx:  "any-context",
+			want: false,
+		},
+		{
+			name: "node_metrics prometheus",
+			cfg: map[string]model.MonitoringConfig{
+				"my-ctx": {NodeMetrics: "prometheus"},
+			},
+			ctx:  "my-ctx",
+			want: true,
+		},
+		{
+			name: "explicit prometheus endpoint block",
+			cfg: map[string]model.MonitoringConfig{
+				"my-ctx": {Prometheus: &model.MonitoringEndpoint{Namespaces: []string{"monitoring"}}},
+			},
+			ctx:  "my-ctx",
+			want: true,
+		},
+		{
+			name: "node_metrics metrics-api with no prometheus block",
+			cfg: map[string]model.MonitoringConfig{
+				"my-ctx": {NodeMetrics: "metrics-api"},
+			},
+			ctx:  "my-ctx",
+			want: false,
+		},
+		{
+			name: "_global fallback with prometheus",
+			cfg: map[string]model.MonitoringConfig{
+				"_global": {NodeMetrics: "prometheus"},
+			},
+			ctx:  "unrelated-ctx",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := model.ConfigMonitoring
+			t.Cleanup(func() { model.ConfigMonitoring = prev })
+			model.ConfigMonitoring = tt.cfg
+
+			assert.Equal(t, tt.want, nodeUptimeQueryEnabled(tt.ctx))
+		})
+	}
+}
+
+// --- GetNodeUptimes ---
+
+func TestGetNodeUptimes_DisabledReturnsEmpty(t *testing.T) {
+	prev := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = prev })
+	model.ConfigMonitoring = nil
+
+	c := &Client{}
+	result, err := c.GetNodeUptimes(t.Context(), "any-context")
+	require.NoError(t, err)
+	assert.True(t, result.Empty())
+}
+
+// fakeProxyResponse implements rest.ResponseWrapper for injecting a canned
+// Prometheus proxy response through a fake clientset's ProxyReactor chain.
+type fakeProxyResponse struct {
+	body []byte
+	err  error
+}
+
+func (f fakeProxyResponse) DoRaw(context.Context) ([]byte, error) { return f.body, f.err }
+
+func (f fakeProxyResponse) Stream(context.Context) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func TestGetNodeUptimes_EnabledQueriesPrometheus(t *testing.T) {
+	prev := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = prev })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"test-ctx": {
+			Prometheus: &model.MonitoringEndpoint{
+				Namespaces: []string{"monitoring"},
+				Services:   []string{"prometheus"},
+				Port:       "9090",
+			},
+		},
+	}
+
+	cs := fake.NewSimpleClientset(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: "monitoring"},
+	})
+	cs.PrependProxyReactor("services", func(clienttesting.Action) (bool, restclient.ResponseWrapper, error) {
+		body := []byte(`{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"node-1"},"value":[1700000000,"7200"]}
+		]}}`)
+		return true, fakeProxyResponse{body: body}, nil
+	})
+
+	c := NewTestClient(cs, nil)
+	result, err := c.GetNodeUptimes(t.Context(), "test-ctx")
+	require.NoError(t, err)
+	require.Contains(t, result.ByName, "node-1")
+	assert.Equal(t, 2*time.Hour, result.ByName["node-1"])
+	assert.Empty(t, result.ByAddr)
+}
+
+func TestGetNodeUptimes_QueryErrorIsWrapped(t *testing.T) {
+	prev := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = prev })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"test-ctx": {
+			Prometheus: &model.MonitoringEndpoint{
+				Namespaces: []string{"monitoring"},
+				Services:   []string{"prometheus"},
+				Port:       "9090",
+			},
+		},
+	}
+
+	cs := fake.NewSimpleClientset()
+	cs.PrependProxyReactor("services", func(clienttesting.Action) (bool, restclient.ResponseWrapper, error) {
+		return true, fakeProxyResponse{err: assert.AnError}, nil
+	})
+
+	c := NewTestClient(cs, nil)
+	result, err := c.GetNodeUptimes(t.Context(), "test-ctx")
+	require.Error(t, err)
+	assert.True(t, result.Empty())
+}
+
+// TestGetNodeUptimes_NameAddrKeyspacesStayIndependent is the end-to-end
+// regression guard for defect #4: a node whose name collides with another
+// node's instance address must not overwrite either value once GetNodeUptimes
+// converts seconds to durations.
+func TestGetNodeUptimes_NameAddrKeyspacesStayIndependent(t *testing.T) {
+	prev := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = prev })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"test-ctx": {
+			Prometheus: &model.MonitoringEndpoint{
+				Namespaces: []string{"monitoring"},
+				Services:   []string{"prometheus"},
+				Port:       "9090",
+			},
+		},
+	}
+
+	cs := fake.NewSimpleClientset(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: "monitoring"},
+	})
+	cs.PrependProxyReactor("services", func(clienttesting.Action) (bool, restclient.ResponseWrapper, error) {
+		body := []byte(`{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"node":"10.0.1.5"},"value":[1700000000,"3600"]},
+			{"metric":{"instance":"10.0.1.5:9100"},"value":[1700000000,"7200"]}
+		]}}`)
+		return true, fakeProxyResponse{body: body}, nil
+	})
+
+	c := NewTestClient(cs, nil)
+	result, err := c.GetNodeUptimes(t.Context(), "test-ctx")
+	require.NoError(t, err)
+	require.Contains(t, result.ByName, "10.0.1.5")
+	require.Contains(t, result.ByAddr, "10.0.1.5")
+	assert.Equal(t, time.Hour, result.ByName["10.0.1.5"])
+	assert.Equal(t, 2*time.Hour, result.ByAddr["10.0.1.5"])
+}

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -97,6 +97,7 @@ type colInfo struct {
 var canonicalColumnPriority = map[string]int{
 	"CPU": 0, "CPU%": 1, "CPU/R": 2, "CPU/L": 3,
 	"MEM": 4, "MEM%": 5, "MEM/R": 6, "MEM/L": 7,
+	"Uptime": 8,
 }
 
 // sortDiscoveryOrder reorders detected column keys in place into a canonical,


### PR DESCRIPTION
## Summary

Adds an `Uptime` column to the nodes list so you can see how long since each node last booted, and spot restarts at a glance.

The Kubernetes API exposes no node boot time. `status.nodeInfo` carries a `bootID` that changes on reboot, but no timestamp, so there is no native source and no fallback. This reads node_exporter's `node_boot_time_seconds` through the Prometheus service proxy that already backs node CPU/MEM. The subtraction runs server-side (`time() - node_boot_time_seconds`) so the value does not depend on local clock skew.

## Type of change

- [x] feat: new user-facing feature

## Related issue

<!-- none -->

## Changes

- `internal/k8s/metrics_prometheus_nodes.go` (new): `GetNodeUptimes` queries Prometheus and returns uptimes keyed into **separate name and address keyspaces**. node_exporter's `instance` label is an `IP:port`, never a node name, so a single flat map would let one node's identifier silently overwrite another's value. Lookup resolves per node by name, then `InternalIP`, then `Hostname`.
- `internal/k8s/metrics.go`: generalized `queryPrometheusNodeMetric` into `queryPrometheusMetric`, which takes a response parser. Cache/discovery semantics unchanged; existing callers unaffected.
- **Gating:** the fetch only runs when Prometheus is the configured monitoring source (`monitoring.prometheus` set, or `node_metrics: prometheus`). An unconditional query would re-run a full namespace × service discovery sweep on every watch tick on metrics-server-only clusters. No new config key.
- **Availability degrades in two directions on purpose.** A column that never had data stays absent, so clusters without node_exporter never get a permanently-`n/a` column. A column that had data and lost it degrades to `n/a` instead of freezing the last value on screen, where it would silently age into a lie.
- **Sorting:** `time.ParseDuration` does not understand the `d`/`y` suffixes `formatAge` emits, so `"10d"` would sort before `"9h"` lexically. Added a dedicated parser, registered under `"Uptime"` in `columnValueCmp`, with `n/a` sorting last in both directions. It rejects integer overflow, since a CRD `additionalPrinterColumns` entry named `Uptime` can feed the comparator arbitrary cluster-supplied text.
- Rejects `NaN`/`±Inf` samples. Both pass a plain `val < 0` check under IEEE-754, and `NaN` converts to `0s` — which would render as "just rebooted", worse than rendering nothing.
- Column position is stable: `carryOverMetricsColumnsFrom` prepends carried columns each watch tick, so the enrichment handler updates in place and only prepends on first insert. Appending made the row flap between second and last on every refresh, because the detail pane renders `Item.Columns` in raw slice order.
- The handler replaces the `Columns` slice rather than writing through it: `cloneCurrentTab` shallow-copies `Item` values, so tab snapshots share the backing array.
- Docs: `README.md`, `docs/config-reference.md` (new "Node Uptime Column" section), `docs/config-example.yaml`.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (with `-race`)
- [x] `golangci-lint run` passes (0 issues)
- [x] Manually verified against a real cluster (k3s / openSUSE MicroOS)

Test coverage is the bulk of the diff. Notable regression guards, each confirmed failing before its fix:

- `TestUpdateNodeUptimeEnrichedStableAcrossCarryOverTicks` and `TestUpdateNodeUptimeEnrichedOrderIndependentFromMetrics` — column never reorders, regardless of which enrichment message lands first.
- `TestUpdateNodeUptimeEnrichedFreezePreventedAcrossTicks` — a value does not survive a failed fetch.
- `TestUpdateNodeUptimeEnrichedEmptyMapAddsNoColumn` — no column on clusters without node_exporter.
- `TestSetUptimeColumnDoesNotMutateSharedBackingArray` — no cross-tab aliasing.
- `TestLookupNodeUptimeNameAndAddrCollisionResolvesIndependently` — a node whose name equals another node's IP still resolves to its own uptime.
- `TestParseAgeDuration` — `"9h"` vs `"10d"` order by real duration; overflow rejected.

Note: the column was observed live on a real cluster (which is how the position flap was found). The flap fix itself is covered by the tests above but has not yet been re-observed live.

## Checklist

- [x] Commits follow conventional commit style
- [x] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed — n/a, no keybinding change
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch (not `main`)

## Known limitation

If node_exporter runs without `hostNetwork`, its `instance` label is a pod IP, which matches neither the node name nor its `InternalIP`/`Hostname`. The result map is non-empty, so the column appears but every row reads `n/a`. The fix is a relabeling that puts a `node` label on the series. Happy to add a one-shot log line distinguishing "no exporter" from "exporter present, labels wrong" if that's wanted.
