### PR TITLE
fix(nodes): describe drain in the drain confirmation, not delete

### DIFF
--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -447,7 +447,10 @@ func (m Model) executeActionToggleCordon() (tea.Model, tea.Cmd) {
 
 // executeActionDrain handles the "Drain" action.
 func (m Model) executeActionDrain() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
-	m.confirmAction = m.actionCtx.name + " (drain)"
+	m.confirmTitle = "Confirm Drain"
+	m.confirmQuestion = fmt.Sprintf(
+		"Drain node %s? Pods will be evicted and the node cordoned (DaemonSet pods stay, emptyDir data is deleted).",
+		m.actionCtx.name)
 	m.pendingAction = "Drain"
 	m.overlay = overlayConfirm
 	return m, nil

--- a/internal/app/update_actions_test.go
+++ b/internal/app/update_actions_test.go
@@ -1835,6 +1835,12 @@ func TestFinalExecuteActionDrain(t *testing.T) {
 	rm := result.(Model)
 	assert.Equal(t, overlayConfirm, rm.overlay)
 	assert.Equal(t, "Drain", rm.pendingAction)
+	// The confirm must describe a drain, not fall back to the overlay's
+	// default "Delete X?" wording (drain evicts pods, it does not delete
+	// the node).
+	assert.Equal(t, "Confirm Drain", rm.confirmTitle)
+	assert.Contains(t, rm.confirmQuestion, "Drain node test-resource?")
+	assert.Contains(t, rm.confirmQuestion, "evict")
 }
 
 func TestFinalExecuteActionTaints(t *testing.T) {

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -20,6 +20,8 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			label := m.pendingAction
 			m.pendingAction = ""
 			m.confirmAction = ""
+			m.confirmTitle = ""
+			m.confirmQuestion = ""
 			m.resetBulkAction()
 			m.setStatusMessage(readOnlyBlockedMessage(label), true)
 			return m, scheduleStatusClear()


### PR DESCRIPTION
## Summary
- The node **Drain** action opened the confirm overlay without setting a title/question, so it fell back to the overlay's default delete wording — users saw **"Confirm Delete" / "Delete <node> (drain)?"** for an action that evicts pods and cordons the node but never deletes it.
- Drain now sets its own wording: **"Confirm Drain"** / **"Drain node <name>? Pods will be evicted and the node cordoned (DaemonSet pods stay, emptyDir data is deleted)."** — matching the actual `kubectl drain --ignore-daemonsets --delete-emptydir-data` command.
- The read-only-block path in the confirm handler now also clears `confirmTitle`/`confirmQuestion`, so a drain blocked by read-only mode can't leak stale "Confirm Drain" text into the next default delete confirm.

## Test plan
- [x] Extended `TestFinalExecuteActionDrain` to assert the drain-specific title and question (red before the fix, green after)
- [x] `go build ./...`
- [x] `go test ./internal/app/ -count=1` — full package passes
- [x] `golangci-lint run ./...` — 0 issues