### PR TITLE
fix(explorer): stop cursor-less renders from writing pane scroll state

### DIFF
--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -225,10 +225,14 @@ func RenderColumn(header string, items []model.Item, cursor int, width, height i
 	startEntry := 0
 
 	// Use persistent scroll position if available (vim-style stable viewport).
-	if isActive && ActiveMiddleScroll >= 0 {
+	// Cursor-less renders (cursor < 0: preview/measure passes, or a left pane
+	// whose parent highlight has no match) must not persist a viewport —
+	// VimScrollOff with cursor=-1 returns 0, so writing it back would reset
+	// the pane's scroll and make it visibly jump (issues #398/#524).
+	if isActive && ActiveMiddleScroll >= 0 && cursor >= 0 {
 		startEntry = VimScrollOff(ActiveMiddleScroll, cursor, len(entries), height, scrollOff, displayLines)
 		ActiveMiddleScroll = startEntry
-	} else if !isActive && ActiveLeftScroll >= 0 {
+	} else if !isActive && ActiveLeftScroll >= 0 && cursor >= 0 {
 		startEntry = VimScrollOff(ActiveLeftScroll, cursor, len(entries), height, scrollOff, displayLines)
 		ActiveLeftScroll = startEntry
 	} else {
@@ -293,8 +297,9 @@ func RenderColumn(header string, items []model.Item, cursor int, width, height i
 		endEntry++
 	}
 
-	// Build display-line-to-item map for mouse click handling (active middle column only).
-	if isActive {
+	// Build display-line-to-item map for mouse click handling (active middle
+	// column only; a cursor-less render is never the real middle column).
+	if isActive && cursor >= 0 {
 		ActiveMiddleLineMap = ActiveMiddleLineMap[:0]
 		for ei := startEntry; ei < endEntry; ei++ {
 			e := entries[ei]

--- a/internal/ui/explorer_scroll_clobber_test.go
+++ b/internal/ui/explorer_scroll_clobber_test.go
@@ -1,0 +1,122 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Issue #524 (class of #398): a cursor-less render (cursor < 0) is always a
+// preview/measure render — the right pane's children table, a context list, a
+// measurement pass. Those renders must never write the persistent middle/left
+// pane scroll positions or the middle-pane click/sort layout globals:
+// VimScrollOff with cursor=-1 returns 0, so an unguarded write resets the
+// neighbouring pane's viewport and it visibly jumps. The #399 fix parked the
+// globals around the then-known call sites; these tests pin the invariant in
+// the renderers themselves so no future unguarded caller can clobber state.
+
+// saveRenderGlobals pins the pane-scroll and layout globals to known values
+// and restores the originals on cleanup.
+func saveRenderGlobals(t *testing.T) {
+	t.Helper()
+	origMiddle, origLeft := ActiveMiddleScroll, ActiveLeftScroll
+	origLineMap := ActiveMiddleLineMap
+	origLayout := ActiveMiddleColumnLayout
+	origSortable := ActiveSortableColumns
+	origSortableCount := ActiveSortableColumnCount
+	origExtraKeys := ActiveExtraColumnKeys
+	t.Cleanup(func() {
+		ActiveMiddleScroll, ActiveLeftScroll = origMiddle, origLeft
+		ActiveMiddleLineMap = origLineMap
+		ActiveMiddleColumnLayout = origLayout
+		ActiveSortableColumns = origSortable
+		ActiveSortableColumnCount = origSortableCount
+		ActiveExtraColumnKeys = origExtraKeys
+	})
+}
+
+func clobberTestItems() []model.Item {
+	items := make([]model.Item, 8)
+	for i := range items {
+		items[i] = model.Item{Name: "item-" + string(rune('a'+i)), Kind: "Pod", Namespace: "default", Status: "Running"}
+	}
+	return items
+}
+
+func TestRenderTableCursorlessKeepsGlobals(t *testing.T) {
+	saveRenderGlobals(t)
+	ActiveMiddleScroll, ActiveLeftScroll = 7, 4
+	ActiveMiddleLineMap = []int{0, 1, 2}
+	ActiveMiddleColumnLayout = []MiddleColumnRegion{{Key: "Name", StartX: 0, EndX: 20}}
+	ActiveSortableColumns = []string{"Name", "Age"}
+	ActiveSortableColumnCount = 2
+	ActiveExtraColumnKeys = []string{"IP"}
+
+	// Cursor-less render, as used for the right-pane children/preview tables.
+	RenderTable("POD", clobberTestItems(), -1, 60, 5, false, "", "")
+
+	assert.Equal(t, 7, ActiveMiddleScroll, "cursor-less render must not clobber the middle pane scroll")
+	assert.Equal(t, 4, ActiveLeftScroll, "cursor-less render must not clobber the left pane scroll")
+	assert.Equal(t, []int{0, 1, 2}, ActiveMiddleLineMap, "cursor-less render must not rebuild the middle click map")
+	assert.Equal(t, []MiddleColumnRegion{{Key: "Name", StartX: 0, EndX: 20}}, ActiveMiddleColumnLayout, "cursor-less render must not rebuild the middle column layout")
+	assert.Equal(t, []string{"Name", "Age"}, ActiveSortableColumns, "cursor-less render must not rebuild the sortable columns")
+	assert.Equal(t, 2, ActiveSortableColumnCount)
+	assert.Equal(t, []string{"IP"}, ActiveExtraColumnKeys, "cursor-less render must not rebuild the extra column keys")
+}
+
+func TestRenderTableWithCursorStillPersistsScroll(t *testing.T) {
+	saveRenderGlobals(t)
+	ActiveMiddleScroll, ActiveLeftScroll = 0, 4
+
+	// Real middle-column render: 8 items, viewport of 3 rows, cursor at the
+	// bottom — the persistent scroll must follow the cursor as before.
+	RenderTable("POD", clobberTestItems(), 7, 60, 4, false, "", "")
+
+	assert.Positive(t, ActiveMiddleScroll, "cursor-ful render must keep maintaining the persistent scroll")
+	assert.Equal(t, 4, ActiveLeftScroll)
+}
+
+func TestRenderColumnCursorlessKeepsGlobals(t *testing.T) {
+	saveRenderGlobals(t)
+
+	t.Run("inactive column (left/preview) with cursor=-1", func(t *testing.T) {
+		ActiveMiddleScroll, ActiveLeftScroll = 7, 4
+		ActiveMiddleLineMap = []int{0, 1, 2}
+
+		// Right-pane context/resource-type list preview renders with
+		// isActive=false and cursor=-1 (renderRightClusters), and the left
+		// pane renders with cursor=-1 whenever parentIndex has no match.
+		RenderColumn("CONTEXT", clobberTestItems(), -1, 40, 5, false, false, "", "")
+
+		assert.Equal(t, 7, ActiveMiddleScroll, "cursor-less render must not clobber the middle pane scroll")
+		assert.Equal(t, 4, ActiveLeftScroll, "cursor-less render must not clobber the left pane scroll")
+		assert.Equal(t, []int{0, 1, 2}, ActiveMiddleLineMap, "inactive render must not rebuild the middle click map")
+	})
+
+	t.Run("active column with cursor=-1", func(t *testing.T) {
+		ActiveMiddleScroll, ActiveLeftScroll = 7, 4
+		ActiveMiddleLineMap = []int{0, 1, 2}
+
+		RenderColumn("HEADER", clobberTestItems(), -1, 40, 5, true, false, "", "")
+
+		assert.Equal(t, 7, ActiveMiddleScroll, "cursor-less active render must not clobber the middle pane scroll")
+		assert.Equal(t, []int{0, 1, 2}, ActiveMiddleLineMap, "cursor-less active render must not rebuild the middle click map")
+	})
+}
+
+func TestRenderColumnWithCursorStillPersistsScroll(t *testing.T) {
+	saveRenderGlobals(t)
+	ActiveMiddleScroll, ActiveLeftScroll = 0, 0
+
+	// Active middle column: cursor at the bottom of a list taller than the
+	// viewport — the persistent scroll must follow the cursor as before.
+	RenderColumn("HEADER", clobberTestItems(), 7, 40, 3, true, false, "", "")
+	assert.Positive(t, ActiveMiddleScroll, "cursor-ful active render must keep maintaining the persistent scroll")
+
+	// Inactive left column with a valid parent highlight keeps its viewport.
+	ActiveLeftScroll = 0
+	RenderColumn("PARENT", clobberTestItems(), 7, 40, 3, false, false, "", "")
+	assert.Positive(t, ActiveLeftScroll, "cursor-ful inactive render must keep maintaining the persistent scroll")
+}

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -302,7 +302,13 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		}
 	}
 
-	if ActiveMiddleScroll >= 0 {
+	// The ActiveMiddleScroll >= 0 && cursor >= 0 gates below scope the
+	// middle-pane globals (scroll, click map, sort/column layout) to the real
+	// middle-column render. Cursor-less renders (right-pane children tables,
+	// measure passes) must leave them untouched: VimScrollOff with cursor=-1
+	// returns 0, so an unguarded write resets the neighbouring pane's viewport
+	// and rebuilds the click map from the wrong items (issues #398/#524).
+	if ActiveMiddleScroll >= 0 && cursor >= 0 {
 		ActiveExtraColumnKeys = ActiveExtraColumnKeys[:0]
 		for _, ec := range extraCols {
 			ActiveExtraColumnKeys = append(ActiveExtraColumnKeys, ec.key)
@@ -311,7 +317,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 
 	order := orderedColumnKeys(hasName, hasContext, hasNs, hasReady, hasRestarts, hasStatus, hasAge, extraCols)
 
-	if ActiveMiddleScroll >= 0 {
+	if ActiveMiddleScroll >= 0 && cursor >= 0 {
 		ActiveSortableColumns = ActiveSortableColumns[:0]
 		// order now carries "Name" at its configured position, so the sortable
 		// list mirrors the on-screen column order directly.
@@ -371,7 +377,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 	b.WriteString(renderStyledHeader(hdrSegments, width))
 	height--
 
-	if ActiveMiddleScroll >= 0 {
+	if ActiveMiddleScroll >= 0 && cursor >= 0 {
 		ActiveMiddleColumnLayout = ActiveMiddleColumnLayout[:0]
 		x := 0
 		if wantMarker {
@@ -432,7 +438,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 
 	scrollOff := ConfigScrollOff
 	startIdx := 0
-	if ActiveMiddleScroll >= 0 {
+	if ActiveMiddleScroll >= 0 && cursor >= 0 {
 		startIdx = VimScrollOff(ActiveMiddleScroll, cursor, len(items), height, scrollOff, tableDisplayLines)
 		ActiveMiddleScroll = startIdx
 	} else {
@@ -492,7 +498,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		endIdx++
 	}
 
-	if ActiveMiddleScroll >= 0 {
+	if ActiveMiddleScroll >= 0 && cursor >= 0 {
 		ActiveMiddleLineMap = ActiveMiddleLineMap[:0]
 		for i := startIdx; i < endIdx; i++ {
 			if hasSepForItem[i] && i > startIdx {


### PR DESCRIPTION
## Summary

- Should fix #524 (the scroll-up flavour of #398): scrolling a list up past its top could make the pane to its left visibly jump.
- Root cause class (confirmed in #398/#399): a cursor-less `RenderTable`/`RenderColumn` call — always a preview/measure render — writes the persistent pane-scroll globals. `VimScrollOff` with `cursor=-1` returns 0, so any such render running outside the #399 parking guards resets the neighbouring pane's viewport; `RenderTable` also rebuilds the middle-pane click map and sort/column layout from right-pane items.
- Instead of guarding each caller (the #399 approach — which left whatever path #524 is hitting uncovered), the invariant now lives in the renderers: every write to `ActiveMiddleScroll` / `ActiveLeftScroll` / `ActiveMiddleLineMap` / `ActiveMiddleColumnLayout` / `ActiveSortableColumns` / `ActiveExtraColumnKeys` is gated on `cursor >= 0`. Cursor-less renders become side-effect-free, killing the whole bug class regardless of the call path.
- Behaviour is unchanged for real renders: the middle column always renders with `m.cursor() >= 0`, the left column with a matched `parentIndex`. A left-pane render whose `parentIndex` has no match now renders from the top *without erasing* the stored viewport (previously it persisted 0 every frame).

## Reproduction notes

Could not reproduce #524 directly (tested v0.15.1 and main against a kind cluster: wheel + ctrl+u/ctrl+b/pgup/shift+up/k over all three panes at the contexts, kinds, resources, and owned levels, with live content churn at 500 ms watch intervals, and overlay lists) — every currently known render path is guarded. Since the reporter identifies it as the same clobber as #398, this hardens the invariant at the source so the remaining unguarded path — wherever it is — can no longer move a neighbouring pane. Asked the reporter for repro details on the issue to confirm.

## Test plan

- [x] New regression tests: cursor-less `RenderTable`/`RenderColumn` leave scroll/click-map/layout globals untouched; cursor-ful renders still maintain the persistent scroll (`internal/ui/explorer_scroll_clobber_test.go`)
- [x] `go test ./...` and `go test -race ./internal/ui ./internal/app`
- [x] `golangci-lint run` clean
- [x] Manual smoke test in tmux against a kind cluster: wheel scrolling in all panes behaves as before, parent panes stay pinned