### PR TITLE
fix(dashboard): scroll the fullscreen dashboard with the mouse wheel (#524)

### DIFF
--- a/internal/app/dashboard_wheel_test.go
+++ b/internal/app/dashboard_wheel_test.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// Issue #524 follow-up: the fullscreen (pinned) cluster dashboard reuses
+// previewScroll for its own content and has no right pane, so the mouse wheel
+// must scroll the dashboard, mirroring the j/k keys. Before the fix the
+// collapsed column boundaries routed the wheel to moveCursor, which moved the
+// hidden middle-list cursor instead of scrolling and left the dashboard frozen.
+
+func dashboardModel(preview string) Model {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResourceTypes
+	m.middleItems = []model.Item{
+		{Name: "Cluster Dashboard", Kind: "__dashboard__", Extra: "__overview__"},
+		{Name: "Pods", Kind: "ResourceType"},
+		{Name: "Services", Kind: "ResourceType"},
+	}
+	m.setCursor(0)
+	m.fullscreenDashboard = true
+	m.dashboardPreview = preview
+	return m
+}
+
+func TestDashboardWheelScrollsContentNotCursor(t *testing.T) {
+	m := dashboardModel(strings.Repeat("dashboard line\n", 200))
+	startCursor := m.cursor()
+
+	mdl, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: 60})
+	m = mdl.(Model)
+
+	assert.Equal(t, startCursor, m.cursor(), "wheel in the fullscreen dashboard must not move the middle cursor")
+	assert.Positive(t, m.previewScroll, "wheel down in the fullscreen dashboard must scroll the content")
+}
+
+// The reported symptom is scrolling up past the top. Wheel-up at the top must
+// clamp at 0 and never move the underlying cursor.
+func TestDashboardWheelUpClampsAtTop(t *testing.T) {
+	m := dashboardModel(strings.Repeat("dashboard line\n", 200))
+	startCursor := m.cursor()
+
+	for range 5 {
+		mdl, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp, X: 60})
+		m = mdl.(Model)
+	}
+
+	assert.Equal(t, 0, m.previewScroll, "wheel up at the top of the dashboard must clamp at 0")
+	assert.Equal(t, startCursor, m.cursor(), "wheel up at the top must not move the middle cursor")
+}
+
+// The monitoring dashboard shares the fullscreen path; the wheel scrolls its
+// preview the same way.
+func TestMonitoringDashboardWheelScrolls(t *testing.T) {
+	m := dashboardModel("")
+	m.middleItems[0] = model.Item{Name: "Monitoring", Kind: "__dashboard__", Extra: "__monitoring__"}
+	m.monitoringPreview = strings.Repeat("metric line\n", 200)
+
+	mdl, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: 60})
+	m = mdl.(Model)
+
+	assert.Positive(t, m.previewScroll, "wheel down in the monitoring dashboard must scroll the content")
+}
+
+// Scrolling a Service's details (right) pane must not move the parent
+// resource-kinds list on the left (the render-clobber class of #398/#524).
+func TestServiceDetailsScrollNoParentJump(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{DisplayName: "Services", Kind: "Service", Resource: "services"}
+	left := make([]model.Item, 30)
+	for i := range left {
+		left[i] = model.Item{Name: "kind-" + string(rune('a'+i%26)), Kind: "ResourceType"}
+	}
+	left[25] = model.Item{Name: "Services", Kind: "ResourceType"}
+	m.leftItems = left
+	m.middleItems = []model.Item{{Name: "svc-a", Kind: "Service"}, {Name: "svc-b", Kind: "Service"}}
+	m.setCursor(0)
+	m.rightItems = []model.Item{{Name: "pod-1", Kind: "Pod"}, {Name: "pod-2", Kind: "Pod"}}
+	m.previewYAML = strings.Repeat("field: value\n", 200)
+
+	_ = m.View()
+	leftBefore := ui.ActiveLeftScroll
+
+	for range 5 {
+		mdl, _ := m.handleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown, X: 110})
+		m = mdl.(Model)
+		_ = m.View()
+	}
+
+	assert.Equal(t, leftBefore, ui.ActiveLeftScroll, "scrolling the service details pane must not move the parent list")
+}

--- a/internal/app/update_mouse.go
+++ b/internal/app/update_mouse.go
@@ -146,6 +146,16 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 // never reach the right pane and the wheel keeps moving the cursor,
 // preserving the prior fullscreen behaviour.
 func (m Model) handleExplorerWheel(x, delta int) (tea.Model, tea.Cmd) {
+	// The fullscreen dashboard has no right pane and reuses previewScroll for
+	// its own content, so route the wheel straight to the dashboard scroll
+	// (mirroring the j/k keys). Without this the collapsed columnBoundaries
+	// (0, m.width) make x never reach a right pane, so the wheel would move the
+	// hidden middle-list cursor instead of scrolling the dashboard (#524).
+	if m.fullscreenDashboard {
+		m.previewScroll += delta
+		m.clampDashboardScroll()
+		return m, nil
+	}
 	_, middleEnd := m.columnBoundaries()
 	if x >= middleEnd {
 		// Live-log preview uses a bottom-anchored offset (fromBottom): wheel up


### PR DESCRIPTION
## Summary

The fullscreen (pinned) cluster dashboard was frozen to the mouse wheel — only `j`/`k` scrolled it. Follow-up to #524 (reported by @fallenleavesgocrunch).

**Root cause:** in the fullscreen dashboard the column boundaries collapse to `(0, m.width)`, so the per-pane wheel routing in `handleExplorerWheel` never reached a right pane and fell through to `moveCursor` — moving the hidden middle-list cursor instead of scrolling the dashboard content (`previewScroll`).

**Fix:** an early-return branch in `handleExplorerWheel` that routes the wheel straight to the dashboard scroll (`previewScroll += delta; clampDashboardScroll()`), mirroring the `j`/`k` keys. Covers the single-column, two-column, and monitoring dashboards; wheel-up clamps at the top.

## Scope note

While investigating I also audited the other reported surface (Services > service details) via model tests and live driving against a real cluster. The explorer right/details-pane wheel is structurally isolated from the cursor (`x >= middleEnd` → `previewScroll` only) and the #398/#524 render-clobber class stays closed by #526 — no escape-to-parent there. Only the fullscreen dashboard was broken.

## Test plan

- [x] `TestDashboardWheelScrollsContentNotCursor` — wheel scrolls content, cursor stays put
- [x] `TestDashboardWheelUpClampsAtTop` — wheel-up at top clamps at 0 (the reported symptom)
- [x] `TestMonitoringDashboardWheelScrolls` — monitoring dashboard shares the path
- [x] `TestServiceDetailsScrollNoParentJump` — service details scroll leaves the parent list stable
- [x] `go build`, `go vet`, `go test -race ./internal/app/`, `golangci-lint` (0 issues)