### PR TITLE
fix(dashboard): stop trackpad momentum from scrolling the wrong list (#524)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -509,6 +509,8 @@ type Model struct {
 	// no-op.
 	mouseAvailable bool
 	mouseCaptured  bool
+	// wheel tracks the active wheel-scroll burst for momentum-tail dropping (#524).
+	wheel wheelBurst
 
 	// Metrics content: rendered bar graph for the preview column.
 	metricsContent string

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -34,6 +34,19 @@ const (
 	modeLogTop
 )
 
+// wheelBurst tracks a single mouse/trackpad wheel burst. Trackpad momentum
+// keeps emitting wheel ticks after the physical gesture ends; those queued
+// ticks otherwise "play out" on whatever list is under the pointer once the
+// user has navigated away or moved the pointer (#524). A gesture is a run of
+// ticks less than wheelQuietGap apart; once it is marked dead (a boundary was
+// reached, a left/right navigation happened, or the pointer moved to another
+// pane) the rest of the gesture is dropped until a real pause starts a new one.
+type wheelBurst struct {
+	lastAt time.Time // when the last wheel tick was processed
+	target string    // wheelTargetID the burst started on
+	dead   bool      // drop remaining ticks in this burst
+}
+
 // overlayKind tracks which overlay is currently open.
 type overlayKind int
 

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -432,6 +432,7 @@ func (m Model) selectedNodePath() []string {
 // objectExplorerDrill descends into the object/array field under the cursor.
 // In tree mode the tree re-roots at the selected node's path.
 func (m *Model) objectExplorerDrill() {
+	m.wheel.dead = true // drilling in empties the wheel momentum queue (#524)
 	rt := &m.objectExplorerView
 	if rt.tree {
 		row, ok := rt.selectedTreeRow()
@@ -457,6 +458,7 @@ func (m *Model) objectExplorerDrill() {
 // field it was drilled from. At root it is a no-op (callers decide whether to
 // close).
 func (m *Model) objectExplorerBack() {
+	m.wheel.dead = true // backing out empties the wheel momentum queue (#524)
 	rt := &m.objectExplorerView
 	if len(rt.path) == 0 {
 		return

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -434,6 +434,7 @@ func (m *Model) saveCurrentTab() {
 // If the tab was restored from a session and has not been loaded yet (needsLoad),
 // it returns a tea.Cmd that fetches the tab's data; otherwise it returns nil.
 func (m *Model) loadTab(idx int) tea.Cmd {
+	m.wheel.dead = true // switching/reloading a tab empties the wheel momentum queue (#524)
 	t := m.tabs[idx]
 	needsLoad := t.needsLoad
 	m.activeTab = idx

--- a/internal/app/update_mouse.go
+++ b/internal/app/update_mouse.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -45,6 +47,19 @@ func (m Model) toggleMouseCapture() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// Trackpad momentum keeps emitting wheel ticks after the physical gesture
+	// ends. Drop the tail once the burst is no longer productive (a boundary
+	// was reached, the pointer moved to another pane, or a left/right
+	// navigation happened) so the queued ticks don't "play out" on whatever
+	// list is now under the pointer (#524).
+	if msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown {
+		next, drop := m.beginWheelTick(msg.X)
+		if drop {
+			return next, nil
+		}
+		m = next
+	}
+
 	// Mouse wheel inside the embedded PTY pane scrolls the scrollback
 	// ring (when present). One line per tick matches what most native
 	// terminals do for their own scrollback. We only intercept the
@@ -136,6 +151,78 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// wheelQuietGap is how long the wheel must be silent before a tick counts as a
+// brand-new gesture. It must exceed the largest gap between two ticks of a
+// decelerating trackpad-momentum stream (its sparse tail can be 150-300ms
+// apart), so the whole tail of a voided gesture stays suppressed until the
+// momentum actually stops — not just its dense head. Too small and the tail
+// revives on the wrong list (the #524 "jumps by 3 after navigating" case); too
+// large and a deliberate re-scroll right after navigating feels laggy.
+const wheelQuietGap = 350 * time.Millisecond
+
+// beginWheelTick advances the wheel-burst state machine for a wheel tick at
+// pointer column x and reports whether the tick should be dropped. After
+// wheelQuietGap of silence the tick starts a brand-new gesture and always
+// scrolls; otherwise it is dropped once the gesture has been marked dead (a
+// boundary was reached or a navigation happened) or when the pointer has moved
+// to a different target than the one the gesture started on. Dropped ticks keep
+// the gesture alive (lastAt advances), so a continuous momentum tail stays
+// suppressed until it truly stops.
+func (m Model) beginWheelTick(x int) (Model, bool) {
+	now := time.Now()
+	prev := m.wheel.lastAt
+	m.wheel.lastAt = now
+	target := m.wheelTargetID(x)
+
+	if prev.IsZero() || now.Sub(prev) > wheelQuietGap {
+		m.wheel.target = target
+		m.wheel.dead = false
+		return m, false
+	}
+	if m.wheel.dead || target != m.wheel.target {
+		m.wheel.dead = true // keep suppressing the rest of the tail
+		return m, true
+	}
+	return m, false
+}
+
+// wheelTargetID names what a wheel tick at pointer column x would currently
+// scroll. Its only job is to detect when the pointer (or the screen) has moved
+// off the target a momentum burst started on; the exact strings are internal.
+// It mirrors the routing in handleMouse so a burst is bound to one scroll
+// target.
+func (m Model) wheelTargetID(x int) string {
+	switch {
+	case m.mode == modeExec:
+		return "exec"
+	case m.mode == modeLogs:
+		if logW, previewW := splitLogPreviewWidth(m.width); m.logView.previewVisible && previewW > 0 && x >= logW {
+			return "logs-preview"
+		}
+		return "logs"
+	case m.mode == modeObjectExplorer:
+		if x >= m.objectExplorerRightPaneStart() {
+			return "oe-preview"
+		}
+		return "oe-tree"
+	case isViewerMode(m.mode):
+		return "viewer"
+	case m.mode != modeExplorer:
+		return "other"
+	case m.overlay != overlayNone:
+		return "overlay"
+	case m.fullscreenDashboard:
+		return "dash"
+	}
+	if _, middleEnd := m.columnBoundaries(); x >= middleEnd {
+		if m.fullLogPreview {
+			return "ex-logpreview"
+		}
+		return "ex-preview"
+	}
+	return "ex-cursor"
+}
+
 // handleExplorerWheel routes a wheel tick to the pane under the pointer
 // at x. The right pane scrolls its preview content; the left and middle
 // panes move the row cursor — the whole-window behaviour the wheel had
@@ -152,8 +239,10 @@ func (m Model) handleExplorerWheel(x, delta int) (tea.Model, tea.Cmd) {
 	// (0, m.width) make x never reach a right pane, so the wheel would move the
 	// hidden middle-list cursor instead of scrolling the dashboard (#524).
 	if m.fullscreenDashboard {
+		before := m.previewScroll
 		m.previewScroll += delta
 		m.clampDashboardScroll()
+		m.markWheelBurstDeadIfClamped(before, m.previewScroll)
 		return m, nil
 	}
 	_, middleEnd := m.columnBoundaries()
@@ -162,11 +251,13 @@ func (m Model) handleExplorerWheel(x, delta int) (tea.Model, tea.Cmd) {
 		// (delta<0) scrolls into older lines, wheel down (delta>0) toward the
 		// newest. Subtracting delta maps the shared scroll direction onto it.
 		if m.fullLogPreview {
+			before := m.previewLog.fromBottom
 			m.previewLog.fromBottom -= delta
 			if m.previewLog.fromBottom < 0 {
 				m.previewLog.fromBottom = 0
 			}
 			m.clampPreviewScroll()
+			m.markWheelBurstDeadIfClamped(before, m.previewLog.fromBottom)
 			// Trigger lazy history loading when scrolling up (delta<0) and at top.
 			if delta < 0 {
 				m, cmd := m.maybeLoadMorePreviewHistory()
@@ -177,6 +268,7 @@ func (m Model) handleExplorerWheel(x, delta int) (tea.Model, tea.Cmd) {
 		// Right pane: scroll the preview, mirroring the PreviewUp/PreviewDown
 		// keys (J/K). Scroll-up is a plain decrement with a zero floor;
 		// scroll-down increments and clamps to the rendered content height.
+		before := m.previewScroll
 		m.previewScroll += delta
 		if delta < 0 {
 			if m.previewScroll < 0 {
@@ -185,10 +277,29 @@ func (m Model) handleExplorerWheel(x, delta int) (tea.Model, tea.Cmd) {
 		} else {
 			m.clampPreviewScroll()
 		}
+		m.markWheelBurstDeadIfClamped(before, m.previewScroll)
 		return m, nil
 	}
-	// Left and middle panes: move the selection cursor.
-	return m.moveCursor(delta)
+	// Left and middle panes: move the selection cursor. Reaching the top or
+	// bottom of the list empties the momentum queue so the tail can't keep
+	// firing once there's nothing left to scroll (#524).
+	mdl, cmd := m.moveCursor(delta)
+	m = mdl.(Model)
+	if visible := len(m.visibleMiddleItems()); visible == 0 ||
+		(delta < 0 && m.cursor() == 0) || (delta > 0 && m.cursor() == visible-1) {
+		m.wheel.dead = true
+	}
+	return m, cmd
+}
+
+// markWheelBurstDeadIfClamped ends the current wheel burst when a scroll tick
+// produced no movement — the content is already at the top or bottom, so the
+// rest of a momentum burst has nothing left to do and must not leak onto
+// another target (#524).
+func (m *Model) markWheelBurstDeadIfClamped(before, after int) {
+	if before == after {
+		m.wheel.dead = true
+	}
 }
 
 // handleObjectExplorerWheel routes a wheel tick in the Object Explorer to
@@ -203,6 +314,7 @@ func (m Model) handleObjectExplorerWheel(x, dir int) (tea.Model, tea.Cmd) {
 		// Scroll-up is a plain decrement with a zero floor; scroll-down
 		// increments and clamps to the preview content height (which
 		// re-marshals the node YAML, so only do it when scrolling down).
+		before := rt.previewScroll
 		rt.previewScroll += dir * wheelStep
 		if dir < 0 {
 			if rt.previewScroll < 0 {
@@ -211,10 +323,13 @@ func (m Model) handleObjectExplorerWheel(x, dir int) (tea.Model, tea.Cmd) {
 		} else {
 			m.clampObjectExplorerPreviewScroll()
 		}
+		m.markWheelBurstDeadIfClamped(before, rt.previewScroll)
 		return m, nil
 	}
+	before := rt.cursor
 	m.moveObjectExplorerCursor(dir * wheelStep)
 	m.clampObjectExplorerScroll()
+	m.markWheelBurstDeadIfClamped(before, rt.cursor)
 	return m, nil
 }
 

--- a/internal/app/update_mouse_momentum_test.go
+++ b/internal/app/update_mouse_momentum_test.go
@@ -1,0 +1,145 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Issue #524: trackpad momentum keeps emitting wheel ticks after the gesture
+// ends. Those queued ticks must not "play out" on whatever list is under the
+// pointer once the burst's target changes, the cursor hits a boundary, or the
+// user navigates away.
+
+func wheel(m Model, button tea.MouseButton, x int) Model {
+	mdl, _ := m.handleMouse(tea.MouseMsg{Button: button, X: x})
+	return mdl.(Model)
+}
+
+func longListModel(n int) Model {
+	m := baseExplorerModel()
+	items := make([]model.Item, n)
+	for i := range items {
+		items[i] = model.Item{Name: "pod", Kind: "Pod"}
+	}
+	m.middleItems = items
+	m.setCursor(0)
+	m.previewYAML = strings.Repeat("field: value\n", 200)
+	return m
+}
+
+// Momentum from the right (preview) pane must not scroll the middle list when
+// the pointer moves onto it mid-burst (the reporter's repro: swipe the detail
+// pane, then move the mouse over the main list).
+func TestWheelMomentumDoesNotLeakAcrossPanes(t *testing.T) {
+	m := longListModel(30)
+	m.previewScroll = 10
+
+	// Burst tick 1 over the right pane (X=100 >= middleEnd=75) scrolls preview.
+	m = wheel(m, tea.MouseButtonWheelUp, 100)
+	require.Less(t, m.previewScroll, 10, "wheel over the right pane scrolls the preview")
+	cursorBefore := m.cursor()
+
+	// Same burst, pointer now over the middle list: the momentum tail must be
+	// dropped, not moved onto the list cursor.
+	m = wheel(m, tea.MouseButtonWheelDown, 30)
+	assert.Equal(t, cursorBefore, m.cursor(),
+		"momentum from the preview pane must not scroll the list once the pointer moves")
+}
+
+// Reaching the bottom of the list empties the momentum queue (user rule 1).
+func TestWheelMomentumStopsAtListBottom(t *testing.T) {
+	m := longListModel(4)
+
+	// Fling down through the whole list within a single burst.
+	for range 10 {
+		m = wheel(m, tea.MouseButtonWheelDown, 30)
+	}
+	require.Equal(t, len(m.middleItems)-1, m.cursor(), "cursor reaches the last item")
+	assert.True(t, m.wheel.dead, "reaching the list bottom empties the momentum queue")
+}
+
+// Reaching the top of the list empties the momentum queue (user rule 1).
+func TestWheelMomentumStopsAtListTop(t *testing.T) {
+	m := longListModel(4)
+	m.setCursor(1)
+
+	for range 5 {
+		m = wheel(m, tea.MouseButtonWheelUp, 30)
+	}
+	require.Equal(t, 0, m.cursor(), "cursor reaches the first item")
+	assert.True(t, m.wheel.dead, "reaching the list top empties the momentum queue")
+}
+
+// Navigating left (to the parent) empties the momentum queue so the tail does
+// not scroll the list it returns to (user rule 2, the reporter's repro).
+func TestNavigateLeftEmptiesWheelQueue(t *testing.T) {
+	m := longListModel(30)
+	m = wheel(m, tea.MouseButtonWheelDown, 30) // start a burst on the middle list
+	require.False(t, m.wheel.dead)
+
+	mdl, _ := m.navigateParent()
+	assert.True(t, mdl.(Model).wheel.dead, "navigating left must empty the momentum queue")
+}
+
+// Switching (or reloading) a tab empties the momentum queue so a fling in one
+// tab does not scroll the list of the tab it lands on (#524).
+func TestTabSwitchEmptiesWheelQueue(t *testing.T) {
+	m := longListModel(30)
+	m.wheel.dead = false
+	m.wheel.lastAt = time.Now()
+
+	_ = m.loadTab(0)
+	assert.True(t, m.wheel.dead, "switching tabs must empty the momentum queue")
+}
+
+// Drilling into / backing out of the Object Explorer empties the momentum
+// queue, mirroring left/right navigation in the main explorer (#524).
+func TestObjectExplorerNavEmptiesWheelQueue(t *testing.T) {
+	m := baseExplorerModel()
+	m.mode = modeObjectExplorer
+
+	m.wheel.dead = false
+	m.objectExplorerDrill()
+	assert.True(t, m.wheel.dead, "drilling in must empty the momentum queue")
+
+	m.wheel.dead = false
+	m.objectExplorerBack()
+	assert.True(t, m.wheel.dead, "backing out must empty the momentum queue")
+}
+
+// A decelerating trackpad-momentum tail has inter-tick gaps larger than a
+// dense burst. After navigation voids the gesture, such a sparse tail tick must
+// still be dropped, not misread as a fresh gesture that scrolls the list the
+// nav landed on (#524 "jumps by 3 after navigating back").
+func TestWheelMomentumTailAfterNavStaysDropped(t *testing.T) {
+	m := longListModel(30)
+	m.setCursor(10)
+	m.wheel.dead = true          // navigation just voided the gesture
+	m.wheel.target = "ex-cursor" // parent list is the same target kind
+	m.wheel.lastAt = time.Now().Add(-200 * time.Millisecond)
+
+	before := m.cursor()
+	m = wheel(m, tea.MouseButtonWheelUp, 30)
+	assert.Equal(t, before, m.cursor(),
+		"a sparse momentum tail after navigation must not scroll the list")
+}
+
+// A deliberate new scroll after a real pause is a fresh burst and scrolls
+// normally, even if the previous burst was marked dead at a boundary.
+func TestNewWheelBurstScrollsAfterPause(t *testing.T) {
+	m := longListModel(30)
+	m.setCursor(5)
+	m.wheel.dead = true
+	m.wheel.target = "ex-cursor"
+	m.wheel.lastAt = time.Now().Add(-time.Second) // long pause -> new burst
+
+	m = wheel(m, tea.MouseButtonWheelDown, 30)
+	assert.Greater(t, m.cursor(), 5, "a fresh burst after a pause scrolls normally")
+}

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -59,6 +59,7 @@ func (m Model) moveCursor(delta int) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) navigateParent() (tea.Model, tea.Cmd) {
+	m.wheel.dead = true // left/right nav empties the wheel momentum queue (#524)
 	m.cancelAndReset()
 	m.requestGen++
 	m.reclaimStaleBgWork()
@@ -253,6 +254,7 @@ func (m Model) navigateChild() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	m.wheel.dead = true // left/right nav empties the wheel momentum queue (#524)
 	m.cancelAndReset()
 	m.requestGen++
 	m.reclaimStaleBgWork()


### PR DESCRIPTION
## Summary

Fixes the remaining #524 symptom: trackpad **momentum** keeps emitting mouse-wheel ticks after the physical gesture ends, and those queued ticks were routed by the *current* context. Pressing ← to go back, drilling in, switching tabs, or moving the pointer to another pane mid-fling made the leftover momentum "play out" on whatever list was now focused — most visibly **the list jumping up by three** (one wheel tick) right after navigating back.

This is a different root cause than the earlier #398/#526 "render clobber" hypothesis. Terminal wheel events carry no gesture-phase info and Bubble Tea exposes no input queue to flush, so the fix treats a run of ticks as one **gesture** and drops its tail once it stops being productive.

## What empties the momentum queue

- **Boundary reached** — cursor/scroll clamps at top or bottom (main explorer + Object Explorer).
- **Left/right navigation** — `navigateParent` / `navigateChild`.
- **Tab switch or reload** — `loadTab` (covers mouse tab-bar clicks, `NextTab`/`PrevTab`, exec tabs).
- **Object Explorer drill/back** — `objectExplorerDrill` / `objectExplorerBack`.
- **Pointer moves to a different pane** — the target changes mid-gesture.

A gesture is considered over only after `wheelQuietGap` (350ms) of silence. This must exceed the largest inter-tick gap of a *decelerating* momentum tail (its sparse tail ticks are 150–300ms apart); a shorter window let a lone tail tick get misread as a fresh gesture and revive the voided one, scrolling the wrong list (the "jumps by 3" report).

## Implementation

- New `wheelBurst` state on `Model` (`lastAt` / `target` / `dead`).
- `beginWheelTick` guard at the top of `handleMouse`; `wheelTargetID` mirrors `handleMouse`'s dispatch so a gesture is bound to one scroll target.
- Boundary detection in `handleExplorerWheel` / `handleObjectExplorerWheel`; `m.wheel.dead = true` on every nav/tab/drill transition.

## Tradeoff

For ~350ms after navigating, a deliberate re-scroll of the new list is also suppressed (a fresh flick is indistinguishable from leftover momentum). In practice the user has paused longer than that; the window is a single named constant if it needs tuning.

## Test plan

- [x] `internal/app/update_mouse_momentum_test.go` — 8 targeted tests (cross-pane leak, boundary, navigate, tab switch, OE drill/back, sparse-tail-after-nav regression, fresh-scroll-after-pause). Each verified to fail without the fix.
- [x] Existing wheel/mouse/dashboard tests unchanged and passing.
- [x] `go vet`, `golangci-lint` (0 issues), full `internal/app` suite with `-race`.
- [ ] Reporter to confirm the live "jumps by 3 after navigating back" case is gone.