### PR TITLE
fix: roll up generic CRD summaries by phase (#536)

### DIFF
--- a/internal/k8s/client_crd.go
+++ b/internal/k8s/client_crd.go
@@ -277,6 +277,18 @@ func extractContainerNotReadyReason(containerStatuses []any) string {
 	return ""
 }
 
+// statusPhase returns the non-empty string value of .status.phase, if present.
+// extractStatus prefers phase, so a match tells the caller Status originated
+// from phase (see model.Item.StatusFromPhase, issue #536).
+func statusPhase(obj map[string]any) (string, bool) {
+	status, ok := obj["status"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	phase, ok := status["phase"].(string)
+	return phase, ok && phase != ""
+}
+
 // extractStatus pulls a human-readable status string from an unstructured object.
 func extractStatus(obj map[string]any) string {
 	status, ok := obj["status"]

--- a/internal/k8s/client_crd_status_test.go
+++ b/internal/k8s/client_crd_status_test.go
@@ -2,9 +2,121 @@ package k8s
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
+
+// --- statusPhase / StatusFromPhase (issue #536) ---
+
+func TestStatusPhase(t *testing.T) {
+	got, ok := statusPhase(map[string]any{"status": map[string]any{"phase": "Jumping"}})
+	assert.True(t, ok)
+	assert.Equal(t, "Jumping", got)
+
+	_, ok = statusPhase(map[string]any{"status": map[string]any{"phase": ""}})
+	assert.False(t, ok, "empty phase is not a signal")
+
+	_, ok = statusPhase(map[string]any{"status": map[string]any{"conditions": []any{}}})
+	assert.False(t, ok, "no phase key")
+
+	_, ok = statusPhase(map[string]any{})
+	assert.False(t, ok, "no status")
+}
+
+// TestBuildResourceItem_StatusFromPhase reproduces issue #536: a generic CRD
+// exposing .status.phase both as the built-in Status and as a Phase printer
+// column. The duplicate Phase column is suppressed, but StatusFromPhase is set
+// so the list summary can still roll up by phase.
+func TestBuildResourceItem_StatusFromPhase(t *testing.T) {
+	c := &Client{}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Chore",
+		"metadata":   map[string]any{"name": "mow-lawn", "namespace": "default"},
+		"status": map[string]any{
+			"phase": "Jumping",
+			"conditions": []any{
+				map[string]any{"type": "Jumping", "status": "True"},
+			},
+		},
+	}}
+	rt := &model.ResourceTypeEntry{
+		Kind:       "Chore",
+		Namespaced: true,
+		PrinterColumns: []model.PrinterColumn{
+			{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
+		},
+	}
+
+	ti := c.buildResourceItem(obj, rt)
+
+	assert.Equal(t, "Jumping", ti.Status)
+	assert.True(t, ti.StatusFromPhase, "Status derived from .status.phase must be flagged")
+	assert.Empty(t, ti.ColumnValue("Phase"), "duplicate Phase column stays suppressed")
+}
+
+// TestBuildResourceItem_StatusFromPhase_Deleting documents the call-order
+// interaction with deletion: applyDeletionStatus overwrites Status to
+// "Terminating" after StatusFromPhase is set, but populatePrinterColumns runs
+// later still, so a declared Phase printer column no longer matches the
+// (now "Terminating") Status and survives the dedup. The summary then rolls up
+// by that surviving column, not the StatusFromPhase fallback.
+func TestBuildResourceItem_StatusFromPhase_Deleting(t *testing.T) {
+	c := &Client{}
+	now := metav1.Now()
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Chore",
+		"metadata": map[string]any{
+			"name":              "mow-lawn",
+			"namespace":         "default",
+			"deletionTimestamp": now.Format(time.RFC3339),
+		},
+		"status": map[string]any{"phase": "Jumping"},
+	}}
+	rt := &model.ResourceTypeEntry{
+		Kind:       "Chore",
+		Namespaced: true,
+		PrinterColumns: []model.PrinterColumn{
+			{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
+		},
+	}
+
+	ti := c.buildResourceItem(obj, rt)
+
+	assert.Equal(t, "Terminating", ti.Status)
+	assert.True(t, ti.StatusFromPhase)
+	assert.Equal(t, "Jumping", ti.ColumnValue("Phase"),
+		"Phase column survives dedup once Status is overridden to Terminating")
+}
+
+// TestBuildResourceItem_StatusNotFromPhase guards the inverse: a resource whose
+// Status comes from conditions (not phase) must leave StatusFromPhase unset.
+func TestBuildResourceItem_StatusNotFromPhase(t *testing.T) {
+	c := &Client{}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]any{"name": "w1"},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "True"},
+			},
+		},
+	}}
+	rt := &model.ResourceTypeEntry{Kind: "Widget"}
+
+	ti := c.buildResourceItem(obj, rt)
+
+	require.Equal(t, "Ready", ti.Status)
+	assert.False(t, ti.StatusFromPhase)
+}
 
 // --- extractStatus: additional branch coverage ---
 

--- a/internal/k8s/client_resources.go
+++ b/internal/k8s/client_resources.go
@@ -230,6 +230,13 @@ func (c *Client) buildResourceItem(item *unstructured.Unstructured, rt *model.Re
 		Status: extractStatus(item.Object),
 	}
 
+	// Record when Status was derived from .status.phase, so a generic CRD whose
+	// duplicate Phase column is suppressed still rolls up by phase in the list
+	// summary rather than falling back to conditions (issue #536).
+	if phase, ok := statusPhase(item.Object); ok && phase == ti.Status {
+		ti.StatusFromPhase = true
+	}
+
 	// Check if the resource is being deleted.
 	if item.GetDeletionTimestamp() != nil {
 		ti.Deleting = true

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -262,8 +262,13 @@ type Item struct {
 	Selected      bool             // Whether this item is part of a multi-selection
 	Deprecated    bool             // Whether this resource uses a deprecated API version
 	Deleting      bool             // Whether this resource has a deletionTimestamp set
-	Hidden        bool             // Resource-type row the user hid; rendered dimmed when revealed via ShowRareResources
-	Rare          bool             // Rarely-used type surfaced only via ShowRareResources; rendered dimmed and not user-hideable
+	// StatusFromPhase records that Status was derived from .status.phase.
+	// Set for generic CRDs whose Phase printer column is suppressed as a
+	// duplicate of Status, so the list summary can still roll up by phase
+	// rather than falling back to coarse Ready/NotReady conditions (issue #536).
+	StatusFromPhase bool
+	Hidden          bool // Resource-type row the user hid; rendered dimmed when revealed via ShowRareResources
+	Rare            bool // Rarely-used type surfaced only via ShowRareResources; rendered dimmed and not user-hideable
 
 	ReadOnly     bool   // Whether this item represents a context locked in read-only mode (renders as a [RO] suffix in the picker)
 	ClusterColor string // Optional named color (one of ui.ClusterColorNames) for context rows; empty = no swatch.

--- a/internal/ui/listsummary.go
+++ b/internal/ui/listsummary.go
@@ -101,7 +101,7 @@ func genericSummaryDimensions(items []model.Item) []summaryDimension {
 	distinct := make(map[string]struct{})
 	hasConditions := false
 	for _, it := range items {
-		if v := strings.TrimSpace(it.ColumnValue("Phase")); v != "" {
+		if v := strings.TrimSpace(genericPhaseValue(it)); v != "" {
 			distinct[v] = struct{}{}
 		}
 		if len(it.Conditions) > 0 {
@@ -109,12 +109,27 @@ func genericSummaryDimensions(items []model.Item) []summaryDimension {
 		}
 	}
 	if len(distinct) > 0 && len(distinct) <= maxGenericPhaseValues {
-		return []summaryDimension{{label: "Phase", valueOf: columnValueFn("Phase")}}
+		return []summaryDimension{{label: "Phase", valueOf: genericPhaseValue}}
 	}
 	if hasConditions {
 		return []summaryDimension{{label: "Status", valueOf: genericConditionValue}}
 	}
 	return nil
+}
+
+// genericPhaseValue returns an item's .status.phase for the generic rollup: the
+// visible "Phase" column when the CRD exposes one, otherwise the built-in Status
+// when it was derived from .status.phase. Generic CRDs suppress the Phase
+// printer column as a duplicate of Status, so without this fallback the summary
+// would lose the phase signal and drop to coarse conditions (issue #536).
+func genericPhaseValue(it model.Item) string {
+	if v := it.ColumnValue("Phase"); v != "" {
+		return v
+	}
+	if it.StatusFromPhase {
+		return it.Status
+	}
+	return ""
 }
 
 // genericConditionValue maps an item's primary status condition to a coarse

--- a/internal/ui/listsummary_test.go
+++ b/internal/ui/listsummary_test.go
@@ -184,6 +184,54 @@ func TestBuildListSummary_GenericPhaseFallback(t *testing.T) {
 	assert.Equal(t, "Running", bar.Buckets[2].Value)
 }
 
+// TestBuildListSummary_GenericPhaseFromStatus verifies the issue #536 fix: a
+// generic CRD whose Phase printer column is suppressed as a duplicate of Status
+// still rolls up by phase (via StatusFromPhase) instead of falling back to
+// conditions. Each item also carries a condition, which must be ignored here.
+func TestBuildListSummary_GenericPhaseFromStatus(t *testing.T) {
+	mk := func(phase string) model.Item {
+		return model.Item{
+			Kind:            "Chore",
+			Status:          phase,
+			StatusFromPhase: true,
+			Conditions:      []model.ConditionEntry{{Type: "Ready", Status: "True"}},
+		}
+	}
+	items := []model.Item{
+		mk("Running"), mk("Running"), mk("Failed"),
+		mk("Pending"), mk("Succeeded"), mk("Succeeded"),
+	}
+
+	s := BuildListSummary("Chore", items)
+
+	require.Len(t, s.Bars, 1)
+	bar := s.Bars[0]
+	assert.Equal(t, "Phase", bar.Label)
+	assert.Equal(t, 6, bar.Total)
+	// Worst-first: Failed leads; the phase values (not Ready/NotReady) survive.
+	assert.Equal(t, "Failed", bar.Buckets[0].Value)
+	values := make(map[string]int)
+	for _, b := range bar.Buckets {
+		values[b.Value] = b.Count
+	}
+	assert.Equal(t, map[string]int{"Failed": 1, "Pending": 1, "Running": 2, "Succeeded": 2}, values)
+}
+
+// TestBuildListSummary_StatusNotFromPhaseStaysNoise guards the inverse: a
+// non-phase Status (StatusFromPhase false) must not be treated as a phase, so a
+// StorageClass-style "default" marker still gets no phase bar.
+func TestBuildListSummary_StatusNotFromPhaseStaysNoise(t *testing.T) {
+	items := []model.Item{
+		{Kind: "StorageClass", Status: "default"},
+		{Kind: "StorageClass", Status: "default"},
+	}
+
+	s := BuildListSummary("StorageClass", items)
+
+	assert.Equal(t, 2, s.Total)
+	assert.Empty(t, s.Bars, "non-phase Status must not be rolled up as a phase")
+}
+
 // TestBuildListSummary_GenericPhaseCardinalityCap verifies the noise guard:
 // when the Phase column carries more than maxGenericPhaseValues distinct values
 // (likely free-form text, not a status), no Phase bar is built — it falls back

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -483,8 +484,52 @@ func statusSeverity(status string) statusSev {
 		if status == "" {
 			return sevBlank
 		}
-		return sevUnknown
+		return phraseSeverity(status)
 	}
+}
+
+// phraseSeverityWords maps lowercase words to a severity for statuses that miss
+// the exact-match table above — operators that put free-form phrases in
+// .status.phase (e.g. CloudNativePG's "Cluster in healthy state", "Failing
+// over") instead of conventional CamelCase values. Word-based, so "Unavailable"
+// or "Jumping" never match a fragment.
+var phraseSeverityWords = map[string]statusSev{
+	"failed": sevFailed, "failing": sevFailed, "error": sevFailed,
+	"errored": sevFailed, "degraded": sevFailed, "unhealthy": sevFailed,
+	"pending": sevProgressing, "waiting": sevProgressing, "creating": sevProgressing,
+	"initializing": sevProgressing, "starting": sevProgressing, "setting": sevProgressing,
+	"upgrading": sevProgressing, "provisioning": sevProgressing, "progressing": sevProgressing,
+	"progress": sevProgressing, "reconciling": sevProgressing, "restarting": sevProgressing,
+	"restarted": sevProgressing, "terminating": sevProgressing, "deleting": sevProgressing,
+	"healthy": sevRunning, "ready": sevRunning, "running": sevRunning, "active": sevRunning,
+	"succeeded": sevDone, "completed": sevDone,
+}
+
+// phraseSeverity classifies an unknown status string by scanning its words
+// against phraseSeverityWords. The worst-severity word wins ("Healthy but
+// degraded" is failed); no recognized word yields sevUnknown (gray).
+func phraseSeverity(status string) statusSev {
+	sev := sevUnknown
+	rank := func(s statusSev) int {
+		switch s {
+		case sevFailed:
+			return 3
+		case sevProgressing:
+			return 2
+		case sevRunning, sevDone:
+			return 1
+		default:
+			return 0
+		}
+	}
+	for _, w := range strings.FieldsFunc(strings.ToLower(status), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if s, ok := phraseSeverityWords[w]; ok && rank(s) > rank(sev) {
+			sev = s
+		}
+	}
+	return sev
 }
 
 // StatusStyle returns the appropriate style for a resource status string.

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -507,7 +507,9 @@ var phraseSeverityWords = map[string]statusSev{
 
 // phraseSeverity classifies an unknown status string by scanning its words
 // against phraseSeverityWords. The worst-severity word wins ("Healthy but
-// degraded" is failed); no recognized word yields sevUnknown (gray).
+// degraded" is failed); a positive word preceded by "not" reads as
+// progressing-amber, mirroring the exact-match "NotReady"; no recognized word
+// yields sevUnknown (gray).
 func phraseSeverity(status string) statusSev {
 	sev := sevUnknown
 	rank := func(s statusSev) int {
@@ -522,12 +524,23 @@ func phraseSeverity(status string) statusSev {
 			return 0
 		}
 	}
+	negated := false
 	for _, w := range strings.FieldsFunc(strings.ToLower(status), func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	}) {
-		if s, ok := phraseSeverityWords[w]; ok && rank(s) > rank(sev) {
-			sev = s
+		if w == "not" {
+			negated = true
+			continue
 		}
+		if s, ok := phraseSeverityWords[w]; ok {
+			if negated && (s == sevRunning || s == sevDone) {
+				s = sevProgressing
+			}
+			if rank(s) > rank(sev) {
+				sev = s
+			}
+		}
+		negated = false
 	}
 	return sev
 }

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -187,6 +187,12 @@ func TestStatusSeverity_FreeFormPhrases(t *testing.T) {
 		{"Healthy but degraded", sevFailed},
 		// Single unknown words classify too.
 		{"Unhealthy", sevFailed},
+		// Negated positives are amber, mirroring the exact-match "NotReady".
+		{"Not ready", sevProgressing},
+		{"Not healthy", sevProgressing},
+		{"Cluster not ready", sevProgressing},
+		// Negation only flips the word it precedes.
+		{"Ready or not", sevRunning},
 		// No recognized word stays unknown (gray).
 		{"Jumping", sevUnknown},
 		{"Some bespoke text", sevUnknown},

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -161,6 +161,46 @@ func TestStatusSeverity_Established(t *testing.T) {
 	assert.Equal(t, StatusSeverityRank("Running"), StatusSeverityRank("Established"))
 }
 
+// --- statusSeverity: free-form phrases ---
+
+// Operators that break the CamelCase-phase convention (e.g. CloudNativePG's
+// "Cluster in healthy state", "Failing over") must still color by severity in
+// status columns and summary bars, not fall through to the gray unknown bucket
+// (issue #536 follow-up). Classification is word-based on the unknown-status
+// fallback path; exact matches above keep precedence.
+func TestStatusSeverity_FreeFormPhrases(t *testing.T) {
+	tests := []struct {
+		status string
+		want   statusSev
+	}{
+		// CloudNativePG cluster phases.
+		{"Cluster in healthy state", sevRunning},
+		{"Failing over", sevFailed},
+		{"Failing over to replica", sevFailed},
+		{"Setting up primary", sevProgressing},
+		{"Creating a new replica", sevProgressing},
+		{"Waiting for the instances to become active", sevProgressing},
+		{"Upgrading cluster", sevProgressing},
+		{"Switchover in progress", sevProgressing},
+		{"Primary instance is being restarted in-place", sevProgressing},
+		// Worst word wins within a phrase.
+		{"Healthy but degraded", sevFailed},
+		// Single unknown words classify too.
+		{"Unhealthy", sevFailed},
+		// No recognized word stays unknown (gray).
+		{"Jumping", sevUnknown},
+		{"Some bespoke text", sevUnknown},
+		// Exact matches keep precedence over word scanning.
+		{"Failed", sevFailed},
+		{"Running", sevRunning},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, statusSeverity(tt.status))
+		})
+	}
+}
+
 // --- FillLinesBg ---
 
 // TestFillLinesBgReestablishesBgAfterShortReset guards issue #293's recurrence


### PR DESCRIPTION
Fixes #536.

## Problem

Generic CRD list summaries showed only coarse `Ready`/`NotReady` buckets instead of grouping by `.status.phase` (e.g. `Pending`/`Running`/`Succeeded`/`Failed`). Root cause:

1. `buildResourceItem` sets `Item.Status` from `.status.phase` via `extractStatus`.
2. `populatePrinterColumns` / `populateGenericCRDResource` suppress the `Phase` column because its value duplicates `Status`.
3. `genericSummaryDimensions` only inspected the (now missing) `Phase` column, so it fell back to `.status.conditions` -> `Ready`/`NotReady`.

## Fix

Preserve the origin of `Status` rather than the duplicate column:

| File | Change |
|---|---|
| `internal/model/types.go` | Add `Item.StatusFromPhase bool` |
| `internal/k8s/client_crd.go` | Add `statusPhase()` helper |
| `internal/k8s/client_resources.go` | `buildResourceItem` sets `StatusFromPhase` when `Status` came from `.status.phase` |
| `internal/ui/listsummary.go` | New `genericPhaseValue()` - uses the visible `Phase` column, else falls back to `Status` when `StatusFromPhase` is set |

The duplicate column stays suppressed in the table, but the summary regains the phase signal. Deleting resources also surface as `Terminating` (addresses the reporter's follow-up). The existing noise-rejection guard (StorageClass `Status: "default"`) is untouched because that Status is not phase-derived.

## Tests

- `TestStatusPhase`
- `TestBuildResourceItem_StatusFromPhase` / `_Deleting` / `_StatusNotFromPhase`
- `TestBuildListSummary_GenericPhaseFromStatus` / `_StatusNotFromPhaseStaysNoise`

## Verification

- `go build ./...`, `go vet` - clean
- `go test -race` on `internal/ui`, `internal/k8s`, `internal/model` - pass
- `golangci-lint` - 0 issues
- `go-reviewer` pass - approved, no CRITICAL/HIGH issues

## Follow-up: severity coloring for free-form phases

Rolling up by phase surfaced operators that put sentences in `.status.phase` (CloudNativePG: "Cluster in healthy state", "Failing over", ...). These missed the exact-match severity table in `statusSeverity`, so the whole summary bar rendered gray.

`statusSeverity` now classifies unknown statuses word-by-word against a small severity map (`healthy`/`ready`/`active` -> green; `waiting`/`creating`/`setting`/`progress`/... -> amber; `failing`/`failed`/`error`/`degraded`/`unhealthy` -> red), worst word winning. Exact matches keep precedence; unrecognized values stay gray. Living in `statusSeverity` keeps colors and worst-first bucket ordering in sync (also applies to Status columns).

Additional test: `TestStatusSeverity_FreeFormPhrases` (17 cases, TDD). Gate re-run clean (build, vet, `go test -race` on ui+app, golangci-lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
