### PR TITLE
fix(netpol): match Cilium namespace-derived label selectors

### DIFF
--- a/internal/k8s/netpol_cilium.go
+++ b/internal/k8s/netpol_cilium.go
@@ -351,11 +351,12 @@ func (c *Client) GetCiliumNetworkPolicyInfo(ctx context.Context, kubeCtx, namesp
 		pods = podList.Items
 	}
 
+	nsLabels := lazyNamespaceLabels(ctx, dynClient)
 	parsed := parseCiliumPolicy(obj, kind)
 	infos := make([]NetworkPolicyInfo, 0, len(parsed))
 	for _, ps := range parsed {
 		if ps.selector != nil {
-			ps.info.AffectedPods = matchingCiliumPodNames(pods, ps.selector)
+			ps.info.AffectedPods = matchingCiliumPodNames(pods, ps.selector, nsLabels())
 		}
 		infos = append(infos, ps.info)
 	}

--- a/internal/k8s/netpol_matching.go
+++ b/internal/k8s/netpol_matching.go
@@ -62,14 +62,18 @@ func (c *Client) GetNetworkPoliciesForPod(ctx context.Context, kubeCtx, namespac
 		result.Policies = append(result.Policies, NetpolForResource{NetworkPolicyInfo: *info})
 	}
 
-	augmented := ciliumPodLabels(pod.GetLabels(), namespace)
 	clusterPods := lazyClusterPods(ctx, dynClient, pods)
+	nsLabels := lazyNamespaceLabels(ctx, dynClient)
 	for _, ps := range listCiliumPolicySpecs(ctx, dynClient, namespace) {
-		if ps.selector == nil || !ps.selector.Matches(augmented) {
+		if ps.selector == nil {
+			continue
+		}
+		augmented := ciliumPodLabels(pod.GetLabels(), namespace, nsLabels()[namespace])
+		if !ps.selector.Matches(augmented) {
 			continue
 		}
 		info := ps.info
-		info.AffectedPods = matchingCiliumPodNames(ciliumAffectedPodPool(ps, pods, clusterPods), ps.selector)
+		info.AffectedPods = matchingCiliumPodNames(ciliumAffectedPodPool(ps, pods, clusterPods), ps.selector, nsLabels())
 		result.Policies = append(result.Policies, NetpolForResource{NetworkPolicyInfo: info})
 	}
 
@@ -135,6 +139,7 @@ func (c *Client) GetNetworkPoliciesForService(ctx context.Context, kubeCtx, name
 	}
 
 	clusterPods := lazyClusterPods(ctx, dynClient, pods)
+	nsLabels := lazyNamespaceLabels(ctx, dynClient)
 	for _, ps := range listCiliumPolicySpecs(ctx, dynClient, namespace) {
 		if ps.selector == nil {
 			continue
@@ -144,7 +149,7 @@ func (c *Client) GetNetworkPoliciesForService(ctx context.Context, kubeCtx, name
 			if !svcSelector.Matches(labels.Set(p.GetLabels())) {
 				continue
 			}
-			if ps.selector.Matches(ciliumPodLabels(p.GetLabels(), namespace)) {
+			if ps.selector.Matches(ciliumPodLabels(p.GetLabels(), namespace, nsLabels()[namespace])) {
 				matched = append(matched, p.GetName())
 			}
 		}
@@ -153,7 +158,7 @@ func (c *Client) GetNetworkPoliciesForService(ctx context.Context, kubeCtx, name
 		}
 		sort.Strings(matched)
 		info := ps.info
-		info.AffectedPods = matchingCiliumPodNames(ciliumAffectedPodPool(ps, pods, clusterPods), ps.selector)
+		info.AffectedPods = matchingCiliumPodNames(ciliumAffectedPodPool(ps, pods, clusterPods), ps.selector, nsLabels())
 		result.Policies = append(result.Policies, NetpolForResource{NetworkPolicyInfo: info, MatchedPods: matched})
 	}
 
@@ -247,15 +252,47 @@ func listCiliumPolicySpecs(ctx context.Context, dynClient dynamic.Interface, nam
 	return out
 }
 
-// ciliumPodLabels returns the pod's labels augmented with the namespace
-// pseudo-label Cilium injects on endpoints, so clusterwide selectors that
-// scope by namespace match correctly. Standard NetworkPolicy matching must
-// NOT use this: pods do not actually carry the pseudo-label.
-func ciliumPodLabels(lbls map[string]string, namespace string) labels.Set {
-	set := make(labels.Set, len(lbls)+1)
+// ciliumNamespaceLabelPrefix is the prefix Cilium adds to each namespace label
+// when projecting it onto endpoints in that namespace.
+const ciliumNamespaceLabelPrefix = "io.cilium.k8s.namespace.labels."
+
+// ciliumPodLabels returns the pod's labels augmented with the pseudo-labels
+// Cilium injects on endpoints: the namespace name, plus every label of the
+// pod's namespace under the io.cilium.k8s.namespace.labels.<key> prefix. This
+// lets selectors that scope by namespace or by namespace label match
+// correctly. Standard NetworkPolicy matching must NOT use this: pods do not
+// actually carry the pseudo-labels. nsOwnLabels is the label map of the pod's
+// namespace (nil is fine).
+func ciliumPodLabels(lbls map[string]string, namespace string, nsOwnLabels map[string]string) labels.Set {
+	set := make(labels.Set, len(lbls)+len(nsOwnLabels)+1)
 	maps.Copy(set, lbls)
 	set["io.kubernetes.pod.namespace"] = namespace
+	for k, v := range nsOwnLabels {
+		set[ciliumNamespaceLabelPrefix+k] = v
+	}
 	return set
+}
+
+// lazyNamespaceLabels returns a function that lists all namespaces once, on
+// first use, into a namespace-name -> labels map. Cilium namespace-derived
+// selectors need this to resolve which namespaces carry a given label; on list
+// failure (e.g. no permission) it yields an empty map, disabling only the
+// namespace-derived matching.
+func lazyNamespaceLabels(ctx context.Context, dynClient dynamic.Interface) func() map[string]map[string]string {
+	var cached map[string]map[string]string
+	nsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	return func() map[string]map[string]string {
+		if cached != nil {
+			return cached
+		}
+		cached = map[string]map[string]string{}
+		if list, err := dynClient.Resource(nsGVR).List(ctx, metav1.ListOptions{}); err == nil {
+			for i := range list.Items {
+				cached[list.Items[i].GetName()] = list.Items[i].GetLabels()
+			}
+		}
+		return cached
+	}
 }
 
 // lazyClusterPods returns a function that lists pods across all namespaces
@@ -290,11 +327,13 @@ func ciliumAffectedPodPool(ps ciliumParsedSpec, nsPods []unstructured.Unstructur
 }
 
 // matchingCiliumPodNames is matchingPodNames with Cilium-augmented labels;
-// each pod is augmented with its own namespace pseudo-label.
-func matchingCiliumPodNames(pods []unstructured.Unstructured, sel labels.Selector) []string {
+// each pod is augmented with its own namespace pseudo-labels, resolved from
+// nsLabels (namespace name -> namespace labels).
+func matchingCiliumPodNames(pods []unstructured.Unstructured, sel labels.Selector, nsLabels map[string]map[string]string) []string {
 	var names []string
 	for _, p := range pods {
-		if sel.Matches(ciliumPodLabels(p.GetLabels(), p.GetNamespace())) {
+		ns := p.GetNamespace()
+		if sel.Matches(ciliumPodLabels(p.GetLabels(), ns, nsLabels[ns])) {
 			names = append(names, p.GetName())
 		}
 	}

--- a/internal/k8s/netpol_matching_cilium_test.go
+++ b/internal/k8s/netpol_matching_cilium_test.go
@@ -78,6 +78,124 @@ func TestGetNetworkPoliciesForPod_ClusterwideMatchesByNamespaceLabel(t *testing.
 	assert.Equal(t, "CiliumClusterwideNetworkPolicy", info.Policies[0].Kind)
 }
 
+func TestGetNetworkPoliciesForPod_ClusterwideMatchesByNamespaceDerivedLabel(t *testing.T) {
+	// Cilium projects a namespace's labels onto every endpoint in that
+	// namespace under the io.cilium.k8s.namespace.labels.<key> prefix, so a
+	// policy selecting such a label must match all pods in labeled namespaces.
+	dyn := netpolMatchFakeDyn(
+		testNamespace("mynamespace", map[string]any{"egress/kube-dns": "true"}),
+		testNamespace("other", map[string]any{}),
+		testPodInNS("app-1", "mynamespace", map[string]any{"app": "foo"}),
+		testPodInNS("app-2", "other", map[string]any{"app": "foo"}),
+		testCCNP("egress-kube-dns", map[string]any{
+			"endpointSelector": map[string]any{
+				"matchLabels": map[string]any{
+					"k8s:io.cilium.k8s.namespace.labels.egress/kube-dns": "true",
+				},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "mynamespace", "app-1")
+	require.NoError(t, err)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "egress-kube-dns", info.Policies[0].Name)
+	// app-2 sits in "other" (no matching namespace label) -> excluded.
+	assert.Equal(t, []string{"app-1"}, info.Policies[0].AffectedPods)
+}
+
+func TestGetNetworkPoliciesForPod_NamespaceDerivedLabelExcludesUnlabeledNS(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testNamespace("mynamespace", map[string]any{"egress/kube-dns": "true"}),
+		testNamespace("other", map[string]any{}),
+		testPodInNS("app-2", "other", map[string]any{"app": "foo"}),
+		testCCNP("egress-kube-dns", map[string]any{
+			"endpointSelector": map[string]any{
+				"matchLabels": map[string]any{
+					"k8s:io.cilium.k8s.namespace.labels.egress/kube-dns": "true",
+				},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "other", "app-2")
+	require.NoError(t, err)
+	assert.Empty(t, info.Policies, "pod in an unlabeled namespace must not match")
+}
+
+func TestGetCiliumNetworkPolicyInfo_MatchesByNamespaceDerivedLabel(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testNamespace("mynamespace", map[string]any{"egress/kube-dns": "true"}),
+		testPodInNS("app-1", "mynamespace", map[string]any{"app": "foo"}),
+		testCCNP("egress-kube-dns", map[string]any{
+			"endpointSelector": map[string]any{
+				"matchLabels": map[string]any{
+					"k8s:io.cilium.k8s.namespace.labels.egress/kube-dns": "true",
+				},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	infos, err := c.GetCiliumNetworkPolicyInfo(t.Context(), "test-ctx", "", "egress-kube-dns", "CiliumClusterwideNetworkPolicy")
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, []string{"app-1"}, infos[0].AffectedPods)
+}
+
+func TestGetNetworkPoliciesForPod_NamespacedCNPMatchesByNamespaceDerivedLabel(t *testing.T) {
+	// A namespaced CiliumNetworkPolicy (not clusterwide) may also select on a
+	// namespace-derived label; the service/pod matcher must resolve it too.
+	dyn := netpolMatchFakeDyn(
+		testNamespace("mynamespace", map[string]any{"egress/kube-dns": "true"}),
+		testPodInNS("app-1", "mynamespace", map[string]any{"app": "foo"}),
+		testCNP("cnp-egress", "mynamespace", map[string]any{
+			"endpointSelector": map[string]any{
+				"matchLabels": map[string]any{
+					"k8s:io.cilium.k8s.namespace.labels.egress/kube-dns": "true",
+				},
+			},
+		}, nil),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForPod(t.Context(), "test-ctx", "mynamespace", "app-1")
+	require.NoError(t, err)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "cnp-egress", info.Policies[0].Name)
+	assert.Equal(t, "CiliumNetworkPolicy", info.Policies[0].Kind)
+	assert.Equal(t, []string{"app-1"}, info.Policies[0].AffectedPods)
+}
+
+func TestGetNetworkPoliciesForService_MatchesByNamespaceDerivedLabel(t *testing.T) {
+	dyn := netpolMatchFakeDyn(
+		testNamespace("mynamespace", map[string]any{"egress/kube-dns": "true"}),
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata":   map[string]any{"name": "web-svc", "namespace": "mynamespace"},
+			"spec":       map[string]any{"selector": map[string]any{"app": "foo"}},
+		}},
+		testPodInNS("app-1", "mynamespace", map[string]any{"app": "foo"}),
+		testCCNP("egress-kube-dns", map[string]any{
+			"endpointSelector": map[string]any{
+				"matchLabels": map[string]any{
+					"k8s:io.cilium.k8s.namespace.labels.egress/kube-dns": "true",
+				},
+			},
+		}),
+	)
+	c := NewTestClient(nil, dyn)
+
+	info, err := c.GetNetworkPoliciesForService(t.Context(), "test-ctx", "mynamespace", "web-svc")
+	require.NoError(t, err)
+	require.Len(t, info.Policies, 1)
+	assert.Equal(t, "egress-kube-dns", info.Policies[0].Name)
+	assert.Equal(t, []string{"app-1"}, info.Policies[0].MatchedPods)
+}
+
 func TestGetNetworkPoliciesForPod_CiliumNodePolicySkipped(t *testing.T) {
 	dyn := netpolMatchFakeDyn(
 		testPod("web-1", map[string]any{"app": "web"}),

--- a/internal/k8s/netpol_matching_test.go
+++ b/internal/k8s/netpol_matching_test.go
@@ -17,6 +17,7 @@ func netpolMatchFakeDyn(objects ...runtime.Object) *dynamicfake.FakeDynamicClien
 	gvrs := map[schema.GroupVersionResource]string{
 		{Group: "", Version: "v1", Resource: "pods"}:                                      "PodList",
 		{Group: "", Version: "v1", Resource: "services"}:                                  "ServiceList",
+		{Group: "", Version: "v1", Resource: "namespaces"}:                                "NamespaceList",
 		{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}:          "NetworkPolicyList",
 		{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"}:            "CiliumNetworkPolicyList",
 		{Group: "cilium.io", Version: "v2", Resource: "ciliumclusterwidenetworkpolicies"}: "CiliumClusterwideNetworkPolicyList",
@@ -32,6 +33,29 @@ func testPod(name string, lbls map[string]any) *unstructured.Unstructured {
 			"name":      name,
 			"namespace": "default",
 			"labels":    lbls,
+		},
+	}}
+}
+
+func testPodInNS(name, namespace string, lbls map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+			"labels":    lbls,
+		},
+	}}
+}
+
+func testNamespace(name string, lbls map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":   name,
+			"labels": lbls,
 		},
 	}}
 }


### PR DESCRIPTION
## Summary

Fixes #544. A `CiliumClusterwideNetworkPolicy` / `CiliumNetworkPolicy` whose `endpointSelector` matches on a namespace-derived label (`io.cilium.k8s.namespace.labels.<key>`) listed **no affected pods** in the network Visualizer, even though Cilium applied the policy correctly.

**Root cause:** Cilium projects every namespace label onto each endpoint in that namespace under the `io.cilium.k8s.namespace.labels.<key>` prefix. lfk's matcher only injected the namespace *name* pseudo-label (`io.kubernetes.pod.namespace`), so namespace-derived selectors never matched.

**Fix:**
- Add `ciliumNamespaceLabelPrefix` and `lazyNamespaceLabels` (one namespaces `List` per request, cached; errors swallowed like the sibling `lazyClusterPods`, so RBAC-restricted clusters degrade gracefully).
- Project the pod's namespace labels under the prefix in `ciliumPodLabels`.
- Thread a `namespace -> labels` map through `matchingCiliumPodNames` and all three matcher entry points: pod view, service view, and the direct policy view (`GetCiliumNetworkPolicyInfo`).
- Standard Kubernetes `NetworkPolicy` matching is untouched (pods do not carry the pseudo-labels).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/k8s/`
- [x] `golangci-lint run ./internal/k8s/` (0 issues)
- [x] `go test -race ./internal/k8s/`
- [x] 5 new tests: namespace-derived matching across pod / service / direct-policy views, for both CCNP and namespaced CNP, plus a negative case (pod in an unlabeled namespace excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)