### PR TITLE
feat(explorer): make @ cycle Cluster/Monitoring dashboard from any level

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `-` | Reset sort to default (Name ascending) |
 | `W` | Save resource to file / toggle warnings-only (Events) |
 | `Ctrl+T` | Cycle terminal mode (pty / exec / mux — mux skipped without tmux/zellij) |
-| `@` | Monitoring overview (active Prometheus alerts) |
+| `@` | Cycle Cluster / Monitoring dashboard |
 | `Q` | Namespace resource quota dashboard |
 
 ### Actions

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -78,7 +78,7 @@ All built-in chords are rebindable under `keybindings`.
 | `C` | Session manager (save/switch/delete named workspace sessions) |
 | `Ctrl+G` | Finalizer search and remove |
 | `!` | Error log |
-| `@` | Monitoring overview (active Prometheus alerts) |
+| `@` | Cycle Cluster / Monitoring dashboard |
 | `Ctrl+N` | Open the Local Clusters Manager overlay (only at LevelClusters) |
 | `Q` | Namespace resource quota dashboard |
 | `` ` `` | Scheduler / task queue overlay (Tab toggles running / completed history; `a` toggles show-all entries in completed view) |

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -746,9 +746,25 @@ func (m Model) handleExplorerActionKeyMonitoring() (tea.Model, tea.Cmd, bool) {
 		m.setStatusMessage("Select a cluster first", true)
 		return m, scheduleStatusClear(), true
 	}
-	// Find the Monitoring item in the middle column and select it.
+	// The dashboards live at the resource-types level. Back out to it so the
+	// key works from the resource list or any deeper view, not only when the
+	// resource-type column is focused.
+	for m.nav.Level > model.LevelResourceTypes {
+		before := m.nav.Level
+		ret, _ := m.navigateParent()
+		m = ret.(Model)
+		if m.nav.Level == before {
+			break
+		}
+	}
+	// Cycle Cluster -> Monitoring -> Cluster. Start with the Cluster dashboard
+	// unless it is already selected, in which case switch to Monitoring.
+	target := "__overview__"
+	if sel := m.selectedMiddleItem(); sel != nil && sel.Extra == "__overview__" {
+		target = "__monitoring__"
+	}
 	for i, item := range m.middleItems {
-		if item.Extra == "__monitoring__" {
+		if item.Extra == target {
 			m.setCursor(i)
 			m.clampCursor()
 			return m, m.loadPreview(), true

--- a/internal/app/update_keys_actions_test.go
+++ b/internal/app/update_keys_actions_test.go
@@ -1290,3 +1290,59 @@ func TestLoadDiffSecurityNoFetch(t *testing.T) {
 	require.Error(t, msg.err)
 	assert.Contains(t, msg.err.Error(), "__security_falco__", "error must identify the synthetic kind")
 }
+
+// --- handleExplorerActionKeyMonitoring: cycle Cluster <-> Monitoring ---
+
+// dashboardTypesModel builds a resource-types view with a normal resource type
+// followed by the two dashboard pseudo-items.
+func dashboardTypesModel(cursor int) Model {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelResourceTypes
+	m.nav.ResourceType = model.ResourceTypeEntry{}
+	m.middleItems = []model.Item{
+		{Name: "Pods", Kind: "Pod"},
+		{Name: "Cluster", Kind: "__overview__", Extra: "__overview__", Category: "Dashboards"},
+		{Name: "Monitoring", Kind: "__monitoring__", Extra: "__monitoring__", Category: "Dashboards"},
+	}
+	m.setCursor(cursor)
+	return m
+}
+
+func TestActionKeyMonitoringStartsWithCluster(t *testing.T) {
+	m := dashboardTypesModel(0) // cursor on a normal resource type
+	ret, _, handled := m.handleExplorerActionKeyMonitoring()
+	assert.True(t, handled)
+	rm := ret.(Model)
+	sel := rm.selectedMiddleItem()
+	require.NotNil(t, sel)
+	assert.Equal(t, "__overview__", sel.Extra, "first press opens the Cluster dashboard")
+}
+
+func TestActionKeyMonitoringClusterToMonitoring(t *testing.T) {
+	m := dashboardTypesModel(1) // cursor already on Cluster dashboard
+	ret, _, handled := m.handleExplorerActionKeyMonitoring()
+	assert.True(t, handled)
+	rm := ret.(Model)
+	sel := rm.selectedMiddleItem()
+	require.NotNil(t, sel)
+	assert.Equal(t, "__monitoring__", sel.Extra, "from Cluster the key switches to Monitoring")
+}
+
+func TestActionKeyMonitoringMonitoringBackToCluster(t *testing.T) {
+	m := dashboardTypesModel(2) // cursor on Monitoring dashboard
+	ret, _, handled := m.handleExplorerActionKeyMonitoring()
+	assert.True(t, handled)
+	rm := ret.(Model)
+	sel := rm.selectedMiddleItem()
+	require.NotNil(t, sel)
+	assert.Equal(t, "__overview__", sel.Extra, "from Monitoring the key cycles back to Cluster")
+}
+
+func TestActionKeyMonitoringNeedsCluster(t *testing.T) {
+	m := baseExplorerModel()
+	m.nav.Level = model.LevelClusters
+	ret, _, handled := m.handleExplorerActionKeyMonitoring()
+	assert.True(t, handled)
+	rm := ret.(Model)
+	assert.Equal(t, "Select a cluster first", rm.statusMessage)
+}

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -67,7 +67,7 @@ func helpSections() []helpSection {
 				{kb.SessionManager, "Session manager (save/switch/delete named workspace sessions)"},
 				{helpKeyDisplay(kb.FinalizerSearch), "Finalizer search and remove (scan, select, remove finalizers)"},
 				{kb.ErrorLog, "Error log"},
-				{kb.Monitoring, "Monitoring overview (active Prometheus alerts)"},
+				{kb.Monitoring, "Cycle Cluster / Monitoring dashboard"},
 				{kb.QuotaDashboard, "Namespace resource quota dashboard"},
 				{kb.TasksOverlay, "Scheduler / task queue overlay (Tab: running/completed, a: show all entries)"},
 			},


### PR DESCRIPTION
## Summary

Reworks the `@` hotkey behaviour:

- **Works from any explorer level** - previously `@` only opened the Monitoring dashboard when the resource-type column was focused. It now backs out to the resource-types level first (reusing the same `navigateParent` loop the level-jump keys use), so it works from the resource list or any deeper view.
- **Cycles Cluster / Monitoring** - repeated presses toggle Cluster -> Monitoring -> Cluster, starting with the Cluster dashboard.

## Changes

- `internal/app/update_keys_actions.go` - `handleExplorerActionKeyMonitoring` navigates up to the resource-types level, then targets the Cluster dashboard unless it is already selected (then Monitoring).
- `internal/app/update_keys_actions_test.go` - 4 tests: start-with-cluster, cluster->monitoring, monitoring->cluster, and the "select a cluster first" guard.
- `internal/ui/help_sections.go`, `README.md`, `docs/keybindings.md` - help/hint text updated.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/app ./internal/ui`
- [x] `go test ./internal/app ./internal/ui`
- [x] `golangci-lint run` (0 issues, also enforced by pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)