### PR TITLE
fix(explorer): keep focused row untinted in foreground row-status-tint (#540)

### DIFF
--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -590,13 +590,16 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 				b.WriteString(RenderOverPrestyled(row, bgTint))
 				continue
 			}
-			// Foreground / off / non-tinted cursor row: the selection owns the
-			// background. A failed/progressing row keeps its status on the
-			// foreground color over the selection style, but only when this
-			// render actually tints (so "no tint while the Status column is
-			// visible" holds for the cursor row too).
+			// Cursor row: the selection highlight owns the row. In foreground
+			// mode the focused row is left as the plain selection — no severity
+			// tint fights the highlight (issue #540: the tint on the focused row
+			// was either invisible when the severity color matched the selection
+			// background, or flooded the whole bar). Background mode is the loud
+			// opt-in and keeps its cursor emphasis: the color path is handled
+			// above via cursorKeptBackgroundTint, so only its no-color
+			// fallthrough reaches here.
 			selStyle := ActiveSelectedStyle(i)
-			if tintWholeRow || tintNameOnly {
+			if ConfigRowStatusTint == RowStatusTintBackground {
 				if tint, tinted := rowTintForeground(item.Status); tinted {
 					selStyle = mergeRowTintIntoSelected(selStyle, tint)
 				}

--- a/internal/ui/row_tint_test.go
+++ b/internal/ui/row_tint_test.go
@@ -344,25 +344,46 @@ func TestTintedSelectionMarker_CarriesBackground(t *testing.T) {
 	}
 }
 
-// TestRenderTable_ForegroundSelectedShowsSeverity asserts that in foreground
-// mode the cursor row on a failed item still carries the severity foreground
-// over the selection style (foreground has no background to preserve).
-func TestRenderTable_ForegroundSelectedShowsSeverity(t *testing.T) {
+// TestRenderTable_ForegroundSelectedIsPlainSelection asserts that in foreground
+// mode the focused (cursor) row is the plain selection highlight with no
+// severity tint, even on a failed row with the Status column hidden. The tint
+// on the focused row was either invisible (severity color == selection
+// background) or flooded the whole bar, so foreground mode now leaves the
+// cursor row untinted (issue #540).
+func TestRenderTable_ForegroundSelectedIsPlainSelection(t *testing.T) {
 	setTestColorProfile(t)
 	snapshotRowTintGlobals(t)
 	withHiddenColumns(t, "Status")
-	ConfigRowStatusTint = RowStatusTintForeground
 
 	items := []model.Item{
 		{Name: "pod-a", Namespace: "ns1", Kind: "Pod", Status: "CrashLoopBackOff", Age: "1d"},
 		{Name: "pod-b", Namespace: "ns1", Kind: "Pod", Status: "Running", Age: "2d"},
 	}
-	r := NewTableRenderer()
-	out := r.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
 
-	sel := SelectedStyle.Foreground(lipgloss.Color(ColorError))
-	if !strings.Contains(out, styleOpenCodes(sel)) {
-		t.Fatal("foreground-mode selected failed row must carry selection bg + severity fg")
+	// The focused failed row must render identically in off mode and foreground
+	// mode: foreground adds no tint to the cursor row.
+	ConfigRowStatusTint = RowStatusTintOff
+	off := NewTableRenderer()
+	offOut := off.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+
+	ConfigRowStatusTint = RowStatusTintForeground
+	fg := NewTableRenderer()
+	fgOut := fg.Render("NAME", items, 0, 80, 20, false, "", "", 0, 0)
+
+	cursorLine := func(out string) string {
+		for line := range strings.SplitSeq(out, "\n") {
+			if strings.Contains(stripANSI(line), "pod-a") {
+				return line
+			}
+		}
+		return ""
+	}
+	if offLine, fgLine := cursorLine(offOut), cursorLine(fgOut); offLine != fgLine {
+		t.Fatalf("foreground mode must leave the focused row as the plain selection.\noff=%q\nfg =%q", offLine, fgLine)
+	}
+	// And it must not carry the severity color on the foreground channel.
+	if strings.Contains(fgOut, styleOpenCodes(SelectedStyle.Foreground(lipgloss.Color(ColorError)))) {
+		t.Fatal("foreground-mode focused row must not carry the severity tint")
 	}
 }
 

--- a/internal/ui/row_tint_test.go
+++ b/internal/ui/row_tint_test.go
@@ -378,11 +378,15 @@ func TestRenderTable_ForegroundSelectedIsPlainSelection(t *testing.T) {
 		}
 		return ""
 	}
-	if offLine, fgLine := cursorLine(offOut), cursorLine(fgOut); offLine != fgLine {
+	offLine, fgLine := cursorLine(offOut), cursorLine(fgOut)
+	if fgLine == "" {
+		t.Fatal("expected to find pod-a in the rendered output")
+	}
+	if offLine != fgLine {
 		t.Fatalf("foreground mode must leave the focused row as the plain selection.\noff=%q\nfg =%q", offLine, fgLine)
 	}
 	// And it must not carry the severity color on the foreground channel.
-	if strings.Contains(fgOut, styleOpenCodes(SelectedStyle.Foreground(lipgloss.Color(ColorError)))) {
+	if strings.Contains(fgLine, styleOpenCodes(SelectedStyle.Foreground(lipgloss.Color(ColorError)))) {
 		t.Fatal("foreground-mode focused row must not carry the severity tint")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the focused-row behavior of the row-status-tint feature (#540).

In **foreground** mode the cursor row applied the severity color over the selection highlight. Two problems resulted:

- When the severity color matched the selection background (e.g. `theme.primary == theme.selected_bg` on the default Tokyonight theme), the focused row's text went **invisible** (blue-on-blue). This is the case reported in #540.
- Otherwise the tint **flooded the whole selection bar** (the Name column expands to fill the freed width when Status is hidden, so the focused row read as an all-red bar).

## Change

Foreground mode now leaves the focused (cursor) row as the **plain selection highlight** — no severity tint fights the selection.

- Non-focused rows still carry the name tint, so failing pods remain visible while scanning the list.
- **Background** mode (the deliberate loud opt-in) keeps its existing cursor treatment (`cursorKeptBackgroundTint`).

Rendered result (Status hidden, foreground mode):

| Row | Result |
|---|---|
| Focused failed row | plain selection — identical to off mode, nothing invisible |
| Non-focused failed row | red name text (tint preserved) |

## Test plan

- [x] `TestRenderTable_ForegroundSelectedIsPlainSelection` — the focused failed row renders identically in off and foreground modes, and never carries the severity color on the foreground channel.
- [x] `go build ./...`, `go vet ./internal/ui/`, `golangci-lint run ./internal/ui/...` (0 issues), `gofmt`
- [x] `go test -race ./internal/ui/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)