### PR TITLE
fix(release): lint PR titles as conventional commits to prevent missed releases

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -7,6 +7,11 @@
 #
 # Only workflow-level expressions reference `github.head_ref`; the branch name
 # is never expanded into shell input, avoiding script-injection risks.
+#
+# It also lints the PR title against Conventional Commits. Because PRs are
+# squash-merged with the PR title as the commit subject, a non-conventional
+# title (e.g. a raw branch name) makes release-please skip the release. This
+# check blocks that before merge.
 name: Validate PR
 
 on:
@@ -36,3 +41,14 @@ jobs:
           echo ""
           echo "See the Contributing section in README.md for the full workflow."
           exit 1
+
+  lint-pr-title:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title against Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

PR #554 merged but release-please did **not** cut a release. The squash-merge subject was the raw branch name (\`Fix/storageclass rbac viewer command bar crds\`), which is not a Conventional Commit. release-please only parses the squash commit **subject** (= PR title), so it saw nothing releasable and skipped the version bump.

This PR does two things:

### 1. Fixes it now
The PR title here is a conventional \`fix(release):\`. Merging it (squash) lands a releasable commit on \`main\`, so release-please will open/refresh a Release PR bumping to **v0.15.14** — which bundles #554's already-merged changes into the release binaries.

> Note: config has \`bump-patch-for-minor-pre-major: true\`, so pre-1.0 both \`feat\` and \`fix\` bump patch. #554's commandbar feature ships in 0.15.14; it just isn't itemized in the changelog because its own commit subject wasn't conventional.

### 2. Prevents recurrence
Adds a \`Conventional PR title\` job to \`validate-pr.yml\` using \`amannn/action-semantic-pull-request\` (pinned to SHA). Since PRs are squash-merged with the title as the commit subject, this blocks non-conventional titles before merge.

## Follow-up (manual, repo settings)
- Mark **Conventional PR title** as a required status check on \`main\`.
- Consider restricting merges to **squash-only** so the release path stays predictable.

## Test plan
- [ ] CI passes (this PR's own title is conventional, so the new check passes)
- [ ] After merge: release-please opens a Release PR for v0.15.14