### PR TITLE
fix(sort): derive Status order from the shared severity classifier

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -177,58 +177,6 @@ func TestSelectionKey(t *testing.T) {
 	}
 }
 
-// --- statusPriority ---
-
-func TestStatusPriority(t *testing.T) {
-	tests := []struct {
-		status   string
-		priority int
-	}{
-		// Priority 0: healthy statuses.
-		{"Running", 0},
-		{"Active", 0},
-		{"Bound", 0},
-		{"Available", 0},
-		{"Ready", 0},
-		{"Healthy", 0},
-		{"Healthy/Synced", 0},
-		{"Deployed", 0},
-		// Priority 1: in-progress statuses.
-		{"Pending", 1},
-		{"ContainerCreating", 1},
-		{"Waiting", 1},
-		{"Init", 1},
-		{"Progressing", 1},
-		{"Progressing/Synced", 1},
-		{"Suspended", 1},
-		{"Pending-install", 1},
-		{"Pending-upgrade", 1},
-		{"Pending-rollback", 1},
-		{"Uninstalling", 1},
-		// Priority 2: failed statuses.
-		{"Failed", 2},
-		{"CrashLoopBackOff", 2},
-		{"Error", 2},
-		{"ImagePullBackOff", 2},
-		{"Degraded", 2},
-		{"Degraded/OutOfSync", 2},
-		// Priority 3: unknown statuses.
-		{"Unknown", 3},
-		{"SomeRandomStatus", 3},
-		{"", 3},
-	}
-
-	for _, tt := range tests {
-		name := tt.status
-		if name == "" {
-			name = "empty string"
-		}
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.priority, statusPriority(tt.status))
-		})
-	}
-}
-
 // --- severityRank ---
 
 func TestSeverityRank(t *testing.T) {

--- a/internal/app/status_sort_test.go
+++ b/internal/app/status_sort_test.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// statusesInOrder returns each item's status in the order they currently sit,
+// so a sort assertion reads as the column the user sees.
+func statusesInOrder(items []model.Item) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.Status
+	}
+	return out
+}
+
+// Sorting by Status must group rows carrying the same status string together.
+// Before the fix, statuses missing from the app-local priority table
+// (Terminating, Succeeded, NotReady, ...) all shared one catch-all bucket and
+// tie-broke on Name, so a real pod list interleaved them alphabetically and
+// looked unsorted.
+func TestSortByStatusGroupsIdenticalStatuses(t *testing.T) {
+	// Names deliberately interleave the statuses alphabetically — this is the
+	// shape of a real cluster list (argocd-* Terminating sorting between
+	// backup-* Succeeded rows).
+	items := []model.Item{
+		{Name: "argocd-application-controller-0", Status: "Terminating"},
+		{Name: "backup-db-cronjob-8f7gx", Status: "Succeeded"},
+		{Name: "instance-manager-9c5ff", Status: "Terminating"},
+		{Name: "laravel-cron-7wcfl", Status: "Succeeded"},
+		{Name: "logging-alloy-lf29t", Status: "NotReady"},
+		{Name: "magento-cron-7wk4k", Status: "Succeeded"},
+		{Name: "overprovisioning-jf2xb", Status: "Pending"},
+		{Name: "varnish-1", Status: "Running"},
+	}
+
+	sortItemsByColumn(items, "Status", true, "Pod")
+
+	assert.Equal(t, []string{
+		"Running",
+		// NotReady, Pending and Terminating share the in-progress bucket;
+		// within it each status string still groups.
+		"NotReady",
+		"Pending",
+		"Terminating", "Terminating",
+		"Succeeded", "Succeeded", "Succeeded",
+	}, statusesInOrder(items))
+}
+
+// Within one status string, rows still order by name, so a refresh can never
+// reshuffle same-status rows.
+func TestSortByStatusOrdersByNameWithinStatus(t *testing.T) {
+	items := []model.Item{
+		{Name: "zeta", Status: "Succeeded"},
+		{Name: "alpha", Status: "Succeeded"},
+		{Name: "mid", Status: "Succeeded"},
+	}
+
+	sortItemsByColumn(items, "Status", true, "Pod")
+
+	assert.Equal(t, []string{"alpha", "mid", "zeta"}, itemNames(items))
+}
+
+// Descending Status flips the buckets and the status groups, but same-status
+// rows keep their ascending name order — matching the direction-independent
+// tiebreaker chain the other columns use.
+func TestSortByStatusDescendingKeepsNameOrderWithinStatus(t *testing.T) {
+	items := []model.Item{
+		{Name: "beta", Status: "Running"},
+		{Name: "alpha", Status: "Succeeded"},
+		{Name: "gamma", Status: "Running"},
+	}
+
+	sortItemsByColumn(items, "Status", false, "Pod")
+
+	assert.Equal(t, []string{"Succeeded", "Running", "Running"}, statusesInOrder(items))
+	assert.Equal(t, []string{"alpha", "beta", "gamma"}, itemNames(items))
+}
+
+// Free-form CRD statuses bucket through the same word fallback that colors
+// them, so an operator phrase sorts with its severity peers instead of
+// dropping into the no-signal bucket.
+func TestSortByStatusBucketsFreeFormPhrases(t *testing.T) {
+	items := []model.Item{
+		{Name: "b", Status: "Succeeded"},
+		{Name: "a", Status: "Cluster in healthy state"},
+	}
+
+	sortItemsByColumn(items, "Status", true, "Cluster")
+
+	assert.Equal(t, []string{"Cluster in healthy state", "Succeeded"}, statusesInOrder(items))
+}

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -209,10 +209,15 @@ func comparePrimaryColumn(a, b model.Item, colName string) int {
 	case "Restarts":
 		return compareNumericCmp(a.Restarts, b.Restarts)
 	case "Status":
-		if c := cmpInt(statusPriority(a.Status), statusPriority(b.Status)); c != 0 {
+		if c := cmpInt(ui.StatusSortRank(a.Status), ui.StatusSortRank(b.Status)); c != 0 {
 			return c
 		}
-		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+		// Same bucket: group identical status strings. Without this, every
+		// status sharing a bucket (Terminating and NotReady, Succeeded and
+		// Completed) interleaves alphabetically by name and the column reads
+		// as unsorted. Equal statuses fall through to the shared tiebreaker
+		// chain, which orders by name ascending in both directions.
+		return strings.Compare(a.Status, b.Status)
 	case "Age":
 		return compareAgeCmp(a, b)
 	case "Ports":
@@ -633,19 +638,4 @@ func severityRank(sev string) int {
 		return 3
 	}
 	return 4
-}
-
-// statusPriority returns a sort priority for a status string.
-func statusPriority(status string) int {
-	switch status {
-	case "Running", "Active", "Bound", "Available", "Ready", "Healthy", "Healthy/Synced", "Deployed":
-		return 0
-	case "Pending", "ContainerCreating", "Waiting", "Init", "Progressing", "Progressing/Synced", "Suspended",
-		"Pending-install", "Pending-upgrade", "Pending-rollback", "Uninstalling":
-		return 1
-	case "Failed", "CrashLoopBackOff", "Error", "ImagePullBackOff", "Degraded", "Degraded/OutOfSync":
-		return 2
-	default:
-		return 3
-	}
 }

--- a/internal/app/tabs_test.go
+++ b/internal/app/tabs_test.go
@@ -1732,13 +1732,6 @@ func TestCov80CompareNumeric(t *testing.T) {
 	assert.True(t, compareNumeric("abc", "1")) // "abc" parses as 0
 }
 
-func TestCov80StatusPriority(t *testing.T) {
-	assert.Equal(t, 0, statusPriority("Running"))
-	assert.Equal(t, 1, statusPriority("Pending"))
-	assert.Equal(t, 2, statusPriority("Failed"))
-	assert.Equal(t, 3, statusPriority("Unknown"))
-}
-
 func TestCov80SortModeName(t *testing.T) {
 	m := basePush80Model()
 	m.sortColumnName = ""
@@ -2013,15 +2006,6 @@ func TestCovCompareNumeric(t *testing.T) {
 	assert.True(t, compareNumeric("1", "2"))
 	assert.False(t, compareNumeric("5", "3"))
 	assert.False(t, compareNumeric("abc", "def"))
-}
-
-func TestCovStatusPriority(t *testing.T) {
-	assert.Equal(t, 0, statusPriority("Running"))
-	assert.Equal(t, 0, statusPriority("Active"))
-	assert.Equal(t, 1, statusPriority("Pending"))
-	assert.Equal(t, 2, statusPriority("Failed"))
-	assert.Equal(t, 2, statusPriority("CrashLoopBackOff"))
-	assert.Equal(t, 3, statusPriority("Unknown"))
 }
 
 func TestCovGetColumnValue(t *testing.T) {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -600,6 +600,27 @@ func StatusSeverityRank(status string) int {
 	}
 }
 
+// StatusSortRank orders a status string healthy-first (0 = healthy) for the
+// Status column sort, where ascending has always put Running at the top.
+// Completed work ranks below both live and broken rows so a wall of Succeeded
+// cron pods never buries them. Derived from statusSeverity, so every status the
+// coloring understands gets a real bucket — the catch-all is reserved for rows
+// carrying no signal at all.
+func StatusSortRank(status string) int {
+	switch statusSeverity(status) {
+	case sevRunning:
+		return 0
+	case sevProgressing:
+		return 1
+	case sevFailed:
+		return 2
+	case sevDone:
+		return 3
+	default: // normal / default / blank / unknown
+		return 4
+	}
+}
+
 // condPolarity classifies how a status condition's type relates to health.
 type condPolarity int
 

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -243,3 +243,63 @@ func TestFillLinesBgReestablishesBgAfterShortReset(t *testing.T) {
 	assert.NotContains(t, got, "\x1b[m ",
 		"no un-backgrounded padding may follow a parameterless reset")
 }
+
+// --- StatusSortRank ---
+
+// StatusSortRank drives the Status column sort. It orders healthy-first
+// (matching the column's long-standing ascending order) and, unlike the old
+// hand-maintained table in internal/app, derives every bucket from
+// statusSeverity — so a status the coloring understands can never fall into an
+// unranked catch-all and sort by name instead.
+func TestStatusSortRank(t *testing.T) {
+	tests := []struct {
+		status string
+		want   int
+	}{
+		// 0: healthy.
+		{"Running", 0},
+		{"Active", 0},
+		{"Ready", 0},
+		{"Healthy/Synced", 0},
+		{"Established", 0},
+		// 1: in progress, including the statuses the old table never ranked.
+		{"Pending", 1},
+		{"ContainerCreating", 1},
+		{"Terminating", 1},
+		{"NotReady", 1},
+		{"Unknown", 1},
+		{"Suspended", 1},
+		// 2: failed.
+		{"Failed", 2},
+		{"CrashLoopBackOff", 2},
+		{"OOMKilled", 2},
+		{"Degraded/OutOfSync", 2},
+		// 3: terminal success — completed rows are noise, so they sit below
+		// anything still running or broken instead of burying it.
+		{"Succeeded", 3},
+		{"Completed", 3},
+		{"Superseded", 3},
+		// 4: no signal.
+		{"", 4},
+		{"Normal", 4},
+		{"SomeRandomStatus", 4},
+	}
+	for _, tt := range tests {
+		name := tt.status
+		if name == "" {
+			name = "empty string"
+		}
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, StatusSortRank(tt.status))
+		})
+	}
+}
+
+// Free-form CRD phrases must bucket through the same word fallback the
+// coloring uses, so an operator's "Cluster in healthy state" sorts with the
+// healthy rows rather than dropping into the no-signal bucket.
+func TestStatusSortRank_FreeFormPhrases(t *testing.T) {
+	assert.Equal(t, StatusSortRank("Running"), StatusSortRank("Cluster in healthy state"))
+	assert.Equal(t, StatusSortRank("Failed"), StatusSortRank("Failing over"))
+	assert.Equal(t, StatusSortRank("Pending"), StatusSortRank("Setting up primary"))
+}


### PR DESCRIPTION
Sorting the middle column by Status produced an apparently random order — `Terminating`, `Succeeded` and `NotReady` rows interleaved alphabetically by name:

```
varnish-1                        Running
overprovisioning-68cf7fb8b       Pending
argocd-application-controller-0  Terminating
backup-db-cronjob-29751720-8f7gx Succeeded
instance-manager-9c5ffafaa3      Terminating   <- mid-run
laravel-cron-29752621-7wcfl      Succeeded
logging-alloy-lf29t              NotReady      <- mid-run
```

## Root cause

`app.statusPriority` was a second, hand-maintained status table that only ranked the Running / Pending / Failed families. Everything else — `Terminating`, `Succeeded`, `Completed`, `NotReady`, `OOMKilled` — fell into one catch-all bucket and tie-broke on `Name`. The rows above are in perfect name order within that bucket; they just had no bucket of their own.

`internal/ui/styles.go` already owns the single source of truth: the `statusSeverity` classifier (plus its word fallback for free-form CRD phrases) that drives status coloring.

## Changes

- **`ui.StatusSortRank`** — new, derived from `statusSeverity`, so status ordering and status coloring cannot drift apart again. Free-form operator phrases (`Cluster in healthy state`) bucket through the same fallback that colors them.
- **Grouping** — identical status strings now sort adjacently before falling back to name.
- **`app.statusPriority` deleted** along with its three duplicated table tests; the vocabulary is tested once, in `internal/ui`.
- **Descending fix** — the Status case had an inline name comparison that got sign-flipped under descending sort, unlike every other column, which defers to the always-ascending `itemTiebreakerLess` chain. Equal statuses now fall through to that shared chain and keep ascending name order in both directions (and also order by Context / Namespace / Age).

Ordering keeps the column's long-standing ascending direction — running 0, progressing 1, failed 2, done 3, no-signal 4 — so a wall of Succeeded cron pods sinks below anything still live or broken.

### Behavior changes worth noting

- `Unknown` moves from the catch-all into the progressing bucket, matching how it is already colored.
- `OOMKilled`, `Terminated`, `ErrImagePull` and peers now rank as failed rather than unranked.

## Test plan

- [x] `internal/ui/styles_test.go`: `TestStatusSortRank` (21 statuses) + `TestStatusSortRank_FreeFormPhrases`
- [x] `internal/app/status_sort_test.go`: 4 tests, one reproducing the pod list above
- [x] `go test -race ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues