### PR TITLE
fix(actions): target the correct API group when two kinds collide

### DIFF
--- a/internal/app/commands_bulk.go
+++ b/internal/app/commands_bulk.go
@@ -138,7 +138,7 @@ func (m Model) bulkForceDeleteResources() tea.Cmd {
 
 			// Remove finalizers first.
 			patchArgs := []string{
-				"patch", rt.Resource, ref.Name, "--context", kubectlCtx,
+				"patch", kubectlResourceArg(rt), ref.Name, "--context", kubectlCtx,
 				"--type", "merge", "-p", `{"metadata":{"finalizers":null}}`,
 			}
 			if rt.Namespaced {
@@ -160,7 +160,7 @@ func (m Model) bulkForceDeleteResources() tea.Cmd {
 
 			// Force delete.
 			deleteArgs := []string{
-				"delete", rt.Resource, ref.Name, "--context", kubectlCtx,
+				"delete", kubectlResourceArg(rt), ref.Name, "--context", kubectlCtx,
 				"--grace-period=0", "--force",
 			}
 			if rt.Namespaced {

--- a/internal/app/commands_exec.go
+++ b/internal/app/commands_exec.go
@@ -70,7 +70,7 @@ func (m Model) execKubectlEdit() tea.Cmd {
 
 	ns := m.actionNamespace()
 	rt := m.actionCtx.resourceType
-	args := []string{"edit", rt.Resource, m.actionCtx.name, "--context", m.kubectlContext(m.actionCtx.context)}
+	args := []string{"edit", kubectlResourceArg(rt), m.actionCtx.name, "--context", m.kubectlContext(m.actionCtx.context)}
 	if rt.Namespaced {
 		args = append(args, "-n", ns)
 	}
@@ -97,7 +97,7 @@ func (m Model) execKubectlDescribe() tea.Cmd {
 	ns := m.actionNamespace()
 	rt := m.actionCtx.resourceType
 	name := m.actionCtx.name
-	args := []string{"describe", rt.Resource, name, "--context", m.kubectlContext(m.actionCtx.context)}
+	args := []string{"describe", kubectlResourceArg(rt), name, "--context", m.kubectlContext(m.actionCtx.context)}
 	if rt.Namespaced {
 		args = append(args, "-n", ns)
 	}

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -48,7 +48,7 @@ func (m Model) forceDeleteResource() tea.Cmd {
 	logger.Info("Force deleting resource", "resource", rt.Resource, "name", name, "namespace", ns, "context", ctx)
 
 	deleteArgs := []string{
-		"delete", rt.Resource, name, "--context", m.kubectlContext(ctx),
+		"delete", kubectlResourceArg(rt), name, "--context", m.kubectlContext(ctx),
 		"--grace-period=0", "--force",
 	}
 	if rt.Namespaced {
@@ -82,7 +82,7 @@ func (m Model) removeFinalizers() tea.Cmd {
 	logger.Info("Removing finalizers from resource", "resource", rt.Resource, "name", name, "namespace", ns, "context", ctx)
 
 	patchArgs := []string{
-		"patch", rt.Resource, name, "--context", m.kubectlContext(ctx),
+		"patch", kubectlResourceArg(rt), name, "--context", m.kubectlContext(ctx),
 		"--type", "merge", "-p", `{"metadata":{"finalizers":null}}`,
 	}
 	if rt.Namespaced {

--- a/internal/app/jump_history_test.go
+++ b/internal/app/jump_history_test.go
@@ -74,7 +74,7 @@ func TestTeleportThenJumpBackReturnsToOrigin(t *testing.T) {
 	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
 		{Kind: "Deployment", APIVersion: "apps/v1", Resource: "deployments"},
 	}
-	result, _ := m.navigateToOwner("Deployment", "my-deploy")
+	result, _ := m.navigateToOwner("Deployment", "my-deploy", "apps/v1")
 	rm := result.(Model)
 	require.Len(t, rm.jumpBackStack, 1, "navigateToOwner must record the origin")
 
@@ -225,7 +225,7 @@ func TestJumpHistoryIsIndependentPerTab(t *testing.T) {
 	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
 		{Kind: "Deployment", APIVersion: "apps/v1", Resource: "deployments"},
 	}
-	resA, _ := m.navigateToOwner("Deployment", "deploy-a")
+	resA, _ := m.navigateToOwner("Deployment", "deploy-a", "apps/v1")
 	m = resA.(Model)
 	require.Len(t, m.jumpBackStack, 1, "tab A must record its own jump")
 	m.saveCurrentTab()

--- a/internal/app/kubectl_args.go
+++ b/internal/app/kubectl_args.go
@@ -1,0 +1,18 @@
+package app
+
+import "github.com/janosmiko/lfk/internal/model"
+
+// kubectlResourceArg returns how kubectl should address rt on the command
+// line: the bare plural for core types, "resource.group" for everything else.
+//
+// A bare plural is ambiguous the moment two groups define the same Kind —
+// kubectl picks whichever group discovery returns first, so an action on one
+// CRD lands on the other (issue #562). Every kubectl call site builds its
+// resource argument through here; the group is always at hand, because the
+// ResourceTypeEntry the action was launched from carries it.
+func kubectlResourceArg(rt model.ResourceTypeEntry) string {
+	if rt.Resource == "" || rt.APIGroup == "" {
+		return rt.Resource
+	}
+	return rt.Resource + "." + rt.APIGroup
+}

--- a/internal/app/kubectl_args_test.go
+++ b/internal/app/kubectl_args_test.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// A bare plural is ambiguous when two groups define the same Kind — kubectl
+// resolves it to whichever group discovery returns first, which is how issue
+// #562 hit the wrong CRD. The qualified "resource.group" form is unambiguous.
+func TestKubectlResourceArg(t *testing.T) {
+	tests := []struct {
+		name string
+		rt   model.ResourceTypeEntry
+		want string
+	}{
+		{
+			name: "core type stays bare",
+			rt:   model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1"},
+			want: "pods",
+		},
+		{
+			name: "built-in group is qualified",
+			rt:   model.ResourceTypeEntry{Kind: "Deployment", Resource: "deployments", APIGroup: "apps", APIVersion: "v1"},
+			want: "deployments.apps",
+		},
+		{
+			name: "CRD group is qualified",
+			rt:   model.ResourceTypeEntry{Kind: "MyKind", Resource: "mykinds", APIGroup: "foo.com", APIVersion: "v1"},
+			want: "mykinds.foo.com",
+		},
+		{
+			name: "same Kind in another group targets that group",
+			rt:   model.ResourceTypeEntry{Kind: "MyKind", Resource: "mykinds", APIGroup: "bar.com", APIVersion: "v1"},
+			want: "mykinds.bar.com",
+		},
+		{
+			name: "empty resource degrades to the empty string",
+			rt:   model.ResourceTypeEntry{Kind: "MyKind", APIGroup: "foo.com"},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, kubectlResourceArg(tt.rt))
+		})
+	}
+}
+
+// Two CRDs sharing a Kind must produce different kubectl targets — the whole
+// point of the fix.
+func TestKubectlResourceArg_SameKindDifferentGroups(t *testing.T) {
+	foo := model.ResourceTypeEntry{Kind: "MyKind", Resource: "mykinds", APIGroup: "foo.com", APIVersion: "v1"}
+	bar := model.ResourceTypeEntry{Kind: "MyKind", Resource: "mykinds", APIGroup: "bar.com", APIVersion: "v1"}
+
+	assert.NotEqual(t, kubectlResourceArg(foo), kubectlResourceArg(bar))
+}

--- a/internal/app/navigate_owner_group_test.go
+++ b/internal/app/navigate_owner_group_test.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// sameKindTwoGroups is the issue #562 shape: one Kind, two groups. foo.com is
+// listed first, so any Kind-only lookup resolves to it.
+func sameKindTwoGroups() []model.ResourceTypeEntry {
+	return []model.ResourceTypeEntry{
+		{Kind: "MyKind", Resource: "mykinds", APIGroup: "foo.com", APIVersion: "v1", Namespaced: true},
+		{Kind: "MyKind", Resource: "mykinds", APIGroup: "bar.com", APIVersion: "v1", Namespaced: true},
+	}
+}
+
+// Owner navigation already parses the owner's apiVersion; it must use it.
+// Jumping to a bar.com owner had been landing on foo.com because the group was
+// parsed and then dropped on the way to the Kind-only lookup.
+func TestResolveOwnerResourceType_PrefersTheOwnersGroup(t *testing.T) {
+	discovered := sameKindTwoGroups()
+
+	rt, ok := resolveOwnerResourceType("MyKind", "bar.com/v1", discovered)
+	require.True(t, ok)
+	assert.Equal(t, "bar.com", rt.APIGroup, "must follow the owner's apiVersion")
+
+	rt, ok = resolveOwnerResourceType("MyKind", "foo.com/v1", discovered)
+	require.True(t, ok)
+	assert.Equal(t, "foo.com", rt.APIGroup)
+}
+
+// A core-group owner ("v1", no slash) resolves against the empty group.
+func TestResolveOwnerResourceType_CoreGroupOwner(t *testing.T) {
+	discovered := []model.ResourceTypeEntry{
+		{Kind: "Pod", Resource: "pods", APIGroup: "", APIVersion: "v1", Namespaced: true},
+		{Kind: "Pod", Resource: "pods", APIGroup: "shadow.com", APIVersion: "v1", Namespaced: true},
+	}
+
+	rt, ok := resolveOwnerResourceType("Pod", "v1", discovered)
+	require.True(t, ok)
+	assert.Empty(t, rt.APIGroup, "core apiVersion means the core group")
+}
+
+// Callers without an apiVersion (internal jumps that pass a bare Kind) keep
+// the old first-match behavior rather than failing to resolve at all.
+func TestResolveOwnerResourceType_NoAPIVersionFallsBackToKind(t *testing.T) {
+	rt, ok := resolveOwnerResourceType("MyKind", "", sameKindTwoGroups())
+	require.True(t, ok)
+	assert.Equal(t, "foo.com", rt.APIGroup)
+}
+
+// An apiVersion naming a group that was never discovered still resolves by
+// Kind — better a best-effort jump than a dead "unknown resource type".
+func TestResolveOwnerResourceType_UndiscoveredGroupFallsBackToKind(t *testing.T) {
+	rt, ok := resolveOwnerResourceType("MyKind", "gone.com/v1", sameKindTwoGroups())
+	require.True(t, ok)
+	assert.Equal(t, "foo.com", rt.APIGroup)
+}
+
+func TestResolveOwnerResourceType_UnknownKind(t *testing.T) {
+	_, ok := resolveOwnerResourceType("Nope", "foo.com/v1", sameKindTwoGroups())
+	assert.False(t, ok)
+}

--- a/internal/app/update_actions_helm_misc.go
+++ b/internal/app/update_actions_helm_misc.go
@@ -45,7 +45,7 @@ func (m Model) executeActionGoToPod() (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 	if len(podNames) == 1 {
-		return m.navigateToOwner("Pod", podNames[0])
+		return m.navigateToOwner("Pod", podNames[0], "v1")
 	}
 	var items []model.Item
 	for _, pn := range podNames {
@@ -79,7 +79,7 @@ func (m Model) executeActionGoToNode() (tea.Model, tea.Cmd) {
 		m.setStatusMessage("Pod is not scheduled to a node", true)
 		return m, scheduleStatusClear()
 	}
-	return m.navigateToOwner("Node", nodeName)
+	return m.navigateToOwner("Node", nodeName, "v1")
 }
 
 // executeActionDebugMount handles the "Debug Mount" action.

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -498,7 +498,7 @@ func (m Model) handleExplorerActionKeyJumpOwner() (tea.Model, tea.Cmd, bool) {
 	}
 	// Use first owner (most resources have exactly one).
 	owner := owners[0]
-	ret, cmd := m.navigateToOwner(owner.kind, owner.name)
+	ret, cmd := m.navigateToOwner(owner.kind, owner.name, owner.apiVersion)
 	return ret, cmd, true
 }
 

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -216,9 +216,32 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) navigateToOwner(kind, name string) (tea.Model, tea.Cmd) {
+// resolveOwnerResourceType finds the resource type an owner reference points
+// at. apiVersion ("group/version", or "v1" for the core group) disambiguates
+// the Kind: two CRDs can share one Kind across groups, and the Kind-only
+// lookup returns whichever group discovery listed first — which sent jumps to
+// the wrong CRD entirely (issue #562). Falls back to the Kind-only lookup when
+// the caller has no apiVersion, or names a group this cluster never
+// discovered, so a best-effort jump still beats a dead end.
+func resolveOwnerResourceType(kind, apiVersion string, discovered []model.ResourceTypeEntry) (model.ResourceTypeEntry, bool) {
+	if apiVersion != "" {
+		group, _, _ := strings.Cut(apiVersion, "/")
+		if !strings.Contains(apiVersion, "/") {
+			group = "" // bare "v1" is the core group
+		}
+		if rt, ok := model.FindResourceTypeByKindAndGroup(kind, group, discovered); ok {
+			return rt, true
+		}
+	}
+	return model.FindResourceTypeByKind(kind, discovered)
+}
+
+// navigateToOwner teleports to the owning resource. apiVersion may be empty
+// for callers that only know a built-in Kind ("Pod", "Node"); see
+// resolveOwnerResourceType.
+func (m Model) navigateToOwner(kind, name, apiVersion string) (tea.Model, tea.Cmd) {
 	crds := m.discoveredResources[m.discoveryContext()]
-	rt, ok := model.FindResourceTypeByKind(kind, crds)
+	rt, ok := resolveOwnerResourceType(kind, apiVersion, crds)
 	if !ok {
 		m.setStatusMessage(fmt.Sprintf("Unknown resource type: %s", kind), true)
 		return m, scheduleStatusClear()

--- a/internal/app/update_navigation_test.go
+++ b/internal/app/update_navigation_test.go
@@ -257,7 +257,7 @@ func TestCov80EnterFullViewNoSel(t *testing.T) {
 func TestCov80NavigateToOwnerUnknownKind(t *testing.T) {
 	m := basePush80Model()
 	m.nav.Level = model.LevelResources
-	result, cmd := m.navigateToOwner("UnknownKind999", "my-resource")
+	result, cmd := m.navigateToOwner("UnknownKind999", "my-resource", "")
 	rm := result.(Model)
 	assert.True(t, rm.statusMessageErr)
 	assert.NotNil(t, cmd)
@@ -407,7 +407,7 @@ func TestCovBoost2NavigateChildNoSelection(t *testing.T) {
 func TestCovNavigateToOwnerUnknownKind(t *testing.T) {
 	m := baseModelCov()
 	m.discoveredResources = map[string][]model.ResourceTypeEntry{}
-	ret, cmd := m.navigateToOwner("UnknownKind", "some-name")
+	ret, cmd := m.navigateToOwner("UnknownKind", "some-name", "")
 	result := ret.(Model)
 	assert.True(t, result.hasStatusMessage())
 	assert.NotNil(t, cmd)

--- a/internal/app/update_overlays_logs.go
+++ b/internal/app/update_overlays_logs.go
@@ -40,7 +40,7 @@ func (m Model) handlePodSelectOverlayKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.logView.podFilterActive = false
 			if m.pendingAction == "Go to Pod" {
 				m.pendingAction = ""
-				return m.navigateToOwner("Pod", sel.Name)
+				return m.navigateToOwner("Pod", sel.Name, "v1")
 			}
 			if m.pendingAction == "Logs" {
 				m.pendingAction = ""


### PR DESCRIPTION
Fixes #562.

With two CRDs sharing a Kind across groups (`foo.com` and `bar.com`), actions on an instance of one hit the other:

```
Error from server (NotFound): foo.com "my-instance" not found
```

Two distinct causes.

## 1. kubectl invocations passed the bare plural

`kubectl describe mykinds my-instance` is ambiguous the moment two groups define the same Kind — kubectl resolves it to whichever group discovery returns first.

New `kubectlResourceArg(rt)` returns `resource.group` when the type has an API group, and the bare plural for core types. The group is always at hand: the `ResourceTypeEntry` the action launched from carries it.

| Call site | File |
|---|---|
| describe, edit | `commands_exec.go` |
| force delete, finalizer patch | `commands_exec_misc.go` |
| bulk finalizer patch, bulk force delete | `commands_bulk.go` |

## 2. Owner navigation parsed the group, then dropped it

`handleExplorerActionKeyJumpOwner` reads `apiVersion||kind||name` off the owner-reference column and called `navigateToOwner(kind, name)`, which resolved through `model.FindResourceTypeByKind` — documented first-match-wins across groups.

`navigateToOwner` now takes the apiVersion and resolves through `FindResourceTypeByKindAndGroup`, falling back to the Kind-only lookup when the caller has no apiVersion (built-in `Pod` / `Node` jumps) or names a group this cluster never discovered — a best-effort jump beats a dead end.

## Left alone, deliberately

Two Kind-only lookups have no group available without changing the data feeding them:

- `jumpToFindingResource` — the security-finding `__resource_key__` column is `namespace/Kind/name`; qualifying it means changing the producer's key format.
- `jumpToOrphan` — the orphan detector only emits core kinds (Pod, Secret, ConfigMap, Service), which cannot collide.

Worth a follow-up if the reporter sees the bug outside actions and owner jumps.

## Test plan

- [x] `internal/app/kubectl_args_test.go` — 7 cases including the same-Kind-different-group pair producing different targets
- [x] `internal/app/navigate_owner_group_test.go` — 5 cases: both groups resolve correctly, core-group owner, and both fallbacks
- [x] `go test -race ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues

@duizabojul — if you can, testing this branch against your two CRDs would confirm the fix covers the places you hit it.