### PR TITLE
chore(nix): refresh vendorHash for updated Go dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-ZyCJnSI0Lq+Fm5w6hhd/lWMZTUt0NirpwAkFrGU80lQ=";
+            vendorHash = "sha256-AsjzKYlodNv9TsWGSh34OjD/jgepx4YpGS59W9iwlSs=";
 
             subPackages = [ "." ];
 


### PR DESCRIPTION
## Summary

- Update `vendorHash` in `flake.nix` to match the current Go module vendor tree.

Without this, `nix build` fails with a hash mismatch after the last dependency bumps.

## Test plan

- [ ] `nix build` succeeds (no hash mismatch error)