### PR TITLE
fix: scope Ctrl+C bulk-action cancel to the tab that started it

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -985,7 +985,7 @@ Invalid config values are dropped at startup with a warning in the error log.
 | `[` | Previous tab |
 | `}` | Move current tab right (shift+]) |
 | `{` | Move current tab left (shift+[) |
-| `Ctrl+C` | Close current tab (quit if last tab) |
+| `Ctrl+C` | Close current tab (quit if last tab). Cancels a bulk action first, but only one started on this tab |
 
 ## Read-Only Mode
 

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -137,6 +137,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		reqCancel:                  reqCancel,
 		middleTableRenderer:        ui.NewTableRenderer(),
 		tabs: []TabState{{
+			uid:                nextTabUID(),
 			nav:                model.NavigationState{Level: model.LevelClusters},
 			namespace:          defaultNS,
 			splitPreview:       ui.ConfigSplitPreview,

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -443,6 +443,11 @@ type hpaScaleState struct {
 
 // TabState holds per-tab navigation state so each tab is fully independent.
 type TabState struct {
+	// uid identifies this tab for the lifetime of the process. Background
+	// work records it so Ctrl+C only cancels operations started from the
+	// tab the user is on (tab index shifts when tabs close or reorder).
+	uid uint64
+
 	// needsLoad is true for tabs restored from a session file that have not
 	// yet had their items loaded.  When loadTab detects this flag it triggers
 	// a full refreshCurrentLevel instead of the lighter loadPreview.

--- a/internal/app/commands_bulk.go
+++ b/internal/app/commands_bulk.go
@@ -21,12 +21,13 @@ func (m Model) bulkDeleteResources() tea.Cmd {
 	client := m.client
 	ns := m.actionNamespace()
 	registry := m.scheduler
+	owner := m.currentTabUID()
 	total := len(refs)
 	policy := m.deletePropagation()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	taskName := fmt.Sprintf("Delete %s (%d)", rt.Resource, total)
-	id := registry.StartCancellable(scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
+	id := registry.StartCancellable(owner, scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
 
 	return func() tea.Msg {
 		defer registry.Finish(id)
@@ -98,12 +99,13 @@ func (m Model) bulkForceDeleteResources() tea.Cmd {
 	client := m.client
 	ns := m.actionNamespace()
 	registry := m.scheduler
+	owner := m.currentTabUID()
 	total := len(refs)
 	cascade := m.deletePropagation()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	taskName := fmt.Sprintf("Force delete %s (%d)", rt.Resource, total)
-	id := registry.StartCancellable(scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
+	id := registry.StartCancellable(owner, scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
 
 	return func() tea.Msg {
 		defer registry.Finish(id)
@@ -190,11 +192,12 @@ func (m Model) bulkScaleResources(replicas int32) tea.Cmd {
 	client := m.client
 	ns := m.actionNamespace()
 	registry := m.scheduler
+	owner := m.currentTabUID()
 	total := len(items)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	taskName := fmt.Sprintf("Scale %s (%d)", rt.Resource, total)
-	id := registry.StartCancellable(scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
+	id := registry.StartCancellable(owner, scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
 
 	return func() tea.Msg {
 		defer registry.Finish(id)
@@ -238,11 +241,12 @@ func (m Model) bulkRestartResources() tea.Cmd {
 	client := m.client
 	ns := m.actionNamespace()
 	registry := m.scheduler
+	owner := m.currentTabUID()
 	total := len(items)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	taskName := fmt.Sprintf("Restart %s (%d)", rt.Resource, total)
-	id := registry.StartCancellable(scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
+	id := registry.StartCancellable(owner, scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
 
 	return func() tea.Msg {
 		defer registry.Finish(id)
@@ -287,6 +291,7 @@ func (m Model) batchPatchLabels(key, value string, remove bool, isAnnotation boo
 	client := m.client
 	ns := m.actionNamespace()
 	registry := m.scheduler
+	owner := m.currentTabUID()
 	total := len(items)
 
 	labelOrAnnotation := "labels"
@@ -296,7 +301,7 @@ func (m Model) batchPatchLabels(key, value string, remove bool, isAnnotation boo
 
 	ctx, cancel := context.WithCancel(context.Background())
 	taskName := fmt.Sprintf("Patch %s (%d)", labelOrAnnotation, total)
-	id := registry.StartCancellable(scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
+	id := registry.StartCancellable(owner, scheduler.KindMutation, taskName, bgtaskTarget(actionCtx, ns), cancel)
 
 	return func() tea.Msg {
 		defer registry.Finish(id)

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -695,7 +695,7 @@ func (m Model) trackBgTask(kind scheduler.Kind, name, target string, inner func(
 	if m.suppressBgtasks {
 		id = registry.StartUntracked()
 	} else {
-		id = registry.Start(kind, name, target)
+		id = registry.StartOwned(m.currentTabUID(), kind, name, target)
 	}
 	return func() tea.Msg {
 		defer registry.Finish(id)
@@ -726,6 +726,7 @@ func (m Model) scheduleK8sCall(prio scheduler.Priority, kind scheduler.Kind, nam
 		Target:      target,
 		Gen:         m.requestGen,
 		SilentTrack: m.suppressBgtasks,
+		Owner:       m.currentTabUID(),
 		Fn: func(ctx context.Context) (any, error) {
 			return fn(ctx), nil
 		},

--- a/internal/app/commands_localcluster.go
+++ b/internal/app/commands_localcluster.go
@@ -110,6 +110,7 @@ func (m Model) dispatchCreateLocalCluster(p localcluster.Provider, spec localclu
 	registry := m.scheduler
 	ctx, cancel := context.WithCancel(context.Background())
 	id := registry.StartCancellable(
+		m.currentTabUID(),
 		scheduler.KindMutation,
 		fmt.Sprintf("Create %s/%s", p.Name(), spec.Name),
 		"",
@@ -127,6 +128,7 @@ func (m Model) dispatchStartLocalCluster(p localcluster.LifecycleProvider, name 
 	registry := m.scheduler
 	ctx, cancel := context.WithCancel(context.Background())
 	id := registry.StartCancellable(
+		m.currentTabUID(),
 		scheduler.KindMutation,
 		fmt.Sprintf("Start %s/%s", p.Name(), name),
 		"",
@@ -140,6 +142,7 @@ func (m Model) dispatchStopLocalCluster(p localcluster.LifecycleProvider, name s
 	registry := m.scheduler
 	ctx, cancel := context.WithCancel(context.Background())
 	id := registry.StartCancellable(
+		m.currentTabUID(),
 		scheduler.KindMutation,
 		fmt.Sprintf("Stop %s/%s", p.Name(), name),
 		"",
@@ -153,6 +156,7 @@ func (m Model) dispatchDeleteLocalCluster(p localcluster.Provider, name string) 
 	registry := m.scheduler
 	ctx, cancel := context.WithCancel(context.Background())
 	id := registry.StartCancellable(
+		m.currentTabUID(),
 		scheduler.KindMutation,
 		fmt.Sprintf("Delete %s/%s", p.Name(), name),
 		"",

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -108,6 +108,10 @@ type Task struct {
 	Silent     bool      // suppress from title-bar indicator only
 	Current    int       // progress: items processed so far (0 = not started)
 	Total      int       // progress: total items (0 = unknown/not applicable)
+	// Owner is the UID of the tab that started the task, so Ctrl+C only
+	// cancels work started from the tab the user is looking at. 0 means
+	// no owning tab and matches every tab.
+	Owner uint64
 }
 
 // IsFinished reports whether the task has had Finish() called and is
@@ -224,14 +228,21 @@ func (r *Registry) SetLingerDurationForTest(d time.Duration) {
 // without a registry (e.g. minimal test fixtures). Finish(0) is already
 // a no-op, so the standard defer pattern still works.
 func (r *Registry) Start(kind Kind, name, target string) uint64 {
-	return r.startWithPriority(kind, DefaultPriorityFor(kind), name, target, false)
+	return r.StartOwned(0, kind, name, target)
+}
+
+// StartOwned is Start with an owning tab UID recorded on the task, so
+// per-tab cancellation (Ctrl+C) only reaches work started from that tab.
+// Owner 0 means "no owning tab" and matches every tab.
+func (r *Registry) StartOwned(owner uint64, kind Kind, name, target string) uint64 {
+	return r.startWithPriority(kind, DefaultPriorityFor(kind), name, target, false, owner)
 }
 
 // startWithPriority is the internal variant of Start that lets scheduler
 // workers override the priority lookup with the submission's explicit
 // choice and mark routine work as silent. External callers use Start
 // and get DefaultPriorityFor(kind), Silent=false.
-func (r *Registry) startWithPriority(kind Kind, prio Priority, name, target string, silent bool) uint64 {
+func (r *Registry) startWithPriority(kind Kind, prio Priority, name, target string, silent bool, owner uint64) uint64 {
 	if r == nil {
 		return 0
 	}
@@ -244,6 +255,7 @@ func (r *Registry) startWithPriority(kind Kind, prio Priority, name, target stri
 		Target:    target,
 		StartedAt: time.Now(),
 		Silent:    silent,
+		Owner:     owner,
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -275,9 +287,9 @@ func (r *Registry) StartUntracked() uint64 {
 
 // StartCancellable records a new tracked task with a cancel function and
 // returns its ID. The cancel function can be invoked later via Cancel(id)
-// or CancelMutations(). Otherwise identical to Start.
-func (r *Registry) StartCancellable(kind Kind, name, target string, cancel context.CancelFunc) uint64 {
-	id := r.Start(kind, name, target)
+// or CancelMutationsOwnedBy(owner). Otherwise identical to StartOwned.
+func (r *Registry) StartCancellable(owner uint64, kind Kind, name, target string, cancel context.CancelFunc) uint64 {
+	id := r.StartOwned(owner, kind, name, target)
 	if r == nil || id == 0 {
 		return id
 	}
@@ -322,17 +334,41 @@ func (r *Registry) Cancel(id uint64) {
 	}
 }
 
-// CancelMutations cancels all in-flight tasks of KindMutation that have
-// a registered cancel function. Used when the user presses Ctrl+C or Esc
-// during bulk operations.
-func (r *Registry) CancelMutations() {
+// ownedBy reports whether a task belongs to the given tab. Tasks started
+// without an owner (Owner 0) match every tab so untagged work stays
+// cancellable from wherever the user is.
+func (t *Task) ownedBy(owner uint64) bool {
+	return t.Owner == 0 || t.Owner == owner
+}
+
+// DisownTasks clears the owner on every task started by the given tab, so
+// work outliving its tab stays cancellable from the remaining ones. Called
+// when a tab closes — UIDs are never reused, so an owner that no longer
+// exists would otherwise match no tab at all.
+func (r *Registry) DisownTasks(owner uint64) {
+	if r == nil || owner == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, t := range r.tasks {
+		if t.Owner == owner {
+			t.Owner = 0
+		}
+	}
+}
+
+// CancelMutationsOwnedBy cancels the in-flight KindMutation tasks started
+// from the given tab that have a registered cancel function. Used when
+// the user presses Ctrl+C or Esc during bulk operations.
+func (r *Registry) CancelMutationsOwnedBy(owner uint64) {
 	if r == nil {
 		return
 	}
 	r.mu.Lock()
 	var toCancel []context.CancelFunc
 	for id, t := range r.tasks {
-		if t.Kind == KindMutation {
+		if t.Kind == KindMutation && t.ownedBy(owner) {
 			if fn, ok := r.cancels[id]; ok {
 				toCancel = append(toCancel, fn)
 				delete(r.cancels, id)
@@ -345,10 +381,11 @@ func (r *Registry) CancelMutations() {
 	}
 }
 
-// HasActiveMutations returns true if there are any in-flight KindMutation
-// tasks. Used by the key handler to decide whether Ctrl+C/Esc should
-// cancel bulk operations instead of closing the tab/quitting.
-func (r *Registry) HasActiveMutations() bool {
+// HasActiveMutationsOwnedBy returns true if the given tab has in-flight
+// KindMutation tasks. Used by the key handler to decide whether Ctrl+C/Esc
+// should cancel bulk operations instead of closing the tab/quitting — work
+// started on another tab must not swallow the key.
+func (r *Registry) HasActiveMutationsOwnedBy(owner uint64) bool {
 	if r == nil {
 		return false
 	}
@@ -357,7 +394,7 @@ func (r *Registry) HasActiveMutations() bool {
 	for _, t := range r.tasks {
 		// Finished-lingering mutations are not "active" — they have
 		// already returned. Only in-flight mutations count.
-		if t.Kind == KindMutation && t.FinishedAt.IsZero() {
+		if t.Kind == KindMutation && t.FinishedAt.IsZero() && t.ownedBy(owner) {
 			return true
 		}
 	}

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -37,6 +37,12 @@ const DefaultCompletedCap = 1000
 // and only the history entry remains.
 const DefaultLingerDuration = 10 * time.Second
 
+// disownedCap bounds the set of closed-tab UIDs kept for stripping
+// ownership off work queued before the tab closed. Only tabs closed
+// while work is still queued matter, and queues drain in seconds, so a
+// small window is enough.
+const disownedCap = 64
+
 // Kind classifies a tracked async operation. Used to label rows in the
 // :tasks overlay.
 type Kind int
@@ -147,10 +153,15 @@ func (c CompletedTask) Duration() time.Duration {
 // Registry is a process-global record of tracked operations.
 // Safe for concurrent use from any number of goroutines.
 type Registry struct {
-	mu             sync.Mutex
-	tasks          map[uint64]*Task
-	cancels        map[uint64]context.CancelFunc // cancel funcs for cancellable tasks
-	order          []uint64                      // insertion order for stable Snapshot output
+	mu      sync.Mutex
+	tasks   map[uint64]*Task
+	cancels map[uint64]context.CancelFunc // cancel funcs for cancellable tasks
+	// disowned holds the UIDs of closed tabs. Work already queued when a
+	// tab closes registers later, so the owner is stripped at Start time
+	// too — otherwise it would come back owned by a tab that is gone.
+	disowned       map[uint64]struct{}
+	disownedOrder  []uint64 // insertion order, for the cap
+	order          []uint64 // insertion order for stable Snapshot output
 	nextID         atomic.Uint64
 	threshold      time.Duration
 	lingerDuration time.Duration   // how long finished tasks stay in the Running list
@@ -189,6 +200,7 @@ func NewWithCap(threshold time.Duration, completedCap int) *Registry {
 	return &Registry{
 		tasks:          make(map[uint64]*Task),
 		cancels:        make(map[uint64]context.CancelFunc),
+		disowned:       make(map[uint64]struct{}),
 		threshold:      threshold,
 		lingerDuration: DefaultLingerDuration,
 		completedCap:   completedCap,
@@ -259,9 +271,14 @@ func (r *Registry) startWithPriority(kind Kind, prio Priority, name, target stri
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	// Dedupe: drop any prior task with the same visible signature.
+	if _, dead := r.disowned[task.Owner]; dead {
+		task.Owner = 0
+	}
+	// Dedupe: drop any prior task with the same visible signature. Owner is
+	// part of the signature — two tabs running the same operation are two
+	// operations, and collapsing them would leave the loser uncancellable.
 	for oldID, t := range r.tasks {
-		if t.Kind == kind && t.Name == name && t.Target == target {
+		if t.Kind == kind && t.Name == name && t.Target == target && t.Owner == task.Owner {
 			delete(r.tasks, oldID)
 			delete(r.cancels, oldID)
 			for i, oid := range r.order {
@@ -355,6 +372,17 @@ func (r *Registry) DisownTasks(owner uint64) {
 		if t.Owner == owner {
 			t.Owner = 0
 		}
+	}
+	if _, seen := r.disowned[owner]; seen {
+		return
+	}
+	r.disowned[owner] = struct{}{}
+	r.disownedOrder = append(r.disownedOrder, owner)
+	// Evict the oldest entries past the cap. Queued work starts within
+	// seconds, so a UID that old can no longer have anything pending.
+	for len(r.disownedOrder) > disownedCap {
+		delete(r.disowned, r.disownedOrder[0])
+		r.disownedOrder = r.disownedOrder[1:]
 	}
 }
 

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -37,12 +37,6 @@ const DefaultCompletedCap = 1000
 // and only the history entry remains.
 const DefaultLingerDuration = 10 * time.Second
 
-// disownedCap bounds the set of closed-tab UIDs kept for stripping
-// ownership off work queued before the tab closed. Only tabs closed
-// while work is still queued matter, and queues drain in seconds, so a
-// small window is enough.
-const disownedCap = 64
-
 // Kind classifies a tracked async operation. Used to label rows in the
 // :tasks overlay.
 type Kind int
@@ -159,8 +153,11 @@ type Registry struct {
 	// disowned holds the UIDs of closed tabs. Work already queued when a
 	// tab closes registers later, so the owner is stripped at Start time
 	// too — otherwise it would come back owned by a tab that is gone.
+	// Entries are never evicted: a queued task can register at any later
+	// point, and there is no moment where that becomes impossible (it may
+	// sit behind arbitrarily long work). Growth is one 8-byte key per tab
+	// the user closes, so even an extreme session stays well under 100 KB.
 	disowned       map[uint64]struct{}
-	disownedOrder  []uint64 // insertion order, for the cap
 	order          []uint64 // insertion order for stable Snapshot output
 	nextID         atomic.Uint64
 	threshold      time.Duration
@@ -373,17 +370,7 @@ func (r *Registry) DisownTasks(owner uint64) {
 			t.Owner = 0
 		}
 	}
-	if _, seen := r.disowned[owner]; seen {
-		return
-	}
 	r.disowned[owner] = struct{}{}
-	r.disownedOrder = append(r.disownedOrder, owner)
-	// Evict the oldest entries past the cap. Queued work starts within
-	// seconds, so a UID that old can no longer have anything pending.
-	for len(r.disownedOrder) > disownedCap {
-		delete(r.disowned, r.disownedOrder[0])
-		r.disownedOrder = r.disownedOrder[1:]
-	}
 }
 
 // CancelMutationsOwnedBy cancels the in-flight KindMutation tasks started

--- a/internal/app/scheduler/registry_test.go
+++ b/internal/app/scheduler/registry_test.go
@@ -624,16 +624,21 @@ func TestStartStripsOwnerOfAlreadyClosedTab(t *testing.T) {
 	assert.True(t, r.HasActiveMutationsOwnedBy(9), "work from a closed tab must be cancellable anywhere")
 }
 
-func TestDisownedSetIsBounded(t *testing.T) {
+// A queued task can register long after its tab closed, with any number of
+// other tabs closing in between. The closed-owner record must survive that.
+func TestStartStripsOwnerAfterManyLaterClosures(t *testing.T) {
 	r := New(0)
-	for i := uint64(1); i <= disownedCap+10; i++ {
+	r.DisownTasks(1)
+	for i := uint64(2); i <= 200; i++ {
 		r.DisownTasks(i)
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	assert.Len(t, r.disowned, disownedCap)
-	assert.Len(t, r.disownedOrder, disownedCap)
+	cancelled := false
+	r.StartCancellable(1, KindMutation, "Delete", "ns", func() { cancelled = true })
+
+	assert.True(t, r.HasActiveMutationsOwnedBy(999), "late registration from a closed tab must stay cancellable")
+	r.CancelMutationsOwnedBy(999)
+	assert.True(t, cancelled)
 }
 
 func TestDisownTasksIgnoresOtherOwners(t *testing.T) {

--- a/internal/app/scheduler/registry_test.go
+++ b/internal/app/scheduler/registry_test.go
@@ -602,6 +602,40 @@ func TestDisownTasksMakesThemCancellableFromAnyTab(t *testing.T) {
 	assert.True(t, cancelled)
 }
 
+func TestSameSignatureTasksFromTwoTabsBothSurvive(t *testing.T) {
+	r := New(0)
+	cancelledA, cancelledB := false, false
+	r.StartCancellable(7, KindMutation, "Delete pods (5)", "prod / ns", func() { cancelledA = true })
+	r.StartCancellable(8, KindMutation, "Delete pods (5)", "prod / ns", func() { cancelledB = true })
+
+	assert.Len(t, r.Snapshot(), 2, "identical labels from two tabs are two operations")
+
+	r.CancelMutationsOwnedBy(8)
+	assert.False(t, cancelledA, "the other tab's task must keep its cancel func")
+	assert.True(t, cancelledB)
+}
+
+func TestStartStripsOwnerOfAlreadyClosedTab(t *testing.T) {
+	r := New(0)
+	// The tab closes while the work is still queued; it registers afterwards.
+	r.DisownTasks(7)
+	r.StartOwned(7, KindMutation, "Delete", "ns")
+
+	assert.True(t, r.HasActiveMutationsOwnedBy(9), "work from a closed tab must be cancellable anywhere")
+}
+
+func TestDisownedSetIsBounded(t *testing.T) {
+	r := New(0)
+	for i := uint64(1); i <= disownedCap+10; i++ {
+		r.DisownTasks(i)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	assert.Len(t, r.disowned, disownedCap)
+	assert.Len(t, r.disownedOrder, disownedCap)
+}
+
 func TestDisownTasksIgnoresOtherOwners(t *testing.T) {
 	r := New(0)
 	r.StartOwned(7, KindMutation, "Delete", "ns")

--- a/internal/app/scheduler/registry_test.go
+++ b/internal/app/scheduler/registry_test.go
@@ -529,7 +529,7 @@ func TestUpdateProgressNilReceiver(t *testing.T) {
 func TestStartCancellable(t *testing.T) {
 	r := New(0)
 	cancelled := false
-	id := r.StartCancellable(KindMutation, "Delete", "ns", func() { cancelled = true })
+	id := r.StartCancellable(0, KindMutation, "Delete", "ns", func() { cancelled = true })
 	assert.NotZero(t, id)
 	snap := r.Snapshot()
 	require.Len(t, snap, 1)
@@ -551,10 +551,10 @@ func TestCancelNilReceiver(t *testing.T) {
 func TestCancelMutations(t *testing.T) {
 	r := New(0)
 	cancelled1, cancelled2, cancelled3 := false, false, false
-	r.StartCancellable(KindMutation, "Delete", "ns", func() { cancelled1 = true })
-	r.StartCancellable(KindMutation, "Scale", "ns", func() { cancelled2 = true })
-	r.StartCancellable(KindResourceList, "List Pods", "ns", func() { cancelled3 = true })
-	r.CancelMutations()
+	r.StartCancellable(0, KindMutation, "Delete", "ns", func() { cancelled1 = true })
+	r.StartCancellable(0, KindMutation, "Scale", "ns", func() { cancelled2 = true })
+	r.StartCancellable(0, KindResourceList, "List Pods", "ns", func() { cancelled3 = true })
+	r.CancelMutationsOwnedBy(1)
 	assert.True(t, cancelled1, "mutation task 1 should be cancelled")
 	assert.True(t, cancelled2, "mutation task 2 should be cancelled")
 	assert.False(t, cancelled3, "non-mutation task should not be cancelled")
@@ -562,30 +562,95 @@ func TestCancelMutations(t *testing.T) {
 
 func TestCancelMutationsNilReceiver(t *testing.T) {
 	var r *Registry
-	r.CancelMutations() // should not panic
+	r.CancelMutationsOwnedBy(1) // should not panic
+}
+
+func TestCancelMutationsOwnedByScopesToOwner(t *testing.T) {
+	r := New(0)
+	mine, theirs, unowned := false, false, false
+	r.StartCancellable(7, KindMutation, "Delete", "ns", func() { mine = true })
+	r.StartCancellable(8, KindMutation, "Scale", "ns", func() { theirs = true })
+	r.StartCancellable(0, KindMutation, "Restart", "ns", func() { unowned = true })
+
+	r.CancelMutationsOwnedBy(7)
+
+	assert.True(t, mine, "own tab's mutation should be cancelled")
+	assert.False(t, theirs, "another tab's mutation should survive")
+	assert.True(t, unowned, "unowned mutation should be cancelled from any tab")
+}
+
+func TestHasActiveMutationsOwnedByScopesToOwner(t *testing.T) {
+	r := New(0)
+	id := r.StartOwned(7, KindMutation, "Delete", "ns")
+
+	assert.True(t, r.HasActiveMutationsOwnedBy(7))
+	assert.False(t, r.HasActiveMutationsOwnedBy(8), "another tab must not see this mutation")
+
+	r.Finish(id)
+	assert.False(t, r.HasActiveMutationsOwnedBy(7))
+}
+
+func TestDisownTasksMakesThemCancellableFromAnyTab(t *testing.T) {
+	r := New(0)
+	cancelled := false
+	r.StartCancellable(7, KindMutation, "Delete", "ns", func() { cancelled = true })
+
+	r.DisownTasks(7)
+
+	assert.True(t, r.HasActiveMutationsOwnedBy(9), "disowned task should match any tab")
+	r.CancelMutationsOwnedBy(9)
+	assert.True(t, cancelled)
+}
+
+func TestDisownTasksIgnoresOtherOwners(t *testing.T) {
+	r := New(0)
+	r.StartOwned(7, KindMutation, "Delete", "ns")
+
+	r.DisownTasks(8)
+
+	assert.False(t, r.HasActiveMutationsOwnedBy(9), "another tab's task must keep its owner")
+}
+
+func TestDisownTasksZeroOwnerAndNilReceiver(t *testing.T) {
+	r := New(0)
+	r.StartOwned(7, KindMutation, "Delete", "ns")
+	r.DisownTasks(0) // no-op: 0 is the unowned sentinel, not a tab
+	assert.False(t, r.HasActiveMutationsOwnedBy(9))
+
+	var nilReg *Registry
+	nilReg.DisownTasks(1) // should not panic
+}
+
+func TestStartOwnedRecordsOwnerInSnapshot(t *testing.T) {
+	r := New(0)
+	r.StartOwned(42, KindMutation, "Delete", "ns")
+
+	snap := r.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, uint64(42), snap[0].Owner)
 }
 
 func TestHasActiveMutations(t *testing.T) {
 	r := New(0)
-	assert.False(t, r.HasActiveMutations())
+	assert.False(t, r.HasActiveMutationsOwnedBy(1))
 	id := r.Start(KindResourceList, "List", "ns")
-	assert.False(t, r.HasActiveMutations())
+	assert.False(t, r.HasActiveMutationsOwnedBy(1))
 	r.Finish(id)
 	mutID := r.Start(KindMutation, "Delete", "ns")
-	assert.True(t, r.HasActiveMutations())
+	assert.True(t, r.HasActiveMutationsOwnedBy(1))
 	r.Finish(mutID)
-	assert.False(t, r.HasActiveMutations())
+	assert.False(t, r.HasActiveMutationsOwnedBy(1))
 }
 
 func TestHasActiveMutationsNilReceiver(t *testing.T) {
 	var r *Registry
-	assert.False(t, r.HasActiveMutations())
+	assert.False(t, r.HasActiveMutationsOwnedBy(1))
 }
 
 func TestFinishCleansCancelFunc(t *testing.T) {
 	r := New(0)
 	cancelled := false
-	id := r.StartCancellable(KindMutation, "Delete", "ns", func() { cancelled = true })
+	id := r.StartCancellable(0, KindMutation, "Delete", "ns", func() { cancelled = true })
 	r.Finish(id)
 	r.Cancel(id) // should be no-op after Finish
 	assert.False(t, cancelled, "cancel func should be removed by Finish")

--- a/internal/app/scheduler/scheduler.go
+++ b/internal/app/scheduler/scheduler.go
@@ -23,6 +23,7 @@ type SubmitReq struct {
 	Timeout     time.Duration                      // 0 = use config-default for Kind
 	SilentTrack bool                               // mirrors existing suppressBgtasks
 	Gen         uint64                             // caller's requestGen for Sig
+	Owner       uint64                             // UID of the tab that submitted the work
 }
 
 // Sig returns the coalesce signature for this submission.

--- a/internal/app/scheduler/scheduler_workers.go
+++ b/internal/app/scheduler/scheduler_workers.go
@@ -374,7 +374,7 @@ func (r *Registry) runTask(task *queuedTask) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	rt := &runningTask{task: task, cancel: cancel}
 
-	visID := r.startWithPriority(task.req.Kind, task.req.Priority, task.req.Name, task.req.Target, task.req.SilentTrack)
+	visID := r.startWithPriority(task.req.Kind, task.req.Priority, task.req.Name, task.req.Target, task.req.SilentTrack, task.req.Owner)
 	r.registerRunning(task.req.KubeContext, rt)
 	value, err := task.req.Fn(ctx)
 	cancel()

--- a/internal/app/tab_scoped_cancel_test.go
+++ b/internal/app/tab_scoped_cancel_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+)
+
+// ctrlC builds the key message the explorer nav handler sees for Ctrl+C.
+func ctrlC() tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+}
+
+// TestCtrlCOnOtherTabClosesTabInsteadOfCancelling covers the reported bug: a
+// bulk mutation started on tab 0 swallowed Ctrl+C on every other tab, so the
+// user could not close the tab they were actually looking at.
+func TestCtrlCOnOtherTabClosesTabInsteadOfCancelling(t *testing.T) {
+	m := threeTabModel(0)
+	m.scheduler = scheduler.New(0)
+	owner := m.currentTabUID()
+	cancelled := false
+	m.scheduler.StartCancellable(owner, scheduler.KindMutation, "Sync ArgoApps (12)", "prod", func() { cancelled = true })
+
+	// Move to a different tab and press Ctrl+C.
+	m.activeTab = 1
+	ret, _, handled := m.handleExplorerNavKey(ctrlC())
+	assert.True(t, handled, "ctrl+c must be handled")
+	result := ret.(Model)
+
+	assert.False(t, cancelled, "mutation owned by another tab must not be cancelled")
+	assert.Len(t, result.tabs, 2, "ctrl+c on a foreign tab must close that tab")
+}
+
+// TestCtrlCOnOwningTabCancelsMutation keeps the original behaviour: on the tab
+// that started the mutation, Ctrl+C cancels instead of closing the tab.
+func TestCtrlCOnOwningTabCancelsMutation(t *testing.T) {
+	m := threeTabModel(0)
+	m.scheduler = scheduler.New(0)
+	owner := m.currentTabUID()
+	cancelled := false
+	m.scheduler.StartCancellable(owner, scheduler.KindMutation, "Sync ArgoApps (12)", "prod", func() { cancelled = true })
+
+	ret, _, handled := m.handleExplorerNavKey(ctrlC())
+	assert.True(t, handled, "ctrl+c must be handled")
+	result := ret.(Model)
+
+	assert.True(t, cancelled, "mutation owned by the active tab must be cancelled")
+	assert.Len(t, result.tabs, 3, "the owning tab must stay open")
+}
+
+// TestClosingOwningTabDisownsItsMutations covers the orphan case: tab UIDs are
+// never reused, so a mutation left owned by a closed tab could never be
+// cancelled again. Closing the tab hands its work back to every tab.
+func TestClosingOwningTabDisownsItsMutations(t *testing.T) {
+	m := threeTabModel(0)
+	m.scheduler = scheduler.New(0)
+	owner := m.currentTabUID()
+	cancelled := false
+	m.scheduler.StartCancellable(owner, scheduler.KindMutation, "Sync ArgoApps (12)", "prod", func() { cancelled = true })
+
+	ret, _ := m.closeTabOrQuit()
+	result := ret.(Model)
+	require.Len(t, result.tabs, 2, "owning tab should be closed")
+
+	// A surviving tab must still be able to cancel the orphaned mutation.
+	assert.True(t, result.scheduler.HasActiveMutationsOwnedBy(result.currentTabUID()))
+	result.scheduler.CancelMutationsOwnedBy(result.currentTabUID())
+	assert.True(t, cancelled, "orphaned mutation must stay cancellable")
+}
+
+// TestTabUIDsAreUnique guards the identity the ownership check relies on:
+// cloned tabs must not share the source tab's UID.
+func TestTabUIDsAreUnique(t *testing.T) {
+	m := threeTabModel(0)
+	first := m.currentTabUID()
+	clone := m.cloneCurrentTab()
+
+	assert.NotZero(t, first, "active tab must have a UID")
+	assert.NotZero(t, clone.uid, "cloned tab must get its own UID")
+	assert.NotEqual(t, first, clone.uid, "cloned tab must not inherit the source tab's UID")
+}

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -12,6 +13,10 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
+
+// tabUIDSeq issues tab UIDs. Process-global so every tab of every Model
+// gets a distinct value.
+var tabUIDSeq atomic.Uint64
 
 // pushLeft saves the current leftItems and promotes middleItems to become the new leftItems.
 func (m *Model) pushLeft() {
@@ -661,9 +666,29 @@ func (m *Model) moveActiveTab(direction int) bool {
 	return true
 }
 
+// nextTabUID hands out the stable per-tab identity used to attribute
+// background work to the tab that started it. Tab index cannot serve as
+// that identity: closing or reordering tabs shifts it.
+func nextTabUID() uint64 {
+	return tabUIDSeq.Add(1)
+}
+
+// currentTabUID returns the active tab's UID, or 0 when there is no tab
+// (minimal test fixtures). 0 means "unowned" to the scheduler.
+func (m *Model) currentTabUID() uint64 {
+	if m.activeTab < 0 || m.activeTab >= len(m.tabs) {
+		return 0
+	}
+	if m.tabs[m.activeTab].uid == 0 {
+		m.tabs[m.activeTab].uid = nextTabUID()
+	}
+	return m.tabs[m.activeTab].uid
+}
+
 // cloneCurrentTab creates a deep copy of the current model state as a new TabState.
 func (m *Model) cloneCurrentTab() TabState {
 	newTab := TabState{
+		uid:                     nextTabUID(),
 		nav:                     m.nav,
 		leftItems:               append([]model.Item(nil), m.leftItems...),
 		middleItems:             append([]model.Item(nil), m.middleItems...),

--- a/internal/app/update_actions_misc.go
+++ b/internal/app/update_actions_misc.go
@@ -126,6 +126,7 @@ func (m *Model) cancelAllTabLogStreams() {
 func (m Model) closeTabOrQuit() (tea.Model, tea.Cmd) {
 	if len(m.tabs) > 1 {
 		m.cancelActiveTabLogStreams()
+		m.scheduler.DisownTasks(m.currentTabUID())
 		m.tabs = append(m.tabs[:m.activeTab], m.tabs[m.activeTab+1:]...)
 		if m.activeTab > 0 {
 			m.activeTab--

--- a/internal/app/update_bookmarks_session.go
+++ b/internal/app/update_bookmarks_session.go
@@ -242,6 +242,7 @@ func (m Model) restoreMultiTabSession(sess *SessionState, contexts []model.Item)
 
 func buildSessionTabState(st *SessionTab, discovered []model.ResourceTypeEntry) TabState {
 	tab := TabState{
+		uid: nextTabUID(),
 		nav: model.NavigationState{
 			Context: st.Context,
 		},

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -137,11 +137,16 @@ func (m Model) handleExplorerSelectionKey(msg tea.KeyPressMsg) (tea.Model, tea.C
 func (m Model) handleExplorerNavKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
 	kb := ui.ActiveKeybindings
 
-	if m.scheduler != nil && m.scheduler.HasActiveMutations() {
+	// Only this tab's own mutations intercept Ctrl+C/Esc. Work started on
+	// another tab must not swallow the key — the user expects it to close
+	// the tab they are looking at.
+	if m.scheduler != nil {
 		if key := msg.String(); key == "ctrl+c" || key == "esc" {
-			m.scheduler.CancelMutations()
-			m.setStatusMessage("Cancelling...", false)
-			return m, nil, true
+			if owner := m.currentTabUID(); m.scheduler.HasActiveMutationsOwnedBy(owner) {
+				m.scheduler.CancelMutationsOwnedBy(owner)
+				m.setStatusMessage("Cancelling...", false)
+				return m, nil, true
+			}
 		}
 	}
 
@@ -290,6 +295,7 @@ func (m Model) handleExplorerEsc() (tea.Model, tea.Cmd) {
 	}
 	if m.nav.Level == model.LevelClusters && len(m.tabs) > 1 {
 		m.cancelActiveTabLogStreams()
+		m.scheduler.DisownTasks(m.currentTabUID())
 		m.tabs = append(m.tabs[:m.activeTab], m.tabs[m.activeTab+1:]...)
 		if m.activeTab > 0 {
 			m.activeTab--

--- a/internal/app/update_keys_test.go
+++ b/internal/app/update_keys_test.go
@@ -1594,7 +1594,7 @@ func TestDescribeSearchSwallowsNewTabKey(t *testing.T) {
 func TestCtrlCCancelsMutationsInsteadOfClosingTab(t *testing.T) {
 	cancelled := false
 	r := scheduler.New(0)
-	r.StartCancellable(scheduler.KindMutation, "Delete pods (5)", "ctx / ns", func() { cancelled = true })
+	r.StartCancellable(0, scheduler.KindMutation, "Delete pods (5)", "ctx / ns", func() { cancelled = true })
 
 	m := baseModelNav()
 	m.scheduler = r
@@ -1610,7 +1610,7 @@ func TestCtrlCCancelsMutationsInsteadOfClosingTab(t *testing.T) {
 func TestEscCancelsMutationsInsteadOfNavigatingBack(t *testing.T) {
 	cancelled := false
 	r := scheduler.New(0)
-	r.StartCancellable(scheduler.KindMutation, "Scale deploys (3)", "ctx / ns", func() { cancelled = true })
+	r.StartCancellable(0, scheduler.KindMutation, "Scale deploys (3)", "ctx / ns", func() { cancelled = true })
 
 	m := baseModelNav()
 	m.scheduler = r


### PR DESCRIPTION
## Problem

Start a long-running bulk action (e.g. select all ArgoCD Applications, `x` -> `s`), switch to a different tab, press `Ctrl+C`: the tab does not close, the action is "cancelled" instead.

The scheduler registry was global. `HasActiveMutations()` returned true for any in-flight mutation anywhere, so the `Ctrl+C`/`Esc` gate in `handleExplorerNavKey` swallowed the key on every tab.

## Fix

- `TabState.uid` — stable per-tab identity (tab index shifts on close/reorder, so it cannot serve).
- `scheduler.Task.Owner` — every task records the tab that started it. Tagged at all three mutation entry points: `trackBgTask`, `scheduleK8sCall`, `StartCancellable`. Owner `0` means unowned and matches every tab.
- `Ctrl+C`/`Esc` uses `HasActiveMutationsOwnedBy` / `CancelMutationsOwnedBy`. Foreign work no longer intercepts the key.
- Closing a tab calls `DisownTasks(uid)` so its still-running work stays cancellable from the remaining tabs — UIDs are never reused, so the task would otherwise be permanently orphaned.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] New tests: `internal/app/tab_scoped_cancel_test.go` (foreign tab closes, owning tab cancels, closing owner disowns, UID uniqueness) and owner-scoping unit tests in `internal/app/scheduler/registry_test.go`
- [x] Verified the new tests fail when the ownership check is removed
- [ ] Manual: bulk ArgoCD sync on tab 1, switch to tab 2, `Ctrl+C` closes tab 2 and the sync keeps running

## Notes

Out of scope: `bulkSyncArgoApps` / `bulkRefreshArgoApps` register via `trackBgTask` with no cancel func, so even on the owning tab `Ctrl+C` shows "Cancelling..." without stopping them. Separate fix.