### PR TITLE
fix: apply dual colorscheme again under Bubble Tea v2 (#580)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/atotto/clipboard v0.1.4
+	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/google/gopacket v1.1.19
@@ -26,7 +27,6 @@ require (
 
 require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/internal/app/recompose_theme_test.go
+++ b/internal/app/recompose_theme_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -140,6 +141,44 @@ func TestColorschemeLivePreviewRecomposesFooters(t *testing.T) {
 	assert.Equal(t, overlayColorscheme, result.overlay, "overlay stays open during preview")
 	assert.NotEqual(t, before, result.metricsContent,
 		"moving the cursor must recompose the metrics footer with the previewed theme")
+}
+
+// TestColorModeReportRecomposesFooters guards the auto dark/light path: when
+// the terminal reports a color-mode flip, the configured scheme is applied
+// outside the model, so the cached footers must be recomposed too — otherwise
+// they keep the previous theme's baked colors until the next data tick.
+func TestColorModeReportRecomposesFooters(t *testing.T) {
+	withTrueColor(t)
+	origDark := ui.ConfigDarkColorscheme
+	origLight := ui.ConfigLightColorscheme
+	t.Cleanup(func() {
+		ui.ConfigDarkColorscheme = origDark
+		ui.ConfigLightColorscheme = origLight
+	})
+	ui.ConfigDarkColorscheme = "dracula"
+	ui.ConfigLightColorscheme = "rose-pine-dawn"
+	ui.SetColorMode(true)
+
+	m := Model{
+		width:  120,
+		height: 40,
+		tabs:   []TabState{{}},
+		metricsData: &metricsInputs{
+			cpuUsed: 500, cpuReq: 1000, cpuLim: 2000,
+			memUsed: 256, memReq: 512, memLim: 1024,
+		},
+		nav: model.NavigationState{Context: "ctx"},
+	}
+	m = m.recomposeMetrics()
+	before := m.metricsContent
+	require.NotEmpty(t, before)
+
+	ret, _ := m.updateImpl(uv.LightColorSchemeEvent{})
+	result := ret.(Model)
+
+	assert.Equal(t, "rose-pine-dawn", ui.ActiveSchemeName, "light report must apply the light scheme")
+	assert.NotEqual(t, before, result.metricsContent,
+		"a color-mode flip must recompose the metrics footer with the new theme")
 }
 
 // TestRecomposeIsNoOpWithoutRetainedData ensures recompose leaves the footers

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -75,7 +75,10 @@ func (m Model) updateImpl(msg tea.Msg) (tea.Model, tea.Cmd) {
 	default:
 		if dark, ok := ui.ParseColorModeMsg(msg); ok {
 			ui.SetColorMode(dark)
-			return m, nil
+			// The scheme is applied outside the model, so the cached previews
+			// still hold the previous theme's baked colors; re-render them now
+			// instead of leaving them stale until the next data tick.
+			return m.recomposeThemedContent(), nil
 		}
 		if mdl, cmd, ok := m.updateResourceMsg(msg); ok {
 			return mdl, cmd

--- a/internal/ui/colormode.go
+++ b/internal/ui/colormode.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	tea "charm.land/bubbletea/v2"
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -19,17 +20,25 @@ var (
 )
 
 // ParseColorModeMsg inspects an arbitrary bubbletea message to determine
-// whether it is an unrecognized CSI sequence carrying a CSI ?997 dark/light
-// color-mode report (Color Palette Update Notifications protocol).
+// whether it carries a CSI ?997 dark/light color-mode report (Color Palette
+// Update Notifications protocol).
 //
-// bubbletea wraps unknown CSI sequences in an unexported named []byte type
-// (unknownCSISequenceMsg). We use reflection to reach the raw bytes and match
-// against the known sequences without importing that private type.
-// A named-type check (Name() != "") ensures plain []byte values are ignored.
+// bubbletea v2 decodes the report into a typed ultraviolet event, which it
+// passes through untranslated. Older bubbletea wrapped unrecognized CSI
+// sequences in an unexported named []byte type (unknownCSISequenceMsg); that
+// path is kept as a fallback, matched by reflection so the private type need
+// not be imported. A named-type check (Name() != "") ensures plain []byte
+// values are ignored.
 //
 // Returns (dark=true, true) for a dark-mode report, (dark=false, true) for a
 // light-mode report, and (_, false) when msg is unrelated.
 func ParseColorModeMsg(msg tea.Msg) (dark bool, ok bool) {
+	switch msg.(type) {
+	case uv.DarkColorSchemeEvent:
+		return true, true
+	case uv.LightColorSchemeEvent:
+		return false, true
+	}
 	rv := reflect.ValueOf(msg)
 	rt := reflect.TypeOf(msg)
 	// Require a named slice-of-bytes (like unknownCSISequenceMsg), not plain []byte.

--- a/internal/ui/colormode_test.go
+++ b/internal/ui/colormode_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"testing"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,6 +25,18 @@ func TestParseColorModeMsg_Light(t *testing.T) {
 	dark, ok := ParseColorModeMsg(msg)
 	assert.True(t, ok, "CSI ?997;2n should be recognized as a color-mode report")
 	assert.False(t, dark, "CSI ?997;2n should report light mode")
+}
+
+// bubbletea v2 decodes CSI ?997 into typed ultraviolet events instead of the
+// raw byte message v1 delivered; both shapes must keep working.
+func TestParseColorModeMsg_UltravioletEvents(t *testing.T) {
+	dark, ok := ParseColorModeMsg(uv.DarkColorSchemeEvent{})
+	assert.True(t, ok, "uv.DarkColorSchemeEvent should be recognized as a color-mode report")
+	assert.True(t, dark, "uv.DarkColorSchemeEvent should report dark mode")
+
+	dark, ok = ParseColorModeMsg(uv.LightColorSchemeEvent{})
+	assert.True(t, ok, "uv.LightColorSchemeEvent should be recognized as a color-mode report")
+	assert.False(t, dark, "uv.LightColorSchemeEvent should report light mode")
 }
 
 func TestParseColorModeMsg_Unrelated(t *testing.T) {


### PR DESCRIPTION
Fixes #580.

## What broke

`colorscheme: "dark:X,light:Y"` stopped applying in 0.16.0. The terminal's `CSI ?997` light/dark report used to reach `ParseColorModeMsg` as an unknown-CSI byte message, matched by reflection. Bubble Tea v2 decodes it into `uv.DarkColorSchemeEvent` / `uv.LightColorSchemeEvent` and passes those through untranslated, so the reflection match never fired — `SetColorMode` never ran and the default theme stayed.

The v2 migration gave `internal/ui/colormode.go` only a mechanical import swap, which is why a compiler-checked migration missed it. A plain single-name `colorscheme:` was unaffected.

## Changes

- `ParseColorModeMsg` matches the typed ultraviolet events first, keeping the byte path as a fallback.
- A color-mode flip now recomposes the cached previews. `SetColorMode` applies the scheme outside the model, so dashboard/monitoring/metrics/events previews kept the old theme's baked colors until the next data tick — the manual scheme picker already recomposed, the automatic path did not. Only observable now that the report reaches the handler again.

## Test plan

- [x] Unit: `ParseColorModeMsg` accepts both uv events and the legacy byte form; unrelated messages still rejected.
- [x] Unit: a color-mode report recomposes the metrics footer (red before the fix).
- [x] Live: real terminal round-trip confirmed — the report parses as `uv.DarkColorSchemeEvent` 15ms after startup. Reporter confirmed the built binary applies their dual config.
- [x] `go test ./...`, `-race` on `internal/app` + `internal/ui`, `golangci-lint run`: clean.