### PR TITLE
feat: show field-manager blame in the YAML viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 
 - **YAML preview** in the right column with syntax highlighting
 - **Full-screen YAML viewer** with scrollable output, search, section folding (`Tab`/`z`), and in-place editing
+- **Field-manager blame** (`m`) in the YAML viewer: who and when last wrote the line under the cursor, from `.metadata.managedFields`
 - **Resource details** summary in split preview (toggle with `Shift+P`)
 - **List status summary** band pinned at the bottom of the children pane (like the resource-usage footer) when hovering a resource type in the resource-type list — always shows the resource count, plus a colored status rollup for kinds with a health signal (ArgoCD Application health/sync, Pod phase, workload ready ratios, Node readiness, Namespace/PV/PVC phase, Flux & cert-manager Ready) — plus a generic `.status.phase` or `.status.conditions` rollup for any other kind that surfaces one — so you can confirm a whole list is healthy without drilling in
 - **Inline log viewer** with streaming, search, live text filter (`f`: plain/`~`fuzzy/regex/`\`literal), severity filter (`i`/`o`: step the minimum level shown — INFO+/WARN+/ERROR+), line numbers, word wrap, follow mode (`F`), timestamps toggle, previous container logs, container filter, tail-first loading, line jump, structured preview pane (`P`: parses the selected line as JSON or logfmt, falls back to plain text), and automatic reconnect across init-container transitions (stays attached as each init container finishes and the next one starts)

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -403,6 +403,7 @@ The in-app screen is a quick reference: one binding per line, keys right-aligned
 | `z` | Toggle fold on section under cursor |
 | `Z` | Toggle all folds (collapse / expand all) |
 | `>` | Toggle line wrapping (configurable via `toggle_wrap`) |
+| `m` | Toggle inline field-manager blame on the cursor line |
 | `R` | Re-fetch the resource and refresh the view, keeping cursor/scroll (configurable via `refresh`) |
 | `Ctrl+E` | Edit resource in `$KUBE_EDITOR` or `$EDITOR` |
 | `O` | Switch to the Object Explorer at the attribute under the cursor (keeps position) |

--- a/internal/app/commands_yaml_blame.go
+++ b/internal/app/commands_yaml_blame.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"hash/fnv"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// errNoBlameTarget means the viewer is showing something with no API object
+// behind it, so there are no field managers to read.
+var errNoBlameTarget = errors.New("field owners are not available for this view")
+
+// builtinPodResourceType is the built-in type for the levels that show a Pod without
+// carrying a ResourceTypeEntry (owned Pods and the container level).
+var builtinPodResourceType = model.ResourceTypeEntry{
+	Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true,
+}
+
+// yamlBlameTarget names the object the YAML viewer is showing. It mirrors the
+// selection logic of loadYAML rather than sharing it: loadYAML branches on
+// three levels with two different fetch calls, and blame only needs the
+// address of the object.
+func (m Model) yamlBlameTarget() (kctx, ns string, rt model.ResourceTypeEntry, name string, ok bool) {
+	kctx, ns = m.effectiveContext(), m.resolveNamespace()
+
+	if m.nav.Level == model.LevelContainers {
+		return kctx, ns, builtinPodResourceType, m.nav.OwnedName, m.nav.OwnedName != ""
+	}
+
+	sel := m.selectedMiddleItem()
+	if sel == nil {
+		return "", "", model.ResourceTypeEntry{}, "", false
+	}
+	if sel.Namespace != "" {
+		ns = sel.Namespace
+	}
+	if sel.ClusterName != "" {
+		kctx = sel.ClusterName
+	}
+
+	switch m.nav.Level {
+	case model.LevelResources:
+		return kctx, ns, m.nav.ResourceType, sel.Name, true
+	case model.LevelOwned:
+		if sel.Kind == "Pod" {
+			return kctx, ns, builtinPodResourceType, sel.Name, true
+		}
+		owned, found := m.resolveOwnedResourceType(sel)
+		return kctx, ns, owned, sel.Name, found
+	}
+	return "", "", model.ResourceTypeEntry{}, "", false
+}
+
+// loadYAMLBlame fetches the field managers of the object on screen. It is a
+// second GET on purpose: the YAML fetch strips managedFields so the rendered
+// document stays readable, and this runs only when the user asks for blame.
+func (m Model) loadYAMLBlame() tea.Cmd {
+	kctx, ns, rt, name, ok := m.yamlBlameTarget()
+	if !ok {
+		return func() tea.Msg {
+			return yamlBlameLoadedMsg{err: errNoBlameTarget}
+		}
+	}
+	client := m.client
+	content := m.yamlView.content
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindYAMLFetch,
+		"Field owners: "+name,
+		bgtaskTarget(kctx, ns),
+		func(ctx context.Context) tea.Msg {
+			owners, err := client.GetFieldOwners(ctx, kctx, ns, rt, name)
+			if err != nil {
+				return yamlBlameLoadedMsg{err: err}
+			}
+			return yamlBlameLoadedMsg{
+				blame:       computeYAMLBlame(content, owners),
+				contentHash: yamlContentHash(content),
+				contentLen:  len(content),
+			}
+		},
+	)
+}
+
+// yamlContentHash identifies a rendered document cheaply, so a late reply can
+// be matched against what is on screen now.
+func yamlContentHash(content string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(content))
+	return h.Sum64()
+}
+
+// yamlBlameMinInlineWidth is the space the trailing blame note needs before it
+// is worth printing. Below this the note would be truncated to nothing useful,
+// so the line is left alone.
+const yamlBlameMinInlineWidth = 14

--- a/internal/app/commands_yaml_blame.go
+++ b/internal/app/commands_yaml_blame.go
@@ -60,15 +60,17 @@ func (m Model) yamlBlameTarget() (kctx, ns string, rt model.ResourceTypeEntry, n
 // second GET on purpose: the YAML fetch strips managedFields so the rendered
 // document stays readable, and this runs only when the user asks for blame.
 func (m Model) loadYAMLBlame() tea.Cmd {
+	// Every reply carries the request number, the failures too. A reply
+	// without it is dropped, and the view then waits on a fetch that ended.
+	req := m.yamlView.blameReq
 	kctx, ns, rt, name, ok := m.yamlBlameTarget()
 	if !ok {
 		return func() tea.Msg {
-			return yamlBlameLoadedMsg{err: errNoBlameTarget}
+			return yamlBlameLoadedMsg{req: req, err: errNoBlameTarget}
 		}
 	}
 	client := m.client
 	content := m.yamlView.content
-	req := m.yamlView.blameReq
 	return m.scheduleK8sCall(
 		scheduler.PriorityHigh,
 		scheduler.KindYAMLFetch,

--- a/internal/app/commands_yaml_blame.go
+++ b/internal/app/commands_yaml_blame.go
@@ -68,6 +68,7 @@ func (m Model) loadYAMLBlame() tea.Cmd {
 	}
 	client := m.client
 	content := m.yamlView.content
+	req := m.yamlView.blameReq
 	return m.scheduleK8sCall(
 		scheduler.PriorityHigh,
 		scheduler.KindYAMLFetch,
@@ -76,10 +77,11 @@ func (m Model) loadYAMLBlame() tea.Cmd {
 		func(ctx context.Context) tea.Msg {
 			owners, err := client.GetFieldOwners(ctx, kctx, ns, rt, name)
 			if err != nil {
-				return yamlBlameLoadedMsg{err: err}
+				return yamlBlameLoadedMsg{req: req, err: err}
 			}
 			return yamlBlameLoadedMsg{
 				blame:       computeYAMLBlame(content, owners),
+				req:         req,
 				contentHash: yamlContentHash(content),
 				contentLen:  len(content),
 			}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -117,8 +117,11 @@ type yamlLoadedMsg struct {
 // instead of naming the wrong owner. The length is compared with the hash,
 // because the hash alone is unkeyed and a collision would attach the wrong
 // lines to the document on screen.
+// req numbers the fetch this reply answers, because two fetches over one
+// unchanged document share a hash and would otherwise land in either order.
 type yamlBlameLoadedMsg struct {
 	blame       []blameLine
+	req         uint64
 	contentHash uint64
 	contentLen  int
 	err         error

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -108,6 +108,22 @@ type yamlLoadedMsg struct {
 	err      error
 }
 
+// yamlBlameLoadedMsg carries the finished blame lines for the YAML viewer.
+// It arrives from a separate fetch, because the YAML itself is rendered
+// without managedFields. The per-line walk happens in the loader goroutine,
+// like the content and section parse in buildYAMLLoadedMsg, so a 50k-line CRD
+// does not stall the event loop. contentHash identifies the document the
+// lines were built from, so a reply that lands after a refresh is dropped
+// instead of naming the wrong owner. The length is compared with the hash,
+// because the hash alone is unkeyed and a collision would attach the wrong
+// lines to the document on screen.
+type yamlBlameLoadedMsg struct {
+	blame       []blameLine
+	contentHash uint64
+	contentLen  int
+	err         error
+}
+
 // previewYAMLLoadedMsg carries YAML content for the split/full preview in the
 // right column. As with yamlLoadedMsg, the content is pre-indented inside the
 // loading goroutine to keep the main event loop responsive.

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -407,6 +407,7 @@ func (m Model) openSelectedResourceYAML() (tea.Model, tea.Cmd) {
 	m.yamlView.content = "Loading..."
 	m.yamlView.sections = nil
 	m.yamlView.visualCurCol = yamlFoldPrefixLen
+	m.yamlView.resetBlame()
 	return m, m.loadYAML()
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -131,6 +131,9 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case securityIgnoresSaveErrMsg:
 		mdl, cmd := m.updateSecurityIgnoresSaveErr(msg)
 		return mdl, cmd, true
+	case yamlBlameLoadedMsg:
+		mdl, cmd := m.updateYamlBlameLoaded(msg)
+		return mdl, cmd, true
 	case yamlLoadedMsg:
 		mdl, cmd := m.updateYamlLoaded(msg)
 		return mdl, cmd, true

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -768,6 +768,7 @@ func (m Model) enterFullView() (tea.Model, tea.Cmd) {
 	m.yamlView.content = "Loading..."
 	m.yamlView.sections = nil
 	m.yamlView.visualCurCol = yamlFoldPrefixLen
+	m.yamlView.resetBlame()
 	return m, m.loadYAML()
 }
 

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -139,6 +139,7 @@ func (m Model) handleYAMLToggleBlame() (tea.Model, tea.Cmd) {
 	}
 	m.yamlView.blameOn = true
 	m.yamlView.blameLoading = true
+	m.yamlView.blameReq++
 	m.setStatusMessage("Loading field owners…", false)
 	return m, m.loadYAMLBlame()
 }

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -127,6 +127,22 @@ func (m Model) handleYAMLNormalCopy() (tea.Model, tea.Cmd) {
 	return m, tea.Batch(copyToSystemClipboard(strings.Join(parts, "\n")), scheduleStatusClear())
 }
 
+// handleYAMLToggleBlame shows or hides the field-manager note. Turning it on
+// triggers a second fetch, because the YAML on screen was loaded without
+// managedFields.
+func (m Model) handleYAMLToggleBlame() (tea.Model, tea.Cmd) {
+	if m.yamlView.blameOn {
+		m.yamlView.blameOn = false
+		m.yamlView.blameLoading = false
+		m.yamlView.blame = nil
+		return m, nil
+	}
+	m.yamlView.blameOn = true
+	m.yamlView.blameLoading = true
+	m.setStatusMessage("Loading field owners…", false)
+	return m, m.loadYAMLBlame()
+}
+
 // handleYAMLRefresh re-fetches the resource and replaces the viewer content in
 // place. Scroll, cursor, and fold state are preserved (updateYamlLoaded only
 // swaps content/sections), so a manual refresh doesn't lose the user's spot.
@@ -170,6 +186,8 @@ func (m Model) handleYAMLNormalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case kb.Help, "f1":
 		return m.handleYAMLKeyQuestion()
+	case "m":
+		return m.handleYAMLToggleBlame()
 	case "O":
 		return m.handleYAMLKeyObjectExplorer()
 	case "I":

--- a/internal/app/update_yaml_msgs.go
+++ b/internal/app/update_yaml_msgs.go
@@ -36,6 +36,39 @@ func (m Model) updateYamlLoaded(msg yamlLoadedMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// updateYamlBlameLoaded stores the per-line blame entries. Any failure turns
+// blame off again rather than leaving the note permanently empty.
+func (m Model) updateYamlBlameLoaded(msg yamlBlameLoadedMsg) (tea.Model, tea.Cmd) {
+	m.yamlView.blameLoading = false
+	if !m.yamlView.blameOn {
+		// The user turned blame off while the fetch was in flight. Their
+		// key press wins over the reply.
+		return m, nil
+	}
+	if isContextCanceled(msg.err) {
+		m.yamlView.blameOn = false
+		return m, nil
+	}
+	if msg.err != nil {
+		m.yamlView.blameOn = false
+		m.setStatusMessage("Field owners: "+msg.err.Error(), true)
+		return m, scheduleStatusClear()
+	}
+	if msg.contentLen != len(m.yamlView.content) || msg.contentHash != yamlContentHash(m.yamlView.content) {
+		// The document was refreshed while the managers were in flight.
+		m.yamlView.blameOn = false
+		return m, nil
+	}
+	m.yamlView.blame = msg.blame
+	if m.yamlView.blame == nil {
+		m.yamlView.blameOn = false
+		m.setStatusMessage("This object records no field managers", false)
+		return m, scheduleStatusClear()
+	}
+	m.setStatusMessage("Field owners on. Press m to hide.", false)
+	return m, scheduleStatusClear()
+}
+
 func (m Model) updatePreviewYAMLLoaded(msg previewYAMLLoadedMsg) Model {
 	if msg.gen != m.requestGen {
 		return m // stale response, discard

--- a/internal/app/update_yaml_msgs.go
+++ b/internal/app/update_yaml_msgs.go
@@ -39,6 +39,11 @@ func (m Model) updateYamlLoaded(msg yamlLoadedMsg) (tea.Model, tea.Cmd) {
 // updateYamlBlameLoaded stores the per-line blame entries. Any failure turns
 // blame off again rather than leaving the note permanently empty.
 func (m Model) updateYamlBlameLoaded(msg yamlBlameLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.req != m.yamlView.blameReq {
+		// An earlier fetch answering late. The document may be byte-identical,
+		// so the hash below cannot catch this one.
+		return m, nil
+	}
 	m.yamlView.blameLoading = false
 	if !m.yamlView.blameOn {
 		// The user turned blame off while the fetch was in flight. Their

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -47,6 +47,7 @@ func (m Model) viewYAML() string {
 			{Key: "y", Desc: "copy"},
 			{Key: ui.ActiveKeybindings.ToggleFold, Desc: "fold"},
 			{Key: ui.ActiveKeybindings.ToggleWrap, Desc: "wrap"},
+			{Key: "m", Desc: "blame"},
 			{Key: "ctrl+e", Desc: "edit"},
 			{Key: "O", Desc: "object explorer"},
 			{Key: "I", Desc: "explain"},

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -142,6 +142,8 @@ func (m Model) viewYAML() string {
 
 	// Apply YAML highlighting to visible lines, with search highlights and cursor.
 	renderCtx := yamlRenderCtx{
+		blame:          m.yamlView.blame,
+		blameInline:    m.yamlView.blameOn,
 		yamlScroll:     yamlScroll,
 		mapping:        mapping,
 		matchSet:       matchSet,
@@ -240,6 +242,8 @@ type yamlRenderCtx struct {
 	currentMatch                        int
 	searchQuery                         string
 	gutterWidth, contentWidth, maxLines int
+	blame                               []blameLine
+	blameInline                         bool
 	yamlCursor                          int
 	visualMode                          bool
 	visualType                          rune
@@ -312,12 +316,50 @@ func yamlPrependGutter(content, lineNum, foldPrefix string, isCursor, isSelected
 		if visualMode {
 			return ui.YamlCursorIndicatorStyle.Render("\u258e") + ui.DimStyle.Render(lineNum) + foldPrefix + content
 		}
-		return ui.YamlCursorIndicatorStyle.Render("\u258e") + ui.DimStyle.Render(lineNum) + foldPrefix + ui.RenderCursorAtCol(content, rawContent, curCol)
+		return ui.YamlCursorIndicatorStyle.Render("\u258e") + ui.DimStyle.Render(lineNum) + foldPrefix +
+			ui.RenderCursorAtCol(content, rawContent, curCol)
 	}
 	if isSelected {
 		return ui.YamlCursorIndicatorStyle.Render(" ") + ui.DimStyle.Render(lineNum) + foldPrefix + content
 	}
 	return " " + ui.DimStyle.Render(lineNum) + foldPrefix + content
+}
+
+// yamlBlameInline renders the field-manager note that trails the cursor line,
+// the way an editor shows git blame as virtual text. Only the cursor line gets
+// it: managedFields records one timestamp per manager entry, so printing it on
+// every line would repeat the same value down the whole document.
+//
+// used is the display width the line already occupies.
+func yamlBlameInline(ctx yamlRenderCtx, origLine, used int) string {
+	if !ctx.blameInline || ctx.visualMode || origLine < 0 || origLine >= len(ctx.blame) {
+		return ""
+	}
+	entry := ctx.blame[origLine]
+	if entry.manager == "" {
+		return ""
+	}
+	text := "  " + strings.Join(yamlBlameParts(entry), " \u2022 ")
+	available := ctx.contentWidth - used
+	if available < yamlBlameMinInlineWidth {
+		return ""
+	}
+	return ui.FieldManagerStyle(entry.manager, true).Render(ui.Truncate(text, available))
+}
+
+func yamlBlameParts(entry blameLine) []string {
+	parts := make([]string, 0, 4)
+	parts = append(parts, entry.manager)
+	if entry.owner.Operation != "" {
+		parts = append(parts, entry.owner.Operation)
+	}
+	if !entry.owner.Time.IsZero() {
+		parts = append(parts, ui.FormatAge(entry.owner.Time)+" ago")
+	}
+	if entry.rolled {
+		parts = append(parts, "inherited")
+	}
+	return parts
 }
 
 // renderYAMLWrappedLine renders a single YAML line with word wrapping.
@@ -339,6 +381,9 @@ func renderYAMLWrappedLine(result []string, contentLine, foldPrefix string, visI
 			pad := strings.Repeat(" ", 1+ctx.gutterWidth+1+yamlFoldPrefixLen+2)
 			hl = pad + hl
 		}
+		if si == len(subLines)-1 && visIdx == ctx.yamlCursor {
+			hl += yamlBlameInline(ctx, origLine, lipgloss.Width(hl))
+		}
 		result = append(result, hl)
 		if len(result) >= ctx.maxLines {
 			break
@@ -357,5 +402,8 @@ func renderYAMLNonWrappedLine(result []string, contentLine, foldPrefix string, v
 	}
 	lineNum := yamlLineNumStr(origLine, ctx.gutterWidth)
 	hl = yamlPrependGutter(hl, lineNum, foldPrefix, visIdx == ctx.yamlCursor, isSelected, ctx.visualMode, ctx.visualCurCol-yamlFoldPrefixLen, contentLine)
+	if visIdx == ctx.yamlCursor {
+		hl += yamlBlameInline(ctx, origLine, lipgloss.Width(hl))
+	}
 	return append(result, hl)
 }

--- a/internal/app/view_yaml_blame_test.go
+++ b/internal/app/view_yaml_blame_test.go
@@ -1,0 +1,243 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+)
+
+func blameRenderCtx(blame []blameLine, inline bool) yamlRenderCtx {
+	return yamlRenderCtx{
+		blame:        blame,
+		blameInline:  inline,
+		mapping:      []int{0, 1},
+		gutterWidth:  3,
+		contentWidth: 80,
+		maxLines:     10,
+		yamlCursor:   0,
+	}
+}
+
+func TestYamlBlameInline_ShowsManagerOperationAndAge(t *testing.T) {
+	entry := blameLine{manager: "kubectl-client-side-apply"}
+	entry.owner = k8s.FieldOwner{
+		Manager:   "kubectl-client-side-apply",
+		Operation: "Update",
+		Time:      time.Now().Add(-4 * time.Minute),
+	}
+	ctx := blameRenderCtx([]blameLine{entry}, true)
+
+	got := stripANSI(yamlBlameInline(ctx, 0, 10))
+
+	assert.Contains(t, got, "kubectl-client-side-apply", "inline has room, so the name is not cut")
+	assert.Contains(t, got, "Update")
+	assert.Contains(t, got, "ago")
+}
+
+func TestYamlBlameInline_MarksAnInheritedOwner(t *testing.T) {
+	ctx := blameRenderCtx([]blameLine{{manager: "helm", rolled: true}}, true)
+
+	assert.Contains(t, stripANSI(yamlBlameInline(ctx, 0, 10)), "inherited")
+}
+
+func TestYamlBlameInline_EmptyWhenOffOrUnknown(t *testing.T) {
+	entry := []blameLine{{manager: "kubectl"}}
+	assert.Empty(t, yamlBlameInline(blameRenderCtx(entry, false), 0, 10), "toggle off")
+	assert.Empty(t, yamlBlameInline(blameRenderCtx(entry, true), 42, 10), "line past the data")
+	assert.Empty(t, yamlBlameInline(blameRenderCtx([]blameLine{{}}, true), 0, 10), "no manager")
+}
+
+func TestYamlBlameInline_SkippedInVisualMode(t *testing.T) {
+	ctx := blameRenderCtx([]blameLine{{manager: "kubectl"}}, true)
+	ctx.visualMode = true
+
+	assert.Empty(t, yamlBlameInline(ctx, 0, 10), "a selection must not gain trailing text")
+}
+
+func TestYamlBlameInline_SkippedWhenTheLineFillsTheWidth(t *testing.T) {
+	ctx := blameRenderCtx([]blameLine{{manager: "kubectl"}}, true)
+
+	assert.Empty(t, yamlBlameInline(ctx, 0, ctx.contentWidth-2), "no room left to say anything useful")
+}
+
+func TestRenderYAMLViewportLines_InlineOnlyOnTheCursorLine(t *testing.T) {
+	blame := []blameLine{{manager: "argocd"}, {manager: "kubectl"}}
+	ctx := blameRenderCtx(blame, true)
+
+	out := renderYAMLViewportLines([]string{"  spec:", "    replicas: 3"}, ctx)
+
+	require.Len(t, out, 2)
+	assert.Contains(t, stripANSI(out[0]), "argocd", "cursor line carries the note")
+	assert.NotContains(t, stripANSI(out[1]), "kubectl", "other lines stay clean")
+}
+
+func TestRenderYAMLViewportLines_LineStartsWithTheLineNumberAgain(t *testing.T) {
+	off := renderYAMLViewportLines([]string{"  spec:"}, blameRenderCtx(nil, false))
+	on := renderYAMLViewportLines([]string{"  spec:"}, blameRenderCtx([]blameLine{{manager: "kubectl"}}, true))
+
+	assert.True(t, strings.HasPrefix(stripANSI(on[0]), stripANSI(off[0])),
+		"the blame trails the line instead of shifting it right")
+}
+
+func TestHandleYAMLToggleBlame_OnThenOff(t *testing.T) {
+	m := Model{}
+	m.yamlView.content = "spec:\n  replicas: 3\n"
+
+	mdl, cmd := m.handleYAMLToggleBlame()
+	on := mdl.(Model)
+	assert.True(t, on.yamlView.blameOn)
+	assert.True(t, on.yamlView.blameLoading)
+	assert.NotNil(t, cmd, "turning the blame on has to fetch the managers")
+
+	on.yamlView.blame = []blameLine{{manager: "kubectl"}}
+	mdl, _ = on.handleYAMLToggleBlame()
+	off := mdl.(Model)
+	assert.False(t, off.yamlView.blameOn)
+	assert.Nil(t, off.yamlView.blame, "hiding the blame drops the data with it")
+}
+
+func TestUpdateYamlBlameLoaded_ErrorClosesTheBlame(t *testing.T) {
+	m := Model{}
+	m.yamlView.blameOn = true
+	m.yamlView.blameLoading = true
+
+	mdl, _ := m.updateYamlBlameLoaded(yamlBlameLoadedMsg{err: errNoBlameTarget})
+
+	got := mdl.(Model)
+	assert.False(t, got.yamlView.blameOn)
+	assert.False(t, got.yamlView.blameLoading)
+	assert.Nil(t, got.yamlView.blame)
+}
+
+func TestYamlViewStateCopy_ClonesTheBlameSlice(t *testing.T) {
+	s := yamlViewState{blame: []blameLine{{manager: "kubectl"}}}
+
+	cp := s.copy()
+	cp.blame[0].manager = "changed"
+
+	assert.Equal(t, "kubectl", s.blame[0].manager, "a tab snapshot must not alias the live viewer")
+}
+
+func TestUpdateYamlBlameLoaded_DropsAReplyForOldContent(t *testing.T) {
+	m := Model{}
+	m.yamlView.content = "spec:\n  replicas: 3\n"
+	m.yamlView.blameOn = true
+	m.yamlView.blameLoading = true
+
+	other := "something the viewer no longer shows"
+	stale := yamlBlameLoadedMsg{
+		blame:       []blameLine{{manager: "kubectl"}},
+		contentHash: yamlContentHash(other),
+		contentLen:  len(other),
+	}
+	mdl, _ := m.updateYamlBlameLoaded(stale)
+
+	got := mdl.(Model)
+	assert.Nil(t, got.yamlView.blame, "blame built for other content would sit on the wrong lines")
+	assert.False(t, got.yamlView.blameOn)
+}
+
+func TestUpdateYamlBlameLoaded_AcceptsAReplyForTheCurrentContent(t *testing.T) {
+	content := "spec:\n  replicas: 3\n"
+	m := Model{}
+	m.yamlView.content = content
+	m.yamlView.blameOn = true
+
+	mdl, _ := m.updateYamlBlameLoaded(yamlBlameLoadedMsg{
+		blame:       []blameLine{{}, {manager: "kubectl"}},
+		contentHash: yamlContentHash(content),
+		contentLen:  len(content),
+	})
+
+	got := mdl.(Model)
+	require.Len(t, got.yamlView.blame, 2)
+	assert.Equal(t, "kubectl", got.yamlView.blame[1].manager)
+	assert.True(t, got.yamlView.blameOn)
+}
+
+func TestUpdateYamlBlameLoaded_ToggleOffDuringTheFetchWins(t *testing.T) {
+	content := "spec:\n  replicas: 3\n"
+	m := Model{}
+	m.yamlView.content = content
+	m.yamlView.blameLoading = true
+	m.yamlView.blameOn = false // the user pressed m again while the fetch ran
+
+	mdl, _ := m.updateYamlBlameLoaded(yamlBlameLoadedMsg{
+		blame:       []blameLine{{}, {manager: "kubectl"}},
+		contentHash: yamlContentHash(content),
+		contentLen:  len(content),
+	})
+
+	got := mdl.(Model)
+	assert.False(t, got.yamlView.blameOn, "the reply must not reopen blame the user closed")
+	assert.Nil(t, got.yamlView.blame)
+	assert.False(t, got.yamlView.blameLoading)
+}
+
+func TestComputeYAMLBlame_StripsBidiOverrideFromTheManagerName(t *testing.T) {
+	// U+202E reverses the text that follows it, so a name can read as another.
+	owners := ownersFrom(t, "kube\u202ectl\u2066x", `{"f:spec":{"f:replicas":{}}}`)
+
+	got := computeYAMLBlame("spec:\n  replicas: 3\n", owners)
+
+	assert.Equal(t, "kubectlx", got[1].manager)
+}
+
+func TestRenderYAMLViewportLines_WrappedNoteDroppedWhenTheViewportCutsTheLine(t *testing.T) {
+	ctx := blameRenderCtx([]blameLine{{manager: "kubectl"}}, true)
+	ctx.wrap = true
+	ctx.contentWidth = 40
+	ctx.maxLines = 2
+
+	long := "  key: " + strings.Repeat("value ", 30)
+	out := renderYAMLViewportLines([]string{long}, ctx)
+
+	require.Len(t, out, 2, "the viewport cut the line before its last piece")
+	for _, line := range out {
+		assert.NotContains(t, stripANSI(line), "kubectl",
+			"the note belongs after the end of the line, which is off screen here")
+	}
+}
+
+func TestRenderYAMLViewportLines_WrappedNoteOnTheLastSubLine(t *testing.T) {
+	ctx := blameRenderCtx([]blameLine{{manager: "kubectl"}}, true)
+	ctx.wrap = true
+	ctx.contentWidth = 60
+	ctx.maxLines = 20
+
+	out := renderYAMLViewportLines([]string{"  key: " + strings.Repeat("v ", 30)}, ctx)
+
+	require.Greater(t, len(out), 1, "the line has to wrap for this test to mean anything")
+	// The last piece must be short enough to leave room for the note.
+	assert.NotContains(t, stripANSI(out[0]), "kubectl", "not on the first piece")
+	assert.Contains(t, stripANSI(out[len(out)-1]), "kubectl", "on the last piece")
+}
+
+func TestRenderYAMLViewportLines_WrapModeNotesOnlyTheCursorLine(t *testing.T) {
+	ctx := blameRenderCtx([]blameLine{{manager: "argocd"}, {manager: "kubectl"}}, true)
+	ctx.wrap = true
+	ctx.contentWidth = 60
+	ctx.maxLines = 20
+	ctx.yamlCursor = 1
+
+	out := renderYAMLViewportLines([]string{"  a: 1", "  b: 2"}, ctx)
+
+	joined := stripANSI(strings.Join(out, "\n"))
+	assert.NotContains(t, joined, "argocd", "a line that is not the cursor gets no note")
+	assert.Contains(t, joined, "kubectl", "the cursor line gets one")
+}
+
+func TestResetBlame_ClearsEverything(t *testing.T) {
+	s := yamlViewState{blameOn: true, blameLoading: true, blame: []blameLine{{manager: "kubectl"}}}
+
+	s.resetBlame()
+
+	assert.False(t, s.blameOn)
+	assert.False(t, s.blameLoading)
+	assert.Nil(t, s.blame)
+}

--- a/internal/app/view_yaml_blame_test.go
+++ b/internal/app/view_yaml_blame_test.go
@@ -281,3 +281,21 @@ func TestHandleYAMLToggleBlame_EachRequestGetsANewNumber(t *testing.T) {
 
 	assert.Greater(t, mdl.(Model).yamlView.blameReq, first)
 }
+
+func TestLoadYAMLBlame_NoTargetReplyCarriesTheRequestNumber(t *testing.T) {
+	// An empty Model has no selected item, so the target lookup fails. The
+	// reply still has to reach the handler, or the view stays on "Loading".
+	m := Model{}
+	m.yamlView.blameOn = true
+	m.yamlView.blameLoading = true
+	m.yamlView.blameReq = 3
+
+	msg, ok := m.loadYAMLBlame()().(yamlBlameLoadedMsg)
+	require.True(t, ok)
+	assert.Equal(t, uint64(3), msg.req)
+
+	mdl, _ := m.updateYamlBlameLoaded(msg)
+	got := mdl.(Model)
+	assert.False(t, got.yamlView.blameLoading, "the reply has to clear the loading state")
+	assert.False(t, got.yamlView.blameOn)
+}

--- a/internal/app/view_yaml_blame_test.go
+++ b/internal/app/view_yaml_blame_test.go
@@ -241,3 +241,43 @@ func TestResetBlame_ClearsEverything(t *testing.T) {
 	assert.False(t, s.blameLoading)
 	assert.Nil(t, s.blame)
 }
+
+func TestUpdateYamlBlameLoaded_DropsAnOlderRequestForTheSameContent(t *testing.T) {
+	// Two toggles in a row put two fetches in flight over one document, so
+	// the content hash cannot tell them apart. Only the newer owners count.
+	content := "spec:\n  replicas: 3\n"
+	m := Model{}
+	m.yamlView.content = content
+	m.yamlView.blameOn = true
+	m.yamlView.blameReq = 2
+
+	reply := func(req uint64, manager string) yamlBlameLoadedMsg {
+		return yamlBlameLoadedMsg{
+			blame:       []blameLine{{}, {manager: manager}},
+			req:         req,
+			contentHash: yamlContentHash(content),
+			contentLen:  len(content),
+		}
+	}
+
+	mdl, _ := m.updateYamlBlameLoaded(reply(2, "current"))
+	mdl, _ = mdl.(Model).updateYamlBlameLoaded(reply(1, "stale"))
+
+	got := mdl.(Model)
+	require.Len(t, got.yamlView.blame, 2)
+	assert.Equal(t, "current", got.yamlView.blame[1].manager,
+		"a reply from the earlier fetch must not overwrite the later one")
+	assert.True(t, got.yamlView.blameOn, "a dropped reply leaves the view as it is")
+}
+
+func TestHandleYAMLToggleBlame_EachRequestGetsANewNumber(t *testing.T) {
+	m := Model{}
+	m.yamlView.content = "spec:\n  replicas: 3\n"
+
+	mdl, _ := m.handleYAMLToggleBlame()
+	first := mdl.(Model).yamlView.blameReq
+	mdl, _ = mdl.(Model).handleYAMLToggleBlame() // off
+	mdl, _ = mdl.(Model).handleYAMLToggleBlame() // on again
+
+	assert.Greater(t, mdl.(Model).yamlView.blameReq, first)
+}

--- a/internal/app/whichkey_yaml.go
+++ b/internal/app/whichkey_yaml.go
@@ -148,6 +148,7 @@ var whichKeyYAMLActionList = []wkAction[*wkYAMLCtx]{
 	{Key: func(kb ui.Keybindings) string { return kb.ToggleFold }, Label: "Fold section at cursor", Group: wkViews, Avail: func(c *wkYAMLCtx) bool { return !c.visual && c.foldSection != "" }},
 	{Key: func(kb ui.Keybindings) string { return kb.ToggleFoldAll }, Label: "Fold / unfold all", Group: wkViews, Avail: func(c *wkYAMLCtx) bool { return !c.visual && c.foldable }},
 	{Key: func(kb ui.Keybindings) string { return kb.ToggleWrap }, Label: "Toggle line wrapping", Group: wkSettings, Avail: wkYAMLNormal},
+	{Key: wkLiteralKey("m"), Label: "Toggle field-manager blame", Group: wkSettings, Avail: wkYAMLNormal},
 
 	// update_yaml.go:187-188 / 183-184 — search, then the two things q does.
 	{Key: func(kb ui.Keybindings) string { return kb.Search }, Label: "Search in content", Group: wkFilter, Avail: wkYAMLNormal},

--- a/internal/app/yamlblame.go
+++ b/internal/app/yamlblame.go
@@ -1,0 +1,251 @@
+package app
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// blameLine is the blame entry for one rendered YAML line. rolled marks a
+// manager that was derived rather than recorded: either inherited from an
+// owned ancestor, or rolled up from a subtree whose lines share one manager.
+type blameLine struct {
+	manager string
+	owner   k8s.FieldOwner
+	rolled  bool
+}
+
+// linePath is what one YAML line points at in the object.
+type linePath struct {
+	segs   []k8s.PathSeg
+	header bool // a key with no inline value, so it can inherit from its subtree
+	body   bool // a line inside a block scalar, which belongs to the key above it
+}
+
+// computeYAMLBlame maps each line of the rendered YAML to the field manager
+// that last wrote it. The result has one entry per line, so a line index
+// addresses it directly, including blank and comment lines.
+func computeYAMLBlame(content string, owners *k8s.FieldOwners) []blameLine {
+	if owners.Empty() {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	paths := buildLinePaths(lines)
+	out := make([]blameLine, len(lines))
+	for i := range lines {
+		if paths[i].segs == nil {
+			continue
+		}
+		out[i] = resolveOwner(owners, paths[i].segs)
+	}
+	rollUpHeaders(lines, paths, out)
+	return out
+}
+
+// resolveOwner takes the exact owner of a path, or the nearest owned ancestor.
+// A field the manifest never named still belongs to whoever wrote the block
+// around it. The manager name is cluster-controlled, so it is stripped of
+// control characters here, at the one point every blame entry passes.
+func resolveOwner(owners *k8s.FieldOwners, segs []k8s.PathSeg) blameLine {
+	if o, ok := owners.At(segs); ok {
+		return blameLine{manager: ui.SanitizeTerminalText(o.Manager), owner: o}
+	}
+	for n := len(segs) - 1; n > 0; n-- {
+		if o, ok := owners.At(segs[:n]); ok {
+			return blameLine{manager: ui.SanitizeTerminalText(o.Manager), owner: o, rolled: true}
+		}
+	}
+	return blameLine{}
+}
+
+// rollUpHeaders gives a section header the manager of its subtree when every
+// line below it has the same one. Without this there is no owner on exactly
+// the lines that organize the document.
+func rollUpHeaders(lines []string, paths []linePath, out []blameLine) {
+	for i := range slices.Backward(lines) {
+		if !paths[i].header || out[i].manager != "" {
+			continue
+		}
+		if child, ok := uniformChildManager(lines, out, i); ok {
+			out[i] = blameLine{manager: child.manager, owner: child.owner, rolled: true}
+		}
+	}
+}
+
+// uniformChildManager returns the single owner of everything below a header,
+// or reports false when the lines below disagree. The child entry is carried
+// whole, so the header can show the same timestamp as the block it covers.
+func uniformChildManager(lines []string, out []blameLine, header int) (blameLine, bool) {
+	indent := countIndent(lines[header])
+	var child blameLine
+	for j := header + 1; j < len(lines); j++ {
+		trimmed := strings.TrimSpace(lines[j])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if countIndent(lines[j]) <= indent {
+			break
+		}
+		if out[j].manager == "" {
+			return blameLine{}, false
+		}
+		if child.manager != "" && child.manager != out[j].manager {
+			return blameLine{}, false
+		}
+		child = out[j]
+	}
+	return child, child.manager != ""
+}
+
+type pathFrame struct {
+	childIndent int
+	seg         k8s.PathSeg
+}
+
+// buildLinePaths walks the document once and records the object path each line
+// points at. List items are identified by their scalar fields rather than by
+// index, because that is how managedFields names them.
+//
+//nolint:gocyclo // one pass over YAML line shapes: the branches are the shapes, not nesting
+func buildLinePaths(lines []string) []linePath {
+	paths := make([]linePath, len(lines))
+	stack := make([]pathFrame, 0, 8)
+	blockIndent := -1
+	var blockPath []k8s.PathSeg
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		indent := countIndent(line)
+
+		if blockIndent >= 0 {
+			if trimmed == "" || indent >= blockIndent {
+				paths[i] = linePath{segs: blockPath, body: true}
+				continue
+			}
+			blockIndent, blockPath = -1, nil
+		}
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == "---" {
+			stack = stack[:0]
+			continue
+		}
+
+		for len(stack) > 0 && stack[len(stack)-1].childIndent > indent {
+			stack = stack[:len(stack)-1]
+		}
+
+		if strings.HasPrefix(trimmed, "- ") {
+			stack = append(stack, pathFrame{
+				childIndent: indent + 2,
+				seg:         k8s.PathSeg{Item: collectItemFields(lines, i, indent)},
+			})
+			trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+			indent += 2
+		} else if trimmed == "-" {
+			continue
+		}
+
+		key, afterColon, ok := splitYAMLPair(trimmed)
+		if !ok {
+			paths[i] = linePath{segs: segsOf(stack)}
+			continue
+		}
+		segs := append(segsOf(stack), k8s.PathSeg{Key: key})
+		paths[i] = linePath{segs: segs, header: afterColon == ""}
+
+		switch {
+		case afterColon == "":
+			stack = append(stack, pathFrame{childIndent: indent + 2, seg: k8s.PathSeg{Key: key}})
+		case isBlockIndicator(afterColon):
+			blockIndent, blockPath = indent+1, segs
+		}
+	}
+	return paths
+}
+
+// collectItemFields reads the scalar fields of one list item so it can be
+// matched against a managedFields selector such as k:{"name":"nginx"}.
+func collectItemFields(lines []string, start, itemIndent int) map[string]string {
+	fields := make(map[string]string, 4)
+	if key, value, ok := splitYAMLPair(strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[start]), "- "))); ok &&
+		value != "" {
+		fields[key] = unquoteYAML(value)
+	}
+	for j := start + 1; j < len(lines); j++ {
+		trimmed := strings.TrimSpace(lines[j])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		indent := countIndent(lines[j])
+		if indent <= itemIndent || strings.HasPrefix(trimmed, "- ") {
+			break
+		}
+		if indent != itemIndent+2 {
+			continue
+		}
+		key, value, ok := splitYAMLPair(trimmed)
+		if ok && value != "" && !isBlockIndicator(value) {
+			fields[key] = unquoteYAML(value)
+		}
+	}
+	return fields
+}
+
+// isBlockIndicator reports a real block scalar opener. isBlockScalar in
+// yamlfold.go also accepts an empty value, because a fold section treats a
+// bare header the same way; here the two must stay apart.
+func isBlockIndicator(afterColon string) bool {
+	return afterColon != "" && isBlockScalar(afterColon)
+}
+
+// splitYAMLPair splits "key: value" at the colon that ends the key. A quoted
+// key may contain a colon of its own, so the scan skips quoted spans. The
+// value may be empty, which marks a section header.
+func splitYAMLPair(trimmed string) (key, value string, ok bool) {
+	idx := keyColonIndex(trimmed)
+	if idx <= 0 {
+		return "", "", false
+	}
+	return unquoteYAML(trimmed[:idx]), strings.TrimSpace(trimmed[idx+1:]), true
+}
+
+// keyColonIndex returns the offset of the colon that separates key from value,
+// or -1 when the line is not a pair.
+func keyColonIndex(trimmed string) int {
+	var quote byte
+	for i := range len(trimmed) {
+		c := trimmed[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == ':':
+			return i
+		}
+	}
+	return -1
+}
+
+func unquoteYAML(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func segsOf(stack []pathFrame) []k8s.PathSeg {
+	segs := make([]k8s.PathSeg, len(stack))
+	for i := range stack {
+		segs[i] = stack[i].seg
+	}
+	return segs
+}

--- a/internal/app/yamlblame.go
+++ b/internal/app/yamlblame.go
@@ -91,7 +91,10 @@ func uniformChildManager(lines []string, out []blameLine, header int) (blameLine
 		if out[j].manager == "" {
 			return blameLine{}, false
 		}
-		if child.manager != "" && child.manager != out[j].manager {
+		// The whole owner has to match, not just the name: one manager can
+		// write two children in two applies, and the header would then show
+		// the write time of whichever child came last.
+		if child.manager != "" && (child.manager != out[j].manager || child.owner != out[j].owner) {
 			return blameLine{}, false
 		}
 		child = out[j]

--- a/internal/app/yamlblame_test.go
+++ b/internal/app/yamlblame_test.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+)
+
+func ownersFrom(t *testing.T, pairs ...string) *k8s.FieldOwners {
+	t.Helper()
+	require.Zero(t, len(pairs)%2, "pairs must be manager, fieldsJSON")
+	now := metav1.NewTime(time.Now())
+	entries := make([]metav1.ManagedFieldsEntry, 0, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		fields := &metav1.FieldsV1{}
+		fields.SetRawBytes([]byte(pairs[i+1]))
+		entries = append(entries, metav1.ManagedFieldsEntry{
+			Manager:   pairs[i],
+			Operation: metav1.ManagedFieldsOperationUpdate,
+			Time:      &now,
+			FieldsV1:  fields,
+		})
+	}
+	return k8s.NewFieldOwners(entries)
+}
+
+// managersOf reduces the blame result to one manager name per line, so a test
+// reads as a picture of the gutter.
+func managersOf(blame []blameLine) []string {
+	out := make([]string, len(blame))
+	for i, b := range blame {
+		out[i] = b.manager
+	}
+	return out
+}
+
+func TestComputeYAMLBlame_MapFields(t *testing.T) {
+	content := "apiVersion: apps/v1\n" +
+		"kind: Deployment\n" +
+		"spec:\n" +
+		"  replicas: 3\n" +
+		"  paused: false\n"
+	owners := ownersFrom(t, "kubectl", `{"f:spec":{"f:replicas":{}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	// One entry per split line, so the trailing newline contributes a last blank.
+	assert.Equal(t, []string{"", "", "", "kubectl", "", ""}, managersOf(got))
+}
+
+func TestComputeYAMLBlame_ListItemMatchedByName(t *testing.T) {
+	content := "spec:\n" +
+		"  containers:\n" +
+		"    - name: nginx\n" +
+		"      image: nginx:1.27\n" +
+		"    - name: sidecar\n" +
+		"      image: proxy:2\n"
+	owners := ownersFrom(t, "kubectl",
+		`{"f:spec":{"f:containers":{"k:{\"name\":\"nginx\"}":{".":{},"f:image":{}}}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	assert.Equal(t, "kubectl", got[3].manager, "nginx image is owned")
+	assert.Empty(t, got[5].manager, "the sidecar image is not covered by that selector")
+}
+
+func TestComputeYAMLBlame_HeaderTakesTheManagerOfAUniformSubtree(t *testing.T) {
+	content := "metadata:\n" +
+		"  labels:\n" +
+		"    app: web\n" +
+		"    tier: front\n"
+	owners := ownersFrom(t, "argocd",
+		`{"f:metadata":{"f:labels":{"f:app":{},"f:tier":{}}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	assert.Equal(t, "argocd", got[1].manager, "labels header rolls up from its children")
+	assert.True(t, got[1].rolled)
+	assert.False(t, got[2].rolled, "an owned line is not a rollup")
+}
+
+func TestComputeYAMLBlame_MixedSubtreeLeavesTheHeaderBlank(t *testing.T) {
+	content := "metadata:\n" +
+		"  labels:\n" +
+		"    app: web\n" +
+		"    tier: front\n"
+	owners := ownersFrom(t,
+		"argocd", `{"f:metadata":{"f:labels":{"f:app":{}}}}`,
+		"kubectl", `{"f:metadata":{"f:labels":{"f:tier":{}}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	assert.Empty(t, got[1].manager, "two managers below, so no single owner")
+}
+
+func TestComputeYAMLBlame_BlockScalarBodyFollowsItsKey(t *testing.T) {
+	content := "data:\n" +
+		"  script: |\n" +
+		"    line one: not a key\n" +
+		"    line two\n" +
+		"  other: x\n"
+	owners := ownersFrom(t, "helm", `{"f:data":{"f:script":{}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	assert.Equal(t, "helm", got[1].manager)
+	assert.Equal(t, "helm", got[2].manager, "block body belongs to the key that opened it")
+	assert.Equal(t, "helm", got[3].manager)
+	assert.Empty(t, got[4].manager)
+}
+
+func TestComputeYAMLBlame_KeysContainingDots(t *testing.T) {
+	content := "metadata:\n" +
+		"  annotations:\n" +
+		"    kubectl.kubernetes.io/last-applied-configuration: '{}'\n"
+	owners := ownersFrom(t, "kubectl",
+		`{"f:metadata":{"f:annotations":{"f:kubectl.kubernetes.io/last-applied-configuration":{}}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	assert.Equal(t, "kubectl", got[2].manager)
+}
+
+func TestComputeYAMLBlame_NoOwnersReturnsNothing(t *testing.T) {
+	assert.Nil(t, computeYAMLBlame("spec:\n  replicas: 1\n", nil))
+	assert.Nil(t, computeYAMLBlame("spec:\n  replicas: 1\n", k8s.NewFieldOwners(nil)))
+}
+
+func TestComputeYAMLBlame_LineCountMatchesTheContent(t *testing.T) {
+	content := "spec:\n\n  # a comment\n  replicas: 3\n"
+	owners := ownersFrom(t, "kubectl", `{"f:spec":{"f:replicas":{}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	require.Len(t, got, 5, "one entry per line, so the gutter stays aligned")
+	assert.Equal(t, "kubectl", got[3].manager)
+}
+
+func TestComputeYAMLBlame_StripsControlBytesFromTheManagerName(t *testing.T) {
+	// A manager name is cluster-controlled. A non-core apiserver can set it
+	// to anything, including an escape sequence aimed at the terminal.
+	// \u009b is the C1 CSI, encoded as two UTF-8 bytes but one rune above
+	// 0x7f, which an ASCII-only filter would let through.
+	hostile := "kubectl\x1b[2J\u009bAevil\x7f"
+	owners := ownersFrom(t, hostile, `{"f:spec":{"f:replicas":{}}}`)
+
+	got := computeYAMLBlame("spec:\n  replicas: 3\n", owners)
+
+	assert.Equal(t, "kubectl[2JAevil", got[1].manager)
+	assert.NotContains(t, got[1].manager, "\x1b")
+	assert.NotContains(t, got[1].manager, "\u009b")
+}
+
+func TestComputeYAMLBlame_QuotedKeyContainingAColon(t *testing.T) {
+	content := "metadata:\n" +
+		"  annotations:\n" +
+		"    \"weird:key\": value\n"
+	owners := ownersFrom(t, "kubectl",
+		`{"f:metadata":{"f:annotations":{"f:weird:key":{}}}}`)
+
+	got := computeYAMLBlame(content, owners)
+
+	assert.Equal(t, "kubectl", got[2].manager, "the key ends at the colon outside the quotes")
+}
+
+func TestKeyColonIndex(t *testing.T) {
+	assert.Equal(t, 3, keyColonIndex("abc: v"))
+	assert.Equal(t, 11, keyColonIndex(`"weird:key": v`))
+	assert.Equal(t, 11, keyColonIndex("'weird:key': v"))
+	assert.Equal(t, -1, keyColonIndex("no colon here"))
+}

--- a/internal/app/yamlblame_test.go
+++ b/internal/app/yamlblame_test.go
@@ -174,3 +174,34 @@ func TestKeyColonIndex(t *testing.T) {
 	assert.Equal(t, 11, keyColonIndex("'weird:key': v"))
 	assert.Equal(t, -1, keyColonIndex("no colon here"))
 }
+
+func TestComputeYAMLBlame_HeaderStaysBlankWhenChildrenDifferInTime(t *testing.T) {
+	// One manager wrote both labels, but in two separate applies. The header
+	// has no single write time, so it must not borrow one from a child.
+	content := "metadata:\n" +
+		"  labels:\n" +
+		"    app: web\n" +
+		"    tier: front\n"
+	older := metav1.NewTime(time.Now().Add(-72 * time.Hour))
+	newer := metav1.NewTime(time.Now())
+	entry := func(at metav1.Time, raw string) metav1.ManagedFieldsEntry {
+		fields := &metav1.FieldsV1{}
+		fields.SetRawBytes([]byte(raw))
+		return metav1.ManagedFieldsEntry{
+			Manager:   "argocd",
+			Operation: metav1.ManagedFieldsOperationApply,
+			Time:      &at,
+			FieldsV1:  fields,
+		}
+	}
+	owners := k8s.NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry(older, `{"f:metadata":{"f:labels":{"f:app":{}}}}`),
+		entry(newer, `{"f:metadata":{"f:labels":{"f:tier":{}}}}`),
+	})
+
+	got := computeYAMLBlame(content, owners)
+
+	assert.Equal(t, "argocd", got[2].manager, "the child keeps its own owner")
+	assert.Empty(t, got[1].manager,
+		"the header covers two different writes, so it names neither")
+}

--- a/internal/app/yamlview.go
+++ b/internal/app/yamlview.go
@@ -33,8 +33,12 @@ type yamlViewState struct {
 	// Field-manager blame, shown as a trailing note on the cursor line.
 	// blame has one entry per original content line and is rebuilt whenever
 	// the content or the owners change.
+	// blameReq numbers each fetch. Two toggles over one document produce two
+	// replies the content hash cannot tell apart, so only the newest number
+	// is accepted.
 	blameOn      bool
 	blameLoading bool
+	blameReq     uint64
 	blame        []blameLine
 
 	sections  []yamlSection   // parsed hierarchical sections

--- a/internal/app/yamlview.go
+++ b/internal/app/yamlview.go
@@ -30,8 +30,23 @@ type yamlViewState struct {
 
 	wrap bool // word-wrap toggle
 
+	// Field-manager blame, shown as a trailing note on the cursor line.
+	// blame has one entry per original content line and is rebuilt whenever
+	// the content or the owners change.
+	blameOn      bool
+	blameLoading bool
+	blame        []blameLine
+
 	sections  []yamlSection   // parsed hierarchical sections
 	collapsed map[string]bool // collapsed state per section key (persists across resources)
+}
+
+// resetBlame turns the field-manager note off. Blame is per resource and
+// costs a fetch, so opening the viewer on something else starts without it.
+func (s *yamlViewState) resetBlame() {
+	s.blameOn = false
+	s.blameLoading = false
+	s.blame = nil
 }
 
 // copy returns a deep copy: slices and the map are cloned so a value stored
@@ -44,6 +59,9 @@ func (s yamlViewState) copy() yamlViewState {
 	}
 	if s.sections != nil {
 		cp.sections = append([]yamlSection(nil), s.sections...)
+	}
+	if s.blame != nil {
+		cp.blame = append([]blameLine(nil), s.blame...)
 	}
 	cp.collapsed = copyMapStringBool(s.collapsed)
 	return cp

--- a/internal/k8s/fieldowners.go
+++ b/internal/k8s/fieldowners.go
@@ -1,0 +1,323 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// GetFieldOwners fetches one object and returns which field manager last
+// wrote each of its paths. This is a separate call from GetResourceYAML on
+// purpose: that path strips managedFields so the rendered YAML stays free of
+// the noise, and the gutter is loaded only when the user asks for it.
+// Virtual resource types have no API object, so they return empty owners.
+func (c *Client) GetFieldOwners(
+	ctx context.Context, contextName, namespace string, rt model.ResourceTypeEntry, name string,
+) (*FieldOwners, error) {
+	if strings.HasPrefix(rt.APIGroup, "_") {
+		return NewFieldOwners(nil), nil
+	}
+
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+
+	gvr := schema.GroupVersionResource{Group: rt.APIGroup, Version: rt.APIVersion, Resource: rt.Resource}
+	var getter dynamic.ResourceInterface = dynClient.Resource(gvr)
+	if rt.Namespaced {
+		getter = dynClient.Resource(gvr).Namespace(namespace)
+	}
+
+	obj, err := getter.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting field owners: %w", err)
+	}
+	return NewFieldOwners(obj.GetManagedFields()), nil
+}
+
+// FieldOwner is the field manager that last wrote one path of an object.
+type FieldOwner struct {
+	Manager     string
+	Operation   string
+	Subresource string
+	Time        time.Time
+}
+
+// PathSeg is one step of a path into an object. Key names a map field. Item
+// holds the scalar fields of a list element, which is how managedFields
+// identifies list entries: it stores a selector such as k:{"name":"nginx"}
+// rather than an index, because indexes move.
+type PathSeg struct {
+	Key  string
+	Item map[string]string
+}
+
+// FieldOwners answers "which manager last wrote this path" for one object,
+// built from .metadata.managedFields. Ownership is recorded per path, so a
+// parent is owned only when a manager wrote the parent itself.
+type FieldOwners struct {
+	root     *ownerNode
+	managers []string
+}
+
+type ownerNode struct {
+	owner  *FieldOwner
+	fields map[string]*ownerNode
+
+	// items is indexed twice over: first by which fields the selector names
+	// (almost always "name"), then by those field values joined. A linear
+	// scan here would be O(list length) per line, which squares on a large
+	// tracked list in a big CRD.
+	items map[string]map[string]*ownerNode
+}
+
+// NewFieldOwners builds the lookup from the managedFields of one object.
+// Entries without usable FieldsV1 data are skipped: a malformed entry must
+// not invent ownership.
+func NewFieldOwners(entries []metav1.ManagedFieldsEntry) *FieldOwners {
+	f := &FieldOwners{root: newOwnerNode()}
+	seen := make(map[string]struct{}, len(entries))
+	for i := range entries {
+		e := &entries[i]
+		if e.FieldsV1 == nil || e.Manager == "" {
+			continue
+		}
+		owner := FieldOwner{
+			Manager:     e.Manager,
+			Operation:   string(e.Operation),
+			Subresource: e.Subresource,
+		}
+		if e.Time != nil {
+			owner.Time = e.Time.Time
+		}
+		if err := f.root.merge(e.FieldsV1.GetRawBytes(), owner, 0); err != nil {
+			continue
+		}
+		if _, ok := seen[e.Manager]; !ok {
+			seen[e.Manager] = struct{}{}
+			f.managers = append(f.managers, e.Manager)
+		}
+	}
+	slices.Sort(f.managers)
+	return f
+}
+
+// Empty reports whether there is no ownership information at all.
+func (f *FieldOwners) Empty() bool {
+	return f == nil || f.root == nil || (len(f.root.fields) == 0 && len(f.root.items) == 0)
+}
+
+// Managers returns the distinct field managers, sorted. The order is stable
+// so a color assigned to a manager does not move between renders.
+func (f *FieldOwners) Managers() []string {
+	if f == nil {
+		return nil
+	}
+	return f.managers
+}
+
+// At returns the owner of an exact path. A path with no manager of its own
+// returns false; the caller decides whether to inherit from an ancestor.
+func (f *FieldOwners) At(path []PathSeg) (FieldOwner, bool) {
+	if f == nil || f.root == nil {
+		return FieldOwner{}, false
+	}
+	node := f.root
+	for _, seg := range path {
+		if node = node.child(seg); node == nil {
+			return FieldOwner{}, false
+		}
+	}
+	if node.owner == nil {
+		return FieldOwner{}, false
+	}
+	return *node.owner, true
+}
+
+func newOwnerNode() *ownerNode {
+	return &ownerNode{fields: make(map[string]*ownerNode)}
+}
+
+// selectorKeyNames returns the sorted field names of a selector, which is how
+// the item index is bucketed.
+func selectorKeyNames(sel map[string]string) string {
+	names := make([]string, 0, len(sel))
+	for k := range sel {
+		names = append(names, k)
+	}
+	slices.Sort(names)
+	return strings.Join(names, "\x00")
+}
+
+// selectorValueKey joins the values of the named fields, or reports false when
+// the item does not carry all of them.
+func selectorValueKey(names string, fields map[string]string) (string, bool) {
+	var b strings.Builder
+	for i, name := range strings.Split(names, "\x00") {
+		value, ok := fields[name]
+		if !ok {
+			return "", false
+		}
+		if i > 0 {
+			b.WriteByte(0)
+		}
+		b.WriteString(value)
+	}
+	return b.String(), true
+}
+
+func (n *ownerNode) child(seg PathSeg) *ownerNode {
+	if seg.Item != nil {
+		return n.matchItem(seg.Item)
+	}
+	return n.fields[seg.Key]
+}
+
+// matchItem finds the list entry whose selector the YAML item satisfies. A
+// selector matches when every field it names is present with the same value.
+func (n *ownerNode) matchItem(fields map[string]string) *ownerNode {
+	for names, byValue := range n.items {
+		key, ok := selectorValueKey(names, fields)
+		if !ok {
+			continue
+		}
+		if node, found := byValue[key]; found {
+			return node
+		}
+	}
+	return nil
+}
+
+// merge folds one managedFields entry into the tree. Keys follow the FieldsV1
+// encoding: "f:" a map field, "k:" a list entry selector, "." the node itself.
+// "v:" and "i:" entries are skipped, because a value or index selector has no
+// stable anchor in the rendered YAML.
+func (n *ownerNode) merge(raw []byte, owner FieldOwner, depth int) error {
+	if depth > maxFieldsV1Depth {
+		return errFieldsV1TooDeep
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	for key, value := range fields {
+		switch {
+		case key == ".":
+			n.setOwner(owner)
+		case strings.HasPrefix(key, "f:"):
+			child := n.field(strings.TrimPrefix(key, "f:"))
+			n.mergeChild(child, value, owner, depth+1)
+		case strings.HasPrefix(key, "k:"):
+			sel, err := parseSelector(strings.TrimPrefix(key, "k:"))
+			if err != nil {
+				continue
+			}
+			n.mergeChild(n.item(sel), value, owner, depth+1)
+		}
+	}
+	return nil
+}
+
+// mergeChild owns the child when the value is an empty object, which is how
+// FieldsV1 marks a leaf, and otherwise recurses.
+func (n *ownerNode) mergeChild(child *ownerNode, value json.RawMessage, owner FieldOwner, depth int) {
+	if isEmptyObject(value) {
+		child.setOwner(owner)
+		return
+	}
+	_ = child.merge(value, owner, depth)
+}
+
+func (n *ownerNode) field(name string) *ownerNode {
+	if child, ok := n.fields[name]; ok {
+		return child
+	}
+	child := newOwnerNode()
+	n.fields[name] = child
+	return child
+}
+
+func (n *ownerNode) item(sel map[string]string) *ownerNode {
+	if len(sel) == 0 {
+		return newOwnerNode()
+	}
+	names := selectorKeyNames(sel)
+	key, _ := selectorValueKey(names, sel)
+	if n.items == nil {
+		n.items = make(map[string]map[string]*ownerNode, 1)
+	}
+	byValue, ok := n.items[names]
+	if !ok {
+		byValue = make(map[string]*ownerNode, 4)
+		n.items[names] = byValue
+	}
+	if child, found := byValue[key]; found {
+		return child
+	}
+	child := newOwnerNode()
+	byValue[key] = child
+	return child
+}
+
+// setOwner keeps the most recent writer when two entries claim one path.
+func (n *ownerNode) setOwner(owner FieldOwner) {
+	if n.owner != nil && !owner.Time.After(n.owner.Time) {
+		return
+	}
+	n.owner = &owner
+}
+
+// parseSelector reads a k: selector such as {"name":"nginx"} or
+// {"containerPort":80,"protocol":"TCP"}. Numbers keep their literal text so
+// they compare equal to the value printed in the YAML.
+func parseSelector(raw string) (map[string]string, error) {
+	dec := json.NewDecoder(bytes.NewBufferString(raw))
+	dec.UseNumber()
+	var fields map[string]any
+	if err := dec.Decode(&fields); err != nil {
+		return nil, err
+	}
+	sel := make(map[string]string, len(fields))
+	for k, v := range fields {
+		switch t := v.(type) {
+		case string:
+			sel[k] = t
+		case json.Number:
+			sel[k] = t.String()
+		case bool:
+			if t {
+				sel[k] = "true"
+			} else {
+				sel[k] = "false"
+			}
+		default:
+			return nil, errUnsupportedSelector
+		}
+	}
+	return sel, nil
+}
+
+var (
+	errUnsupportedSelector = errors.New("unsupported managedFields selector value")
+	errFieldsV1TooDeep     = errors.New("managedFields entry nests deeper than lfk walks")
+)
+
+// maxFieldsV1Depth bounds the walk. Real Kubernetes objects stay well under
+// this; the cap stops a hostile or corrupt entry from driving the recursion.
+const maxFieldsV1Depth = 32
+
+func isEmptyObject(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("{}"))
+}

--- a/internal/k8s/fieldowners_test.go
+++ b/internal/k8s/fieldowners_test.go
@@ -1,0 +1,230 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func entry(manager, operation, fieldsJSON string, at time.Time) metav1.ManagedFieldsEntry {
+	t := metav1.NewTime(at)
+	fields := &metav1.FieldsV1{}
+	fields.SetRawBytes([]byte(fieldsJSON))
+	return metav1.ManagedFieldsEntry{
+		Manager:    manager,
+		Operation:  metav1.ManagedFieldsOperationType(operation),
+		Time:       &t,
+		FieldsType: "FieldsV1",
+		FieldsV1:   fields,
+	}
+}
+
+func TestFieldOwnersAt_MapFields(t *testing.T) {
+	base := time.Date(2026, 8, 8, 10, 0, 0, 0, time.UTC)
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry("kubectl", "Update", `{"f:spec":{"f:replicas":{}}}`, base),
+		entry("argocd-controller", "Apply", `{"f:metadata":{"f:labels":{"f:app":{}}}}`, base),
+	})
+
+	got, ok := owners.At([]PathSeg{{Key: "spec"}, {Key: "replicas"}})
+	require.True(t, ok)
+	assert.Equal(t, "kubectl", got.Manager)
+	assert.Equal(t, "Update", got.Operation)
+
+	got, ok = owners.At([]PathSeg{{Key: "metadata"}, {Key: "labels"}, {Key: "app"}})
+	require.True(t, ok)
+	assert.Equal(t, "argocd-controller", got.Manager)
+}
+
+func TestFieldOwnersAt_UnownedPathReturnsFalse(t *testing.T) {
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry("kubectl", "Update", `{"f:spec":{"f:replicas":{}}}`, time.Now()),
+	})
+
+	_, ok := owners.At([]PathSeg{{Key: "spec"}, {Key: "paused"}})
+	assert.False(t, ok)
+
+	// A parent that only routes to an owned child is not itself owned.
+	_, ok = owners.At([]PathSeg{{Key: "spec"}})
+	assert.False(t, ok)
+}
+
+func TestFieldOwnersAt_DotMarksTheNodeItself(t *testing.T) {
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry("helm", "Update", `{"f:spec":{".":{},"f:replicas":{}}}`, time.Now()),
+	})
+
+	got, ok := owners.At([]PathSeg{{Key: "spec"}})
+	require.True(t, ok)
+	assert.Equal(t, "helm", got.Manager)
+}
+
+func TestFieldOwnersAt_ListItemBySelector(t *testing.T) {
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry("kubectl", "Update",
+			`{"f:spec":{"f:containers":{"k:{\"name\":\"nginx\"}":{".":{},"f:image":{}}}}}`,
+			time.Now()),
+	})
+
+	path := []PathSeg{
+		{Key: "spec"},
+		{Key: "containers"},
+		{Item: map[string]string{"name": "nginx", "image": "nginx:1.27"}},
+		{Key: "image"},
+	}
+	got, ok := owners.At(path)
+	require.True(t, ok)
+	assert.Equal(t, "kubectl", got.Manager)
+
+	// A different list item is not covered by that selector.
+	other := []PathSeg{
+		{Key: "spec"},
+		{Key: "containers"},
+		{Item: map[string]string{"name": "sidecar"}},
+		{Key: "image"},
+	}
+	_, ok = owners.At(other)
+	assert.False(t, ok)
+}
+
+func TestFieldOwnersAt_NewerEntryWinsTheSamePath(t *testing.T) {
+	older := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry("old-manager", "Update", `{"f:spec":{"f:replicas":{}}}`, older),
+		entry("new-manager", "Update", `{"f:spec":{"f:replicas":{}}}`, newer),
+	})
+
+	got, ok := owners.At([]PathSeg{{Key: "spec"}, {Key: "replicas"}})
+	require.True(t, ok)
+	assert.Equal(t, "new-manager", got.Manager)
+}
+
+func TestNewFieldOwners_SkipsUnusableEntries(t *testing.T) {
+	now := time.Now()
+	broken := &metav1.FieldsV1{}
+	broken.SetRawBytes([]byte(`{`))
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		{Manager: "no-fields", Operation: "Update"},
+		{Manager: "bad-json", Operation: "Update", FieldsV1: broken},
+		entry("good", "Update", `{"f:spec":{"f:replicas":{}}}`, now),
+	})
+
+	got, ok := owners.At([]PathSeg{{Key: "spec"}, {Key: "replicas"}})
+	require.True(t, ok)
+	assert.Equal(t, "good", got.Manager)
+}
+
+func TestNewFieldOwners_SubresourceEntriesAreLabelled(t *testing.T) {
+	now := time.Now()
+	e := entry("horizontal-pod-autoscaler", "Update", `{"f:spec":{"f:replicas":{}}}`, now)
+	e.Subresource = "scale"
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{e})
+
+	got, ok := owners.At([]PathSeg{{Key: "spec"}, {Key: "replicas"}})
+	require.True(t, ok)
+	assert.Equal(t, "horizontal-pod-autoscaler", got.Manager)
+	assert.Equal(t, "scale", got.Subresource)
+}
+
+func TestFieldOwners_EmptyIsSafeToQuery(t *testing.T) {
+	var owners *FieldOwners
+	_, ok := owners.At([]PathSeg{{Key: "spec"}})
+	assert.False(t, ok)
+	assert.True(t, owners.Empty())
+
+	owners = NewFieldOwners(nil)
+	assert.True(t, owners.Empty())
+}
+
+func TestFieldOwners_Managers(t *testing.T) {
+	now := time.Now()
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry("b-manager", "Update", `{"f:spec":{"f:replicas":{}}}`, now),
+		entry("a-manager", "Apply", `{"f:metadata":{"f:labels":{}}}`, now),
+		entry("b-manager", "Update", `{"f:status":{}}`, now),
+	})
+
+	assert.Equal(t, []string{"a-manager", "b-manager"}, owners.Managers())
+}
+
+func TestGetFieldOwners_VirtualTypesReturnEmpty(t *testing.T) {
+	c := &Client{}
+	for _, group := range []string{"_helm", "_portforward"} {
+		owners, err := c.GetFieldOwners(t.Context(), "ctx", "ns",
+			model.ResourceTypeEntry{APIGroup: group, Resource: "releases"}, "name")
+		require.NoError(t, err)
+		assert.True(t, owners.Empty())
+	}
+}
+
+func TestNewFieldOwners_RejectsAnOverDeepEntry(t *testing.T) {
+	var deep strings.Builder
+	for range maxFieldsV1Depth + 5 {
+		deep.WriteString(`{"f:a":`)
+	}
+	deep.WriteString("{}")
+	for range maxFieldsV1Depth + 5 {
+		deep.WriteString("}")
+	}
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{entry("deep", "Update", deep.String(), time.Now())})
+
+	// The walk stops at the cap rather than recursing without a bound. What
+	// it recorded before the cap is allowed; what matters is that it returns.
+	assert.NotNil(t, owners)
+}
+
+func TestFieldOwnersAt_ManyListItemsStayFast(t *testing.T) {
+	const items = 2000
+	var raw strings.Builder
+	raw.WriteString(`{"f:spec":{"f:containers":{`)
+	for i := range items {
+		if i > 0 {
+			raw.WriteString(",")
+		}
+		fmt.Fprintf(&raw, `"k:{\"name\":\"c%d\"}":{"f:image":{}}`, i)
+	}
+	raw.WriteString("}}}")
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{entry("kubectl", "Update", raw.String(), time.Now())})
+
+	for i := range items {
+		got, ok := owners.At([]PathSeg{
+			{Key: "spec"},
+			{Key: "containers"},
+			{Item: map[string]string{"name": fmt.Sprintf("c%d", i)}},
+			{Key: "image"},
+		})
+		require.True(t, ok, "item %d", i)
+		assert.Equal(t, "kubectl", got.Manager)
+	}
+}
+
+func TestFieldOwnersAt_MultiFieldSelector(t *testing.T) {
+	owners := NewFieldOwners([]metav1.ManagedFieldsEntry{
+		entry("kubectl", "Update",
+			`{"f:spec":{"f:ports":{"k:{\"port\":80,\"protocol\":\"TCP\"}":{".":{}}}}}`,
+			time.Now()),
+	})
+
+	got, ok := owners.At([]PathSeg{
+		{Key: "spec"},
+		{Key: "ports"},
+		{Item: map[string]string{"port": "80", "protocol": "TCP", "name": "http"}},
+	})
+	require.True(t, ok)
+	assert.Equal(t, "kubectl", got.Manager)
+
+	_, ok = owners.At([]PathSeg{
+		{Key: "spec"},
+		{Key: "ports"},
+		{Item: map[string]string{"port": "80", "protocol": "UDP"}},
+	})
+	assert.False(t, ok, "a selector matches only when every field it names matches")
+}

--- a/internal/ui/fieldmanager.go
+++ b/internal/ui/fieldmanager.go
@@ -1,0 +1,38 @@
+package ui
+
+import (
+	"hash/fnv"
+
+	"charm.land/lipgloss/v2"
+)
+
+// fieldManagerPalette are the theme colors the blame gutter cycles through.
+// They are read at call time, not captured, so a runtime theme switch moves
+// the gutter with everything else. In no-color mode the variables are blank
+// and lipgloss emits no color.
+func fieldManagerPalette() []string {
+	return []string{ColorPrimary, ColorCyan, ColorPurple, ColorOrange, ColorWarning, ColorSecondary}
+}
+
+// FieldManagerStyle returns the color for one field manager. The same name
+// always maps to the same color, so a manager keeps its color between
+// renders and between resources. dim marks a manager that was derived from
+// a parent or a subtree rather than recorded on the line itself.
+func FieldManagerStyle(manager string, dim bool) lipgloss.Style {
+	palette := fieldManagerPalette()
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(manager))
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(palette[int(h.Sum32())%len(palette)]))
+	if dim {
+		style = style.Faint(true)
+	}
+	return style
+}
+
+// FieldManagerColorIndex returns which palette slot a manager lands in. The
+// help and the legend use it to show the same color as the gutter.
+func FieldManagerColorIndex(manager string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(manager))
+	return int(h.Sum32()) % len(fieldManagerPalette())
+}

--- a/internal/ui/fieldmanager_test.go
+++ b/internal/ui/fieldmanager_test.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldManagerColorIndex_IsStableAndInRange(t *testing.T) {
+	for _, name := range []string{"kubectl", "argocd-controller", "helm", ""} {
+		idx := FieldManagerColorIndex(name)
+		assert.GreaterOrEqual(t, idx, 0)
+		assert.Less(t, idx, len(fieldManagerPalette()))
+		assert.Equal(t, idx, FieldManagerColorIndex(name), "same name, same slot")
+	}
+}
+
+func TestFieldManagerStyle_DimIsFaint(t *testing.T) {
+	assert.False(t, FieldManagerStyle("kubectl", false).GetFaint())
+	assert.True(t, FieldManagerStyle("kubectl", true).GetFaint())
+}
+
+func TestFieldManagerStyle_FollowsTheActiveTheme(t *testing.T) {
+	original := ColorPrimary
+	t.Cleanup(func() { ColorPrimary = original })
+
+	before := FieldManagerStyle("kubectl", false).GetForeground()
+	ColorPrimary = "#ff0000"
+	after := FieldManagerStyle("kubectl", false).GetForeground()
+
+	if FieldManagerColorIndex("kubectl") == 0 {
+		assert.NotEqual(t, before, after, "the gutter must follow a theme change")
+	}
+}
+
+func TestSanitizeTerminalText_DropsControlsAndBidiOverrides(t *testing.T) {
+	assert.Equal(t, "abc", SanitizeTerminalText("a\x1bb\x7fc"))
+	assert.Equal(t, "abc", SanitizeTerminalText("ab\u202ec"))
+	assert.Equal(t, "abc", SanitizeTerminalText("a\u2066b\u2069c"))
+	assert.Equal(t, "\u200eab", SanitizeTerminalText("\u200eab"),
+		"a plain direction mark is not an override")
+	assert.Equal(t, "kube-controller-manager", SanitizeTerminalText("kube-controller-manager"))
+}

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -293,6 +293,7 @@ func viewerHelpSections(kb Keybindings) []helpSection {
 				{kb.ToggleFold, "Toggle fold on section under cursor"},
 				{kb.ToggleFoldAll, "Toggle all folds"},
 				{kb.ToggleWrap, "Toggle line wrapping"},
+				{"m", "Toggle inline field-manager blame"},
 				{kb.Refresh, "Re-fetch and refresh (keeps position)"},
 				{"ctrl+e", "Edit resource in editor"},
 				{"O", "Open Object Explorer at the attribute under cursor"},

--- a/internal/ui/listsummary.go
+++ b/internal/ui/listsummary.go
@@ -279,15 +279,33 @@ func buildSummaryBar(dim summaryDimension, items []model.Item) SummaryBar {
 // UTF-8-encoded as two bytes but decode to a single rune >= 0x7f, so an
 // ASCII-only filter (r < 0x20 || r == 0x7f) lets them through as if printable.
 func sanitizeSummaryValue(s string) string {
+	return SanitizeTerminalText(s)
+}
+
+// SanitizeTerminalText strips the control characters described above from any
+// cluster-controlled string before it reaches the screen. Exported so every
+// such string passes through one implementation: the YAML blame gutter shows
+// field manager names, which a non-core apiserver can set to anything.
+//
+// It also drops the bidi embedding, override, and isolate characters
+// (U+202A-U+202E, U+2066-U+2069). Those reorder the text that follows them,
+// so a hostile name can make one value read as another on screen. The plain
+// direction marks U+200E and U+200F stay, because they only hint at direction
+// and legitimate right-to-left text uses them.
+func SanitizeTerminalText(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	for _, r := range s {
-		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) || isBidiOverride(r) {
 			continue
 		}
 		b.WriteRune(r)
 	}
 	return b.String()
+}
+
+func isBidiOverride(r rune) bool {
+	return (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069)
 }
 
 const summaryBarCells = 14


### PR DESCRIPTION
Press `m` in the full-screen YAML viewer to see which field manager last wrote the line under the cursor. The note trails the line as faded text with the manager, the operation, and the age.

```
    5   bla: blabla    kubectl-edit • Update • 4m ago
```

## What it does

- Reads `.metadata.managedFields`, which every object already carries. No new dependency, no extra RBAC.
- `GetResourceYAML` still strips managedFields, so the rendered document is unchanged and folding, search, and wrap behave exactly as before. The managers come from a separate GET, made only while blame is on.
- A line with no manager of its own inherits the nearest owned ancestor. A section header takes the manager of its subtree when every line below agrees. Both are marked `inherited`.
- The note is skipped in visual mode, and when fewer than 14 columns are free.
- Blame resets when the viewer opens, so it never carries over to another resource.

Note on what managedFields can answer: it records the tool, not the person. `kubectl-edit` means someone hand-edited the object, but Kubernetes does not store the user in the object.

## Notable

- List entries are matched by their managedFields selector, for example `k:{"name":"nginx"}`, not by index, so blame follows a container when the list is reordered.
- The per-line walk runs in the loader goroutine, like the content and section parse, so a large CRD does not stall the event loop. A reply that lands after a refresh is dropped rather than naming the wrong owner.
- Manager names are cluster-controlled and pass through the shared terminal sanitizer, which now also drops bidi overrides. That hardens the pinned-summary path too, which shares it.

## Test plan

- [x] `make test`
- [x] `make lint`, 0 issues
- [x] `go test -race ./internal/app/ ./internal/k8s/ ./internal/ui/`
- [x] 3 review passes plus a security pass
- [x] Manual: press `m` on a pod, move the cursor, toggle wrap with `>`, switch theme with `T`, reopen on another resource