### PR TITLE
test: wait on the port-forward status instead of a 5 second timer

### DIFF
--- a/internal/k8s/portforward_stderr_race_test.go
+++ b/internal/k8s/portforward_stderr_race_test.go
@@ -3,12 +3,19 @@ package k8s
 import (
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// portForwardSettleTimeout is how long the test waits for the fake binary to
+// spawn, write to stderr, and exit. It is generous on purpose: a full
+// `go test -race ./...` run competes for cores, and the first exec of a file
+// just written to a temp directory can take seconds on a loaded machine.
+const portForwardSettleTimeout = 30 * time.Second
 
 // The port-forward monitor reads the captured stderr after cmd.Wait(). The
 // stderr capture must be synchronized with that read — a bare bytes.Buffer
@@ -24,25 +31,30 @@ func TestPortForwardStderrCaptureNoRace(t *testing.T) {
 	require.NoError(t, os.WriteFile(fake, []byte(script), 0o700))
 
 	mgr := NewPortForwardManager()
-	done := make(chan struct{}, 16)
-	mgr.SetUpdateCallback(func() { done <- struct{}{} })
+	// The callback runs on the monitor goroutine. Counting it keeps that
+	// concurrent write under the race detector without letting a slow reader
+	// block the monitor, which a channel would.
+	var updates atomic.Int64
+	mgr.SetUpdateCallback(func() { updates.Add(1) })
 
 	_, err := mgr.Start(fake, "/dev/null", "Pod", "p", "ns", "ctx", "ctx", "8080", "80")
 	require.NoError(t, err, "Start should launch the fake binary")
 
-	// Wait for the monitor goroutine to reach a terminal status.
-	deadline := time.After(5 * time.Second)
-	for {
+	// Poll the status itself. Waiting on the callback instead would tie the
+	// test to how many times the monitor happens to report. EventuallyWithT
+	// reports the last status it saw, so a timeout names the state it got
+	// stuck in.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		entries := mgr.Entries()
-		if len(entries) == 1 && entries[0].Status == PortForwardFailed {
-			assert.Contains(t, entries[0].Error, "unable to listen on port",
-				"captured stderr must surface in entry.Error")
-			return
+		if assert.Len(c, entries, 1) {
+			assert.Equal(c, PortForwardFailed, entries[0].Status)
 		}
-		select {
-		case <-done:
-		case <-deadline:
-			t.Fatalf("port-forward did not reach Failed status; entries=%+v", mgr.Entries())
-		}
-	}
+	}, portForwardSettleTimeout, 10*time.Millisecond)
+
+	// Failed is terminal, so this second read sees the same entry.
+	entries := mgr.Entries()
+	require.Len(t, entries, 1)
+	assert.Contains(t, entries[0].Error, "unable to listen on port",
+		"captured stderr must surface in entry.Error")
+	assert.Positive(t, updates.Load(), "the manager must report the change")
 }

--- a/internal/k8s/portforward_stderr_race_test.go
+++ b/internal/k8s/portforward_stderr_race_test.go
@@ -56,5 +56,11 @@ func TestPortForwardStderrCaptureNoRace(t *testing.T) {
 	require.Len(t, entries, 1)
 	assert.Contains(t, entries[0].Error, "unable to listen on port",
 		"captured stderr must surface in entry.Error")
-	assert.Positive(t, updates.Load(), "the manager must report the change")
+	// Start reports once before it returns, the monitor once more after
+	// cmd.Wait. Reading the count here would be a race the other way: the
+	// monitor calls back after it releases the lock, so the status can be
+	// visible before the report is.
+	require.Eventually(t, func() bool { return updates.Load() >= 2 },
+		portForwardSettleTimeout, 10*time.Millisecond,
+		"the manager must report the move to Failed, not only the start")
 }


### PR DESCRIPTION
`TestPortForwardStderrCaptureNoRace` failed intermittently during a full `go test -race ./...` run, with the port-forward still in `Starting` after the 5 second wait. It passed standalone and on a clean tree.

## Root cause

Not a starved wait loop. `Start` fires the update callback before it returns, and the monitor fires again after `cmd.Wait`, so the old channel loop always had enough tokens to reach `Failed`. The plain 5 second deadline was the whole problem: on a loaded machine, fork and exec of a script just written to a temp directory can take longer than that.

## Change

Test-only. No lfk behavior changes.

- Poll the status with `require.EventuallyWithT` on a 30 second budget. A timeout now names the state it got stuck in (`expected: "Failed" actual: "Stopped"`) instead of dumping the entry as it was at call time.
- Count the update callback with an `atomic.Int64` instead of a channel, so a slow reader can never block the monitor goroutine.
- Wait for the second callback rather than reading the count directly. The monitor calls back after it releases the lock, so the status can be visible before the report is.

The test still catches the data race it was written for. That race lives in `portforward.go`, which this PR does not touch.

## Test plan

- [x] 10 consecutive full `go test -race -count=1 ./...` runs under 16 CPU burners: 10/10 pass, 0 failures, 0 data races
- [x] Soak ran in a detached worktree with the same HEAD before and after, so no other session moved the source mid-run
- [x] Still fails on a genuine hang: making the fake binary `exit 0` fails the test with `expected: "Failed" actual: "Stopped"`
- [x] Still fails on a missing terminal report: deleting the post-`Wait` `onUpdate` in `portforward.go` fails it with `the manager must report the move to Failed, not only the start`
- [x] `golangci-lint run ./...` 0 issues, `go vet ./...` clean

## Limit

The soak proves this on one Mac. The original failure was on CI, so real proof is the suite running green there a few times.