### PR TITLE
feat: show the cluster schema description of the field under the cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **Monitoring dashboard** with active Prometheus/Alertmanager alerts (`@` key), configurable endpoints per cluster
 - **API Explorer** for interactively browsing resource structure (`I` key) with recursive field browser and an ASCII-art tree view (`T`, sticky across navigation; `Space` folds branches)
 - **Object Explorer** for drilling into the selected resource's live object (`O` key); arrays expand into indexed elements, so recursive status trees (e.g. `.status.steps[].steps[]`) are walkable; live-refreshes under watch mode (`w` to pause, `R` to refresh manually); `T` toggles a tree view that expands the whole subtree with ASCII-art guides, `Space` folds branches
+- **Schema footnotes** (`Ctrl+K`) show the cluster's own description of the field under the cursor in a pane at the bottom of the YAML viewer and Object Explorer; the pane follows the cursor, reads the connected cluster so CRDs resolve like built-in kinds, and caches what it reads
 - **Namespace selector** overlay with type-to-filter
 - **All-namespaces mode** (enabled by default)
 - **Local cluster management** — create, list, and delete `kind` clusters; create, list, start, stop, and delete `k3d` and `minikube` clusters (kind has no native start/stop) from inside lfk via the `Ctrl+N` manager overlay.
@@ -282,6 +283,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `Ctrl+G` | Finalizer search and remove |
 | `I` | API Explorer (browse resource structure interactively) |
 | `O` | Object Explorer (browse the selected resource's live object as a drill-in tree) |
+| `Ctrl+K` | Schema footnote for the field under the cursor (YAML viewer, Object Explorer) |
 | `U` | RBAC permissions browser (can-i) |
 | `T` | Open theme selector |
 | `:` | Command bar: resource jumps (`:pod`, `:dep`), built-ins (`:ns`, `:ctx`, `:set`, `:sort`, `:export`), kubectl (`:k get pod`), shell (`:! cmd`) |
@@ -403,6 +405,7 @@ All search and filter inputs support three modes, auto-detected from the query s
 - Walk any resource's live object with `O` (Object Explorer): `r` finds keys recursively, `T` expands an ASCII tree, `y` copies the field path
 - Forget `kubectl explain` - `I` opens the API Explorer, and `n`/`N` searches auto-drill into nested fields
 - In the YAML viewer, press `O` on a line to jump into the Object Explorer at that attribute, or `I` to see its schema
+- `Ctrl+K` opens a footnote with the schema description of the field under the cursor, and keeps it in step as you move
 - Fold YAML sections with `z` (`Z` folds all); edit the resource in your `$EDITOR` with `Ctrl+E`
 - Every viewer speaks vim: counts (`100j`, `42G`, `5n`), visual selections (`v` / `V` / `Ctrl+V`), and text objects (`viw`) work everywhere
 - Make noisy logs readable with `P` - the structured preview parses JSON, logfmt, klog, zap, nginx, envoy, Java, and postgres lines

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 - **Monitoring dashboard** with active Prometheus/Alertmanager alerts (`@` key), configurable endpoints per cluster
 - **API Explorer** for interactively browsing resource structure (`I` key) with recursive field browser and an ASCII-art tree view (`T`, sticky across navigation; `Space` folds branches)
 - **Object Explorer** for drilling into the selected resource's live object (`O` key); arrays expand into indexed elements, so recursive status trees (e.g. `.status.steps[].steps[]`) are walkable; live-refreshes under watch mode (`w` to pause, `R` to refresh manually); `T` toggles a tree view that expands the whole subtree with ASCII-art guides, `Space` folds branches
-- **Schema footnotes** (`Ctrl+K`) show the cluster's own description of the field under the cursor in a pane at the bottom of the YAML viewer and Object Explorer; the pane follows the cursor, reads the connected cluster so CRDs resolve like built-in kinds, and caches what it reads
+- **Schema side pane** (`Ctrl+K`) shows the cluster's own description of the field under the cursor, in a bordered pane beside the YAML viewer and Object Explorer; it follows the cursor, reads the connected cluster so CRDs resolve like built-in kinds, and caches what it reads
 - **Namespace selector** overlay with type-to-filter
 - **All-namespaces mode** (enabled by default)
 - **Local cluster management** — create, list, and delete `kind` clusters; create, list, start, stop, and delete `k3d` and `minikube` clusters (kind has no native start/stop) from inside lfk via the `Ctrl+N` manager overlay.
@@ -283,7 +283,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `Ctrl+G` | Finalizer search and remove |
 | `I` | API Explorer (browse resource structure interactively) |
 | `O` | Object Explorer (browse the selected resource's live object as a drill-in tree) |
-| `Ctrl+K` | Schema footnote for the field under the cursor (YAML viewer, Object Explorer) |
+| `Ctrl+K` | Schema side pane for the field under the cursor (YAML viewer, Object Explorer) |
 | `U` | RBAC permissions browser (can-i) |
 | `T` | Open theme selector |
 | `:` | Command bar: resource jumps (`:pod`, `:dep`), built-ins (`:ns`, `:ctx`, `:set`, `:sort`, `:export`), kubectl (`:k get pod`), shell (`:! cmd`) |
@@ -405,7 +405,7 @@ All search and filter inputs support three modes, auto-detected from the query s
 - Walk any resource's live object with `O` (Object Explorer): `r` finds keys recursively, `T` expands an ASCII tree, `y` copies the field path
 - Forget `kubectl explain` - `I` opens the API Explorer, and `n`/`N` searches auto-drill into nested fields
 - In the YAML viewer, press `O` on a line to jump into the Object Explorer at that attribute, or `I` to see its schema
-- `Ctrl+K` opens a footnote with the schema description of the field under the cursor, and keeps it in step as you move
+- `Ctrl+K` opens a side pane with the schema description of the field under the cursor, and keeps it in step as you move
 - Fold YAML sections with `z` (`Z` folds all); edit the resource in your `$EDITOR` with `Ctrl+E`
 - Every viewer speaks vim: counts (`100j`, `42G`, `5n`), visual selections (`v` / `V` / `Ctrl+V`), and text objects (`viw`) work everywhere
 - Make noisy logs readable with `P` - the structured preview parses JSON, logfmt, klog, zap, nginx, envoy, Java, and postgres lines

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -418,6 +418,7 @@ keybindings:
   toggle_prefixes: "p" # Toggle pod/container line prefixes in the log viewer (default: p)
   toggle_unified: "u" # Toggle unified vs side-by-side in the diff viewer (default: u)
   tree_view: "T" # Toggle the ASCII-art tree view in the Object/API Explorers (default: T)
+  field_doc: "ctrl+k" # Toggle the schema footnote for the field under the cursor in the YAML viewer and Object Explorer (default: ctrl+k)
   mouse_toggle: "ctrl+alt+y" # Suspend/resume mouse capture for native text selection (Ctrl+Option+Y; default: ctrl+alt+y)
   cluster_color_picker: "L" # Open cluster-color picker (default: Shift+L; shares "L" with toggle_preview_logs, gated by level — at the cluster picker "L" opens this, at deeper levels it toggles the live-log preview)
   security_ignore_toggle: "i" # Show/hide ignored security findings (default: i; security view only — shadows the Label Editor there)

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -418,7 +418,7 @@ keybindings:
   toggle_prefixes: "p" # Toggle pod/container line prefixes in the log viewer (default: p)
   toggle_unified: "u" # Toggle unified vs side-by-side in the diff viewer (default: u)
   tree_view: "T" # Toggle the ASCII-art tree view in the Object/API Explorers (default: T)
-  field_doc: "ctrl+k" # Toggle the schema footnote for the field under the cursor in the YAML viewer and Object Explorer (default: ctrl+k)
+  field_doc: "ctrl+k" # Toggle the schema side pane for the field under the cursor in the YAML viewer and Object Explorer (default: ctrl+k)
   mouse_toggle: "ctrl+alt+y" # Suspend/resume mouse capture for native text selection (Ctrl+Option+Y; default: ctrl+alt+y)
   cluster_color_picker: "L" # Open cluster-color picker (default: Shift+L; shares "L" with toggle_preview_logs, gated by level — at the cluster picker "L" opens this, at deeper levels it toggles the live-log preview)
   security_ignore_toggle: "i" # Show/hide ignored security findings (default: i; security view only — shadows the Label Editor there)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -492,7 +492,7 @@ The fullscreen viewers (YAML, diff, describe, log, events) honor the shared `sea
 | `toggle_prefixes` | `p` | Toggle `[pod/name/container]` line prefixes (log viewer). |
 | `toggle_unified` | `u` | Toggle unified vs side-by-side layout (diff viewer). |
 | `tree_view` | `T` | Toggle the ASCII-art tree view (Object Explorer, API Explorer). Shares the `T` default with `theme_selector`, but they apply in separate contexts (explorers vs. resource list). |
-| `field_doc` | `ctrl+k` | Toggle the schema footnote for the field under the cursor (YAML viewer, Object Explorer). |
+| `field_doc` | `ctrl+k` | Toggle the schema side pane for the field under the cursor (YAML viewer, Object Explorer). |
 | `toggle_preview` | `P` | Toggle the structured preview side panel (log viewer) / details↔YAML preview (explorer). |
 | `toggle_preview_logs` | `L` | Toggle the right-pane live-log preview for the selected pod or container (explorer; deeper levels only). |
 | `fullscreen` | `F` | Explorer: cycle layout (hide sidebar -> fullscreen -> restore). Dashboard / event timeline / error log: fullscreen toggle. |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -492,6 +492,7 @@ The fullscreen viewers (YAML, diff, describe, log, events) honor the shared `sea
 | `toggle_prefixes` | `p` | Toggle `[pod/name/container]` line prefixes (log viewer). |
 | `toggle_unified` | `u` | Toggle unified vs side-by-side layout (diff viewer). |
 | `tree_view` | `T` | Toggle the ASCII-art tree view (Object Explorer, API Explorer). Shares the `T` default with `theme_selector`, but they apply in separate contexts (explorers vs. resource list). |
+| `field_doc` | `ctrl+k` | Toggle the schema footnote for the field under the cursor (YAML viewer, Object Explorer). |
 | `toggle_preview` | `P` | Toggle the structured preview side panel (log viewer) / details↔YAML preview (explorer). |
 | `toggle_preview_logs` | `L` | Toggle the right-pane live-log preview for the selected pod or container (explorer; deeper levels only). |
 | `fullscreen` | `F` | Explorer: cycle layout (hide sidebar -> fullscreen -> restore). Dashboard / event timeline / error log: fullscreen toggle. |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -437,6 +437,7 @@
         "secret_toggle": { "type": "string" },
         "finalizer_search": { "type": "string" },
         "api_explorer": { "type": "string" },
+        "field_doc": { "type": "string" },
         "object_explorer": { "type": "string" },
         "tree_view": { "type": "string" },
         "rbac_browser": { "type": "string" },

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -408,7 +408,7 @@ The in-app screen is a quick reference: one binding per line, keys right-aligned
 | `Ctrl+E` | Edit resource in `$KUBE_EDITOR` or `$EDITOR` |
 | `O` | Switch to the Object Explorer at the attribute under the cursor (keeps position) |
 | `I` | Open the API Explorer at the schema of the attribute under the cursor |
-| `Ctrl+K` | Toggle the schema footnote for the attribute under the cursor (configurable via `field_doc`) |
+| `Ctrl+K` | Toggle the schema side pane for the attribute under the cursor (configurable via `field_doc`) |
 | `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` / `Esc` | Back to explorer |
@@ -434,7 +434,7 @@ The top breadcrumb shows the resource name and the attribute path under the curs
 | `y` / `Y` | Yank the selected node's path / full YAML |
 | `P` | Open the whole resource in the full YAML viewer |
 | `I` | Open the API Explorer at the selected item's schema |
-| `Ctrl+K` | Toggle the schema footnote for the selected item (configurable via `field_doc`) |
+| `Ctrl+K` | Toggle the schema side pane for the selected item (configurable via `field_doc`) |
 | `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` | Close the Object Explorer |
@@ -1306,7 +1306,7 @@ keybindings:
   theme_selector: "T"    # Theme selector
   finalizer_search: "ctrl+g"  # Finalizer search
   api_explorer: "I"      # API Explorer
-  field_doc: "ctrl+k"    # Schema footnote for the field under the cursor
+  field_doc: "ctrl+k"    # Schema side pane for the field under the cursor
   object_explorer: "O"   # Object Explorer (browse live object)
   rbac_browser: "U"      # RBAC browser
   secret_toggle: "ctrl+s" # Secret visibility

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -408,6 +408,7 @@ The in-app screen is a quick reference: one binding per line, keys right-aligned
 | `Ctrl+E` | Edit resource in `$KUBE_EDITOR` or `$EDITOR` |
 | `O` | Switch to the Object Explorer at the attribute under the cursor (keeps position) |
 | `I` | Open the API Explorer at the schema of the attribute under the cursor |
+| `Ctrl+K` | Toggle the schema footnote for the attribute under the cursor (configurable via `field_doc`) |
 | `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` / `Esc` | Back to explorer |
@@ -433,6 +434,7 @@ The top breadcrumb shows the resource name and the attribute path under the curs
 | `y` / `Y` | Yank the selected node's path / full YAML |
 | `P` | Open the whole resource in the full YAML viewer |
 | `I` | Open the API Explorer at the selected item's schema |
+| `Ctrl+K` | Toggle the schema footnote for the selected item (configurable via `field_doc`) |
 | `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` | Close the Object Explorer |
@@ -1304,6 +1306,7 @@ keybindings:
   theme_selector: "T"    # Theme selector
   finalizer_search: "ctrl+g"  # Finalizer search
   api_explorer: "I"      # API Explorer
+  field_doc: "ctrl+k"    # Schema footnote for the field under the cursor
   object_explorer: "O"   # Object Explorer (browse live object)
   rbac_browser: "U"      # RBAC browser
   secret_toggle: "ctrl+s" # Secret visibility

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -162,6 +162,7 @@ and follow their own dismissal rules.
 | ------------------ | --------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `overlayErrorLog`  | `!`             | Application error log overlay (lfk's own error buffer). Has its own `errorLogFullscreen` toggle for full-screen mode. |
 | `commandBarActive` | `:`             | Bottom-of-screen `:command [args]` input with autocomplete, history, and ghost-text preview.                          |
+| `fieldDoc.on`      | `Ctrl+K`        | Schema footnote pane in the YAML viewer and Object Explorer. Shows the cluster's description of the field under the cursor and follows it as the cursor moves. Takes its 6 lines out of the body above it, so both `yamlViewportLines` and `objectExplorerBodyHeight` subtract it. |
 
 ## Adding a new view, fullscreen flag, or overlay
 

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -162,7 +162,7 @@ and follow their own dismissal rules.
 | ------------------ | --------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `overlayErrorLog`  | `!`             | Application error log overlay (lfk's own error buffer). Has its own `errorLogFullscreen` toggle for full-screen mode. |
 | `commandBarActive` | `:`             | Bottom-of-screen `:command [args]` input with autocomplete, history, and ghost-text preview.                          |
-| `fieldDoc.on`      | `Ctrl+K`        | Schema footnote pane in the YAML viewer and Object Explorer. Shows the cluster's description of the field under the cursor and follows it as the cursor moves. Takes its 6 lines out of the body above it, so both `yamlViewportLines` and `objectExplorerBodyHeight` subtract it. |
+| `fieldDoc.on`      | `Ctrl+K`        | Schema side pane in the YAML viewer and Object Explorer. Shows the cluster's description of the field under the cursor and follows it as the cursor moves. Drawn like the log viewer's structured preview (`RenderLogPreviewPane`) and joined horizontally, so it takes columns rather than rows. `splitFieldDocWidth` sizes it and reports zero on a terminal too narrow for both. |
 
 ## Adding a new view, fullscreen flag, or overlay
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,7 +62,7 @@ type Model struct {
 	// distinct right-pane preview state and are intentionally not part of it.
 	yamlView yamlViewState
 
-	// Schema footnote pane (ctrl+k) and its description cache; see fielddoc.go.
+	// Schema side pane (ctrl+k) and its description cache; see fielddoc.go.
 	fieldDoc fieldDocState
 
 	// yamlReturnMode is the mode the full-screen YAML viewer returns to on

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,6 +62,9 @@ type Model struct {
 	// distinct right-pane preview state and are intentionally not part of it.
 	yamlView yamlViewState
 
+	// Schema footnote pane (ctrl+k) and its description cache; see fielddoc.go.
+	fieldDoc fieldDocState
+
 	// yamlReturnMode is the mode the full-screen YAML viewer returns to on
 	// q/esc. Defaults to modeExplorer (the zero value); set to
 	// modeObjectExplorer when the YAML viewer is opened from the Object Explorer
@@ -183,8 +186,7 @@ type Model struct {
 
 	// Fullscreen toggles: middle = hides left and right columns; dashboard
 	// = renders the cluster dashboard full screen.
-	fullscreenMiddle    bool
-	fullscreenDashboard bool
+	fullscreenMiddle, fullscreenDashboard bool
 	// hideLeftPane hides only the left resource-type sidebar; middle and
 	// right preview stay visible. One phase of the kb.Fullscreen cycle.
 	hideLeftPane bool
@@ -235,9 +237,8 @@ type Model struct {
 	// ui.ConfigObjectExplorerLive; runtime toggle is w inside the explorer.
 	// objectExplorerForceSync forces a single re-sync on the next list refresh
 	// even when live is off, so manual refresh (R) updates the view once.
-	objectExplorerLive      bool
-	objectExplorerForceSync bool
-	objectExplorerTree      bool // session tree-view pref (T); seeded from ui.ConfigObjectExplorerTree
+	objectExplorerLive, objectExplorerForceSync bool
+	objectExplorerTree                          bool // session tree-view pref (T); seeded from ui.ConfigObjectExplorerTree
 
 	// Read-only mode: blocks all mutating actions for the active tab. Mirrors
 	// the active TabState.readOnly; re-evaluated on context switch and tab
@@ -443,9 +444,8 @@ type Model struct {
 	// running ↔ history; tasksOverlayShowAll (`a`, history only) lifts
 	// the sub-second filter; tasksOverlayFrozenHistory pauses the live
 	// history while scrolled (cleared on scroll-to-top, Tab, `a`, esc).
-	tasksOverlayShowCompleted bool
-	tasksOverlayShowAll       bool
-	tasksOverlayFrozenHistory []ui.BackgroundTaskRow
+	tasksOverlayShowCompleted, tasksOverlayShowAll bool
+	tasksOverlayFrozenHistory                      []ui.BackgroundTaskRow
 
 	// tasksOverlayScroll is the first-visible-row index for the :tasks
 	// overlay. Bumped by j/k (and friends) inside the overlay; reset on

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -131,6 +131,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		eventGrouping:              ui.ConfigEventsGrouping,
 		scheduler:                  scheduler.New(scheduler.DefaultThreshold),
 		diffView:                   diffViewState{wrap: ui.ConfigDiffViewerWrap, lineNumbers: ui.ConfigDiffViewerLineNumbers, unified: ui.ConfigDiffViewerUnified, diffCache: &ui.DiffCache{}},
+		fieldDoc:                   fieldDocState{cache: newFieldDocCache()},
 		execTickGen:                &atomic.Uint64{},
 		logReaderInFlight:          make(map[chan string]bool),
 		reqCtx:                     reqCtx,

--- a/internal/app/commands_fielddoc.go
+++ b/internal/app/commands_fielddoc.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,6 +18,10 @@ import (
 // about the field under it. One kubectl explain costs a process spawn and a
 // round trip, so a key held down must not start one per line.
 const fieldDocDebounce = 250 * time.Millisecond
+
+// fieldDocFetchTimeout bounds one explain call, so an unreachable cluster or a
+// credential plugin waiting on input cannot hold a worker for the session.
+const fieldDocFetchTimeout = 15 * time.Second
 
 // fieldDocKeyForPath addresses the field under the cursor in the schema of the
 // resource the viewer is showing. It reports false when the navigation state
@@ -63,18 +68,28 @@ func (m Model) execKubectlExplainField(req uint64, key fieldDocKey) tea.Cmd {
 		target = key.resource + "." + key.path
 	}
 	kubectlContext := m.kubectlContext(key.context)
+	parentCtx := m.reqCtx
 
 	return m.trackBgTask(scheduler.KindSubprocess, "Field doc: "+target, key.context, func() tea.Msg {
+		// The pane fetches on cursor movement, so a cluster that never answers
+		// would tie up one scheduler worker per field visited. Retargeting only
+		// drops the reply; the deadline is what ends the process.
+		ctx, cancel := context.WithTimeout(parentCtx, fieldDocFetchTimeout)
+		defer cancel()
+
 		args := []string{"explain", target, "--context", kubectlContext}
 		if key.apiVersion != "" {
 			args = append(args, "--api-version", key.apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.CommandContext(ctx, kubectlPath, args...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
-			logger.Error("kubectl explain failed", "cmd", cmd.String(), "error", cmdErr, "output", string(output))
+			// The output is not logged: on an auth failure it carries whatever
+			// the credential plugin printed. The parsed message still reaches
+			// the pane, where the user asked for it.
+			logger.Error("kubectl explain failed", "target", target, "apiVersion", key.apiVersion, "error", cmdErr)
 			return fieldDocLoadedMsg{req: req, key: key, err: parseExplainError(string(output), cmdErr)}
 		}
 

--- a/internal/app/commands_fielddoc.go
+++ b/internal/app/commands_fielddoc.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// fieldDocDebounce is how long the cursor must rest before the schema is asked
+// about the field under it. One kubectl explain costs a process spawn and a
+// round trip, so a key held down must not start one per line.
+const fieldDocDebounce = 250 * time.Millisecond
+
+// fieldDocKeyForPath addresses the field under the cursor in the schema of the
+// resource the viewer is showing. It reports false when the navigation state
+// carries no resource type, which leaves nothing to ask the schema about.
+func (m Model) fieldDocKeyForPath(objPath []string) (fieldDocKey, bool) {
+	rt := m.nav.ResourceType
+	resource, apiVersion := buildExplainResourceFromType(rt)
+	if resource == "" && rt.Kind != "" {
+		resource = strings.ToLower(rt.Kind) + "s"
+	}
+	if resource == "" {
+		return fieldDocKey{}, false
+	}
+	return fieldDocKey{
+		context:    m.effectiveContext(),
+		apiVersion: apiVersion,
+		resource:   resource,
+		path:       fieldDocPath(objPath),
+	}, true
+}
+
+// scheduleFieldDocFetch waits out the debounce and then reports back with the
+// request number, which updateFieldDocDebounce checks before it spends a fetch.
+func scheduleFieldDocFetch(req uint64) tea.Cmd {
+	return tea.Tick(fieldDocDebounce, func(time.Time) tea.Msg {
+		return fieldDocDebounceMsg{req: req}
+	})
+}
+
+// execKubectlExplainField reads one field description from the schema of the
+// connected cluster. It shells out to kubectl explain rather than reading a
+// bundled copy, so the text matches the cluster version and covers CRDs.
+func (m Model) execKubectlExplainField(req uint64, key fieldDocKey) tea.Cmd {
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		return func() tea.Msg {
+			return fieldDocLoadedMsg{req: req, key: key, err: fmt.Errorf("kubectl not found: %w", err)}
+		}
+	}
+
+	kubeconfigPaths := m.client.KubeconfigPathForContext(key.context)
+	target := key.resource
+	if key.path != "" {
+		target = key.resource + "." + key.path
+	}
+	kubectlContext := m.kubectlContext(key.context)
+
+	return m.trackBgTask(scheduler.KindSubprocess, "Field doc: "+target, key.context, func() tea.Msg {
+		args := []string{"explain", target, "--context", kubectlContext}
+		if key.apiVersion != "" {
+			args = append(args, "--api-version", key.apiVersion)
+		}
+		cmd := exec.Command(kubectlPath, args...)
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
+		logExecCmd("Running kubectl command", cmd)
+		output, cmdErr := cmd.CombinedOutput()
+		if cmdErr != nil {
+			logger.Error("kubectl explain failed", "cmd", cmd.String(), "error", cmdErr, "output", string(output))
+			return fieldDocLoadedMsg{
+				req: req, key: key,
+				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
+			}
+		}
+
+		desc, _ := parseExplainOutput(string(output), key.path)
+		_, fieldType := parseExplainFieldHeader(string(output))
+		return fieldDocLoadedMsg{
+			req: req, key: key,
+			entry: fieldDocEntry{fieldType: fieldType, desc: desc},
+		}
+	})
+}

--- a/internal/app/commands_fielddoc.go
+++ b/internal/app/commands_fielddoc.go
@@ -75,10 +75,7 @@ func (m Model) execKubectlExplainField(req uint64, key fieldDocKey) tea.Cmd {
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
 			logger.Error("kubectl explain failed", "cmd", cmd.String(), "error", cmdErr, "output", string(output))
-			return fieldDocLoadedMsg{
-				req: req, key: key,
-				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
-			}
+			return fieldDocLoadedMsg{req: req, key: key, err: parseExplainError(string(output), cmdErr)}
 		}
 
 		desc, _ := parseExplainOutput(string(output), key.path)

--- a/internal/app/commands_fielddoc.go
+++ b/internal/app/commands_fielddoc.go
@@ -23,6 +23,10 @@ const fieldDocDebounce = 250 * time.Millisecond
 // credential plugin waiting on input cannot hold a worker for the session.
 const fieldDocFetchTimeout = 15 * time.Second
 
+// fieldDocWaitDelay is how long to wait for output pipes to close after the
+// process is killed, before giving up on them and returning.
+const fieldDocWaitDelay = 2 * time.Second
+
 // fieldDocKeyForPath addresses the field under the cursor in the schema of the
 // resource the viewer is showing. It reports false when the navigation state
 // carries no resource type, which leaves nothing to ask the schema about.
@@ -82,6 +86,10 @@ func (m Model) execKubectlExplainField(reqCtx context.Context, req uint64, key f
 			args = append(args, "--api-version", key.apiVersion)
 		}
 		cmd := exec.CommandContext(ctx, kubectlPath, args...)
+		// Killing kubectl does not close pipes a grandchild still holds (a
+		// credential plugin, say), and CombinedOutput reads to EOF. Without a
+		// WaitDelay the worker would stay blocked on a process already killed.
+		cmd.WaitDelay = fieldDocWaitDelay
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		output, cmdErr := cmd.CombinedOutput()

--- a/internal/app/commands_fielddoc.go
+++ b/internal/app/commands_fielddoc.go
@@ -54,7 +54,7 @@ func scheduleFieldDocFetch(req uint64) tea.Cmd {
 // execKubectlExplainField reads one field description from the schema of the
 // connected cluster. It shells out to kubectl explain rather than reading a
 // bundled copy, so the text matches the cluster version and covers CRDs.
-func (m Model) execKubectlExplainField(req uint64, key fieldDocKey) tea.Cmd {
+func (m Model) execKubectlExplainField(reqCtx context.Context, req uint64, key fieldDocKey) tea.Cmd {
 	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil {
 		return func() tea.Msg {
@@ -68,13 +68,13 @@ func (m Model) execKubectlExplainField(req uint64, key fieldDocKey) tea.Cmd {
 		target = key.resource + "." + key.path
 	}
 	kubectlContext := m.kubectlContext(key.context)
-	parentCtx := m.reqCtx
 
 	return m.trackBgTask(scheduler.KindSubprocess, "Field doc: "+target, key.context, func() tea.Msg {
-		// The pane fetches on cursor movement, so a cluster that never answers
-		// would tie up one scheduler worker per field visited. Retargeting only
-		// drops the reply; the deadline is what ends the process.
-		ctx, cancel := context.WithTimeout(parentCtx, fieldDocFetchTimeout)
+		// Two ways out: the caller cancels reqCtx when the cursor moves on or
+		// the pane closes, and the deadline ends a cluster that never answers.
+		// The pane fetches on cursor movement, so without both a slow cluster
+		// would tie up one scheduler worker per field visited.
+		ctx, cancel := context.WithTimeout(reqCtx, fieldDocFetchTimeout)
 		defer cancel()
 
 		args := []string{"explain", target, "--context", kubectlContext}

--- a/internal/app/commands_fielddoc_test.go
+++ b/internal/app/commands_fielddoc_test.go
@@ -147,8 +147,13 @@ func TestExecKubectlExplainFieldReportsMissingKubectl(t *testing.T) {
 
 // A cancelled request must end the process, not wait out its deadline. The stub
 // sleeps far longer than the test would tolerate if cancellation did not work.
+//
+// The sleep runs as a CHILD of the stub shell on purpose. Killing the shell
+// leaves that child holding the output pipe, which is what a credential plugin
+// does in the real failure, and CombinedOutput reads to EOF. Only cmd.WaitDelay
+// gets the worker back. Without it this hangs for the full sleep.
 func TestExecKubectlExplainFieldStopsOnCancel(t *testing.T) {
-	fakeKubectl(t, "sleep 60")
+	fakeKubectl(t, "sleep 60 &\nwait")
 	m := fieldDocExecModel(t)
 	ctx, cancel := context.WithCancel(t.Context())
 

--- a/internal/app/commands_fielddoc_test.go
+++ b/internal/app/commands_fielddoc_test.go
@@ -1,0 +1,193 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// fakeKubectl puts a stub kubectl first on PATH and returns the file the stub
+// writes its argv to. The stub is the only way to exercise the subprocess path
+// without a cluster: it lets the test assert on the arguments the app builds
+// and choose what kubectl "prints" back.
+func fakeKubectl(t *testing.T, script string) (argvPath string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	argvPath = filepath.Join(dir, "argv")
+	body := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argvPath + "\n" + script + "\n"
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kubectl"), []byte(body), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argvPath
+}
+
+func fieldDocExecModel(t *testing.T) Model {
+	t.Helper()
+	m := basePush80Model()
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true,
+	}
+	m.fieldDoc.cache = newFieldDocCache()
+	m.reqCtx = t.Context()
+	return m
+}
+
+func TestExecKubectlExplainFieldBuildsTheArguments(t *testing.T) {
+	argvPath := fakeKubectl(t, `cat <<'OUT'
+KIND:       Deployment
+VERSION:    apps/v1
+
+FIELD: replicas <integer>
+
+DESCRIPTION:
+    Number of desired pods.
+OUT`)
+	m := fieldDocExecModel(t)
+	key := fieldDocKey{
+		context: "test-ctx", apiVersion: "apps/v1", resource: "deployments", path: "spec.replicas",
+	}
+
+	msg := m.execKubectlExplainField(t.Context(), 1, key)()
+
+	got, ok := msg.(fieldDocLoadedMsg)
+	require.True(t, ok)
+	require.NoError(t, got.err)
+
+	argv, err := os.ReadFile(argvPath)
+	require.NoError(t, err)
+	args := strings.Fields(string(argv))
+
+	assert.Equal(t, "explain", args[0])
+	assert.Contains(t, args, "deployments.spec.replicas", "the target joins the resource and the field path")
+	assert.Contains(t, args, "--api-version")
+	assert.Contains(t, args, "apps/v1")
+	assert.Contains(t, args, "--context")
+}
+
+// A core resource has no group/version, so the flag must be left off entirely
+// rather than passed empty.
+func TestExecKubectlExplainFieldOmitsEmptyAPIVersion(t *testing.T) {
+	argvPath := fakeKubectl(t, `echo "FIELD: dnsPolicy <string>"`)
+	m := fieldDocExecModel(t)
+
+	m.execKubectlExplainField(t.Context(), 1,
+		fieldDocKey{context: "test-ctx", resource: "pods", path: "spec.dnsPolicy"})()
+
+	argv, err := os.ReadFile(argvPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(argv), "--api-version")
+}
+
+func TestExecKubectlExplainFieldParsesDescriptionAndType(t *testing.T) {
+	fakeKubectl(t, `cat <<'OUT'
+KIND:       Pod
+VERSION:    v1
+
+FIELD: dnsPolicy <string>
+
+DESCRIPTION:
+    Set DNS policy for the pod. Defaults to "ClusterFirst".
+OUT`)
+	m := fieldDocExecModel(t)
+
+	msg := m.execKubectlExplainField(t.Context(), 4,
+		fieldDocKey{context: "test-ctx", resource: "pods", path: "spec.dnsPolicy"})()
+
+	got := msg.(fieldDocLoadedMsg)
+	require.NoError(t, got.err)
+	assert.Equal(t, uint64(4), got.req, "the reply carries the request it answers")
+	assert.Equal(t, "<string>", got.entry.fieldType)
+	assert.Contains(t, got.entry.desc, "Set DNS policy for the pod.")
+}
+
+// The reported bug, end to end through the subprocess: kubectl exits non-zero
+// after printing the preamble, and only the error line may reach the pane.
+func TestExecKubectlExplainFieldTrimsTheErrorOutput(t *testing.T) {
+	fakeKubectl(t, `cat >&2 <<'OUT'
+KIND:       Pod
+VERSION:    v1
+
+error: field "checksum/config" does not exist
+OUT
+exit 1`)
+	m := fieldDocExecModel(t)
+
+	msg := m.execKubectlExplainField(t.Context(), 1, fieldDocKey{
+		context: "test-ctx", resource: "pods", path: "metadata.annotations.checksum/config",
+	})()
+
+	got := msg.(fieldDocLoadedMsg)
+	require.Error(t, got.err)
+	assert.Equal(t, `field "checksum/config" does not exist`, got.err.Error())
+	assert.NotContains(t, got.err.Error(), "exit status")
+	assert.NotContains(t, got.err.Error(), "VERSION:")
+}
+
+func TestExecKubectlExplainFieldReportsMissingKubectl(t *testing.T) {
+	m := fieldDocExecModel(t)
+	t.Setenv("PATH", "/nonexistent")
+
+	msg := m.execKubectlExplainField(t.Context(), 1,
+		fieldDocKey{context: "test-ctx", resource: "pods", path: "spec"})()
+
+	got := msg.(fieldDocLoadedMsg)
+	require.Error(t, got.err)
+	assert.Contains(t, got.err.Error(), "kubectl not found")
+}
+
+// A cancelled request must end the process, not wait out its deadline. The stub
+// sleeps far longer than the test would tolerate if cancellation did not work.
+func TestExecKubectlExplainFieldStopsOnCancel(t *testing.T) {
+	fakeKubectl(t, "sleep 60")
+	m := fieldDocExecModel(t)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan tea.Msg, 1)
+	started := time.Now()
+	go func() {
+		done <- m.execKubectlExplainField(ctx, 1,
+			fieldDocKey{context: "test-ctx", resource: "pods", path: "spec"})()
+	}()
+
+	// Let the process actually start, or this would only prove that an
+	// already-cancelled context never spawns one.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+
+	select {
+	case res := <-done:
+		got, ok := res.(fieldDocLoadedMsg)
+		require.True(t, ok)
+		assert.Error(t, got.err, "a killed process reports an error, which the pane then ignores")
+		assert.Less(t, time.Since(started), 30*time.Second,
+			"the process must die on cancel, not run out its 60 second sleep")
+	case <-time.After(30 * time.Second):
+		t.Fatal("cancelling the request did not stop the kubectl process")
+	}
+}
+
+// isContextCanceled is what keeps a cancelled fetch from painting an error into
+// the pane, so the two halves have to agree on what cancellation looks like.
+func TestFieldDocCancelledFetchLeavesThePaneClean(t *testing.T) {
+	m := fieldDocExecModel(t)
+	m.fieldDoc.on = true
+	m.fieldDoc.loading = true
+	m.fieldDoc.req = 1
+
+	got := m.updateFieldDocLoaded(fieldDocLoadedMsg{
+		req: 1, key: fieldDocKey{path: "spec"}, err: context.Canceled,
+	})
+
+	assert.Empty(t, got.fieldDoc.err)
+	assert.False(t, got.fieldDoc.loading)
+}

--- a/internal/app/commands_fielddoc_test.go
+++ b/internal/app/commands_fielddoc_test.go
@@ -153,20 +153,25 @@ func TestExecKubectlExplainFieldReportsMissingKubectl(t *testing.T) {
 // does in the real failure, and CombinedOutput reads to EOF. Only cmd.WaitDelay
 // gets the worker back. Without it this hangs for the full sleep.
 func TestExecKubectlExplainFieldStopsOnCancel(t *testing.T) {
-	fakeKubectl(t, "sleep 60 &\nwait")
+	argvPath := fakeKubectl(t, "sleep 60 &\nwait")
 	m := fieldDocExecModel(t)
 	ctx, cancel := context.WithCancel(t.Context())
 
 	done := make(chan tea.Msg, 1)
-	started := time.Now()
 	go func() {
 		done <- m.execKubectlExplainField(ctx, 1,
 			fieldDocKey{context: "test-ctx", resource: "pods", path: "spec"})()
 	}()
 
-	// Let the process actually start, or this would only prove that an
+	// The stub writes its argv first, so the file appearing means the process
+	// is really running. Cancelling before that would only prove that an
 	// already-cancelled context never spawns one.
-	time.Sleep(300 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(argvPath)
+		return err == nil
+	}, 10*time.Second, 20*time.Millisecond, "the stub kubectl never started")
+
+	cancelledAt := time.Now()
 	cancel()
 
 	select {
@@ -174,9 +179,13 @@ func TestExecKubectlExplainFieldStopsOnCancel(t *testing.T) {
 		got, ok := res.(fieldDocLoadedMsg)
 		require.True(t, ok)
 		assert.Error(t, got.err, "a killed process reports an error, which the pane then ignores")
-		assert.Less(t, time.Since(started), 30*time.Second,
-			"the process must die on cancel, not run out its 60 second sleep")
-	case <-time.After(30 * time.Second):
+		// Well under fieldDocFetchTimeout, so a fetch that ignored cancellation
+		// and merely ran out its 15 second deadline cannot pass this. The
+		// allowance covers cmd.WaitDelay, which is what unblocks the read when
+		// the backgrounded sleep keeps holding the pipe.
+		assert.Less(t, time.Since(cancelledAt), fieldDocFetchTimeout/2,
+			"cancelling must end the fetch, not leave it to the deadline")
+	case <-time.After(fieldDocFetchTimeout / 2):
 		t.Fatal("cancelling the request did not stop the kubectl process")
 	}
 }

--- a/internal/app/fielddoc.go
+++ b/internal/app/fielddoc.go
@@ -80,11 +80,16 @@ func (c *fieldDocCache) len() int {
 // after the cursor moved on is dropped instead of overwriting the new field.
 // The cache is a pointer so every copy of the Model shares one map: the
 // descriptions belong to the cluster, not to a tab or a viewer.
+// display is the path as the user sees it, built by formatObjectPath from the
+// original segments. key.path is the dot-joined form kubectl explain takes; a
+// segment that itself contains a dot (an annotation key, say) survives only in
+// display, so the title never has to be un-joined to read correctly.
 type fieldDocState struct {
 	on      bool
 	loading bool
 	req     uint64
 	key     fieldDocKey
+	display string
 	entry   fieldDocEntry
 	err     string
 	cache   *fieldDocCache
@@ -95,7 +100,7 @@ type fieldDocState struct {
 // the schema says does not change when the user closes a pane.
 func (s *fieldDocState) reset() {
 	s.on, s.loading = false, false
-	s.key, s.entry, s.err = fieldDocKey{}, fieldDocEntry{}, ""
+	s.key, s.entry, s.err, s.display = fieldDocKey{}, fieldDocEntry{}, "", ""
 }
 
 // fieldDocPath turns an object path into the schema path kubectl explain takes.

--- a/internal/app/fielddoc.go
+++ b/internal/app/fielddoc.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"strings"
 )
@@ -93,12 +94,27 @@ type fieldDocState struct {
 	entry   fieldDocEntry
 	err     string
 	cache   *fieldDocCache
+
+	// cancel stops the fetch in flight. Dropping a superseded reply is not
+	// enough on its own: the kubectl process would keep a scheduler worker
+	// until its own deadline, and the pool is small.
+	cancel context.CancelFunc
+}
+
+// cancelInFlight stops any running fetch. It is safe to call when none is
+// running, and safe to call twice: a cancel func is idempotent.
+func (s *fieldDocState) cancelInFlight() {
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
 }
 
 // reset closes the pane. The pane is per resource and costs a fetch, so opening
 // the viewer on something else starts with it closed. The cache survives: what
 // the schema says does not change when the user closes a pane.
 func (s *fieldDocState) reset() {
+	s.cancelInFlight()
 	s.on, s.loading = false, false
 	s.key, s.entry, s.err, s.display = fieldDocKey{}, fieldDocEntry{}, "", ""
 }

--- a/internal/app/fielddoc.go
+++ b/internal/app/fielddoc.go
@@ -1,6 +1,9 @@
 package app
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
 
 // fieldDocMaxEntries bounds the description cache. One entry is a short string,
 // so a few hundred cost little, and the bound stops a long session from growing
@@ -107,6 +110,23 @@ func fieldDocPath(objPath []string) string {
 		segs = append(segs, s)
 	}
 	return strings.Join(segs, ".")
+}
+
+// parseExplainError reduces a failed kubectl explain run to the one line worth
+// showing. kubectl prints the KIND/VERSION preamble even when it fails and then
+// exits non-zero, so the raw output plus the exit status fills the pane with
+// noise around a single "error:" line.
+func parseExplainError(output string, cmdErr error) error {
+	for line := range strings.SplitSeq(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if msg, ok := strings.CutPrefix(trimmed, "error:"); ok {
+			return errors.New(strings.TrimSpace(msg))
+		}
+	}
+	if trimmed := strings.TrimSpace(output); trimmed != "" {
+		return errors.New(trimmed)
+	}
+	return cmdErr
 }
 
 // parseExplainFieldHeader reads the "FIELD: name <type>" line that kubectl

--- a/internal/app/fielddoc.go
+++ b/internal/app/fielddoc.go
@@ -1,0 +1,138 @@
+package app
+
+import "strings"
+
+// fieldDocMaxEntries bounds the description cache. One entry is a short string,
+// so a few hundred cost little, and the bound stops a long session from growing
+// the map without end.
+const fieldDocMaxEntries = 256
+
+// fieldDocKey addresses one field description. The context is part of the key
+// because two clusters can serve different schema versions of the same kind,
+// and the api-version because two versions of one resource differ as well.
+type fieldDocKey struct {
+	context    string
+	apiVersion string
+	resource   string
+	path       string
+}
+
+// fieldDocEntry is what the schema says about one field. An empty desc is a
+// real answer, not a miss: some fields carry no description at all.
+type fieldDocEntry struct {
+	fieldType string
+	desc      string
+}
+
+// fieldDocCache holds descriptions already read from the cluster. Eviction is
+// first-in-first-out, which needs only an insertion list and is enough here:
+// the cost of a wrong eviction is one extra kubectl call.
+type fieldDocCache struct {
+	entries map[fieldDocKey]fieldDocEntry
+	order   []fieldDocKey // insertion order, oldest first
+}
+
+func newFieldDocCache() *fieldDocCache {
+	return &fieldDocCache{entries: make(map[fieldDocKey]fieldDocEntry)}
+}
+
+func (c *fieldDocCache) get(k fieldDocKey) (fieldDocEntry, bool) {
+	if c == nil || c.entries == nil {
+		return fieldDocEntry{}, false
+	}
+	e, ok := c.entries[k]
+	return e, ok
+}
+
+func (c *fieldDocCache) put(k fieldDocKey, e fieldDocEntry) {
+	if c == nil {
+		return
+	}
+	if c.entries == nil {
+		c.entries = make(map[fieldDocKey]fieldDocEntry)
+	}
+	// Overwriting must not add a second order record, or the cache evicts
+	// live entries early and settles below the cap.
+	if _, exists := c.entries[k]; !exists {
+		c.order = append(c.order, k)
+	}
+	c.entries[k] = e
+
+	for len(c.order) > fieldDocMaxEntries {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		delete(c.entries, oldest)
+	}
+}
+
+func (c *fieldDocCache) len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.entries)
+}
+
+// fieldDocState is the footnote pane: whether it is open, what it shows, and
+// which fetch it is waiting for. req numbers each fetch so a reply that arrives
+// after the cursor moved on is dropped instead of overwriting the new field.
+// The cache is a pointer so every copy of the Model shares one map: the
+// descriptions belong to the cluster, not to a tab or a viewer.
+type fieldDocState struct {
+	on      bool
+	loading bool
+	req     uint64
+	key     fieldDocKey
+	entry   fieldDocEntry
+	err     string
+	cache   *fieldDocCache
+}
+
+// reset closes the pane. The pane is per resource and costs a fetch, so opening
+// the viewer on something else starts with it closed. The cache survives: what
+// the schema says does not change when the user closes a pane.
+func (s *fieldDocState) reset() {
+	s.on, s.loading = false, false
+	s.key, s.entry, s.err = fieldDocKey{}, fieldDocEntry{}, ""
+}
+
+// fieldDocPath turns an object path into the schema path kubectl explain takes.
+// Array indices ("[0]") are dropped because the schema describes the element
+// type, not one element: spec.containers[0].image is spec.containers.image.
+func fieldDocPath(objPath []string) string {
+	segs := make([]string, 0, len(objPath))
+	for _, s := range objPath {
+		if strings.HasPrefix(s, "[") {
+			continue
+		}
+		segs = append(segs, s)
+	}
+	return strings.Join(segs, ".")
+}
+
+// parseExplainFieldHeader reads the "FIELD: name <type>" line that kubectl
+// prints when explaining a single field. parseExplainOutput consumes that line
+// as a section header and keeps only the description, so the type is read here.
+// A root explain has no such line and returns empty strings.
+func parseExplainFieldHeader(output string) (name, fieldType string) {
+	for line := range strings.SplitSeq(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		rest, ok := strings.CutPrefix(trimmed, "FIELD:")
+		if !ok {
+			continue
+		}
+		parts := strings.Fields(rest)
+		if len(parts) == 0 {
+			return "", ""
+		}
+		name = parts[0]
+		// The remainder can hold a type, a -required- marker, or both. Only a
+		// <bracketed> word is a type.
+		for _, p := range parts[1:] {
+			if strings.HasPrefix(p, "<") {
+				return name, p
+			}
+		}
+		return name, ""
+	}
+	return "", ""
+}

--- a/internal/app/fielddoc_error_test.go
+++ b/internal/app/fielddoc_error_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// kubectl explain prints the KIND/VERSION preamble even when it fails, and the
+// only useful line is the one starting with "error:". Showing the rest fills
+// the pane with noise.
+func TestParseExplainError(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		cmdErr error
+		want   string
+	}{
+		{
+			name: "field does not exist",
+			output: "KIND:       Pod\nVERSION:    v1\n\n" +
+				`error: field "checksum/config" does not exist` + "\n",
+			cmdErr: errors.New("exit status 1"),
+			want:   `field "checksum/config" does not exist`,
+		},
+		{
+			name:   "error line without a preamble",
+			output: "error: the server doesn't have a resource type \"widgets\"\n",
+			cmdErr: errors.New("exit status 1"),
+			want:   `the server doesn't have a resource type "widgets"`,
+		},
+		{
+			name:   "multi-line error keeps the first line only",
+			output: "error: field \"x\" does not exist\nUse \"kubectl api-resources\" for a complete list\n",
+			cmdErr: errors.New("exit status 1"),
+			want:   `field "x" does not exist`,
+		},
+		{
+			name:   "no error line falls back to the output",
+			output: "something went sideways\n",
+			cmdErr: errors.New("exit status 1"),
+			want:   "something went sideways",
+		},
+		{
+			name:   "empty output falls back to the command error",
+			output: "",
+			cmdErr: errors.New("exit status 1"),
+			want:   "exit status 1",
+		},
+		{
+			name:   "preamble only, no error line",
+			output: "KIND:       Pod\nVERSION:    v1\n",
+			cmdErr: errors.New("exit status 1"),
+			want:   "KIND:       Pod\nVERSION:    v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseExplainError(tt.output, tt.cmdErr)
+			assert.EqualError(t, got, tt.want)
+		})
+	}
+}
+
+// The exit status carries no information the message does not already give, so
+// it must not be prefixed onto what the pane shows.
+func TestParseExplainErrorDropsExitStatus(t *testing.T) {
+	got := parseExplainError(
+		"KIND:       Pod\n\nerror: field \"nope\" does not exist\n",
+		errors.New("exit status 1"),
+	)
+
+	assert.NotContains(t, got.Error(), "exit status")
+	assert.NotContains(t, got.Error(), "KIND:")
+}

--- a/internal/app/fielddoc_keys_test.go
+++ b/internal/app/fielddoc_keys_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func TestFieldDocKeybindingDefault(t *testing.T) {
+	assert.Equal(t, "ctrl+k", ui.DefaultKeybindings().FieldDoc)
+}
+
+// ctrl+k has to stay clear of every other default, or the viewer that owns the
+// other binding never sees the footnote key.
+func TestFieldDocKeybindingDoesNotCollide(t *testing.T) {
+	kb := ui.DefaultKeybindings()
+
+	assert.NotEqual(t, kb.FieldDoc, kb.PreviewUp, "K stays with preview scroll")
+	assert.NotEqual(t, kb.FieldDoc, kb.PreviewDown)
+	assert.NotEqual(t, kb.FieldDoc, kb.APIExplorer)
+	assert.NotEqual(t, kb.FieldDoc, kb.ObjectExplorer)
+	assert.NotEqual(t, kb.FieldDoc, kb.WhichKeyLeader)
+}
+
+func yamlFieldDocModel(t *testing.T) Model {
+	t.Helper()
+	m := basePush80Model()
+	m.mode = modeYAML
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true,
+	}
+	m.fieldDoc.cache = newFieldDocCache()
+	m.yamlView.content = "spec:\n  dnsPolicy: ClusterFirst\n  restartPolicy: Always\n"
+	m.yamlView.cursor = 1
+	return m
+}
+
+func TestYAMLViewerCtrlKOpensFieldDoc(t *testing.T) {
+	m := yamlFieldDocModel(t)
+	require.False(t, m.fieldDoc.on)
+
+	mdl, _ := m.handleYAMLKey(keyMsg("ctrl+k"))
+	got := mdl.(Model)
+
+	assert.True(t, got.fieldDoc.on, "ctrl+k must open the footnote pane")
+}
+
+func TestYAMLViewerCtrlKTogglesOff(t *testing.T) {
+	m := yamlFieldDocModel(t)
+	m.fieldDoc.on = true
+	m.fieldDoc.entry = fieldDocEntry{desc: "text"}
+
+	mdl, _ := m.handleYAMLKey(keyMsg("ctrl+k"))
+	got := mdl.(Model)
+
+	assert.False(t, got.fieldDoc.on)
+	assert.Empty(t, got.fieldDoc.entry.desc)
+}
+
+// With the pane open, walking the document has to re-target it, or the footnote
+// keeps describing the field the user already left.
+func TestYAMLViewerCursorMoveRetargetsFieldDoc(t *testing.T) {
+	m := yamlFieldDocModel(t)
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{
+		context: m.effectiveContext(), apiVersion: "v1", resource: "pods", path: "spec.dnsPolicy",
+	}
+	m.fieldDoc.entry = fieldDocEntry{desc: "dns text"}
+
+	mdl, _ := m.handleYAMLKey(keyMsg("j"))
+	got := mdl.(Model)
+
+	require.True(t, got.fieldDoc.on)
+	assert.Equal(t, "spec.restartPolicy", got.fieldDoc.key.path,
+		"the pane must follow the cursor to the next field")
+}
+
+// A closed pane must stay closed and must not fetch when the cursor moves.
+func TestYAMLViewerCursorMoveWithPaneClosedDoesNothing(t *testing.T) {
+	m := yamlFieldDocModel(t)
+
+	mdl, _ := m.handleYAMLKey(keyMsg("j"))
+	got := mdl.(Model)
+
+	assert.False(t, got.fieldDoc.on)
+	assert.Empty(t, got.fieldDoc.key.path)
+}
+
+func objectExplorerFieldDocModel(t *testing.T) Model {
+	t.Helper()
+	m := basePush80Model()
+	m.mode = modeObjectExplorer
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true,
+	}
+	m.fieldDoc.cache = newFieldDocCache()
+	return m
+}
+
+func TestObjectExplorerCtrlKOpensFieldDoc(t *testing.T) {
+	m := objectExplorerFieldDocModel(t)
+
+	mdl, _ := m.handleObjectExplorerKey(keyMsg("ctrl+k"))
+	got := mdl.(Model)
+
+	assert.True(t, got.fieldDoc.on, "ctrl+k must open the footnote pane in the Object Explorer")
+}
+
+// The whole reason ctrl+k was chosen over K: the Object Explorer keeps J and K
+// on preview scrolling.
+func TestObjectExplorerKStillScrollsPreview(t *testing.T) {
+	m := objectExplorerFieldDocModel(t)
+	m.objectExplorerView.previewScroll = 3
+
+	mdl, _ := m.handleObjectExplorerKey(keyMsg("K"))
+	got := mdl.(Model)
+
+	assert.False(t, got.fieldDoc.on, "K must not open the footnote pane")
+	// The empty test model clamps the scroll to 0; what matters is that K
+	// reached the preview handler at all instead of the footnote toggle.
+	assert.NotEqual(t, 3, got.objectExplorerView.previewScroll, "K must still reach preview scrolling")
+}

--- a/internal/app/fielddoc_test.go
+++ b/internal/app/fielddoc_test.go
@@ -1,0 +1,227 @@
+package app
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldDocPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		objPath []string
+		want    string
+	}{
+		{name: "empty", objPath: nil, want: ""},
+		{name: "root field", objPath: []string{"spec"}, want: "spec"},
+		{name: "nested leaf", objPath: []string{"spec", "dnsPolicy"}, want: "spec.dnsPolicy"},
+		{
+			name:    "array index dropped",
+			objPath: []string{"spec", "containers", "[0]", "image"},
+			want:    "spec.containers.image",
+		},
+		{
+			name:    "trailing array index dropped",
+			objPath: []string{"spec", "containers", "[2]"},
+			want:    "spec.containers",
+		},
+		{
+			name:    "crd nested path",
+			objPath: []string{"spec", "instances", "[1]", "storage", "size"},
+			want:    "spec.instances.storage.size",
+		},
+		{name: "only an index", objPath: []string{"[0]"}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, fieldDocPath(tt.objPath))
+		})
+	}
+}
+
+func TestParseExplainFieldHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		wantName string
+		wantType string
+	}{
+		{
+			name: "leaf field with type",
+			output: "KIND:       Pod\nVERSION:    v1\n\n" +
+				"FIELD: dnsPolicy <string>\n\nDESCRIPTION:\n    Set DNS policy for the pod.\n",
+			wantName: "dnsPolicy",
+			wantType: "<string>",
+		},
+		{
+			name:     "required marker kept out of the type",
+			output:   "FIELD: name <string> -required-\n\nDESCRIPTION:\n    The container name.\n",
+			wantName: "name",
+			wantType: "<string>",
+		},
+		{
+			name:     "object type",
+			output:   "FIELD: resources <ResourceRequirements>\n\nDESCRIPTION:\n    Compute resources.\n",
+			wantName: "resources",
+			wantType: "<ResourceRequirements>",
+		},
+		{
+			name:     "no FIELD header on a root explain",
+			output:   "KIND:       Pod\nVERSION:    v1\n\nDESCRIPTION:\n    Pod is a collection of containers.\n\nFIELDS:\n  spec\t<PodSpec>\n",
+			wantName: "",
+			wantType: "",
+		},
+		{
+			name:     "field header without a type",
+			output:   "FIELD: metadata\n\nDESCRIPTION:\n    Standard object metadata.\n",
+			wantName: "metadata",
+			wantType: "",
+		},
+		{name: "empty output", output: "", wantName: "", wantType: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotType := parseExplainFieldHeader(tt.output)
+			assert.Equal(t, tt.wantName, gotName, "name")
+			assert.Equal(t, tt.wantType, gotType, "type")
+		})
+	}
+}
+
+// A field the schema documents, a CRD field, and a field with no description
+// all go through the same parse path, so they are covered together here.
+func TestParseExplainOutputLeafDescription(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name: "built-in field",
+			output: "KIND:       Pod\nVERSION:    v1\n\nFIELD: dnsPolicy <string>\n\n" +
+				"DESCRIPTION:\n    Set DNS policy for the pod. Defaults to \"ClusterFirst\".\n",
+			want: `Set DNS policy for the pod. Defaults to "ClusterFirst".`,
+		},
+		{
+			name: "crd field",
+			output: "GROUP:      postgresql.cnpg.io\nKIND:       Cluster\nVERSION:    v1\n\n" +
+				"FIELD: instances <integer>\n\nDESCRIPTION:\n    Number of instances required in the cluster\n",
+			want: "Number of instances required in the cluster",
+		},
+		{
+			name:   "field the schema leaves undocumented",
+			output: "KIND:       Widget\nVERSION:    v1\n\nFIELD: opaque <string>\n\nDESCRIPTION:\n\n",
+			want:   "",
+		},
+		{
+			name:   "no description section at all",
+			output: "KIND:       Widget\nVERSION:    v1\n\nFIELD: opaque <string>\n",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc, _ := parseExplainOutput(tt.output, "")
+			assert.Equal(t, tt.want, desc)
+		})
+	}
+}
+
+func TestFieldDocCacheGetPut(t *testing.T) {
+	c := newFieldDocCache()
+
+	k := fieldDocKey{context: "kind-a", apiVersion: "v1", resource: "pods", path: "spec.dnsPolicy"}
+	_, ok := c.get(k)
+	assert.False(t, ok, "empty cache must miss")
+
+	c.put(k, fieldDocEntry{fieldType: "<string>", desc: "Set DNS policy."})
+	got, ok := c.get(k)
+	require.True(t, ok, "put then get must hit")
+	assert.Equal(t, "Set DNS policy.", got.desc)
+	assert.Equal(t, "<string>", got.fieldType)
+}
+
+// An empty description is a real answer from the schema, not a miss. Caching it
+// stops a documented-as-blank field from re-spawning kubectl on every visit.
+func TestFieldDocCacheStoresEmptyDescription(t *testing.T) {
+	c := newFieldDocCache()
+	k := fieldDocKey{context: "kind-a", apiVersion: "v1", resource: "widgets", path: "spec.opaque"}
+
+	c.put(k, fieldDocEntry{fieldType: "<string>", desc: ""})
+
+	got, ok := c.get(k)
+	require.True(t, ok, "an empty description must still count as cached")
+	assert.Empty(t, got.desc)
+}
+
+func TestFieldDocCacheKeySeparatesClustersAndVersions(t *testing.T) {
+	c := newFieldDocCache()
+	base := fieldDocKey{context: "kind-a", apiVersion: "v1", resource: "pods", path: "spec.dnsPolicy"}
+
+	otherCtx := base
+	otherCtx.context = "kind-b"
+	otherVer := base
+	otherVer.apiVersion = "v2"
+	otherPath := base
+	otherPath.path = "spec.restartPolicy"
+
+	c.put(base, fieldDocEntry{desc: "base"})
+	c.put(otherCtx, fieldDocEntry{desc: "other context"})
+	c.put(otherVer, fieldDocEntry{desc: "other version"})
+	c.put(otherPath, fieldDocEntry{desc: "other path"})
+
+	for _, tt := range []struct {
+		key  fieldDocKey
+		want string
+	}{
+		{base, "base"},
+		{otherCtx, "other context"},
+		{otherVer, "other version"},
+		{otherPath, "other path"},
+	} {
+		got, ok := c.get(tt.key)
+		require.True(t, ok)
+		assert.Equal(t, tt.want, got.desc)
+	}
+}
+
+func TestFieldDocCacheEvictsAtTheCap(t *testing.T) {
+	c := newFieldDocCache()
+
+	for i := range fieldDocMaxEntries + 10 {
+		c.put(fieldDocKey{context: "kind-a", resource: "pods", path: pathForIndex(i)},
+			fieldDocEntry{desc: "d"})
+	}
+
+	assert.LessOrEqual(t, c.len(), fieldDocMaxEntries, "cache must stay bounded")
+
+	// The oldest keys go first, the newest survive.
+	_, ok := c.get(fieldDocKey{context: "kind-a", resource: "pods", path: pathForIndex(0)})
+	assert.False(t, ok, "oldest entry must be evicted")
+
+	newest := fieldDocMaxEntries + 9
+	_, ok = c.get(fieldDocKey{context: "kind-a", resource: "pods", path: pathForIndex(newest)})
+	assert.True(t, ok, "newest entry must survive")
+}
+
+// Re-putting a key must not add a second eviction-order record, or the cache
+// evicts live entries early and holds fewer than the cap.
+func TestFieldDocCacheRepeatedPutKeepsOneOrderRecord(t *testing.T) {
+	c := newFieldDocCache()
+	k := fieldDocKey{context: "kind-a", resource: "pods", path: "spec"}
+
+	for range 5 {
+		c.put(k, fieldDocEntry{desc: "d"})
+	}
+
+	assert.Equal(t, 1, c.len())
+}
+
+func pathForIndex(i int) string {
+	return "spec.field" + strconv.Itoa(i)
+}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -127,6 +127,24 @@ type yamlBlameLoadedMsg struct {
 	err         error
 }
 
+// fieldDocLoadedMsg carries one field description read from the cluster schema.
+// req numbers the fetch this reply answers: moving the cursor bumps the number,
+// so a reply for the line the user already left is dropped instead of painting
+// the wrong text under the new one. key names the field the text describes and
+// is what the reply is cached under.
+type fieldDocLoadedMsg struct {
+	req   uint64
+	key   fieldDocKey
+	entry fieldDocEntry
+	err   error
+}
+
+// fieldDocDebounceMsg fires after the cursor has rested for fieldDocDebounce.
+// Without it, holding j down would spawn one kubectl process per line.
+type fieldDocDebounceMsg struct {
+	req uint64
+}
+
 // previewYAMLLoadedMsg carries YAML content for the split/full preview in the
 // right column. As with yamlLoadedMsg, the content is pre-indented inside the
 // loading goroutine to keep the main event loop responsive.

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -513,7 +513,14 @@ func (m *Model) moveObjectExplorerCursor(delta int) {
 // objectExplorerBodyHeight mirrors the contentHeight the renderer uses
 // (title + hint bar + column borders + outer frame consume 6 lines).
 func (m Model) objectExplorerBodyHeight() int {
-	return max(m.height-6, 3)
+	h := m.height
+	if m.fieldDocPaneWidth() > 0 {
+		// The columns give up one row to the shared hint bar under both panes,
+		// and the render path does the same. They must agree or the cursor
+		// scrolls out of view by a row.
+		h--
+	}
+	return max(h-6, 3)
 }
 
 // previewPaneHeight is the number of YAML lines visible in the preview pane.
@@ -569,18 +576,22 @@ func (m Model) viewObjectExplorer() string {
 		ui.HintEntry{Key: kb.Refresh, Desc: "refresh"},
 		ui.HintEntry{Key: kb.WatchMode, Desc: "live on/off"},
 		ui.HintEntry{Key: "I", Desc: "explain"},
-		ui.HintEntry{Key: kb.FieldDoc, Desc: "field doc"},
+		ui.HintEntry{Key: kb.FieldDoc, Desc: "schema"},
 		ui.HintEntry{Key: "q", Desc: "close"},
 	)
-	// The schema pane takes columns off the right, so narrow m.width before
-	// anything below measures itself against it. m is a value copy, so the
-	// narrowing stays inside this render.
-	schemaPane := m.renderFieldDocPane(m.height, false)
+	// The schema pane takes columns off the right. The hint bar keeps the full
+	// terminal width and goes under both panes, or it would lose entries to
+	// the narrower column. m is a value copy, so the narrowing below stays
+	// inside this render.
+	fullWidth := m.width
+	schemaPane := m.renderFieldDocPane(m.height, true)
+	hint := ui.RenderHintBar(hints, fullWidth)
+	viewHeight := m.height
 	if schemaPane != "" {
 		m.width -= lipgloss.Width(schemaPane)
+		// The columns give up one row to the shared hint bar below them.
+		viewHeight--
 	}
-
-	hint := ui.RenderHintBar(hints, m.width)
 
 	title := "Object Explorer: " + rt.title
 	if !m.objectExplorerLive {
@@ -590,8 +601,15 @@ func (m Model) viewObjectExplorer() string {
 		title += " [TREE]"
 	}
 
+	// With the pane open the inner hint row is left blank and the real hint bar
+	// is drawn once, full width, under both panes.
+	innerHint := hint
+	if schemaPane != "" {
+		innerHint = ""
+	}
+
 	if rt.tree {
-		return joinFieldDocPane(m.viewObjectExplorerTree(title, hint), schemaPane)
+		return joinFieldDocPane(m.viewObjectExplorerTree(title, innerHint), schemaPane, hint)
 	}
 
 	parentFields, parentCursor := m.objectExplorerParentLevel()
@@ -605,19 +623,21 @@ func (m Model) viewObjectExplorer() string {
 		m.selectedNodeYAML(),
 		rt.previewScroll,
 		rt.filterBar(),
-		hint,
+		innerHint,
 		m.width,
-		m.height,
-	), schemaPane)
+		viewHeight,
+	), schemaPane, hint)
 }
 
-// joinFieldDocPane puts the schema pane beside a rendered view, or returns the
-// view untouched when the pane is closed or does not fit.
-func joinFieldDocPane(view, pane string) string {
+// joinFieldDocPane puts the schema pane beside a rendered view and draws one
+// full-width hint bar under both. With no pane it returns the view untouched,
+// because the view already carries its own hint bar.
+func joinFieldDocPane(view, pane, hint string) string {
 	if pane == "" {
 		return view
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, view, pane)
+	return lipgloss.JoinVertical(lipgloss.Left,
+		lipgloss.JoinHorizontal(lipgloss.Top, view, pane), hint)
 }
 
 // objectExplorerParentLevel returns the fields of the level above the current

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"sigs.k8s.io/yaml"
 
 	"github.com/janosmiko/lfk/internal/model"
@@ -512,7 +513,7 @@ func (m *Model) moveObjectExplorerCursor(delta int) {
 // objectExplorerBodyHeight mirrors the contentHeight the renderer uses
 // (title + hint bar + column borders + outer frame consume 6 lines).
 func (m Model) objectExplorerBodyHeight() int {
-	return max(m.height-6-m.fieldDocPaneHeight(), 3)
+	return max(m.height-6, 3)
 }
 
 // previewPaneHeight is the number of YAML lines visible in the preview pane.
@@ -571,12 +572,15 @@ func (m Model) viewObjectExplorer() string {
 		ui.HintEntry{Key: kb.FieldDoc, Desc: "field doc"},
 		ui.HintEntry{Key: "q", Desc: "close"},
 	)
-	hint := ui.RenderHintBar(hints, m.width)
-	// The footnote rides above the hint bar, which both the flat and the tree
-	// renderer draw at the bottom of whatever height they are given.
-	if pane := m.renderFieldDocPane(); pane != "" {
-		hint = pane + "\n" + hint
+	// The schema pane takes columns off the right, so narrow m.width before
+	// anything below measures itself against it. m is a value copy, so the
+	// narrowing stays inside this render.
+	schemaPane := m.renderFieldDocPane(m.height, false)
+	if schemaPane != "" {
+		m.width -= lipgloss.Width(schemaPane)
 	}
+
+	hint := ui.RenderHintBar(hints, m.width)
 
 	title := "Object Explorer: " + rt.title
 	if !m.objectExplorerLive {
@@ -587,11 +591,11 @@ func (m Model) viewObjectExplorer() string {
 	}
 
 	if rt.tree {
-		return m.viewObjectExplorerTree(title, hint)
+		return joinFieldDocPane(m.viewObjectExplorerTree(title, hint), schemaPane)
 	}
 
 	parentFields, parentCursor := m.objectExplorerParentLevel()
-	return ui.RenderObjectExplorerView(
+	return joinFieldDocPane(ui.RenderObjectExplorerView(
 		rt.visible(),
 		rt.cursor,
 		rt.scroll,
@@ -603,8 +607,17 @@ func (m Model) viewObjectExplorer() string {
 		rt.filterBar(),
 		hint,
 		m.width,
-		m.height-m.fieldDocPaneHeight(),
-	)
+		m.height,
+	), schemaPane)
+}
+
+// joinFieldDocPane puts the schema pane beside a rendered view, or returns the
+// view untouched when the pane is closed or does not fit.
+func joinFieldDocPane(view, pane string) string {
+	if pane == "" {
+		return view
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Top, view, pane)
 }
 
 // objectExplorerParentLevel returns the fields of the level above the current

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -246,7 +246,8 @@ func (m Model) handleObjectExplorerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 	if m.objectExplorerView.filterActive {
 		return m.handleObjectExplorerFilterKey(msg)
 	}
-	return m.handleObjectExplorerNavKey(msg)
+	mdl, cmd := m.handleObjectExplorerNavKey(msg)
+	return followFieldDocCursor(mdl, cmd, func(u Model) []string { return u.selectedNodePath() })
 }
 
 // handleObjectExplorerNavKey handles normal browsing keys.
@@ -299,6 +300,10 @@ func (m Model) handleObjectExplorerNavKey(msg tea.KeyPressMsg) (tea.Model, tea.C
 		return m.refreshObjectExplorer()
 	case "I":
 		return m.openExplainAtObjectPath(m.selectedNodePath(), modeObjectExplorer)
+	// Before PreviewDown/PreviewUp: a user who rebinds the footnote onto J or K
+	// gets the footnote, rather than a key that silently does nothing.
+	case kb.FieldDoc:
+		return m.toggleFieldDoc(m.selectedNodePath())
 	case "y":
 		return m.copySelectedNodePath()
 	case "Y":
@@ -507,7 +512,7 @@ func (m *Model) moveObjectExplorerCursor(delta int) {
 // objectExplorerBodyHeight mirrors the contentHeight the renderer uses
 // (title + hint bar + column borders + outer frame consume 6 lines).
 func (m Model) objectExplorerBodyHeight() int {
-	return max(m.height-6, 3)
+	return max(m.height-6-m.fieldDocPaneHeight(), 3)
 }
 
 // previewPaneHeight is the number of YAML lines visible in the preview pane.
@@ -563,9 +568,15 @@ func (m Model) viewObjectExplorer() string {
 		ui.HintEntry{Key: kb.Refresh, Desc: "refresh"},
 		ui.HintEntry{Key: kb.WatchMode, Desc: "live on/off"},
 		ui.HintEntry{Key: "I", Desc: "explain"},
+		ui.HintEntry{Key: kb.FieldDoc, Desc: "field doc"},
 		ui.HintEntry{Key: "q", Desc: "close"},
 	)
 	hint := ui.RenderHintBar(hints, m.width)
+	// The footnote rides above the hint bar, which both the flat and the tree
+	// renderer draw at the bottom of whatever height they are given.
+	if pane := m.renderFieldDocPane(); pane != "" {
+		hint = pane + "\n" + hint
+	}
 
 	title := "Object Explorer: " + rt.title
 	if !m.objectExplorerLive {
@@ -592,7 +603,7 @@ func (m Model) viewObjectExplorer() string {
 		rt.filterBar(),
 		hint,
 		m.width,
-		m.height,
+		m.height-m.fieldDocPaneHeight(),
 	)
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -134,6 +134,11 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case yamlBlameLoadedMsg:
 		mdl, cmd := m.updateYamlBlameLoaded(msg)
 		return mdl, cmd, true
+	case fieldDocDebounceMsg:
+		mdl, cmd := m.updateFieldDocDebounce(msg)
+		return mdl, cmd, true
+	case fieldDocLoadedMsg:
+		return m.updateFieldDocLoaded(msg), nil, true
 	case yamlLoadedMsg:
 		mdl, cmd := m.updateYamlLoaded(msg)
 		return mdl, cmd, true

--- a/internal/app/update_fielddoc.go
+++ b/internal/app/update_fielddoc.go
@@ -53,7 +53,7 @@ func (m Model) renderFieldDocPane(height int, omitFooter bool) string {
 		return ""
 	}
 	return ui.RenderFieldDocPane(paneW, height, ui.FieldDocPane{
-		Path:      m.fieldDoc.key.path,
+		Path:      m.fieldDoc.display,
 		FieldType: m.fieldDoc.entry.fieldType,
 		Desc:      m.fieldDoc.entry.desc,
 		Err:       m.fieldDoc.err,
@@ -99,6 +99,9 @@ func (m Model) showFieldDoc(objPath []string) (Model, tea.Cmd) {
 	}
 
 	m.fieldDoc.key = key
+	// Formatted from the segments, not from key.path: array indices read as
+	// "[0]" and a segment holding a dot stays one segment.
+	m.fieldDoc.display = formatObjectPath(objPath)
 	m.fieldDoc.err = ""
 	// A new target invalidates any fetch still in flight.
 	m.fieldDoc.req++

--- a/internal/app/update_fielddoc.go
+++ b/internal/app/update_fielddoc.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// fieldDocPaneHeight is the number of body lines the footnote takes away from
+// the viewer above it, so the cursor keeps a viewport it fits in.
+func (m Model) fieldDocPaneHeight() int {
+	if !m.fieldDoc.on {
+		return 0
+	}
+	return ui.FieldDocPaneHeight
+}
+
+// renderFieldDocPane draws the footnote, or nothing when it is closed.
+func (m Model) renderFieldDocPane() string {
+	if !m.fieldDoc.on {
+		return ""
+	}
+	return ui.RenderFieldDocPane(m.width, ui.FieldDocPane{
+		Path:      m.fieldDoc.key.path,
+		FieldType: m.fieldDoc.entry.fieldType,
+		Desc:      m.fieldDoc.entry.desc,
+		Err:       m.fieldDoc.err,
+		Loading:   m.fieldDoc.loading,
+	})
+}
+
+// toggleFieldDoc opens or closes the schema footnote pane. Opening it shows the
+// field under the cursor; closing it drops what was on screen but keeps the
+// cache, so re-opening on a visited field costs nothing.
+func (m Model) toggleFieldDoc(objPath []string) (tea.Model, tea.Cmd) {
+	if m.fieldDoc.on {
+		m.fieldDoc.reset()
+		return m, nil
+	}
+	if _, ok := m.fieldDocKeyForPath(objPath); !ok {
+		m.setStatusMessage("Cannot determine resource type", true)
+		return m, scheduleStatusClear()
+	}
+	m.fieldDoc.on = true
+	updated, cmd := m.showFieldDoc(objPath)
+	return updated, cmd
+}
+
+// showFieldDoc points the pane at the field under the cursor. A description
+// already read from this cluster renders at once; anything else starts the
+// debounce, so walking the document line by line spawns no processes.
+func (m Model) showFieldDoc(objPath []string) (Model, tea.Cmd) {
+	if !m.fieldDoc.on {
+		return m, nil
+	}
+	key, ok := m.fieldDocKeyForPath(objPath)
+	if !ok {
+		return m, nil
+	}
+	if key == m.fieldDoc.key && (m.fieldDoc.loading || m.fieldDoc.err != "" || m.fieldDoc.entry.desc != "") {
+		// Already showing this field, or already fetching it.
+		return m, nil
+	}
+
+	m.fieldDoc.key = key
+	m.fieldDoc.err = ""
+	// A new target invalidates any fetch still in flight.
+	m.fieldDoc.req++
+
+	if entry, hit := m.fieldDoc.cache.get(key); hit {
+		m.fieldDoc.entry = entry
+		m.fieldDoc.loading = false
+		return m, nil
+	}
+
+	m.fieldDoc.entry = fieldDocEntry{}
+	m.fieldDoc.loading = true
+	return m, scheduleFieldDocFetch(m.fieldDoc.req)
+}
+
+// updateFieldDocDebounce runs when the cursor has rested long enough. It fetches
+// only when the pane is still open and the request it was started for is still
+// the current one, so a superseded timer spends nothing.
+func (m Model) updateFieldDocDebounce(msg fieldDocDebounceMsg) (tea.Model, tea.Cmd) {
+	if !m.fieldDoc.on || msg.req != m.fieldDoc.req || !m.fieldDoc.loading {
+		return m, nil
+	}
+	return m, m.execKubectlExplainField(m.fieldDoc.req, m.fieldDoc.key)
+}
+
+// updateFieldDocLoaded stores a description and caches it. An empty description
+// is cached too: a field the schema leaves undocumented is a real answer, and
+// re-asking for it on every visit would spawn kubectl for nothing.
+func (m Model) updateFieldDocLoaded(msg fieldDocLoadedMsg) Model {
+	if msg.req != m.fieldDoc.req {
+		// An earlier fetch answering late, for a field the cursor has left.
+		return m
+	}
+	m.fieldDoc.loading = false
+	if !m.fieldDoc.on {
+		// The user closed the pane while the fetch was in flight.
+		return m
+	}
+	if isContextCanceled(msg.err) {
+		return m
+	}
+	if msg.err != nil {
+		m.fieldDoc.err = msg.err.Error()
+		return m
+	}
+	m.fieldDoc.cache.put(msg.key, msg.entry)
+	m.fieldDoc.entry = msg.entry
+	return m
+}

--- a/internal/app/update_fielddoc.go
+++ b/internal/app/update_fielddoc.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/janosmiko/lfk/internal/ui"
@@ -103,7 +105,9 @@ func (m Model) showFieldDoc(objPath []string) (Model, tea.Cmd) {
 	// "[0]" and a segment holding a dot stays one segment.
 	m.fieldDoc.display = formatObjectPath(objPath)
 	m.fieldDoc.err = ""
-	// A new target invalidates any fetch still in flight.
+	// A new target invalidates the fetch in flight. Stop the process too, not
+	// just its reply, or it holds a scheduler worker until its own deadline.
+	m.fieldDoc.cancelInFlight()
 	m.fieldDoc.req++
 
 	if entry, hit := m.fieldDoc.cache.get(key); hit {
@@ -124,7 +128,13 @@ func (m Model) updateFieldDocDebounce(msg fieldDocDebounceMsg) (tea.Model, tea.C
 	if !m.fieldDoc.on || msg.req != m.fieldDoc.req || !m.fieldDoc.loading {
 		return m, nil
 	}
-	return m, m.execKubectlExplainField(m.fieldDoc.req, m.fieldDoc.key)
+	// The request context outlives this call: showFieldDoc cancels it when the
+	// cursor moves on, reset when the pane closes, and the reply handler when
+	// the fetch answers.
+	ctx, cancel := context.WithCancel(m.reqCtx)
+	m.fieldDoc.cancelInFlight()
+	m.fieldDoc.cancel = cancel
+	return m, m.execKubectlExplainField(ctx, m.fieldDoc.req, m.fieldDoc.key)
 }
 
 // updateFieldDocLoaded stores a description and caches it. An empty description
@@ -135,6 +145,9 @@ func (m Model) updateFieldDocLoaded(msg fieldDocLoadedMsg) Model {
 		// An earlier fetch answering late, for a field the cursor has left.
 		return m
 	}
+	// The fetch is done, so release its context rather than leaving it to the
+	// parent to clean up when the app exits.
+	m.fieldDoc.cancelInFlight()
 	m.fieldDoc.loading = false
 	if !m.fieldDoc.on {
 		// The user closed the pane while the fetch was in flight.

--- a/internal/app/update_fielddoc.go
+++ b/internal/app/update_fielddoc.go
@@ -9,10 +9,12 @@ import (
 // Pane sizing. The schema pane sits beside the viewer, so it takes columns,
 // not rows. Below fieldDocMinTotalWidth there is no split worth making: the
 // viewer would be squeezed to nothing.
+// The bounds match the log viewer's structured preview, so the two side panes
+// come out the same width on the same terminal.
 const (
 	fieldDocMinTotalWidth = 90
-	fieldDocMinPaneWidth  = 32
-	fieldDocMaxPaneWidth  = 60
+	fieldDocMinPaneWidth  = 30
+	fieldDocMaxPaneWidth  = 80
 	fieldDocMinViewWidth  = 50
 )
 

--- a/internal/app/update_fielddoc.go
+++ b/internal/app/update_fielddoc.go
@@ -6,30 +6,60 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// fieldDocPaneHeight is the number of body lines the footnote takes away from
-// the viewer above it, so the cursor keeps a viewport it fits in.
-func (m Model) fieldDocPaneHeight() int {
+// Pane sizing. The schema pane sits beside the viewer, so it takes columns,
+// not rows. Below fieldDocMinTotalWidth there is no split worth making: the
+// viewer would be squeezed to nothing.
+const (
+	fieldDocMinTotalWidth = 90
+	fieldDocMinPaneWidth  = 32
+	fieldDocMaxPaneWidth  = 60
+	fieldDocMinViewWidth  = 50
+)
+
+// splitFieldDocWidth divides the terminal between the viewer and the schema
+// pane. A zero pane width means the terminal is too narrow to show both, and
+// the caller keeps the viewer at full width. It mirrors splitLogPreviewWidth.
+func splitFieldDocWidth(total int) (viewW, paneW int) {
+	if total < fieldDocMinTotalWidth {
+		return total, 0
+	}
+	paneW = min(max(total*2/5, fieldDocMinPaneWidth), fieldDocMaxPaneWidth)
+	if total-paneW < fieldDocMinViewWidth {
+		paneW = total - fieldDocMinViewWidth
+	}
+	if paneW < fieldDocMinPaneWidth {
+		return total, 0
+	}
+	return total - paneW, paneW
+}
+
+// fieldDocPaneWidth is the columns the pane takes right now: zero when it is
+// closed, and zero when the terminal cannot fit both it and the viewer.
+func (m Model) fieldDocPaneWidth() int {
 	if !m.fieldDoc.on {
 		return 0
 	}
-	return ui.FieldDocPaneHeight
+	_, paneW := splitFieldDocWidth(m.width)
+	return paneW
 }
 
-// renderFieldDocPane draws the footnote, or nothing when it is closed.
-func (m Model) renderFieldDocPane() string {
-	if !m.fieldDoc.on {
+// renderFieldDocPane draws the schema pane at the given height, or nothing when
+// it is closed or does not fit.
+func (m Model) renderFieldDocPane(height int, omitFooter bool) string {
+	paneW := m.fieldDocPaneWidth()
+	if paneW == 0 {
 		return ""
 	}
-	return ui.RenderFieldDocPane(m.width, ui.FieldDocPane{
+	return ui.RenderFieldDocPane(paneW, height, ui.FieldDocPane{
 		Path:      m.fieldDoc.key.path,
 		FieldType: m.fieldDoc.entry.fieldType,
 		Desc:      m.fieldDoc.entry.desc,
 		Err:       m.fieldDoc.err,
 		Loading:   m.fieldDoc.loading,
-	})
+	}, omitFooter)
 }
 
-// toggleFieldDoc opens or closes the schema footnote pane. Opening it shows the
+// toggleFieldDoc opens or closes the schema side pane. Opening it shows the
 // field under the cursor; closing it drops what was on screen but keeps the
 // cache, so re-opening on a visited field costs nothing.
 func (m Model) toggleFieldDoc(objPath []string) (tea.Model, tea.Cmd) {
@@ -39,6 +69,10 @@ func (m Model) toggleFieldDoc(objPath []string) (tea.Model, tea.Cmd) {
 	}
 	if _, ok := m.fieldDocKeyForPath(objPath); !ok {
 		m.setStatusMessage("Cannot determine resource type", true)
+		return m, scheduleStatusClear()
+	}
+	if _, paneW := splitFieldDocWidth(m.width); paneW == 0 {
+		m.setStatusMessage("Terminal too narrow for the schema pane", true)
 		return m, scheduleStatusClear()
 	}
 	m.fieldDoc.on = true

--- a/internal/app/update_fielddoc_test.go
+++ b/internal/app/update_fielddoc_test.go
@@ -193,6 +193,76 @@ func TestFieldDocDebounceIgnoredWhenPaneClosed(t *testing.T) {
 	assert.Nil(t, cmd, "a closed pane must not fetch")
 }
 
+// Dropping a superseded reply is not enough: the kubectl process would keep a
+// scheduler worker until its own deadline. Moving on has to cancel it.
+func TestFieldDocRetargetCancelsTheFetchInFlight(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	ctx, cancel := context.WithCancel(t.Context())
+	m.fieldDoc.cancel = cancel
+	m.fieldDoc.key, _ = m.fieldDocKeyForPath([]string{"spec", "dnsPolicy"})
+	m.fieldDoc.loading = true
+
+	got, _ := m.showFieldDoc([]string{"spec", "restartPolicy"})
+
+	require.Error(t, ctx.Err(), "the superseded fetch must be cancelled")
+	assert.Nil(t, got.fieldDoc.cancel, "the spent cancel must not be kept")
+}
+
+func TestFieldDocCloseCancelsTheFetchInFlight(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	ctx, cancel := context.WithCancel(t.Context())
+	m.fieldDoc.cancel = cancel
+
+	mdl, _ := m.toggleFieldDoc([]string{"spec", "dnsPolicy"})
+
+	require.Error(t, ctx.Err(), "closing the pane must cancel the fetch")
+	assert.False(t, mdl.(Model).fieldDoc.on)
+}
+
+// A finished fetch releases its context rather than leaving it to the parent.
+func TestFieldDocLoadedReleasesTheRequestContext(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.loading = true
+	m.fieldDoc.req = 2
+	ctx, cancel := context.WithCancel(t.Context())
+	m.fieldDoc.cancel = cancel
+	key := fieldDocKey{context: "test-ctx", resource: "pods", path: "spec.dnsPolicy"}
+
+	got := m.updateFieldDocLoaded(fieldDocLoadedMsg{req: 2, key: key, entry: fieldDocEntry{desc: "d"}})
+
+	require.Error(t, ctx.Err(), "a completed fetch must release its context")
+	assert.Nil(t, got.fieldDoc.cancel)
+}
+
+// A cache hit answers without a fetch, so anything still running is stale.
+func TestFieldDocCacheHitCancelsTheFetchInFlight(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	ctx, cancel := context.WithCancel(t.Context())
+	m.fieldDoc.cancel = cancel
+	key, ok := m.fieldDocKeyForPath([]string{"spec", "dnsPolicy"})
+	require.True(t, ok)
+	m.fieldDoc.cache.put(key, fieldDocEntry{desc: "cached"})
+
+	got, cmd := m.showFieldDoc([]string{"spec", "dnsPolicy"})
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, "cached", got.fieldDoc.entry.desc)
+	require.Error(t, ctx.Err(), "the stale fetch must be cancelled on a cache hit")
+}
+
+func TestFieldDocCancelInFlightIsSafeWhenIdle(t *testing.T) {
+	s := &fieldDocState{}
+
+	assert.NotPanics(t, func() {
+		s.cancelInFlight()
+		s.cancelInFlight()
+	}, "cancelling with nothing running must be a no-op")
+}
+
 func TestFieldDocToggleClosesAndClears(t *testing.T) {
 	m := fieldDocModel()
 	m.fieldDoc.on = true

--- a/internal/app/update_fielddoc_test.go
+++ b/internal/app/update_fielddoc_test.go
@@ -1,0 +1,218 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// fieldDocModel returns a model sitting on a Pod, which is what both viewers
+// show when the footnote pane is opened.
+func fieldDocModel() Model {
+	m := basePush80Model()
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true,
+	}
+	m.fieldDoc.cache = newFieldDocCache()
+	return m
+}
+
+func TestFieldDocKeyForPath(t *testing.T) {
+	m := fieldDocModel()
+
+	key, ok := m.fieldDocKeyForPath([]string{"spec", "containers", "[0]", "image"})
+
+	require.True(t, ok)
+	assert.Equal(t, "pods", key.resource)
+	assert.Equal(t, "spec.containers.image", key.path, "array indices must be stripped")
+	assert.Equal(t, m.effectiveContext(), key.context)
+}
+
+func TestFieldDocKeyForPathRejectsUnknownResource(t *testing.T) {
+	m := basePush80Model()
+	m.nav.ResourceType = model.ResourceTypeEntry{}
+
+	_, ok := m.fieldDocKeyForPath([]string{"spec"})
+
+	assert.False(t, ok, "no resource type means no schema to ask for")
+}
+
+func TestFieldDocKeyForPathCarriesCRDAPIVersion(t *testing.T) {
+	m := basePush80Model()
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Cluster", APIGroup: "postgresql.cnpg.io", APIVersion: "v1",
+		Resource: "clusters", Namespaced: true,
+	}
+
+	key, ok := m.fieldDocKeyForPath([]string{"spec", "instances"})
+
+	require.True(t, ok)
+	assert.Equal(t, "clusters", key.resource)
+	assert.Equal(t, "postgresql.cnpg.io/v1", key.apiVersion, "a CRD resolves through its group/version")
+	assert.Equal(t, "spec.instances", key.path)
+}
+
+func TestFieldDocLoadedStoresAndCaches(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.loading = true
+	m.fieldDoc.req = 7
+	key := fieldDocKey{context: "test-ctx", apiVersion: "v1", resource: "pods", path: "spec.dnsPolicy"}
+	m.fieldDoc.key = key
+
+	got := m.updateFieldDocLoaded(fieldDocLoadedMsg{
+		req:   7,
+		key:   key,
+		entry: fieldDocEntry{fieldType: "<string>", desc: "Set DNS policy for the pod."},
+	})
+
+	assert.False(t, got.fieldDoc.loading)
+	assert.Equal(t, "Set DNS policy for the pod.", got.fieldDoc.entry.desc)
+	assert.Equal(t, "<string>", got.fieldDoc.entry.fieldType)
+
+	cached, ok := got.fieldDoc.cache.get(key)
+	require.True(t, ok, "a loaded description must be cached")
+	assert.Equal(t, "Set DNS policy for the pod.", cached.desc)
+}
+
+func TestFieldDocLoadedDropsStaleReply(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.loading = true
+	m.fieldDoc.req = 9
+	m.fieldDoc.entry = fieldDocEntry{desc: "current field"}
+
+	// A reply for request 8 arrives after the cursor already moved to 9.
+	got := m.updateFieldDocLoaded(fieldDocLoadedMsg{
+		req:   8,
+		key:   fieldDocKey{path: "spec.old"},
+		entry: fieldDocEntry{desc: "stale field"},
+	})
+
+	assert.Equal(t, "current field", got.fieldDoc.entry.desc, "a late reply must not overwrite the new field")
+	assert.True(t, got.fieldDoc.loading, "the in-flight fetch must still be pending")
+}
+
+func TestFieldDocLoadedIgnoredWhenPaneClosed(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = false
+	m.fieldDoc.req = 3
+
+	got := m.updateFieldDocLoaded(fieldDocLoadedMsg{
+		req:   3,
+		key:   fieldDocKey{path: "spec.dnsPolicy"},
+		entry: fieldDocEntry{desc: "arrived too late"},
+	})
+
+	assert.Empty(t, got.fieldDoc.entry.desc, "closing the pane wins over an in-flight reply")
+}
+
+func TestFieldDocLoadedRecordsError(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.loading = true
+	m.fieldDoc.req = 1
+
+	got := m.updateFieldDocLoaded(fieldDocLoadedMsg{
+		req: 1,
+		key: fieldDocKey{path: "spec.nope"},
+		err: errors.New("field \"nope\" does not exist"),
+	})
+
+	assert.False(t, got.fieldDoc.loading)
+	assert.True(t, got.fieldDoc.on, "an error keeps the pane open so the message is readable")
+	assert.Contains(t, got.fieldDoc.err, "does not exist")
+}
+
+// A cancelled fetch is the app shutting work down, not a schema problem, so it
+// must not paint an error into the pane.
+func TestFieldDocLoadedIgnoresCancellation(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.loading = true
+	m.fieldDoc.req = 1
+
+	got := m.updateFieldDocLoaded(fieldDocLoadedMsg{
+		req: 1, key: fieldDocKey{path: "spec"}, err: context.Canceled,
+	})
+
+	assert.Empty(t, got.fieldDoc.err)
+	assert.False(t, got.fieldDoc.loading)
+}
+
+func TestFieldDocShowFieldUsesCacheWithoutFetching(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	key, ok := m.fieldDocKeyForPath([]string{"spec", "dnsPolicy"})
+	require.True(t, ok)
+	m.fieldDoc.cache.put(key, fieldDocEntry{fieldType: "<string>", desc: "cached text"})
+
+	got, cmd := m.showFieldDoc([]string{"spec", "dnsPolicy"})
+
+	assert.Nil(t, cmd, "a cache hit must not schedule a fetch")
+	assert.False(t, got.fieldDoc.loading)
+	assert.Equal(t, "cached text", got.fieldDoc.entry.desc)
+}
+
+func TestFieldDocShowFieldSchedulesOnMiss(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+
+	got, cmd := m.showFieldDoc([]string{"spec", "dnsPolicy"})
+
+	require.NotNil(t, cmd, "a cache miss must schedule the debounced fetch")
+	assert.True(t, got.fieldDoc.loading)
+	assert.Equal(t, "spec.dnsPolicy", got.fieldDoc.key.path)
+}
+
+// Moving the cursor bumps the request number, so the debounce timer started for
+// the previous line finds itself stale and never spawns kubectl.
+func TestFieldDocDebounceDropsSupersededRequest(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.loading = true
+	m.fieldDoc.req = 4
+
+	_, cmd := m.updateFieldDocDebounce(fieldDocDebounceMsg{req: 3})
+
+	assert.Nil(t, cmd, "a superseded debounce tick must not fetch")
+}
+
+func TestFieldDocDebounceIgnoredWhenPaneClosed(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = false
+	m.fieldDoc.req = 2
+
+	_, cmd := m.updateFieldDocDebounce(fieldDocDebounceMsg{req: 2})
+
+	assert.Nil(t, cmd, "a closed pane must not fetch")
+}
+
+func TestFieldDocToggleClosesAndClears(t *testing.T) {
+	m := fieldDocModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.entry = fieldDocEntry{desc: "something"}
+	m.fieldDoc.err = "boom"
+
+	mdl, _ := m.toggleFieldDoc([]string{"spec", "dnsPolicy"})
+	got := mdl.(Model)
+
+	assert.False(t, got.fieldDoc.on)
+	assert.Empty(t, got.fieldDoc.entry.desc)
+	assert.Empty(t, got.fieldDoc.err)
+}
+
+func TestFieldDocToggleOpens(t *testing.T) {
+	m := fieldDocModel()
+
+	mdl, cmd := m.toggleFieldDoc([]string{"spec", "dnsPolicy"})
+	got := mdl.(Model)
+
+	assert.True(t, got.fieldDoc.on)
+	assert.NotNil(t, cmd, "opening on a cache miss must schedule a fetch")
+}

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -19,9 +19,7 @@ func (m Model) yamlViewportLines() int {
 	if len(m.tabs) > 1 {
 		overhead = 6
 	}
-	// The footnote pane eats into the same body the render path measures, so
-	// both have to subtract it or the cursor scrolls in behind the pane.
-	lines := max(m.height-overhead-m.fieldDocPaneHeight(), 3)
+	lines := max(m.height-overhead, 3)
 	return lines
 }
 

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -19,7 +19,9 @@ func (m Model) yamlViewportLines() int {
 	if len(m.tabs) > 1 {
 		overhead = 6
 	}
-	lines := max(m.height-overhead, 3)
+	// The footnote pane eats into the same body the render path measures, so
+	// both have to subtract it or the cursor scrolls in behind the pane.
+	lines := max(m.height-overhead-m.fieldDocPaneHeight(), 3)
 	return lines
 }
 
@@ -34,7 +36,24 @@ func (m Model) handleYAMLKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleYAMLVisualKey(msg)
 	}
 
-	return m.handleYAMLNormalKey(msg)
+	mdl, cmd := m.handleYAMLNormalKey(msg)
+	return followFieldDocCursor(mdl, cmd, func(u Model) []string { return u.yamlCursorPath() })
+}
+
+// followFieldDocCursor re-points an open footnote pane at whatever the cursor
+// landed on. It runs once per key press instead of inside each motion, because
+// the viewers move the cursor from a dozen places (j, G, ctrl+d, a search jump)
+// and every one of them would otherwise need the same call.
+func followFieldDocCursor(mdl tea.Model, cmd tea.Cmd, path func(Model) []string) (tea.Model, tea.Cmd) {
+	updated, ok := mdl.(Model)
+	if !ok || !updated.fieldDoc.on {
+		return mdl, cmd
+	}
+	updated, followCmd := updated.showFieldDoc(path(updated))
+	if followCmd == nil {
+		return updated, cmd
+	}
+	return updated, tea.Batch(cmd, followCmd)
 }
 
 // handleYAMLSearchInput handles key events when the YAML search input is active.
@@ -193,6 +212,8 @@ func (m Model) handleYAMLNormalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleYAMLKeyObjectExplorer()
 	case "I":
 		return m.openExplainAtObjectPath(m.yamlCursorPath(), modeYAML)
+	case kb.FieldDoc:
+		return m.toggleFieldDoc(m.yamlCursorPath())
 	case "V":
 		return m.handleYAMLKeyV()
 	case "v":

--- a/internal/app/view_fielddoc_test.go
+++ b/internal/app/view_fielddoc_test.go
@@ -51,15 +51,17 @@ func TestSplitFieldDocWidth(t *testing.T) {
 	}
 }
 
-// The pane takes columns now, not rows, so neither viewer loses body height.
-func TestFieldDocPaneDoesNotShrinkHeights(t *testing.T) {
+// The pane takes columns, not rows. The YAML viewer keeps every body line; the
+// Object Explorer gives up exactly one row, to the hint bar that moves out from
+// under its columns to span both panes.
+func TestFieldDocPaneCostsNoYAMLRowsAndOneOERow(t *testing.T) {
 	m := fieldDocViewModel()
 	yamlBefore, oeBefore := m.yamlViewportLines(), m.objectExplorerBodyHeight()
 
 	m.fieldDoc.on = true
 
 	assert.Equal(t, yamlBefore, m.yamlViewportLines())
-	assert.Equal(t, oeBefore, m.objectExplorerBodyHeight())
+	assert.Equal(t, oeBefore-1, m.objectExplorerBodyHeight())
 }
 
 func TestFieldDocPaneWidthZeroWhenClosed(t *testing.T) {
@@ -83,6 +85,63 @@ func TestYAMLViewWithSchemaPaneKeepsTerminalBox(t *testing.T) {
 	assert.Equal(t, m.width, lipgloss.Width(open), "the view must fill the terminal width")
 	assert.Equal(t, lipgloss.Height(closed.viewYAML()), lipgloss.Height(open),
 		"opening the pane must not change the view height")
+}
+
+// lastLine returns the hint bar, which both viewers draw as the bottom row.
+func hintBarRow(t *testing.T, view string) string {
+	t.Helper()
+	rows := strings.Split(stripANSI(view), "\n")
+	return rows[len(rows)-1]
+}
+
+// The hint bar spans the terminal under both panes. Drawing it inside the
+// narrowed viewer column cost it entries instead. It must read the same open
+// as closed; how many entries fit at a given width is a separate matter.
+func TestYAMLViewHintBarUnchangedByPane(t *testing.T) {
+	m := fieldDocViewModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+
+	assert.Equal(t, hintBarRow(t, fieldDocViewModel().viewYAML()), hintBarRow(t, m.viewYAML()),
+		"the pane must not cost the hint bar any entries")
+}
+
+func TestObjectExplorerHintBarUnchangedByPane(t *testing.T) {
+	closed := fieldDocViewModel()
+	closed.mode = modeObjectExplorer
+	m := fieldDocViewModel()
+	m.mode = modeObjectExplorer
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+
+	assert.Equal(t, hintBarRow(t, closed.viewObjectExplorer()), hintBarRow(t, m.viewObjectExplorer()),
+		"the pane must not cost the hint bar any entries")
+}
+
+// A terminal wide enough for every entry must show every entry with the pane
+// open, which is the case the report came from.
+func TestYAMLViewHintBarCompleteOnAWideTerminal(t *testing.T) {
+	m := fieldDocViewModel()
+	m.width = 300
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+
+	hint := hintBarRow(t, m.viewYAML())
+
+	for _, want := range []string{"scroll", "visual select", "object explorer", "explain", "schema", "back"} {
+		assert.Contains(t, hint, want, "hint entry %q must survive the pane", want)
+	}
+}
+
+// The pane is sized like the log viewer's structured preview, so the same
+// terminal gives both the same width.
+func TestFieldDocPaneMatchesLogPreviewWidth(t *testing.T) {
+	for _, total := range []int{100, 120, 160, 200, 300} {
+		_, logPaneW := splitLogPreviewWidth(total)
+		_, docPaneW := splitFieldDocWidth(total)
+
+		assert.Equal(t, logPaneW, docPaneW, "width %d: the two side panes must agree", total)
+	}
 }
 
 func TestYAMLViewRendersSchemaPane(t *testing.T) {

--- a/internal/app/view_fielddoc_test.go
+++ b/internal/app/view_fielddoc_test.go
@@ -78,6 +78,7 @@ func TestYAMLViewWithSchemaPaneKeepsTerminalBox(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", apiVersion: "v1", path: "spec.dnsPolicy"}
+	m.fieldDoc.display = "spec.dnsPolicy"
 	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: strings.Repeat("word ", 200)}
 
 	open := m.viewYAML()
@@ -101,6 +102,7 @@ func TestYAMLViewHintBarUnchangedByPane(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+	m.fieldDoc.display = "spec.dnsPolicy"
 
 	assert.Equal(t, hintBarRow(t, fieldDocViewModel().viewYAML()), hintBarRow(t, m.viewYAML()),
 		"the pane must not cost the hint bar any entries")
@@ -113,6 +115,7 @@ func TestObjectExplorerHintBarUnchangedByPane(t *testing.T) {
 	m.mode = modeObjectExplorer
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+	m.fieldDoc.display = "spec.dnsPolicy"
 
 	assert.Equal(t, hintBarRow(t, closed.viewObjectExplorer()), hintBarRow(t, m.viewObjectExplorer()),
 		"the pane must not cost the hint bar any entries")
@@ -125,6 +128,7 @@ func TestYAMLViewHintBarCompleteOnAWideTerminal(t *testing.T) {
 	m.width = 300
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+	m.fieldDoc.display = "spec.dnsPolicy"
 
 	hint := hintBarRow(t, m.viewYAML())
 
@@ -148,6 +152,7 @@ func TestYAMLViewRendersSchemaPane(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", apiVersion: "v1", path: "spec.dnsPolicy"}
+	m.fieldDoc.display = "spec.dnsPolicy"
 	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: "Set DNS policy for the pod."}
 
 	view := stripANSI(m.viewYAML())
@@ -155,6 +160,19 @@ func TestYAMLViewRendersSchemaPane(t *testing.T) {
 	assert.Contains(t, view, "SCHEMA")
 	assert.Contains(t, view, "spec.dnsPolicy")
 	assert.Contains(t, view, "Set DNS policy for the pod.")
+}
+
+// The title is formatted from the original segments, so an array index reads
+// as "[0]" instead of vanishing into the dot-joined path kubectl is given.
+func TestYAMLViewSchemaPaneTitleKeepsArrayIndex(t *testing.T) {
+	m := fieldDocViewModel()
+	m.fieldDoc.on = true
+	got, _ := m.showFieldDoc([]string{"spec", "containers", "[0]", "image"})
+
+	assert.Equal(t, "spec.containers.image", got.fieldDoc.key.path,
+		"kubectl explain takes the element schema, so the index is dropped there")
+	assert.Contains(t, got.fieldDoc.display, "[0]", "the title keeps the index the user is on")
+	assert.Contains(t, stripANSI(got.viewYAML()), "[0]")
 }
 
 func TestYAMLViewOmitsSchemaPaneWhenClosed(t *testing.T) {
@@ -171,6 +189,7 @@ func TestYAMLViewSchemaPaneEmptyState(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.opaque"}
+	m.fieldDoc.display = "spec.opaque"
 
 	view := stripANSI(m.viewYAML())
 
@@ -183,6 +202,7 @@ func TestYAMLViewSchemaPaneShowsErrorAlone(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "metadata.annotations.checksum/config"}
+	m.fieldDoc.display = "metadata.annotations.checksum/config"
 	m.fieldDoc.err = parseExplainError(
 		"KIND:       Pod\nVERSION:    v1\n\nerror: field \"checksum/config\" does not exist\n",
 		errors.New("exit status 1"),
@@ -202,6 +222,7 @@ func TestObjectExplorerViewKeepsTerminalBox(t *testing.T) {
 
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+	m.fieldDoc.display = "spec.dnsPolicy"
 	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: "Set DNS policy."}
 	open := m.viewObjectExplorer()
 

--- a/internal/app/view_fielddoc_test.go
+++ b/internal/app/view_fielddoc_test.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func fieldDocViewModel() Model {
+	m := basePush80Model()
+	m.mode = modeYAML
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true,
+	}
+	m.fieldDoc.cache = newFieldDocCache()
+	m.yamlView.content = "spec:\n  dnsPolicy: ClusterFirst\n  restartPolicy: Always\n"
+	return m
+}
+
+// The pane takes its lines out of the body, not off the bottom of the terminal.
+// If Update and View disagree the cursor scrolls in behind the pane.
+func TestFieldDocPaneShrinksYAMLViewport(t *testing.T) {
+	m := fieldDocViewModel()
+	before := m.yamlViewportLines()
+
+	m.fieldDoc.on = true
+	after := m.yamlViewportLines()
+
+	assert.Equal(t, before-ui.FieldDocPaneHeight, after,
+		"the viewport must lose exactly the pane's lines")
+}
+
+func TestFieldDocPaneShrinksObjectExplorerBody(t *testing.T) {
+	m := fieldDocViewModel()
+	before := m.objectExplorerBodyHeight()
+
+	m.fieldDoc.on = true
+	after := m.objectExplorerBodyHeight()
+
+	assert.Equal(t, before-ui.FieldDocPaneHeight, after)
+}
+
+func TestFieldDocPaneHeightZeroWhenClosed(t *testing.T) {
+	m := fieldDocViewModel()
+
+	assert.Equal(t, 0, m.fieldDocPaneHeight())
+	assert.Empty(t, m.renderFieldDocPane())
+}
+
+func TestYAMLViewRendersFieldDocPane(t *testing.T) {
+	m := fieldDocViewModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{resource: "pods", apiVersion: "v1", path: "spec.dnsPolicy"}
+	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: "Set DNS policy for the pod."}
+
+	view := stripANSI(m.viewYAML())
+
+	assert.Contains(t, view, "spec.dnsPolicy")
+	assert.Contains(t, view, "Set DNS policy for the pod.")
+}
+
+func TestYAMLViewOmitsFieldDocPaneWhenClosed(t *testing.T) {
+	m := fieldDocViewModel()
+	m.fieldDoc.entry = fieldDocEntry{desc: "Set DNS policy for the pod."}
+
+	view := stripANSI(m.viewYAML())
+
+	assert.NotContains(t, view, "Set DNS policy for the pod.")
+}
+
+// The whole view must keep fitting the terminal, or the pane pushes the hint
+// bar off the bottom of the screen.
+func TestYAMLViewWithFieldDocPaneFitsTerminalHeight(t *testing.T) {
+	m := fieldDocViewModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: strings.Repeat("long ", 200)}
+
+	closed := len(strings.Split(stripANSI(fieldDocViewModel().viewYAML()), "\n"))
+	open := len(strings.Split(stripANSI(m.viewYAML()), "\n"))
+
+	require.Positive(t, closed)
+	assert.Equal(t, closed, open, "opening the pane must not make the view taller")
+}
+
+func TestYAMLViewFieldDocEmptyState(t *testing.T) {
+	m := fieldDocViewModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.opaque"}
+
+	view := stripANSI(m.viewYAML())
+
+	assert.Contains(t, view, "No description")
+}

--- a/internal/app/view_fielddoc_test.go
+++ b/internal/app/view_fielddoc_test.go
@@ -1,14 +1,15 @@
 package app
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
-	"github.com/janosmiko/lfk/internal/ui"
 )
 
 func fieldDocViewModel() Model {
@@ -22,37 +23,69 @@ func fieldDocViewModel() Model {
 	return m
 }
 
-// The pane takes its lines out of the body, not off the bottom of the terminal.
-// If Update and View disagree the cursor scrolls in behind the pane.
-func TestFieldDocPaneShrinksYAMLViewport(t *testing.T) {
+func TestSplitFieldDocWidth(t *testing.T) {
+	tests := []struct {
+		name        string
+		total       int
+		wantPaneNil bool
+	}{
+		{name: "narrow terminal gets no pane", total: 80, wantPaneNil: true},
+		{name: "tiny terminal gets no pane", total: 40, wantPaneNil: true},
+		{name: "roomy terminal gets a pane", total: 120},
+		{name: "wide terminal gets a pane", total: 200},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viewW, paneW := splitFieldDocWidth(tt.total)
+
+			assert.Equal(t, tt.total, viewW+paneW, "the split must account for every column")
+			if tt.wantPaneNil {
+				assert.Zero(t, paneW)
+				return
+			}
+			assert.GreaterOrEqual(t, paneW, fieldDocMinPaneWidth)
+			assert.LessOrEqual(t, paneW, fieldDocMaxPaneWidth)
+			assert.GreaterOrEqual(t, viewW, fieldDocMinViewWidth, "the viewer must keep room to read")
+		})
+	}
+}
+
+// The pane takes columns now, not rows, so neither viewer loses body height.
+func TestFieldDocPaneDoesNotShrinkHeights(t *testing.T) {
 	m := fieldDocViewModel()
-	before := m.yamlViewportLines()
+	yamlBefore, oeBefore := m.yamlViewportLines(), m.objectExplorerBodyHeight()
 
 	m.fieldDoc.on = true
-	after := m.yamlViewportLines()
 
-	assert.Equal(t, before-ui.FieldDocPaneHeight, after,
-		"the viewport must lose exactly the pane's lines")
+	assert.Equal(t, yamlBefore, m.yamlViewportLines())
+	assert.Equal(t, oeBefore, m.objectExplorerBodyHeight())
 }
 
-func TestFieldDocPaneShrinksObjectExplorerBody(t *testing.T) {
+func TestFieldDocPaneWidthZeroWhenClosed(t *testing.T) {
 	m := fieldDocViewModel()
-	before := m.objectExplorerBodyHeight()
 
+	assert.Zero(t, m.fieldDocPaneWidth())
+	assert.Empty(t, m.renderFieldDocPane(m.height, false))
+}
+
+// The joined view must stay exactly as wide and as tall as the terminal, or
+// lipgloss pads one side and the layout tears.
+func TestYAMLViewWithSchemaPaneKeepsTerminalBox(t *testing.T) {
+	closed := fieldDocViewModel()
+	m := fieldDocViewModel()
 	m.fieldDoc.on = true
-	after := m.objectExplorerBodyHeight()
+	m.fieldDoc.key = fieldDocKey{resource: "pods", apiVersion: "v1", path: "spec.dnsPolicy"}
+	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: strings.Repeat("word ", 200)}
 
-	assert.Equal(t, before-ui.FieldDocPaneHeight, after)
+	open := m.viewYAML()
+
+	assert.Equal(t, m.width, lipgloss.Width(open), "the view must fill the terminal width")
+	assert.Equal(t, lipgloss.Height(closed.viewYAML()), lipgloss.Height(open),
+		"opening the pane must not change the view height")
 }
 
-func TestFieldDocPaneHeightZeroWhenClosed(t *testing.T) {
-	m := fieldDocViewModel()
-
-	assert.Equal(t, 0, m.fieldDocPaneHeight())
-	assert.Empty(t, m.renderFieldDocPane())
-}
-
-func TestYAMLViewRendersFieldDocPane(t *testing.T) {
+func TestYAMLViewRendersSchemaPane(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", apiVersion: "v1", path: "spec.dnsPolicy"}
@@ -60,34 +93,22 @@ func TestYAMLViewRendersFieldDocPane(t *testing.T) {
 
 	view := stripANSI(m.viewYAML())
 
+	assert.Contains(t, view, "SCHEMA")
 	assert.Contains(t, view, "spec.dnsPolicy")
 	assert.Contains(t, view, "Set DNS policy for the pod.")
 }
 
-func TestYAMLViewOmitsFieldDocPaneWhenClosed(t *testing.T) {
+func TestYAMLViewOmitsSchemaPaneWhenClosed(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.entry = fieldDocEntry{desc: "Set DNS policy for the pod."}
 
 	view := stripANSI(m.viewYAML())
 
+	assert.NotContains(t, view, "SCHEMA")
 	assert.NotContains(t, view, "Set DNS policy for the pod.")
 }
 
-// The whole view must keep fitting the terminal, or the pane pushes the hint
-// bar off the bottom of the screen.
-func TestYAMLViewWithFieldDocPaneFitsTerminalHeight(t *testing.T) {
-	m := fieldDocViewModel()
-	m.fieldDoc.on = true
-	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: strings.Repeat("long ", 200)}
-
-	closed := len(strings.Split(stripANSI(fieldDocViewModel().viewYAML()), "\n"))
-	open := len(strings.Split(stripANSI(m.viewYAML()), "\n"))
-
-	require.Positive(t, closed)
-	assert.Equal(t, closed, open, "opening the pane must not make the view taller")
-}
-
-func TestYAMLViewFieldDocEmptyState(t *testing.T) {
+func TestYAMLViewSchemaPaneEmptyState(t *testing.T) {
 	m := fieldDocViewModel()
 	m.fieldDoc.on = true
 	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.opaque"}
@@ -95,4 +116,50 @@ func TestYAMLViewFieldDocEmptyState(t *testing.T) {
 	view := stripANSI(m.viewYAML())
 
 	assert.Contains(t, view, "No description")
+}
+
+// The reported bug: the raw exit status and the KIND/VERSION preamble reached
+// the pane instead of the one line that says what went wrong.
+func TestYAMLViewSchemaPaneShowsErrorAlone(t *testing.T) {
+	m := fieldDocViewModel()
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "metadata.annotations.checksum/config"}
+	m.fieldDoc.err = parseExplainError(
+		"KIND:       Pod\nVERSION:    v1\n\nerror: field \"checksum/config\" does not exist\n",
+		errors.New("exit status 1"),
+	).Error()
+
+	view := stripANSI(m.viewYAML())
+
+	assert.Contains(t, view, `field "checksum/config" does not exist`)
+	assert.NotContains(t, view, "exit status")
+	assert.NotContains(t, view, "VERSION:")
+}
+
+func TestObjectExplorerViewKeepsTerminalBox(t *testing.T) {
+	m := fieldDocViewModel()
+	m.mode = modeObjectExplorer
+	closedH := lipgloss.Height(m.viewObjectExplorer())
+
+	m.fieldDoc.on = true
+	m.fieldDoc.key = fieldDocKey{resource: "pods", path: "spec.dnsPolicy"}
+	m.fieldDoc.entry = fieldDocEntry{fieldType: "<string>", desc: "Set DNS policy."}
+	open := m.viewObjectExplorer()
+
+	require.Contains(t, stripANSI(open), "SCHEMA")
+	assert.Equal(t, m.width, lipgloss.Width(open))
+	assert.Equal(t, closedH, lipgloss.Height(open))
+}
+
+// Opening on a terminal that cannot fit both panes has to say so rather than
+// toggling a pane the user never sees.
+func TestToggleFieldDocRefusesNarrowTerminal(t *testing.T) {
+	m := fieldDocViewModel()
+	m.width = 70
+
+	mdl, _ := m.toggleFieldDoc([]string{"spec", "dnsPolicy"})
+	got := mdl.(Model)
+
+	assert.False(t, got.fieldDoc.on)
+	assert.Contains(t, got.statusMessage, "too narrow")
 }

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -12,6 +12,14 @@ import (
 )
 
 func (m Model) viewYAML() string {
+	// The schema pane takes columns off the right. Render it first, then
+	// narrow m.width so the whole viewer below lays itself out in what is
+	// left; m is a value copy, so the narrowing stays inside this render.
+	schemaPane := m.renderFieldDocPane(m.height, false)
+	if schemaPane != "" {
+		m.width -= lipgloss.Width(schemaPane)
+	}
+
 	yamlTitleText := m.yamlTitle()
 	if m.yamlView.wrap {
 		yamlTitleText += " [WRAP]"
@@ -79,7 +87,7 @@ func (m Model) viewYAML() string {
 		hint = ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(searchBar)
 	}
 
-	maxLines := max(m.height-4-m.fieldDocPaneHeight(), 3)
+	maxLines := max(m.height-4, 3)
 
 	// Build visible lines with fold indicators, respecting collapsed sections.
 	visLines, mapping := buildVisibleLines(m.yamlView.content, m.yamlView.sections, m.yamlView.collapsed)
@@ -187,10 +195,11 @@ func (m Model) viewYAML() string {
 	borderStyle := ui.FullscreenBorderStyle(m.width, maxLines)
 	body := borderStyle.Render(bodyContent)
 
-	if pane := m.renderFieldDocPane(); pane != "" {
-		return lipgloss.JoinVertical(lipgloss.Left, title, body, pane, hint)
+	view := lipgloss.JoinVertical(lipgloss.Left, title, body, hint)
+	if schemaPane != "" {
+		return lipgloss.JoinHorizontal(lipgloss.Top, view, schemaPane)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, title, body, hint)
+	return view
 }
 
 func (m Model) yamlTitle() string {

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -51,6 +51,7 @@ func (m Model) viewYAML() string {
 			{Key: "ctrl+e", Desc: "edit"},
 			{Key: "O", Desc: "object explorer"},
 			{Key: "I", Desc: "explain"},
+			{Key: ui.ActiveKeybindings.FieldDoc, Desc: "field doc"},
 			{Key: "q/esc", Desc: "back"},
 		}
 	}
@@ -78,7 +79,7 @@ func (m Model) viewYAML() string {
 		hint = ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(searchBar)
 	}
 
-	maxLines := max(m.height-4, 3)
+	maxLines := max(m.height-4-m.fieldDocPaneHeight(), 3)
 
 	// Build visible lines with fold indicators, respecting collapsed sections.
 	visLines, mapping := buildVisibleLines(m.yamlView.content, m.yamlView.sections, m.yamlView.collapsed)
@@ -186,6 +187,9 @@ func (m Model) viewYAML() string {
 	borderStyle := ui.FullscreenBorderStyle(m.width, maxLines)
 	body := borderStyle.Render(bodyContent)
 
+	if pane := m.renderFieldDocPane(); pane != "" {
+		return lipgloss.JoinVertical(lipgloss.Left, title, body, pane, hint)
+	}
 	return lipgloss.JoinVertical(lipgloss.Left, title, body, hint)
 }
 

--- a/internal/app/view_yaml.go
+++ b/internal/app/view_yaml.go
@@ -12,10 +12,13 @@ import (
 )
 
 func (m Model) viewYAML() string {
-	// The schema pane takes columns off the right. Render it first, then
-	// narrow m.width so the whole viewer below lays itself out in what is
-	// left; m is a value copy, so the narrowing stays inside this render.
-	schemaPane := m.renderFieldDocPane(m.height, false)
+	// The schema pane takes columns off the right. The hint bar keeps the full
+	// terminal width and goes under both panes, or it would lose entries to
+	// the narrower column. Render the pane first, then narrow m.width so the
+	// viewer lays itself out in what is left; m is a value copy, so the
+	// narrowing stays inside this render.
+	fullWidth := m.width
+	schemaPane := m.renderFieldDocPane(m.height, true)
 	if schemaPane != "" {
 		m.width -= lipgloss.Width(schemaPane)
 	}
@@ -59,11 +62,11 @@ func (m Model) viewYAML() string {
 			{Key: "ctrl+e", Desc: "edit"},
 			{Key: "O", Desc: "object explorer"},
 			{Key: "I", Desc: "explain"},
-			{Key: ui.ActiveKeybindings.FieldDoc, Desc: "field doc"},
+			{Key: ui.ActiveKeybindings.FieldDoc, Desc: "schema"},
 			{Key: "q/esc", Desc: "back"},
 		}
 	}
-	hint := ui.RenderHintBar(yamlHints, m.width)
+	hint := ui.RenderHintBar(yamlHints, fullWidth)
 
 	// Status messages (e.g. copy feedback) take precedence over the hint
 	// bar and any search prompt \u2014 same pattern the log viewer uses.
@@ -73,7 +76,7 @@ func (m Model) viewYAML() string {
 	case m.yamlView.searchMode:
 		yamlModeInd := ui.SearchModeIndicator(m.yamlView.searchText.Value)
 		searchBar := ui.HelpKeyStyle.Render(ui.ActiveKeybindings.Search) + ui.BarDimStyle.Render(yamlModeInd) + ui.BarNormalStyle.Render(m.yamlView.searchText.CursorLeft()) + ui.BarDimStyle.Render("\u2588") + ui.BarNormalStyle.Render(m.yamlView.searchText.CursorRight())
-		hint = ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(searchBar)
+		hint = ui.StatusBarBgStyle.Width(fullWidth).MaxWidth(fullWidth).MaxHeight(1).Render(searchBar)
 	case m.yamlView.searchText.Value != "":
 		matchInfo := fmt.Sprintf(" [%d/%d]", m.yamlView.matchIdx+1, len(m.yamlView.matchLines))
 		if len(m.yamlView.matchLines) == 0 {
@@ -84,7 +87,7 @@ func (m Model) viewYAML() string {
 			nav = ui.BarDimStyle.Render(" | ") + ui.HelpKeyStyle.Render(ui.ActiveKeybindings.NextMatch+"/"+ui.ActiveKeybindings.PrevMatch) + ui.BarDimStyle.Render(": next/prev")
 		}
 		searchBar := ui.HelpKeyStyle.Render(ui.ActiveKeybindings.Search) + ui.BarNormalStyle.Render(m.yamlView.searchText.Value) + ui.BarDimStyle.Render(matchInfo) + nav
-		hint = ui.StatusBarBgStyle.Width(m.width).MaxWidth(m.width).MaxHeight(1).Render(searchBar)
+		hint = ui.StatusBarBgStyle.Width(fullWidth).MaxWidth(fullWidth).MaxHeight(1).Render(searchBar)
 	}
 
 	maxLines := max(m.height-4, 3)
@@ -195,11 +198,12 @@ func (m Model) viewYAML() string {
 	borderStyle := ui.FullscreenBorderStyle(m.width, maxLines)
 	body := borderStyle.Render(bodyContent)
 
-	view := lipgloss.JoinVertical(lipgloss.Left, title, body, hint)
 	if schemaPane != "" {
-		return lipgloss.JoinHorizontal(lipgloss.Top, view, schemaPane)
+		panes := lipgloss.JoinHorizontal(lipgloss.Top,
+			lipgloss.JoinVertical(lipgloss.Left, title, body), schemaPane)
+		return lipgloss.JoinVertical(lipgloss.Left, panes, hint)
 	}
-	return view
+	return lipgloss.JoinVertical(lipgloss.Left, title, body, hint)
 }
 
 func (m Model) yamlTitle() string {

--- a/internal/app/whichkey_objectexplorer.go
+++ b/internal/app/whichkey_objectexplorer.go
@@ -95,6 +95,12 @@ var whichKeyObjectExplorerActionList = []wkAction[*wkObjectExplorerCtx]{
 		rt := c.m.nav.ResourceType
 		return rt.Resource != "" || rt.Kind != ""
 	}},
+	// objectexplorer.go — kb.FieldDoc. Same availability rule as the API
+	// Explorer above: both resolve the resource type to reach the schema.
+	{Key: func(kb ui.Keybindings) string { return kb.FieldDoc }, Label: "Field description", Group: wkViews, Avail: func(c *wkObjectExplorerCtx) bool {
+		rt := c.m.nav.ResourceType
+		return rt.Resource != "" || rt.Kind != ""
+	}},
 
 	// objectexplorer.go:298-299 — a one-shot re-fetch, independent of the live
 	// setting and of the cursor.

--- a/internal/app/whichkey_yaml.go
+++ b/internal/app/whichkey_yaml.go
@@ -141,6 +141,10 @@ var whichKeyYAMLActionList = []wkAction[*wkYAMLCtx]{
 	{Key: whichKeyHelpKey, Label: "Full help", Group: wkViews, Avail: wkYAMLNormal},
 	{Key: wkLiteralKey("O"), Label: "Object Explorer", Group: wkViews, Avail: wkYAMLObjectExplorerAvailable},
 	{Key: wkLiteralKey("I"), Label: "API Explorer", Group: wkViews, Avail: wkYAMLAPIExplorerAvailable},
+	// update_yaml.go — kb.FieldDoc, read from the binding because the handler
+	// reads it too, so a rebind shows the key the user actually presses. The
+	// availability rule is the API Explorer's: both need a resolvable type.
+	{Key: func(kb ui.Keybindings) string { return kb.FieldDoc }, Label: "Field description", Group: wkViews, Avail: wkYAMLAPIExplorerAvailable},
 	{Key: func(kb ui.Keybindings) string { return kb.Refresh }, Label: "Re-fetch YAML", Group: wkActions, Avail: wkYAMLRefreshAvailable},
 	{Key: wkLiteralKey("ctrl+e"), Label: "Edit in $EDITOR", Group: wkActions, Avail: wkYAMLEditAvailable},
 

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -56,6 +56,7 @@ type Keybindings struct {
 	SecretToggle      string `json:"secret_toggle" yaml:"secret_toggle"`
 	FinalizerSearch   string `json:"finalizer_search" yaml:"finalizer_search"`
 	APIExplorer       string `json:"api_explorer" yaml:"api_explorer"`
+	FieldDoc          string `json:"field_doc" yaml:"field_doc"`
 	ObjectExplorer    string `json:"object_explorer" yaml:"object_explorer"`
 	TreeView          string `json:"tree_view" yaml:"tree_view"`
 	RBACBrowser       string `json:"rbac_browser" yaml:"rbac_browser"`
@@ -229,6 +230,10 @@ func DefaultKeybindings() Keybindings {
 		ToggleFollow: "F", ToggleTimestamps: "s", TogglePrefixes: "p", ToggleUnified: "u",
 		FilterPresets: ".", ErrorLog: "!", SecretToggle: "ctrl+s",
 		FinalizerSearch: "ctrl+g", APIExplorer: "I", ObjectExplorer: "O", RBACBrowser: "U",
+		// Schema footnote. "ctrl+k" and not "K": K is PreviewUp, and the
+		// footnote has to work in the Object Explorer, which scrolls its
+		// preview pane with J/K.
+		FieldDoc: "ctrl+k",
 		// "T" is also the explorer-level ThemeSelector; TreeView only dispatches
 		// inside the Object/API Explorer modes, which have their own handlers.
 		TreeView:      "T",

--- a/internal/ui/fielddocpane.go
+++ b/internal/ui/fielddocpane.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// FieldDocPaneHeight is the total line count the footnote pane claims, header
+// included. It is fixed rather than sized to the text so the body above does
+// not resize under the cursor as the user walks the document.
+const FieldDocPaneHeight = 6
+
+// fieldDocBodyLines is what is left for the description once the header takes
+// its line.
+const fieldDocBodyLines = FieldDocPaneHeight - 1
+
+// FieldDocPane is what the footnote shows about one field. Err wins over Desc:
+// a description left over from another field would read as if it belonged to
+// the field that failed.
+type FieldDocPane struct {
+	Path      string
+	FieldType string
+	Desc      string
+	Err       string
+	Loading   bool
+}
+
+// RenderFieldDocPane draws the schema footnote: a header naming the field and
+// its type, then the description. It always returns FieldDocPaneHeight lines.
+func RenderFieldDocPane(width int, p FieldDocPane) string {
+	if width < 1 {
+		width = 1
+	}
+
+	lines := make([]string, 0, FieldDocPaneHeight)
+	lines = append(lines, fieldDocHeader(width, p))
+
+	for _, l := range fieldDocBody(width, p) {
+		lines = append(lines, FieldDocTextStyle.Render(l))
+	}
+
+	return FillLinesBg(strings.Join(lines, "\n"), width, BaseBg)
+}
+
+// fieldDocHeader names the field, its type, and rules off the pane from the
+// body above it.
+func fieldDocHeader(width int, p FieldDocPane) string {
+	label := p.Path
+	if label == "" {
+		label = "(root)"
+	}
+	if p.FieldType != "" {
+		label += " " + p.FieldType
+	}
+	label = " " + label + " "
+
+	head := "──" + label
+	if w := ansi.StringWidth(head); w < width {
+		head += strings.Repeat("─", width-w)
+	}
+	return FieldDocHeaderStyle.Render(Truncate(head, width))
+}
+
+// fieldDocBody returns exactly fieldDocBodyLines lines of text, wrapped to the
+// width and padded out so the pane keeps its height.
+func fieldDocBody(width int, p FieldDocPane) []string {
+	text := ""
+	switch {
+	case p.Err != "":
+		text = p.Err
+	case p.Loading:
+		text = "Loading description from the cluster schema…"
+	case p.Desc != "":
+		text = p.Desc
+	default:
+		text = "No description in the cluster schema for this field."
+	}
+
+	// One leading space keeps the text off the left edge; the trailing one
+	// stops a wrapped word from touching the right edge.
+	textWidth := max(width-2, 1)
+	wrapped := strings.Split(ansi.Wordwrap(text, textWidth, ""), "\n")
+
+	out := make([]string, 0, fieldDocBodyLines)
+	for i := range fieldDocBodyLines {
+		if i >= len(wrapped) {
+			out = append(out, "")
+			continue
+		}
+		line := " " + strings.TrimRight(wrapped[i], " ")
+		// The last line absorbs any overflow marker, so a long description
+		// reads as cut off rather than as ending mid-sentence.
+		if i == fieldDocBodyLines-1 && len(wrapped) > fieldDocBodyLines {
+			line = Truncate(line, max(textWidth-1, 1)) + "…"
+		}
+		out = append(out, Truncate(line, width))
+	}
+	return out
+}

--- a/internal/ui/fielddocpane.go
+++ b/internal/ui/fielddocpane.go
@@ -3,19 +3,11 @@ package ui
 import (
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 )
 
-// FieldDocPaneHeight is the total line count the footnote pane claims, header
-// included. It is fixed rather than sized to the text so the body above does
-// not resize under the cursor as the user walks the document.
-const FieldDocPaneHeight = 6
-
-// fieldDocBodyLines is what is left for the description once the header takes
-// its line.
-const fieldDocBodyLines = FieldDocPaneHeight - 1
-
-// FieldDocPane is what the footnote shows about one field. Err wins over Desc:
+// FieldDocPane is what the side pane shows about one field. Err wins over Desc:
 // a description left over from another field would read as if it belonged to
 // the field that failed.
 type FieldDocPane struct {
@@ -26,46 +18,73 @@ type FieldDocPane struct {
 	Loading   bool
 }
 
-// RenderFieldDocPane draws the schema footnote: a header naming the field and
-// its type, then the description. It always returns FieldDocPaneHeight lines.
-func RenderFieldDocPane(width int, p FieldDocPane) string {
-	if width < 1 {
-		width = 1
+// RenderFieldDocPane draws the schema side pane: a title bar naming the field,
+// a bordered body holding the description, and a status row that keeps the
+// pane level with the viewer's hint bar. The result is exactly width columns
+// and height rows, so it joins horizontally next to the main view.
+//
+// omitFooter drops the status row, for callers that draw one full-width footer
+// under both panes. The output is then one row shorter.
+//
+// It mirrors RenderLogPreviewPane, which solves the same layout problem for the
+// log viewer's structured preview.
+func RenderFieldDocPane(width, height int, p FieldDocPane, omitFooter bool) string {
+	if width < 10 {
+		width = 10
+	}
+	if height < 3 {
+		height = 3
 	}
 
-	lines := make([]string, 0, FieldDocPaneHeight)
-	lines = append(lines, fieldDocHeader(width, p))
+	// The pane must come out exactly height rows, or JoinHorizontal pads the
+	// shorter side and the two panes drift apart. The rows it does not own:
+	// the title bar, the two border rows, and the status row.
+	// omitFooter drops the status row rather than growing the body, so the
+	// body keeps the same size and the pane comes out one row shorter.
+	contentHeight := max(height-4, 1)
+	contentWidth := max(width-4, 6) // border 2 + padding 2
 
-	for _, l := range fieldDocBody(width, p) {
-		lines = append(lines, FieldDocTextStyle.Render(l))
+	titleBar := FillLinesBg(
+		TitleStyle.Width(width).MaxWidth(width).MaxHeight(1).Render(fieldDocTitle(p)),
+		width, BarBg)
+
+	bodyLines := fieldDocBody(contentWidth, p)
+	if len(bodyLines) > contentHeight {
+		bodyLines = bodyLines[:contentHeight]
 	}
+	for len(bodyLines) < contentHeight {
+		bodyLines = append(bodyLines, "")
+	}
+	bodyContent := FillLinesBg(strings.Join(bodyLines, "\n"), contentWidth, BaseBg)
+	body := FullscreenBorderStyle(width, contentHeight).Render(bodyContent)
 
-	return FillLinesBg(strings.Join(lines, "\n"), width, BaseBg)
+	if omitFooter {
+		return lipgloss.JoinVertical(lipgloss.Left, titleBar, body)
+	}
+	// An empty status row keeps the pane's height level with the viewer's
+	// title + body + hint-bar layout, so JoinHorizontal pads neither side.
+	footer := StatusBarBgStyle.Width(width).MaxWidth(width).MaxHeight(1).Render("")
+	return lipgloss.JoinVertical(lipgloss.Left, titleBar, body, footer)
 }
 
-// fieldDocHeader names the field, its type, and rules off the pane from the
-// body above it.
-func fieldDocHeader(width int, p FieldDocPane) string {
+// fieldDocTitle names the field and its type. A deep path is cut from the
+// front, because the leaf is what says which field is being read.
+func fieldDocTitle(p FieldDocPane) string {
 	label := p.Path
 	if label == "" {
 		label = "(root)"
 	}
+	title := " SCHEMA "
 	if p.FieldType != "" {
-		label += " " + p.FieldType
+		title += HelpKeyStyle.Render(p.FieldType) + " "
 	}
-	label = " " + label + " "
-
-	head := "──" + label
-	if w := ansi.StringWidth(head); w < width {
-		head += strings.Repeat("─", width-w)
-	}
-	return FieldDocHeaderStyle.Render(Truncate(head, width))
+	return title + label
 }
 
-// fieldDocBody returns exactly fieldDocBodyLines lines of text, wrapped to the
-// width and padded out so the pane keeps its height.
-func fieldDocBody(width int, p FieldDocPane) []string {
-	text := ""
+// fieldDocBody wraps the text the pane is showing to the content width. Each
+// line is padded out so the border encloses a solid block.
+func fieldDocBody(contentWidth int, p FieldDocPane) []string {
+	var text string
 	switch {
 	case p.Err != "":
 		text = p.Err
@@ -77,24 +96,24 @@ func fieldDocBody(width int, p FieldDocPane) []string {
 		text = "No description in the cluster schema for this field."
 	}
 
-	// One leading space keeps the text off the left edge; the trailing one
-	// stops a wrapped word from touching the right edge.
-	textWidth := max(width-2, 1)
-	wrapped := strings.Split(ansi.Wordwrap(text, textWidth, ""), "\n")
+	style := FieldDocTextStyle
+	if p.Err != "" {
+		style = FieldDocErrorStyle
+	}
 
-	out := make([]string, 0, fieldDocBodyLines)
-	for i := range fieldDocBodyLines {
-		if i >= len(wrapped) {
+	out := make([]string, 0, 8)
+	for para := range strings.SplitSeq(text, "\n") {
+		if strings.TrimSpace(para) == "" {
 			out = append(out, "")
 			continue
 		}
-		line := " " + strings.TrimRight(wrapped[i], " ")
-		// The last line absorbs any overflow marker, so a long description
-		// reads as cut off rather than as ending mid-sentence.
-		if i == fieldDocBodyLines-1 && len(wrapped) > fieldDocBodyLines {
-			line = Truncate(line, max(textWidth-1, 1)) + "…"
+		for line := range strings.SplitSeq(ansi.Wordwrap(para, contentWidth, ""), "\n") {
+			out = append(out, style.Render(Truncate(strings.TrimRight(line, " "), contentWidth)))
 		}
-		out = append(out, Truncate(line, width))
 	}
 	return out
 }
+
+// FieldDocTitleFor is what the pane's title bar would read for a field. It lets
+// callers advertise the same label elsewhere without re-rendering the pane.
+func FieldDocTitleFor(p FieldDocPane) string { return fieldDocTitle(p) }

--- a/internal/ui/fielddocpane.go
+++ b/internal/ui/fielddocpane.go
@@ -45,7 +45,7 @@ func RenderFieldDocPane(width, height int, p FieldDocPane, omitFooter bool) stri
 	contentWidth := max(width-4, 6) // border 2 + padding 2
 
 	titleBar := FillLinesBg(
-		TitleStyle.Width(width).MaxWidth(width).MaxHeight(1).Render(fieldDocTitle(p)),
+		TitleStyle.Width(width).MaxWidth(width).MaxHeight(1).Render(fieldDocTitle(width, p)),
 		width, BarBg)
 
 	bodyLines := fieldDocBody(contentWidth, p)
@@ -67,16 +67,23 @@ func RenderFieldDocPane(width, height int, p FieldDocPane, omitFooter bool) stri
 	return lipgloss.JoinVertical(lipgloss.Left, titleBar, body, footer)
 }
 
-// fieldDocTitle names the field and its type. A deep path is cut from the
-// front, because the leaf is what says which field is being read.
-func fieldDocTitle(p FieldDocPane) string {
+// fieldDocTitle names the field and its type. A path too long for the pane is
+// cut from the FRONT, because the leaf is what says which field is being read;
+// letting the title truncate from the right drops exactly the useful part.
+func fieldDocTitle(width int, p FieldDocPane) string {
+	title := " SCHEMA "
+	if p.FieldType != "" {
+		title += HelpKeyStyle.Render(p.FieldType) + " "
+	}
+
 	label := p.Path
 	if label == "" {
 		label = "(root)"
 	}
-	title := " SCHEMA "
-	if p.FieldType != "" {
-		title += HelpKeyStyle.Render(p.FieldType) + " "
+	// TitleStyle pads by one column on each side, so the label gets what is
+	// left of the pane after the prefix and that padding.
+	if room := width - ansi.StringWidth(title) - 2; room > 0 {
+		label = TruncateStart(label, room)
 	}
 	return title + label
 }
@@ -113,7 +120,3 @@ func fieldDocBody(contentWidth int, p FieldDocPane) []string {
 	}
 	return out
 }
-
-// FieldDocTitleFor is what the pane's title bar would read for a field. It lets
-// callers advertise the same label elsewhere without re-rendering the pane.
-func FieldDocTitleFor(p FieldDocPane) string { return fieldDocTitle(p) }

--- a/internal/ui/fielddocpane_test.go
+++ b/internal/ui/fielddocpane_test.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fieldDocLines(t *testing.T, s string) []string {
+	t.Helper()
+	return strings.Split(stripANSI(s), "\n")
+}
+
+func TestRenderFieldDocPaneHeight(t *testing.T) {
+	got := RenderFieldDocPane(60, FieldDocPane{
+		Path: "spec.dnsPolicy", FieldType: "<string>", Desc: "Set DNS policy for the pod.",
+	})
+
+	assert.Len(t, fieldDocLines(t, got), FieldDocPaneHeight,
+		"the pane must always claim the same height so the layout does not jump")
+}
+
+func TestRenderFieldDocPaneShowsPathAndType(t *testing.T) {
+	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{
+		Path: "spec.dnsPolicy", FieldType: "<string>", Desc: "Set DNS policy for the pod.",
+	}))
+
+	assert.Contains(t, got, "spec.dnsPolicy")
+	assert.Contains(t, got, "<string>")
+	assert.Contains(t, got, "Set DNS policy for the pod.")
+}
+
+func TestRenderFieldDocPaneWrapsLongText(t *testing.T) {
+	long := strings.Repeat("word ", 200)
+
+	got := RenderFieldDocPane(40, FieldDocPane{Path: "spec", Desc: long})
+
+	lines := fieldDocLines(t, got)
+	require.Len(t, lines, FieldDocPaneHeight)
+	for i, l := range lines {
+		assert.LessOrEqual(t, len([]rune(l)), 40, "line %d must stay inside the width", i)
+	}
+}
+
+// A field the schema documents nowhere must say so. A blank pane reads as a
+// bug, not as an answer.
+func TestRenderFieldDocPaneEmptyState(t *testing.T) {
+	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{Path: "spec.opaque", FieldType: "<string>"}))
+
+	assert.Contains(t, got, "No description")
+	assert.Contains(t, got, "spec.opaque", "the empty state still names the field")
+}
+
+func TestRenderFieldDocPaneLoadingState(t *testing.T) {
+	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{Path: "spec.dnsPolicy", Loading: true}))
+
+	assert.Contains(t, strings.ToLower(got), "loading")
+}
+
+func TestRenderFieldDocPaneErrorState(t *testing.T) {
+	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{
+		Path: "spec.nope", Err: `field "nope" does not exist`,
+	}))
+
+	assert.Contains(t, got, "does not exist")
+}
+
+// An error wins over a stale description: showing old text next to a failed
+// lookup would read as if the text belonged to the field that failed.
+func TestRenderFieldDocPaneErrorBeatsDesc(t *testing.T) {
+	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{
+		Path: "spec.nope", Desc: "stale text", Err: "boom",
+	}))
+
+	assert.NotContains(t, got, "stale text")
+	assert.Contains(t, got, "boom")
+}
+
+// The root of a document has no field path. The pane still renders rather than
+// collapsing the layout.
+func TestRenderFieldDocPaneEmptyPath(t *testing.T) {
+	got := RenderFieldDocPane(60, FieldDocPane{Path: "", Desc: "Pod is a collection of containers."})
+
+	assert.Len(t, fieldDocLines(t, got), FieldDocPaneHeight)
+}
+
+func TestRenderFieldDocPaneNarrowWidth(t *testing.T) {
+	got := RenderFieldDocPane(8, FieldDocPane{Path: "spec.containers.image", Desc: "The container image name."})
+
+	lines := fieldDocLines(t, got)
+	assert.Len(t, lines, FieldDocPaneHeight)
+	for i, l := range lines {
+		assert.LessOrEqual(t, len([]rune(l)), 8, "line %d must stay inside a narrow width", i)
+	}
+}

--- a/internal/ui/fielddocpane_test.go
+++ b/internal/ui/fielddocpane_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,85 +14,98 @@ func fieldDocLines(t *testing.T, s string) []string {
 	return strings.Split(stripANSI(s), "\n")
 }
 
-func TestRenderFieldDocPaneHeight(t *testing.T) {
-	got := RenderFieldDocPane(60, FieldDocPane{
+// The pane is joined horizontally next to the viewer, so it has to claim
+// exactly the height it was given or lipgloss pads the shorter side.
+func TestRenderFieldDocPaneClaimsGivenHeight(t *testing.T) {
+	got := RenderFieldDocPane(40, 20, FieldDocPane{
 		Path: "spec.dnsPolicy", FieldType: "<string>", Desc: "Set DNS policy for the pod.",
-	})
+	}, false)
 
-	assert.Len(t, fieldDocLines(t, got), FieldDocPaneHeight,
-		"the pane must always claim the same height so the layout does not jump")
+	assert.Len(t, fieldDocLines(t, got), 20)
+}
+
+// omitFooter drops the empty status row so a caller can put one full-width
+// footer under both panes, the way the log viewer does.
+func TestRenderFieldDocPaneOmitFooterIsOneShorter(t *testing.T) {
+	withFooter := RenderFieldDocPane(40, 20, FieldDocPane{Path: "spec", Desc: "text"}, false)
+	without := RenderFieldDocPane(40, 20, FieldDocPane{Path: "spec", Desc: "text"}, true)
+
+	assert.Len(t, fieldDocLines(t, withFooter), 20)
+	assert.Len(t, fieldDocLines(t, without), 19)
+}
+
+func TestRenderFieldDocPaneClaimsGivenWidth(t *testing.T) {
+	got := RenderFieldDocPane(40, 12, FieldDocPane{
+		Path: "spec.containers.image", FieldType: "<string>", Desc: strings.Repeat("word ", 100),
+	}, false)
+
+	for i, l := range fieldDocLines(t, got) {
+		assert.Equal(t, 40, ansi.StringWidth(l), "row %d must fill the pane width exactly", i)
+	}
 }
 
 func TestRenderFieldDocPaneShowsPathAndType(t *testing.T) {
-	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{
+	got := stripANSI(RenderFieldDocPane(60, 12, FieldDocPane{
 		Path: "spec.dnsPolicy", FieldType: "<string>", Desc: "Set DNS policy for the pod.",
-	}))
+	}, false))
 
 	assert.Contains(t, got, "spec.dnsPolicy")
 	assert.Contains(t, got, "<string>")
 	assert.Contains(t, got, "Set DNS policy for the pod.")
 }
 
-func TestRenderFieldDocPaneWrapsLongText(t *testing.T) {
-	long := strings.Repeat("word ", 200)
+// A long path keeps its tail: the leaf is what names the field being read.
+func TestRenderFieldDocPaneKeepsPathTail(t *testing.T) {
+	got := stripANSI(RenderFieldDocPane(30, 12, FieldDocPane{
+		Path: "spec.template.spec.containers.livenessProbe.httpGet.port", Desc: "The port.",
+	}, false))
 
-	got := RenderFieldDocPane(40, FieldDocPane{Path: "spec", Desc: long})
-
-	lines := fieldDocLines(t, got)
-	require.Len(t, lines, FieldDocPaneHeight)
-	for i, l := range lines {
-		assert.LessOrEqual(t, len([]rune(l)), 40, "line %d must stay inside the width", i)
-	}
+	assert.Contains(t, got, "port")
 }
 
-// A field the schema documents nowhere must say so. A blank pane reads as a
-// bug, not as an answer.
 func TestRenderFieldDocPaneEmptyState(t *testing.T) {
-	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{Path: "spec.opaque", FieldType: "<string>"}))
+	got := stripANSI(RenderFieldDocPane(60, 12, FieldDocPane{Path: "spec.opaque", FieldType: "<string>"}, false))
 
 	assert.Contains(t, got, "No description")
-	assert.Contains(t, got, "spec.opaque", "the empty state still names the field")
 }
 
 func TestRenderFieldDocPaneLoadingState(t *testing.T) {
-	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{Path: "spec.dnsPolicy", Loading: true}))
+	got := stripANSI(RenderFieldDocPane(60, 12, FieldDocPane{Path: "spec.dnsPolicy", Loading: true}, false))
 
 	assert.Contains(t, strings.ToLower(got), "loading")
 }
 
 func TestRenderFieldDocPaneErrorState(t *testing.T) {
-	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{
+	got := stripANSI(RenderFieldDocPane(60, 12, FieldDocPane{
 		Path: "spec.nope", Err: `field "nope" does not exist`,
-	}))
+	}, false))
 
 	assert.Contains(t, got, "does not exist")
 }
 
-// An error wins over a stale description: showing old text next to a failed
-// lookup would read as if the text belonged to the field that failed.
 func TestRenderFieldDocPaneErrorBeatsDesc(t *testing.T) {
-	got := stripANSI(RenderFieldDocPane(60, FieldDocPane{
+	got := stripANSI(RenderFieldDocPane(60, 12, FieldDocPane{
 		Path: "spec.nope", Desc: "stale text", Err: "boom",
-	}))
+	}, false))
 
 	assert.NotContains(t, got, "stale text")
 	assert.Contains(t, got, "boom")
 }
 
-// The root of a document has no field path. The pane still renders rather than
-// collapsing the layout.
-func TestRenderFieldDocPaneEmptyPath(t *testing.T) {
-	got := RenderFieldDocPane(60, FieldDocPane{Path: "", Desc: "Pod is a collection of containers."})
+// A tall pane fits a long description without cutting it, which is the point
+// of moving from a 6-line footnote to a full-height side pane.
+func TestRenderFieldDocPaneTallPaneShowsMoreText(t *testing.T) {
+	desc := strings.Repeat("sentence ", 60)
 
-	assert.Len(t, fieldDocLines(t, got), FieldDocPaneHeight)
+	short := stripANSI(RenderFieldDocPane(40, 8, FieldDocPane{Path: "spec", Desc: desc}, false))
+	tall := stripANSI(RenderFieldDocPane(40, 30, FieldDocPane{Path: "spec", Desc: desc}, false))
+
+	assert.Greater(t, strings.Count(tall, "sentence"), strings.Count(short, "sentence"))
 }
 
-func TestRenderFieldDocPaneNarrowWidth(t *testing.T) {
-	got := RenderFieldDocPane(8, FieldDocPane{Path: "spec.containers.image", Desc: "The container image name."})
-
-	lines := fieldDocLines(t, got)
-	assert.Len(t, lines, FieldDocPaneHeight)
-	for i, l := range lines {
-		assert.LessOrEqual(t, len([]rune(l)), 8, "line %d must stay inside a narrow width", i)
+func TestRenderFieldDocPaneDegenerateSizes(t *testing.T) {
+	for _, tc := range []struct{ w, h int }{{0, 0}, {1, 1}, {5, 2}, {-3, -3}} {
+		got := RenderFieldDocPane(tc.w, tc.h, FieldDocPane{Path: "spec", Desc: "x"}, false)
+		require.NotEmpty(t, got, "w=%d h=%d must still render", tc.w, tc.h)
 	}
 }

--- a/internal/ui/fielddocpane_test.go
+++ b/internal/ui/fielddocpane_test.go
@@ -55,12 +55,18 @@ func TestRenderFieldDocPaneShowsPathAndType(t *testing.T) {
 }
 
 // A long path keeps its tail: the leaf is what names the field being read.
+// The description deliberately omits the leaf, or this passes on the body.
 func TestRenderFieldDocPaneKeepsPathTail(t *testing.T) {
-	got := stripANSI(RenderFieldDocPane(30, 12, FieldDocPane{
-		Path: "spec.template.spec.containers.livenessProbe.httpGet.port", Desc: "The port.",
-	}, false))
+	got := RenderFieldDocPane(30, 12, FieldDocPane{
+		Path: "spec.template.spec.containers.livenessProbe.httpGet.port",
+		Desc: "Which one to probe.",
+	}, false)
 
-	assert.Contains(t, got, "port")
+	titleRow := fieldDocLines(t, got)[0]
+
+	assert.Contains(t, titleRow, "port", "the title must keep the leaf segment")
+	assert.NotContains(t, stripANSI(got), "Which one to probe.\nport",
+		"guard against the assertion passing on the description")
 }
 
 func TestRenderFieldDocPaneEmptyState(t *testing.T) {

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -298,6 +298,7 @@ func viewerHelpSections(kb Keybindings) []helpSection {
 				{"ctrl+e", "Edit resource in editor"},
 				{"O", "Open Object Explorer at the attribute under cursor"},
 				{"I", "Open API Explorer at the schema of the attribute"},
+				{kb.FieldDoc, "Toggle schema description of the field under cursor"},
 				{"q/esc", "Back to explorer"},
 			}...),
 		},
@@ -357,6 +358,7 @@ func viewerHelpSections(kb Keybindings) []helpSection {
 				{"Y", "Yank the selected node's full YAML"},
 				{"P", "Open the whole resource in the YAML viewer"},
 				{"I", "Open API Explorer at the schema of the item"},
+				{kb.FieldDoc, "Toggle schema description of the item under cursor"},
 			}, append(objectExplorerScrollEntries(kb), []helpEntry{
 				// Two rows, not "q/esc": objectexplorer.go:258-274 gives them
 				// different jobs — q always closes, esc walks out one step at

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -90,19 +90,15 @@ var (
 			Foreground(lipgloss.Color(ColorSelectedFg)).
 			Background(lipgloss.Color(ColorSelectedBg))
 
-	NormalStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorFile))
+	NormalStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile))
 
-	DimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorDimmed))
+	DimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorDimmed))
 
 	// BarDimStyle is DimStyle but with bar background (for status bar hints).
-	BarDimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorDimmed))
+	BarDimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorDimmed))
 
 	// BarNormalStyle is NormalStyle but with bar background (for status bar text).
-	BarNormalStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorFile))
+	BarNormalStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile))
 
 	// Category header in resource type list.
 	CategoryStyle = lipgloss.NewStyle().
@@ -117,8 +113,7 @@ var (
 				Bold(true)
 
 	// Resource type icon style.
-	IconStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorPrimary))
+	IconStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary))
 
 	// Status colors: Green=running, Blue=progressing, Red=error, Grey=completed/other, Amber=warning.
 	StatusRunning     = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
@@ -262,6 +257,11 @@ var (
 	HelpKeyStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(ColorSecondary)).
 			Bold(true)
+
+	// Schema footnote pane (ctrl+k): the header names the field and carries
+	// the accent; the description is prose to read, so it stays plain.
+	FieldDocHeaderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Bold(true)
+	FieldDocTextStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile))
 
 	// Which-key panel. The panel draws one flat list with no section
 	// headers, so the description's color is the only thing left that says

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -207,8 +207,7 @@ var (
 			Foreground(lipgloss.Color(ColorPrimary)).
 			Bold(true)
 
-	YamlValueStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(ColorFile))
+	YamlValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile))
 
 	YamlPunctuationStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(ColorDimmed))
@@ -258,10 +257,11 @@ var (
 			Foreground(lipgloss.Color(ColorSecondary)).
 			Bold(true)
 
-	// Schema footnote pane (ctrl+k): the header names the field and carries
+	// Schema side pane (ctrl+k): the header names the field and carries
 	// the accent; the description is prose to read, so it stays plain.
 	FieldDocHeaderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Bold(true)
 	FieldDocTextStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile))
+	FieldDocErrorStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError))
 
 	// Which-key panel. The panel draws one flat list with no section
 	// headers, so the description's color is the only thing left that says

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -334,13 +334,15 @@ func ApplyTheme(t Theme) {
 		Bold(true).
 		Background(barBg)
 
-	// Schema footnote pane (ctrl+k). It sits inside the document body, so it
+	// Schema side pane (ctrl+k). It sits inside the document body, so it
 	// takes the base background, not the bar background the hint bar uses.
 	FieldDocHeaderStyle = lipgloss.NewStyle().
 		Foreground(lipgloss.Color(t.Secondary)).
 		Bold(true)
 	FieldDocTextStyle = lipgloss.NewStyle().
 		Foreground(lipgloss.Color(t.Text))
+	FieldDocErrorStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(t.Error))
 
 	// Which-key group accents, which tint the DESCRIPTION (the key keeps one
 	// accent throughout — t.Secondary, the same hotkey green every hint bar

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -334,6 +334,14 @@ func ApplyTheme(t Theme) {
 		Bold(true).
 		Background(barBg)
 
+	// Schema footnote pane (ctrl+k). It sits inside the document body, so it
+	// takes the base background, not the bar background the hint bar uses.
+	FieldDocHeaderStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(t.Secondary)).
+		Bold(true)
+	FieldDocTextStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(t.Text))
+
 	// Which-key group accents, which tint the DESCRIPTION (the key keeps one
 	// accent throughout — t.Secondary, the same hotkey green every hint bar
 	// draws its keys in, which is why no group may claim it). Three track the

--- a/internal/ui/theme_nocolor.go
+++ b/internal/ui/theme_nocolor.go
@@ -121,10 +121,13 @@ func applyNoColorTheme() {
 	StatusBarStyle = lipgloss.NewStyle().Faint(true).Padding(0, 1)
 	HelpKeyStyle = lipgloss.NewStyle().Bold(true)
 
-	// Schema footnote pane: without color the header keeps bold, which is the
+	// Schema side pane: without color the header keeps bold, which is the
 	// only cue left that separates it from the description below it.
 	FieldDocHeaderStyle = lipgloss.NewStyle().Bold(true)
 	FieldDocTextStyle = lipgloss.NewStyle()
+	// Without color, bold is the only thing left to mark an error apart from
+	// the description it replaces.
+	FieldDocErrorStyle = lipgloss.NewStyle().Bold(true)
 
 	// Which-key: the group accent is purely a color cue on the description, so
 	// without color every group collapses to the same plain description the

--- a/internal/ui/theme_nocolor.go
+++ b/internal/ui/theme_nocolor.go
@@ -121,6 +121,11 @@ func applyNoColorTheme() {
 	StatusBarStyle = lipgloss.NewStyle().Faint(true).Padding(0, 1)
 	HelpKeyStyle = lipgloss.NewStyle().Bold(true)
 
+	// Schema footnote pane: without color the header keeps bold, which is the
+	// only cue left that separates it from the description below it.
+	FieldDocHeaderStyle = lipgloss.NewStyle().Bold(true)
+	FieldDocTextStyle = lipgloss.NewStyle()
+
 	// Which-key: the group accent is purely a color cue on the description, so
 	// without color every group collapses to the same plain description the
 	// panel had before groups were colored at all. Faint/italic/underline are


### PR DESCRIPTION
Closes TASK-863.

`Ctrl+K` opens a side pane in the YAML viewer and the Object Explorer showing what the connected cluster says about the field under the cursor. The pane follows the cursor as it moves.

The text comes from `kubectl explain` against the current context, not from a bundled schema, so it matches the cluster version and CRD fields resolve the same way built-in kinds do.

```
┌─ pod.yaml ──────────────────┐  SCHEMA <string> spec.dnsPolicy
│ spec:                       │ ╭─────────────────────────────╮
│   dnsPolicy: ClusterFirst   │ │ Set DNS policy for the pod. │
│   restartPolicy: Always     │ │ Defaults to "ClusterFirst". │
│   containers:               │ │                             │
└─────────────────────────────┘ ╰─────────────────────────────╯
 j/k scroll  ...  ctrl+k schema  q/esc back
```

## Design notes

**Cost.** One `kubectl explain` is a process spawn and a round trip. The pane waits 250ms for the cursor to rest before asking, so holding `j` spawns nothing. Every answer is cached per context, api-version, resource and field path, bounded at 256 entries with FIFO eviction. An empty description is cached too: a field the schema leaves undocumented is an answer, and re-asking on each visit would spawn `kubectl` for nothing.

**Stale replies.** Each fetch carries a request number. Moving the cursor bumps it, so a reply for a field the user has left is dropped instead of painting the wrong text under the new one.

**Layout.** The pane is built on the same shape as the log viewer's structured preview (`RenderLogPreviewPane`) and joined horizontally, with one full-width hint bar under both panes. It takes columns, not rows. `splitFieldDocWidth` uses the same bounds as `splitLogPreviewWidth`, so the two side panes come out the same width on the same terminal. Below 90 columns `Ctrl+K` reports that the terminal is too narrow rather than toggling a pane nobody can see.

**`Ctrl+K`, not `K`.** `K` is `kb.PreviewUp`, and the Object Explorer scrolls its preview with `J`/`K`. No existing binding moved. Configurable via `keybindings.field_doc`.

**Errors.** `kubectl explain` prints the `KIND`/`VERSION` preamble even when it fails, so the pane showed `exit status 1: KIND: Pod ...` wrapped around the one useful line. `parseExplainError` keeps the `error:` line alone.

## Note on AC #3

The task asks for the "cluster OpenAPI schema". The text comes from the live cluster through the `kubectl explain` path — discovery never fetched an OpenAPI schema; `openapi` appears nowhere in the code, only in `go.sum`. The intent is met (the cluster's own descriptions, not a bundled copy), but the criterion's wording describes a mechanism that does not exist.

## Docs

README features and hotkey table, `docs/keybindings.md` (both viewer sections and the config block), `docs/config-reference.md`, `docs/config-example.yaml`, `docs/config.schema.json`, `docs/views-and-overlays.md`, in-app help, and the which-key catalogs for both viewers.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — exit 0
- [x] `golangci-lint run ./...` — 0 issues
- [x] 60 new tests: parser, error extraction, cache bounds and eviction, key wiring, `K` still scrolls the OE preview, pane rendering in every state, width split, hint-bar parity, joined view keeps the exact terminal box
- [ ] **Not verified:** never run against a live cluster. The `kubectl explain` subprocess itself is not exercised by any test — only its output parsing. Worth a manual pass on a Pod and on a CRD before merge.