### PR TITLE
refactor: remove dead mapToTheme in cmd/themegen

### DIFF
--- a/cmd/themegen/main.go
+++ b/cmd/themegen/main.go
@@ -67,12 +67,11 @@ func run(inputDir, output, skipList string) error {
 			continue
 		}
 
-		theme := mapToTheme(td)
 		isLight := luminance(mustParseHex(td.Background)) > 0.5
 
 		themes = append(themes, themeEntry{
 			Name:    name,
-			Theme:   theme,
+			Theme:   td,
 			IsLight: isLight,
 		})
 	}
@@ -112,8 +111,6 @@ type rawTheme struct {
 	Foreground string
 	Palette    [16]string // palette[0..15]
 }
-
-type themeData = rawTheme
 
 func parseThemeFile(path string) (rawTheme, error) {
 	f, err := os.Open(path)
@@ -261,41 +258,6 @@ func darken(hex string, amount float64) string {
 
 // --- Theme mapping ---
 
-func mapToTheme(t rawTheme) themeData {
-	isLight := luminance(mustParseHex(t.Background)) > 0.5
-
-	// Derive BarBg: slightly offset from background.
-	var barBg, surface string
-	if isLight {
-		barBg = darken(t.Background, 0.06)
-		surface = darken(t.Background, 0.03)
-	} else {
-		barBg = lighten(t.Background, 0.06)
-		surface = lighten(t.Background, 0.03)
-	}
-
-	// Use palette 8 (bright black) for border/dimmed if distinct enough,
-	// otherwise derive from bg/fg midpoint.
-	border := t.Palette[8]
-	if border == t.Background || border == t.Foreground {
-		border = blendColor(t.Background, t.Foreground, 0.25)
-	}
-
-	// Store derived values back into the struct for template output.
-	// We reuse rawTheme fields but the template reads from the mapped values below.
-	_ = barBg
-	_ = surface
-	_ = border
-
-	// Return a rawTheme with the mapped colors stored for template use.
-	// The template will read Primary, Secondary, etc. from this struct.
-	return rawTheme{
-		Background: t.Background,
-		Foreground: t.Foreground,
-		Palette:    t.Palette,
-	}
-}
-
 // themeFields returns the 13 Theme field values for a rawTheme.
 func themeFields(t rawTheme) [13]string {
 	isLight := luminance(mustParseHex(t.Background)) > 0.5
@@ -335,7 +297,7 @@ func themeFields(t rawTheme) [13]string {
 
 type themeEntry struct {
 	Name    string
-	Theme   themeData
+	Theme   rawTheme
 	IsLight bool
 }
 

--- a/cmd/themegen/main_test.go
+++ b/cmd/themegen/main_test.go
@@ -378,64 +378,6 @@ func TestParseThemeFile(t *testing.T) {
 	})
 }
 
-// --- mapToTheme ---
-
-func TestMapToTheme(t *testing.T) {
-	t.Run("dark theme", func(t *testing.T) {
-		raw := rawTheme{
-			Background: "#1a1b26",
-			Foreground: "#c0caf5",
-			Palette:    buildPaletteArray(fullPalette()),
-		}
-
-		result := mapToTheme(raw)
-		assert.Equal(t, raw.Background, result.Background)
-		assert.Equal(t, raw.Foreground, result.Foreground)
-		assert.Equal(t, raw.Palette, result.Palette)
-	})
-
-	t.Run("light theme", func(t *testing.T) {
-		pal := buildPaletteArray(fullPalette())
-		raw := rawTheme{
-			Background: "#f5f5f5",
-			Foreground: "#333333",
-			Palette:    pal,
-		}
-
-		result := mapToTheme(raw)
-		assert.Equal(t, raw.Background, result.Background)
-		assert.Equal(t, raw.Foreground, result.Foreground)
-	})
-
-	t.Run("border fallback when palette8 equals bg", func(t *testing.T) {
-		pal := buildPaletteArray(fullPalette())
-		pal[8] = "#1a1b26" // same as background
-		raw := rawTheme{
-			Background: "#1a1b26",
-			Foreground: "#c0caf5",
-			Palette:    pal,
-		}
-
-		result := mapToTheme(raw)
-		// mapToTheme still returns the raw theme unchanged, but exercises the
-		// border fallback code path internally.
-		assert.Equal(t, raw.Background, result.Background)
-	})
-
-	t.Run("border fallback when palette8 equals fg", func(t *testing.T) {
-		pal := buildPaletteArray(fullPalette())
-		pal[8] = "#c0caf5" // same as foreground
-		raw := rawTheme{
-			Background: "#1a1b26",
-			Foreground: "#c0caf5",
-			Palette:    pal,
-		}
-
-		result := mapToTheme(raw)
-		assert.Equal(t, raw.Foreground, result.Foreground)
-	})
-}
-
 // --- themeFields ---
 
 func TestThemeFields(t *testing.T) {


### PR DESCRIPTION
mapToTheme computed derived barBg/surface/border values, discarded them and returned an unchanged copy of the input — the real mapping happens in themeFields, which the output template already uses.

* Removes `mapToTheme`, the unused `themeData` alias and the no-op `TestMapToTheme` (its own comment admitted "returns the raw theme unchanged").
* `go test ./...` and `go vet` green before and after.