### PR TITLE
feat: add a built-in demo cluster behind --demo (TASK-865)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint lint-fix test coverage fuzz build generate-themes sonar bump-version refresh-vendor-hash release goreleaser-check
+.PHONY: setup lint lint-fix test e2e coverage fuzz build generate-themes sonar bump-version refresh-vendor-hash release goreleaser-check
 
 setup:
 	git config core.hooksPath .githooks
@@ -65,6 +65,10 @@ lint-fix:
 
 test:
 	go test ./...
+
+e2e: ## Run e2e tests that drive the built lfk binary under a pty (--demo mode)
+	golangci-lint run --build-tags e2e ./e2e/...
+	go test -tags e2e -count=1 -timeout 2m ./e2e/...
 
 coverage: ## Run tests with coverage report
 	go test ./... -coverprofile=coverage.out

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ go install github.com/janosmiko/lfk@latest
 nix run github:janosmiko/lfk
 ```
 
-`kubectl` is required and must be configured. `helm` and `trivy` are optional (Helm management, image vulnerability scanning).
+`kubectl` is required and must be configured. `helm` and `trivy` are optional (Helm management, image vulnerability scanning). No cluster yet? `lfk --demo` runs against a built-in fake cluster instead.
 
 > See [docs/installation.md](docs/installation.md) for Windows, Docker, NixOS/home-manager flake input, building from source, and the full list of optional CLI dependencies.
 
@@ -200,6 +200,9 @@ nix run github:janosmiko/lfk
 ```bash
 # Use default kubeconfig (~/.kube/config + ~/.kube/config.d/*)
 lfk
+
+# Try it without a cluster (no kubeconfig required)
+lfk --demo
 
 # Start in a specific context / namespace
 lfk --context my-cluster -n kube-system

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -158,7 +158,7 @@ docker run -it --rm \
 lfk --demo
 ```
 
-Runs against a built-in fake cluster; no kubeconfig required. Exec, port-forward, drain, debug, and Helm are unavailable in demo mode.
+Runs against a built-in fake cluster; no kubeconfig required. Exec, port-forward, drain, debug, Helm, and vuln scan are unavailable in demo mode.
 
 ## External Dependencies
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,6 +152,14 @@ docker run -it --rm \
   janosmiko/lfk
 ```
 
+## Try it without a cluster
+
+```bash
+lfk --demo
+```
+
+Runs against a built-in fake cluster; no kubeconfig required. Exec, port-forward, drain, debug, and Helm are unavailable in demo mode.
+
 ## External Dependencies
 
 **Required:**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,7 +78,7 @@ KUBECONFIG_DIR=/path/to/configs/ lfk
 KUBECONFIG_DIR=/team-a/configs:/team-b/configs lfk
 ```
 
-In `--demo`, exec, port-forward, drain, debug, and Helm are unavailable.
+In `--demo`, exec, port-forward, drain, debug, Helm, and vuln scan are unavailable.
 
 `KUBECONFIG` is exclusive by default, exactly like kubectl and k9s: when it is
 set, lfk loads only the files it lists and does **not** also add the default

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,6 +48,9 @@ lfk --kubeconfig-dir /path/to/configs/
 # Merge multiple custom directories (repeat the flag)
 lfk --kubeconfig-dir /team-a/configs/ --kubeconfig-dir /team-b/configs/
 
+# Start with a built-in fake cluster (no kubeconfig required)
+lfk --demo
+
 # Disable mouse capture (enables native terminal text selection)
 lfk --no-mouse
 
@@ -74,6 +77,8 @@ KUBECONFIG_DIR=/path/to/configs/ lfk
 # Merge multiple custom directories via env var (colon-separated, like KUBECONFIG)
 KUBECONFIG_DIR=/team-a/configs:/team-b/configs lfk
 ```
+
+In `--demo`, exec, port-forward, drain, debug, and Helm are unavailable.
 
 `KUBECONFIG` is exclusive by default, exactly like kubectl and k9s: when it is
 set, lfk loads only the files it lists and does **not** also add the default

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -105,8 +105,8 @@ func TestDemoModeStartup(t *testing.T) {
 		"TERM=xterm-256color",
 	}
 
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr // stdout must stay on the pty, or bubbletea's terminal handshake hangs
+	stderr := &output{}
+	cmd.Stderr = stderr // stdout must stay on the pty, or bubbletea's terminal handshake hangs
 
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 200})
 	if err != nil {
@@ -149,8 +149,8 @@ func TestDemoModeStartup(t *testing.T) {
 			t.Log("pty reader goroutine did not finish within shutdownTimeout")
 		}
 
-		if stderr.Len() > 0 {
-			t.Logf("lfk stderr:\n%s", stderr.String())
+		if s := stderr.String(); s != "" {
+			t.Logf("lfk stderr:\n%s", s)
 		}
 	}()
 

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -1,0 +1,184 @@
+//go:build e2e
+
+// Package e2e drives the built lfk binary under --demo inside a real pty
+// and asserts on what it renders. Unit tests exercise app.Model and the
+// demo fake cluster in isolation; this is the only test that launches the
+// process the way a user actually would, so it catches startup-path
+// panics unit tests structurally cannot reach -- a --demo startup crash
+// once shipped past a fully green unit suite.
+//
+// teatest (github.com/charmbracelet/x/exp/teatest) was considered first,
+// but it pins github.com/charmbracelet/bubbletea v1, a different module
+// than this repo's charm.land/bubbletea/v2 -- its tea.Program type isn't
+// assignable to ours, so it can't drive this app. A pty-driven subprocess
+// works against any bubbletea version because it only depends on the
+// binary's terminal output.
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+const (
+	startupTimeout  = 15 * time.Second
+	shutdownTimeout = 5 * time.Second
+)
+
+// buildBinary compiles lfk from the repo root into a temp dir so
+// `go test -tags e2e ./e2e/...` is self-sufficient and never runs against
+// a stale ./lfk left over from a previous `make build`.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+
+	binPath := filepath.Join(t.TempDir(), "lfk-e2e")
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+// output is a goroutine-safe buffer that accumulates everything read from
+// the pty, polled by waitFor.
+type output struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (o *output) Write(p []byte) (int, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.buf.Write(p)
+}
+
+func (o *output) String() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.buf.String()
+}
+
+// waitFor polls out for substr until it appears or timeout elapses.
+func waitFor(t *testing.T, out *output, substr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(out.String(), substr) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %q; captured output:\n%s", timeout, substr, out.String())
+}
+
+// TestDemoModeStartup launches `lfk --demo` under a pty with HOME and
+// KUBECONFIG pointed at an empty temp dir, then checks it renders the DEMO
+// badge and a seeded workload without panicking.
+func TestDemoModeStartup(t *testing.T) {
+	binPath := buildBinary(t)
+
+	home := t.TempDir()
+	kubeconfig := filepath.Join(home, "kubeconfig")
+
+	cmd := exec.Command(binPath, "--demo")
+	// An explicit, minimal env -- not os.Environ() plus overrides -- so a
+	// developer's own XDG_CONFIG_HOME, LFK_CONFIG_DIR, or KUBECONFIG_DIR
+	// can never leak a real config or kubeconfig into the demo run.
+	cmd.Env = []string{
+		"HOME=" + home,
+		"KUBECONFIG=" + kubeconfig,
+		"PATH=" + os.Getenv("PATH"),
+		"TERM=xterm-256color",
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr // stdout must stay on the pty, or bubbletea's terminal handshake hangs
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 200})
+	if err != nil {
+		t.Fatalf("starting lfk under pty: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+
+	out := &output{}
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		buf := make([]byte, 4096)
+		for {
+			n, err := ptmx.Read(buf)
+			if n > 0 {
+				_, _ = out.Write(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Always kill the process, however the test ends -- it's a TUI that
+	// otherwise sits waiting for input forever.
+	defer func() {
+		_ = cmd.Process.Kill()
+
+		waitErr := make(chan error, 1)
+		go func() { waitErr <- cmd.Wait() }()
+		select {
+		case <-waitErr:
+		case <-time.After(shutdownTimeout):
+			t.Log("lfk process did not exit after kill within shutdownTimeout")
+		}
+
+		select {
+		case <-readDone:
+		case <-time.After(shutdownTimeout):
+			t.Log("pty reader goroutine did not finish within shutdownTimeout")
+		}
+
+		if stderr.Len() > 0 {
+			t.Logf("lfk stderr:\n%s", stderr.String())
+		}
+	}()
+
+	waitFor(t, out, "DEMO", startupTimeout)
+	if strings.Contains(out.String(), "panic:") {
+		t.Fatalf("lfk panicked during startup:\n%s", out.String())
+	}
+
+	// Drill into the (only) context, then jump to the Deployments resource
+	// type via search rather than counting arrow-key presses: the
+	// resource-type list grows as source discovery completes, so a fixed
+	// key count is order-dependent and flaky.
+	sendKeys(t, ptmx, "\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "/Deployments\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "\r")
+
+	waitFor(t, out, "web", startupTimeout)
+
+	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {
+		t.Fatalf("lfk panicked; pty output:\n%s\nstderr:\n%s", out.String(), stderr.String())
+	}
+}
+
+func sendKeys(t *testing.T, f *os.File, s string) {
+	t.Helper()
+	if _, err := f.Write([]byte(s)); err != nil {
+		t.Fatalf("writing to pty: %v", err)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,9 @@ type Model struct {
 	client  *k8s.Client
 	version string // application version string shown in the title bar
 
+	// demoMode mirrors k8s.Client.IsDemo(); drives the title-bar DEMO badge.
+	demoMode bool
+
 	nav model.NavigationState // navigation state
 
 	// Column data.
@@ -508,8 +511,7 @@ type Model struct {
 	// keybinding can suspend capture for native terminal text selection and
 	// later re-enable it. When mouse was never available the toggle is a
 	// no-op.
-	mouseAvailable bool
-	mouseCaptured  bool
+	mouseAvailable, mouseCaptured bool
 	// wheel tracks the active wheel-scroll burst for momentum-tail dropping (#524).
 	wheel wheelBurst
 
@@ -626,10 +628,8 @@ type Model struct {
 	labelResourceType        model.ResourceTypeEntry // the resource type being edited
 
 	// ArgoCD autosync overlay state.
-	autoSyncEnabled  bool
-	autoSyncSelfHeal bool
-	autoSyncPrune    bool
-	autoSyncCursor   int // 0=autosync, 1=selfheal, 2=prune
+	autoSyncEnabled, autoSyncSelfHeal, autoSyncPrune bool
+	autoSyncCursor                                   int // 0=autosync, 1=selfheal, 2=prune
 
 	// Quick filter preset state.
 	filterPresets         []FilterPreset

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -52,7 +52,8 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	// persisted active session, else the default workspace (session.yaml).
 	activeSession, pendingSession := loadStartupSession(opts.Session)
 	m := Model{
-		client: client,
+		client:   client,
+		demoMode: client.IsDemo(),
 		// Start in the loading state. Init() dispatches loadContexts()
 		// asynchronously, so the first frame renders before any
 		// contextsLoadedMsg arrives; loading=false there falls through to the

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -714,6 +714,7 @@ func (m Model) executeKubectlCommand(input string) tea.Cmd {
 	args = m.injectKubectlDefaults(args)
 
 	m.addLogEntry("DBG", fmt.Sprintf("$ kubectl %s", strings.Join(args, " ")))
+	args = k8s.DemoKubectlArgs(args)
 
 	if ui.ConfigTerminalMode == ui.TerminalModePTY {
 		c := exec.Command(kubectlPath, args...)

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"sigs.k8s.io/yaml"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -689,7 +690,7 @@ func positionalArgCount(args []string) int {
 // is handed over via tea.ExecProcess and lfk is suspended until the
 // command exits.
 func (m Model) executeKubectlCommand(input string) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -227,7 +227,7 @@ func (m Model) loadPodsForLogAction() tea.Cmd {
 
 		// Fetch pods matching the selector.
 		args := []string{"get", "pods", "-l", selector, "-n", ns, "--context", m.kubectlContext(kctx), "-o", "json"}
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		out, err := cmd.Output()

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -13,6 +13,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/atotto/clipboard"
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -204,7 +205,7 @@ func (m Model) loadPodsForAction() tea.Cmd {
 // loadPodsForLogAction fetches pods matching the parent resource's selector using kubectl.
 // Uses kubectl instead of the Go client to avoid separate OIDC auth flows.
 func (m Model) loadPodsForLogAction() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return podLogSelectMsg{err: fmt.Errorf("kubectl not found: %w", err)}

--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -170,6 +170,11 @@ func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
 // Client.ApplyManifest and cleans it up, mirroring applyTemplateFile's
 // kubectl path without shelling out.
 func (m Model) applyTemplateFileDemo(tmpFile, ctx, ns string) tea.Cmd {
+	applyCtx := m.reqCtx
+	if applyCtx == nil {
+		applyCtx = context.Background()
+	}
+
 	return func() tea.Msg {
 		defer func() { _ = os.Remove(tmpFile) }()
 
@@ -177,7 +182,7 @@ func (m Model) applyTemplateFileDemo(tmpFile, ctx, ns string) tea.Cmd {
 		if err != nil {
 			return actionResultMsg{err: fmt.Errorf("reading manifest: %w", err)}
 		}
-		if err := m.client.ApplyManifest(context.Background(), ctx, ns, string(content)); err != nil {
+		if err := m.client.ApplyManifest(applyCtx, ctx, ns, string(content)); err != nil {
 			return actionResultMsg{err: fmt.Errorf("apply: %w", err)}
 		}
 		return actionResultMsg{

--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/atotto/clipboard"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 )
@@ -122,7 +123,7 @@ func (m Model) applyTemplate(tmpl model.ResourceTemplate) tea.Cmd {
 
 // applyTemplateFile runs kubectl apply -f on the given temp file and cleans it up.
 func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		_ = os.Remove(tmpFile)
 		return func() tea.Msg {

--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -122,7 +123,15 @@ func (m Model) applyTemplate(tmpl model.ResourceTemplate) tea.Cmd {
 }
 
 // applyTemplateFile runs kubectl apply -f on the given temp file and cleans it up.
+// In demo mode it instead routes through Client.ApplyManifest: the demo
+// backend's fake dynamic client lives only in this process, so a kubectl
+// subprocess would write into a separate tracker the UI never reads from —
+// see internal/k8s.Client.ApplyManifest.
 func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
+	if m.client.IsDemo() {
+		return m.applyTemplateFileDemo(tmpFile, ctx, ns)
+	}
+
 	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		_ = os.Remove(tmpFile)
@@ -152,6 +161,27 @@ func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
 		// GetNamespaces round-trip per template apply.
 		return actionResultMsg{
 			message:                  strings.TrimSpace(string(output)),
+			invalidateNamespaceCache: true,
+		}
+	}
+}
+
+// applyTemplateFileDemo applies the temp file's manifest in-process through
+// Client.ApplyManifest and cleans it up, mirroring applyTemplateFile's
+// kubectl path without shelling out.
+func (m Model) applyTemplateFileDemo(tmpFile, ctx, ns string) tea.Cmd {
+	return func() tea.Msg {
+		defer func() { _ = os.Remove(tmpFile) }()
+
+		content, err := os.ReadFile(tmpFile)
+		if err != nil {
+			return actionResultMsg{err: fmt.Errorf("reading manifest: %w", err)}
+		}
+		if err := m.client.ApplyManifest(context.Background(), ctx, ns, string(content)); err != nil {
+			return actionResultMsg{err: fmt.Errorf("apply: %w", err)}
+		}
+		return actionResultMsg{
+			message:                  "applied",
 			invalidateNamespaceCache: true,
 		}
 	}

--- a/internal/app/commands_apply_test.go
+++ b/internal/app/commands_apply_test.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+// TestApplyTemplateFile_DemoModeAppliesThroughDynamicClient is acceptance
+// criterion 5: a demo-mode apply must change the object as read back
+// through the dynamic client, never through a kubectl subprocess. PATH is
+// cleared so any accidental kubectl resolution would fail loudly instead
+// of silently applying against whatever kubectl happens to be installed.
+func TestApplyTemplateFile_DemoModeAppliesThroughDynamicClient(t *testing.T) {
+	c, err := k8s.NewDemoClient()
+	require.NoError(t, err)
+	defer c.Shutdown()
+
+	t.Setenv("PATH", t.TempDir())
+
+	m := Model{client: c}
+
+	manifest := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: apply-test-cm\ndata:\n  hello: world\n"
+	tmpPath := filepath.Join(t.TempDir(), "apply-test.yaml")
+	require.NoError(t, os.WriteFile(tmpPath, []byte(manifest), 0o600))
+
+	cmd := m.applyTemplateFile(tmpPath, c.CurrentContext(), demo.NamespaceDemo)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	result, ok := msg.(actionResultMsg)
+	require.True(t, ok, "expected actionResultMsg, got %T", msg)
+	require.NoError(t, result.err)
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	obj, err := c.RawDynamicForContext(c.CurrentContext()).Resource(gvr).Namespace(demo.NamespaceDemo).
+		Get(t.Context(), "apply-test-cm", metav1.GetOptions{})
+	require.NoError(t, err, "applied ConfigMap must be readable back through the dynamic client")
+
+	value, found, err := unstructured.NestedString(obj.Object, "data", "hello")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "world", value)
+
+	_, statErr := os.Stat(tmpPath)
+	assert.True(t, os.IsNotExist(statErr), "temp file should be removed after apply")
+}
+
+// TestApplyTemplateFile_DemoModeNeverResolvesKubectl guards the other half
+// of acceptance criterion 5: demo mode must never even look for kubectl,
+// since a resolved kubectl would shell out to a subprocess whose fake
+// backend the UI can never read from.
+func TestApplyTemplateFile_DemoModeNeverResolvesKubectl(t *testing.T) {
+	c, err := k8s.NewDemoClient()
+	require.NoError(t, err)
+	defer c.Shutdown()
+
+	// No PATH at all: any lookup for a kubectl binary fails.
+	t.Setenv("PATH", "")
+
+	m := Model{client: c}
+
+	manifest := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: apply-test-cm2\ndata:\n  hello: world\n"
+	tmpPath := filepath.Join(t.TempDir(), "apply-test2.yaml")
+	require.NoError(t, os.WriteFile(tmpPath, []byte(manifest), 0o600))
+
+	cmd := m.applyTemplateFile(tmpPath, c.CurrentContext(), demo.NamespaceDemo)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	result, ok := msg.(actionResultMsg)
+	require.True(t, ok, "expected actionResultMsg, got %T", msg)
+	assert.NoError(t, result.err, "demo apply must succeed even with an empty PATH")
+}

--- a/internal/app/commands_bulk.go
+++ b/internal/app/commands_bulk.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -110,7 +111,7 @@ func (m Model) bulkForceDeleteResources() tea.Cmd {
 	return func() tea.Msg {
 		defer registry.Finish(id)
 
-		kubectlPath, err := exec.LookPath("kubectl")
+		kubectlPath, err := k8s.KubectlPath()
 		if err != nil {
 			return bulkActionResultMsg{failed: total, errors: []string{"kubectl not found"}}
 		}

--- a/internal/app/commands_bulk.go
+++ b/internal/app/commands_bulk.go
@@ -149,7 +149,7 @@ func (m Model) bulkForceDeleteResources() tea.Cmd {
 			if rt.Namespaced {
 				patchArgs = append(patchArgs, "-n", itemNs)
 			}
-			patchCmd := exec.CommandContext(ctx, kubectlPath, patchArgs...)
+			patchCmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(patchArgs)...)
 			patchCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 			logExecCmd("Running kubectl command", patchCmd)
 			// Best-effort: a failure here (RBAC denial, resource already
@@ -165,7 +165,7 @@ func (m Model) bulkForceDeleteResources() tea.Cmd {
 
 			// Force delete.
 			deleteArgs := forceDeleteArgs(rt, ref.Name, kubectlCtx, itemNs, cascade)
-			cmd := exec.CommandContext(ctx, kubectlPath, deleteArgs...)
+			cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(deleteArgs)...)
 			cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 			logExecCmd("Running kubectl command", cmd)
 			if _, err := cmd.CombinedOutput(); err != nil {

--- a/internal/app/commands_capture.go
+++ b/internal/app/commands_capture.go
@@ -153,6 +153,17 @@ func (m Model) launchKubeshark(target model.Item) tea.Cmd {
 	mgr := m.portForwardMgr
 	ctx := m.reqCtx
 	return func() tea.Msg {
+		// Demo mode never seeds a kubeshark-hub Service, so DetectKubeshark
+		// already turns this away before any subprocess would spawn — but
+		// that's an implicit guard resting on absent seed data. Refuse
+		// explicitly, matching resolveHelmPath, rather than rely on it: in
+		// demo mode k8s.KubectlPath() returns this process's own
+		// executable, and a future demo-seeded kubeshark-hub Service would
+		// otherwise turn this into a real subprocess launch of "this
+		// binary" as kubectl.
+		if client.IsDemo() {
+			return kubesharkLaunchedMsg{err: fmt.Errorf("kubeshark is not available in demo mode")}
+		}
 		kubectlPath, err := k8s.KubectlPath()
 		if err != nil {
 			return kubesharkLaunchedMsg{err: fmt.Errorf("kubectl not found: %w", err)}

--- a/internal/app/commands_capture.go
+++ b/internal/app/commands_capture.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"os/exec"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/janosmiko/lfk/internal/k8s"
@@ -154,7 +153,7 @@ func (m Model) launchKubeshark(target model.Item) tea.Cmd {
 	mgr := m.portForwardMgr
 	ctx := m.reqCtx
 	return func() tea.Msg {
-		kubectlPath, err := exec.LookPath("kubectl")
+		kubectlPath, err := k8s.KubectlPath()
 		if err != nil {
 			return kubesharkLaunchedMsg{err: fmt.Errorf("kubectl not found: %w", err)}
 		}

--- a/internal/app/commands_capture_demo_test.go
+++ b/internal/app/commands_capture_demo_test.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestLaunchKubeshark_RefusesInDemoMode guards against launchKubeshark ever
+// resolving k8s.KubectlPath() in demo mode: that call returns this process's
+// own executable, so an unguarded launch would kubectl port-forward through
+// "this binary" instead of a real kubectl. The kubeshark backend chip is
+// normally unreachable in demo mode too (no kubeshark-hub Service is seeded),
+// but this guard must hold even if a caller reaches launchKubeshark directly.
+func TestLaunchKubeshark_RefusesInDemoMode(t *testing.T) {
+	c, err := k8s.NewDemoClient()
+	require.NoError(t, err)
+	defer c.Shutdown()
+
+	m := baseFinalModel()
+	m.client = c
+	m.actionCtx.context = c.CurrentContext()
+
+	cmd := m.launchKubeshark(model.Item{Name: "web", Namespace: "demo"})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	result, ok := msg.(kubesharkLaunchedMsg)
+	require.True(t, ok, "expected kubesharkLaunchedMsg, got %T", msg)
+	require.Error(t, result.err)
+	require.True(t, strings.Contains(result.err.Error(), "not available in demo mode"),
+		"expected a demo-mode refusal, got: %v", result.err)
+}

--- a/internal/app/commands_exec.go
+++ b/internal/app/commands_exec.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -61,7 +62,7 @@ func runInteractiveShellExec(cmd *exec.Cmd, title, sessionLabel string, clearBef
 }
 
 func (m Model) execKubectlEdit() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -87,7 +88,7 @@ func (m Model) execKubectlEdit() tea.Cmd {
 }
 
 func (m Model) execKubectlDescribe() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}

--- a/internal/app/commands_exec.go
+++ b/internal/app/commands_exec.go
@@ -76,7 +76,7 @@ func (m Model) execKubectlEdit() tea.Cmd {
 		args = append(args, "-n", ns)
 	}
 
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(m.actionCtx.context))
 	logExecCmd("Running kubectl command", cmd)
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
@@ -110,7 +110,7 @@ func (m Model) execKubectlDescribe() tea.Cmd {
 	title := "Describe: " + resourceTitleLabel(m.actionCtx.kind, titleNs, name)
 
 	return m.trackBgTask(scheduler.KindSubprocess, title, bgtaskTarget(m.actionCtx.context, ns), func() tea.Msg {
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(m.actionCtx.context))
 		logExecCmd("Running kubectl command", cmd)
 		output, err := cmd.CombinedOutput()

--- a/internal/app/commands_exec_helm.go
+++ b/internal/app/commands_exec_helm.go
@@ -9,8 +9,22 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 )
+
+// resolveHelmPath finds the helm binary, refusing outright in demo mode.
+// Unlike kubectl, helm has no in-process demo stub (k8s.KubectlPath does not
+// cover it, since call sites shell out via exec.LookPath("helm") directly),
+// so every one of those call sites resolves through here instead of
+// exec.LookPath so a real, cluster-connected helm can never run under
+// --demo.
+func resolveHelmPath() (string, error) {
+	if k8s.DemoModeEnabled() {
+		return "", fmt.Errorf("helm is not available in demo mode")
+	}
+	return exec.LookPath("helm")
+}
 
 // runHelmCmdResult runs a prepared helm command to completion and maps the
 // outcome to an actionResultMsg. Used for the non-interactive helm operations
@@ -31,7 +45,7 @@ func runHelmCmdResult(cmd *exec.Cmd, successMsg, failPrefix string) tea.Msg {
 }
 
 func (m Model) uninstallHelmRelease() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("helm not found: %w", err)}
@@ -150,7 +164,7 @@ func buildHelmUpgradeCmd(helmPath, release, ns, ctx, kubeconfig string) *exec.Cm
 }
 
 func (m Model) editHelmValues() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("helm not found: %w", err)}
@@ -175,7 +189,7 @@ func (m Model) editHelmValues() tea.Cmd {
 }
 
 func (m Model) helmDiff() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return diffLoadedMsg{err: fmt.Errorf("helm not found: %w", err)}
@@ -301,7 +315,7 @@ func parseFirstJSONField(jsonStr, field, suffix string) string {
 }
 
 func (m Model) helmUpgrade() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("helm not found: %w", err)}
@@ -321,7 +335,7 @@ func (m Model) helmUpgrade() tea.Cmd {
 }
 
 func (m Model) rollbackHelmRelease(revision int) tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return helmRollbackDoneMsg{err: fmt.Errorf("helm not found: %w", err)}

--- a/internal/app/commands_exec_helm_test.go
+++ b/internal/app/commands_exec_helm_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+)
+
+// TestResolveHelmPath_RefusesInDemoMode guards the last hole in acceptance
+// criterion 5: helm shells out via exec.LookPath directly (KubectlPath does
+// not cover it), so demo mode must be checked explicitly before ever
+// resolving a real helm binary.
+func TestResolveHelmPath_RefusesInDemoMode(t *testing.T) {
+	k8s.SetDemoMode(true)
+	defer k8s.SetDemoMode(false)
+
+	path, err := resolveHelmPath()
+	if err == nil {
+		t.Fatalf("resolveHelmPath() = (%q, nil), want an error in demo mode", path)
+	}
+	if !strings.Contains(err.Error(), "demo mode") {
+		t.Errorf("resolveHelmPath() error = %v, want it to mention demo mode", err)
+	}
+	if path != "" {
+		t.Errorf("resolveHelmPath() path = %q, want empty on refusal", path)
+	}
+}
+
+func TestResolveHelmPath_NormalModeMatchesLookPath(t *testing.T) {
+	k8s.SetDemoMode(false)
+
+	want, wantErr := exec.LookPath("helm")
+	got, err := resolveHelmPath()
+
+	if wantErr != nil {
+		if err == nil {
+			t.Fatalf("resolveHelmPath() = (%q, nil); want error when helm is absent from PATH", got)
+		}
+		if !errors.Is(err, exec.ErrNotFound) && !strings.Contains(err.Error(), "not found") {
+			t.Errorf("resolveHelmPath() error = %v, want it to surface the LookPath failure", err)
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("resolveHelmPath() unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("resolveHelmPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -100,6 +100,20 @@ func (m Model) removeFinalizers() tea.Cmd {
 }
 
 func (m Model) vulnScanImage(image string) tea.Cmd {
+	// trivy has no in-process demo stub (unlike kubectl) and no cluster
+	// context to refuse through, so demo mode is checked directly here,
+	// the same way resolveHelmPath refuses helm — before ever resolving a
+	// real trivy binary that would pull the image manifest and vuln DB
+	// over the network.
+	if k8s.DemoModeEnabled() {
+		return func() tea.Msg {
+			return describeLoadedMsg{
+				title: "Vulnerability Scan",
+				err:   fmt.Errorf("vuln scan is not available in demo mode"),
+			}
+		}
+	}
+
 	trivyPath, err := exec.LookPath("trivy")
 	if err != nil {
 		return func() tea.Msg {

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -35,7 +36,7 @@ func (m Model) deleteResource() tea.Cmd {
 }
 
 func (m Model) forceDeleteResource() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -65,7 +66,7 @@ func (m Model) forceDeleteResource() tea.Cmd {
 }
 
 func (m Model) removeFinalizers() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -217,7 +218,7 @@ func (m Model) execKubectlDrain() tea.Cmd {
 // hand-over. Shared by the Node "Drain" action and the Karpenter
 // "Drain Node" action (which resolves the bound node first).
 func (m Model) drainNodeCmd(nodeName string) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -54,7 +54,7 @@ func (m Model) forceDeleteResource() tea.Cmd {
 	deleteArgs := forceDeleteArgs(rt, name, m.kubectlContext(ctx), ns, cascade)
 
 	return m.trackBgTask(scheduler.KindMutation, fmt.Sprintf("Force delete %s/%s", rt.Resource, name), bgtaskTarget(ctx, ns), func() tea.Msg {
-		cmd := exec.Command(kubectlPath, deleteArgs...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(deleteArgs)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 		logExecCmd("Running kubectl command", cmd)
 		if output, err := cmd.CombinedOutput(); err != nil {
@@ -88,7 +88,7 @@ func (m Model) removeFinalizers() tea.Cmd {
 	}
 
 	return m.trackBgTask(scheduler.KindMutation, fmt.Sprintf("Remove finalizers: %s/%s", rt.Resource, name), bgtaskTarget(ctx, ns), func() tea.Msg {
-		cmd := exec.Command(kubectlPath, patchArgs...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(patchArgs)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 		logExecCmd("Running kubectl command", cmd)
 		if output, err := cmd.CombinedOutput(); err != nil {
@@ -244,7 +244,7 @@ func (m Model) drainNodeCmd(nodeName string) tea.Cmd {
 		"--ignore-daemonsets", "--delete-emptydir-data",
 	}
 
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(kctx))
 	logExecCmd("Running kubectl command", cmd)
 

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -99,7 +99,7 @@ func (m Model) execKubectlExec() tea.Cmd {
 	args := execShellArgs(m.actionCtx.name, ns, m.kubectlContext(m.actionCtx.context), m.actionCtx.containerName, m.actionCtx.os)
 
 	logger.Info("Starting kubectl exec", "args", strings.Join(args, " "))
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(m.actionCtx.context))
 
 	if ui.ConfigTerminalMode == ui.TerminalModePTY {
@@ -133,7 +133,7 @@ func (m Model) execKubectlAttach() tea.Cmd {
 		args = append(args, "-c", m.actionCtx.containerName)
 	}
 
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(m.actionCtx.context))
 	logExecCmd("Running kubectl command", cmd)
 
@@ -165,7 +165,7 @@ func (m Model) execKubectlDebug() tea.Cmd {
 	ns := m.actionNamespace()
 	args := []string{"debug", m.actionCtx.name, "-it", "--image=busybox", "--context", m.kubectlContext(m.actionCtx.context), "-n", ns}
 
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(m.actionCtx.context))
 	logExecCmd("Running kubectl command", cmd)
 
@@ -205,7 +205,7 @@ func (m Model) runDebugPod() tea.Cmd {
 
 	logger.Info("Running debug pod", "pod", podName, "namespace", ns, "context", ctx)
 
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 
 	if ui.ConfigTerminalMode == ui.TerminalModePTY {
@@ -262,7 +262,7 @@ func (m Model) runDebugPodWithPVC() tea.Cmd {
 		"--overrides", manifest, "--", "sh",
 	}
 
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 	logExecCmd("Running kubectl command", cmd)
 
@@ -375,7 +375,7 @@ func (m Model) execKubectlNodeShell() tea.Cmd {
 	}
 
 	args := nodeShellArgs(podName, nodeShellNamespace, m.kubectlContext(ctx), overrides)
-	cmd := exec.Command(kubectlPath, args...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 	logExecCmd("Running kubectl command", cmd)
 
@@ -425,7 +425,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
@@ -462,7 +462,7 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
@@ -501,7 +501,7 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
@@ -551,7 +551,7 @@ func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath strin
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logExecCmd("Running kubectl command", cmd)
 		output, cmdErr := cmd.CombinedOutput()

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -87,7 +88,7 @@ func execShellArgs(name, namespace, displayCtx, container, podOS string) []strin
 }
 
 func (m Model) execKubectlExec() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -119,7 +120,7 @@ func (m Model) execKubectlExec() tea.Cmd {
 }
 
 func (m Model) execKubectlAttach() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -154,7 +155,7 @@ func (m Model) execKubectlAttach() tea.Cmd {
 }
 
 func (m Model) execKubectlDebug() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -186,7 +187,7 @@ func (m Model) execKubectlDebug() tea.Cmd {
 }
 
 func (m Model) runDebugPod() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -225,7 +226,7 @@ func (m Model) runDebugPod() tea.Cmd {
 }
 
 func (m Model) runDebugPodWithPVC() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -355,7 +356,7 @@ func nodeShellArgs(podName, namespace, kctx, overrides string) []string {
 }
 
 func (m Model) execKubectlNodeShell() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -396,7 +397,7 @@ func (m Model) execKubectlNodeShell() tea.Cmd {
 }
 
 func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return explainLoadedMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -446,7 +447,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 }
 
 func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return explainRecursiveMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -480,7 +481,7 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 // for the API Explorer's tree mode. Parsed paths come back relative to the
 // output root, so they are re-anchored at fieldPath.
 func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return explainTreeLoadedMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -529,7 +530,7 @@ func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath strin
 	kctx := m.effectiveContext()
 	ident := explainTreeDescMsg{resource: resource, apiVersion: apiVersion, kctx: kctx, parent: parentPath}
 
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			msg := ident

--- a/internal/app/commands_exec_test.go
+++ b/internal/app/commands_exec_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 	"github.com/stretchr/testify/assert"
@@ -378,6 +379,25 @@ func TestPush3HelmUpgradeNoHelm(t *testing.T) {
 	amsg, ok := msg.(actionResultMsg)
 	require.True(t, ok)
 	assert.Error(t, amsg.err)
+}
+
+// TestVulnScanImage_RefusesInDemoMode guards TASK-865 finding 2: trivy is
+// the one binary lookup that never went through k8s.KubectlPath, so a demo
+// session could reach a real network scan (image pull, vuln DB download)
+// against ghcr.io. Vuln Scan must refuse the same way helm's
+// resolveHelmPath does, before ever calling exec.LookPath("trivy").
+func TestVulnScanImage_RefusesInDemoMode(t *testing.T) {
+	k8s.SetDemoMode(true)
+	defer k8s.SetDemoMode(false)
+
+	m := basePush80v3Model()
+	cmd := m.vulnScanImage("nginx:latest")
+	require.NotNil(t, cmd)
+	msg := cmd()
+	dmsg, ok := msg.(describeLoadedMsg)
+	require.True(t, ok)
+	require.Error(t, dmsg.err)
+	assert.Contains(t, dmsg.err.Error(), "demo mode")
 }
 
 func TestPush3VulnScanImageNoTrivy(t *testing.T) {

--- a/internal/app/commands_fielddoc.go
+++ b/internal/app/commands_fielddoc.go
@@ -86,7 +86,7 @@ func (m Model) execKubectlExplainField(reqCtx context.Context, req uint64, key f
 		if key.apiVersion != "" {
 			args = append(args, "--api-version", key.apiVersion)
 		}
-		cmd := exec.CommandContext(ctx, kubectlPath, args...)
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
 		// Killing kubectl does not close pipes a grandchild still holds (a
 		// credential plugin, say), and CombinedOutput reads to EOF. Without a
 		// WaitDelay the worker would stay blocked on a process already killed.

--- a/internal/app/commands_fielddoc.go
+++ b/internal/app/commands_fielddoc.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 )
 
@@ -59,7 +60,7 @@ func scheduleFieldDocFetch(req uint64) tea.Cmd {
 // connected cluster. It shells out to kubectl explain rather than reading a
 // bundled copy, so the text matches the cluster version and covers CRDs.
 func (m Model) execKubectlExplainField(reqCtx context.Context, req uint64, key fieldDocKey) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return fieldDocLoadedMsg{req: req, key: key, err: fmt.Errorf("kubectl not found: %w", err)}

--- a/internal/app/commands_load_helm_history.go
+++ b/internal/app/commands_load_helm_history.go
@@ -101,7 +101,7 @@ func fetchHelmHistory(helmPath, name, ns, kubeCtx, kubeconfigPaths string) ([]ui
 
 // loadHelmRevisions fetches the revision history for a Helm release.
 func (m Model) loadHelmRevisions() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return helmRevisionListMsg{err: fmt.Errorf("helm not found: %w", err)}
@@ -126,7 +126,7 @@ func (m Model) loadHelmRevisions() tea.Cmd {
 // It reuses fetchHelmHistory but routes the result to helmHistoryListMsg so
 // the update path opens overlayHelmHistory instead of overlayHelmRollback.
 func (m Model) loadHelmHistory() tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return helmHistoryListMsg{err: fmt.Errorf("helm not found: %w", err)}

--- a/internal/app/commands_load_preview.go
+++ b/internal/app/commands_load_preview.go
@@ -453,7 +453,7 @@ func (m Model) loadNetworkPoliciesForResource() tea.Cmd {
 // loadHelmValues runs `helm get values` and returns the output as a message.
 // If allValues is true, the --all flag is included to show computed defaults too.
 func (m Model) loadHelmValues(allValues bool) tea.Cmd {
-	helmPath, err := exec.LookPath("helm")
+	helmPath, err := resolveHelmPath()
 	if err != nil {
 		return func() tea.Msg {
 			return helmValuesLoadedMsg{err: fmt.Errorf("helm not found: %w", err)}

--- a/internal/app/commands_logs.go
+++ b/internal/app/commands_logs.go
@@ -15,6 +15,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -82,7 +83,7 @@ func (m Model) scheduleLogStreamRestart(ch chan string) tea.Cmd {
 // starts a goroutine that reads stdout line by line. Returns a tea.Cmd that
 // reads the first line from the channel.
 func (m *Model) startLogStream() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -369,7 +370,7 @@ func (m Model) waitForLogLineIfIdle() tea.Cmd {
 // merges their output into a single log channel. This supports streaming logs
 // from multiple pods or parent resources simultaneously.
 func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return m, func() tea.Msg { return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)} }
 	}
@@ -492,7 +493,7 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 // restartMultiLogStream restarts a multi-log stream using stored items,
 // preserving current viewer settings (used when toggling timestamps).
 func (m Model) restartMultiLogStream() (Model, tea.Cmd) {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return m, func() tea.Msg { return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)} }
 	}
@@ -589,7 +590,7 @@ func (m Model) restartMultiLogStream() (Model, tea.Cmd) {
 // fetchOlderLogs fetches an additional batch of older log lines using a
 // one-shot kubectl logs call (no -f). The result is returned as a logHistoryMsg.
 func (m *Model) fetchOlderLogs() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg { return logHistoryMsg{err: err} }
 	}
@@ -722,7 +723,7 @@ func (m *Model) saveLoadedLogs() (string, error) {
 
 // saveAllLogs runs a one-shot kubectl logs (without --tail) and writes everything to a file.
 func (m *Model) saveAllLogs() tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg { return logSaveAllMsg{err: err} }
 	}

--- a/internal/app/commands_logs.go
+++ b/internal/app/commands_logs.go
@@ -183,7 +183,7 @@ func (m *Model) startLogStream() tea.Cmd {
 
 		logger.Info("Starting kubectl logs", "args", strings.Join(args, " "), "kubeconfig", kubeconfigPaths)
 
-		cmd := exec.CommandContext(ctx, kubectlPath, args...)
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
@@ -255,7 +255,7 @@ func kubectlGetPodSelector(kubectlPath, kubeconfigPaths, ns, kind, name, kctx st
 		"-o", "json",
 	}
 
-	cmd := exec.Command(kubectlPath, getArgs...)
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 	logExecCmd("Running kubectl command", cmd)
 	out, err := cmd.Output()
@@ -448,7 +448,7 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 
 		m.addLogEntry("DBG", "kubectl "+strings.Join(args, " "))
 
-		cmd := exec.CommandContext(ctx, kubectlPath, args...)
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(itemCtx))
 		logger.Info("Starting multi-log kubectl",
 			"item", item.Name,
@@ -549,7 +549,7 @@ func (m Model) restartMultiLogStream() (Model, tea.Cmd) {
 
 		args = append(args, "--timestamps")
 
-		cmd := exec.CommandContext(ctx, kubectlPath, args...)
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(itemCtx))
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
@@ -652,7 +652,7 @@ func (m *Model) fetchOlderLogs() tea.Cmd {
 		args = append(args, "--timestamps")
 
 		kubeconfigEnv := "KUBECONFIG=" + kubeconfigPaths
-		cmd := exec.CommandContext(ctx, kubectlPath, args...)
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), kubeconfigEnv)
 
 		output, err := cmd.Output()
@@ -774,7 +774,7 @@ func (m *Model) saveAllLogs() tea.Cmd {
 			args = append(args, "--previous")
 		}
 
-		cmd := exec.CommandContext(context.Background(), kubectlPath, args...)
+		cmd := exec.CommandContext(context.Background(), kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		// Match commands_exec.go convention: log every kubectl invocation
 		// before running so the slog file records what we actually ran.

--- a/internal/app/commands_portforward.go
+++ b/internal/app/commands_portforward.go
@@ -2,10 +2,10 @@ package app
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 )
 
@@ -13,7 +13,7 @@ import (
 
 // execKubectlPortForward starts a port forward as a background process via the manager.
 func (m Model) execKubectlPortForward(portMapping string) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return portForwardStartedMsg{err: fmt.Errorf("kubectl not found: %w", err)}
@@ -80,7 +80,7 @@ func (m Model) restartPortForward(id int) tea.Cmd {
 			return portForwardStartedMsg{err: fmt.Errorf("port forward %d not found", id)}
 		}
 	}
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return portForwardStartedMsg{err: fmt.Errorf("kubectl not found: %w", err)}

--- a/internal/app/options.go
+++ b/internal/app/options.go
@@ -27,6 +27,7 @@ type StartupOptions struct {
 	NoMouse                 bool
 	NoColor                 bool          // --no-color: forces monochrome output regardless of env/config.
 	ReadOnly                bool          // --read-only: blocks all mutating actions; sticky for the process.
+	Demo                    bool          // --demo: run against an in-memory fake cluster; no kubeconfig needed.
 	WatchInterval           time.Duration // 0 means not set — fall back to config/default.
 	BackgroundWatchInterval time.Duration // 0 means not set — fall back to config/default.
 	ForegroundIdleTimeout   time.Duration // < 0 (default -1) means not set — fall back to config/default; 0 disables.

--- a/internal/app/portforward_state.go
+++ b/internal/app/portforward_state.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	tea "charm.land/bubbletea/v2"
@@ -99,7 +98,7 @@ func (m *Model) saveCurrentPortForwards() {
 // restorePortForwards re-establishes saved port forwards from the previous session.
 // Returns tea.Cmds that will start each port forward asynchronously.
 func (m *Model) restorePortForwards() []tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		logger.Error("Cannot restore port forwards: kubectl not found", "error", err)
 		m.addLogEntry("ERR", fmt.Sprintf("Cannot restore port forwards: kubectl not found: %v", err))

--- a/internal/app/previewlog.go
+++ b/internal/app/previewlog.go
@@ -196,7 +196,7 @@ func (m Model) startPreviewLogStream(ref podRef, reconnect bool) (Model, tea.Cmd
 	go func() {
 		defer close(ch)
 
-		cmd := exec.CommandContext(ctx, kubectlPath, args...)
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logger.Info("Starting preview kubectl logs", "args", args, "kubeconfig", kubeconfigPaths)
 
@@ -621,7 +621,7 @@ func (m Model) fetchOlderPreviewLogs(ref podRef, tail int) tea.Cmd {
 	args := kubectlPodLogArgs(ref.name, ref.namespace, m.kubectlContext(ref.context), false, tail, ref.container)
 
 	return func() tea.Msg {
-		cmd := exec.Command(kubectlPath, args...) //nolint:gosec
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...) //nolint:gosec
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 		logger.Info("Fetching older preview log history", "args", args)
 

--- a/internal/app/previewlog.go
+++ b/internal/app/previewlog.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -158,7 +159,7 @@ func (m Model) startPreviewLogStream(ref podRef, reconnect bool) (Model, tea.Cmd
 	// needing kubectl to be present.
 	m.previewLog.podKey = ref.key()
 
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		m.previewLog.err = fmt.Sprintf("kubectl not found: %v", err)
 		return m, nil
@@ -607,7 +608,7 @@ func (m Model) selectedPodForLogPreview() (podRef, bool) {
 // previewLogHistoryMsg. The fetch runs in the background; the model correlates
 // the result by podKey to drop stale responses.
 func (m Model) fetchOlderPreviewLogs(ref podRef, tail int) tea.Cmd {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
 			return previewLogHistoryMsg{podKey: ref.key(), err: err}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -536,6 +536,11 @@ func (m Model) renderTitleBar() string {
 		readOnlyIndicator = ui.ReadOnlyBadgeStyle.Render("RO")
 	}
 
+	var demoIndicator string
+	if m.demoMode {
+		demoIndicator = ui.DemoBadgeStyle.Render("DEMO")
+	}
+
 	var mutationProgress, tasksIndicator string
 	if m.scheduler != nil && m.scheduler.LenIndicator() > 0 {
 		// Watch-mode auto-refresh marks its tasks Silent so the spinner
@@ -564,7 +569,7 @@ func (m Model) renderTitleBar() string {
 	}
 
 	// Calculate available width for breadcrumb.
-	fixedWidth := lipgloss.Width(watchIndicator) + lipgloss.Width(readOnlyIndicator) + lipgloss.Width(mutationProgress) + lipgloss.Width(tasksIndicator) + lipgloss.Width(nsLabel) + lipgloss.Width(versionLabel)
+	fixedWidth := lipgloss.Width(watchIndicator) + lipgloss.Width(readOnlyIndicator) + lipgloss.Width(demoIndicator) + lipgloss.Width(mutationProgress) + lipgloss.Width(tasksIndicator) + lipgloss.Width(nsLabel) + lipgloss.Width(versionLabel)
 	maxBcWidth := max(
 		// -1 for minimum gap
 		innerWidth-fixedWidth-1, 10)
@@ -585,7 +590,7 @@ func (m Model) renderTitleBar() string {
 		bc = ui.TitleBreadcrumbStyle.Render(bcText)
 	}
 
-	contentWidth := lipgloss.Width(bc) + lipgloss.Width(watchIndicator) + lipgloss.Width(readOnlyIndicator) + lipgloss.Width(mutationProgress) + lipgloss.Width(tasksIndicator) + lipgloss.Width(nsLabel) + lipgloss.Width(versionLabel)
+	contentWidth := lipgloss.Width(bc) + lipgloss.Width(watchIndicator) + lipgloss.Width(readOnlyIndicator) + lipgloss.Width(demoIndicator) + lipgloss.Width(mutationProgress) + lipgloss.Width(tasksIndicator) + lipgloss.Width(nsLabel) + lipgloss.Width(versionLabel)
 	gap := max(innerWidth-contentWidth, 0)
 
 	var gapContent string
@@ -604,6 +609,7 @@ func (m Model) renderTitleBar() string {
 		lipgloss.Width(bc) +
 		lipgloss.Width(watchIndicator) +
 		lipgloss.Width(readOnlyIndicator) +
+		lipgloss.Width(demoIndicator) +
 		lipgloss.Width(gapContent) +
 		lipgloss.Width(mutationProgress) +
 		lipgloss.Width(tasksIndicator)
@@ -612,7 +618,7 @@ func (m Model) renderTitleBar() string {
 		nsEndX:   nsStartX + lipgloss.Width(nsLabel),
 	})
 
-	barContent := bc + watchIndicator + readOnlyIndicator + gapContent + mutationProgress + tasksIndicator + nsLabel + versionLabel
+	barContent := bc + watchIndicator + readOnlyIndicator + demoIndicator + gapContent + mutationProgress + tasksIndicator + nsLabel + versionLabel
 	if tint != "" {
 		// Outer wrap also uses the tint so the Padding(0, 1) cells share
 		// the bar background — the inner segments each carry the tint

--- a/internal/app/view_titlebar_demo_test.go
+++ b/internal/app/view_titlebar_demo_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// renderTitleBar must show a DEMO badge when the model is running against
+// the --demo in-memory cluster, and must omit it otherwise — acceptance
+// criterion 6.
+func TestRenderTitleBar_DemoBadge(t *testing.T) {
+	baseNav := model.NavigationState{
+		Context: "my-cluster",
+		Level:   model.LevelResources,
+		ResourceType: model.ResourceTypeEntry{
+			DisplayName: "Pods",
+		},
+	}
+
+	t.Run("shown in demo mode", func(t *testing.T) {
+		m := Model{
+			width:     120,
+			height:    30,
+			namespace: "default",
+			nav:       baseNav,
+			tabs:      []TabState{{}},
+			demoMode:  true,
+		}
+		stripped := stripANSI(m.renderTitleBar())
+		assert.Contains(t, stripped, "DEMO")
+	})
+
+	t.Run("omitted outside demo mode", func(t *testing.T) {
+		m := Model{
+			width:     120,
+			height:    30,
+			namespace: "default",
+			nav:       baseNav,
+			tabs:      []TabState{{}},
+		}
+		stripped := stripANSI(m.renderTitleBar())
+		assert.NotContains(t, stripped, "DEMO")
+	})
+}

--- a/internal/app/view_titlebar_demo_test.go
+++ b/internal/app/view_titlebar_demo_test.go
@@ -21,26 +21,16 @@ func TestRenderTitleBar_DemoBadge(t *testing.T) {
 	}
 
 	t.Run("shown in demo mode", func(t *testing.T) {
-		m := Model{
-			width:     120,
-			height:    30,
-			namespace: "default",
-			nav:       baseNav,
-			tabs:      []TabState{{}},
-			demoMode:  true,
-		}
+		m := basePush80Model()
+		m.nav = baseNav
+		m.demoMode = true
 		stripped := stripANSI(m.renderTitleBar())
 		assert.Contains(t, stripped, "DEMO")
 	})
 
 	t.Run("omitted outside demo mode", func(t *testing.T) {
-		m := Model{
-			width:     120,
-			height:    30,
-			namespace: "default",
-			nav:       baseNav,
-			tabs:      []TabState{{}},
-		}
+		m := basePush80Model()
+		m.nav = baseNav
 		stripped := stripANSI(m.renderTitleBar())
 		assert.NotContains(t, stripped, "DEMO")
 	})

--- a/internal/democli/args.go
+++ b/internal/democli/args.go
@@ -1,0 +1,102 @@
+package democli
+
+import (
+	"strconv"
+	"strings"
+)
+
+// logArgs is the subset of `kubectl logs` flags the app actually passes
+// (see internal/app/commands_logs.go, previewlog.go, logshared.go).
+type logArgs struct {
+	target     string // pod name, "kind/name" resource ref, or the -l selector value
+	isSelector bool
+	namespace  string
+	kctx       string
+	container  string
+	follow     bool
+	prefix     bool
+	tail       int // -1 means unset (no --tail flag was passed)
+}
+
+// parseLogArgs reads kubectl-style argv (flags in "--flag value" or
+// "--flag=value" form, one leading positional resource ref/pod name) into a
+// logArgs. Unrecognized flags are accepted and ignored — this parser only
+// needs to understand what the app's call sites actually emit.
+func parseLogArgs(args []string) logArgs {
+	a := logArgs{tail: -1}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-f":
+			a.follow = true
+		case arg == "--prefix":
+			a.prefix = true
+		case arg == "-l":
+			i++
+			if i < len(args) {
+				a.target, a.isSelector = args[i], true
+			}
+		case strings.HasPrefix(arg, "-l="):
+			a.target, a.isSelector = strings.TrimPrefix(arg, "-l="), true
+		case arg == "-n":
+			i++
+			if i < len(args) {
+				a.namespace = args[i]
+			}
+		case strings.HasPrefix(arg, "-n="):
+			a.namespace = strings.TrimPrefix(arg, "-n=")
+		case arg == "--context":
+			i++
+			if i < len(args) {
+				a.kctx = args[i]
+			}
+		case strings.HasPrefix(arg, "--context="):
+			a.kctx = strings.TrimPrefix(arg, "--context=")
+		case arg == "-c":
+			i++
+			if i < len(args) {
+				a.container = args[i]
+			}
+		case strings.HasPrefix(arg, "-c="):
+			a.container = strings.TrimPrefix(arg, "-c=")
+		case strings.HasPrefix(arg, "--tail="):
+			if n, err := strconv.Atoi(strings.TrimPrefix(arg, "--tail=")); err == nil {
+				a.tail = n
+			}
+		case strings.HasPrefix(arg, "-"):
+			// Accepted no-ops: --all-containers=true, --max-log-requests=N,
+			// --ignore-errors, --timestamps, --previous.
+		default:
+			if a.target == "" {
+				a.target = arg
+			}
+		}
+	}
+	return a
+}
+
+// podName derives a stable, readable pod identity from the parsed target:
+// a literal pod name is used as-is, a "kind/name" resource ref contributes
+// its name, and a label selector ("app=web,tier=x") contributes the first
+// label's value. Different targets deterministically produce different
+// identities, which is what seeds a different (but reproducible) log stream
+// per pod.
+func (a logArgs) podName() string {
+	if a.target == "" {
+		return "demo-pod"
+	}
+	if !a.isSelector {
+		if _, name, ok := strings.Cut(a.target, "/"); ok {
+			return name
+		}
+		return a.target
+	}
+	first := a.target
+	if idx := strings.IndexByte(first, ','); idx >= 0 {
+		first = first[:idx]
+	}
+	if _, val, ok := strings.Cut(first, "="); ok {
+		return val
+	}
+	return first
+}

--- a/internal/democli/democli.go
+++ b/internal/democli/democli.go
@@ -1,0 +1,38 @@
+// Package democli implements the hidden "__demo-kubectl" subcommand that
+// --demo mode re-enters instead of a real kubectl binary (see
+// k8s.KubectlPath). Every existing kubectl call site in the app keeps
+// running unmodified; only the resolved binary path changes, so this
+// package must accept the same argument shapes the app already passes.
+package democli
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// Run dispatches args (the kubectl-style argv, verb first) to the matching
+// verb handler. Verbs the app never needs to serve in demo mode (exec,
+// port-forward, drain, debug, apply, and anything else unimplemented) print
+// a single clear refusal line and return a non-nil error so the caller exits
+// non-zero — never falling through to a real binary.
+func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "__demo-kubectl: no kubectl verb given") //nolint:errcheck
+		return fmt.Errorf("no kubectl verb given")
+	}
+
+	verb, rest := args[0], args[1:]
+	switch verb {
+	case "logs":
+		return runLogs(ctx, rest, stdout)
+	case "get":
+		return runGet(rest, stdout)
+	case "describe":
+		return runDescribe(rest, stdout)
+	default:
+		msg := fmt.Sprintf("%s is not available in demo mode", verb)
+		fmt.Fprintln(stderr, msg) //nolint:errcheck
+		return fmt.Errorf("%s", msg)
+	}
+}

--- a/internal/democli/democli_test.go
+++ b/internal/democli/democli_test.go
@@ -1,0 +1,68 @@
+package democli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+func TestRun_LogsVerb(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"logs", "web-7d8f9c6b5-9k2pl", "-n", "demo", "--tail=2", "--timestamps"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if strings.Count(stdout.String(), "\n") != 2 {
+		t.Errorf("stdout = %q, want 2 lines", stdout.String())
+	}
+}
+
+func TestRun_GetVerb(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"get", "deployment/" + demo.DeploymentWeb, "-n", demo.NamespaceDemo, "--context", "demo", "-o", "json"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"matchLabels"`) {
+		t.Errorf("stdout = %q, want matchLabels selector JSON", stdout.String())
+	}
+}
+
+func TestRun_DescribeVerb(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"describe", "pod", demo.PodWebCrashLoop, "-n", demo.NamespaceDemo, "--context", "demo"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "CrashLoopBackOff") {
+		t.Errorf("stdout = %q, want CrashLoopBackOff for the known crash-loop pod", stdout.String())
+	}
+}
+
+// TestRun_RefusesUnsupportedVerbs guards acceptance criterion 5: every verb
+// this package does not implement must refuse clearly and exit non-zero
+// (via a non-nil error) rather than silently doing nothing or falling
+// through to a real binary.
+func TestRun_RefusesUnsupportedVerbs(t *testing.T) {
+	for _, verb := range []string{"exec", "port-forward", "drain", "cordon", "debug", "apply", "delete"} {
+		t.Run(verb, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			err := Run(t.Context(), []string{verb, "pod/x", "-n", "demo"}, &stdout, &stderr)
+			if err == nil {
+				t.Fatalf("Run(%q) error = nil, want non-nil (refusal must exit non-zero)", verb)
+			}
+			if !strings.Contains(stderr.String(), "not available in demo mode") {
+				t.Errorf("stderr = %q, want a clear demo-mode refusal message", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRun_NoArgsRefuses(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := Run(t.Context(), nil, &stdout, &stderr); err == nil {
+		t.Fatal("Run(nil) error = nil, want non-nil")
+	}
+}

--- a/internal/democli/describe.go
+++ b/internal/democli/describe.go
@@ -72,9 +72,9 @@ func renderDescribe(kind, name, namespace, kctx string) string {
 			"  Warning  BackOff  2m    Back-off restarting failed container=web\n")
 	case demo.PodDBMigrate:
 		fmt.Fprintf(&b, "Node:         %s\n", demo.NodeWorker1)
-		b.WriteString("Status:       Succeeded\n")
+		b.WriteString("Status:       Failed\n")
 		b.WriteString("Containers:\n  migrate:\n    State:          Terminated\n" +
-			"    Reason:         Completed\n    Exit Code:      0\n")
+			"    Reason:         Error\n    Exit Code:      1\n")
 	default:
 		fmt.Fprintf(&b, "Kind:         %s\n", kind)
 		b.WriteString("Status:       Running\n")

--- a/internal/democli/describe.go
+++ b/internal/democli/describe.go
@@ -1,0 +1,85 @@
+package democli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+// runDescribe emulates `kubectl describe pod <name> -n <ns> --context <ctx>`
+// (internal/k8s/describe_pod.go), rendering plain-text describe output from
+// the demo seed data in internal/k8s/demo.
+func runDescribe(args []string, stdout io.Writer) error {
+	var kind, name, namespace, kctx string
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-n":
+			i++
+			if i < len(args) {
+				namespace = args[i]
+			}
+		case "--context":
+			i++
+			if i < len(args) {
+				kctx = args[i]
+			}
+		default:
+			if !strings.HasPrefix(args[i], "-") {
+				positional = append(positional, args[i])
+			}
+		}
+	}
+	if len(positional) > 0 {
+		kind = positional[0]
+	}
+	if len(positional) > 1 {
+		name = positional[1]
+	}
+
+	_, err := io.WriteString(stdout, renderDescribe(kind, name, namespace, kctx))
+	return err
+}
+
+// renderDescribe builds a plain-text kubectl-describe-shaped body for the
+// known demo pods, falling back to a minimal generic body for anything else
+// (namespace/context are still echoed so the caller sees the object it
+// asked about, rather than an error).
+func renderDescribe(kind, name, namespace, kctx string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Name:         %s\n", name)
+	fmt.Fprintf(&b, "Namespace:    %s\n", namespace)
+	fmt.Fprintf(&b, "Context:      %s\n", kctx)
+
+	switch name {
+	case demo.PodWebHealthy1, demo.PodWebHealthy2:
+		fmt.Fprintf(&b, "Node:         %s\n", demo.NodeWorker1)
+		b.WriteString("Status:       Running\n")
+		b.WriteString("Containers:\n  web:\n    Image:          ghcr.io/example/web:1.4.2\n" +
+			"    State:          Running\n    Ready:          True\n    Restart Count:  0\n")
+		b.WriteString("Conditions:\n  Ready  True\n")
+	case demo.PodWebCrashLoop:
+		fmt.Fprintf(&b, "Node:         %s\n", demo.NodeWorker1)
+		b.WriteString("Status:       Running\n")
+		b.WriteString("Containers:\n  web:\n    Image:          ghcr.io/example/web:1.4.2\n" +
+			"    State:          Waiting\n    Reason:         CrashLoopBackOff\n" +
+			"    Last State:     Terminated\n    Reason:         Error\n    Exit Code:      1\n" +
+			"    Restart Count:  7\n")
+		b.WriteString("Conditions:\n  Ready  False\n")
+		b.WriteString("Events:\n  Type     Reason   Age   Message\n  ----     ------   ---   -------\n" +
+			"  Warning  BackOff  2m    Back-off restarting failed container=web\n")
+	case demo.PodDBMigrate:
+		fmt.Fprintf(&b, "Node:         %s\n", demo.NodeWorker1)
+		b.WriteString("Status:       Succeeded\n")
+		b.WriteString("Containers:\n  migrate:\n    State:          Terminated\n" +
+			"    Reason:         Completed\n    Exit Code:      0\n")
+	default:
+		fmt.Fprintf(&b, "Kind:         %s\n", kind)
+		b.WriteString("Status:       Running\n")
+		b.WriteString("(no demo seed data for this object; showing a generic description)\n")
+	}
+
+	return b.String()
+}

--- a/internal/democli/describe_test.go
+++ b/internal/democli/describe_test.go
@@ -1,0 +1,34 @@
+package democli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+// TestRun_DescribeDBMigratePod guards against describe.go drifting out of
+// sync with the seed data in internal/k8s/demo/jobs.go, which seeds
+// PodDBMigrate as PodFailed with a Terminated{Reason: "Error", ExitCode: 1}
+// container -- a failed migration, not a completed one.
+func TestRun_DescribeDBMigratePod(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"describe", "pod", demo.PodDBMigrate, "-n", demo.NamespaceJobs, "--context", "demo"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"Failed", "Reason:         Error", "Exit Code:      1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout = %q, want it to contain %q", out, want)
+		}
+	}
+	if strings.Contains(out, "Succeeded") {
+		t.Errorf("stdout = %q, must not report Succeeded for a failed migration pod", out)
+	}
+	if strings.Contains(out, "Completed") {
+		t.Errorf("stdout = %q, must not report Completed for a failed migration pod", out)
+	}
+}

--- a/internal/democli/get.go
+++ b/internal/democli/get.go
@@ -1,0 +1,45 @@
+package democli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// runGet emulates `kubectl get <kind>/<name> -n <ns> --context <ctx> -o
+// json`, the only "get" shape the app issues (kubectlGetPodSelector in
+// internal/app/commands_logs.go, to discover a parent resource's pod
+// selector before following its logs). It returns a minimal JSON object
+// carrying a synthetic selector derived from the resource name, which is
+// enough for the caller to extract a usable "-l" value — the exact label set
+// need not match real cluster data since demo log generation does not filter
+// by it.
+func runGet(args []string, stdout io.Writer) error {
+	var resourceRef string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-n", "--context", "-o":
+			i++ // skip the flag's value; unused by this stub
+		default:
+			if !strings.HasPrefix(args[i], "-") && resourceRef == "" {
+				resourceRef = args[i]
+			}
+		}
+	}
+
+	kind, name, ok := strings.Cut(resourceRef, "/")
+	if !ok {
+		name = resourceRef
+	}
+
+	var body string
+	if strings.EqualFold(kind, "service") {
+		// Service selectors are a flat map, not matchLabels-wrapped.
+		body = fmt.Sprintf(`{"spec":{"selector":{"app":%q}}}`, name)
+	} else {
+		body = fmt.Sprintf(`{"spec":{"selector":{"matchLabels":{"app":%q}}}}`, name)
+	}
+
+	_, err := fmt.Fprintln(stdout, body)
+	return err
+}

--- a/internal/democli/logs.go
+++ b/internal/democli/logs.go
@@ -1,0 +1,135 @@
+package democli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"math/rand"
+	"time"
+)
+
+// defaultTailLines is how many lines to emit when the caller passed no
+// --tail (kubectl's own default backlog size).
+const defaultTailLines = 20
+
+// demoLineInterval paces follow-mode line emission so a streamed session
+// looks live instead of dumping instantly.
+const demoLineInterval = 150 * time.Millisecond
+
+// demoPaths and demoMethods are the synthetic request shapes mixed into the
+// generated access log so Log Top has varied paths/methods to rank.
+var demoPaths = []string{
+	"/api/users", "/api/users/42", "/api/orders", "/api/orders/1183",
+	"/api/products", "/api/products/7", "/healthz", "/readyz", "/api/cart", "/api/checkout",
+}
+
+var demoMethods = []string{"GET", "GET", "GET", "POST", "PUT", "DELETE"}
+
+// runLogs emulates `kubectl logs`. Non-follow requests emit `tail` (or
+// defaultTailLines) historical lines and return. Follow requests replay the
+// same backlog, then keep emitting new lines on demoLineInterval until ctx is
+// cancelled — mirroring a real `-f` stream that only ends when the caller
+// tears down the process.
+func runLogs(ctx context.Context, args []string, stdout io.Writer) error {
+	a := parseLogArgs(args)
+	pod := a.podName()
+	rng := rand.New(rand.NewSource(podSeed(a.namespace, pod, a.container))) //nolint:gosec // deterministic demo data, not security-sensitive
+
+	w := bufio.NewWriter(stdout)
+	defer w.Flush() //nolint:errcheck
+
+	tail := a.tail
+	if tail < 0 {
+		tail = defaultTailLines
+	}
+
+	now := time.Now()
+	for i := range tail {
+		ts := now.Add(-time.Duration(tail-i) * demoLineInterval)
+		if err := writeLogLine(w, rng, a, pod, ts); err != nil {
+			return err
+		}
+	}
+	if !a.follow {
+		return w.Flush()
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(demoLineInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case t := <-ticker.C:
+			if err := writeLogLine(w, rng, a, pod, t); err != nil {
+				return nil // consumer closed the read end; not an error to report
+			}
+			if err := w.Flush(); err != nil {
+				return nil
+			}
+		}
+	}
+}
+
+// writeLogLine renders and writes one line, adding the "[pod/name/container]"
+// prefix kubectl's --prefix flag adds when the app streams all containers.
+func writeLogLine(w io.Writer, rng *rand.Rand, a logArgs, pod string, ts time.Time) error {
+	line := generateLine(rng, pod, ts)
+	if a.prefix {
+		container := a.container
+		if container == "" {
+			container = "app"
+		}
+		line = fmt.Sprintf("[pod/%s/%s] %s", pod, container, line)
+	}
+	_, err := fmt.Fprintln(w, line)
+	return err
+}
+
+// podSeed derives a stable RNG seed from a pod's identity so the same pod
+// always yields the same stream and different pods deterministically diverge.
+func podSeed(namespace, pod, container string) int64 {
+	h := fnv.New64a()
+	_, _ = io.WriteString(h, namespace+"/"+pod+"/"+container)
+	return int64(h.Sum64()) //nolint:gosec // truncation is fine, only used as a PRNG seed
+}
+
+// generateLine renders one synthetic JSON access-log line timestamped ts,
+// prefixed with kubectl's own RFC3339Nano --timestamps format (which is what
+// every real call site requests). The JSON body uses logagg's normalized
+// field names directly (method/path/status/duration_ms/host) so
+// logagg.ParserFor(logagg.ProfileJSON) groups it without any aliasing.
+func generateLine(rng *rand.Rand, pod string, ts time.Time) string {
+	method := demoMethods[rng.Intn(len(demoMethods))]
+	path := demoPaths[rng.Intn(len(demoPaths))]
+	status := statusOutcome(rng)
+	durationMS := 2 + rng.Float64()*40
+	switch {
+	case status >= 500:
+		durationMS += 200 + rng.Float64()*300
+	case status >= 400:
+		durationMS += 20
+	}
+	return fmt.Sprintf(
+		`%s {"level":"info","method":%q,"path":%q,"status":%d,"duration_ms":%.2f,"host":%q,"msg":"request handled"}`,
+		ts.Format(time.RFC3339Nano), method, path, status, durationMS, pod,
+	)
+}
+
+// statusOutcome picks an HTTP status weighted mostly-200 with a handful of
+// 4xx/5xx so the Log Top aggregation has real errors to rank.
+func statusOutcome(rng *rand.Rand) int {
+	switch roll := rng.Intn(100); {
+	case roll < 85:
+		return []int{200, 200, 200, 201, 204}[rng.Intn(5)]
+	case roll < 95:
+		return []int{400, 401, 404, 404}[rng.Intn(4)]
+	default:
+		return []int{500, 502, 503}[rng.Intn(3)]
+	}
+}

--- a/internal/democli/logs.go
+++ b/internal/democli/logs.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"math/rand"
 	"time"
+
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 // defaultTailLines is how many lines to emit when the caller passed no
@@ -78,6 +80,13 @@ func runLogs(ctx context.Context, args []string, stdout io.Writer) error {
 
 // writeLogLine renders and writes one line, adding the "[pod/name/container]"
 // prefix kubectl's --prefix flag adds when the app streams all containers.
+//
+// pod is attacker-controllable: the demo apply path builds it from
+// metadata.name in arbitrary user-supplied YAML with no RFC1123 validation
+// (see Client.ApplyManifest), so it can carry terminal escape sequences.
+// Sanitized here (not just at the write side) as defense in depth, the same
+// way listsummary and yamlblame guard their own sinks against
+// cluster-controlled strings.
 func writeLogLine(w io.Writer, rng *rand.Rand, a logArgs, pod string, ts time.Time) error {
 	line := generateLine(rng, pod, ts)
 	if a.prefix {
@@ -85,7 +94,7 @@ func writeLogLine(w io.Writer, rng *rand.Rand, a logArgs, pod string, ts time.Ti
 		if container == "" {
 			container = "app"
 		}
-		line = fmt.Sprintf("[pod/%s/%s] %s", pod, container, line)
+		line = fmt.Sprintf("[pod/%s/%s] %s", ui.SanitizeTerminalText(pod), ui.SanitizeTerminalText(container), line)
 	}
 	_, err := fmt.Fprintln(w, line)
 	return err

--- a/internal/democli/logs_test.go
+++ b/internal/democli/logs_test.go
@@ -203,3 +203,27 @@ func TestRunLogs_FollowTerminatesOnContextCancel(t *testing.T) {
 		t.Errorf("goroutine count after cancel = %d, want <= baseline %d (leak)", got, baseline)
 	}
 }
+
+// TestRunLogs_SanitizesPodNameInPrefix guards TASK-865 finding 4: the demo
+// apply path accepts arbitrary YAML with no RFC1123 name validation, so a
+// crafted metadata.name can carry a terminal escape sequence. That name
+// reaches here unescaped, in the "[pod/name/container]" prefix generated
+// log lines carry. Fixing name validation on the write side (ApplyManifest)
+// is necessary but not sufficient defense in depth — this sink must also
+// sanitize before writing, the same way listsummary and yamlblame already
+// do via ui.SanitizeTerminalText.
+func TestRunLogs_SanitizesPodNameInPrefix(t *testing.T) {
+	const evilEscape = "\x1b[31m"
+	evilPod := "web" + evilEscape + "HACKED\x1b[0m"
+
+	var buf bytes.Buffer
+	args := []string{evilPod, "-n", "demo", "--context", "demo", "--prefix", "--tail=1"}
+
+	if err := runLogs(t.Context(), args, &buf); err != nil {
+		t.Fatalf("runLogs() error = %v", err)
+	}
+
+	if out := buf.String(); strings.Contains(out, evilEscape) {
+		t.Fatalf("expected the pod name's escape sequence to be sanitized out of the log prefix, got: %q", out)
+	}
+}

--- a/internal/democli/logs_test.go
+++ b/internal/democli/logs_test.go
@@ -1,0 +1,205 @@
+package democli
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/janosmiko/lfk/internal/logagg"
+)
+
+// TestRunLogs_RoundTripsThroughLogagg is the criterion-4 proof: generated log
+// lines, once the app strips the pod prefix and timestamp (as
+// logTopSample/logTopParseInto do), must parse as ProfileJSON and carry
+// fields the Top view groups by (method, path, status, duration_ms).
+func TestRunLogs_RoundTripsThroughLogagg(t *testing.T) {
+	var buf bytes.Buffer
+	args := []string{
+		"web-7d8f9c6b5-9k2pl", "-n", "demo", "--context", "demo",
+		"--all-containers=true", "--prefix", "--tail=30", "--timestamps",
+	}
+
+	if err := runLogs(t.Context(), args, &buf); err != nil {
+		t.Fatalf("runLogs() error = %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 30 {
+		t.Fatalf("got %d lines, want 30", len(lines))
+	}
+
+	sample := make([]string, len(lines))
+	for i, line := range lines {
+		sample[i] = stripPrefixAndTimestamp(t, line)
+	}
+
+	kind := logagg.DetectKind(sample)
+	if kind != logagg.ProfileJSON {
+		t.Fatalf("DetectKind() = %v, want %v", kind, logagg.ProfileJSON)
+	}
+
+	parser := logagg.ParserFor(kind)
+	var saw4xx, saw5xx bool
+	for _, body := range sample {
+		f, ok := parser.Parse(body)
+		if !ok {
+			t.Fatalf("parser.Parse(%q) failed", body)
+		}
+		for _, key := range []string{logagg.FieldMethod, logagg.FieldPath, logagg.FieldStatus, logagg.FieldDurationMS} {
+			if f[key] == "" {
+				t.Errorf("line %q missing field %q after parse", body, key)
+			}
+		}
+		if logagg.IsHTTPError(f) {
+			if strings.HasPrefix(f[logagg.FieldStatus], "4") {
+				saw4xx = true
+			}
+			if strings.HasPrefix(f[logagg.FieldStatus], "5") {
+				saw5xx = true
+			}
+		}
+	}
+
+	// Build an aggregation the same way the app's Log Top view does, and
+	// confirm the generated lines actually group.
+	agg := logagg.NewAggregation([]string{logagg.FieldMethod, logagg.FieldPath}, nil, logagg.IsHTTPError)
+	for _, body := range sample {
+		if f, ok := parser.Parse(body); ok {
+			agg.Add(f)
+		}
+	}
+	if agg.Total() != 30 {
+		t.Fatalf("aggregation total = %d, want 30", agg.Total())
+	}
+	if len(agg.Rows(logagg.SortReq)) == 0 {
+		t.Fatalf("aggregation produced no rows")
+	}
+	if !saw4xx && !saw5xx {
+		t.Logf("no 4xx/5xx in this 30-line sample; acceptable but worth widening tail if flaky")
+	}
+}
+
+// stripPrefixAndTimestamp mirrors ui.StripPodPrefix + logagg.SplitTimestamp
+// so the test exercises the exact transformation the app performs before
+// handing a line to the parser.
+func stripPrefixAndTimestamp(t *testing.T, line string) string {
+	t.Helper()
+	if strings.HasPrefix(line, "[") {
+		_, rest, ok := strings.Cut(line, "] ")
+		if !ok {
+			t.Fatalf("line %q has a bracket prefix with no closing '] '", line)
+		}
+		line = rest
+	}
+	if _, rest, ok := logagg.SplitTimestamp(line); ok {
+		return rest
+	}
+	t.Fatalf("line %q has no parseable leading RFC3339Nano timestamp", line)
+	return ""
+}
+
+func TestRunLogs_DeterministicPerPod(t *testing.T) {
+	run := func(target string) string {
+		var buf bytes.Buffer
+		args := []string{target, "-n", "demo", "--context", "demo", "--tail=10", "--timestamps"}
+		if err := runLogs(t.Context(), args, &buf); err != nil {
+			t.Fatalf("runLogs() error = %v", err)
+		}
+		// Timestamps are wall-clock and vary run to run; compare only the
+		// JSON body (after the timestamp) for stability.
+		var bodies []string
+		for line := range strings.SplitSeq(strings.TrimRight(buf.String(), "\n"), "\n") {
+			if _, rest, ok := logagg.SplitTimestamp(line); ok {
+				bodies = append(bodies, rest)
+			}
+		}
+		return strings.Join(bodies, "\n")
+	}
+
+	first := run("web-7d8f9c6b5-9k2pl")
+	second := run("web-7d8f9c6b5-9k2pl")
+	if first != second {
+		t.Errorf("same pod produced different streams:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+
+	other := run("web-7d8f9c6b5-x7bwn")
+	if first == other {
+		t.Errorf("different pods produced identical streams")
+	}
+}
+
+func TestRunLogs_PrefixFormat(t *testing.T) {
+	var buf bytes.Buffer
+	args := []string{
+		"web-7d8f9c6b5-9k2pl", "-n", "demo", "--context", "demo",
+		"--all-containers=true", "--prefix", "--tail=1", "--timestamps",
+	}
+	if err := runLogs(t.Context(), args, &buf); err != nil {
+		t.Fatalf("runLogs() error = %v", err)
+	}
+	line := strings.TrimRight(buf.String(), "\n")
+	want := "[pod/web-7d8f9c6b5-9k2pl/app] "
+	if !strings.HasPrefix(line, want) {
+		t.Errorf("line = %q, want prefix %q", line, want)
+	}
+}
+
+func TestRunLogs_ContainerFlagOmitsPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	args := []string{
+		"web-7d8f9c6b5-9k2pl", "-n", "demo", "--context", "demo",
+		"-c", "web", "--tail=1", "--timestamps",
+	}
+	if err := runLogs(t.Context(), args, &buf); err != nil {
+		t.Fatalf("runLogs() error = %v", err)
+	}
+	line := strings.TrimRight(buf.String(), "\n")
+	if strings.HasPrefix(line, "[pod/") {
+		t.Errorf("line = %q, want no bracket prefix when -c is set without --prefix", line)
+	}
+}
+
+// TestRunLogs_FollowTerminatesOnContextCancel is the leak-guard proof:
+// follow mode must return promptly when the caller's context is cancelled,
+// and must not leave any goroutine of its own running afterward.
+func TestRunLogs_FollowTerminatesOnContextCancel(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	args := []string{
+		"web-7d8f9c6b5-9k2pl", "-n", "demo", "--context", "demo",
+		"-f", "--tail=0", "--timestamps",
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		var buf bytes.Buffer
+		done <- runLogs(ctx, args, &buf)
+	}()
+
+	// Give the goroutine a moment to enter the follow select loop, then cancel.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("runLogs() error = %v, want nil on context cancel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runLogs() did not return within 2s of context cancellation")
+	}
+
+	// Allow the runtime a brief window to finish tearing down the goroutine's
+	// stack before comparing counts.
+	deadline := time.Now().Add(time.Second)
+	for runtime.NumGoroutine() > baseline && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := runtime.NumGoroutine(); got > baseline {
+		t.Errorf("goroutine count after cancel = %d, want <= baseline %d (leak)", got, baseline)
+	}
+}

--- a/internal/k8s/alerts.go
+++ b/internal/k8s/alerts.go
@@ -41,6 +41,9 @@ type prometheusAlert struct {
 // It uses the Kubernetes API server proxy to reach Prometheus services in well-known
 // monitoring namespaces without requiring direct network access or port-forward.
 func (c *Client) GetActiveAlerts(ctx context.Context, kubeCtx, namespace, resourceName, resourceKind string) ([]AlertInfo, error) {
+	if c.demo {
+		return nil, errPrometheusUnavailableDemo
+	}
 	clientset, err := c.clientsetForContext(kubeCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get clientset: %w", err)
@@ -52,8 +55,7 @@ func (c *Client) GetActiveAlerts(ctx context.Context, kubeCtx, namespace, resour
 	var lastErr error
 	for _, ns := range promNs {
 		for _, svc := range promSvc {
-			result := clientset.CoreV1().Services(ns).ProxyGet("http", svc, promPort, "/api/v1/alerts", nil)
-			data, err := result.DoRaw(ctx)
+			data, err := safeProxyGetRaw(ctx, clientset, ns, svc, promPort, "/api/v1/alerts", nil)
 			if err != nil {
 				lastErr = err
 				continue
@@ -71,8 +73,7 @@ func (c *Client) GetActiveAlerts(ctx context.Context, kubeCtx, namespace, resour
 	// Try Alertmanager as fallback.
 	for _, ns := range amNs {
 		for _, svc := range amSvc {
-			result := clientset.CoreV1().Services(ns).ProxyGet("http", svc, amPort, "/api/v2/alerts", nil)
-			data, err := result.DoRaw(ctx)
+			data, err := safeProxyGetRaw(ctx, clientset, ns, svc, amPort, "/api/v2/alerts", nil)
 			if err != nil {
 				lastErr = err
 				continue
@@ -137,6 +138,9 @@ func parseAndFilterAlerts(data []byte, resourceNs, resourceName, resourceKind st
 // Pass an empty namespace to retrieve alerts across all namespaces.
 // It tries Prometheus first, then falls back to Alertmanager if Prometheus is not reachable.
 func (c *Client) GetAllActiveAlerts(ctx context.Context, kubeCtx, namespace string) ([]AlertInfo, error) {
+	if c.demo {
+		return nil, errPrometheusUnavailableDemo
+	}
 	clientset, err := c.clientsetForContext(kubeCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get clientset: %w", err)
@@ -148,8 +152,7 @@ func (c *Client) GetAllActiveAlerts(ctx context.Context, kubeCtx, namespace stri
 	var lastErr error
 	for _, ns := range promNs {
 		for _, svc := range promSvc {
-			result := clientset.CoreV1().Services(ns).ProxyGet("http", svc, promPort, "/api/v1/alerts", nil)
-			data, err := result.DoRaw(ctx)
+			data, err := safeProxyGetRaw(ctx, clientset, ns, svc, promPort, "/api/v1/alerts", nil)
 			if err != nil {
 				lastErr = err
 				continue
@@ -167,8 +170,7 @@ func (c *Client) GetAllActiveAlerts(ctx context.Context, kubeCtx, namespace stri
 	// Try Alertmanager as fallback.
 	for _, ns := range amNs {
 		for _, svc := range amSvc {
-			result := clientset.CoreV1().Services(ns).ProxyGet("http", svc, amPort, "/api/v2/alerts", nil)
-			data, err := result.DoRaw(ctx)
+			data, err := safeProxyGetRaw(ctx, clientset, ns, svc, amPort, "/api/v2/alerts", nil)
 			if err != nil {
 				lastErr = err
 				continue

--- a/internal/k8s/apply_manifest_demo_test.go
+++ b/internal/k8s/apply_manifest_demo_test.go
@@ -1,0 +1,75 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+// TestApplyManifest_RejectsInvalidRFC1123Name guards TASK-865 finding 4:
+// the demo apply path decodes arbitrary YAML with no name validation the
+// way a real apiserver would perform. A crafted metadata.name carrying a
+// bidi-override character (a raw ASCII escape byte like \x1b is already
+// rejected by the YAML decoder itself — "control characters are not
+// allowed" — so it can't reach the name-validation path this test targets)
+// must never reach the fake dynamic client's tracker, since
+// democli/logs.go later formats pod names into generated log output.
+func TestApplyManifest_RejectsInvalidRFC1123Name(t *testing.T) {
+	cs := demo.NewClientset()
+	dyn := demo.NewDynamicClient()
+	c := newFakeClient(cs, dyn)
+
+	const evilChar = "\u202e" // RIGHT-TO-LEFT OVERRIDE
+	const evilName = "web" + evilChar + "HACKED"
+	manifest := "apiVersion: v1\n" +
+		"kind: Pod\n" +
+		"metadata:\n" +
+		"  name: \"" + evilName + "\"\n" +
+		"  namespace: demo\n" +
+		"spec:\n" +
+		"  containers:\n" +
+		"  - name: app\n" +
+		"    image: nginx\n"
+
+	err := c.ApplyManifest(t.Context(), "test-ctx", demo.NamespaceDemo, manifest)
+	require.Error(t, err, "expected ApplyManifest to reject an invalid RFC1123 name")
+
+	list, listErr := dyn.Resource(schema.GroupVersionResource{Version: "v1", Resource: "pods"}).
+		Namespace(demo.NamespaceDemo).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	for _, item := range list.Items {
+		assert.NotContains(t, item.GetName(), evilChar,
+			"a manifest with an invalid name must never reach the fake tracker")
+	}
+}
+
+// TestApplyManifest_AcceptsValidRFC1123Name is the control case: a
+// well-formed name must still apply cleanly.
+func TestApplyManifest_AcceptsValidRFC1123Name(t *testing.T) {
+	cs := demo.NewClientset()
+	dyn := demo.NewDynamicClient()
+	c := newFakeClient(cs, dyn)
+
+	manifest := "apiVersion: v1\n" +
+		"kind: Pod\n" +
+		"metadata:\n" +
+		"  name: web-valid-1\n" +
+		"  namespace: demo\n" +
+		"spec:\n" +
+		"  containers:\n" +
+		"  - name: app\n" +
+		"    image: nginx\n"
+
+	err := c.ApplyManifest(t.Context(), "test-ctx", demo.NamespaceDemo, manifest)
+	require.NoError(t, err)
+
+	_, getErr := dyn.Resource(schema.GroupVersionResource{Version: "v1", Resource: "pods"}).
+		Namespace(demo.NamespaceDemo).Get(t.Context(), "web-valid-1", metav1.GetOptions{})
+	require.NoError(t, getErr, "expected the valid pod to have been created")
+}

--- a/internal/k8s/apply_manifest_get_error_test.go
+++ b/internal/k8s/apply_manifest_get_error_test.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+// TestApplyManifest_SurfacesNonNotFoundGetError guards against ApplyManifest
+// treating a Forbidden (or any non-NotFound) Get error as "object absent,
+// go ahead and Create" -- that would run a blocked read as a write instead
+// of surfacing the real failure to the caller.
+func TestApplyManifest_SurfacesNonNotFoundGetError(t *testing.T) {
+	cs := demo.NewClientset()
+	dyn := demo.NewDynamicClient()
+	dyn.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "web", nil)
+	})
+	c := newFakeClient(cs, dyn)
+
+	manifest := "apiVersion: v1\n" +
+		"kind: Pod\n" +
+		"metadata:\n" +
+		"  name: web\n" +
+		"  namespace: demo\n" +
+		"spec:\n" +
+		"  containers:\n" +
+		"  - name: app\n" +
+		"    image: nginx\n"
+
+	err := c.ApplyManifest(t.Context(), "test-ctx", "demo", manifest)
+	require.Error(t, err, "expected ApplyManifest to surface a non-NotFound Get error instead of treating it as absence")
+	assert.Contains(t, err.Error(), "forbidden")
+}

--- a/internal/k8s/apply_manifest_namespace_test.go
+++ b/internal/k8s/apply_manifest_namespace_test.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+// manifestWithNamespace builds a minimal Pod manifest for the given
+// namespace, reused across the namespace-validation tests below.
+func manifestWithNamespace(namespace string) string {
+	return "apiVersion: v1\n" +
+		"kind: Pod\n" +
+		"metadata:\n" +
+		"  name: web\n" +
+		"  namespace: \"" + namespace + "\"\n" +
+		"spec:\n" +
+		"  containers:\n" +
+		"  - name: app\n" +
+		"    image: nginx\n"
+}
+
+// TestApplyManifest_RejectsBidiNamespace guards TASK-865 finding 1: the
+// reviewer's exact case, a namespace carrying a RIGHT-TO-LEFT OVERRIDE
+// character. Without namespace validation this reaches the fake tracker
+// and later surfaces unescaped in render paths that format "namespace/name"
+// (resourceTitleLabel in internal/app/view_status.go).
+func TestApplyManifest_RejectsBidiNamespace(t *testing.T) {
+	cs := demo.NewClientset()
+	dyn := demo.NewDynamicClient()
+	c := newFakeClient(cs, dyn)
+
+	const evilChar = "\u202e" // RIGHT-TO-LEFT OVERRIDE
+	const evilNamespace = "demo" + evilChar + "HACKED"
+
+	err := c.ApplyManifest(t.Context(), "test-ctx", evilNamespace, manifestWithNamespace(evilNamespace))
+	require.Error(t, err, "expected ApplyManifest to reject a namespace carrying a bidi override character")
+
+	list, listErr := dyn.Resource(schema.GroupVersionResource{Version: "v1", Resource: "pods"}).
+		Namespace(evilNamespace).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	for _, item := range list.Items {
+		assert.NotContains(t, item.GetNamespace(), evilChar,
+			"a manifest with an invalid namespace must never reach the fake tracker")
+	}
+}
+
+// TestApplyManifest_RejectsNamespaceBreakingRFC1123Label guards the "not
+// the same rule as the name" half of finding 1: a namespace is an RFC1123
+// label, not a subdomain, so a dotted value that would pass
+// IsDNS1123Subdomain (like a valid DNS name) must still be rejected.
+func TestApplyManifest_RejectsNamespaceBreakingRFC1123Label(t *testing.T) {
+	cs := demo.NewClientset()
+	dyn := demo.NewDynamicClient()
+	c := newFakeClient(cs, dyn)
+
+	const dottedNamespace = "demo.example" // valid subdomain, invalid label
+
+	err := c.ApplyManifest(t.Context(), "test-ctx", dottedNamespace, manifestWithNamespace(dottedNamespace))
+	require.Error(t, err, "expected ApplyManifest to reject a namespace that is a valid subdomain but not a valid RFC1123 label")
+}
+
+// TestApplyManifest_AcceptsValidNamespace is the control case: a
+// well-formed RFC1123 label namespace must still apply cleanly.
+func TestApplyManifest_AcceptsValidNamespace(t *testing.T) {
+	cs := demo.NewClientset()
+	dyn := demo.NewDynamicClient()
+	c := newFakeClient(cs, dyn)
+
+	const validNamespace = "demo-valid-1"
+
+	err := c.ApplyManifest(t.Context(), "test-ctx", validNamespace, manifestWithNamespace(validNamespace))
+	require.NoError(t, err)
+
+	_, getErr := dyn.Resource(schema.GroupVersionResource{Version: "v1", Resource: "pods"}).
+		Namespace(validNamespace).Get(t.Context(), "web", metav1.GetOptions{})
+	require.NoError(t, getErr, "expected the valid pod to have been created")
+}

--- a/internal/k8s/capture_backend_kubectl_debug.go
+++ b/internal/k8s/capture_backend_kubectl_debug.go
@@ -59,7 +59,7 @@ func (kubectlDebugBackend) Start(ctx context.Context, req CaptureRequest) (io.Re
 	}
 	debugContainer := makeDebugContainerName(time.Now())
 	cctx, cancel := context.WithCancel(ctx)
-	cmd := exec.CommandContext(cctx, kubectlPath, kubectlDebugArgv(req, debugContainer)...)
+	cmd := exec.CommandContext(cctx, kubectlPath, DemoKubectlArgs(kubectlDebugArgv(req, debugContainer))...)
 	cmd.Env = os.Environ()
 
 	stdout, err := cmd.StdoutPipe()
@@ -143,7 +143,7 @@ func terminateRemoteCapture(req CaptureRequest, kubectlPath, debugContainer stri
 		// case where the process is already gone.
 		"kill -TERM 1 2>/dev/null || true; sleep 1; kill -KILL 1 2>/dev/null || true",
 	}
-	cmd := exec.CommandContext(ctx, kubectlPath, args...)
+	cmd := exec.CommandContext(ctx, kubectlPath, DemoKubectlArgs(args)...)
 	if err := cmd.Run(); err != nil {
 		logger.Error("remote capture termination failed",
 			"namespace", req.Namespace, "pod", req.PodName,

--- a/internal/k8s/capture_backend_kubectl_debug.go
+++ b/internal/k8s/capture_backend_kubectl_debug.go
@@ -53,7 +53,7 @@ func makeDebugContainerName(now time.Time) string {
 var remoteCaptureKiller = terminateRemoteCapture
 
 func (kubectlDebugBackend) Start(ctx context.Context, req CaptureRequest) (io.ReadCloser, context.CancelFunc, *exec.Cmd, *stderrBuffer, error) {
-	kubectlPath, err := exec.LookPath("kubectl")
+	kubectlPath, err := KubectlPath()
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("kubectl not in PATH: %w", err)
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -399,6 +399,15 @@ func (c *Client) ApplyManifest(ctx context.Context, contextName, defaultNamespac
 			if ns == "" {
 				ns = defaultNamespace
 			}
+			// A namespace is an RFC1123 label, not a subdomain like the name
+			// above — it cannot contain dots. Same admission gap as the name
+			// check: reject before the value reaches the tracker, since it
+			// surfaces unescaped in resourceTitleLabel's "namespace/name"
+			// render used across the YAML, object explorer, logs, describe,
+			// exec, and events sub-titles.
+			if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+				return fmt.Errorf("invalid namespace %q for %s: %s", ns, obj.GetKind(), strings.Join(errs, "; "))
+			}
 			obj.SetNamespace(ns)
 			ri = res.Namespace(ns)
 		}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -71,12 +71,18 @@ type Client struct {
 	// matches clientcmd's first-writer-wins merge rule for current-context.
 	currentContext string
 
-	// testClientset, testDynClient, and testMetaClient allow tests to inject
-	// fake clients. When set, the corresponding *ForContext helpers return
-	// these instead of building real clients from the kubeconfig.
-	testClientset  any // kubernetes.Interface (avoid import cycle in non-test code)
-	testDynClient  any // dynamic.Interface
-	testMetaClient any // metadata.Interface
+	// injectedClientset, injectedDynClient, and injectedMetaClient let tests
+	// (and NewDemoClient) inject fake clients. When set, the corresponding
+	// *ForContext helpers return these instead of building real clients from
+	// the kubeconfig.
+	injectedClientset  any // kubernetes.Interface (avoid import cycle in non-test code)
+	injectedDynClient  any // dynamic.Interface
+	injectedMetaClient any // metadata.Interface
+
+	// demo is true when this Client was built by NewDemoClient (--demo flag).
+	// It never talks to a real cluster; IsDemo lets the app layer surface a
+	// badge instead of inspecting the injected fields directly.
+	demo bool
 
 	// testPromQuery, when set, replaces the real Service.ProxyGet
 	// pipeline used by the right-sizing Prometheus strategies. Tests
@@ -189,6 +195,13 @@ type Client struct {
 	// by default; toggled via the security ignore-list overlay. Read via
 	// securityIgnoreSnapshot.
 	showIgnored bool
+}
+
+// IsDemo reports whether this Client was built by NewDemoClient (--demo
+// flag) rather than against a real kubeconfig. Nil-safe so callers don't
+// need a guard before checking a possibly-unset client.
+func (c *Client) IsDemo() bool {
+	return c != nil && c.demo
 }
 
 // informerSnapshot returns the current routing config as a single

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/dynamic"
@@ -369,6 +370,14 @@ func (c *Client) ApplyManifest(ctx context.Context, contextName, defaultNamespac
 		}
 		if obj.GetKind() == "" {
 			continue
+		}
+		// The fake dynamic client performs none of a real apiserver's admission
+		// validation, so a crafted metadata.name here would otherwise reach the
+		// tracker unchanged and later surface unescaped in generated output
+		// (e.g. democli/logs.go's pod-name prefix). Reject anything that isn't
+		// a valid RFC1123 subdomain before it is ever created or updated.
+		if errs := validation.IsDNS1123Subdomain(obj.GetName()); len(errs) > 0 {
+			return fmt.Errorf("invalid name %q for %s: %s", obj.GetName(), obj.GetKind(), strings.Join(errs, "; "))
 		}
 
 		gvk := obj.GroupVersionKind()

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -12,13 +12,24 @@ import (
 
 	"golang.org/x/sync/singleflight"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/disk"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/yaml"
 
+	"github.com/janosmiko/lfk/internal/k8s/demo"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/security"
 )
+
+// applyFieldManager marks writes ApplyManifest makes through the dynamic
+// client, matching the field-manager convention demo.Ticker uses for its
+// own mutations.
+const applyFieldManager = "lfk"
 
 // contextInfo decorates a kubeconfig context with its source file plus a
 // display name that is unique across all loaded files. When several
@@ -83,6 +94,12 @@ type Client struct {
 	// It never talks to a real cluster; IsDemo lets the app layer surface a
 	// badge instead of inspecting the injected fields directly.
 	demo bool
+
+	// demoTicker drives periodic mutations against the demo backend's fake
+	// dynamic client (see internal/k8s/demo.Ticker). Nil for real clients;
+	// NewDemoClient starts it and Shutdown stops it, so its goroutine never
+	// outlives this Client.
+	demoTicker *demo.Ticker
 
 	// testPromQuery, when set, replaces the real Service.ProxyGet
 	// pipeline used by the right-sizing Prometheus strategies. Tests
@@ -307,10 +324,87 @@ func (c *Client) SetInformerCacheMode(mode InformerCacheMode) {
 // future stream subscribers). Idempotent and safe to call from a defer in
 // main.go even when no informers were ever started.
 func (c *Client) Shutdown() {
+	if c.demoTicker != nil {
+		c.demoTicker.Stop()
+	}
 	_, infs := c.informerSnapshot()
 	if infs != nil {
 		infs.Stop()
 	}
+}
+
+// ApplyManifest decodes a (possibly multi-document) YAML manifest and
+// creates or updates each object through the dynamic client — no kubectl
+// subprocess. Demo mode's fake dynamic client lives only in this process,
+// so a subprocess kubectl would write into a separate in-memory tracker the
+// UI never reads from; this is the apply path demo mode must use to
+// actually change what the UI shows. defaultNamespace fills in any object
+// that leaves metadata.namespace unset, matching kubectl apply -n.
+func (c *Client) ApplyManifest(ctx context.Context, contextName, defaultNamespace, manifest string) error {
+	dyn, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return fmt.Errorf("getting dynamic client: %w", err)
+	}
+	dc, err := c.discoveryForContext(contextName)
+	if err != nil {
+		return fmt.Errorf("getting discovery client: %w", err)
+	}
+	// ServerPreferredResources + convertAPIResourceLists, not the fuller
+	// DiscoverAPIResources: that also lists CustomResourceDefinitions for
+	// printer columns, which the demo backend's fake dynamic client isn't
+	// registered to LIST and would panic on.
+	lists, err := discovery.ServerPreferredResources(dc)
+	if err != nil {
+		return fmt.Errorf("discovering api resources: %w", err)
+	}
+	entries := convertAPIResourceLists(lists)
+
+	for _, doc := range splitYAMLDocuments(manifest) {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+			return fmt.Errorf("decoding manifest: %w", err)
+		}
+		if obj.GetKind() == "" {
+			continue
+		}
+
+		gvk := obj.GroupVersionKind()
+		var rt *model.ResourceTypeEntry
+		for i := range entries {
+			if entries[i].Kind == gvk.Kind && entries[i].APIGroup == gvk.Group && entries[i].APIVersion == gvk.Version {
+				rt = &entries[i]
+				break
+			}
+		}
+		if rt == nil {
+			return fmt.Errorf("no known resource type for %s", gvk.String())
+		}
+
+		res := dyn.Resource(schema.GroupVersionResource{Group: rt.APIGroup, Version: rt.APIVersion, Resource: rt.Resource})
+		var ri dynamic.ResourceInterface = res
+		if rt.Namespaced {
+			ns := obj.GetNamespace()
+			if ns == "" {
+				ns = defaultNamespace
+			}
+			obj.SetNamespace(ns)
+			ri = res.Namespace(ns)
+		}
+
+		if existing, getErr := ri.Get(ctx, obj.GetName(), metav1.GetOptions{}); getErr == nil {
+			obj.SetResourceVersion(existing.GetResourceVersion())
+			_, err = ri.Update(ctx, &obj, metav1.UpdateOptions{FieldManager: applyFieldManager})
+		} else {
+			_, err = ri.Create(ctx, &obj, metav1.CreateOptions{FieldManager: applyFieldManager})
+		}
+		if err != nil {
+			return fmt.Errorf("applying %s/%s: %w", gvk.Kind, obj.GetName(), err)
+		}
+	}
+	return nil
 }
 
 // NewClient creates a new Kubernetes client, loading configs from:

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 
 	"golang.org/x/sync/singleflight"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -412,11 +413,15 @@ func (c *Client) ApplyManifest(ctx context.Context, contextName, defaultNamespac
 			ri = res.Namespace(ns)
 		}
 
-		if existing, getErr := ri.Get(ctx, obj.GetName(), metav1.GetOptions{}); getErr == nil {
+		existing, getErr := ri.Get(ctx, obj.GetName(), metav1.GetOptions{})
+		switch {
+		case getErr == nil:
 			obj.SetResourceVersion(existing.GetResourceVersion())
 			_, err = ri.Update(ctx, &obj, metav1.UpdateOptions{FieldManager: applyFieldManager})
-		} else {
+		case apierrors.IsNotFound(getErr):
 			_, err = ri.Create(ctx, &obj, metav1.CreateOptions{FieldManager: applyFieldManager})
+		default:
+			return fmt.Errorf("checking existing %s/%s: %w", gvk.Kind, obj.GetName(), getErr)
 		}
 		if err != nil {
 			return fmt.Errorf("applying %s/%s: %w", gvk.Kind, obj.GetName(), err)

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -26,8 +26,8 @@ import (
 // newFakeClient creates a Client with injected fake clientset and dynamic client.
 func newFakeClient(cs *k8sfake.Clientset, dc *dynamicfake.FakeDynamicClient) *Client {
 	return &Client{
-		testClientset: cs,
-		testDynClient: dc,
+		injectedClientset: cs,
+		injectedDynClient: dc,
 	}
 }
 

--- a/internal/k8s/client_operations.go
+++ b/internal/k8s/client_operations.go
@@ -493,8 +493,8 @@ func (c *Client) restConfigForContextThrottled(displayName string) (*rest.Config
 func (c *Client) clientsetForContext(contextName string) (kubernetes.Interface, error) {
 	// Allow tests to inject a fake clientset (before the cache so fakes are
 	// never memoized and every test sees its injected client).
-	if c.testClientset != nil {
-		if cs, ok := c.testClientset.(kubernetes.Interface); ok {
+	if c.injectedClientset != nil {
+		if cs, ok := c.injectedClientset.(kubernetes.Interface); ok {
 			return cs, nil
 		}
 	}
@@ -505,8 +505,8 @@ func (c *Client) clientsetForContext(contextName string) (kubernetes.Interface, 
 
 func (c *Client) dynamicForContext(contextName string) (dynamic.Interface, error) {
 	// Allow tests to inject a fake dynamic client (before the cache).
-	if c.testDynClient != nil {
-		if dc, ok := c.testDynClient.(dynamic.Interface); ok {
+	if c.injectedDynClient != nil {
+		if dc, ok := c.injectedDynClient.(dynamic.Interface); ok {
 			return dc, nil
 		}
 	}
@@ -574,8 +574,8 @@ func (c *Client) RawClientsetForContextThrottled(contextName string) kubernetes.
 	if contextName == "" {
 		return nil
 	}
-	if c.testClientset != nil {
-		if cs, ok := c.testClientset.(kubernetes.Interface); ok {
+	if c.injectedClientset != nil {
+		if cs, ok := c.injectedClientset.(kubernetes.Interface); ok {
 			return cs
 		}
 	}
@@ -594,8 +594,8 @@ func (c *Client) RawDynamicForContextThrottled(contextName string) dynamic.Inter
 	if contextName == "" {
 		return nil
 	}
-	if c.testDynClient != nil {
-		if dc, ok := c.testDynClient.(dynamic.Interface); ok {
+	if c.injectedDynClient != nil {
+		if dc, ok := c.injectedDynClient.(dynamic.Interface); ok {
 			return dc
 		}
 	}
@@ -609,11 +609,11 @@ func (c *Client) RawDynamicForContextThrottled(contextName string) dynamic.Inter
 }
 
 // metadataForContext returns a metadata-only client for the given context.
-// When testMetaClient is set (tests), it is returned directly.
+// When injectedMetaClient is set (tests), it is returned directly.
 func (c *Client) metadataForContext(contextName string) (metadata.Interface, error) {
 	// Allow tests to inject a fake metadata client (before the cache).
-	if c.testMetaClient != nil {
-		if mc, ok := c.testMetaClient.(metadata.Interface); ok {
+	if c.injectedMetaClient != nil {
+		if mc, ok := c.injectedMetaClient.(metadata.Interface); ok {
 			return mc, nil
 		}
 	}

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -152,9 +152,15 @@ func (c *Client) queryPromContainerMetric(ctx context.Context, contextName, quer
 
 // runPrometheusQuery dispatches a Prometheus instant query through the
 // configured Service.ProxyGet pipeline. Tests override via testPromQuery.
+// Demo mode is turned away before ever building a request: the demo
+// backend's fake clientset panics inside ProxyGet itself (see
+// errPrometheusUnavailableDemo), so it must never be called even once.
 func (c *Client) runPrometheusQuery(ctx context.Context, contextName, query string) ([]byte, error) {
 	if c.testPromQuery != nil {
 		return c.testPromQuery(ctx, contextName, query)
+	}
+	if c.demo {
+		return nil, errPrometheusUnavailableDemo
 	}
 	cs, err := c.clientsetForContext(contextName)
 	if err != nil {
@@ -169,8 +175,7 @@ func (c *Client) runPrometheusQuery(ctx context.Context, contextName, query stri
 	doQuery := func(ns, svc string) ([]byte, error) {
 		rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		result := cs.CoreV1().Services(ns).ProxyGet("http", svc, promPort, "/api/v1/query", params)
-		return result.DoRaw(rctx)
+		return safeProxyGetRaw(rctx, cs, ns, svc, promPort, "/api/v1/query", params)
 	}
 	// Keyed by contextName (not the clientset): clientsetForContext builds a
 	// fresh clientset per call, so a clientset key would never hit and re-run

--- a/internal/k8s/client_secret_list_test.go
+++ b/internal/k8s/client_secret_list_test.go
@@ -38,7 +38,7 @@ func newFakeMetaClient(objects ...*metav1.PartialObjectMetadata) *metadatafake.F
 // should flip SetSecretLazyLoading(false) after construction.
 func newClientWithMeta(mc *metadatafake.FakeMetadataClient, dc *dynamicfake.FakeDynamicClient) *Client {
 	c := NewTestClient(nil, dc)
-	c.testMetaClient = mc
+	c.injectedMetaClient = mc
 	c.SetSecretLazyLoading(true)
 	return c
 }

--- a/internal/k8s/demo/convert.go
+++ b/internal/k8s/demo/convert.go
@@ -1,0 +1,50 @@
+package demo
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// demoEpoch anchors every relative seed timestamp (pod start times, event
+// firstSeen/lastSeen, node boot time) to one instant, so an object's fields
+// stay internally consistent (e.g. an event never precedes the pod it
+// describes) no matter when the demo cluster is loaded.
+var demoEpoch = time.Now().UTC()
+
+// mustToUnstructured converts a typed API object into the unstructured form
+// the dynamic fake client serves. It panics on conversion failure, which can
+// only happen here if one of the static builders below is malformed — a
+// programming error the package's own tests catch immediately.
+func mustToUnstructured(obj runtime.Object) *unstructured.Unstructured {
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		panic(fmt.Sprintf("demo: converting %T to unstructured: %v", obj, err))
+	}
+	return &unstructured.Unstructured{Object: m}
+}
+
+// managedField builds one metadata.managedFields entry, mirroring the shape
+// kube-apiserver records for a real field manager: a manager name, the
+// operation that wrote it, and structured FieldsV1 data naming the paths it
+// owns.
+func managedField(manager, operation, fieldsJSON string, at time.Time) metav1.ManagedFieldsEntry {
+	fields := &metav1.FieldsV1{}
+	fields.SetRawBytes([]byte(fieldsJSON))
+	t := metav1.NewTime(at)
+	return metav1.ManagedFieldsEntry{
+		Manager:    manager,
+		Operation:  metav1.ManagedFieldsOperationType(operation),
+		Time:       &t,
+		FieldsType: "FieldsV1",
+		FieldsV1:   fields,
+	}
+}
+
+func ptrTime(t time.Time) *metav1.Time {
+	mt := metav1.NewTime(t)
+	return &mt
+}

--- a/internal/k8s/demo/demo_test.go
+++ b/internal/k8s/demo/demo_test.go
@@ -23,6 +23,7 @@ func seededGVRs() []schema.GroupVersionResource {
 		{Group: "", Version: "v1", Resource: "configmaps"},
 		{Group: "", Version: "v1", Resource: "nodes"},
 		{Group: "", Version: "v1", Resource: "events"},
+		{Group: "", Version: "v1", Resource: "namespaces"},
 		{Group: "apps", Version: "v1", Resource: "deployments"},
 		{Group: "apps", Version: "v1", Resource: "replicasets"},
 		{Group: "batch", Version: "v1", Resource: "jobs"},
@@ -40,6 +41,49 @@ func TestNewDynamicClient_ListsEverySeededKind(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, list.Items, "expected at least one seeded object for %s", gvr)
 		})
+	}
+}
+
+// TestNamespaces_EveryReferencedNamespaceHasAnObject holds the invariant
+// that made "Namespaces: 0" possible: every namespace any seeded namespaced
+// object lives in must have a matching Namespace object, or GetNamespaces
+// (which lists Namespace objects directly, not derived from workloads)
+// reports fewer namespaces than the cluster actually uses. This guards
+// against a future namespace being introduced into the seed data without a
+// matching Namespace object.
+func TestNamespaces_EveryReferencedNamespaceHasAnObject(t *testing.T) {
+	dyn := NewDynamicClient()
+	ctx := t.Context()
+
+	nsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	nsList, err := dyn.Resource(nsGVR).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	seeded := map[string]bool{}
+	for _, item := range nsList.Items {
+		seeded[item.GetName()] = true
+	}
+
+	assert.True(t, seeded[NamespaceDemo], "expected a Namespace object for %q", NamespaceDemo)
+	assert.True(t, seeded[NamespaceJobs], "expected a Namespace object for %q", NamespaceJobs)
+	assert.True(t, seeded["default"], `expected a Namespace object for "default"`)
+	assert.True(t, seeded["kube-system"], `expected a Namespace object for "kube-system"`)
+
+	for _, gvr := range seededGVRs() {
+		if gvr.Resource == "namespaces" {
+			continue
+		}
+		list, err := dyn.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			ns := item.GetNamespace()
+			if ns == "" {
+				continue // cluster-scoped object
+			}
+			assert.True(t, seeded[ns],
+				"%s %s/%s references namespace %q with no matching Namespace object",
+				gvr.Resource, ns, item.GetName(), ns)
+		}
 	}
 }
 

--- a/internal/k8s/demo/demo_test.go
+++ b/internal/k8s/demo/demo_test.go
@@ -1,0 +1,257 @@
+package demo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+)
+
+// seededGVRs lists every GVR the dynamic fake actually carries data for
+// (excludes the metrics.k8s.io/v1 routes, which are mapped for
+// compatibility but intentionally left empty — see ListKinds).
+func seededGVRs() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "pods"},
+		{Group: "", Version: "v1", Resource: "services"},
+		{Group: "", Version: "v1", Resource: "configmaps"},
+		{Group: "", Version: "v1", Resource: "nodes"},
+		{Group: "", Version: "v1", Resource: "events"},
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "apps", Version: "v1", Resource: "replicasets"},
+		{Group: "batch", Version: "v1", Resource: "jobs"},
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"},
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"},
+	}
+}
+
+func TestNewDynamicClient_ListsEverySeededKind(t *testing.T) {
+	dyn := NewDynamicClient()
+
+	for _, gvr := range seededGVRs() {
+		t.Run(gvr.String(), func(t *testing.T) {
+			list, err := dyn.Resource(gvr).Namespace("").List(t.Context(), metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.NotEmpty(t, list.Items, "expected at least one seeded object for %s", gvr)
+		})
+	}
+}
+
+func TestNewDynamicClient_SpansMultipleNamespaces(t *testing.T) {
+	dyn := NewDynamicClient()
+
+	pods, err := dyn.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).
+		Namespace("").List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	namespaces := map[string]bool{}
+	for _, item := range pods.Items {
+		namespaces[item.GetNamespace()] = true
+	}
+	assert.True(t, namespaces[NamespaceDemo], "expected pods in %q", NamespaceDemo)
+	assert.True(t, namespaces[NamespaceJobs], "expected pods in %q", NamespaceJobs)
+	assert.GreaterOrEqual(t, len(namespaces), 2)
+}
+
+func TestCrashLoopPod_HasRestartsAndWaitingReason(t *testing.T) {
+	dyn := NewDynamicClient()
+
+	obj, err := dyn.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).
+		Namespace(NamespaceDemo).Get(t.Context(), PodWebCrashLoop, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	statuses, found, err := unstructured.NestedSlice(obj.Object, "status", "containerStatuses")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, statuses, 1)
+
+	cs, ok := statuses[0].(map[string]any)
+	require.True(t, ok)
+
+	restartCount, found, err := unstructured.NestedInt64(cs, "restartCount")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, int64(7), restartCount)
+
+	reason, found, err := unstructured.NestedString(cs, "state", "waiting", "reason")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "CrashLoopBackOff", reason)
+}
+
+func TestCrashLoopPod_HasMatchingWarningEvents(t *testing.T) {
+	dyn := NewDynamicClient()
+
+	list, err := dyn.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}).
+		Namespace(NamespaceDemo).List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	var matched int
+	for _, item := range list.Items {
+		kind, _, _ := unstructured.NestedString(item.Object, "involvedObject", "kind")
+		name, _, _ := unstructured.NestedString(item.Object, "involvedObject", "name")
+		eventType, _, _ := unstructured.NestedString(item.Object, "type")
+		if kind == "Pod" && name == PodWebCrashLoop {
+			assert.Equal(t, "Warning", eventType)
+			matched++
+		}
+	}
+	assert.GreaterOrEqual(t, matched, 2, "expected at least two events for the crashlooping pod")
+}
+
+func TestJob_HasFailedCondition(t *testing.T) {
+	dyn := NewDynamicClient()
+
+	obj, err := dyn.Resource(schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}).
+		Namespace(NamespaceJobs).Get(t.Context(), JobDBMigrate, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	require.NoError(t, err)
+	require.True(t, found)
+
+	var sawFailed bool
+	for _, c := range conditions {
+		cm, ok := c.(map[string]any)
+		require.True(t, ok)
+		if cm["type"] == "Failed" && cm["status"] == "True" {
+			sawFailed = true
+		}
+	}
+	assert.True(t, sawFailed, "expected a Failed=True condition on the job")
+}
+
+func TestOwnerReferences_ChainResolvesPodToDeployment(t *testing.T) {
+	dyn := NewDynamicClient()
+	ctx := t.Context()
+
+	pod, err := dyn.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).
+		Namespace(NamespaceDemo).Get(ctx, PodWebCrashLoop, metav1.GetOptions{})
+	require.NoError(t, err)
+	podOwners := pod.GetOwnerReferences()
+	require.Len(t, podOwners, 1)
+	assert.Equal(t, "ReplicaSet", podOwners[0].Kind)
+	assert.Equal(t, ReplicaSetWeb, podOwners[0].Name)
+
+	rs, err := dyn.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}).
+		Namespace(NamespaceDemo).Get(ctx, ReplicaSetWeb, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(podOwners[0].UID), string(rs.GetUID()))
+
+	rsOwners := rs.GetOwnerReferences()
+	require.Len(t, rsOwners, 1)
+	assert.Equal(t, "Deployment", rsOwners[0].Kind)
+	assert.Equal(t, DeploymentWeb, rsOwners[0].Name)
+
+	deploy, err := dyn.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).
+		Namespace(NamespaceDemo).Get(ctx, DeploymentWeb, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(rsOwners[0].UID), string(deploy.GetUID()))
+}
+
+func TestOwnerReferences_JobPodResolvesToJob(t *testing.T) {
+	dyn := NewDynamicClient()
+	ctx := t.Context()
+
+	pod, err := dyn.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).
+		Namespace(NamespaceJobs).Get(ctx, PodDBMigrate, metav1.GetOptions{})
+	require.NoError(t, err)
+	owners := pod.GetOwnerReferences()
+	require.Len(t, owners, 1)
+	assert.Equal(t, "Job", owners[0].Kind)
+	assert.Equal(t, JobDBMigrate, owners[0].Name)
+
+	job, err := dyn.Resource(schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}).
+		Namespace(NamespaceJobs).Get(ctx, JobDBMigrate, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(owners[0].UID), string(job.GetUID()))
+}
+
+func TestSeedObjects_CarryManagedFields(t *testing.T) {
+	dyn := NewDynamicClient()
+	ctx := t.Context()
+
+	cases := []struct {
+		name string
+		gvr  schema.GroupVersionResource
+		ns   string
+		obj  string
+	}{
+		{"deployment", schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, NamespaceDemo, DeploymentWeb},
+		{"crashloop pod", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, NamespaceDemo, PodWebCrashLoop},
+		{"service", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, NamespaceDemo, ServiceWeb},
+		{"configmap", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, NamespaceDemo, ConfigMapWeb},
+		{"job", schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}, NamespaceJobs, JobDBMigrate},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, err := dyn.Resource(tc.gvr).Namespace(tc.ns).Get(ctx, tc.obj, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			mf := obj.GetManagedFields()
+			require.NotEmpty(t, mf, "expected managedFields on %s/%s", tc.ns, tc.obj)
+			for _, e := range mf {
+				assert.NotEmpty(t, e.Manager)
+				assert.NotNil(t, e.FieldsV1)
+			}
+		})
+	}
+}
+
+func TestNewClientset_DiscoveryReportsSeededKinds(t *testing.T) {
+	cs := NewClientset()
+
+	fd, ok := cs.Discovery().(*discoveryfake.FakeDiscovery)
+	require.True(t, ok)
+	require.NotEmpty(t, fd.Resources)
+
+	var kinds []string
+	for _, list := range fd.Resources {
+		for _, r := range list.APIResources {
+			kinds = append(kinds, r.Kind)
+		}
+	}
+	assert.Contains(t, kinds, "Pod")
+	assert.Contains(t, kinds, "Deployment")
+	assert.Contains(t, kinds, "Job")
+	assert.Contains(t, kinds, "Service")
+	assert.Contains(t, kinds, "ConfigMap")
+	assert.Contains(t, kinds, "Node")
+	assert.Contains(t, kinds, "Event")
+	assert.Contains(t, kinds, "PodMetrics")
+	assert.Contains(t, kinds, "NodeMetrics")
+}
+
+func TestNewClientset_SelfSubjectAccessReviewIsAllowed(t *testing.T) {
+	cs := NewClientset()
+
+	sar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: NamespaceDemo, Verb: "delete", Group: "apps", Resource: "deployments",
+			},
+		},
+	}
+	result, err := cs.AuthorizationV1().SelfSubjectAccessReviews().Create(t.Context(), sar, metav1.CreateOptions{})
+	require.NoError(t, err)
+	assert.True(t, result.Status.Allowed)
+}
+
+func TestNewClientset_SelfSubjectRulesReviewIsAllowed(t *testing.T) {
+	cs := NewClientset()
+
+	review := &authorizationv1.SelfSubjectRulesReview{
+		Spec: authorizationv1.SelfSubjectRulesReviewSpec{Namespace: NamespaceDemo},
+	}
+	result, err := cs.AuthorizationV1().SelfSubjectRulesReviews().Create(t.Context(), review, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Status.ResourceRules)
+	assert.Contains(t, result.Status.ResourceRules[0].Verbs, "*")
+}

--- a/internal/k8s/demo/discovery.go
+++ b/internal/k8s/demo/discovery.go
@@ -76,6 +76,7 @@ func APIResourceLists() []*metav1.APIResourceList {
 				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", Verbs: rw},
 				{Name: "nodes", Namespaced: false, Kind: "Node", Verbs: rw},
 				{Name: "events", Namespaced: true, Kind: "Event", Verbs: rw},
+				{Name: "namespaces", Namespaced: false, Kind: "Namespace", Verbs: rw},
 			},
 		},
 		{

--- a/internal/k8s/demo/discovery.go
+++ b/internal/k8s/demo/discovery.go
@@ -5,21 +5,31 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// ListKinds maps every seeded GroupVersionResource to its List kind — the
-// shape dynamicfake.NewSimpleDynamicClientWithCustomListKinds needs to serve
-// List calls. metrics.k8s.io/v1 is mapped alongside v1beta1 because
-// internal/k8s.metricsGVR tries both; only v1beta1 carries seed data since
-// GetPodMetrics/GetNodeMetrics stop at the first route that returns.
+// ListKinds maps every GroupVersionResource any internal/k8s code path can
+// LIST against the dynamic client to its List kind — the shape
+// dynamicfake.NewSimpleDynamicClientWithCustomListKinds needs to serve List
+// calls. An unregistered GVR makes the fake panic on List instead of
+// returning an error, so this map must register every resource a List call
+// can target, not only the ones seeded with data (see
+// TestListKinds_CoversEveryAdvertisedResource and
+// TestNewDemoClient_DiscoverAPIResources_NoPanic). metrics.k8s.io/v1 is
+// mapped alongside v1beta1 because internal/k8s.metricsGVR tries both; only
+// v1beta1 carries seed data since GetPodMetrics/GetNodeMetrics stop at the
+// first route that returns.
 func ListKinds() map[schema.GroupVersionResource]string {
 	return map[schema.GroupVersionResource]string{
-		{Group: "", Version: "v1", Resource: "pods"}:       "PodList",
-		{Group: "", Version: "v1", Resource: "services"}:   "ServiceList",
-		{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
-		{Group: "", Version: "v1", Resource: "nodes"}:      "NodeList",
-		{Group: "", Version: "v1", Resource: "events"}:     "EventList",
+		{Group: "", Version: "v1", Resource: "pods"}:           "PodList",
+		{Group: "", Version: "v1", Resource: "services"}:       "ServiceList",
+		{Group: "", Version: "v1", Resource: "configmaps"}:     "ConfigMapList",
+		{Group: "", Version: "v1", Resource: "nodes"}:          "NodeList",
+		{Group: "", Version: "v1", Resource: "events"}:         "EventList",
+		{Group: "", Version: "v1", Resource: "namespaces"}:     "NamespaceList",
+		{Group: "", Version: "v1", Resource: "secrets"}:        "SecretList",
+		{Group: "", Version: "v1", Resource: "resourcequotas"}: "ResourceQuotaList",
 
-		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
-		{Group: "apps", Version: "v1", Resource: "replicasets"}: "ReplicaSetList",
+		{Group: "apps", Version: "v1", Resource: "deployments"}:  "DeploymentList",
+		{Group: "apps", Version: "v1", Resource: "replicasets"}:  "ReplicaSetList",
+		{Group: "apps", Version: "v1", Resource: "statefulsets"}: "StatefulSetList",
 
 		{Group: "batch", Version: "v1", Resource: "jobs"}: "JobList",
 
@@ -27,6 +37,26 @@ func ListKinds() map[schema.GroupVersionResource]string {
 		{Group: "metrics.k8s.io", Version: "v1", Resource: "pods"}:       "PodMetricsList",
 		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}: "NodeMetricsList",
 		{Group: "metrics.k8s.io", Version: "v1", Resource: "nodes"}:      "NodeMetricsList",
+
+		// apiextensions.k8s.io/v1 CustomResourceDefinitions: fetchCRDPrinterColumns
+		// (internal/k8s/discovery.go) lists this unconditionally as part of
+		// every DiscoverAPIResources call. Zero CRDs are seeded in demo mode,
+		// but the registration must exist regardless or the fake panics
+		// before it gets the chance to return an empty list.
+		{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
+
+		// networking.k8s.io/v1 NetworkPolicies and their Cilium CRD
+		// counterparts: listed by internal/k8s/netpol_matching.go when
+		// resolving policies affecting a pod or service.
+		{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}:          "NetworkPolicyList",
+		{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"}:            "CiliumNetworkPolicyList",
+		{Group: "cilium.io", Version: "v2", Resource: "ciliumclusterwidenetworkpolicies"}: "CiliumClusterwideNetworkPolicyList",
+
+		// autoscaling.k8s.io VerticalPodAutoscalers: listed by
+		// internal/k8s/client_rightsizing.go's findVPA across both served
+		// API versions.
+		{Group: "autoscaling.k8s.io", Version: "v1", Resource: "verticalpodautoscalers"}:      "VerticalPodAutoscalerList",
+		{Group: "autoscaling.k8s.io", Version: "v1beta2", Resource: "verticalpodautoscalers"}: "VerticalPodAutoscalerList",
 	}
 }
 

--- a/internal/k8s/demo/discovery.go
+++ b/internal/k8s/demo/discovery.go
@@ -1,0 +1,72 @@
+package demo
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ListKinds maps every seeded GroupVersionResource to its List kind — the
+// shape dynamicfake.NewSimpleDynamicClientWithCustomListKinds needs to serve
+// List calls. metrics.k8s.io/v1 is mapped alongside v1beta1 because
+// internal/k8s.metricsGVR tries both; only v1beta1 carries seed data since
+// GetPodMetrics/GetNodeMetrics stop at the first route that returns.
+func ListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}:       "PodList",
+		{Group: "", Version: "v1", Resource: "services"}:   "ServiceList",
+		{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+		{Group: "", Version: "v1", Resource: "nodes"}:      "NodeList",
+		{Group: "", Version: "v1", Resource: "events"}:     "EventList",
+
+		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
+		{Group: "apps", Version: "v1", Resource: "replicasets"}: "ReplicaSetList",
+
+		{Group: "batch", Version: "v1", Resource: "jobs"}: "JobList",
+
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}:  "PodMetricsList",
+		{Group: "metrics.k8s.io", Version: "v1", Resource: "pods"}:       "PodMetricsList",
+		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}: "NodeMetricsList",
+		{Group: "metrics.k8s.io", Version: "v1", Resource: "nodes"}:      "NodeMetricsList",
+	}
+}
+
+// APIResourceLists is the discovery output installed on the fake clientset's
+// FakeDiscovery.Resources, covering every kind ListKinds serves so
+// DiscoverAPIResources (internal/k8s/discovery.go) populates the sidebar
+// from the demo cluster the same way it would from a real one.
+func APIResourceLists() []*metav1.APIResourceList {
+	rw := metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
+	ro := metav1.Verbs{"get", "list"}
+	return []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: rw},
+				{Name: "services", Namespaced: true, Kind: "Service", Verbs: rw},
+				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", Verbs: rw},
+				{Name: "nodes", Namespaced: false, Kind: "Node", Verbs: rw},
+				{Name: "events", Namespaced: true, Kind: "Event", Verbs: rw},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Namespaced: true, Kind: "Deployment", Verbs: rw},
+				{Name: "replicasets", Namespaced: true, Kind: "ReplicaSet", Verbs: rw},
+			},
+		},
+		{
+			GroupVersion: "batch/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "jobs", Namespaced: true, Kind: "Job", Verbs: rw},
+			},
+		},
+		{
+			GroupVersion: "metrics.k8s.io/v1beta1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "PodMetrics", Verbs: ro},
+				{Name: "nodes", Namespaced: false, Kind: "NodeMetrics", Verbs: ro},
+			},
+		},
+	}
+}

--- a/internal/k8s/demo/discovery_test.go
+++ b/internal/k8s/demo/discovery_test.go
@@ -1,0 +1,30 @@
+package demo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestListKinds_CoversEveryAdvertisedResource holds the invariant that made
+// the --demo startup crash possible: any resource DiscoverAPIResources can
+// see via APIResourceLists must have a matching ListKind entry, or the fake
+// dynamic client panics instead of erroring on List. This guards against a
+// future resource being added to APIResourceLists without its ListKind
+// counterpart.
+func TestListKinds_CoversEveryAdvertisedResource(t *testing.T) {
+	kinds := ListKinds()
+
+	for _, list := range APIResourceLists() {
+		gv, err := schema.ParseGroupVersion(list.GroupVersion)
+		if !assert.NoError(t, err, "unparseable GroupVersion %q", list.GroupVersion) {
+			continue
+		}
+		for _, r := range list.APIResources {
+			gvr := schema.GroupVersionResource{Group: gv.Group, Version: gv.Version, Resource: r.Name}
+			assert.Contains(t, kinds, gvr, "APIResourceLists advertises %s but ListKinds has no registration for it", gvr)
+		}
+	}
+}

--- a/internal/k8s/demo/doc.go
+++ b/internal/k8s/demo/doc.go
@@ -1,0 +1,11 @@
+// Package demo provides seed data for an in-memory fake Kubernetes cluster,
+// used to run lfk against a realistic dataset without a live cluster. It
+// builds a small set of Pods, a Deployment, a ReplicaSet, a Job, a Service, a
+// ConfigMap, Nodes and Events spanning two namespaces, with ownerReferences,
+// managedFields and status fields shaped the way a real API server would
+// populate them.
+//
+// NewClientset and NewDynamicClient hand back fake clients already wired
+// with this data, RBAC reactors that grant every action, and the discovery
+// metadata internal/k8s reads through NewTestClient's injection points.
+package demo

--- a/internal/k8s/demo/events.go
+++ b/internal/k8s/demo/events.go
@@ -1,0 +1,69 @@
+package demo
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func buildEvents() []*corev1.Event {
+	crashFirst := demoEpoch.Add(-35 * time.Minute)
+	crashLast := demoEpoch.Add(-3 * time.Minute)
+	return []*corev1.Event{
+		podWarningEvent("web-crash-backoff", uidEventPodCrashBackOff, PodWebCrashLoop, uidPodWebCrash,
+			"BackOff", "Back-off restarting failed container web in pod "+PodWebCrashLoop+"_"+NamespaceDemo+
+				"("+uidPodWebCrash+")",
+			12, crashFirst, crashLast),
+		podWarningEvent("web-crash-unhealthy", uidEventPodCrashUnhealthy, PodWebCrashLoop, uidPodWebCrash,
+			"Unhealthy", "Readiness probe failed: dial tcp 10.0.2.13:8080: connect: connection refused",
+			8, crashFirst.Add(2*time.Minute), crashLast.Add(-30*time.Second)),
+		jobWarningEvent(),
+	}
+}
+
+func podWarningEvent(name, uid, podName, podUID, reason, message string, count int32, first, last time.Time) *corev1.Event {
+	return &corev1.Event{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Event"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         NamespaceDemo,
+			UID:               k8stypes.UID(uid),
+			CreationTimestamp: metav1.NewTime(last),
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod", Name: podName, Namespace: NamespaceDemo, UID: k8stypes.UID(podUID),
+		},
+		Reason:         reason,
+		Message:        message,
+		Type:           corev1.EventTypeWarning,
+		Count:          count,
+		Source:         corev1.EventSource{Component: "kubelet", Host: NodeWorker1},
+		FirstTimestamp: metav1.NewTime(first),
+		LastTimestamp:  metav1.NewTime(last),
+	}
+}
+
+func jobWarningEvent() *corev1.Event {
+	at := demoEpoch.Add(-2 * time.Minute)
+	return &corev1.Event{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Event"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              JobDBMigrate + ".backofflimit",
+			Namespace:         NamespaceJobs,
+			UID:               k8stypes.UID(uidEventJobBackoffLimit),
+			CreationTimestamp: metav1.NewTime(at),
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Job", Name: JobDBMigrate, Namespace: NamespaceJobs, UID: k8stypes.UID(uidJobDBMigrate),
+		},
+		Reason:         "BackoffLimitExceeded",
+		Message:        "Job has reached the specified backoff limit",
+		Type:           corev1.EventTypeWarning,
+		Count:          1,
+		Source:         corev1.EventSource{Component: "job-controller"},
+		FirstTimestamp: metav1.NewTime(at),
+		LastTimestamp:  metav1.NewTime(at),
+	}
+}

--- a/internal/k8s/demo/fake.go
+++ b/internal/k8s/demo/fake.go
@@ -1,0 +1,88 @@
+package demo
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// NewClientset returns a fake kubernetes.Interface seeded with the demo
+// cluster's typed objects, RBAC reactors that grant every action (see
+// AddRBACReactors), and a discovery client reporting every kind the dynamic
+// client serves (see APIResourceLists).
+func NewClientset() *k8sfake.Clientset {
+	cs := k8sfake.NewClientset(typedObjects()...)
+	AddRBACReactors(cs)
+	if fd, ok := cs.Discovery().(*discoveryfake.FakeDiscovery); ok {
+		fd.Resources = APIResourceLists()
+	}
+	return cs
+}
+
+// NewDynamicClient returns a fake dynamic.Interface seeded with the demo
+// cluster's objects (converted to unstructured) plus synthetic
+// metrics.k8s.io readings, registered against ListKinds so List resolves
+// for every seeded GVR.
+func NewDynamicClient() *dynamicfake.FakeDynamicClient {
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), ListKinds(), typedUnstructuredObjects()...)
+	seedMetrics(dyn)
+	return dyn
+}
+
+// seedMetrics adds the metrics.k8s.io readings directly against their real
+// GVR ({metrics.k8s.io, v1beta1, pods|nodes}). They can't go through the
+// constructor's objects... path: ObjectTracker.Add guesses the resource
+// name from the object's Kind via naive pluralization, and "PodMetrics" /
+// "NodeMetrics" guess to "podmetricses" / "nodemetricses" — not the "pods" /
+// "nodes" resource name the real metrics API (and internal/k8s.metricsGVR)
+// actually uses. Tracker().Create takes the GVR explicitly, bypassing the guess.
+func seedMetrics(dyn *dynamicfake.FakeDynamicClient) {
+	podGVR := schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}
+	for _, m := range buildPodMetrics() {
+		if err := dyn.Tracker().Create(podGVR, m, m.GetNamespace()); err != nil {
+			panic(fmt.Sprintf("demo: seeding pod metrics: %v", err))
+		}
+	}
+
+	nodeGVR := schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}
+	for _, m := range buildNodeMetrics() {
+		if err := dyn.Tracker().Create(nodeGVR, m, ""); err != nil {
+			panic(fmt.Sprintf("demo: seeding node metrics: %v", err))
+		}
+	}
+}
+
+// typedObjects returns every seed object as its typed API type — what the
+// fake clientset's tracker and Discovery() need.
+func typedObjects() []runtime.Object {
+	objs := make([]runtime.Object, 0, 13)
+	objs = append(objs,
+		buildDeployment(), buildReplicaSet(), buildService(), buildConfigMap(),
+		buildJob(), buildJobPod(),
+	)
+	for _, n := range buildNodes() {
+		objs = append(objs, n)
+	}
+	for _, p := range buildWebPods() {
+		objs = append(objs, p)
+	}
+	for _, e := range buildEvents() {
+		objs = append(objs, e)
+	}
+	return objs
+}
+
+// typedUnstructuredObjects converts typedObjects to unstructured form for
+// the dynamic fake client's constructor.
+func typedUnstructuredObjects() []runtime.Object {
+	typed := typedObjects()
+	objs := make([]runtime.Object, 0, len(typed))
+	for _, o := range typed {
+		objs = append(objs, mustToUnstructured(o))
+	}
+	return objs
+}

--- a/internal/k8s/demo/fake.go
+++ b/internal/k8s/demo/fake.go
@@ -59,11 +59,14 @@ func seedMetrics(dyn *dynamicfake.FakeDynamicClient) {
 // typedObjects returns every seed object as its typed API type — what the
 // fake clientset's tracker and Discovery() need.
 func typedObjects() []runtime.Object {
-	objs := make([]runtime.Object, 0, 13)
+	objs := make([]runtime.Object, 0, 17)
 	objs = append(objs,
 		buildDeployment(), buildReplicaSet(), buildService(), buildConfigMap(),
 		buildJob(), buildJobPod(),
 	)
+	for _, ns := range buildNamespaces() {
+		objs = append(objs, ns)
+	}
 	for _, n := range buildNodes() {
 		objs = append(objs, n)
 	}

--- a/internal/k8s/demo/guard.go
+++ b/internal/k8s/demo/guard.go
@@ -1,0 +1,72 @@
+package demo
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// GuardListPanics wraps a dynamic.Interface so a List call against an
+// unregistered GVR degrades to an error instead of panicking. The fake
+// dynamic client (dynamicfake.NewSimpleDynamicClientWithCustomListKinds)
+// panics rather than errors when its ListKinds map is missing an entry —
+// see ListKinds for the registration this guards against ever missing
+// again. DiscoverAPIResources and similar calls run on a scheduler worker
+// goroutine with nothing upstream able to recover a panic, so a fixture
+// gap here would otherwise crash the whole app instead of degrading one
+// feature. This wrapper is demo-only: a real cluster's dynamic client talks
+// to an API server and never panics on List, so production code paths
+// never carry this guard.
+func GuardListPanics(dyn dynamic.Interface) dynamic.Interface {
+	return recoveringDynamicClient{Interface: dyn}
+}
+
+type recoveringDynamicClient struct {
+	dynamic.Interface
+}
+
+func (r recoveringDynamicClient) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return recoveringNamespaceableResourceInterface{
+		NamespaceableResourceInterface: r.Interface.Resource(gvr),
+		gvr:                            gvr,
+	}
+}
+
+type recoveringNamespaceableResourceInterface struct {
+	dynamic.NamespaceableResourceInterface
+	gvr schema.GroupVersionResource
+}
+
+func (r recoveringNamespaceableResourceInterface) Namespace(ns string) dynamic.ResourceInterface {
+	return recoveringResourceInterface{
+		ResourceInterface: r.NamespaceableResourceInterface.Namespace(ns),
+		gvr:               r.gvr,
+	}
+}
+
+func (r recoveringNamespaceableResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (list *unstructured.UnstructuredList, err error) {
+	defer recoverListPanic(r.gvr, &err)
+	return r.NamespaceableResourceInterface.List(ctx, opts)
+}
+
+type recoveringResourceInterface struct {
+	dynamic.ResourceInterface
+	gvr schema.GroupVersionResource
+}
+
+func (r recoveringResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (list *unstructured.UnstructuredList, err error) {
+	defer recoverListPanic(r.gvr, &err)
+	return r.ResourceInterface.List(ctx, opts)
+}
+
+// recoverListPanic converts a panic from the fake dynamic client's List
+// into an error on the named return, identified by gvr for the caller.
+func recoverListPanic(gvr schema.GroupVersionResource, err *error) {
+	if p := recover(); p != nil {
+		*err = fmt.Errorf("demo: listing %s: %v", gvr, p)
+	}
+}

--- a/internal/k8s/demo/guard_test.go
+++ b/internal/k8s/demo/guard_test.go
@@ -1,0 +1,44 @@
+package demo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestGuardListPanics_UnregisteredGVR_ReturnsErrorNotPanic is the Layer 2
+// regression guard: a List against a GVR missing from ListKinds must
+// degrade to an error, not unwind the goroutine that called it. This is
+// independent of the Layer 1 registration fix — it holds even for a GVR
+// nobody has registered yet, which is exactly the case a future missing
+// registration would hit.
+func TestGuardListPanics_UnregisteredGVR_ReturnsErrorNotPanic(t *testing.T) {
+	dyn := GuardListPanics(NewDynamicClient())
+	unregistered := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+
+	assert.NotPanics(t, func() {
+		_, err := dyn.Resource(unregistered).Namespace("default").List(t.Context(), metav1.ListOptions{})
+		require.Error(t, err)
+	})
+
+	assert.NotPanics(t, func() {
+		_, err := dyn.Resource(unregistered).List(t.Context(), metav1.ListOptions{})
+		require.Error(t, err)
+	})
+}
+
+// TestGuardListPanics_RegisteredGVR_PassesThrough proves the guard is
+// transparent for the normal path: seeded, registered resources still list
+// their data through the wrapper.
+func TestGuardListPanics_RegisteredGVR_PassesThrough(t *testing.T) {
+	dyn := GuardListPanics(NewDynamicClient())
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+	list, err := dyn.Resource(podGVR).Namespace("").List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, list.Items)
+}

--- a/internal/k8s/demo/jobs.go
+++ b/internal/k8s/demo/jobs.go
@@ -1,0 +1,109 @@
+package demo
+
+import (
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func buildJob() *batchv1.Job {
+	started := demoEpoch.Add(-25 * time.Minute)
+	backoffLimit := int32(4)
+	return &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{APIVersion: "batch/v1", Kind: "Job"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              JobDBMigrate,
+			Namespace:         NamespaceJobs,
+			UID:               k8stypes.UID(uidJobDBMigrate),
+			Labels:            map[string]string{"job-name": JobDBMigrate},
+			CreationTimestamp: metav1.NewTime(started),
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kubectl-client-side-apply", "Create",
+					`{"f:spec":{"f:backoffLimit":{},"f:template":{}}}`, started),
+				managedField("kube-controller-manager", "Update",
+					`{"f:status":{"f:conditions":{},"f:failed":{},"f:startTime":{}}}`, demoEpoch.Add(-2*time.Minute)),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"job-name": JobDBMigrate}},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{Name: "migrate", Image: "ghcr.io/example/db-migrate:2.3.0"},
+					},
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Failed:    3,
+			StartTime: ptrTime(started),
+			Conditions: []batchv1.JobCondition{
+				{
+					Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+					Reason: "BackoffLimitExceeded", Message: "Job has reached the specified backoff limit",
+				},
+			},
+		},
+	}
+}
+
+func buildJobPod() *corev1.Pod {
+	started := demoEpoch.Add(-25 * time.Minute)
+	finished := demoEpoch.Add(-22 * time.Minute)
+	controller, block := true, true
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              PodDBMigrate,
+			Namespace:         NamespaceJobs,
+			UID:               k8stypes.UID(uidPodDBMigrate),
+			Labels:            map[string]string{"job-name": JobDBMigrate},
+			CreationTimestamp: metav1.NewTime(started),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1", Kind: "Job", Name: JobDBMigrate,
+					UID: k8stypes.UID(uidJobDBMigrate), Controller: &controller, BlockOwnerDeletion: &block,
+				},
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kube-controller-manager", "Update",
+					`{"f:metadata":{"f:ownerReferences":{}}}`, started),
+				managedField("kubelet", "Update",
+					`{"f:status":{"f:containerStatuses":{},"f:phase":{}}}`, finished),
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:      NodeWorker1,
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{Name: "migrate", Image: "ghcr.io/example/db-migrate:2.3.0"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:     corev1.PodFailed,
+			StartTime: ptrTime(started),
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "migrate",
+					Ready:        false,
+					RestartCount: 0,
+					Image:        "ghcr.io/example/db-migrate:2.3.0",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode:   1,
+							Reason:     "Error",
+							Message:    `migration failed: relation "accounts" already exists`,
+							StartedAt:  metav1.NewTime(started),
+							FinishedAt: metav1.NewTime(finished),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/k8s/demo/metrics.go
+++ b/internal/k8s/demo/metrics.go
@@ -1,0 +1,70 @@
+package demo
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// buildPodMetrics and buildNodeMetrics seed the metrics.k8s.io/v1beta1
+// PodMetrics/NodeMetrics objects internal/k8s.getPodMetricsFromAPI and
+// getNodeMetricsFromAPI read. They are unstructured because no typed Go
+// package for metrics.k8s.io is vendored here — internal/k8s reads them as
+// unstructured too, so the shape only needs to match what parsePodMetrics
+// and getNodeMetricsFromAPI expect: a top-level "containers[].usage" map for
+// pods, a top-level "usage" map for nodes.
+
+func buildPodMetrics() []*unstructured.Unstructured {
+	ts := demoEpoch.Add(-30 * time.Second).Format(time.RFC3339)
+	return []*unstructured.Unstructured{
+		podMetrics(PodWebHealthy1, "45m", "96Mi", ts),
+		podMetrics(PodWebHealthy2, "52m", "101Mi", ts),
+		podMetrics(PodWebCrashLoop, "5m", "24Mi", ts),
+	}
+}
+
+func podMetrics(name, cpu, mem, ts string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "metrics.k8s.io/v1beta1",
+		"kind":       "PodMetrics",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": NamespaceDemo,
+		},
+		"timestamp": ts,
+		"window":    "30s",
+		"containers": []any{
+			map[string]any{
+				"name": "web",
+				"usage": map[string]any{
+					"cpu":    cpu,
+					"memory": mem,
+				},
+			},
+		},
+	}}
+}
+
+func buildNodeMetrics() []*unstructured.Unstructured {
+	ts := demoEpoch.Add(-30 * time.Second).Format(time.RFC3339)
+	return []*unstructured.Unstructured{
+		nodeMetrics(NodeControlPlane, "620m", "2.1Gi", ts),
+		nodeMetrics(NodeWorker1, "1100m", "4.8Gi", ts),
+	}
+}
+
+func nodeMetrics(name, cpu, mem, ts string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "metrics.k8s.io/v1beta1",
+		"kind":       "NodeMetrics",
+		"metadata": map[string]any{
+			"name": name,
+		},
+		"timestamp": ts,
+		"window":    "30s",
+		"usage": map[string]any{
+			"cpu":    cpu,
+			"memory": mem,
+		},
+	}}
+}

--- a/internal/k8s/demo/names.go
+++ b/internal/k8s/demo/names.go
@@ -1,9 +1,13 @@
 package demo
 
-// Namespaces spanned by the seed data.
+// Namespaces spanned by the seed data. NamespaceDefault and
+// NamespaceKubeSystem carry no workloads but are seeded as Namespace objects
+// so the namespace picker looks like a real cluster (see buildNamespaces).
 const (
-	NamespaceDemo = "demo"
-	NamespaceJobs = "demo-jobs"
+	NamespaceDemo       = "demo"
+	NamespaceJobs       = "demo-jobs"
+	NamespaceDefault    = "default"
+	NamespaceKubeSystem = "kube-system"
 )
 
 // Object names, exported so tests (in this package and internal/k8s) can
@@ -16,6 +20,9 @@ const (
 	ReplicaSetWeb   = "web-7d8f9c6b5"
 	PodWebHealthy1  = "web-7d8f9c6b5-9k2pl"
 	PodWebHealthy2  = "web-7d8f9c6b5-4m8qz"
+	PodWebHealthy3  = "web-7d8f9c6b5-2rvft"
+	PodWebHealthy4  = "web-7d8f9c6b5-8jdmn"
+	PodWebHealthy5  = "web-7d8f9c6b5-5wqxc"
 	PodWebCrashLoop = "web-7d8f9c6b5-x7bwn"
 
 	ServiceWeb   = "web"
@@ -36,6 +43,9 @@ const (
 	uidPodWebHealthy1 = "b0000000-0000-4000-8000-000000000003"
 	uidPodWebHealthy2 = "b0000000-0000-4000-8000-000000000004"
 	uidPodWebCrash    = "b0000000-0000-4000-8000-000000000005"
+	uidPodWebHealthy3 = "b0000000-0000-4000-8000-000000000008"
+	uidPodWebHealthy4 = "b0000000-0000-4000-8000-000000000009"
+	uidPodWebHealthy5 = "b0000000-0000-4000-8000-00000000000a"
 
 	uidServiceWeb   = "b0000000-0000-4000-8000-000000000006"
 	uidConfigMapWeb = "b0000000-0000-4000-8000-000000000007"
@@ -46,4 +56,9 @@ const (
 	uidEventPodCrashBackOff   = "d0000000-0000-4000-8000-000000000001"
 	uidEventPodCrashUnhealthy = "d0000000-0000-4000-8000-000000000002"
 	uidEventJobBackoffLimit   = "d0000000-0000-4000-8000-000000000003"
+
+	uidNamespaceDemo       = "f0000000-0000-4000-8000-000000000001"
+	uidNamespaceJobs       = "f0000000-0000-4000-8000-000000000002"
+	uidNamespaceDefault    = "f0000000-0000-4000-8000-000000000003"
+	uidNamespaceKubeSystem = "f0000000-0000-4000-8000-000000000004"
 )

--- a/internal/k8s/demo/names.go
+++ b/internal/k8s/demo/names.go
@@ -1,0 +1,49 @@
+package demo
+
+// Namespaces spanned by the seed data.
+const (
+	NamespaceDemo = "demo"
+	NamespaceJobs = "demo-jobs"
+)
+
+// Object names, exported so tests (in this package and internal/k8s) can
+// reference the seed data without hardcoding strings.
+const (
+	NodeControlPlane = "demo-control-plane"
+	NodeWorker1      = "demo-worker-1"
+
+	DeploymentWeb   = "web"
+	ReplicaSetWeb   = "web-7d8f9c6b5"
+	PodWebHealthy1  = "web-7d8f9c6b5-9k2pl"
+	PodWebHealthy2  = "web-7d8f9c6b5-4m8qz"
+	PodWebCrashLoop = "web-7d8f9c6b5-x7bwn"
+
+	ServiceWeb   = "web"
+	ConfigMapWeb = "web-config"
+
+	JobDBMigrate = "db-migrate-28472913"
+	PodDBMigrate = "db-migrate-28472913-9f2lk"
+)
+
+// uids are fixed so ownerReferences and event involvedObject links stay
+// stable across process runs instead of being regenerated each time.
+const (
+	uidNodeControlPlane = "a0000000-0000-4000-8000-000000000001"
+	uidNodeWorker1      = "a0000000-0000-4000-8000-000000000002"
+
+	uidDeploymentWeb  = "b0000000-0000-4000-8000-000000000001"
+	uidReplicaSetWeb  = "b0000000-0000-4000-8000-000000000002"
+	uidPodWebHealthy1 = "b0000000-0000-4000-8000-000000000003"
+	uidPodWebHealthy2 = "b0000000-0000-4000-8000-000000000004"
+	uidPodWebCrash    = "b0000000-0000-4000-8000-000000000005"
+
+	uidServiceWeb   = "b0000000-0000-4000-8000-000000000006"
+	uidConfigMapWeb = "b0000000-0000-4000-8000-000000000007"
+
+	uidJobDBMigrate = "c0000000-0000-4000-8000-000000000001"
+	uidPodDBMigrate = "c0000000-0000-4000-8000-000000000002"
+
+	uidEventPodCrashBackOff   = "d0000000-0000-4000-8000-000000000001"
+	uidEventPodCrashUnhealthy = "d0000000-0000-4000-8000-000000000002"
+	uidEventJobBackoffLimit   = "d0000000-0000-4000-8000-000000000003"
+)

--- a/internal/k8s/demo/namespaces.go
+++ b/internal/k8s/demo/namespaces.go
@@ -1,0 +1,38 @@
+package demo
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+// buildNamespaces returns a Namespace object for every namespace the seed
+// data uses (NamespaceDemo, NamespaceJobs), plus the two namespaces every
+// real cluster has (default, kube-system), so the namespace picker and
+// GetNamespaces count reflect a coherent cluster instead of reporting zero.
+func buildNamespaces() []*corev1.Namespace {
+	return []*corev1.Namespace{
+		namespace(NamespaceDemo, uidNamespaceDemo, demoEpoch.Add(-30*24*time.Hour)),
+		namespace(NamespaceJobs, uidNamespaceJobs, demoEpoch.Add(-30*24*time.Hour)),
+		namespace(NamespaceDefault, uidNamespaceDefault, demoEpoch.Add(-60*24*time.Hour)),
+		namespace(NamespaceKubeSystem, uidNamespaceKubeSystem, demoEpoch.Add(-60*24*time.Hour)),
+	}
+}
+
+func namespace(name, uid string, created time.Time) *corev1.Namespace {
+	return &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			UID:               k8stypes.UID(uid),
+			Labels:            map[string]string{"kubernetes.io/metadata.name": name},
+			CreationTimestamp: metav1.NewTime(created),
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kube-apiserver", "Update", `{"f:status":{"f:phase":{}}}`, created),
+			},
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+}

--- a/internal/k8s/demo/network.go
+++ b/internal/k8s/demo/network.go
@@ -1,0 +1,56 @@
+package demo
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func buildService() *corev1.Service {
+	created := demoEpoch.Add(-7 * 24 * time.Hour)
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              ServiceWeb,
+			Namespace:         NamespaceDemo,
+			UID:               k8stypes.UID(uidServiceWeb),
+			Labels:            map[string]string{"app": "web"},
+			CreationTimestamp: metav1.NewTime(created),
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kubectl-client-side-apply", "Update",
+					`{"f:spec":{"f:ports":{},"f:selector":{},"f:type":{}}}`, created),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: "10.96.0.42",
+			Selector:  map[string]string{"app": "web"},
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+}
+
+func buildConfigMap() *corev1.ConfigMap {
+	created := demoEpoch.Add(-7 * 24 * time.Hour)
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              ConfigMapWeb,
+			Namespace:         NamespaceDemo,
+			UID:               k8stypes.UID(uidConfigMapWeb),
+			CreationTimestamp: metav1.NewTime(created),
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kubectl-client-side-apply", "Update", `{"f:data":{}}`, created),
+			},
+		},
+		Data: map[string]string{
+			"APP_ENV":   "production",
+			"LOG_LEVEL": "info",
+		},
+	}
+}

--- a/internal/k8s/demo/nodes.go
+++ b/internal/k8s/demo/nodes.go
@@ -1,0 +1,73 @@
+package demo
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func buildNodes() []*corev1.Node {
+	return []*corev1.Node{
+		node(NodeControlPlane, uidNodeControlPlane, map[string]string{
+			"kubernetes.io/hostname":                NodeControlPlane,
+			"node-role.kubernetes.io/control-plane": "",
+		}),
+		node(NodeWorker1, uidNodeWorker1, map[string]string{
+			"kubernetes.io/hostname": NodeWorker1,
+		}),
+	}
+}
+
+func node(name, uid string, labels map[string]string) *corev1.Node {
+	created := demoEpoch.Add(-30 * 24 * time.Hour)
+	heartbeat := demoEpoch.Add(-time.Minute)
+	return &corev1.Node{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Node"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			UID:               k8stypes.UID(uid),
+			Labels:            labels,
+			CreationTimestamp: metav1.NewTime(created),
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kubectl-client-side-apply", "Update", `{"f:metadata":{"f:labels":{}}}`, created),
+				managedField("kubelet", "Update", `{"f:status":{"f:conditions":{},"f:nodeInfo":{}}}`, heartbeat),
+			},
+		},
+		Status: corev1.NodeStatus{
+			NodeInfo: corev1.NodeSystemInfo{
+				KubeletVersion:          "v1.31.2",
+				OSImage:                 "Ubuntu 22.04.4 LTS",
+				ContainerRuntimeVersion: "containerd://1.7.20",
+				Architecture:            "amd64",
+				OperatingSystem:         "linux",
+			},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+				corev1.ResourcePods:   resource.MustParse("110"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3800m"),
+				corev1.ResourceMemory: resource.MustParse("15Gi"),
+				corev1.ResourcePods:   resource.MustParse("110"),
+			},
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					Reason:             "KubeletReady",
+					Message:            "kubelet is posting ready status",
+					LastHeartbeatTime:  metav1.NewTime(heartbeat),
+					LastTransitionTime: metav1.NewTime(created),
+				},
+			},
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.1.10"},
+				{Type: corev1.NodeHostName, Address: name},
+			},
+		},
+	}
+}

--- a/internal/k8s/demo/reactors.go
+++ b/internal/k8s/demo/reactors.go
@@ -1,0 +1,65 @@
+package demo
+
+import (
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// reactingClientset is the subset of *k8sfake.Clientset (via its embedded
+// testing.Fake) AddRBACReactors needs. Declared here instead of importing
+// k8sfake so the reactor logic doesn't depend on the fake package's full
+// surface.
+type reactingClientset interface {
+	PrependReactor(verb, resource string, reaction clienttesting.ReactionFunc)
+}
+
+// AddRBACReactors wires SelfSubjectAccessReview and SelfSubjectRulesReview
+// reactors that report the demo user as fully authorized. Neither review
+// type is a tracked object, so the fake clientset has no built-in reactor
+// for them: Create falls through to a zero-value response (Allowed: false,
+// no resource rules), which hides every action in the UI. See
+// internal/k8s/client_rbac.go CheckRBAC and GetSelfRulesAs for the exact
+// request/response shape the app reads.
+func AddRBACReactors(cs reactingClientset) {
+	cs.PrependReactor("create", "selfsubjectaccessreviews", reactSelfSubjectAccessReview)
+	cs.PrependReactor("create", "selfsubjectrulesreviews", reactSelfSubjectRulesReview)
+}
+
+func reactSelfSubjectAccessReview(action clienttesting.Action) (bool, runtime.Object, error) {
+	create, ok := action.(clienttesting.CreateAction)
+	if !ok {
+		return false, nil, nil
+	}
+	sar, ok := create.GetObject().(*authorizationv1.SelfSubjectAccessReview)
+	if !ok {
+		return false, nil, nil
+	}
+	out := sar.DeepCopy()
+	out.Status = authorizationv1.SubjectAccessReviewStatus{
+		Allowed: true,
+		Reason:  "demo cluster grants all actions",
+	}
+	return true, out, nil
+}
+
+func reactSelfSubjectRulesReview(action clienttesting.Action) (bool, runtime.Object, error) {
+	create, ok := action.(clienttesting.CreateAction)
+	if !ok {
+		return false, nil, nil
+	}
+	review, ok := create.GetObject().(*authorizationv1.SelfSubjectRulesReview)
+	if !ok {
+		return false, nil, nil
+	}
+	out := review.DeepCopy()
+	out.Status = authorizationv1.SubjectRulesReviewStatus{
+		ResourceRules: []authorizationv1.ResourceRule{
+			{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+		},
+		NonResourceRules: []authorizationv1.NonResourceRule{
+			{Verbs: []string{"*"}, NonResourceURLs: []string{"*"}},
+		},
+	}
+	return true, out, nil
+}

--- a/internal/k8s/demo/ticker.go
+++ b/internal/k8s/demo/ticker.go
@@ -1,0 +1,310 @@
+package demo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// tickerFieldManager marks writes the Ticker makes through the dynamic
+// client, distinguishing them from the initial seed data in managedFields.
+const tickerFieldManager = "lfk-demo-ticker"
+
+// maxTickerEvents caps how many Warning Events the ticker keeps appending
+// for the crashlooping pod. A demo session left running ticks indefinitely;
+// without a cap the Event list would grow without bound.
+const maxTickerEvents = 20
+
+// healthyPodFlipEvery is how many ticks pass between phase flips on
+// PodWebHealthy2.
+const healthyPodFlipEvery = 5
+
+var (
+	podGVR        = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	eventGVR      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
+	deploymentGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+)
+
+// waitingReasons is the sequence of waiting-container reasons the
+// crashlooping pod cycles through on each restart tick.
+var waitingReasons = []string{"CrashLoopBackOff", "Error"}
+
+// deploymentReadyReplicaCycle is the sequence of readyReplicas values the
+// web Deployment cycles through, out of its 3 desired replicas.
+var deploymentReadyReplicaCycle = []int64{2, 1, 3}
+
+// Ticker mutates a demo cluster's fake dynamic client on a fixed interval so
+// its informer-backed watchers see live changes: the crashlooping pod
+// restarts and its waiting reason rotates, a matching Warning Event lands, a
+// healthy pod's phase flips occasionally, and the web Deployment's
+// readyReplicas drifts. Every mutation is a deterministic function of the
+// tick count, so driving a fresh Ticker N times always reaches the same
+// state — tests and screenshots stay stable.
+//
+// Ticker only touches the dynamic client passed to NewTicker; it is not
+// wired into any client lifecycle here.
+type Ticker struct {
+	dyn      dynamic.Interface
+	interval time.Duration
+
+	mu            sync.Mutex
+	tick          uint64
+	running       bool
+	cancel        context.CancelFunc
+	done          chan struct{}
+	restartEvents []string // FIFO of ticker-created event names, oldest first
+}
+
+// NewTicker returns a Ticker over dyn that, once started, mutates the demo
+// cluster every interval. It does not touch dyn until Start or Tick is
+// called.
+func NewTicker(dyn dynamic.Interface, interval time.Duration) *Ticker {
+	return &Ticker{dyn: dyn, interval: interval}
+}
+
+// Start launches the ticker's goroutine, which calls Tick every interval
+// until Stop is called or ctx is cancelled. Calling Start while already
+// running is a no-op.
+func (t *Ticker) Start(ctx context.Context) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.running {
+		return
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	t.cancel = cancel
+	t.done = make(chan struct{})
+	t.running = true
+
+	go t.run(runCtx, t.done)
+}
+
+func (t *Ticker) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
+
+	// time.NewTicker panics for a non-positive duration; treat a
+	// misconfigured interval as a no-op run instead of crashing the
+	// process from a background goroutine.
+	if t.interval <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Best-effort: a single failed mutation should not take down
+			// the background loop. The caller wiring this in decides
+			// whether failures need surfacing.
+			_ = t.Tick(ctx)
+		}
+	}
+}
+
+// Stop cancels the ticker's goroutine and blocks until it has exited.
+// Idempotent and safe to call even if Start was never called; concurrent
+// Stop calls all wait for the same goroutine to exit before any of them
+// return. Start and Stop are not safe to call concurrently with each
+// other — serialize lifecycle calls at the call site.
+func (t *Ticker) Stop() {
+	t.mu.Lock()
+	if !t.running {
+		t.mu.Unlock()
+		return
+	}
+	cancel := t.cancel
+	done := t.done
+	t.mu.Unlock()
+
+	cancel()
+	<-done
+
+	t.mu.Lock()
+	t.running = false
+	t.mu.Unlock()
+}
+
+// Tick performs one deterministic mutation step against the tracked demo
+// objects. Exported so tests can drive the sequence precisely without
+// sleeping on real time; Start's internal loop calls it the same way. The
+// whole step runs under the Ticker's lock so a direct Tick call never races
+// against Start's background loop calling it concurrently.
+func (t *Ticker) Tick(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	tick := t.tick
+	t.tick++
+
+	if err := t.restartCrashLoopPod(ctx, tick); err != nil {
+		return fmt.Errorf("demo ticker: restarting crashloop pod: %w", err)
+	}
+	if err := t.appendRestartEvent(ctx, tick); err != nil {
+		return fmt.Errorf("demo ticker: appending restart event: %w", err)
+	}
+	if err := t.flipHealthyPodPhase(ctx, tick); err != nil {
+		return fmt.Errorf("demo ticker: flipping healthy pod phase: %w", err)
+	}
+	if err := t.driftDeploymentReadyReplicas(ctx, tick); err != nil {
+		return fmt.Errorf("demo ticker: drifting deployment ready replicas: %w", err)
+	}
+	return nil
+}
+
+// restartCrashLoopPod increments PodWebCrashLoop's restartCount and rotates
+// its waiting reason through waitingReasons.
+func (t *Ticker) restartCrashLoopPod(ctx context.Context, tick uint64) error {
+	client := t.dyn.Resource(podGVR).Namespace(NamespaceDemo)
+	obj, err := client.Get(ctx, PodWebCrashLoop, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	statuses, found, err := unstructured.NestedSlice(obj.Object, "status", "containerStatuses")
+	if err != nil {
+		return err
+	}
+	if !found || len(statuses) == 0 {
+		return fmt.Errorf("pod %s has no containerStatuses", PodWebCrashLoop)
+	}
+	cs, ok := statuses[0].(map[string]any)
+	if !ok {
+		return fmt.Errorf("pod %s containerStatuses[0] has an unexpected shape", PodWebCrashLoop)
+	}
+
+	restartCount, _, err := unstructured.NestedInt64(cs, "restartCount")
+	if err != nil {
+		return err
+	}
+	if err := unstructured.SetNestedField(cs, restartCount+1, "restartCount"); err != nil {
+		return err
+	}
+
+	reason := waitingReasons[tick%uint64(len(waitingReasons))]
+	if err := unstructured.SetNestedField(cs, reason, "state", "waiting", "reason"); err != nil {
+		return err
+	}
+	message := fmt.Sprintf("back-off restarting failed container=web pod=%s_%s(%s)",
+		PodWebCrashLoop, NamespaceDemo, uidPodWebCrash)
+	if err := unstructured.SetNestedField(cs, message, "state", "waiting", "message"); err != nil {
+		return err
+	}
+
+	statuses[0] = cs
+	if err := unstructured.SetNestedSlice(obj.Object, statuses, "status", "containerStatuses"); err != nil {
+		return err
+	}
+
+	_, err = client.Update(ctx, obj, metav1.UpdateOptions{FieldManager: tickerFieldManager})
+	return err
+}
+
+// appendRestartEvent creates a fresh Warning Event for the crashlooping
+// pod's restart, then evicts the oldest ticker-created event once the count
+// exceeds maxTickerEvents.
+func (t *Ticker) appendRestartEvent(ctx context.Context, tick uint64) error {
+	client := t.dyn.Resource(eventGVR).Namespace(NamespaceDemo)
+
+	name := fmt.Sprintf("web-crash-restart-%d", tick)
+	uid := fmt.Sprintf("e0000000-0000-4000-8000-%012d", tick)
+	now := time.Now().UTC()
+	message := fmt.Sprintf("Back-off restarting failed container web in pod %s_%s(%s)",
+		PodWebCrashLoop, NamespaceDemo, uidPodWebCrash)
+	evt := podWarningEvent(name, uid, PodWebCrashLoop, uidPodWebCrash, "BackOff", message, 1, now, now)
+
+	if _, err := client.Create(ctx, mustToUnstructured(evt), metav1.CreateOptions{FieldManager: tickerFieldManager}); err != nil {
+		return err
+	}
+
+	// Tick already holds t.mu for the duration of this call, so the FIFO
+	// update below needs no locking of its own.
+	t.restartEvents = append(t.restartEvents, name)
+	var evict string
+	if len(t.restartEvents) > maxTickerEvents {
+		evict, t.restartEvents = t.restartEvents[0], t.restartEvents[1:]
+	}
+
+	if evict == "" {
+		return nil
+	}
+	if err := client.Delete(ctx, evict, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("evicting event %s: %w", evict, err)
+	}
+	return nil
+}
+
+// flipHealthyPodPhase toggles PodWebHealthy2 between Running and Pending
+// every healthyPodFlipEvery ticks, keeping its Ready condition consistent
+// with the phase.
+func (t *Ticker) flipHealthyPodPhase(ctx context.Context, tick uint64) error {
+	client := t.dyn.Resource(podGVR).Namespace(NamespaceDemo)
+	obj, err := client.Get(ctx, PodWebHealthy2, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	phase := string(corev1.PodRunning)
+	condStatus := string(corev1.ConditionTrue)
+	if (tick/healthyPodFlipEvery)%2 == 1 {
+		phase = string(corev1.PodPending)
+		condStatus = string(corev1.ConditionFalse)
+	}
+
+	if err := unstructured.SetNestedField(obj.Object, phase, "status", "phase"); err != nil {
+		return err
+	}
+
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil {
+		return err
+	}
+	if found && len(conditions) > 0 {
+		c0, ok := conditions[0].(map[string]any)
+		if !ok {
+			return fmt.Errorf("pod %s conditions[0] has an unexpected shape", PodWebHealthy2)
+		}
+		if err := unstructured.SetNestedField(c0, condStatus, "status"); err != nil {
+			return err
+		}
+		conditions[0] = c0
+		if err := unstructured.SetNestedSlice(obj.Object, conditions, "status", "conditions"); err != nil {
+			return err
+		}
+	}
+
+	_, err = client.Update(ctx, obj, metav1.UpdateOptions{FieldManager: tickerFieldManager})
+	return err
+}
+
+// driftDeploymentReadyReplicas cycles DeploymentWeb's readyReplicas (and
+// availableReplicas alongside it) through deploymentReadyReplicaCycle.
+func (t *Ticker) driftDeploymentReadyReplicas(ctx context.Context, tick uint64) error {
+	client := t.dyn.Resource(deploymentGVR).Namespace(NamespaceDemo)
+	obj, err := client.Get(ctx, DeploymentWeb, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	ready := deploymentReadyReplicaCycle[tick%uint64(len(deploymentReadyReplicaCycle))]
+	if err := unstructured.SetNestedField(obj.Object, ready, "status", "readyReplicas"); err != nil {
+		return err
+	}
+	if err := unstructured.SetNestedField(obj.Object, ready, "status", "availableReplicas"); err != nil {
+		return err
+	}
+
+	_, err = client.Update(ctx, obj, metav1.UpdateOptions{FieldManager: tickerFieldManager})
+	return err
+}

--- a/internal/k8s/demo/ticker.go
+++ b/internal/k8s/demo/ticker.go
@@ -62,13 +62,26 @@ type Ticker struct {
 	cancel        context.CancelFunc
 	done          chan struct{}
 	restartEvents []string // FIFO of ticker-created event names, oldest first
+	extraClearers []actionClearer
+}
+
+// actionClearer matches the ClearActions method promoted from client-go's
+// embedded testing.Fake, satisfied by *dynamicfake.FakeDynamicClient and
+// *k8sfake.Clientset alike. Nothing else drains that log: every Get/List/
+// Create/Update/Delete against a fake client appends to it, so a
+// long-running demo session grows it without bound (see clearActionLogs).
+type actionClearer interface {
+	ClearActions()
 }
 
 // NewTicker returns a Ticker over dyn that, once started, mutates the demo
 // cluster every interval. It does not touch dyn until Start or Tick is
-// called.
-func NewTicker(dyn dynamic.Interface, interval time.Duration) *Ticker {
-	return &Ticker{dyn: dyn, interval: interval}
+// called. extraClearers are additional fake clients (e.g. the typed demo
+// clientset) whose action log gets cleared on the same cadence as dyn's,
+// even though the ticker itself never calls them — the app's own List/Get
+// calls share those fakes and grow their action log too.
+func NewTicker(dyn dynamic.Interface, interval time.Duration, extraClearers ...actionClearer) *Ticker {
+	return &Ticker{dyn: dyn, interval: interval, extraClearers: extraClearers}
 }
 
 // Start launches the ticker's goroutine, which calls Tick every interval
@@ -90,7 +103,21 @@ func (t *Ticker) Start(ctx context.Context) {
 }
 
 func (t *Ticker) run(ctx context.Context, done chan struct{}) {
-	defer close(done)
+	defer func() {
+		// A goroutine that exits because ctx was cancelled by something
+		// other than Stop (Stop cancels this same runCtx too, so this path
+		// also fires there) must clear running itself — otherwise a later
+		// Start call sees running still true and silently no-ops even
+		// though nothing is left mutating the demo cluster. Guarded by
+		// t.done == done so a concurrent Stop that already reset running
+		// (and possibly started a fresh run) is never clobbered.
+		t.mu.Lock()
+		if t.done == done {
+			t.running = false
+		}
+		t.mu.Unlock()
+		close(done)
+	}()
 
 	// time.NewTicker panics for a non-positive duration; treat a
 	// misconfigured interval as a no-op run instead of crashing the
@@ -146,6 +173,7 @@ func (t *Ticker) Stop() {
 func (t *Ticker) Tick(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	defer t.clearActionLogs()
 
 	tick := t.tick
 	t.tick++
@@ -163,6 +191,20 @@ func (t *Ticker) Tick(ctx context.Context) error {
 		return fmt.Errorf("demo ticker: drifting deployment ready replicas: %w", err)
 	}
 	return nil
+}
+
+// clearActionLogs drops the Actions() log accumulated on dyn and every
+// extra clearer since the last call. Runs at the end of every Tick
+// regardless of error, so a demo session left running overnight (about
+// 28,800 ticks a day at the 3s interval) never retains more than one tick's
+// worth of action history in memory.
+func (t *Ticker) clearActionLogs() {
+	if clearer, ok := t.dyn.(actionClearer); ok {
+		clearer.ClearActions()
+	}
+	for _, c := range t.extraClearers {
+		c.ClearActions()
+	}
 }
 
 // restartCrashLoopPod increments PodWebCrashLoop's restartCount and rotates

--- a/internal/k8s/demo/ticker.go
+++ b/internal/k8s/demo/ticker.go
@@ -263,7 +263,7 @@ func (t *Ticker) appendRestartEvent(ctx context.Context, tick uint64) error {
 
 	name := fmt.Sprintf("web-crash-restart-%d", tick)
 	uid := fmt.Sprintf("e0000000-0000-4000-8000-%012d", tick)
-	now := time.Now().UTC()
+	now := demoEpoch.Add(time.Duration(tick) * t.interval)
 	message := fmt.Sprintf("Back-off restarting failed container web in pod %s_%s(%s)",
 		PodWebCrashLoop, NamespaceDemo, uidPodWebCrash)
 	evt := podWarningEvent(name, uid, PodWebCrashLoop, uidPodWebCrash, "BackOff", message, 1, now, now)

--- a/internal/k8s/demo/ticker.go
+++ b/internal/k8s/demo/ticker.go
@@ -37,8 +37,10 @@ var (
 var waitingReasons = []string{"CrashLoopBackOff", "Error"}
 
 // deploymentReadyReplicaCycle is the sequence of readyReplicas values the
-// web Deployment cycles through, out of its 3 desired replicas.
-var deploymentReadyReplicaCycle = []int64{2, 1, 3}
+// web Deployment cycles through, out of its 6 desired replicas. Two of the
+// three values are fully ready so the deployment reads as ready for a
+// majority of the cycle, dipping once for a still-visible sign of drift.
+var deploymentReadyReplicaCycle = []int64{6, 6, 5}
 
 // Ticker mutates a demo cluster's fake dynamic client on a fixed interval so
 // its informer-backed watchers see live changes: the crashlooping pod

--- a/internal/k8s/demo/ticker_test.go
+++ b/internal/k8s/demo/ticker_test.go
@@ -166,6 +166,49 @@ func TestTicker_EachTickAppendsWarningEventAndStaysUnderCap(t *testing.T) {
 	assert.Greater(t, afterMany, before, "ticks should still be producing events")
 }
 
+// TestTicker_TickClearsActionLogAndStaysBounded drives many ticks and
+// asserts the dynamic fake client's Actions() log stays bounded instead of
+// growing linearly with tick count. Each tick performs roughly eight
+// Get/Update/Create/Delete calls against the fake, all recorded into
+// client-go's testing.Fake (embedded in FakeDynamicClient) with nothing to
+// clear it; left unbounded, a long demo session grows into the multi-GB
+// range (see TASK-865 finding 1).
+func TestTicker_TickClearsActionLogAndStaysBounded(t *testing.T) {
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Hour)
+	ctx := t.Context()
+
+	const manyTicks = 500
+	for range manyTicks {
+		require.NoError(t, tk.Tick(ctx))
+	}
+
+	actions := dyn.Actions()
+	assert.Less(t, len(actions), 20,
+		"expected the fake dynamic client's action log to be cleared each tick, not grow with tick count (%d actions after %d ticks)",
+		len(actions), manyTicks)
+}
+
+// TestTicker_TickClearsExtraClientActionLogs verifies NewTicker's extra
+// clearers (e.g. the typed demo clientset, which shares the same
+// unbounded-Actions() problem since the app's own List/Get calls run
+// against it too) get their action log cleared on the same cadence as the
+// dynamic client, independent of whether the ticker itself touched them.
+func TestTicker_TickClearsExtraClientActionLogs(t *testing.T) {
+	dyn := NewDynamicClient()
+	cs := NewClientset()
+	tk := NewTicker(dyn, time.Hour, cs)
+	ctx := t.Context()
+
+	_, err := cs.CoreV1().Pods(NamespaceDemo).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, cs.Actions(), "test setup: expected the List call to be recorded")
+
+	require.NoError(t, tk.Tick(ctx))
+
+	assert.Empty(t, cs.Actions(), "expected the extra clearer's action log to be cleared after a tick")
+}
+
 func TestTicker_StartStopExitsGoroutineCleanly(t *testing.T) {
 	baseline := runtime.NumGoroutine()
 
@@ -185,6 +228,44 @@ func TestTicker_StartStopExitsGoroutineCleanly(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("Stop did not drain the ticker goroutine: baseline=%d, after=%d", baseline, runtime.NumGoroutine())
+}
+
+// TestTicker_ExternalContextCancelResetsRunningState guards TASK-865
+// finding 6: if the context passed to Start is cancelled by anything other
+// than Stop, the goroutine exits but running stayed true forever (only
+// Stop ever cleared it), so a later Start call would silently no-op instead
+// of actually restarting the ticker.
+func TestTicker_ExternalContextCancelResetsRunningState(t *testing.T) {
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Millisecond)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	tk.Start(ctx)
+	cancel()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		tk.mu.Lock()
+		running := tk.running
+		tk.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tk.mu.Lock()
+	running := tk.running
+	tk.mu.Unlock()
+	require.False(t, running, "expected running to reset to false after external context cancellation, not just after Stop")
+
+	// Prove the practical consequence: Start must actually relaunch the
+	// goroutine after an external cancellation, not silently no-op.
+	baseline := runtime.NumGoroutine()
+	tk.Start(t.Context())
+	defer tk.Stop()
+	assert.Greater(t, runtime.NumGoroutine(), baseline,
+		"expected Start to launch a new goroutine after external cancellation, not silently no-op")
 }
 
 func TestTicker_ContextCancelEndsGoroutine(t *testing.T) {

--- a/internal/k8s/demo/ticker_test.go
+++ b/internal/k8s/demo/ticker_test.go
@@ -14,6 +14,20 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
+// gcd and lcm let tests derive an exact cycle length from the ticker's own
+// per-field cycle constants, instead of hardcoding a value that would go
+// stale silently if those constants change.
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int) int {
+	return a / gcd(a, b) * b
+}
+
 func crashLoopContainerStatus(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]any {
 	t.Helper()
 	obj, err := dyn.Resource(podGVR).Namespace(NamespaceDemo).Get(t.Context(), PodWebCrashLoop, metav1.GetOptions{})
@@ -62,7 +76,9 @@ func TestTicker_FullCycleInvariants(t *testing.T) {
 	tk := NewTicker(dyn, time.Hour)
 	ctx := t.Context()
 
-	const cycleLen = 30 // lcm(5, 2, 3)
+	// cycleLen must stay the LCM of every per-field cycle length so the loop
+	// below always covers a full cycle, even if those constants change.
+	cycleLen := lcm(lcm(healthyPodFlipEvery, len(waitingReasons)), len(deploymentReadyReplicaCycle))
 
 	deployClient := dyn.Resource(deploymentGVR).Namespace(NamespaceDemo)
 	deployObj, err := deployClient.Get(ctx, DeploymentWeb, metav1.GetOptions{})
@@ -164,6 +180,38 @@ func TestTicker_EachTickAppendsWarningEventAndStaysUnderCap(t *testing.T) {
 	assert.LessOrEqual(t, afterMany, before+maxTickerEvents,
 		"event count must stay bounded even after many ticks")
 	assert.Greater(t, afterMany, before, "ticks should still be producing events")
+}
+
+// TestTicker_EventTimestampsAreDeterministic drives two independent Tickers
+// through the same tick and asserts they produce identical Warning Event
+// timestamps -- the ticker's doc comment promises every mutation is a
+// deterministic function of the tick count, which time.Now() would break.
+func TestTicker_EventTimestampsAreDeterministic(t *testing.T) {
+	ctx := t.Context()
+
+	tickEvent := func(dyn *dynamicfake.FakeDynamicClient) map[string]any {
+		t.Helper()
+		// restartCrashLoopPod's tick-0 event is always named "web-crash-restart-0".
+		obj, err := dyn.Resource(eventGVR).Namespace(NamespaceDemo).Get(ctx, "web-crash-restart-0", metav1.GetOptions{})
+		require.NoError(t, err)
+		return obj.Object
+	}
+
+	dynA := NewDynamicClient()
+	tkA := NewTicker(dynA, time.Hour)
+	require.NoError(t, tkA.Tick(ctx))
+	firstA, _, err := unstructured.NestedString(tickEvent(dynA), "firstTimestamp")
+	require.NoError(t, err)
+
+	time.Sleep(1100 * time.Millisecond) // cross a second boundary; metav1.Time truncates to seconds
+
+	dynB := NewDynamicClient()
+	tkB := NewTicker(dynB, time.Hour)
+	require.NoError(t, tkB.Tick(ctx))
+	firstB, _, err := unstructured.NestedString(tickEvent(dynB), "firstTimestamp")
+	require.NoError(t, err)
+
+	assert.Equal(t, firstA, firstB, "tick 0 on two fresh tickers must produce identical event timestamps")
 }
 
 // TestTicker_TickClearsActionLogAndStaysBounded drives many ticks and

--- a/internal/k8s/demo/ticker_test.go
+++ b/internal/k8s/demo/ticker_test.go
@@ -1,0 +1,139 @@
+package demo
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func crashLoopContainerStatus(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]any {
+	t.Helper()
+	obj, err := dyn.Resource(podGVR).Namespace(NamespaceDemo).Get(t.Context(), PodWebCrashLoop, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	statuses, found, err := unstructured.NestedSlice(obj.Object, "status", "containerStatuses")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, statuses, 1)
+
+	cs, ok := statuses[0].(map[string]any)
+	require.True(t, ok)
+	return cs
+}
+
+func TestTicker_TickRaisesRestartCountByOnePerCall(t *testing.T) {
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Hour)
+	ctx := t.Context()
+
+	before, _, err := unstructured.NestedInt64(crashLoopContainerStatus(t, dyn), "restartCount")
+	require.NoError(t, err)
+
+	const n = 5
+	for range n {
+		require.NoError(t, tk.Tick(ctx))
+	}
+
+	after, _, err := unstructured.NestedInt64(crashLoopContainerStatus(t, dyn), "restartCount")
+	require.NoError(t, err)
+	assert.Equal(t, before+n, after, "expected restartCount to rise by exactly one per Tick call")
+}
+
+func TestTicker_TickRotatesWaitingReason(t *testing.T) {
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Hour)
+	ctx := t.Context()
+
+	seen := make([]string, 0, len(waitingReasons)*2)
+	for range len(waitingReasons) * 2 {
+		require.NoError(t, tk.Tick(ctx))
+		reason, found, err := unstructured.NestedString(crashLoopContainerStatus(t, dyn), "state", "waiting", "reason")
+		require.NoError(t, err)
+		require.True(t, found)
+		seen = append(seen, reason)
+	}
+
+	for i, reason := range seen {
+		assert.Equal(t, waitingReasons[i%len(waitingReasons)], reason, "reason at tick %d", i)
+	}
+}
+
+func TestTicker_EachTickAppendsWarningEventAndStaysUnderCap(t *testing.T) {
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Hour)
+	ctx := t.Context()
+
+	countEvents := func() int {
+		list, err := dyn.Resource(eventGVR).Namespace(NamespaceDemo).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		return len(list.Items)
+	}
+
+	before := countEvents()
+
+	require.NoError(t, tk.Tick(ctx))
+	afterOne := countEvents()
+	assert.Equal(t, before+1, afterOne, "expected exactly one new event after one Tick")
+
+	const manyTicks = 200
+	for range manyTicks {
+		require.NoError(t, tk.Tick(ctx))
+	}
+
+	afterMany := countEvents()
+	assert.LessOrEqual(t, afterMany, before+maxTickerEvents,
+		"event count must stay bounded even after many ticks")
+	assert.Greater(t, afterMany, before, "ticks should still be producing events")
+}
+
+func TestTicker_StartStopExitsGoroutineCleanly(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Millisecond)
+
+	tk.Start(t.Context())
+	assert.Greater(t, runtime.NumGoroutine(), baseline, "expected a new goroutine after Start")
+
+	tk.Stop()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+1 { // +1 tolerance for runtime jitter
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Stop did not drain the ticker goroutine: baseline=%d, after=%d", baseline, runtime.NumGoroutine())
+}
+
+func TestTicker_ContextCancelEndsGoroutine(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Millisecond)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	tk.Start(ctx)
+	assert.Greater(t, runtime.NumGoroutine(), baseline, "expected a new goroutine after Start")
+
+	cancel()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+1 {
+			tk.Stop() // idempotent cleanup so the test itself leaves nothing running
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("context cancellation did not end the ticker goroutine: baseline=%d, after=%d", baseline, runtime.NumGoroutine())
+}

--- a/internal/k8s/demo/ticker_test.go
+++ b/internal/k8s/demo/ticker_test.go
@@ -29,6 +29,78 @@ func crashLoopContainerStatus(t *testing.T, dyn *dynamicfake.FakeDynamicClient) 
 	return cs
 }
 
+// podEffectivelyRunning reports whether a pod's Phase is Running and its
+// Ready condition is True, mirroring the app's pod-health classification
+// closely enough to catch the crashlooping pod (Phase Running, Ready False)
+// and a Pending flip (Phase Pending) as not-running.
+func podEffectivelyRunning(obj map[string]any) bool {
+	phase, _, _ := unstructured.NestedString(obj, "status", "phase")
+	if phase != "Running" {
+		return false
+	}
+	conditions, _, _ := unstructured.NestedSlice(obj, "status", "conditions")
+	for _, c := range conditions {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cm["type"] == "Ready" {
+			return cm["status"] == "True"
+		}
+	}
+	return false
+}
+
+// TestTicker_FullCycleInvariants drives the ticker across a full cycle
+// (the LCM of every per-field cycle length: healthyPodFlipEvery, len(
+// waitingReasons), len(deploymentReadyReplicaCycle)) and asserts the two
+// demo-polish invariants: Running pods stay a strict majority of all pods at
+// every tick, and the web Deployment reports fully ready for a majority of
+// the ticks in the cycle.
+func TestTicker_FullCycleInvariants(t *testing.T) {
+	dyn := NewDynamicClient()
+	tk := NewTicker(dyn, time.Hour)
+	ctx := t.Context()
+
+	const cycleLen = 30 // lcm(5, 2, 3)
+
+	deployClient := dyn.Resource(deploymentGVR).Namespace(NamespaceDemo)
+	deployObj, err := deployClient.Get(ctx, DeploymentWeb, metav1.GetOptions{})
+	require.NoError(t, err)
+	desired, _, err := unstructured.NestedInt64(deployObj.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.Positive(t, desired)
+
+	readyTicks := 0
+	for i := range cycleLen {
+		require.NoError(t, tk.Tick(ctx))
+
+		podList, err := dyn.Resource(podGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+
+		var running int
+		for _, item := range podList.Items {
+			if podEffectivelyRunning(item.Object) {
+				running++
+			}
+		}
+		total := len(podList.Items)
+		assert.Greater(t, running*2, total,
+			"tick %d: expected Running pods to be a strict majority (%d running of %d total)", i, running, total)
+
+		deployObj, err := deployClient.Get(ctx, DeploymentWeb, metav1.GetOptions{})
+		require.NoError(t, err)
+		ready, _, err := unstructured.NestedInt64(deployObj.Object, "status", "readyReplicas")
+		require.NoError(t, err)
+		if ready >= desired {
+			readyTicks++
+		}
+	}
+
+	assert.Greater(t, readyTicks*2, cycleLen,
+		"expected the web Deployment to be fully ready for a majority of the cycle (%d/%d ticks ready)", readyTicks, cycleLen)
+}
+
 func TestTicker_TickRaisesRestartCountByOnePerCall(t *testing.T) {
 	dyn := NewDynamicClient()
 	tk := NewTicker(dyn, time.Hour)

--- a/internal/k8s/demo/workloads.go
+++ b/internal/k8s/demo/workloads.go
@@ -1,0 +1,233 @@
+package demo
+
+import (
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func webPodTemplateLabels() map[string]string {
+	return map[string]string{"app": "web", "pod-template-hash": "7d8f9c6b5"}
+}
+
+func webContainerSpec() corev1.Container {
+	return corev1.Container{
+		Name:  "web",
+		Image: "ghcr.io/example/web:1.4.2",
+		Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	}
+}
+
+func buildDeployment() *appsv1.Deployment {
+	created := demoEpoch.Add(-7 * 24 * time.Hour)
+	labels := map[string]string{"app": "web"}
+	replicas := int32(3)
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              DeploymentWeb,
+			Namespace:         NamespaceDemo,
+			UID:               k8stypes.UID(uidDeploymentWeb),
+			Labels:            labels,
+			CreationTimestamp: metav1.NewTime(created),
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kubectl-client-side-apply", "Update",
+					`{"f:spec":{"f:replicas":{},"f:selector":{},"f:template":{}}}`, created),
+				managedField("kube-controller-manager", "Update",
+					`{"f:status":{"f:readyReplicas":{},"f:replicas":{},"f:availableReplicas":{},"f:conditions":{}}}`,
+					demoEpoch.Add(-5*time.Minute)),
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: webPodTemplateLabels()},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{webContainerSpec()}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          3,
+			ReadyReplicas:     2,
+			AvailableReplicas: 2,
+			UpdatedReplicas:   3,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue,
+					Reason: "MinimumReplicasAvailable", Message: "Deployment has minimum availability.",
+				},
+				{
+					Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue,
+					Reason:  "NewReplicaSetAvailable",
+					Message: `ReplicaSet "` + ReplicaSetWeb + `" has successfully progressed.`,
+				},
+			},
+		},
+	}
+}
+
+func buildReplicaSet() *appsv1.ReplicaSet {
+	created := demoEpoch.Add(-7 * 24 * time.Hour)
+	labels := webPodTemplateLabels()
+	replicas := int32(3)
+	controller, block := true, true
+	return &appsv1.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "ReplicaSet"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              ReplicaSetWeb,
+			Namespace:         NamespaceDemo,
+			UID:               k8stypes.UID(uidReplicaSetWeb),
+			Labels:            labels,
+			CreationTimestamp: metav1.NewTime(created),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1", Kind: "Deployment", Name: DeploymentWeb,
+					UID: k8stypes.UID(uidDeploymentWeb), Controller: &controller, BlockOwnerDeletion: &block,
+				},
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("deployment-controller", "Update",
+					`{"f:metadata":{"f:ownerReferences":{}},"f:spec":{"f:replicas":{},"f:selector":{}}}`, created),
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{webContainerSpec()}},
+			},
+		},
+		Status: appsv1.ReplicaSetStatus{Replicas: 3, ReadyReplicas: 2, AvailableReplicas: 2},
+	}
+}
+
+func buildWebPods() []*corev1.Pod {
+	return []*corev1.Pod{
+		healthyWebPod(PodWebHealthy1, uidPodWebHealthy1, "10.0.2.11"),
+		healthyWebPod(PodWebHealthy2, uidPodWebHealthy2, "10.0.2.12"),
+		crashLoopWebPod(),
+	}
+}
+
+func webPodOwnerRef() metav1.OwnerReference {
+	controller, block := true, true
+	return metav1.OwnerReference{
+		APIVersion: "apps/v1", Kind: "ReplicaSet", Name: ReplicaSetWeb,
+		UID: k8stypes.UID(uidReplicaSetWeb), Controller: &controller, BlockOwnerDeletion: &block,
+	}
+}
+
+func healthyWebPod(name, uid, ip string) *corev1.Pod {
+	started := demoEpoch.Add(-2 * time.Hour)
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         NamespaceDemo,
+			UID:               k8stypes.UID(uid),
+			Labels:            webPodTemplateLabels(),
+			CreationTimestamp: metav1.NewTime(started),
+			OwnerReferences:   []metav1.OwnerReference{webPodOwnerRef()},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kube-controller-manager", "Update",
+					`{"f:metadata":{"f:ownerReferences":{}},"f:spec":{"f:containers":{}}}`, started),
+				managedField("kubelet", "Update",
+					`{"f:status":{"f:containerStatuses":{},"f:podIP":{},"f:phase":{}}}`, demoEpoch.Add(-time.Minute)),
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   NodeWorker1,
+			Containers: []corev1.Container{webContainerSpec()},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			PodIP:      ip,
+			StartTime:  ptrTime(started),
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "web",
+					Ready:        true,
+					RestartCount: 0,
+					Image:        "ghcr.io/example/web:1.4.2",
+					State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(started)}},
+				},
+			},
+		},
+	}
+}
+
+func crashLoopWebPod() *corev1.Pod {
+	started := demoEpoch.Add(-40 * time.Minute)
+	lastRestart := demoEpoch.Add(-3 * time.Minute)
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              PodWebCrashLoop,
+			Namespace:         NamespaceDemo,
+			UID:               k8stypes.UID(uidPodWebCrash),
+			Labels:            webPodTemplateLabels(),
+			CreationTimestamp: metav1.NewTime(started),
+			OwnerReferences:   []metav1.OwnerReference{webPodOwnerRef()},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kube-controller-manager", "Update",
+					`{"f:metadata":{"f:ownerReferences":{}},"f:spec":{"f:containers":{}}}`, started),
+				managedField("kubelet", "Update",
+					`{"f:status":{"f:containerStatuses":{},"f:podIP":{},"f:phase":{}}}`, lastRestart),
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   NodeWorker1,
+			Containers: []corev1.Container{webContainerSpec()},
+		},
+		Status: corev1.PodStatus{
+			Phase:     corev1.PodRunning,
+			PodIP:     "10.0.2.13",
+			StartTime: ptrTime(started),
+			Conditions: []corev1.PodCondition{
+				{
+					Type: corev1.PodReady, Status: corev1.ConditionFalse,
+					Reason: "ContainersNotReady", Message: "containers with unready status: [web]",
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "web",
+					Ready:        false,
+					RestartCount: 7,
+					Image:        "ghcr.io/example/web:1.4.2",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "CrashLoopBackOff",
+							Message: "back-off 2m40s restarting failed container=web pod=" +
+								PodWebCrashLoop + "_" + NamespaceDemo + "(" + uidPodWebCrash + ")",
+						},
+					},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode:   1,
+							Reason:     "Error",
+							StartedAt:  metav1.NewTime(lastRestart.Add(-5 * time.Second)),
+							FinishedAt: metav1.NewTime(lastRestart),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/k8s/demo/workloads.go
+++ b/internal/k8s/demo/workloads.go
@@ -35,7 +35,10 @@ func webContainerSpec() corev1.Container {
 func buildDeployment() *appsv1.Deployment {
 	created := demoEpoch.Add(-7 * 24 * time.Hour)
 	labels := map[string]string{"app": "web"}
-	replicas := int32(3)
+	// 6 desired replicas: 5 healthy plus the one crashlooping pod, so the
+	// crashloop stays the single obviously-unhealthy workload among a
+	// mostly-healthy deployment instead of dominating a tiny replica set.
+	replicas := int32(6)
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,10 +64,10 @@ func buildDeployment() *appsv1.Deployment {
 			},
 		},
 		Status: appsv1.DeploymentStatus{
-			Replicas:          3,
-			ReadyReplicas:     2,
-			AvailableReplicas: 2,
-			UpdatedReplicas:   3,
+			Replicas:          6,
+			ReadyReplicas:     5,
+			AvailableReplicas: 5,
+			UpdatedReplicas:   6,
 			Conditions: []appsv1.DeploymentCondition{
 				{
 					Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue,
@@ -83,7 +86,7 @@ func buildDeployment() *appsv1.Deployment {
 func buildReplicaSet() *appsv1.ReplicaSet {
 	created := demoEpoch.Add(-7 * 24 * time.Hour)
 	labels := webPodTemplateLabels()
-	replicas := int32(3)
+	replicas := int32(6)
 	controller, block := true, true
 	return &appsv1.ReplicaSet{
 		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "ReplicaSet"},
@@ -112,14 +115,21 @@ func buildReplicaSet() *appsv1.ReplicaSet {
 				Spec:       corev1.PodSpec{Containers: []corev1.Container{webContainerSpec()}},
 			},
 		},
-		Status: appsv1.ReplicaSetStatus{Replicas: 3, ReadyReplicas: 2, AvailableReplicas: 2},
+		Status: appsv1.ReplicaSetStatus{Replicas: 6, ReadyReplicas: 5, AvailableReplicas: 5},
 	}
 }
 
+// buildWebPods returns the "web" ReplicaSet's pods: 5 healthy pods (one of
+// which the Ticker flips between Running and Pending) and the single
+// crashlooping pod, so Running pods stay a majority throughout the ticker
+// cycle.
 func buildWebPods() []*corev1.Pod {
 	return []*corev1.Pod{
 		healthyWebPod(PodWebHealthy1, uidPodWebHealthy1, "10.0.2.11"),
 		healthyWebPod(PodWebHealthy2, uidPodWebHealthy2, "10.0.2.12"),
+		healthyWebPod(PodWebHealthy3, uidPodWebHealthy3, "10.0.2.14"),
+		healthyWebPod(PodWebHealthy4, uidPodWebHealthy4, "10.0.2.15"),
+		healthyWebPod(PodWebHealthy5, uidPodWebHealthy5, "10.0.2.16"),
 		crashLoopWebPod(),
 	}
 }

--- a/internal/k8s/demo_client_test.go
+++ b/internal/k8s/demo_client_test.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestNewClient_NeverSetsInjectedFields guards acceptance criterion 6: the
+// demo backend must never be selected without the --demo flag. NewClient
+// (the real kubeconfig path) must never populate the injected* fields that
+// *ForContext helpers check before building a real client.
+func TestNewClient_NeverSetsInjectedFields(t *testing.T) {
+	kubecfg := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:1
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    namespace: default
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user: {}
+`
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "kubeconfig")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(kubecfg), 0o600))
+
+	c, err := NewClient(cfgPath, nil, true)
+	require.NoError(t, err)
+
+	assert.Nil(t, c.injectedClientset)
+	assert.Nil(t, c.injectedDynClient)
+	assert.Nil(t, c.injectedMetaClient)
+	assert.False(t, c.IsDemo())
+}
+
+// TestNewDemoClient_ListsPodsAndDeployments exercises GetResources against
+// the demo-backed client for the two resource types acceptance criteria
+// call out explicitly.
+func TestNewDemoClient_ListsPodsAndDeployments(t *testing.T) {
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	require.True(t, c.IsDemo())
+
+	ctx := t.Context()
+
+	podsRT := model.ResourceTypeEntry{APIGroup: "", APIVersion: "v1", Resource: "pods", Kind: "Pod", Namespaced: true}
+	pods, err := c.GetResources(ctx, c.CurrentContext(), demo.NamespaceDemo, podsRT)
+	require.NoError(t, err)
+	assert.NotEmpty(t, pods)
+
+	deploymentsRT := model.ResourceTypeEntry{APIGroup: "apps", APIVersion: "v1", Resource: "deployments", Kind: "Deployment", Namespaced: true}
+	deployments, err := c.GetResources(ctx, c.CurrentContext(), demo.NamespaceDemo, deploymentsRT)
+	require.NoError(t, err)
+	assert.NotEmpty(t, deployments)
+}
+
+// TestNewDemoClient_NoKubeconfigNeeded is acceptance criterion 1: demo
+// startup must work with no kubeconfig on disk at all. Pointing HOME and
+// KUBECONFIG at an empty temp dir simulates a machine with none configured.
+func TestNewDemoClient_NoKubeconfigNeeded(t *testing.T) {
+	emptyDir := t.TempDir()
+	t.Setenv("HOME", emptyDir)
+	t.Setenv("KUBECONFIG", filepath.Join(emptyDir, "does-not-exist"))
+
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.True(t, c.IsDemo())
+}

--- a/internal/k8s/demo_client_test.go
+++ b/internal/k8s/demo_client_test.go
@@ -56,6 +56,7 @@ users:
 func TestNewDemoClient_ListsPodsAndDeployments(t *testing.T) {
 	c, err := NewDemoClient()
 	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
 	require.True(t, c.IsDemo())
 
 	ctx := t.Context()
@@ -81,6 +82,7 @@ func TestNewDemoClient_NoKubeconfigNeeded(t *testing.T) {
 
 	c, err := NewDemoClient()
 	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
 	assert.NotNil(t, c)
 	assert.True(t, c.IsDemo())
 }
@@ -95,6 +97,7 @@ func TestNewDemoClient_NoKubeconfigNeeded(t *testing.T) {
 func TestNewDemoClient_DiscoverAPIResources_NoPanic(t *testing.T) {
 	c, err := NewDemoClient()
 	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
 
 	entries, err := c.DiscoverAPIResources(t.Context(), c.CurrentContext())
 	require.NoError(t, err)
@@ -110,6 +113,7 @@ func TestNewDemoClient_TickerLifetime(t *testing.T) {
 
 	c, err := NewDemoClient()
 	require.NoError(t, err)
+	t.Cleanup(c.Shutdown) // idempotent; covers a require failing before the explicit Shutdown below
 	require.NotNil(t, c.demoTicker, "NewDemoClient must start a demo ticker")
 
 	require.Eventually(t, func() bool {

--- a/internal/k8s/demo_client_test.go
+++ b/internal/k8s/demo_client_test.go
@@ -3,7 +3,9 @@ package k8s
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,4 +83,26 @@ func TestNewDemoClient_NoKubeconfigNeeded(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 	assert.True(t, c.IsDemo())
+}
+
+// TestNewDemoClient_TickerLifetime guards the demo ticker's goroutine
+// lifetime: NewDemoClient must start it, and Client.Shutdown must stop it,
+// so a demo session never leaks a background goroutine past the client
+// that owns it.
+func TestNewDemoClient_TickerLifetime(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	require.NotNil(t, c.demoTicker, "NewDemoClient must start a demo ticker")
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() > baseline
+	}, time.Second, 10*time.Millisecond, "expected a new goroutine after NewDemoClient")
+
+	c.Shutdown()
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baseline+1 // +1 tolerance for runtime jitter
+	}, time.Second, 10*time.Millisecond, "Shutdown did not drain the demo ticker goroutine")
 }

--- a/internal/k8s/demo_client_test.go
+++ b/internal/k8s/demo_client_test.go
@@ -85,6 +85,22 @@ func TestNewDemoClient_NoKubeconfigNeeded(t *testing.T) {
 	assert.True(t, c.IsDemo())
 }
 
+// TestNewDemoClient_DiscoverAPIResources_NoPanic is the regression guard for
+// the --demo startup crash: fetchCRDPrinterColumns lists
+// customresourcedefinitions unconditionally, and a demo dynamic fake
+// missing that ListKind registration panics instead of erroring (see
+// dynamicfake's NewSimpleDynamicClientWithCustomListKinds). DiscoverAPIResources
+// runs on a scheduler worker goroutine, so nothing upstream can recover a
+// panic reaching this call.
+func TestNewDemoClient_DiscoverAPIResources_NoPanic(t *testing.T) {
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+
+	entries, err := c.DiscoverAPIResources(t.Context(), c.CurrentContext())
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries)
+}
+
 // TestNewDemoClient_TickerLifetime guards the demo ticker's goroutine
 // lifetime: NewDemoClient must start it, and Client.Shutdown must stop it,
 // so a demo session never leaks a background goroutine past the client

--- a/internal/k8s/demo_prometheus_test.go
+++ b/internal/k8s/demo_prometheus_test.go
@@ -1,0 +1,131 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// withGlobalPrometheusConfig registers a `_global` monitoring config
+// carrying a Prometheus block, mirroring a real user's
+// ~/.config/lfk/config.yaml. Callers exercising a demo Client against this
+// config reproduce the --demo startup crash: demo mode has no real cluster
+// this config could plausibly point at, but the code must not learn that by
+// panicking.
+func withGlobalPrometheusConfig(t *testing.T) {
+	t.Helper()
+	prev := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = prev })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"_global": {
+			Prometheus: &model.MonitoringEndpoint{
+				Namespaces: []string{"monitoring"},
+				Services:   []string{"prometheus"},
+				Port:       "9090",
+			},
+			Alertmanager: &model.MonitoringEndpoint{
+				Namespaces: []string{"monitoring"},
+				Services:   []string{"alertmanager"},
+				Port:       "9093",
+			},
+		},
+	}
+}
+
+// TestNewDemoClient_GetAllNodeMetrics_PrometheusConfigured_NoPanic is the
+// regression guard for the --demo startup crash on a machine with a real
+// lfk config carrying a `_global` Prometheus block: resolveNodeMetricsConfig
+// picks up the global config and routes node metrics through Prometheus
+// first, and the demo backend's fake clientset panics inside ProxyGet
+// itself. Node metrics must instead fall back to the metrics-api route,
+// which the demo backend seeds real data for.
+func TestNewDemoClient_GetAllNodeMetrics_PrometheusConfigured_NoPanic(t *testing.T) {
+	withGlobalPrometheusConfig(t)
+
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
+
+	metrics, err := c.GetAllNodeMetrics(t.Context(), c.CurrentContext())
+	require.NoError(t, err, "must fall back to metrics-api, not error out")
+	assert.Contains(t, metrics, demo.NodeControlPlane)
+	assert.Contains(t, metrics, demo.NodeWorker1)
+}
+
+// TestNewDemoClient_GetAllPodMetrics_PrometheusConfigured_NoPanic mirrors
+// TestNewDemoClient_GetAllNodeMetrics_PrometheusConfigured_NoPanic for the
+// pod-metrics route, which shares the same Prometheus-first routing.
+func TestNewDemoClient_GetAllPodMetrics_PrometheusConfigured_NoPanic(t *testing.T) {
+	withGlobalPrometheusConfig(t)
+
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
+
+	metrics, err := c.GetAllPodMetrics(t.Context(), c.CurrentContext(), demo.NamespaceDemo)
+	require.NoError(t, err, "must fall back to metrics-api, not error out")
+	assert.NotEmpty(t, metrics)
+}
+
+// TestNewDemoClient_GetNodeUptimes_PrometheusConfigured_NoPanic covers the
+// node-uptime path, which shares queryPrometheusMetric with node CPU/mem
+// metrics but has no metrics-api fallback (uptime is Prometheus-only) -- the
+// important assertion here is the absence of a panic, not a populated
+// result.
+func TestNewDemoClient_GetNodeUptimes_PrometheusConfigured_NoPanic(t *testing.T) {
+	withGlobalPrometheusConfig(t)
+
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
+
+	uptimes, err := c.GetNodeUptimes(t.Context(), c.CurrentContext())
+	assert.Error(t, err, "demo mode has no Prometheus to answer this query")
+	assert.True(t, uptimes.Empty())
+}
+
+// TestNewDemoClient_GetActiveAlerts_PrometheusConfigured_NoPanic and
+// TestNewDemoClient_GetAllActiveAlerts_PrometheusConfigured_NoPanic cover
+// alerts.go's separate ProxyGet implementation, reachable from the Cluster
+// Dashboard the same way node metrics are.
+func TestNewDemoClient_GetActiveAlerts_PrometheusConfigured_NoPanic(t *testing.T) {
+	withGlobalPrometheusConfig(t)
+
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
+
+	alerts, err := c.GetActiveAlerts(t.Context(), c.CurrentContext(), demo.NamespaceDemo, "web", "Deployment")
+	assert.Error(t, err)
+	assert.Empty(t, alerts)
+}
+
+func TestNewDemoClient_GetAllActiveAlerts_PrometheusConfigured_NoPanic(t *testing.T) {
+	withGlobalPrometheusConfig(t)
+
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
+
+	alerts, err := c.GetAllActiveAlerts(t.Context(), c.CurrentContext(), "")
+	assert.Error(t, err)
+	assert.Empty(t, alerts)
+}
+
+// TestClient_RunPrometheusQuery_DemoMode_NoPanic covers the right-sizing
+// Prometheus strategies' shared query path directly: GetRightsizing needs a
+// real workload fixture to reach it, but runPrometheusQuery is the single
+// choke point every Prometheus strategy funnels through.
+func TestClient_RunPrometheusQuery_DemoMode_NoPanic(t *testing.T) {
+	c, err := NewDemoClient()
+	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
+
+	data, err := c.runPrometheusQuery(t.Context(), c.CurrentContext(), "up")
+	assert.ErrorIs(t, err, errPrometheusUnavailableDemo)
+	assert.Nil(t, data)
+}

--- a/internal/k8s/describe_pod.go
+++ b/internal/k8s/describe_pod.go
@@ -9,14 +9,12 @@ import (
 )
 
 // kubectlBinForDescribe returns the kubectl binary path used by DescribePod.
-// Tests can override via the KUBECTL_BIN env var; production resolves
-// "kubectl" on PATH at exec.CommandContext time, matching the app-layer
-// describe runner in internal/app/commands_exec.go. Evaluated per-call so
-// tests can change the env between sub-tests without leaking state through
-// a package-init capture.
+// Delegates to KubectlPath; falls back to the bare "kubectl" name (letting
+// exec.CommandContext resolve it on PATH at fork time) when resolution
+// fails, matching this function's original never-erroring contract.
 func kubectlBinForDescribe() string {
-	if v := os.Getenv("KUBECTL_BIN"); v != "" {
-		return v
+	if path, err := KubectlPath(); err == nil {
+		return path
 	}
 	return "kubectl"
 }

--- a/internal/k8s/describe_pod.go
+++ b/internal/k8s/describe_pod.go
@@ -8,17 +8,6 @@ import (
 	"strings"
 )
 
-// kubectlBinForDescribe returns the kubectl binary path used by DescribePod.
-// Delegates to KubectlPath; falls back to the bare "kubectl" name (letting
-// exec.CommandContext resolve it on PATH at fork time) when resolution
-// fails, matching this function's original never-erroring contract.
-func kubectlBinForDescribe() string {
-	if path, err := KubectlPath(); err == nil {
-		return path
-	}
-	return "kubectl"
-}
-
 // DescribePod runs `kubectl describe pod <podName> -n <namespace> --context
 // <contextName>` and returns the combined output. Used by
 // GetCrashInvestigation to fill the Describe tab when no test override is
@@ -27,8 +16,13 @@ func kubectlBinForDescribe() string {
 // kubectl is required on PATH (lfk already requires it for other commands).
 // On non-zero exit the error includes the trimmed stderr/stdout for context.
 func (c *Client) DescribePod(ctx context.Context, contextName, namespace, podName string) (string, error) {
+	kubectlPath, err := KubectlPath()
+	if err != nil {
+		return "", fmt.Errorf("kubectl not found: %w", err)
+	}
+
 	args := []string{"describe", "pod", podName, "-n", namespace, "--context", contextName}
-	cmd := exec.CommandContext(ctx, kubectlBinForDescribe(), args...)
+	cmd := exec.CommandContext(ctx, kubectlPath, args...)
 	if path := c.KubeconfigPathForContext(contextName); path != "" {
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+path)
 	}

--- a/internal/k8s/describe_pod.go
+++ b/internal/k8s/describe_pod.go
@@ -22,7 +22,7 @@ func (c *Client) DescribePod(ctx context.Context, contextName, namespace, podNam
 	}
 
 	args := []string{"describe", "pod", podName, "-n", namespace, "--context", contextName}
-	cmd := exec.CommandContext(ctx, kubectlPath, args...)
+	cmd := exec.CommandContext(ctx, kubectlPath, DemoKubectlArgs(args)...)
 	if path := c.KubeconfigPathForContext(contextName); path != "" {
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+path)
 	}

--- a/internal/k8s/describe_pod_test.go
+++ b/internal/k8s/describe_pod_test.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDescribePod_FailsClosedWhenKubectlNotFound guards TASK-865 finding 5:
+// DescribePod was the only KubectlPath caller in the module that swallowed
+// resolution failure and fell back to the bare "kubectl" name, letting
+// exec.CommandContext resolve it on PATH at fork time instead of surfacing
+// the error the other 31 call sites all return. It must fail closed like
+// every other KubectlPath call site.
+func TestDescribePod_FailsClosedWhenKubectlNotFound(t *testing.T) {
+	emptyPath := t.TempDir()
+	t.Setenv("KUBECTL_BIN", "")
+	t.Setenv("PATH", emptyPath)
+
+	c := NewTestClient(nil, nil)
+	_, err := c.DescribePod(t.Context(), "test-ctx", "default", "web-1")
+	if err == nil {
+		t.Fatal("DescribePod() error = nil, want an error when kubectl is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "kubectl not found") {
+		t.Errorf("DescribePod() error = %v, want it to mention \"kubectl not found\"", err)
+	}
+}

--- a/internal/k8s/discovery_cache.go
+++ b/internal/k8s/discovery_cache.go
@@ -54,11 +54,11 @@ func DiscoveryCacheBaseDir() string {
 }
 
 // discoveryForContext returns a per-context disk-cached discovery client,
-// memoized in-process. testClientset bypasses the disk path so unit tests
-// don't touch the filesystem.
+// memoized in-process. injectedClientset bypasses the disk path so unit
+// tests don't touch the filesystem.
 func (c *Client) discoveryForContext(displayName string) (discovery.DiscoveryInterface, error) {
-	if c.testClientset != nil {
-		if cs, ok := c.testClientset.(kubernetes.Interface); ok {
+	if c.injectedClientset != nil {
+		if cs, ok := c.injectedClientset.(kubernetes.Interface); ok {
 			return cs.Discovery(), nil
 		}
 	}

--- a/internal/k8s/discovery_cache_test.go
+++ b/internal/k8s/discovery_cache_test.go
@@ -130,7 +130,7 @@ func TestInvalidateDiscoveryCache_PresentKey(t *testing.T) {
 }
 
 func TestDiscoveryForContext_TestClientsetEscape(t *testing.T) {
-	// When testClientset is set, discoveryForContext must bypass the
+	// When injectedClientset is set, discoveryForContext must bypass the
 	// disk-cache path entirely and return the fake's Discovery() —
 	// otherwise unit tests would touch ~/.kube/cache.
 	cs := k8sfake.NewClientset()

--- a/internal/k8s/kubectl_path.go
+++ b/internal/k8s/kubectl_path.go
@@ -5,11 +5,33 @@ import (
 	"os/exec"
 )
 
+// demoMode is set once at startup by SetDemoMode when --demo is passed. It
+// defaults to off so every non-demo run resolves a real kubectl exactly as
+// before.
+var demoMode bool
+
+// SetDemoMode turns demo-mode kubectl resolution on or off. Call it once at
+// startup, before any KubectlPath call, when the --demo flag is set.
+func SetDemoMode(on bool) {
+	demoMode = on
+}
+
+// DemoModeEnabled reports whether demo-mode kubectl resolution is active.
+func DemoModeEnabled() bool {
+	return demoMode
+}
+
 // KubectlPath resolves the kubectl binary every call site should invoke.
-// KUBECTL_BIN overrides PATH lookup unconditionally (used by tests and by
-// demo mode to point at a stub instead of a real cluster-connected
-// kubectl); when unset it falls back to exec.LookPath("kubectl").
+// In demo mode it returns this process's own executable, so every call site
+// re-enters the __demo-kubectl subcommand instead of a kubectl on the user's
+// PATH — this takes priority over KUBECTL_BIN so no code path can reach a
+// real cluster while --demo is set.
+// Outside demo mode, KUBECTL_BIN overrides PATH lookup unconditionally (used
+// by tests); when unset it falls back to exec.LookPath("kubectl").
 func KubectlPath() (string, error) {
+	if demoMode {
+		return os.Executable()
+	}
 	if v := os.Getenv("KUBECTL_BIN"); v != "" {
 		return v, nil
 	}

--- a/internal/k8s/kubectl_path.go
+++ b/internal/k8s/kubectl_path.go
@@ -1,0 +1,17 @@
+package k8s
+
+import (
+	"os"
+	"os/exec"
+)
+
+// KubectlPath resolves the kubectl binary every call site should invoke.
+// KUBECTL_BIN overrides PATH lookup unconditionally (used by tests and by
+// demo mode to point at a stub instead of a real cluster-connected
+// kubectl); when unset it falls back to exec.LookPath("kubectl").
+func KubectlPath() (string, error) {
+	if v := os.Getenv("KUBECTL_BIN"); v != "" {
+		return v, nil
+	}
+	return exec.LookPath("kubectl")
+}

--- a/internal/k8s/kubectl_path.go
+++ b/internal/k8s/kubectl_path.go
@@ -37,3 +37,18 @@ func KubectlPath() (string, error) {
 	}
 	return exec.LookPath("kubectl")
 }
+
+// DemoKubectlArgs prepends the hidden __demo-kubectl subcommand name to args
+// when demo-mode kubectl resolution is active. KubectlPath returns this
+// process's own executable in that mode, but the re-exec'd binary is still a
+// full lfk CLI: kubectl-shaped argv (e.g. "edit pod foo --context demo")
+// would otherwise be parsed by the root command itself (matching its own
+// --context/--namespace flags) and launch a second TUI instead of routing
+// into the demo kubectl emulation in internal/democli. Every call site that
+// builds an exec.Command(kubectlPath, ...) must wrap its args with this.
+func DemoKubectlArgs(args []string) []string {
+	if !demoMode {
+		return args
+	}
+	return append([]string{"__demo-kubectl"}, args...)
+}

--- a/internal/k8s/kubectl_path_guard_test.go
+++ b/internal/k8s/kubectl_path_guard_test.go
@@ -1,10 +1,15 @@
 package k8s
 
 import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -73,37 +78,39 @@ func TestNoBareKubectlLookPath(t *testing.T) {
 	}
 }
 
-// literalLookPathRE matches an exec.LookPath call with a literal binary
-// name, e.g. exec.LookPath("trivy"). A dynamic argument (exec.LookPath(name))
-// can't be checked this way and isn't matched.
-var literalLookPathRE = regexp.MustCompile(`exec\.LookPath\("([^"]+)"\)`)
-
-// externalBinaryLookupAllowlist is every literal exec.LookPath("name") call
-// site the module may contain, keyed by its path relative to the module
-// root. Adding an entry here is a deliberate signal: the binary it resolves
-// either can't run in demo mode, or is gated the way resolveHelmPath and
-// vulnScanImage gate helm and trivy — k8s.DemoModeEnabled() checked before
-// the binary is ever resolved. TASK-865 finding 2 found trivy resolving
-// unconditionally because the original sweep only covered kubectl; this
-// guard generalizes TestNoBareKubectlLookPath to every external binary so
-// the next one can't slip through the same way.
-var externalBinaryLookupAllowlist = map[string]string{
-	filepath.Join("internal", "k8s", "kubectl_path.go"):       "kubectl",
-	filepath.Join("internal", "app", "commands_exec_helm.go"): "helm",
-	filepath.Join("internal", "app", "commands_exec_misc.go"): "trivy",
+// execCallSite is one exec.LookPath or exec.Command call whose first
+// argument is a string literal, found by walking the module's AST.
+type execCallSite struct {
+	file   string // path relative to the module root
+	fn     string // "LookPath" or "Command"
+	binary string // the literal argument value
 }
 
-// TestNoUnguardedExternalBinaryLookup walks the module for every literal
-// exec.LookPath("name") call outside of production _test.go files and
-// requires each one to be an already-reviewed entry in
-// externalBinaryLookupAllowlist. Test files are skipped: they exist to
-// exercise the guarded call sites (e.g. comparing resolveHelmPath's output
-// against a raw exec.LookPath("helm")) and never run as part of the shipped
-// binary.
-func TestNoUnguardedExternalBinaryLookup(t *testing.T) {
-	root := moduleRoot(t)
+// collectLiteralExecCalls walks every non-test .go file under root and
+// returns each call to exec.LookPath or exec.Command whose first argument is
+// a string literal.
+//
+// An AST walk is used instead of a regex: a regex matching exec.LookPath("x")
+// or exec.Command("x", ...) is easy to write, but it only matches that exact
+// textual shape — it misses the call when it's spread across multiple lines,
+// and can't reliably tell a literal argument from one reached through a
+// method chain or a renamed import. Walking the parsed syntax tree instead
+// means the shape is checked structurally: a *ast.CallExpr on a selector
+// whose package identifier is exec and whose first argument is a
+// *ast.BasicLit. Formatting never matters, and a variable argument (the
+// pattern every guarded call site already uses) is never mistaken for a
+// literal.
+//
+// A call whose first argument is not a literal (i.e. a variable, like every
+// production exec.Command(kubectlPath, ...) call site) is not collected —
+// by design, since routing the binary name through a variable resolved by a
+// guarded function (KubectlPath, resolveHelmPath, ...) is exactly the
+// pattern this guard exists to enforce.
+func collectLiteralExecCalls(t *testing.T, root string) []execCallSite {
+	t.Helper()
 
-	var offenders []string
+	var sites []execCallSite
+	fset := token.NewFileSet()
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -118,30 +125,98 @@ func TestNoUnguardedExternalBinaryLookup(t *testing.T) {
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
+
+		astFile, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return fmt.Errorf("parsing %s: %w", path, parseErr)
 		}
 		rel, relErr := filepath.Rel(root, path)
 		if relErr != nil {
 			rel = path
 		}
-		for _, m := range literalLookPathRE.FindAllStringSubmatch(string(data), -1) {
-			binary := m[1]
-			if want, ok := externalBinaryLookupAllowlist[rel]; ok && want == binary {
-				continue
+
+		ast.Inspect(astFile, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
 			}
-			offenders = append(offenders, rel+": exec.LookPath(\""+binary+"\")")
-		}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkgIdent, ok := sel.X.(*ast.Ident)
+			if !ok || pkgIdent.Name != "exec" {
+				return true
+			}
+			if sel.Sel.Name != "LookPath" && sel.Sel.Name != "Command" {
+				return true
+			}
+			if len(call.Args) == 0 {
+				return true
+			}
+			lit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			binary, unquoteErr := strconv.Unquote(lit.Value)
+			if unquoteErr != nil {
+				return true
+			}
+			sites = append(sites, execCallSite{file: rel, fn: sel.Sel.Name, binary: binary})
+			return true
+		})
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking module root: %v", err)
 	}
+	return sites
+}
+
+// externalBinaryLookupAllowlist is every literal-argument exec.LookPath or
+// exec.Command call site the module may contain, keyed by its path relative
+// to the module root and then by the literal binary/interpreter name.
+// Adding an entry here is a deliberate signal: the binary it resolves either
+// can't run in demo mode, or is gated the way resolveHelmPath and
+// vulnScanImage gate helm and trivy — k8s.DemoModeEnabled() checked before
+// the binary is ever resolved. The "sh" entries are the shell interpreter
+// invoked with an already-guarded command string (exec.Command("sh", "-c",
+// cmd)), not an external tool being resolved, so they carry no bypass risk
+// of their own.
+//
+// TASK-865 finding 2 found this guard only matched exec.LookPath, so a
+// direct exec.Command("literal", ...) — which skips LookPath entirely —
+// stayed invisible to it. This allowlist now covers both call shapes.
+var externalBinaryLookupAllowlist = map[string]map[string]bool{
+	filepath.Join("internal", "k8s", "kubectl_path.go"):       {"kubectl": true},
+	filepath.Join("internal", "app", "commands_exec_helm.go"): {"helm": true, "sh": true},
+	filepath.Join("internal", "app", "commands_exec_misc.go"): {"trivy": true, "sh": true},
+	filepath.Join("internal", "app", "commandbar_execute.go"): {"sh": true},
+	filepath.Join("internal", "app", "commands.go"):           {"sh": true},
+}
+
+// TestNoUnguardedExternalBinaryLookup walks the module for every
+// literal-argument exec.LookPath or exec.Command call outside of production
+// _test.go files and requires each one to be an already-reviewed entry in
+// externalBinaryLookupAllowlist. Test files are skipped: they exist to
+// exercise the guarded call sites (e.g. comparing resolveHelmPath's output
+// against a raw exec.LookPath("helm")) and never run as part of the shipped
+// binary.
+func TestNoUnguardedExternalBinaryLookup(t *testing.T) {
+	root := moduleRoot(t)
+
+	var offenders []string
+	for _, site := range collectLiteralExecCalls(t, root) {
+		if externalBinaryLookupAllowlist[site.file][site.binary] {
+			continue
+		}
+		offenders = append(offenders, fmt.Sprintf("%s: exec.%s(%q)", site.file, site.fn, site.binary))
+	}
+	sort.Strings(offenders)
 	if len(offenders) > 0 {
-		t.Errorf("found exec.LookPath call(s) not in externalBinaryLookupAllowlist; "+
-			"confirm the binary can't reach a real cluster/network in demo mode (gate it with "+
-			"k8s.DemoModeEnabled() first if it can), then add it to the allowlist:\n%s",
+		t.Errorf("found exec.LookPath/exec.Command call(s) with a literal binary name not in "+
+			"externalBinaryLookupAllowlist; confirm the binary can't reach a real cluster/network in "+
+			"demo mode (gate it with k8s.DemoModeEnabled() first if it can), then add it to the allowlist:\n%s",
 			strings.Join(offenders, "\n"))
 	}
 }

--- a/internal/k8s/kubectl_path_guard_test.go
+++ b/internal/k8s/kubectl_path_guard_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -69,6 +70,79 @@ func TestNoBareKubectlLookPath(t *testing.T) {
 	if len(offenders) > 0 {
 		t.Errorf("found bare %s outside the shared resolver; route these through k8s.KubectlPath() instead:\n%s",
 			bannedKubectlLookup, strings.Join(offenders, "\n"))
+	}
+}
+
+// literalLookPathRE matches an exec.LookPath call with a literal binary
+// name, e.g. exec.LookPath("trivy"). A dynamic argument (exec.LookPath(name))
+// can't be checked this way and isn't matched.
+var literalLookPathRE = regexp.MustCompile(`exec\.LookPath\("([^"]+)"\)`)
+
+// externalBinaryLookupAllowlist is every literal exec.LookPath("name") call
+// site the module may contain, keyed by its path relative to the module
+// root. Adding an entry here is a deliberate signal: the binary it resolves
+// either can't run in demo mode, or is gated the way resolveHelmPath and
+// vulnScanImage gate helm and trivy — k8s.DemoModeEnabled() checked before
+// the binary is ever resolved. TASK-865 finding 2 found trivy resolving
+// unconditionally because the original sweep only covered kubectl; this
+// guard generalizes TestNoBareKubectlLookPath to every external binary so
+// the next one can't slip through the same way.
+var externalBinaryLookupAllowlist = map[string]string{
+	filepath.Join("internal", "k8s", "kubectl_path.go"):       "kubectl",
+	filepath.Join("internal", "app", "commands_exec_helm.go"): "helm",
+	filepath.Join("internal", "app", "commands_exec_misc.go"): "trivy",
+}
+
+// TestNoUnguardedExternalBinaryLookup walks the module for every literal
+// exec.LookPath("name") call outside of production _test.go files and
+// requires each one to be an already-reviewed entry in
+// externalBinaryLookupAllowlist. Test files are skipped: they exist to
+// exercise the guarded call sites (e.g. comparing resolveHelmPath's output
+// against a raw exec.LookPath("helm")) and never run as part of the shipped
+// binary.
+func TestNoUnguardedExternalBinaryLookup(t *testing.T) {
+	root := moduleRoot(t)
+
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		for _, m := range literalLookPathRE.FindAllStringSubmatch(string(data), -1) {
+			binary := m[1]
+			if want, ok := externalBinaryLookupAllowlist[rel]; ok && want == binary {
+				continue
+			}
+			offenders = append(offenders, rel+": exec.LookPath(\""+binary+"\")")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking module root: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("found exec.LookPath call(s) not in externalBinaryLookupAllowlist; "+
+			"confirm the binary can't reach a real cluster/network in demo mode (gate it with "+
+			"k8s.DemoModeEnabled() first if it can), then add it to the allowlist:\n%s",
+			strings.Join(offenders, "\n"))
 	}
 }
 

--- a/internal/k8s/kubectl_path_guard_test.go
+++ b/internal/k8s/kubectl_path_guard_test.go
@@ -1,0 +1,95 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// bannedKubectlLookup is the exact call every production call site must
+// route through KubectlPath instead — see kubectl_path.go. A literal
+// substring match is enough here because the banned expression is a fixed
+// call with a fixed string-literal argument, not a pattern that a method
+// chain or a rename could vary.
+const bannedKubectlLookup = `exec.LookPath("kubectl")`
+
+// guardExemptFiles are the only files allowed to contain the banned call:
+// the resolver's own implementation, its test's expected-value fixture, and
+// this guard file, which necessarily quotes the banned literal to define it.
+var guardExemptFiles = map[string]bool{
+	"kubectl_path.go":            true,
+	"kubectl_path_test.go":       true,
+	"kubectl_path_guard_test.go": true,
+}
+
+// TestNoBareKubectlLookPath walks the module for the literal
+// exec.LookPath("kubectl") call outside the shared resolver. Every other
+// call site must go through KubectlPath so demo mode's KUBECTL_BIN override
+// (which points kubeconfig precedence at /dev/null) cannot be bypassed by a
+// path that falls back to the user's real default kubeconfig.
+func TestNoBareKubectlLookPath(t *testing.T) {
+	root := moduleRoot(t)
+
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if guardExemptFiles[filepath.Base(path)] {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(data), bannedKubectlLookup) {
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				rel = path
+			}
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking module root: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("found bare %s outside the shared resolver; route these through k8s.KubectlPath() instead:\n%s",
+			bannedKubectlLookup, strings.Join(offenders, "\n"))
+	}
+}
+
+// moduleRoot locates the repository root by walking up from this test file
+// until a go.mod is found, so the guard scans the whole module regardless of
+// the working directory `go test` was invoked from.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed to resolve this test file's path")
+	}
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate go.mod above " + thisFile)
+		}
+		dir = parent
+	}
+}

--- a/internal/k8s/kubectl_path_guard_test.go
+++ b/internal/k8s/kubectl_path_guard_test.go
@@ -78,17 +78,99 @@ func TestNoBareKubectlLookPath(t *testing.T) {
 	}
 }
 
-// execCallSite is one exec.LookPath or exec.Command call whose first
-// argument is a string literal, found by walking the module's AST.
+// execNameResolvers maps every os/exec function that resolves or spawns a
+// binary/interpreter from a name argument to the index of that argument.
+// Verified against `go doc -all os/exec`: LookPath and Command take the
+// name first; CommandContext takes a context.Context first, so the name
+// shifts to index 1. Those three are the entire set — no other exported
+// os/exec function accepts a binary or interpreter name. Get the index
+// wrong here and the guard silently stops checking that function's calls.
+var execNameResolvers = map[string]int{
+	"LookPath":       0,
+	"Command":        0,
+	"CommandContext": 1,
+}
+
+// execCallSite is one exec.LookPath, exec.Command, or exec.CommandContext
+// call whose binary-name argument resolves to a constant string, found by
+// walking the module's AST.
 type execCallSite struct {
 	file   string // path relative to the module root
-	fn     string // "LookPath" or "Command"
-	binary string // the literal argument value
+	fn     string // "LookPath", "Command", or "CommandContext"
+	binary string // the resolved argument value
+}
+
+// foldConstString evaluates expr as a compile-time string constant: a string
+// literal, a same-file const identifier (resolved via consts), or a chain of
+// string literals/consts joined with +. It does not use go/types, so it only
+// sees what's visible in the current file: a const defined in another file
+// or package, or a value built by anything other than literal concatenation
+// (a function call, a const block using iota, etc.), is not resolved and the
+// call is skipped rather than misreported.
+func foldConstString(expr ast.Expr, consts map[string]string) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return "", false
+		}
+		v, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return "", false
+		}
+		return v, true
+	case *ast.Ident:
+		v, ok := consts[e.Name]
+		return v, ok
+	case *ast.BinaryExpr:
+		if e.Op != token.ADD {
+			return "", false
+		}
+		l, ok := foldConstString(e.X, consts)
+		if !ok {
+			return "", false
+		}
+		r, ok := foldConstString(e.Y, consts)
+		if !ok {
+			return "", false
+		}
+		return l + r, true
+	default:
+		return "", false
+	}
+}
+
+// fileStringConsts collects every top-level `const` in astFile whose value
+// folds to a string, keyed by name. Consts are resolved in declaration
+// order, so a const defined in terms of an earlier const in the same file
+// folds too; forward references within a file do not.
+func fileStringConsts(astFile *ast.File) map[string]string {
+	consts := make(map[string]string)
+	for _, decl := range astFile.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			vspec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vspec.Names {
+				if i >= len(vspec.Values) {
+					continue
+				}
+				if v, ok := foldConstString(vspec.Values[i], consts); ok {
+					consts[name.Name] = v
+				}
+			}
+		}
+	}
+	return consts
 }
 
 // collectLiteralExecCalls walks every non-test .go file under root and
-// returns each call to exec.LookPath or exec.Command whose first argument is
-// a string literal.
+// returns each call to a function in execNameResolvers whose binary-name
+// argument resolves to a constant string.
 //
 // An AST walk is used instead of a regex: a regex matching exec.LookPath("x")
 // or exec.Command("x", ...) is easy to write, but it only matches that exact
@@ -96,16 +178,17 @@ type execCallSite struct {
 // and can't reliably tell a literal argument from one reached through a
 // method chain or a renamed import. Walking the parsed syntax tree instead
 // means the shape is checked structurally: a *ast.CallExpr on a selector
-// whose package identifier is exec and whose first argument is a
-// *ast.BasicLit. Formatting never matters, and a variable argument (the
-// pattern every guarded call site already uses) is never mistaken for a
-// literal.
+// whose package identifier is exec and whose function name is in
+// execNameResolvers, with the argument at that function's name-index folding
+// to a constant string via foldConstString. Formatting never matters, and a
+// variable argument (the pattern every guarded call site already uses) is
+// never mistaken for a constant.
 //
-// A call whose first argument is not a literal (i.e. a variable, like every
-// production exec.Command(kubectlPath, ...) call site) is not collected —
-// by design, since routing the binary name through a variable resolved by a
-// guarded function (KubectlPath, resolveHelmPath, ...) is exactly the
-// pattern this guard exists to enforce.
+// A call whose name argument is a variable (i.e. every production
+// exec.Command(kubectlPath, ...) call site) is not collected — by design,
+// since routing the binary name through a variable resolved by a guarded
+// function (KubectlPath, resolveHelmPath, ...) is exactly the pattern this
+// guard exists to enforce.
 func collectLiteralExecCalls(t *testing.T, root string) []execCallSite {
 	t.Helper()
 
@@ -134,6 +217,7 @@ func collectLiteralExecCalls(t *testing.T, root string) []execCallSite {
 		if relErr != nil {
 			rel = path
 		}
+		consts := fileStringConsts(astFile)
 
 		ast.Inspect(astFile, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
@@ -148,18 +232,15 @@ func collectLiteralExecCalls(t *testing.T, root string) []execCallSite {
 			if !ok || pkgIdent.Name != "exec" {
 				return true
 			}
-			if sel.Sel.Name != "LookPath" && sel.Sel.Name != "Command" {
+			argIdx, ok := execNameResolvers[sel.Sel.Name]
+			if !ok {
 				return true
 			}
-			if len(call.Args) == 0 {
+			if len(call.Args) <= argIdx {
 				return true
 			}
-			lit, ok := call.Args[0].(*ast.BasicLit)
-			if !ok || lit.Kind != token.STRING {
-				return true
-			}
-			binary, unquoteErr := strconv.Unquote(lit.Value)
-			if unquoteErr != nil {
+			binary, ok := foldConstString(call.Args[argIdx], consts)
+			if !ok {
 				return true
 			}
 			sites = append(sites, execCallSite{file: rel, fn: sel.Sel.Name, binary: binary})
@@ -173,20 +254,29 @@ func collectLiteralExecCalls(t *testing.T, root string) []execCallSite {
 	return sites
 }
 
-// externalBinaryLookupAllowlist is every literal-argument exec.LookPath or
-// exec.Command call site the module may contain, keyed by its path relative
-// to the module root and then by the literal binary/interpreter name.
-// Adding an entry here is a deliberate signal: the binary it resolves either
-// can't run in demo mode, or is gated the way resolveHelmPath and
-// vulnScanImage gate helm and trivy — k8s.DemoModeEnabled() checked before
-// the binary is ever resolved. The "sh" entries are the shell interpreter
-// invoked with an already-guarded command string (exec.Command("sh", "-c",
-// cmd)), not an external tool being resolved, so they carry no bypass risk
-// of their own.
+// externalBinaryLookupAllowlist is every constant-argument exec.LookPath,
+// exec.Command, or exec.CommandContext call site the module may contain,
+// keyed by its path relative to the module root and then by the resolved
+// binary/interpreter name. Adding an entry here is a deliberate signal: the
+// binary it resolves either can't run in demo mode, or is gated the way
+// resolveHelmPath and vulnScanImage gate helm and trivy —
+// k8s.DemoModeEnabled() checked before the binary is ever resolved. The "sh"
+// entries are the shell interpreter invoked with an already-guarded command
+// string (exec.Command("sh", "-c", cmd)), not an external tool being
+// resolved, so they carry no bypass risk of their own.
 //
 // TASK-865 finding 2 found this guard only matched exec.LookPath, so a
 // direct exec.Command("literal", ...) — which skips LookPath entirely —
-// stayed invisible to it. This allowlist now covers both call shapes.
+// stayed invisible to it. Finding 3 found exec.CommandContext skipped for
+// the same reason, plus two shapes collectLiteralExecCalls still can't see:
+// a const or concatenation reached through another file or package (only
+// same-file resolution is done — see foldConstString), and any value built
+// by something other than literal concatenation (fmt.Sprintf, an iota-based
+// const, a computed expression). Those slip through the same way a renamed
+// import or a genuinely dynamic binary name always would; there is no
+// go/types or x/tools/go/analysis dependency here to constant-fold them,
+// since whole-module type-checking is a meaningfully heavier and slower
+// addition than this guard warrants for shapes no current call site uses.
 var externalBinaryLookupAllowlist = map[string]map[string]bool{
 	filepath.Join("internal", "k8s", "kubectl_path.go"):       {"kubectl": true},
 	filepath.Join("internal", "app", "commands_exec_helm.go"): {"helm": true, "sh": true},
@@ -196,12 +286,12 @@ var externalBinaryLookupAllowlist = map[string]map[string]bool{
 }
 
 // TestNoUnguardedExternalBinaryLookup walks the module for every
-// literal-argument exec.LookPath or exec.Command call outside of production
-// _test.go files and requires each one to be an already-reviewed entry in
-// externalBinaryLookupAllowlist. Test files are skipped: they exist to
-// exercise the guarded call sites (e.g. comparing resolveHelmPath's output
-// against a raw exec.LookPath("helm")) and never run as part of the shipped
-// binary.
+// constant-argument exec.LookPath, exec.Command, or exec.CommandContext call
+// (see execNameResolvers) outside of production _test.go files and requires
+// each one to be an already-reviewed entry in externalBinaryLookupAllowlist.
+// Test files are skipped: they exist to exercise the guarded call sites
+// (e.g. comparing resolveHelmPath's output against a raw
+// exec.LookPath("helm")) and never run as part of the shipped binary.
 func TestNoUnguardedExternalBinaryLookup(t *testing.T) {
 	root := moduleRoot(t)
 
@@ -214,9 +304,10 @@ func TestNoUnguardedExternalBinaryLookup(t *testing.T) {
 	}
 	sort.Strings(offenders)
 	if len(offenders) > 0 {
-		t.Errorf("found exec.LookPath/exec.Command call(s) with a literal binary name not in "+
-			"externalBinaryLookupAllowlist; confirm the binary can't reach a real cluster/network in "+
-			"demo mode (gate it with k8s.DemoModeEnabled() first if it can), then add it to the allowlist:\n%s",
+		t.Errorf("found exec.LookPath/exec.Command/exec.CommandContext call(s) with a constant binary "+
+			"name not in externalBinaryLookupAllowlist; confirm the binary can't reach a real "+
+			"cluster/network in demo mode (gate it with k8s.DemoModeEnabled() first if it can), then add "+
+			"it to the allowlist:\n%s",
 			strings.Join(offenders, "\n"))
 	}
 }

--- a/internal/k8s/kubectl_path_test.go
+++ b/internal/k8s/kubectl_path_test.go
@@ -1,0 +1,57 @@
+package k8s
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestKubectlPath_HonoursKubectlBinOverride(t *testing.T) {
+	t.Setenv("KUBECTL_BIN", "/opt/stub/kubectl")
+
+	got, err := KubectlPath()
+	if err != nil {
+		t.Fatalf("KubectlPath() unexpected error: %v", err)
+	}
+	if got != "/opt/stub/kubectl" {
+		t.Errorf("KubectlPath() = %q, want %q", got, "/opt/stub/kubectl")
+	}
+}
+
+func TestKubectlPath_FallsBackToPathLookup(t *testing.T) {
+	t.Setenv("KUBECTL_BIN", "")
+
+	want, lookupErr := exec.LookPath("kubectl")
+
+	got, err := KubectlPath()
+
+	if lookupErr != nil {
+		// kubectl isn't installed in this environment: KubectlPath must
+		// surface the same not-found condition PATH lookup would.
+		if err == nil {
+			t.Fatalf("KubectlPath() = %q, nil; want error when kubectl is absent from PATH", got)
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("KubectlPath() unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("KubectlPath() = %q, want %q", got, want)
+	}
+}
+
+func TestKubectlPath_ErrorWhenKubectlAbsent(t *testing.T) {
+	emptyPath := t.TempDir()
+	t.Setenv("KUBECTL_BIN", "")
+	t.Setenv("PATH", emptyPath)
+
+	got, err := KubectlPath()
+	if err == nil {
+		t.Fatalf("KubectlPath() = %q, nil; want error when kubectl is not on PATH", got)
+	}
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Errorf("KubectlPath() error = %v, want wrapping exec.ErrNotFound", err)
+	}
+}

--- a/internal/k8s/kubectl_path_test.go
+++ b/internal/k8s/kubectl_path_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"testing"
 )
@@ -53,5 +54,65 @@ func TestKubectlPath_ErrorWhenKubectlAbsent(t *testing.T) {
 	}
 	if !errors.Is(err, exec.ErrNotFound) {
 		t.Errorf("KubectlPath() error = %v, want wrapping exec.ErrNotFound", err)
+	}
+}
+
+func TestDemoModeEnabled_DefaultsOff(t *testing.T) {
+	if DemoModeEnabled() {
+		t.Fatalf("DemoModeEnabled() = true by default, want false")
+	}
+}
+
+func TestKubectlPath_DemoModeReturnsOwnExecutable(t *testing.T) {
+	SetDemoMode(true)
+	defer SetDemoMode(false)
+
+	want, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error: %v", err)
+	}
+
+	got, err := KubectlPath()
+	if err != nil {
+		t.Fatalf("KubectlPath() unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("KubectlPath() = %q, want %q (this binary)", got, want)
+	}
+}
+
+// TestKubectlPath_DemoModeOverridesKubectlBin proves the critical property:
+// with demo mode on, no code path may resolve a kubectl on the user's PATH or
+// via KUBECTL_BIN — only this binary.
+func TestKubectlPath_DemoModeOverridesKubectlBin(t *testing.T) {
+	t.Setenv("KUBECTL_BIN", "/opt/stub/kubectl")
+	SetDemoMode(true)
+	defer SetDemoMode(false)
+
+	want, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error: %v", err)
+	}
+
+	got, err := KubectlPath()
+	if err != nil {
+		t.Fatalf("KubectlPath() unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("KubectlPath() = %q, want %q (demo mode must win over KUBECTL_BIN)", got, want)
+	}
+}
+
+func TestKubectlPath_DemoModeOffRestoresNormalResolution(t *testing.T) {
+	SetDemoMode(true)
+	SetDemoMode(false)
+
+	t.Setenv("KUBECTL_BIN", "/opt/stub/kubectl")
+	got, err := KubectlPath()
+	if err != nil {
+		t.Fatalf("KubectlPath() unexpected error: %v", err)
+	}
+	if got != "/opt/stub/kubectl" {
+		t.Errorf("KubectlPath() = %q, want %q after demo mode disabled", got, "/opt/stub/kubectl")
 	}
 }

--- a/internal/k8s/kubectl_path_test.go
+++ b/internal/k8s/kubectl_path_test.go
@@ -103,6 +103,40 @@ func TestKubectlPath_DemoModeOverridesKubectlBin(t *testing.T) {
 	}
 }
 
+// TestDemoKubectlArgs_PrependsSubcommandOnlyInDemoMode guards the fix for
+// the finding that every kubectl exec.Command call site built kubectl-shaped
+// argv without the __demo-kubectl prefix: in demo mode KubectlPath() returns
+// this process's own executable, so the re-exec'd binary must route into the
+// hidden subcommand instead of parsing "edit"/"describe"/etc. as its own
+// root-command argv (which would launch a second TUI instead of the demo
+// kubectl emulation).
+func TestDemoKubectlArgs_PrependsSubcommandOnlyInDemoMode(t *testing.T) {
+	in := []string{"edit", "pod/web", "-n", "demo", "--context", "demo"}
+
+	SetDemoMode(true)
+	got := DemoKubectlArgs(in)
+	SetDemoMode(false)
+	want := append([]string{"__demo-kubectl"}, in...)
+	if len(got) != len(want) {
+		t.Fatalf("DemoKubectlArgs(%v) = %v, want %v", in, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("DemoKubectlArgs(%v)[%d] = %q, want %q", in, i, got[i], want[i])
+		}
+	}
+
+	got = DemoKubectlArgs(in)
+	if len(got) != len(in) {
+		t.Fatalf("DemoKubectlArgs(%v) outside demo mode = %v, want args unchanged", in, got)
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Errorf("DemoKubectlArgs(%v)[%d] outside demo mode = %q, want %q", in, i, got[i], in[i])
+		}
+	}
+}
+
 func TestKubectlPath_DemoModeOffRestoresNormalResolution(t *testing.T) {
 	SetDemoMode(true)
 	SetDemoMode(false)

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -19,12 +20,36 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 )
 
+// errPrometheusUnavailableDemo is returned by every Prometheus/Alertmanager
+// service-proxy query attempted on a demo Client, instead of calling
+// ProxyGet at all. The fake clientset --demo mode runs on has no proxy
+// subresource support: ProxyGet itself (not just the request it builds)
+// panics with a nil pointer dereference, so demo mode must be turned away
+// before that call rather than after it fails.
+var errPrometheusUnavailableDemo = errors.New("prometheus/alertmanager queries are unavailable in demo mode")
+
 // promSvcCache caches the working namespace+service for Prometheus ProxyGet per context.
 var promSvcCache sync.Map // key: contextName, value: promSvcEntry
 
 type promSvcEntry struct {
 	namespace string
 	service   string
+}
+
+// safeProxyGetRaw calls Services(ns).ProxyGet(...).DoRaw(ctx), recovering
+// from any panic the underlying REST client raises. This is defense in
+// depth alongside the explicit demo-mode checks that already turn queries
+// away before reaching this call: a proxy failure of any kind — including
+// one this package didn't anticipate — degrades to an error instead of
+// crashing the TUI.
+func safeProxyGetRaw(ctx context.Context, cs kubernetes.Interface, ns, svc, port, path string, params map[string]string) (data []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("prometheus/alertmanager proxy request panicked: %v", r)
+		}
+	}()
+	result := cs.CoreV1().Services(ns).ProxyGet("http", svc, port, path, params)
+	return result.DoRaw(ctx)
 }
 
 func (c *Client) metricsGVR(resource string) []schema.GroupVersionResource {
@@ -479,7 +504,7 @@ func (c *Client) getNodeMetricsFromPrometheus(contextName string) (map[string]mo
 // queryPrometheusNodeMetric runs a PromQL instant query via Kubernetes service proxy
 // and returns a map of node name -> float64 value.
 func (c *Client) queryPrometheusNodeMetric(ctx context.Context, contextName string, cs kubernetes.Interface, namespaces, services []string, port, query string) (map[string]float64, error) {
-	return queryPrometheusMetric(ctx, contextName, cs, namespaces, services, port, query, parsePrometheusNodeResponse)
+	return queryPrometheusMetric(ctx, contextName, cs, c.demo, namespaces, services, port, query, parsePrometheusNodeResponse)
 }
 
 // queryPrometheusMetric runs a PromQL instant query via Kubernetes service proxy
@@ -487,9 +512,15 @@ func (c *Client) queryPrometheusNodeMetric(ctx context.Context, contextName stri
 // (rather than a method) so it can be generic over the parsed result type T --
 // callers needing a different shape (e.g. node uptime, which splits into
 // name-keyed and address-keyed maps) reuse the same service-discovery and
-// promSvcCache logic instead of duplicating it.
-func queryPrometheusMetric[T any](ctx context.Context, contextName string, cs kubernetes.Interface, namespaces, services []string, port, query string, parse func([]byte) (T, error)) (T, error) {
+// promSvcCache logic instead of duplicating it. isDemo is threaded in
+// (rather than accessed via a *Client) for the same reason: it's a plain
+// value the caller already has, and keeps this function testable without a
+// full Client.
+func queryPrometheusMetric[T any](ctx context.Context, contextName string, cs kubernetes.Interface, isDemo bool, namespaces, services []string, port, query string, parse func([]byte) (T, error)) (T, error) {
 	var zero T
+	if isDemo {
+		return zero, errPrometheusUnavailableDemo
+	}
 	params := map[string]string{"query": query}
 
 	// Check cache for a known working namespace+service. Keyed by contextName
@@ -498,8 +529,7 @@ func queryPrometheusMetric[T any](ctx context.Context, contextName string, cs ku
 	// on every poll.
 	if cached, ok := promSvcCache.Load(contextName); ok {
 		entry := cached.(promSvcEntry)
-		result := cs.CoreV1().Services(entry.namespace).ProxyGet("http", entry.service, port, "/api/v1/query", params)
-		data, err := result.DoRaw(ctx)
+		data, err := safeProxyGetRaw(ctx, cs, entry.namespace, entry.service, port, "/api/v1/query", params)
 		if err == nil {
 			parsed, err := parse(data)
 			if err == nil {
@@ -513,8 +543,7 @@ func queryPrometheusMetric[T any](ctx context.Context, contextName string, cs ku
 	var lastErr error
 	for _, ns := range namespaces {
 		for _, svc := range services {
-			result := cs.CoreV1().Services(ns).ProxyGet("http", svc, port, "/api/v1/query", params)
-			data, err := result.DoRaw(ctx)
+			data, err := safeProxyGetRaw(ctx, cs, ns, svc, port, "/api/v1/query", params)
 			if err != nil {
 				lastErr = err
 				continue

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
@@ -42,9 +43,21 @@ type promSvcEntry struct {
 // away before reaching this call: a proxy failure of any kind — including
 // one this package didn't anticipate — degrades to an error instead of
 // crashing the TUI.
+//
+// The recover stays broad rather than demo-scoped: every call reaching this
+// function already ran on a real-cluster path, since queryPrometheusMetric
+// checks isDemo and returns errPrometheusUnavailableDemo before ever
+// calling here, so a demo-scoped recover would never fire. That means a
+// real panic here is always a genuine client-go failure on a live cluster,
+// which is exactly the case that must not vanish silently: the recovered
+// value and a stack trace are logged at Error before the panic collapses
+// into a plain error.
 func safeProxyGetRaw(ctx context.Context, cs kubernetes.Interface, ns, svc, port, path string, params map[string]string) (data []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			logger.Error("prometheus/alertmanager proxy request panicked",
+				"namespace", ns, "service", svc, "port", port, "path", path,
+				"panic", r, "stack", string(debug.Stack()))
 			err = fmt.Errorf("prometheus/alertmanager proxy request panicked: %v", r)
 		}
 	}()

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -55,10 +55,11 @@ type promSvcEntry struct {
 func safeProxyGetRaw(ctx context.Context, cs kubernetes.Interface, ns, svc, port, path string, params map[string]string) (data []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			redacted := logger.Redact(fmt.Sprintf("%v", r))
 			logger.Error("prometheus/alertmanager proxy request panicked",
 				"namespace", ns, "service", svc, "port", port, "path", path,
-				"panic", r, "stack", string(debug.Stack()))
-			err = fmt.Errorf("prometheus/alertmanager proxy request panicked: %v", r)
+				"panic", redacted, "stack", string(debug.Stack()))
+			err = fmt.Errorf("prometheus/alertmanager proxy request panicked: %s", redacted)
 		}
 	}()
 	result := cs.CoreV1().Services(ns).ProxyGet("http", svc, port, path, params)

--- a/internal/k8s/metrics_prometheus_nodes.go
+++ b/internal/k8s/metrics_prometheus_nodes.go
@@ -161,7 +161,7 @@ func (c *Client) GetNodeUptimes(ctx context.Context, contextName string) (NodeUp
 	// Subtracted server-side so the result is independent of clock skew
 	// between this machine and the cluster.
 	const query = `time() - node_boot_time_seconds`
-	seconds, err := queryPrometheusMetric(qctx, contextName, clientset, promNs, promSvc, promPort, query, parseNodeUptimeVector)
+	seconds, err := queryPrometheusMetric(qctx, contextName, clientset, c.demo, promNs, promSvc, promPort, query, parseNodeUptimeVector)
 	if err != nil {
 		logger.Debug("Prometheus node uptime query failed", "context", contextName, "error", err)
 		return NodeUptimes{}, fmt.Errorf("prometheus node uptime query failed: %w", err)

--- a/internal/k8s/metrics_test.go
+++ b/internal/k8s/metrics_test.go
@@ -1,14 +1,50 @@
 package k8s
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 
+	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
 )
+
+// --- safeProxyGetRaw ---
+
+// TestSafeProxyGetRaw_LogsRecoveredPanicWithStack guards TASK-865 finding 3:
+// safeProxyGetRaw's recover silently converted a panic into an error with no
+// log line and no stack, so a genuine client-go panic on a real cluster
+// would vanish without a trace. The recover stays broad (every caller here
+// already runs only on real-cluster paths — queryPrometheusMetric turns
+// demo queries away before ever reaching this function, so a demo-scoped
+// recover would never fire), but it must now log the recovered value and a
+// stack trace before returning the error.
+func TestSafeProxyGetRaw_LogsRecoveredPanicWithStack(t *testing.T) {
+	buf := &bytes.Buffer{}
+	orig := logger.Logger
+	logger.Logger = slog.New(slog.NewTextHandler(buf, nil))
+	defer func() { logger.Logger = orig }()
+
+	cs := k8sfake.NewClientset()
+	cs.PrependProxyReactor("services", func(_ k8stesting.Action) (bool, restclient.ResponseWrapper, error) {
+		panic("boom: proxy exploded")
+	})
+
+	_, err := safeProxyGetRaw(t.Context(), cs, "monitoring", "prometheus", "9090", "/api/v1/query", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom: proxy exploded")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "boom: proxy exploded", "expected the recovered panic value to be logged")
+	assert.Contains(t, logged, "goroutine", "expected a stack trace to be logged alongside the recovered panic")
+}
 
 // --- parsePodMetrics ---
 

--- a/internal/k8s/metrics_test.go
+++ b/internal/k8s/metrics_test.go
@@ -46,6 +46,32 @@ func TestSafeProxyGetRaw_LogsRecoveredPanicWithStack(t *testing.T) {
 	assert.Contains(t, logged, "goroutine", "expected a stack trace to be logged alongside the recovered panic")
 }
 
+// TestSafeProxyGetRaw_RedactsRecoveredPanicValue guards against a client-go
+// panic value carrying a bearer token or similar secret straight into the
+// log and the returned error -- the panic value comes from a live cluster
+// call and is not trusted content, same as any other log/error source.
+func TestSafeProxyGetRaw_RedactsRecoveredPanicValue(t *testing.T) {
+	buf := &bytes.Buffer{}
+	orig := logger.Logger
+	logger.Logger = slog.New(slog.NewTextHandler(buf, nil))
+	defer func() { logger.Logger = orig }()
+
+	const secret = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+	cs := k8sfake.NewClientset()
+	cs.PrependProxyReactor("services", func(_ k8stesting.Action) (bool, restclient.ResponseWrapper, error) {
+		panic(secret)
+	})
+
+	_, err := safeProxyGetRaw(t.Context(), cs, "monitoring", "prometheus", "9090", "/api/v1/query", nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret, "returned error must not carry the raw panic value")
+	assert.Contains(t, err.Error(), "[REDACTED", "returned error should show the redacted panic value")
+
+	logged := buf.String()
+	assert.NotContains(t, logged, secret, "log line must not carry the raw panic value")
+	assert.Contains(t, logged, "[REDACTED", "log line should show the redacted panic value")
+}
+
 // --- parsePodMetrics ---
 
 func TestParsePodMetrics(t *testing.T) {

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -1,11 +1,19 @@
 package k8s
 
 import (
+	"context"
+	"time"
+
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/janosmiko/lfk/internal/k8s/demo"
 )
+
+// demoTickerInterval is how often NewDemoClient's ticker mutates the fake
+// cluster. Matches ui.DefaultWatchInterval's 2s feel (a few seconds keeps
+// the demo visibly alive without flooding the UI on every watch tick).
+const demoTickerInterval = 3 * time.Second
 
 // NewTestClient creates a Client with injected fake clients for testing.
 // cs should be a kubernetes.Interface (e.g. k8sfake.NewClientset()),
@@ -36,8 +44,11 @@ func NewTestClient(cs, dyn any) *Client {
 // a synthesized context) so a demo Client can never read the user's real
 // kubeconfig, then marks itself IsDemo so the app layer can show a badge.
 func NewDemoClient() (*Client, error) {
-	c := NewTestClient(demo.NewClientset(), demo.NewDynamicClient())
+	dyn := demo.NewDynamicClient()
+	c := NewTestClient(demo.NewClientset(), dyn)
 	c.demo = true
+	c.demoTicker = demo.NewTicker(dyn, demoTickerInterval)
+	c.demoTicker.Start(context.Background())
 	return c, nil
 }
 

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -45,7 +45,11 @@ func NewTestClient(cs, dyn any) *Client {
 // kubeconfig, then marks itself IsDemo so the app layer can show a badge.
 func NewDemoClient() (*Client, error) {
 	dyn := demo.NewDynamicClient()
-	c := NewTestClient(demo.NewClientset(), dyn)
+	// The Client sees a guarded dynamic.Interface (see demo.GuardListPanics)
+	// so a demo fixture gap degrades a List call to an error instead of
+	// panicking a scheduler worker goroutine. The ticker keeps the raw fake
+	// so it can still reach Tracker() to mutate seed data.
+	c := NewTestClient(demo.NewClientset(), demo.GuardListPanics(dyn))
 	c.demo = true
 	c.demoTicker = demo.NewTicker(dyn, demoTickerInterval)
 	c.demoTicker.Start(context.Background())

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -3,14 +3,16 @@ package k8s
 import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
 )
 
 // NewTestClient creates a Client with injected fake clients for testing.
 // cs should be a kubernetes.Interface (e.g. k8sfake.NewClientset()),
 // dyn should be a dynamic.Interface (e.g. dynamicfake.NewSimpleDynamicClient()).
 // Both may be nil if the test does not exercise those code paths.
-// To inject a fake metadata client, set the testMetaClient field directly on
-// the returned *Client (or use NewTestClientWithMeta).
+// To inject a fake metadata client, set the injectedMetaClient field directly
+// on the returned *Client (or use NewTestClientWithMeta).
 func NewTestClient(cs, dyn any) *Client {
 	return &Client{
 		rawConfig: api.Config{
@@ -22,10 +24,21 @@ func NewTestClient(cs, dyn any) *Client {
 		loadingRules: &clientcmd.ClientConfigLoadingRules{
 			Precedence: []string{"/dev/null"},
 		},
-		testClientset:     cs,
-		testDynClient:     dyn,
+		injectedClientset: cs,
+		injectedDynClient: dyn,
 		testHostByDisplay: map[string]string{"test-ctx": "https://test-cluster.example.local:6443"},
 	}
+}
+
+// NewDemoClient builds a Client backed by the internal/k8s/demo fake
+// clientset and dynamic client, for the --demo flag. It reuses
+// NewTestClient's kubeconfig isolation (loadingRules pointed at /dev/null,
+// a synthesized context) so a demo Client can never read the user's real
+// kubeconfig, then marks itself IsDemo so the app layer can show a badge.
+func NewDemoClient() (*Client, error) {
+	c := NewTestClient(demo.NewClientset(), demo.NewDynamicClient())
+	c.demo = true
+	return c, nil
 }
 
 // SetTestHostForContext registers a synthetic host URL for a context so

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -45,13 +45,18 @@ func NewTestClient(cs, dyn any) *Client {
 // kubeconfig, then marks itself IsDemo so the app layer can show a badge.
 func NewDemoClient() (*Client, error) {
 	dyn := demo.NewDynamicClient()
+	cs := demo.NewClientset()
 	// The Client sees a guarded dynamic.Interface (see demo.GuardListPanics)
 	// so a demo fixture gap degrades a List call to an error instead of
 	// panicking a scheduler worker goroutine. The ticker keeps the raw fake
 	// so it can still reach Tracker() to mutate seed data.
-	c := NewTestClient(demo.NewClientset(), demo.GuardListPanics(dyn))
+	c := NewTestClient(cs, demo.GuardListPanics(dyn))
 	c.demo = true
-	c.demoTicker = demo.NewTicker(dyn, demoTickerInterval)
+	// cs is passed as an extra clearer alongside dyn: both fakes' embedded
+	// testing.Fake accumulates every Get/List/Create/Update/Delete the app
+	// makes (not just the ticker's own writes) into an action log nothing
+	// else drains, so both need clearing on the same cadence.
+	c.demoTicker = demo.NewTicker(dyn, demoTickerInterval, cs)
 	c.demoTicker.Start(context.Background())
 	return c, nil
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -106,8 +106,7 @@ var (
 			Bold(true).
 			Italic(true)
 
-	// Category header rendered as a full-width "bar" with a distinct
-	// background, used by explorer columns to separate groups.
+	// Category header rendered as a full-width "bar" with a distinct background, used by explorer columns to separate groups.
 	CategoryBarStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(ColorPrimary)).
 				Bold(true)
@@ -122,10 +121,8 @@ var (
 	StatusOther       = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorDimmed))
 	StatusWarning     = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorWarning))
 
-	// Whole-row status tint (issue #540). Colors mirror the Status cell
-	// (StatusFailed = error, StatusProgressing = primary) so the row tint and
-	// the cell never disagree. Fg variants recolor the row text; Bg variants
-	// lay a muted severity background under the theme's text.
+	// Whole-row status tint (issue #540). Colors mirror the Status cell (StatusFailed = error, StatusProgressing = primary) so
+	// the row tint and the cell never disagree. Fg variants recolor the row text; Bg variants lay a muted severity background.
 	RowTintFailedFg      = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError))
 	RowTintProgressingFg = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary))
 	RowTintFailedBg      = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile)).
@@ -168,6 +165,9 @@ var (
 				Background(lipgloss.Color(ColorWarning)).
 				Bold(true).
 				Padding(0, 1)
+
+	// Demo-mode badge: ReadOnlyBadgeStyle with a distinguishing purple background.
+	DemoBadgeStyle = ReadOnlyBadgeStyle.Background(lipgloss.Color(ColorPurple))
 
 	// Subtle [RO] marker for list rows. Foreground-only so it doesn't
 	// compete with the row content the way a solid-background badge does.

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -239,6 +239,14 @@ func ApplyTheme(t Theme) {
 		Bold(true).
 		Padding(0, 1)
 
+	// Demo-mode badge in title bar. Purple so it reads distinctly from the
+	// warning-colored RO badge.
+	DemoBadgeStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(t.SelectedFg)).
+		Background(lipgloss.Color(t.Purple)).
+		Bold(true).
+		Padding(0, 1)
+
 	ReadOnlyMarkerStyle = lipgloss.NewStyle().
 		Foreground(lipgloss.Color(t.Warning)).
 		Background(baseBg).

--- a/internal/ui/theme_nocolor.go
+++ b/internal/ui/theme_nocolor.go
@@ -97,6 +97,11 @@ func applyNoColorTheme() {
 		Reverse(true).
 		Padding(0, 1)
 
+	DemoBadgeStyle = lipgloss.NewStyle().
+		Bold(true).
+		Reverse(true).
+		Padding(0, 1)
+
 	ReadOnlyMarkerStyle = lipgloss.NewStyle().Bold(true)
 
 	HeaderStyle = lipgloss.NewStyle().Bold(true).Underline(true)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	_ "net/http/pprof" // registers /debug/pprof/* under DefaultServeMux when LFK_PPROF_ADDR is set
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -20,6 +22,7 @@ import (
 
 	"github.com/janosmiko/lfk/internal/app"
 	"github.com/janosmiko/lfk/internal/completion"
+	"github.com/janosmiko/lfk/internal/democli"
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/profiling"
@@ -87,10 +90,33 @@ File locations:
 	}
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(completion.NewCompletionCommand(rootCmd))
+	rootCmd.AddCommand(newDemoKubectlCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// newDemoKubectlCommand builds the hidden "__demo-kubectl" subcommand that
+// --demo mode points every kubectl call site at (via k8s.KubectlPath
+// returning os.Executable()). It is hidden from help and shell completion —
+// it exists only for lfk to re-exec itself, never for a user to invoke
+// directly. Flag parsing is disabled so kubectl-shaped argv (mixed
+// "--flag value" / "--flag=value" / short flags) passes through to
+// democli.Run untouched instead of being parsed by cobra/pflag.
+func newDemoKubectlCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:                "__demo-kubectl",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		SilenceErrors:      true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+			defer stop()
+			return democli.Run(ctx, args, os.Stdout, os.Stderr)
+		},
 	}
 }
 
@@ -102,6 +128,10 @@ File locations:
 // on opts.Demo. Otherwise it runs the real kubeconfig discovery path.
 func resolveStartupClient(opts app.StartupOptions) (*k8s.Client, error) {
 	if opts.Demo {
+		// Redirect every kubectl call site (internal/k8s.KubectlPath) at this
+		// binary's own __demo-kubectl subcommand instead of a kubectl on the
+		// user's PATH, so no code path can reach a real cluster.
+		k8s.SetDemoMode(true)
 		return k8s.NewDemoClient()
 	}
 

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ File locations:
 	rootCmd.Flags().BoolVar(&cliOpts.NoMouse, "no-mouse", false, "Disable mouse capture (enables native terminal text selection)")
 	rootCmd.Flags().BoolVar(&cliOpts.NoColor, "no-color", false, "Disable foreground/background colors; keep bold/reverse for visibility. Also honors the NO_COLOR env var.")
 	rootCmd.Flags().BoolVar(&cliOpts.ReadOnly, "read-only", false, "Disable all mutating actions (delete/edit/scale/restart/exec/port-forward/drain/cordon). Also configurable as read_only: true (global) or clusters.<ctx>.read_only (per-context) in config.")
+	rootCmd.Flags().BoolVar(&cliOpts.Demo, "demo", false, "Run against an in-memory fake cluster instead of a real one. No kubeconfig required; --context, --kubeconfig, and --kubeconfig-dir are ignored.")
 	rootCmd.Flags().DurationVar(&cliOpts.WatchInterval, "watch-interval", 0, "Watch mode polling interval (e.g. 500ms, 2s, 1m). Clamped to [500ms, 10m]. Overrides config.")
 	rootCmd.Flags().DurationVar(&cliOpts.BackgroundWatchInterval, "background-watch-interval", 0, "Watch interval while unfocused/idle (e.g. 10s). Clamped to [500ms, 10m]. Overrides config.")
 	rootCmd.Flags().DurationVar(&cliOpts.ForegroundIdleTimeout, "foreground-idle-timeout", -1, "Idle window before a focused window throttles (e.g. 120s). 0 disables. Overrides config.")
@@ -91,6 +92,43 @@ File locations:
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// resolveStartupClient builds the Kubernetes client for startup. With
+// --demo it builds the in-memory demo client and returns immediately,
+// skipping kubeconfig directory resolution, kubeconfig loading, and
+// --context validation entirely — the demo cluster has no kubeconfig to
+// read and a fixed set of contexts. This is the only place startup diverts
+// on opts.Demo. Otherwise it runs the real kubeconfig discovery path.
+func resolveStartupClient(opts app.StartupOptions) (*k8s.Client, error) {
+	if opts.Demo {
+		return k8s.NewDemoClient()
+	}
+
+	kubeconfigDirs := k8s.ResolveKubeconfigDirs(
+		opts.KubeconfigDirs,
+		os.Getenv("KUBECONFIG_DIR"),
+		ui.ConfigKubeconfigDirs,
+	)
+	if err := k8s.ValidateKubeconfigDirs(kubeconfigDirs); err != nil {
+		return nil, err
+	}
+
+	kubeconfigExclusive := k8s.ResolveKubeconfigExclusive(
+		opts.KubeconfigExclusiveSet, opts.KubeconfigExclusive,
+		os.Getenv("LFK_KUBECONFIG_EXCLUSIVE"), ui.ConfigKubeconfigExclusive,
+	)
+
+	client, err := k8s.NewClient(opts.Kubeconfig, kubeconfigDirs, kubeconfigExclusive)
+	if err != nil {
+		return nil, fmt.Errorf("initializing Kubernetes client: %w", err)
+	}
+
+	if opts.Context != "" && !client.ContextExists(opts.Context) {
+		return nil, fmt.Errorf("context %q not found in kubeconfig", opts.Context)
+	}
+
+	return client, nil
 }
 
 // runTUI initializes the Kubernetes client, logger, and starts the Bubbletea TUI.
@@ -117,27 +155,9 @@ func runTUI(opts app.StartupOptions) error {
 		}
 	}
 
-	kubeconfigDirs := k8s.ResolveKubeconfigDirs(
-		opts.KubeconfigDirs,
-		os.Getenv("KUBECONFIG_DIR"),
-		ui.ConfigKubeconfigDirs,
-	)
-	if err := k8s.ValidateKubeconfigDirs(kubeconfigDirs); err != nil {
-		return err
-	}
-
-	kubeconfigExclusive := k8s.ResolveKubeconfigExclusive(
-		opts.KubeconfigExclusiveSet, opts.KubeconfigExclusive,
-		os.Getenv("LFK_KUBECONFIG_EXCLUSIVE"), ui.ConfigKubeconfigExclusive,
-	)
-
-	client, err := k8s.NewClient(opts.Kubeconfig, kubeconfigDirs, kubeconfigExclusive)
+	client, err := resolveStartupClient(opts)
 	if err != nil {
-		return fmt.Errorf("initializing Kubernetes client: %w", err)
-	}
-
-	if opts.Context != "" && !client.ContextExists(opts.Context) {
-		return fmt.Errorf("context %q not found in kubeconfig", opts.Context)
+		return err
 	}
 
 	// CLI --no-color flag can force monochrome even if config and env don't.

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/janosmiko/lfk/internal/app"
+	"github.com/janosmiko/lfk/internal/k8s"
 )
 
 // armForceQuit must, after the grace period, kill the program first (to
@@ -91,6 +92,7 @@ func TestResolveStartupClient_DemoSkipsKubeconfigResolution(t *testing.T) {
 	t.Setenv("HOME", emptyDir)
 	t.Setenv("KUBECONFIG", filepath.Join(emptyDir, "does-not-exist"))
 	t.Setenv("KUBECONFIG_DIR", "")
+	t.Cleanup(func() { k8s.SetDemoMode(false) })
 
 	client, err := resolveStartupClient(app.StartupOptions{Demo: true, Context: "no-such-context"})
 	if err != nil {
@@ -99,7 +101,17 @@ func TestResolveStartupClient_DemoSkipsKubeconfigResolution(t *testing.T) {
 	if client == nil {
 		t.Fatal("resolveStartupClient() returned nil client")
 	}
+	defer client.Shutdown()
 	if !client.IsDemo() {
 		t.Error("resolveStartupClient() client.IsDemo() = false, want true")
+	}
+}
+
+// TestDemoModeDoesNotLeakAcrossTests guards against k8s.SetDemoMode(true)
+// (set by a prior test's resolveStartupClient call) staying on for the rest
+// of this package's test binary.
+func TestDemoModeDoesNotLeakAcrossTests(t *testing.T) {
+	if k8s.DemoModeEnabled() {
+		t.Fatal("demoMode leaked from a prior test in package main")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/janosmiko/lfk/internal/app"
 )
 
 // armForceQuit must, after the grace period, kill the program first (to
@@ -77,5 +80,26 @@ func TestValidatePprofAddr(t *testing.T) {
 		if !strings.Contains(err.Error(), tt.wantContains) {
 			t.Errorf("validatePprofAddr(%q) error = %q, want it to contain %q", tt.addr, err, tt.wantContains)
 		}
+	}
+}
+
+// --demo must work with no kubeconfig on disk at all (acceptance criterion
+// 1), and must skip --context validation entirely — a bogus --context
+// would otherwise fail against the real kubeconfig path.
+func TestResolveStartupClient_DemoSkipsKubeconfigResolution(t *testing.T) {
+	emptyDir := t.TempDir()
+	t.Setenv("HOME", emptyDir)
+	t.Setenv("KUBECONFIG", filepath.Join(emptyDir, "does-not-exist"))
+	t.Setenv("KUBECONFIG_DIR", "")
+
+	client, err := resolveStartupClient(app.StartupOptions{Demo: true, Context: "no-such-context"})
+	if err != nil {
+		t.Fatalf("resolveStartupClient() error = %v, want nil", err)
+	}
+	if client == nil {
+		t.Fatal("resolveStartupClient() returned nil client")
+	}
+	if !client.IsDemo() {
+		t.Error("resolveStartupClient() client.IsDemo() = false, want true")
 	}
 }


### PR DESCRIPTION
Adds `lfk --demo`: an in-memory fake cluster, so lfk starts with no kubeconfig and no real cluster. Closes TASK-865.

Reuses the existing fake-client seam (`testClientset` / `testDynClient`, now `injected*`) rather than adding a `KubeBackend` interface in front of a `Client` that exposes 150+ methods.

## What it does

- `--demo` builds a fake cluster: 2 nodes, 4 namespaces, a healthy Deployment, a CrashLoopBackOff pod, a failed Job, Services, ConfigMaps, Events, and metrics.
- A 3s ticker mutates the object tracker, so restart counts climb and Warning Events arrive while you watch.
- A DEMO badge marks the session. `NewClient` can never select the demo backend; a test asserts it.
- 32 `exec.LookPath("kubectl")` sites now route through one `k8s.KubectlPath()`. Under `--demo` it returns `os.Executable()`, so call sites re-enter a hidden `__demo-kubectl` serving `logs -f`, `get` and `describe`.
- Generated log lines are JSON access logs that `internal/logagg` detects and groups, so Log Top has real data.

## Not simulated

exec, port-forward, drain, debug, helm and vuln scan are refused with a clear message. Nothing reaches a real cluster, but those actions do not work against the fake either. Documented in README, `docs/usage.md` and `docs/installation.md`.

## Bugs found and fixed on the way

Both got past a fully green `-race` suite and only showed up in a live run:

- The dynamic fake panics on an unregistered ListKind. `fetchCRDPrinterColumns` lists CRDs unconditionally, on a scheduler worker where nothing can recover. Registered a ListKind for every listable resource, not only seeded ones, plus an invariant test. The audit found 9 more, including `resourcequotas`, which would have been the next crash.
- With a real config carrying a `_global` Prometheus block, `--demo` nil-panicked in `queryPrometheusMetric`. Every smoke test used an empty HOME, which is exactly what hid it. Three `ProxyGet` surfaces now guard on demo mode.

## Review findings fixed

- CRITICAL: `client-go`'s `testing.Fake` appends every call to an unbounded slice. Measured 1.52 GB / 12.6M objects at 52,000 ticks; now flat at 2.7 MB / 27K.
- HIGH: Vuln Scan called `exec.LookPath("trivy")` unguarded, so pressing `V` on a demo pod pulled a vulnerability DB over the network. The test proved it by running a real 34s scan before the fix.
- MEDIUM: `safeProxyGetRaw` swallowed real client-go panics with no stack; now logs before returning.
- MEDIUM: `ApplyManifest` validated the name but not the namespace. A bidi override in `metadata.namespace` reached `resourceTitleLabel`, shared by six views.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 -race ./...` (25 packages)
- [x] `make lint` (0 issues)
- [x] `make e2e` (new pty-driven harness; teatest pins bubbletea v1, incompatible with this repo's v2)
- [x] Live tmux run, empty HOME and real HOME, no panic
- [ ] Manual UAT per the guide in TASK-865