### PR TITLE
fix: sanitize terminal escapes in describe, YAML, event and editor sinks (TASK-873)

### DIFF
--- a/internal/app/breadcrumb_viewers_test.go
+++ b/internal/app/breadcrumb_viewers_test.go
@@ -21,6 +21,28 @@ func TestResourceTitleLabel(t *testing.T) {
 	assert.Equal(t, "x", resourceTitleLabel("", "", "x"))
 }
 
+// resourceTitleLabel feeds seven fullscreen view titles (logs, describe,
+// exec, object explorer, YAML, event viewer, logtop) with kind/namespace/name
+// taken raw from cluster-controlled resources. A hostile name must not be
+// able to reorder or hijack the title bar; fixing it once here covers every
+// call site.
+func TestResourceTitleLabel_SanitizesTerminalEscapes(t *testing.T) {
+	label := resourceTitleLabel("Pod", "default", "evil\x1b[2Jpod")
+	assert.NotContains(t, label, "\x1b")
+	assert.Equal(t, "Pod default/evil[2Jpod", label)
+
+	label = resourceTitleLabel("Pod", "default", "evil\u202epod")
+	assert.NotContains(t, label, "\u202e", "bidi override must not survive")
+
+	label = resourceTitleLabel("Pod", "default", "evil\x1b]52;c;ZXZpbA==\x07pod")
+	assert.NotContains(t, label, "\x1b")
+	assert.NotContains(t, label, "\x07")
+
+	// Ordinary names render identically.
+	assert.Equal(t, "Pod argo-cd/argocd-redis-ha-server-2",
+		resourceTitleLabel("Pod", "argo-cd", "argocd-redis-ha-server-2"))
+}
+
 // The fullscreen viewers (logs, exec, describe, diff, events) must surface the
 // object they show in the top breadcrumb, the same way the YAML viewer and the
 // Object Explorer do. Each case is exercised through explorerDrillPath, which

--- a/internal/app/breadcrumb_viewers_test.go
+++ b/internal/app/breadcrumb_viewers_test.go
@@ -52,8 +52,8 @@ func TestContainerTitleSuffix_SanitizesTerminalEscapes(t *testing.T) {
 	assert.NotContains(t, suffix, "\x1b")
 	assert.Equal(t, " [evil[2Jsidecar]", suffix)
 
-	suffix = containerTitleSuffix("app", "evil‮sidecar")
-	assert.NotContains(t, suffix, "‮", "bidi override must not survive")
+	suffix = containerTitleSuffix("app", "evil\u202esidecar")
+	assert.NotContains(t, suffix, "\u202e", "bidi override must not survive")
 	assert.Equal(t, " [app, evilsidecar]", suffix)
 
 	assert.Empty(t, containerTitleSuffix(), "no names means no suffix")

--- a/internal/app/breadcrumb_viewers_test.go
+++ b/internal/app/breadcrumb_viewers_test.go
@@ -43,6 +43,22 @@ func TestResourceTitleLabel_SanitizesTerminalEscapes(t *testing.T) {
 		resourceTitleLabel("Pod", "argo-cd", "argocd-redis-ha-server-2"))
 }
 
+// containerTitleSuffix is the shared choke point for appending container
+// name(s) to a log title. Container names come from the same pod spec as
+// the resource name resourceTitleLabel already sanitizes, but were
+// concatenated after it, so a hostile container name skipped sanitizing.
+func TestContainerTitleSuffix_SanitizesTerminalEscapes(t *testing.T) {
+	suffix := containerTitleSuffix("evil\x1b[2Jsidecar")
+	assert.NotContains(t, suffix, "\x1b")
+	assert.Equal(t, " [evil[2Jsidecar]", suffix)
+
+	suffix = containerTitleSuffix("app", "evil‮sidecar")
+	assert.NotContains(t, suffix, "‮", "bidi override must not survive")
+	assert.Equal(t, " [app, evilsidecar]", suffix)
+
+	assert.Empty(t, containerTitleSuffix(), "no names means no suffix")
+}
+
 // The fullscreen viewers (logs, exec, describe, diff, events) must surface the
 // object they show in the top breadcrumb, the same way the YAML viewer and the
 // Object Explorer do. Each case is exercised through explorerDrillPath, which

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -83,7 +83,7 @@ func (m Model) executeCommandBarInput(input string) (tea.Model, tea.Cmd) {
 		fields := strings.Fields(trimmed)
 		if len(fields) >= 2 && fields[0] == "explain" && fields[1] == "life" {
 			m.mode = modeDescribe
-			m.describeView.content = explainLifeContent()
+			m.describeView.content = sanitizeDescribeContent(explainLifeContent())
 			m.describeView.scroll = 0
 			return m, nil
 		}

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -116,7 +116,7 @@ func (m Model) vulnScanImage(image string) tea.Cmd {
 		cmd.Env = os.Environ()
 		logExecCmd("Running trivy command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
-		content := cleanANSI(strings.TrimSpace(string(output)))
+		content := sanitizeDescribeContent(cleanANSI(strings.TrimSpace(string(output))))
 		if cmdErr != nil {
 			logger.Error("trivy scan failed", "image", image, "error", cmdErr)
 			if content == "" {

--- a/internal/app/commands_gitops.go
+++ b/internal/app/commands_gitops.go
@@ -250,7 +250,7 @@ func (m Model) watchArgoWorkflow() tea.Cmd {
 			if err != nil {
 				return describeLoadedMsg{title: "Watch: " + name, err: err}
 			}
-			return describeLoadedMsg{title: "Watch: " + name, content: content}
+			return describeLoadedMsg{title: "Watch: " + name, content: sanitizeDescribeContent(content)}
 		},
 	)
 }

--- a/internal/app/describe_bench_test.go
+++ b/internal/app/describe_bench_test.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// makeDescribeBenchContent synthesizes describe-style content (tab-aligned
+// key/value pairs, matching real kubectl describe output) at the given
+// line count, for BenchmarkViewDescribe.
+func makeDescribeBenchContent(lines int) string {
+	var b strings.Builder
+	for i := range lines {
+		fmt.Fprintf(&b, "Field%d:\tvalue-%d\n", i, i)
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// BenchmarkViewDescribe measures the per-frame cost of viewDescribe after
+// moving sanitizing to the five content producers (see
+// describe_sanitize.go). Before the fix, viewDescribe re-split and
+// re-sanitized the whole buffer on every bubbletea render; content here is
+// pre-sanitized once via sanitizeDescribeContent, matching what a real
+// producer stores, so this measures only the render path's own cost.
+func BenchmarkViewDescribe(b *testing.B) {
+	for _, lines := range []int{200, 5000, 20000} {
+		b.Run(fmt.Sprintf("%d_lines", lines), func(b *testing.B) {
+			m := baseModelDescribe()
+			m.describeView.content = sanitizeDescribeContent(makeDescribeBenchContent(lines))
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = m.viewDescribe()
+			}
+		})
+	}
+}

--- a/internal/app/describe_sanitize.go
+++ b/internal/app/describe_sanitize.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// sanitizeDescribeContent sanitizes multi-line content before it is stored
+// in describeView.content. Callers are the describe view's five producers:
+// kubectl describe, helm values, command-bar output, trivy/misc command
+// output, and gitops watch — none of it lfk-controlled.
+//
+// This used to run on every call to viewDescribe, a View function bubbletea
+// invokes every frame, re-splitting and re-sanitizing the whole buffer each
+// render even though the content only changes on load. Running it once here,
+// at load time, means viewDescribe just splits already-sanitized content.
+//
+// Sanitize before any styling/highlighting is applied, never after, or
+// lfk's own escapes get stripped along with an injected one. Uses the
+// ANSI-aware body sanitizer (not ui.SanitizeTerminalText) so SGR colour and
+// tab alignment survive.
+func sanitizeDescribeContent(content string) string {
+	rawLines := strings.Split(content, "\n")
+	lines := make([]string, len(rawLines))
+	for i, l := range rawLines {
+		lines[i] = ui.SanitizeLogBody(ui.StripBidiOverrides(l), true)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/app/describe_sanitize_test.go
+++ b/internal/app/describe_sanitize_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// sanitizeDescribeContent is the describe view's single sanitizing choke
+// point, called once by each producer (kubectl describe, helm values,
+// command-bar output, trivy/misc command output, gitops watch) instead of
+// on every viewDescribe render.
+
+func TestSanitizeDescribeContent_StripsInjectedEscapes(t *testing.T) {
+	content := "before\u202eafter\x1b[2Jgone\x1b]52;c;ZXZpbA==\x07tail"
+	out := sanitizeDescribeContent(content)
+	assert.NotContains(t, out, "\u202e", "bidi override must not survive")
+	assert.NotContains(t, out, "\x1b[2J", "raw CSI (screen erase) must not survive")
+	assert.NotContains(t, out, "\x1b]52", "OSC-52 clipboard sequence must not survive")
+	assert.NotContains(t, out, "\x07")
+}
+
+func TestSanitizeDescribeContent_StripsInjectedEscapesAcrossLines(t *testing.T) {
+	content := "line one\nbefore\u202eafter\x1b[2Jgone\nline three"
+	out := sanitizeDescribeContent(content)
+	assert.NotContains(t, out, "\u202e")
+	assert.NotContains(t, out, "\x1b[2J")
+	// Line count must be preserved so scroll/cursor line indices computed
+	// against the raw content before sanitizing still line up.
+	assert.Equal(t, 3, strings.Count(out, "\n")+1)
+}
+
+func TestSanitizeDescribeContent_PreservesSGRColour(t *testing.T) {
+	// Realistic trivy-style coloured table output. SGR must survive so the
+	// severity colouring the scanner intended still renders — the guard
+	// against fixing the injection issue by breaking the feature.
+	trivyLine := "\x1b[31mCRITICAL\x1b[0m CVE-2024-1234  openssl  1.1.1  1.1.1w"
+	out := sanitizeDescribeContent(trivyLine)
+	assert.Contains(t, out, "\x1b[31m", "SGR red-severity colour must survive")
+}
+
+func TestSanitizeDescribeContent_ExpandsTabs(t *testing.T) {
+	// kubectl describe output is tab-and-space aligned; tabs must expand to
+	// the same column stops the log viewer uses, not vanish or collapse.
+	out := sanitizeDescribeContent("Name:\tmy-pod\nNamespace:\tdefault")
+	assert.Contains(t, out, "Name:   my-pod")
+	assert.Contains(t, out, "Namespace:      default")
+}
+
+func TestSanitizeDescribeContent_OrdinaryContentUnaffected(t *testing.T) {
+	content := "Name:         my-pod\nNamespace:    default\nStatus:       Running"
+	assert.Equal(t, content, sanitizeDescribeContent(content))
+}

--- a/internal/app/log_ui.go
+++ b/internal/app/log_ui.go
@@ -61,12 +61,9 @@ func (m *Model) appendLoggerUIEntry(e logger.UIEntry) {
 	if extra := formatLoggerUIArgs(e.Args); extra != "" {
 		line = line + " " + extra
 	}
-	m.errorLog = append(m.errorLog, ui.ErrorLogEntry{
+	m.appendErrorLogEntry(ui.ErrorLogEntry{
 		Time:    e.Time,
 		Message: line,
 		Level:   e.Level,
-	})
-	if len(m.errorLog) > 500 {
-		m.errorLog = m.errorLog[len(m.errorLog)-500:]
-	}
+	}, 500)
 }

--- a/internal/app/log_ui_test.go
+++ b/internal/app/log_ui_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// TestAppendLoggerUIEntry_SanitizesErrorLog guards a fourth writer to
+// m.errorLog beyond addLogEntry/setStatusMessage/setErrorFromErr:
+// appendLoggerUIEntry relays logger.UIEntry values (which can carry
+// err.Error() text from cluster interactions) into the same overlay and
+// bypassed the sanitizing boundary the others use.
+func TestAppendLoggerUIEntry_SanitizesErrorLog(t *testing.T) {
+	m := Model{}
+	m.appendLoggerUIEntry(logger.UIEntry{
+		Time:    time.Now(),
+		Level:   "ERR",
+		Message: "boom \x9d52;c;SGVsbG8=\x9c tail",
+	})
+	require.Len(t, m.errorLog, 1)
+	assert.NotContains(t, m.errorLog[0].Message, "\x9d")
+	assert.NotContains(t, m.errorLog[0].Message, "\x9c")
+}
+
+// TestAppendLoggerUIEntry_OrdinaryContentUnaffected guards against
+// sanitizing legitimate non-ASCII log messages into mush.
+func TestAppendLoggerUIEntry_OrdinaryContentUnaffected(t *testing.T) {
+	m := Model{}
+	m.appendLoggerUIEntry(logger.UIEntry{
+		Time:    time.Now(),
+		Level:   "INF",
+		Message: "café RÉSUMÉ déployé",
+	})
+	require.Len(t, m.errorLog, 1)
+	assert.Equal(t, "café RÉSUMÉ déployé", m.errorLog[0].Message)
+}
+
+// TestAppendLoggerUIEntry_Caps guards the existing 500-entry cap survives
+// routing through the shared sanitizing helper.
+func TestAppendLoggerUIEntry_Caps(t *testing.T) {
+	m := Model{}
+	for range 510 {
+		m.appendLoggerUIEntry(logger.UIEntry{Time: time.Now(), Level: "INF", Message: "entry"})
+	}
+	assert.Len(t, m.errorLog, 500)
+}

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -211,15 +211,11 @@ func (m *Model) setStatusMessage(msg string, isErr bool) {
 	} else {
 		logger.Info("Status message", "message", msg)
 	}
-	m.errorLog = append(m.errorLog, ui.ErrorLogEntry{
+	m.appendErrorLogEntry(ui.ErrorLogEntry{
 		Time:    time.Now(),
 		Message: msg,
 		Level:   level,
-	})
-	// Keep at most 200 entries (drop oldest).
-	if len(m.errorLog) > 200 {
-		m.errorLog = m.errorLog[len(m.errorLog)-200:]
-	}
+	}, 200)
 }
 
 // setErrorFromErr shows a sanitized error in the status bar and logs the
@@ -233,19 +229,34 @@ func (m *Model) setErrorFromErr(prefix string, err error) {
 	// Log the full untruncated error to the error log.
 	full := fullErrorMessage(err)
 	logger.Error("Application error", "message", full)
-	m.errorLog = append(m.errorLog, ui.ErrorLogEntry{
+	m.appendErrorLogEntry(ui.ErrorLogEntry{
 		Time:    time.Now(),
 		Message: prefix + full,
 		Level:   "ERR",
-	})
-	if len(m.errorLog) > 200 {
-		m.errorLog = m.errorLog[len(m.errorLog)-200:]
-	}
+	}, 200)
 }
 
 // hasStatusMessage checks whether there's a non-expired status message.
 func (m *Model) hasStatusMessage() bool {
 	return m.statusMessage != "" && time.Now().Before(m.statusMessageExp)
+}
+
+// appendErrorLogEntry is the single choke point for every writer of
+// m.errorLog (addLogEntry, setStatusMessage, setErrorFromErr,
+// appendLoggerUIEntry in log_ui.go). It sanitizes entry.Message before
+// appending so a future writer can't add a new raw-append path by mistake -
+// this is the third time a sibling writer to an already-sanitized field
+// leaked unsanitized content, so the fix goes at the one place all of them
+// share rather than patching each call site again. maxEntries is the cap to
+// retain (oldest dropped first); callers pass their existing cap so
+// log_ui.go/addLogEntry's larger buffer isn't shrunk to match
+// setStatusMessage/setErrorFromErr's smaller one.
+func (m *Model) appendErrorLogEntry(entry ui.ErrorLogEntry, maxEntries int) {
+	entry.Message = ui.SanitizeTerminalText(entry.Message)
+	m.errorLog = append(m.errorLog, entry)
+	if len(m.errorLog) > maxEntries {
+		m.errorLog = m.errorLog[len(m.errorLog)-maxEntries:]
+	}
 }
 
 // addLogEntry appends an entry to the in-app error log at the given level.
@@ -258,14 +269,11 @@ func (m *Model) hasStatusMessage() bool {
 // because an ErrorLogEntry.Message is a single log line, matching how
 // buildEventTimelineLines treats other single-line table/list values.
 func (m *Model) addLogEntry(level, msg string) {
-	m.errorLog = append(m.errorLog, ui.ErrorLogEntry{
+	m.appendErrorLogEntry(ui.ErrorLogEntry{
 		Time:    time.Now(),
-		Message: ui.SanitizeTerminalText(msg),
+		Message: msg,
 		Level:   level,
-	})
-	if len(m.errorLog) > 500 {
-		m.errorLog = m.errorLog[len(m.errorLog)-500:]
-	}
+	}, 500)
 }
 
 // tabLabels builds a display label for each tab. Inactive tabs render from

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -249,10 +249,18 @@ func (m *Model) hasStatusMessage() bool {
 }
 
 // addLogEntry appends an entry to the in-app error log at the given level.
+//
+// msg is sanitized here rather than at each of its ~80 call sites. Most
+// callers pass lfk-constructed strings (echoed kubectl commands), but a few
+// - command-bar output, err.Error() on a port-forward failure - carry
+// attacker-influenced content, and every entry renders through WrapEventLine
+// in the error-log overlay with no sanitizing of its own. SanitizeTerminalText
+// because an ErrorLogEntry.Message is a single log line, matching how
+// buildEventTimelineLines treats other single-line table/list values.
 func (m *Model) addLogEntry(level, msg string) {
 	m.errorLog = append(m.errorLog, ui.ErrorLogEntry{
 		Time:    time.Now(),
-		Message: msg,
+		Message: ui.SanitizeTerminalText(msg),
 		Level:   level,
 	})
 	if len(m.errorLog) > 500 {

--- a/internal/app/tabs_test.go
+++ b/internal/app/tabs_test.go
@@ -693,6 +693,43 @@ func TestAddLogEntry(t *testing.T) {
 	assert.Len(t, m.errorLog, 500)
 }
 
+// TestAddLogEntry_SanitizesTerminalEscapes guards the missing sink found in
+// review: command-bar output and err.Error() reach addLogEntry unsanitized
+// and are rendered raw by WrapEventLine in the error-log overlay, even
+// though the same values are sanitized separately before landing in the
+// describe view. Fixing this once inside addLogEntry covers every one of
+// its ~80 non-test call sites instead of patching each one.
+func TestAddLogEntry_SanitizesTerminalEscapes(t *testing.T) {
+	m := Model{}
+
+	m.addLogEntry("ERR", "boom \x9d52;c;SGVsbG8=\x9c tail")
+	require.Len(t, m.errorLog, 1)
+	assert.NotContains(t, m.errorLog[0].Message, "\x9d")
+	assert.NotContains(t, m.errorLog[0].Message, "\x9c")
+
+	m.addLogEntry("ERR", "boom \x9b31m tail")
+	require.Len(t, m.errorLog, 2)
+	assert.NotContains(t, m.errorLog[1].Message, "\x9b")
+}
+
+// TestAddLogEntry_OrdinaryContentUnaffected guards against fixing the
+// injection issue by mangling legitimate log entries, including non-ASCII
+// content.
+func TestAddLogEntry_OrdinaryContentUnaffected(t *testing.T) {
+	m := Model{}
+	cases := []string{
+		"$ kubectl get pods -n default",
+		"café RÉSUMÉ déployé",
+		"日本語のログメッセージ",
+	}
+	for _, s := range cases {
+		m.addLogEntry("DBG", s)
+	}
+	for i, s := range cases {
+		assert.Equal(t, s, m.errorLog[i].Message)
+	}
+}
+
 // --- tabLabels ---
 
 func TestTabLabels(t *testing.T) {

--- a/internal/app/tabs_test.go
+++ b/internal/app/tabs_test.go
@@ -668,6 +668,32 @@ func TestSetStatusMessage(t *testing.T) {
 	assert.Equal(t, "ERR", m.errorLog[1].Level)
 }
 
+// TestSetStatusMessage_SanitizesErrorLog guards the second of three siblings
+// writing m.errorLog: addLogEntry sanitized its own append, but
+// setStatusMessage appended msg raw, so the same overlay still reaches the
+// screen unsanitized through this door.
+func TestSetStatusMessage_SanitizesErrorLog(t *testing.T) {
+	m := Model{}
+
+	m.setStatusMessage("boom \x9d52;c;SGVsbG8=\x9c tail", false)
+	require.Len(t, m.errorLog, 1)
+	assert.NotContains(t, m.errorLog[0].Message, "\x9d")
+	assert.NotContains(t, m.errorLog[0].Message, "\x9c")
+
+	m.setStatusMessage("evil\u202etxt", true)
+	require.Len(t, m.errorLog, 2)
+	assert.NotContains(t, m.errorLog[1].Message, "\u202e")
+}
+
+// TestSetStatusMessage_OrdinaryContentUnaffected guards against sanitizing
+// legitimate non-ASCII status messages into mush.
+func TestSetStatusMessage_OrdinaryContentUnaffected(t *testing.T) {
+	m := Model{}
+	m.setStatusMessage("café RÉSUMÉ déployé", false)
+	require.Len(t, m.errorLog, 1)
+	assert.Equal(t, "café RÉSUMÉ déployé", m.errorLog[0].Message)
+}
+
 func TestHasStatusMessageExpired(t *testing.T) {
 	m := Model{
 		statusMessage:    "expired",
@@ -988,6 +1014,17 @@ func TestSetErrorFromErr(t *testing.T) {
 	assert.Len(t, m.errorLog, 1)
 	assert.Equal(t, "ERR", m.errorLog[0].Level)
 	assert.Contains(t, m.errorLog[0].Message, "fetch error: connection refused")
+}
+
+// TestSetErrorFromErr_SanitizesErrorLog guards the third of three siblings
+// writing m.errorLog: setErrorFromErr appended prefix+full raw, bypassing
+// the sanitizing boundary addLogEntry uses for the same overlay.
+func TestSetErrorFromErr_SanitizesErrorLog(t *testing.T) {
+	m := Model{width: 100}
+	m.setErrorFromErr("prefix: ", errors.New("boom \x9d52;c;SGVsbG8=\x9c tail"))
+	require.Len(t, m.errorLog, 1)
+	assert.NotContains(t, m.errorLog[0].Message, "\x9d")
+	assert.NotContains(t, m.errorLog[0].Message, "\x9c")
 }
 
 // --- setStatusMessage log capping ---

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -108,7 +108,7 @@ func (m Model) executeActionLogsWithTail(pendingLabel string, tailLines int) (te
 	}
 	label := resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 	if m.actionCtx.containerName != "" {
-		label += " [" + m.actionCtx.containerName + "]"
+		label += containerTitleSuffix(m.actionCtx.containerName)
 	}
 	m.logView.title = verb + ": " + label
 	return m, m.startLogStream()

--- a/internal/app/update_actions_tail_logs_test.go
+++ b/internal/app/update_actions_tail_logs_test.go
@@ -109,6 +109,25 @@ func TestExecuteActionLogsFullTitleHasNoTailIndicator(t *testing.T) {
 	assert.NotContains(t, mdl.logView.title, "tail", "full Logs title must not contain 'tail'")
 }
 
+// TestExecuteActionLogsSanitizesContainerNameInTitle guards the missing sink
+// found in review: containerName was concatenated into the title after
+// resourceTitleLabel, so it skipped the sanitizing kind/namespace/name get.
+func TestExecuteActionLogsSanitizesContainerNameInTitle(t *testing.T) {
+	m := newTestModelWithClient(t)
+	m.actionCtx = actionContext{
+		kind:          "Pod",
+		name:          "my-pod",
+		containerName: "evil\x1b[2Jsidecar",
+		namespace:     "default",
+		context:       "test-ctx",
+	}
+
+	result, _ := m.executeAction("Logs")
+	mdl := result.(Model)
+
+	assert.NotContains(t, mdl.logView.title, "\x1b")
+}
+
 // TestExecuteActionTailLogsGroupResourceSetsPendingAction verifies that when a
 // group resource (e.g., Deployment) triggers Tail Logs, the pendingAction is
 // set to "Tail Logs" so the pod-select overlay can continue with the correct action.

--- a/internal/app/update_describe_msgs.go
+++ b/internal/app/update_describe_msgs.go
@@ -13,7 +13,7 @@ func (m Model) updateDescribeLoaded(msg describeLoadedMsg) (tea.Model, tea.Cmd) 
 		return m, scheduleStatusClear()
 	}
 	m.mode = modeDescribe
-	m.describeView.content = msg.content
+	m.describeView.content = sanitizeDescribeContent(msg.content)
 	// Preserve scroll/cursor on auto-refresh, reset on first load.
 	if !m.describeView.autoRefresh {
 		m.describeView.scroll = 0
@@ -41,7 +41,7 @@ func (m Model) updateHelmValuesLoaded(msg helmValuesLoadedMsg) (tea.Model, tea.C
 		return m, scheduleStatusClear()
 	}
 	m.mode = modeDescribe
-	m.describeView.content = msg.content
+	m.describeView.content = sanitizeDescribeContent(msg.content)
 	m.describeView.scroll = 0
 	m.describeView.cursor = 0
 	m.describeView.cursorCol = 0

--- a/internal/app/update_dispatch_msgs.go
+++ b/internal/app/update_dispatch_msgs.go
@@ -18,7 +18,7 @@ func (m Model) updateCommandBarResult(msg commandBarResultMsg) (tea.Model, tea.C
 		// Show error output in describe view if there's content, otherwise status bar.
 		if msg.output != "" {
 			m.mode = modeDescribe
-			m.describeView.content = strings.TrimSpace(msg.output)
+			m.describeView.content = sanitizeDescribeContent(strings.TrimSpace(msg.output))
 			m.describeView.scroll = 0
 			m.describeView.cursor = 0
 			m.describeView.cursorCol = 0
@@ -33,7 +33,7 @@ func (m Model) updateCommandBarResult(msg commandBarResultMsg) (tea.Model, tea.C
 		m.addLogEntry("INF", output)
 		// Open output in the describe viewer (scrollable, searchable, wrappable).
 		m.mode = modeDescribe
-		m.describeView.content = output
+		m.describeView.content = sanitizeDescribeContent(output)
 		m.describeView.scroll = 0
 		m.describeView.cursor = 0
 		m.describeView.cursorCol = 0

--- a/internal/app/update_msg_extra_test.go
+++ b/internal/app/update_msg_extra_test.go
@@ -402,6 +402,31 @@ func TestUpdateCommandBarResultErrorNoOutput(t *testing.T) {
 	assert.NotNil(t, cmd) // scheduleStatusClear
 }
 
+// TestUpdateCommandBarResultSanitizesOutput guards the describe view's
+// command-bar producer sink: shell/kubectl output is not lfk-controlled.
+func TestUpdateCommandBarResultSanitizesOutput(t *testing.T) {
+	m := baseModel()
+
+	result, _ := m.Update(commandBarResultMsg{output: "before\x1b[2Jgone\x9b31mHACKED"})
+	mdl := result.(Model)
+	assert.NotContains(t, mdl.describeView.content, "\x1b[2J")
+	assert.NotContains(t, mdl.describeView.content, "\x9b")
+}
+
+// TestUpdateCommandBarResultErrorSanitizesOutput mirrors
+// TestUpdateCommandBarResultSanitizesOutput for the error-with-output path.
+func TestUpdateCommandBarResultErrorSanitizesOutput(t *testing.T) {
+	m := baseModel()
+
+	result, _ := m.Update(commandBarResultMsg{
+		err:    errors.New("exit 1"),
+		output: "before\x1b[2Jgone\x9b31mHACKED",
+	})
+	mdl := result.(Model)
+	assert.NotContains(t, mdl.describeView.content, "\x1b[2J")
+	assert.NotContains(t, mdl.describeView.content, "\x9b")
+}
+
 // --- triggerCronJobMsg ---
 
 func TestUpdateTriggerCronJobSuccess(t *testing.T) {
@@ -535,6 +560,21 @@ func TestUpdateDescribeLoadedError(t *testing.T) {
 	assert.NotNil(t, cmd) // scheduleStatusClear
 }
 
+// TestUpdateDescribeLoadedSanitizesContent guards the describe view's
+// kubectl-describe producer sink: describe output (annotation values,
+// field-manager names, etc.) is not lfk-controlled.
+func TestUpdateDescribeLoadedSanitizesContent(t *testing.T) {
+	m := baseModel()
+
+	result, _ := m.Update(describeLoadedMsg{
+		content: "Name: my-pod\x1b[2Jgone\x9b31mHACKED",
+		title:   "Pod: my-pod",
+	})
+	mdl := result.(Model)
+	assert.NotContains(t, mdl.describeView.content, "\x1b[2J")
+	assert.NotContains(t, mdl.describeView.content, "\x9b")
+}
+
 // --- helmValuesLoadedMsg ---
 
 func TestUpdateHelmValuesLoadedSuccess(t *testing.T) {
@@ -562,6 +602,21 @@ func TestUpdateHelmValuesLoadedError(t *testing.T) {
 	assert.False(t, mdl.loading)
 	assert.True(t, mdl.statusMessageErr)
 	assert.NotNil(t, cmd) // scheduleStatusClear
+}
+
+// TestUpdateHelmValuesLoadedSanitizesContent guards the describe view's helm
+// values producer sink: a values.yaml key can carry attacker-influenced
+// strings (e.g. a chart pulled from an untrusted repo).
+func TestUpdateHelmValuesLoadedSanitizesContent(t *testing.T) {
+	m := baseModel()
+
+	result, _ := m.Update(helmValuesLoadedMsg{
+		content: "replicaCount: 3\x1b[2Jgone\x9b31mHACKED",
+		title:   "Values: my-release",
+	})
+	mdl := result.(Model)
+	assert.NotContains(t, mdl.describeView.content, "\x1b[2J")
+	assert.NotContains(t, mdl.describeView.content, "\x9b")
 }
 
 // --- diffLoadedMsg ---

--- a/internal/app/update_overlays_events.go
+++ b/internal/app/update_overlays_events.go
@@ -21,13 +21,13 @@ const eventTimelineMessageColumn = 8 + 1 + 7 + 1 + 20 + 1
 // for cursor navigation. Each event becomes a single line with format:
 // {age}  {type}  {reason}  {message}
 //
-// Reason, Message, and Source are cluster-controlled - any principal that
-// can create an Event in the namespace sets them - so they are sanitized
-// here, the single place raw k8s.EventInfo values turn into displayed text
-// for this viewer. SanitizeTerminalText, not the ANSI-aware body sanitizer,
-// because these are short table-cell values with no legitimate reason to
-// carry colour or tabs (matches how resourceTitleLabel treats kind/
-// namespace/name).
+// Type, Reason, Message, and Source are cluster-controlled - any principal
+// that can create an Event in the namespace sets them - so they are
+// sanitized here, the single place raw k8s.EventInfo values turn into
+// displayed text for this viewer. SanitizeTerminalText, not the ANSI-aware
+// body sanitizer, because these are short table-cell values with no
+// legitimate reason to carry colour or tabs (matches how resourceTitleLabel
+// treats kind/namespace/name).
 func (m *Model) buildEventTimelineLines() []string {
 	lines := make([]string, 0, len(m.eventTimelineData))
 	for _, e := range m.eventTimelineData {
@@ -36,6 +36,7 @@ func (m *Model) buildEventTimelineLines() []string {
 		if e.Count > 1 {
 			countStr = fmt.Sprintf(" (x%d)", e.Count)
 		}
+		typ := ui.SanitizeTerminalText(e.Type)
 		reason := ui.SanitizeTerminalText(e.Reason)
 		message := ui.SanitizeTerminalText(e.Message)
 		src := ""
@@ -43,7 +44,7 @@ func (m *Model) buildEventTimelineLines() []string {
 			src = " [" + ui.SanitizeTerminalText(e.Source) + "]"
 		}
 		line := fmt.Sprintf("%-8s %-7s %-20s %s%s%s",
-			ts, e.Type, reason, message, countStr, src)
+			ts, typ, reason, message, countStr, src)
 		lines = append(lines, line)
 	}
 	return lines

--- a/internal/app/update_overlays_events.go
+++ b/internal/app/update_overlays_events.go
@@ -6,7 +6,15 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// eventTimelineTypeWidth and eventTimelineReasonWidth are the display-width
+// columns Type and Reason are padded/truncated to in buildEventTimelineLines.
+const (
+	eventTimelineTypeWidth   = 7
+	eventTimelineReasonWidth = 20
 )
 
 // eventTimelineMessageColumn is the column at which the message field
@@ -15,7 +23,21 @@ import (
 // event viewer uses this as the hanging indent for wrap mode so
 // continuation lines align under the message column instead of
 // re-flowing flush to the left margin.
-const eventTimelineMessageColumn = 8 + 1 + 7 + 1 + 20 + 1
+const eventTimelineMessageColumn = 8 + 1 + eventTimelineTypeWidth + 1 + eventTimelineReasonWidth + 1
+
+// padColumn truncates s to at most width display columns (via ui.Truncate)
+// and right-pads it to exactly width with spaces, using lipgloss.Width
+// rather than rune/byte count. Type and Reason are cluster-controlled and
+// can contain wide Unicode; padding by rune count (fmt.Sprintf %-Ns) would
+// shift every column after it because a wide rune occupies two terminal
+// columns but counts as one rune.
+func padColumn(s string, width int) string {
+	s = ui.Truncate(s, width)
+	if pad := width - lipgloss.Width(s); pad > 0 {
+		s += strings.Repeat(" ", pad)
+	}
+	return s
+}
 
 // buildEventTimelineLines converts event timeline data into flat text lines
 // for cursor navigation. Each event becomes a single line with format:
@@ -36,14 +58,14 @@ func (m *Model) buildEventTimelineLines() []string {
 		if e.Count > 1 {
 			countStr = fmt.Sprintf(" (x%d)", e.Count)
 		}
-		typ := ui.SanitizeTerminalText(e.Type)
-		reason := ui.SanitizeTerminalText(e.Reason)
+		typ := padColumn(ui.SanitizeTerminalText(e.Type), eventTimelineTypeWidth)
+		reason := padColumn(ui.SanitizeTerminalText(e.Reason), eventTimelineReasonWidth)
 		message := ui.SanitizeTerminalText(e.Message)
 		src := ""
 		if e.Source != "" {
 			src = " [" + ui.SanitizeTerminalText(e.Source) + "]"
 		}
-		line := fmt.Sprintf("%-8s %-7s %-20s %s%s%s",
+		line := fmt.Sprintf("%-8s %s %s %s%s%s",
 			ts, typ, reason, message, countStr, src)
 		lines = append(lines, line)
 	}

--- a/internal/app/update_overlays_events.go
+++ b/internal/app/update_overlays_events.go
@@ -20,6 +20,14 @@ const eventTimelineMessageColumn = 8 + 1 + 7 + 1 + 20 + 1
 // buildEventTimelineLines converts event timeline data into flat text lines
 // for cursor navigation. Each event becomes a single line with format:
 // {age}  {type}  {reason}  {message}
+//
+// Reason, Message, and Source are cluster-controlled - any principal that
+// can create an Event in the namespace sets them - so they are sanitized
+// here, the single place raw k8s.EventInfo values turn into displayed text
+// for this viewer. SanitizeTerminalText, not the ANSI-aware body sanitizer,
+// because these are short table-cell values with no legitimate reason to
+// carry colour or tabs (matches how resourceTitleLabel treats kind/
+// namespace/name).
 func (m *Model) buildEventTimelineLines() []string {
 	lines := make([]string, 0, len(m.eventTimelineData))
 	for _, e := range m.eventTimelineData {
@@ -28,12 +36,14 @@ func (m *Model) buildEventTimelineLines() []string {
 		if e.Count > 1 {
 			countStr = fmt.Sprintf(" (x%d)", e.Count)
 		}
+		reason := ui.SanitizeTerminalText(e.Reason)
+		message := ui.SanitizeTerminalText(e.Message)
 		src := ""
 		if e.Source != "" {
-			src = " [" + e.Source + "]"
+			src = " [" + ui.SanitizeTerminalText(e.Source) + "]"
 		}
 		line := fmt.Sprintf("%-8s %-7s %-20s %s%s%s",
-			ts, e.Type, e.Reason, e.Message, countStr, src)
+			ts, e.Type, reason, message, countStr, src)
 		lines = append(lines, line)
 	}
 	return lines

--- a/internal/app/update_overlays_events_test.go
+++ b/internal/app/update_overlays_events_test.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -110,6 +112,51 @@ func TestBuildEventTimelineLinesOrdinaryTypeUnaffected(t *testing.T) {
 	lines := m.buildEventTimelineLines()
 	require.Len(t, lines, 1)
 	assert.Contains(t, lines[0], "Warning")
+}
+
+// TestBuildEventTimelineLinesWideUnicodeColumnsAligned guards against
+// padding Type/Reason by rune count (fmt.Sprintf %-Ns): a wide Unicode
+// character counts as one rune but two terminal columns, so rune-based
+// padding shifts the message column right of where eventTimelineMessageColumn
+// expects it. Padding must use display width (lipgloss.Width), matching
+// ordinary ASCII content byte-for-byte.
+func TestBuildEventTimelineLinesWideUnicodeColumnsAligned(t *testing.T) {
+	m := Model{
+		eventTimelineData: []k8s.EventInfo{
+			{Type: "Normal", Reason: "Scheduled", Message: "ascii message"},
+			{Type: "普通", Reason: "スケジュール済み", Message: "wide message"},
+		},
+	}
+	lines := m.buildEventTimelineLines()
+	require.Len(t, lines, 2)
+
+	for i, want := range []string{"ascii message", "wide message"} {
+		idx := strings.Index(lines[i], want)
+		require.Positive(t, idx, "line %d: %q not found in %q", i, want, lines[i])
+		prefixWidth := lipgloss.Width(lines[i][:idx])
+		assert.Equal(t, eventTimelineMessageColumn, prefixWidth,
+			"line %d: message column misaligned by wide Unicode in Type/Reason", i)
+	}
+}
+
+// TestBuildEventTimelineLinesTruncatesOverlongTypeAndReason guards the
+// column width contract when Type/Reason exceed their allotted display
+// width: they must be truncated to fit, not left to overflow into the
+// message column (fmt.Sprintf %-Ns never truncates).
+func TestBuildEventTimelineLinesTruncatesOverlongTypeAndReason(t *testing.T) {
+	m := Model{
+		eventTimelineData: []k8s.EventInfo{{
+			Type:    "VeryLongEventTypeNameThatOverflows",
+			Reason:  "AnEvenLongerReasonStringThatDefinitelyExceedsTwentyColumns",
+			Message: "the message",
+		}},
+	}
+	lines := m.buildEventTimelineLines()
+	require.Len(t, lines, 1)
+
+	idx := strings.Index(lines[0], "the message")
+	require.Positive(t, idx, "message not found in %q", lines[0])
+	assert.Equal(t, eventTimelineMessageColumn, lipgloss.Width(lines[0][:idx]))
 }
 
 func TestEventContentHeight(t *testing.T) {

--- a/internal/app/update_overlays_events_test.go
+++ b/internal/app/update_overlays_events_test.go
@@ -46,6 +46,27 @@ func TestBuildEventTimelineLinesEmpty(t *testing.T) {
 	assert.Empty(t, lines)
 }
 
+// TestBuildEventTimelineLinesSanitizesControlBytes guards the missing sink
+// found in review: Event Reason, Message, and Source are attacker-influenced
+// (any principal that can create an Event in the namespace controls them)
+// and reached the fullscreen event viewer unfiltered.
+func TestBuildEventTimelineLinesSanitizesControlBytes(t *testing.T) {
+	m := Model{
+		eventTimelineData: []k8s.EventInfo{{
+			Type:    "Warning",
+			Reason:  "Hacked\x9b31m",
+			Message: "\x1b]52;c;SGVsbG8=\x07payload",
+			Source:  "evil\x9c",
+		}},
+	}
+	lines := m.buildEventTimelineLines()
+	require.Len(t, lines, 1)
+	assert.NotContains(t, lines[0], "\x9b")
+	assert.NotContains(t, lines[0], "\x1b")
+	assert.NotContains(t, lines[0], "\x07")
+	assert.NotContains(t, lines[0], "\x9c")
+}
+
 func TestEventContentHeight(t *testing.T) {
 	m := newEventModel(10)
 

--- a/internal/app/update_overlays_events_test.go
+++ b/internal/app/update_overlays_events_test.go
@@ -67,6 +67,51 @@ func TestBuildEventTimelineLinesSanitizesControlBytes(t *testing.T) {
 	assert.NotContains(t, lines[0], "\x9c")
 }
 
+// TestBuildEventTimelineLinesSanitizesType guards a second missed field on
+// the same line: Reason, Message, and Source were sanitized, but Type was
+// printed raw in the same fmt.Sprintf call. Type is just as attacker-
+// influenced - an unconstrained string on the Event API, settable by any
+// principal with create-events permission in the namespace.
+func TestBuildEventTimelineLinesSanitizesType(t *testing.T) {
+	m := Model{
+		eventTimelineData: []k8s.EventInfo{{
+			Type:    "\x9d52;c;SGVsbG8=\x9c",
+			Reason:  "Scheduled",
+			Message: "ok",
+		}},
+	}
+	lines := m.buildEventTimelineLines()
+	require.Len(t, lines, 1)
+	assert.NotContains(t, lines[0], "\x9d")
+	assert.NotContains(t, lines[0], "\x9c")
+
+	m2 := Model{
+		eventTimelineData: []k8s.EventInfo{{
+			Type:    "\x9b31m",
+			Reason:  "Scheduled",
+			Message: "ok",
+		}},
+	}
+	lines2 := m2.buildEventTimelineLines()
+	require.Len(t, lines2, 1)
+	assert.NotContains(t, lines2[0], "\x9b")
+}
+
+// TestBuildEventTimelineLinesOrdinaryTypeUnaffected guards against fixing
+// the injection issue by mangling legitimate event types.
+func TestBuildEventTimelineLinesOrdinaryTypeUnaffected(t *testing.T) {
+	m := Model{
+		eventTimelineData: []k8s.EventInfo{{
+			Type:    "Warning",
+			Reason:  "Scheduled",
+			Message: "ok",
+		}},
+	}
+	lines := m.buildEventTimelineLines()
+	require.Len(t, lines, 1)
+	assert.Contains(t, lines[0], "Warning")
+}
+
 func TestEventContentHeight(t *testing.T) {
 	m := newEventModel(10)
 

--- a/internal/app/update_overlays_logs.go
+++ b/internal/app/update_overlays_logs.go
@@ -434,7 +434,7 @@ func (m *Model) restartLogStreamForContainerFilter() tea.Cmd {
 func (m *Model) buildLogTitle() string {
 	base := "Logs: " + resourceTitleLabel(m.actionCtx.kind, m.actionNamespace(), m.actionCtx.name)
 	if len(m.logView.selectedContainers) > 0 && len(m.logView.selectedContainers) < len(m.logView.containers) {
-		base += " [" + strings.Join(m.logView.selectedContainers, ", ") + "]"
+		base += containerTitleSuffix(m.logView.selectedContainers...)
 	}
 	return base
 }

--- a/internal/app/update_overlays_logs_extra_test.go
+++ b/internal/app/update_overlays_logs_extra_test.go
@@ -30,6 +30,23 @@ func TestBuildLogTitleWithContainerFilter(t *testing.T) {
 	assert.Contains(t, title, "sidecar")
 }
 
+// TestBuildLogTitleSanitizesContainerNames guards the missing sink found in
+// review: selectedContainers was joined raw into the title after
+// resourceTitleLabel, so a hostile container name skipped the sanitizing
+// kind/namespace/name get.
+func TestBuildLogTitleSanitizesContainerNames(t *testing.T) {
+	m := Model{
+		namespace: "default",
+		actionCtx: actionContext{name: "my-pod", namespace: "default"},
+		logView: logViewState{
+			containers:         []string{"app", "sidecar", "init"},
+			selectedContainers: []string{"evil\x1b[2Japp", "sidecar"},
+		},
+	}
+	title := m.buildLogTitle()
+	assert.NotContains(t, title, "\x1b")
+}
+
 func TestBuildLogTitleAllContainersSelected(t *testing.T) {
 	m := Model{
 		namespace: "default",

--- a/internal/app/view_modes.go
+++ b/internal/app/view_modes.go
@@ -78,7 +78,17 @@ func (m Model) viewDescribe() string {
 		hint = ui.RenderHintBar(hints, m.width)
 	}
 
-	lines := strings.Split(m.describeView.content, "\n")
+	// Sanitize before any styling/highlighting is applied, never after, or
+	// lfk's own escapes get stripped along with an injected one. This sink
+	// is shared by kubectl describe, helm values, command-bar output,
+	// trivy/misc command output, and gitops watch — none of it lfk-
+	// controlled. Use the ANSI-aware body sanitizer (not
+	// ui.SanitizeTerminalText) so SGR colour and tab alignment survive.
+	rawLines := strings.Split(m.describeView.content, "\n")
+	lines := make([]string, len(rawLines))
+	for i, l := range rawLines {
+		lines[i] = ui.SanitizeLogBody(ui.StripBidiOverrides(l), true)
+	}
 
 	maxLines := max(m.height-4, 3)
 

--- a/internal/app/view_modes.go
+++ b/internal/app/view_modes.go
@@ -78,17 +78,10 @@ func (m Model) viewDescribe() string {
 		hint = ui.RenderHintBar(hints, m.width)
 	}
 
-	// Sanitize before any styling/highlighting is applied, never after, or
-	// lfk's own escapes get stripped along with an injected one. This sink
-	// is shared by kubectl describe, helm values, command-bar output,
-	// trivy/misc command output, and gitops watch — none of it lfk-
-	// controlled. Use the ANSI-aware body sanitizer (not
-	// ui.SanitizeTerminalText) so SGR colour and tab alignment survive.
-	rawLines := strings.Split(m.describeView.content, "\n")
-	lines := make([]string, len(rawLines))
-	for i, l := range rawLines {
-		lines[i] = ui.SanitizeLogBody(ui.StripBidiOverrides(l), true)
-	}
+	// describeView.content is sanitized once by its producer (see
+	// sanitizeDescribeContent) before it lands here, so this View function
+	// - which bubbletea calls every frame - does no per-frame work.
+	lines := strings.Split(m.describeView.content, "\n")
 
 	maxLines := max(m.height-4, 3)
 

--- a/internal/app/view_modes_test.go
+++ b/internal/app/view_modes_test.go
@@ -407,6 +407,94 @@ func TestViewDescribe(t *testing.T) {
 	})
 }
 
+// --- viewDescribe: sanitizing ---
+//
+// describeView.content is fed by kubectl describe, helm values, command-bar
+// output, trivy scans, and gitops watch — none of it lfk-controlled. This
+// sink must run the ANSI-aware sanitizer (ui.SanitizeLogBody), not the
+// name/title one, or SGR colour and tab alignment break.
+
+func TestViewDescribe_StripsInjectedEscapesFromContent(t *testing.T) {
+	m := Model{
+		width:  120,
+		height: 30,
+		describeView: describeViewState{
+			title:   "Command Output",
+			content: "before‮after\x1b[2Jgone\x1b]52;c;ZXZpbA==\x07tail",
+		},
+	}
+	output := m.viewDescribe()
+	assert.NotContains(t, output, "‮", "bidi override must not survive")
+	assert.NotContains(t, output, "\x1b[2J", "raw CSI (screen erase) must not survive")
+	assert.NotContains(t, output, "\x1b]52", "OSC-52 clipboard sequence must not survive")
+	assert.NotContains(t, output, "\x07")
+}
+
+func TestViewDescribe_StripsInjectedEscapesInWrapMode(t *testing.T) {
+	m := Model{
+		width:  120,
+		height: 30,
+		describeView: describeViewState{
+			title:   "Command Output",
+			content: "before‮after\x1b[2Jgone",
+			wrap:    true,
+		},
+	}
+	output := m.viewDescribe()
+	assert.NotContains(t, output, "‮")
+	assert.NotContains(t, output, "\x1b[2J")
+}
+
+func TestViewDescribe_PreservesSGRColour(t *testing.T) {
+	// Realistic trivy-style coloured table output. SGR must survive so the
+	// severity colouring the scanner intended still renders — the guard
+	// against fixing the injection issue by breaking the feature.
+	trivyLine := "\x1b[31mCRITICAL\x1b[0m CVE-2024-1234  openssl  1.1.1  1.1.1w"
+	m := Model{
+		width:  120,
+		height: 30,
+		describeView: describeViewState{
+			title:   "Vuln Scan: nginx:latest",
+			content: trivyLine,
+		},
+	}
+	output := m.viewDescribe()
+	assert.Contains(t, output, "\x1b[31m", "SGR red-severity colour must survive the describe path")
+}
+
+func TestViewDescribe_PreservesTabAlignment(t *testing.T) {
+	// kubectl describe output is tab-and-space aligned; tabs must expand to
+	// the same column stops the log viewer uses, not vanish or collapse.
+	m := Model{
+		width:  120,
+		height: 30,
+		describeView: describeViewState{
+			title:   "Describe: my-pod",
+			content: "Name:\tmy-pod\nNamespace:\tdefault",
+		},
+	}
+	output := m.viewDescribe()
+	stripped := stripANSI(output)
+	assert.Contains(t, stripped, "Name:   my-pod")
+	assert.Contains(t, stripped, "Namespace:      default")
+}
+
+func TestViewDescribe_OrdinaryContentUnaffected(t *testing.T) {
+	m := Model{
+		width:  120,
+		height: 30,
+		describeView: describeViewState{
+			title:   "Describe: my-pod",
+			content: "Name:         my-pod\nNamespace:    default\nStatus:       Running",
+		},
+	}
+	output := m.viewDescribe()
+	stripped := stripANSI(output)
+	assert.Contains(t, stripped, "Name:         my-pod")
+	assert.Contains(t, stripped, "Namespace:    default")
+	assert.Contains(t, stripped, "Status:       Running")
+}
+
 // --- viewDiff ---
 
 func TestViewDiff(t *testing.T) {

--- a/internal/app/view_modes_test.go
+++ b/internal/app/view_modes_test.go
@@ -420,11 +420,11 @@ func TestViewDescribe_StripsInjectedEscapesFromContent(t *testing.T) {
 		height: 30,
 		describeView: describeViewState{
 			title:   "Command Output",
-			content: "before‮after\x1b[2Jgone\x1b]52;c;ZXZpbA==\x07tail",
+			content: "before\u202eafter\x1b[2Jgone\x1b]52;c;ZXZpbA==\x07tail",
 		},
 	}
 	output := m.viewDescribe()
-	assert.NotContains(t, output, "‮", "bidi override must not survive")
+	assert.NotContains(t, output, "\u202e", "bidi override must not survive")
 	assert.NotContains(t, output, "\x1b[2J", "raw CSI (screen erase) must not survive")
 	assert.NotContains(t, output, "\x1b]52", "OSC-52 clipboard sequence must not survive")
 	assert.NotContains(t, output, "\x07")
@@ -436,12 +436,12 @@ func TestViewDescribe_StripsInjectedEscapesInWrapMode(t *testing.T) {
 		height: 30,
 		describeView: describeViewState{
 			title:   "Command Output",
-			content: "before‮after\x1b[2Jgone",
+			content: "before\u202eafter\x1b[2Jgone",
 			wrap:    true,
 		},
 	}
 	output := m.viewDescribe()
-	assert.NotContains(t, output, "‮")
+	assert.NotContains(t, output, "\u202e")
 	assert.NotContains(t, output, "\x1b[2J")
 }
 

--- a/internal/app/view_modes_test.go
+++ b/internal/app/view_modes_test.go
@@ -410,17 +410,21 @@ func TestViewDescribe(t *testing.T) {
 // --- viewDescribe: sanitizing ---
 //
 // describeView.content is fed by kubectl describe, helm values, command-bar
-// output, trivy scans, and gitops watch — none of it lfk-controlled. This
-// sink must run the ANSI-aware sanitizer (ui.SanitizeLogBody), not the
-// name/title one, or SGR colour and tab alignment break.
+// output, trivy scans, and gitops watch — none of it lfk-controlled. Each
+// producer sanitizes once via sanitizeDescribeContent (see
+// describe_sanitize_test.go for the injection/SGR/tab-expansion coverage)
+// before storing the content, so viewDescribe — a View function bubbletea
+// calls every frame — trusts its input and does no per-frame sanitizing.
+// These tests exercise the full producer -> view pipeline.
 
-func TestViewDescribe_StripsInjectedEscapesFromContent(t *testing.T) {
+func TestViewDescribe_RendersProducerSanitizedContent(t *testing.T) {
+	raw := "before\u202eafter\x1b[2Jgone\x1b]52;c;ZXZpbA==\x07tail"
 	m := Model{
 		width:  120,
 		height: 30,
 		describeView: describeViewState{
 			title:   "Command Output",
-			content: "before\u202eafter\x1b[2Jgone\x1b]52;c;ZXZpbA==\x07tail",
+			content: sanitizeDescribeContent(raw),
 		},
 	}
 	output := m.viewDescribe()
@@ -430,13 +434,14 @@ func TestViewDescribe_StripsInjectedEscapesFromContent(t *testing.T) {
 	assert.NotContains(t, output, "\x07")
 }
 
-func TestViewDescribe_StripsInjectedEscapesInWrapMode(t *testing.T) {
+func TestViewDescribe_RendersProducerSanitizedContentInWrapMode(t *testing.T) {
+	raw := "before\u202eafter\x1b[2Jgone"
 	m := Model{
 		width:  120,
 		height: 30,
 		describeView: describeViewState{
 			title:   "Command Output",
-			content: "before\u202eafter\x1b[2Jgone",
+			content: sanitizeDescribeContent(raw),
 			wrap:    true,
 		},
 	}
@@ -446,10 +451,10 @@ func TestViewDescribe_StripsInjectedEscapesInWrapMode(t *testing.T) {
 }
 
 func TestViewDescribe_PreservesSGRColour(t *testing.T) {
-	// Realistic trivy-style coloured table output. SGR must survive so the
-	// severity colouring the scanner intended still renders — the guard
-	// against fixing the injection issue by breaking the feature.
-	trivyLine := "\x1b[31mCRITICAL\x1b[0m CVE-2024-1234  openssl  1.1.1  1.1.1w"
+	// Realistic trivy-style coloured table output, as a producer would have
+	// stored it after sanitizeDescribeContent. SGR must survive so the
+	// severity colouring the scanner intended still renders.
+	trivyLine := sanitizeDescribeContent("\x1b[31mCRITICAL\x1b[0m CVE-2024-1234  openssl  1.1.1  1.1.1w")
 	m := Model{
 		width:  120,
 		height: 30,
@@ -463,14 +468,14 @@ func TestViewDescribe_PreservesSGRColour(t *testing.T) {
 }
 
 func TestViewDescribe_PreservesTabAlignment(t *testing.T) {
-	// kubectl describe output is tab-and-space aligned; tabs must expand to
-	// the same column stops the log viewer uses, not vanish or collapse.
+	// kubectl describe output is tab-and-space aligned; a producer expands
+	// tabs via sanitizeDescribeContent before viewDescribe ever sees them.
 	m := Model{
 		width:  120,
 		height: 30,
 		describeView: describeViewState{
 			title:   "Describe: my-pod",
-			content: "Name:\tmy-pod\nNamespace:\tdefault",
+			content: sanitizeDescribeContent("Name:\tmy-pod\nNamespace:\tdefault"),
 		},
 	}
 	output := m.viewDescribe()

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -213,6 +213,23 @@ func resourceTitleLabel(kind, namespace, name string) string {
 	return label
 }
 
+// containerTitleSuffix formats a bracketed container-name suffix for log
+// titles, e.g. " [app, sidecar]", or "" when names is empty. Container
+// names come from the same pod spec as the resource name resourceTitleLabel
+// already sanitizes, but are appended after it at each log-title call site;
+// sanitizing once here, where the name(s) enter the title, covers every
+// site instead of requiring a fix at each concatenation.
+func containerTitleSuffix(names ...string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	sanitized := make([]string, len(names))
+	for i, n := range names {
+		sanitized[i] = ui.SanitizeTerminalText(n)
+	}
+	return " [" + strings.Join(sanitized, ", ") + "]"
+}
+
 // nameNotInNav returns name unless the nav breadcrumb already ends with it (as
 // ResourceName or OwnedName), in which case it returns "" so the drill path
 // does not duplicate a segment the breadcrumb already shows.

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -198,6 +198,11 @@ func (m Model) explorerDrillPath() []string {
 // The namespace is dropped for cluster-scoped resources (empty namespace) and
 // the kind when it is unknown.
 func resourceTitleLabel(kind, namespace, name string) string {
+	// kind/namespace/name come from cluster-controlled resources; sanitize
+	// once here rather than at each of the nine call sites.
+	kind = ui.SanitizeTerminalText(kind)
+	namespace = ui.SanitizeTerminalText(namespace)
+	name = ui.SanitizeTerminalText(name)
 	label := name
 	if namespace != "" {
 		label = namespace + "/" + name

--- a/internal/app/yamlfold.go
+++ b/internal/app/yamlfold.go
@@ -3,6 +3,8 @@ package app
 import (
 	"strconv"
 	"strings"
+
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 // yamlSection represents a YAML section (a key with nested content below it).
@@ -58,32 +60,56 @@ func hasDeeperContent(lines []string, startLine, minIndent int) bool {
 	return nextIndent >= minIndent
 }
 
-// buildYAMLLoadedMsg constructs a yamlLoadedMsg with the content pre-indented
-// and sections pre-parsed, so the Bubble Tea message handler has no heavy
-// work to do when it lands on the main event loop. Called from inside
-// loader goroutines — never from the main thread — because parseYAMLSections
-// on very large CRD manifests (50k+ lines) can take multiple seconds.
+// sanitizeYAMLContent strips control bytes (including the C1 range) and
+// bidi overrides from raw YAML text before it is folded/indented and shown
+// on screen. YAML values (Secret data, annotations, ConfigMap entries) are
+// cluster-controlled and otherwise reach the viewer unfiltered. Sanitizing
+// here - the single producer both the full viewer and the preview pane load
+// from - keeps the render path (view_yaml.go) free of this work and keeps
+// line counts stable for the section/indent parsing that follows.
+//
+// sanitizeLogLine (via SanitizeLogBody) works one line at a time and would
+// otherwise treat an embedded newline as a stray control byte, so the
+// content is split and rejoined around it. renderAnsi is false: kubectl YAML
+// output has no legitimate reason to carry SGR colour, so any ESC is always
+// replaced rather than risking passing through an attacker-controlled
+// sequence.
+func sanitizeYAMLContent(content string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = ui.SanitizeLogBody(ui.StripBidiOverrides(line), false)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// buildYAMLLoadedMsg constructs a yamlLoadedMsg with the content sanitized,
+// pre-indented, and sections pre-parsed, so the Bubble Tea message handler
+// has no heavy work to do when it lands on the main event loop. Called from
+// inside loader goroutines — never from the main thread — because
+// parseYAMLSections on very large CRD manifests (50k+ lines) can take
+// multiple seconds.
 func buildYAMLLoadedMsg(content string, err error) yamlLoadedMsg {
 	if err != nil {
 		return yamlLoadedMsg{err: err}
 	}
-	indented := indentYAMLListItems(content)
+	indented := indentYAMLListItems(sanitizeYAMLContent(content))
 	return yamlLoadedMsg{
 		content:  indented,
 		sections: parseYAMLSections(indented),
 	}
 }
 
-// buildPreviewYAMLLoadedMsg constructs a previewYAMLLoadedMsg with the content
-// pre-indented, matching buildYAMLLoadedMsg. Preview mode does not need the
-// section tree (no fold indicators in the preview pane), so only the indent
-// pass is run — still non-trivial on huge documents.
+// buildPreviewYAMLLoadedMsg constructs a previewYAMLLoadedMsg with the
+// content sanitized and pre-indented, matching buildYAMLLoadedMsg. Preview
+// mode does not need the section tree (no fold indicators in the preview
+// pane), so only the sanitize and indent passes run — still non-trivial on
+// huge documents.
 func buildPreviewYAMLLoadedMsg(content string, err error, gen uint64) previewYAMLLoadedMsg {
 	if err != nil {
 		return previewYAMLLoadedMsg{err: err, gen: gen}
 	}
 	return previewYAMLLoadedMsg{
-		content: indentYAMLListItems(content),
+		content: indentYAMLListItems(sanitizeYAMLContent(content)),
 		gen:     gen,
 	}
 }

--- a/internal/app/yamlfold_async_test.go
+++ b/internal/app/yamlfold_async_test.go
@@ -87,10 +87,10 @@ func TestBuildYAMLLoadedMsgSanitizesControlBytes(t *testing.T) {
 	msg := buildYAMLLoadedMsg(raw, nil)
 	assert.NotContains(t, msg.content, "\x9b")
 
-	withBidi := "apiVersion: v1\nkind: ConfigMap\ndata:\n  note: ‮evil‬\n"
+	withBidi := "apiVersion: v1\nkind: ConfigMap\ndata:\n  note: \u202eevil\u202c\n"
 	msg = buildYAMLLoadedMsg(withBidi, nil)
-	assert.NotContains(t, msg.content, "‮")
-	assert.NotContains(t, msg.content, "‬")
+	assert.NotContains(t, msg.content, "\u202e")
+	assert.NotContains(t, msg.content, "\u202c")
 }
 
 // TestBuildPreviewYAMLLoadedMsgSanitizesControlBytes is the preview

--- a/internal/app/yamlfold_async_test.go
+++ b/internal/app/yamlfold_async_test.go
@@ -78,6 +78,30 @@ func TestBuildPreviewYAMLLoadedMsgError(t *testing.T) {
 	assert.Empty(t, msg.content)
 }
 
+// TestBuildYAMLLoadedMsgSanitizesControlBytes guards the missing sink found
+// in review: Secret data and annotations are cluster-controlled and were
+// rendered raw, so a hostile value carrying a C1 control or a bidi override
+// reached the screen unfiltered.
+func TestBuildYAMLLoadedMsgSanitizesControlBytes(t *testing.T) {
+	raw := "apiVersion: v1\nkind: Secret\ndata:\n  password: \x9b31mHACKED\x9b0m\n"
+	msg := buildYAMLLoadedMsg(raw, nil)
+	assert.NotContains(t, msg.content, "\x9b")
+
+	withBidi := "apiVersion: v1\nkind: ConfigMap\ndata:\n  note: ‮evil‬\n"
+	msg = buildYAMLLoadedMsg(withBidi, nil)
+	assert.NotContains(t, msg.content, "‮")
+	assert.NotContains(t, msg.content, "‬")
+}
+
+// TestBuildPreviewYAMLLoadedMsgSanitizesControlBytes is the preview
+// counterpart to TestBuildYAMLLoadedMsgSanitizesControlBytes.
+func TestBuildPreviewYAMLLoadedMsgSanitizesControlBytes(t *testing.T) {
+	raw := "apiVersion: v1\nkind: Secret\ndata:\n  token: \x9d52;c;SGVsbG8=\x9c\n"
+	msg := buildPreviewYAMLLoadedMsg(raw, nil, 1)
+	assert.NotContains(t, msg.content, "\x9d")
+	assert.NotContains(t, msg.content, "\x9c")
+}
+
 // TestUpdateYamlLoadedDoesNotReprocess is the core regression guard for the
 // freeze fix: the message handler must NOT call indentYAMLListItems or
 // parseYAMLSections. It only assigns pre-computed fields from the message.

--- a/internal/ui/fieldmanager_test.go
+++ b/internal/ui/fieldmanager_test.go
@@ -41,3 +41,14 @@ func TestSanitizeTerminalText_DropsControlsAndBidiOverrides(t *testing.T) {
 		"a plain direction mark is not an override")
 	assert.Equal(t, "kube-controller-manager", SanitizeTerminalText("kube-controller-manager"))
 }
+
+func TestStripBidiOverrides_DropsOnlyBidiChars(t *testing.T) {
+	// Unlike SanitizeTerminalText, ESC/TAB/SGR must survive - this is for
+	// sinks that already run the ANSI-aware body sanitizer and only need
+	// the bidi-reordering guard on top.
+	assert.Equal(t, "a\tb\x1b[31mc\x1b[0m", StripBidiOverrides("a\tb\x1b[31mc\x1b[0m"))
+	assert.Equal(t, "abc", StripBidiOverrides("ab\u202ec"))
+	assert.Equal(t, "abc", StripBidiOverrides("a\u2066b\u2069c"))
+	assert.Equal(t, "\u200eab", StripBidiOverrides("\u200eab"),
+		"a plain direction mark is not an override")
+}

--- a/internal/ui/kv_editor.go
+++ b/internal/ui/kv_editor.go
@@ -382,7 +382,13 @@ func stylePerLine(body string, w int, style lipgloss.Style) string {
 // Used by every K/V editor renderer for both the key and value cells:
 // passing raw multi-line content to lipgloss/table makes the entire
 // editor window resize to fit the tallest cell, which the user sees
-// as the editor "growing past the screen" instead of truncating.
+// as the editor "growing past the screen" instead of truncating. Every
+// caller renders a Secret, ConfigMap, or Label value straight from the
+// cluster - the highest-value case being a revealed Secret, which is
+// exactly when a user is looking at attacker-supplied bytes - so the
+// result also passes through SanitizeTerminalText to drop ESC/C1
+// control sequences (OSC-52 clipboard writes, CSI SGR/cursor moves)
+// and bidi overrides before they ever reach the terminal.
 func SingleLineCell(s string, maxW int) string {
 	if s == "" || maxW <= 0 {
 		return Truncate(s, maxW)
@@ -395,7 +401,7 @@ func SingleLineCell(s string, maxW int) string {
 		"\r", " ↵ ",
 		"\t", "    ",
 	).Replace(s)
-	return Truncate(flat, maxW)
+	return Truncate(SanitizeTerminalText(flat), maxW)
 }
 
 // FilterKVKeys narrows `keys` to entries that contain `query` as a

--- a/internal/ui/kv_editor_sanitize_test.go
+++ b/internal/ui/kv_editor_sanitize_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSingleLineCell_SanitizesTerminalEscapes guards the missing sink found
+// in review: SingleLineCell only stripped newline/CR/tab, so a revealed
+// Secret/ConfigMap/Label value containing an 8-bit OSC-52 clipboard write or
+// 8-bit CSI SGR sequence passed through byte for byte into the K/V editor's
+// key/value cells.
+func TestSingleLineCell_SanitizesTerminalEscapes(t *testing.T) {
+	osc52 := "\x9d52;c;SGVsbG8=\x9c"
+	csi := "\x9b31m"
+
+	outOSC := SingleLineCell("secret"+osc52+"value", 80)
+	assert.NotContains(t, outOSC, "\x9d")
+	assert.NotContains(t, outOSC, "\x9c")
+
+	outCSI := SingleLineCell("secret"+csi+"value", 80)
+	assert.NotContains(t, outCSI, "\x9b")
+}
+
+// TestSingleLineCell_OrdinaryContentUnaffected guards against fixing the
+// injection issue by mangling legitimate values, including non-ASCII text.
+func TestSingleLineCell_OrdinaryContentUnaffected(t *testing.T) {
+	cases := []string{
+		"plain-secret-value",
+		"café RÉSUMÉ token",
+		"日本語のパスワード",
+	}
+	for _, s := range cases {
+		assert.Equal(t, s, SingleLineCell(s, 80))
+	}
+}

--- a/internal/ui/listsummary.go
+++ b/internal/ui/listsummary.go
@@ -304,6 +304,23 @@ func SanitizeTerminalText(s string) string {
 	return b.String()
 }
 
+// StripBidiOverrides removes only the bidi embedding/override/isolate
+// characters SanitizeTerminalText drops (see its doc comment), leaving
+// everything else - including ESC, tabs, and SGR sequences - untouched.
+// For sinks that need SanitizeLogBody's ANSI/tab handling but still must
+// guard against a hostile value reordering the rendered text.
+func StripBidiOverrides(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isBidiOverride(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
 func isBidiOverride(r rune) bool {
 	return (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069)
 }

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -627,10 +628,13 @@ func SanitizeLogBody(s string, renderAnsi bool) string {
 }
 
 // sanitizeLogLine replaces non-printable control bytes (NUL, DEL, the C0
-// control range minus tab) with the Unicode replacement character and
-// expands tab characters to spaces using a logTabWidth-column tab stop.
-// Binary data from processes like MySQL handshakes contains bytes that
-// break terminal width calculations and corrupt the viewer layout.
+// control range minus tab, and the C1 range U+0080-U+009F) with the
+// Unicode replacement character and expands tab characters to spaces
+// using a logTabWidth-column tab stop. Binary data from processes like
+// MySQL handshakes contains bytes that break terminal width calculations
+// and corrupt the viewer layout; C1 controls (raw or UTF-8-encoded, e.g.
+// U+009B "CSI") let a log line hijack the terminal on emulators that
+// honour 8-bit C1 (VTE, Linux console).
 //
 // Tab expansion is required because lipgloss.Width treats '\t' as
 // zero-width while the terminal renders it as a jump to the next tab
@@ -649,13 +653,24 @@ func SanitizeLogBody(s string, renderAnsi bool) string {
 // viewer and are still replaced. A bare ESC with no valid CSI introducer
 // is replaced too; leaving it would cause terminals to wait for a
 // follow-up byte and mis-interpret subsequent output.
+//
+// C1 detection is decode-aware, not a raw byte-range check: a byte-level
+// test for 0x80-0x9F would also catch UTF-8 continuation bytes of
+// ordinary non-ASCII runes (many common accented Latin, CJK, emoji, and
+// box-drawing characters have a continuation byte in that range) and
+// mangle them. Every non-ASCII byte is instead decoded to its full rune;
+// only a rune that actually equals U+0080-U+009F is replaced, whether it
+// arrived as a raw invalid byte or a valid two-byte UTF-8 encoding (e.g.
+// 0xC2 0x9B for U+009B). Anything else - including genuinely invalid
+// UTF-8 outside the C1 range - copies through as before.
 func sanitizeLogLine(s string, renderAnsi bool) string {
-	// Fast path: no control bytes (incl. tabs that need expansion) means
-	// no work to do.
+	// Fast path: no control bytes, tabs needing expansion, or non-ASCII
+	// bytes means no work to do. Any byte >= 0x80 must go through the
+	// slow path because it might decode to a C1 control character.
 	needsSanitize := false
 	for i := range len(s) {
 		c := s[i]
-		if c < 32 || c == 127 {
+		if c < 32 || c == 127 || c >= 0x80 {
 			needsSanitize = true
 			break
 		}
@@ -687,26 +702,49 @@ func sanitizeLogLine(s string, renderAnsi bool) string {
 			i++
 			continue
 		}
-		if c >= 32 && c != 127 {
-			// Printable ASCII or UTF-8 leading/continuation byte.
-			// UTF-8 continuation bytes are all >= 0x80 so they land
-			// here on subsequent iterations and copy through intact.
-			// Column tracking treats every UTF-8 leading byte and
-			// every ASCII printable as one cell; an approximation
-			// that is fine for tab-stop alignment (CJK in log lines
-			// is rare and the worst case is a 1-cell off-stop nudge,
-			// not a width undercount).
-			b.WriteByte(c)
-			if c < 0x80 || c >= 0xC0 {
+		if c < 0x80 {
+			if c >= 32 && c != 127 {
+				b.WriteByte(c)
 				col++
+			} else {
+				// Control byte (< 32 and not tab, or DEL).
+				b.WriteRune('\ufffd')
 			}
 			i++
 			continue
 		}
-		// Control byte (< 32 and not tab, or DEL). Emit the
-		// replacement character and advance one byte.
-		b.WriteRune('\ufffd')
-		i++
+		// Non-ASCII byte: decode the full rune so a C1 control encoded
+		// as two valid UTF-8 bytes is judged by its decoded value, not
+		// by the raw continuation byte (see the C1 detection note
+		// above).
+		r, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case r == utf8.RuneError && size <= 1:
+			// Invalid UTF-8. A lone byte in the C1 range is still a
+			// control character regardless of encoding; anything else
+			// invalid passes through unchanged, matching legacy
+			// behaviour for non-UTF-8 binary payloads. Column tracking
+			// mirrors the old approximation: only a would-be leading
+			// byte (>= 0xC0) counts as one cell.
+			if c >= 0x80 && c <= 0x9f {
+				b.WriteRune('\ufffd')
+			} else {
+				b.WriteByte(c)
+				if c >= 0xC0 {
+					col++
+				}
+			}
+			i++
+		case r >= 0x80 && r <= 0x9f:
+			// Valid UTF-8 encoding of a C1 control character.
+			b.WriteRune('\ufffd')
+			i += size
+		default:
+			// Ordinary multi-byte rune: copy through untouched.
+			b.WriteString(s[i : i+size])
+			col++
+			i += size
+		}
 	}
 	return b.String()
 }

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -613,6 +613,15 @@ func StripPodPrefix(line string) string {
 // into their shell would expect.
 const logTabWidth = 8
 
+// SanitizeLogBody is the exported entry point to sanitizeLogLine for sinks
+// outside this file (describe content, command-bar output) that render a
+// BODY rather than a name or title: unlike SanitizeTerminalText, it keeps
+// SGR colour sequences and expands tabs instead of dropping them. See
+// sanitizeLogLine for the full behaviour.
+func SanitizeLogBody(s string, renderAnsi bool) string {
+	return sanitizeLogLine(s, renderAnsi)
+}
+
 // sanitizeLogLine replaces non-printable control bytes (NUL, DEL, the C0
 // control range minus tab) with the Unicode replacement character and
 // expands tab characters to spaces using a logTabWidth-column tab stop.

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -588,7 +588,11 @@ func colorizePodPrefix(line string) string {
 	if closeBracket < 0 {
 		return line
 	}
-	prefix := line[1:closeBracket] // "pod/name/container"
+	// The prefix is a resource NAME re-emitted verbatim below, unlike the
+	// rest of the line (already run through the ANSI-aware sanitizeLogLine
+	// upstream in RenderLogViewer) - use SanitizeTerminalText so a hostile
+	// pod/container name can't reorder or hijack the terminal via styling.
+	prefix := SanitizeTerminalText(line[1:closeBracket]) // "pod/name/container"
 	rest := line[closeBracket+2:]
 
 	style := lipgloss.NewStyle().Foreground(ThemeColor(podPrefixColor(prefix)))

--- a/internal/ui/logviewer_test.go
+++ b/internal/ui/logviewer_test.go
@@ -385,16 +385,16 @@ func TestSanitizeLogLine_C1RawByteFormNoLongerSurvives(t *testing.T) {
 func TestSanitizeLogLine_C1UTF8EncodedFormNoLongerSurvives(t *testing.T) {
 	// Same two sequences, properly UTF-8 encoded (U+009D/U+009C/U+009B
 	// as their correct two-byte forms) rather than raw bytes.
-	osc52 := "52;c;SGVsbG8="
-	csi := "31m"
+	osc52 := "\u009d52;c;SGVsbG8=\u009c"
+	csi := "\u009b31m"
 
 	for _, renderAnsi := range []bool{false, true} {
 		outOSC := sanitizeLogLine(osc52, renderAnsi)
-		assert.NotContains(t, outOSC, "")
-		assert.NotContains(t, outOSC, "")
+		assert.NotContains(t, outOSC, "\u009d")
+		assert.NotContains(t, outOSC, "\u009c")
 
 		outCSI := sanitizeLogLine(csi, renderAnsi)
-		assert.NotContains(t, outCSI, "")
+		assert.NotContains(t, outCSI, "\u009b")
 	}
 }
 
@@ -405,8 +405,8 @@ func TestSanitizeLogLine_NonASCIIRoundTrip(t *testing.T) {
 	// byte that itself falls in 0x80-0x9F, so this exercises the exact
 	// case a byte-level filter gets wrong.
 	cases := []string{
-		"café RÉSUMÉ",         // accented Latin (É continuation byte 0x89)
-		"日本語のログ",              // CJK
+		"café RÉSUMÉ",        // accented Latin (É continuation byte 0x89)
+		"日本語のログ",             // CJK
 		"deploy succeeded 🎉", // emoji (continuation bytes include 0x8E)
 		"┌─status─┐",         // box drawing (continuation bytes 0x94/0x80)
 	}

--- a/internal/ui/logviewer_test.go
+++ b/internal/ui/logviewer_test.go
@@ -364,6 +364,60 @@ func TestSanitizeLogLine_RenderAnsiEnabled_PreservesMultibyte(t *testing.T) {
 	assert.Equal(t, input, sanitizeLogLine(input, true))
 }
 
+func TestSanitizeLogLine_C1RawByteFormNoLongerSurvives(t *testing.T) {
+	// Reviewer-reported 8-bit C1 sequences as raw single bytes in the
+	// C1 range (0x80-0x9F): an OSC-52 clipboard write and a CSI SGR.
+	// Terminals honouring 8-bit C1 (VTE, Linux console) act on these if
+	// they reach the screen unfiltered.
+	osc52 := "\x9d52;c;SGVsbG8=\x9c"
+	csi := "\x9b31m"
+
+	for _, renderAnsi := range []bool{false, true} {
+		outOSC := sanitizeLogLine(osc52, renderAnsi)
+		assert.NotContains(t, outOSC, "\x9d")
+		assert.NotContains(t, outOSC, "\x9c")
+
+		outCSI := sanitizeLogLine(csi, renderAnsi)
+		assert.NotContains(t, outCSI, "\x9b")
+	}
+}
+
+func TestSanitizeLogLine_C1UTF8EncodedFormNoLongerSurvives(t *testing.T) {
+	// Same two sequences, properly UTF-8 encoded (U+009D/U+009C/U+009B
+	// as their correct two-byte forms) rather than raw bytes.
+	osc52 := "52;c;SGVsbG8="
+	csi := "31m"
+
+	for _, renderAnsi := range []bool{false, true} {
+		outOSC := sanitizeLogLine(osc52, renderAnsi)
+		assert.NotContains(t, outOSC, "")
+		assert.NotContains(t, outOSC, "")
+
+		outCSI := sanitizeLogLine(csi, renderAnsi)
+		assert.NotContains(t, outCSI, "")
+	}
+}
+
+func TestSanitizeLogLine_NonASCIIRoundTrip(t *testing.T) {
+	// Guards against the byte-range trap: a naive c>=0x80 && c<=0x9F
+	// byte filter mangles UTF-8 continuation bytes of ordinary
+	// non-ASCII text. Several of these characters have a continuation
+	// byte that itself falls in 0x80-0x9F, so this exercises the exact
+	// case a byte-level filter gets wrong.
+	cases := []string{
+		"café RÉSUMÉ",         // accented Latin (É continuation byte 0x89)
+		"日本語のログ",              // CJK
+		"deploy succeeded 🎉", // emoji (continuation bytes include 0x8E)
+		"┌─status─┐",         // box drawing (continuation bytes 0x94/0x80)
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, s, sanitizeLogLine(s, false))
+			assert.Equal(t, s, sanitizeLogLine(s, true))
+		})
+	}
+}
+
 // --- colorizePodPrefix ---
 
 func TestColorizePodPrefix_SanitizesTerminalEscapes(t *testing.T) {

--- a/internal/ui/logviewer_test.go
+++ b/internal/ui/logviewer_test.go
@@ -364,6 +364,32 @@ func TestSanitizeLogLine_RenderAnsiEnabled_PreservesMultibyte(t *testing.T) {
 	assert.Equal(t, input, sanitizeLogLine(input, true))
 }
 
+// --- colorizePodPrefix ---
+
+func TestColorizePodPrefix_SanitizesTerminalEscapes(t *testing.T) {
+	// The bracketed "[pod/name/container]" prefix is a resource NAME, not
+	// log body text, and colorizePodPrefix re-emits it verbatim styled -
+	// it must go through SanitizeTerminalText, not the ANSI-aware body
+	// sanitizer, since a hostile pod name should not be able to reorder or
+	// hijack the terminal via the log viewer's own styling.
+	out := colorizePodPrefix("[evil\x1b[2Jpod] hello")
+	assert.NotContains(t, out, "\x1b[2J")
+	assert.Contains(t, out, "hello")
+
+	out = colorizePodPrefix("[evil\u202epod] hello")
+	assert.NotContains(t, out, "\u202e", "bidi override must not survive")
+
+	// colorizePodPrefix's own styling only ever emits SGR (ESC '['); an
+	// OSC introducer (ESC ']') or a bare BEL can only be leftover injection.
+	out = colorizePodPrefix("[evil\x1b]52;c;ZXZpbA==\x07pod] hello")
+	assert.NotContains(t, out, "\x1b]")
+	assert.NotContains(t, out, "\x07")
+
+	// Ordinary pod prefixes render identically (still styled/colored).
+	out = colorizePodPrefix("[web-1/app] hello world")
+	assert.Contains(t, out, "hello world")
+}
+
 // --- SanitizeLogBody ---
 
 func TestSanitizeLogBody_DelegatesToSanitizeLogLine(t *testing.T) {

--- a/internal/ui/logviewer_test.go
+++ b/internal/ui/logviewer_test.go
@@ -363,3 +363,16 @@ func TestSanitizeLogLine_RenderAnsiEnabled_PreservesMultibyte(t *testing.T) {
 	input := "\x1b[34m☂ rain \x1b[0m日本語"
 	assert.Equal(t, input, sanitizeLogLine(input, true))
 }
+
+// --- SanitizeLogBody ---
+
+func TestSanitizeLogBody_DelegatesToSanitizeLogLine(t *testing.T) {
+	// SanitizeLogBody is the exported entry point non-log sinks (describe
+	// viewer, command output) use to reach the same ANSI-aware sanitizer as
+	// the log viewer, without a second implementation to drift from.
+	assert.Equal(t, sanitizeLogLine("key\tvalue", false), SanitizeLogBody("key\tvalue", false))
+
+	input := "\x1b[0;33mWARNING\x1b[0m rest"
+	assert.Equal(t, input, SanitizeLogBody(input, true), "SGR sequences survive when renderAnsi is true")
+	assert.NotEqual(t, input, SanitizeLogBody(input, false), "ESC is replaced when renderAnsi is false")
+}


### PR DESCRIPTION
Closes the terminal-escape gaps left by the existing sanitising, and fixes a blind spot in the sanitiser itself. Closes TASK-873.

## The sanitiser was blind to half the control range

`sanitizeLogLine` only checked `c < 0x20` and `c == 0x7F`, so C1 (0x80-0x9F) passed through untouched. An 8-bit OSC-52 clipboard write (`\x9d52;c;<base64>\x9c`) and an 8-bit CSI (`\x9b31m`) survived byte for byte, reaching any terminal that honours 8-bit C1 (VTE, Linux console). This predates the branch.

The fix is decode-aware, and that detail matters: `sanitizeLogLine` works on bytes, and UTF-8 continuation bytes also live in 0x80-0xBF. A byte-level range test would have corrupted every accented, CJK, emoji and box-drawing character in the log viewer while still passing an injection test. Only the *decoded* rune is checked. `TestSanitizeLogLine_NonASCIIRoundTrip` is the guard.

Verified against overlong encodings, truncated multibyte sequences, a C1 following a valid multibyte character, and a C1 at end of string.

## Sinks closed

| Sink | Was |
|---|---|
| Describe viewer (both render paths) | no sanitising at all |
| YAML view | no sanitising |
| Event viewer | `Reason`/`Message`/`Source`, later also `Type` |
| `SingleLineCell` (Secret, ConfigMap, Label editors) | stripped only `\n`, `\r`, `\t` |
| `addLogEntry` error-log overlay | raw command output and `err.Error()` |
| Pod prefix, and 7 titles via `resourceTitleLabel` | raw kind, namespace, name, container |

`SingleLineCell` and `addLogEntry` were fixed at the source, so all three editors and all 78 `addLogEntry` call sites are covered without per-site edits.

## Describe sanitising moved off the render path

`viewDescribe` is a View function, so it re-sanitised the whole buffer every frame. Sanitising now happens once in the five producers.

| Lines | Before | After |
|---|---|---|
| 20,000 | 2.45 ms, 22,470 allocs | 494 µs, 2,468 allocs |

Allocations are now independent of buffer size.

## What this does not claim

This closes the sinks found across three review rounds. It does not prove no sink remains. `Event.Type` was printed raw in the same `fmt.Sprintf` where three sibling fields had just been sanitised, so the failure is field-level, not function-level, and neither a lint rule nor a "does this function sanitise" test would catch it. The structural fix is a tainted-string type around cluster-sourced fields, forcing an explicit unwrap — a sizeable refactor, deliberately not attempted here.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 -race ./...` (23 packages)
- [x] `make lint` (0 issues)
- [x] Injection cases per sink: 8-bit OSC-52, 8-bit CSI, bidi override
- [x] SGR colour and tab alignment survive the describe path
- [x] Non-ASCII round-trip: accented Latin, CJK, emoji, box-drawing
- [x] `BenchmarkViewDescribe` before and after
- [ ] Manual UAT per the guide in TASK-873