### PR TITLE
fix: bound and redact the kubectl explain subprocesses (TASK-869)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -79,10 +79,10 @@ type Model struct {
 	// the cursor when switching from the Object Explorer to the YAML viewer.
 	yamlPendingPath []string
 
-	// explainReturnMode is the mode the API Explorer returns to on q/esc.
-	// Defaults to modeExplorer; set to modeYAML or modeObjectExplorer when the
-	// Explorer is opened from those views (I key) so closing returns there.
-	explainReturnMode viewMode
+	// explainReturnMode is the mode the API Explorer returns to on q/esc. Defaults
+	// to modeExplorer; modeYAML or modeObjectExplorer when opened there (I key).
+	explainReturnMode   viewMode
+	explainSessionState // embedded - cancellation scope for the explain calls; see update_explain.go.
 
 	// explainPendingField, when set, is the field name the API Explorer should
 	// place its cursor on once the level finishes loading. Used to land on a

--- a/internal/app/commands_exec_explain_test.go
+++ b/internal/app/commands_exec_explain_test.go
@@ -85,18 +85,64 @@ func TestExplainFetchesStopWhenTheViewCloses(t *testing.T) {
 // must not reach the log; the target and the exit status are what identify the
 // failure.
 func TestExplainFailureLogsNoCommandOutput(t *testing.T) {
-	fakeKubectl(t, `echo "token=s3cret-from-the-credential-plugin" >&2
+	cases := []struct {
+		name   string
+		run    func(m Model) tea.Cmd
+		target string
+	}{
+		{"explain", func(m Model) tea.Cmd { return m.execKubectlExplain("pods", "v1", "spec") }, "pods.spec"},
+		{"recursive", func(m Model) tea.Cmd { return m.execKubectlExplainRecursive("pods", "v1", "") }, "pods"},
+		{"tree", func(m Model) tea.Cmd { return m.execKubectlExplainTree("pods", "v1", "spec") }, "pods.spec"},
+		{"treeDesc", func(m Model) tea.Cmd { return m.execKubectlExplainTreeDesc("pods", "v1", "spec") }, "pods.spec"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeKubectl(t, `echo "token=s3cret-from-the-credential-plugin" >&2
 exit 1`)
-	buf := captureLogger(t)
+			buf := captureLogger(t)
+			m := explainExecModel(t)
+
+			tc.run(m)()
+
+			assert.NotContains(t, buf.String(), "s3cret-from-the-credential-plugin")
+			assert.Contains(t, buf.String(), "kubectl explain failed")
+			assert.Contains(t, buf.String(), tc.target, "the log still names the target that failed")
+			assert.Contains(t, buf.String(), "exit status 1")
+		})
+	}
+}
+
+// A tab restored with the API Explorer open gets a session of its own, so
+// closing the view still stops the fetch it started after the switch back.
+func TestExplainFetchesStopAfterSwitchingBack(t *testing.T) {
+	argvPath := fakeKubectl(t, "sleep 60 &\nwait")
 	m := explainExecModel(t)
+	m.mode = modeExplain
+	m.tabs = []TabState{{}, {}}
+	m.saveCurrentTab()
+	m.loadTab(1)
+	m.loadTab(0)
+	require.Equal(t, modeExplain, m.mode, "the restored tab is still on the API Explorer")
 
-	msg := m.execKubectlExplain("pods", "v1", "spec")()
+	done := make(chan tea.Msg, 1)
+	go func() { done <- m.execKubectlExplainTree("pods", "v1", "spec")() }()
 
-	got, ok := msg.(explainLoadedMsg)
-	require.True(t, ok)
-	require.Error(t, got.err)
-	assert.NotContains(t, buf.String(), "s3cret-from-the-credential-plugin")
-	assert.Contains(t, buf.String(), "pods.spec", "the log still names the target that failed")
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(argvPath)
+		return err == nil
+	}, 10*time.Second, 20*time.Millisecond, "the stub kubectl never started")
+
+	closedAt := time.Now()
+	m.exitExplainView()
+
+	select {
+	case <-done:
+		assert.Less(t, time.Since(closedAt), explainFetchTimeout/2,
+			"a restored tab must be able to cancel its own fetches")
+	case <-time.After(explainFetchTimeout / 2):
+		t.Fatal("closing the API Explorer on a restored tab did not stop the kubectl process")
+	}
 }
 
 // Switching tabs is the other way out of the API Explorer, and the reply of a

--- a/internal/app/commands_exec_explain_test.go
+++ b/internal/app/commands_exec_explain_test.go
@@ -1,0 +1,139 @@
+package app
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// explainExecModel is a model with the API Explorer open on pods, ready to run
+// a real subprocess against the stub kubectl that fakeKubectl puts on PATH.
+func explainExecModel(t *testing.T) Model {
+	t.Helper()
+	m := basePush80Model()
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true,
+	}
+	m.reqCtx = t.Context()
+	m.beginExplainSession()
+	m.explainResource = "pods"
+	return m
+}
+
+// Leaving the API Explorer must end the explain processes still running. The
+// stub sleeps far longer than the deadline the fetch would otherwise wait out.
+//
+// The sleep runs as a CHILD of the stub shell on purpose. Killing the shell
+// leaves that child holding the output pipe, which is what a credential plugin
+// does in the real failure, and CombinedOutput reads to EOF. Only cmd.WaitDelay
+// gets the worker back. Without it this hangs for the full sleep.
+func TestExplainFetchesStopWhenTheViewCloses(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(m Model) tea.Cmd
+	}{
+		{"explain", func(m Model) tea.Cmd { return m.execKubectlExplain("pods", "v1", "spec") }},
+		{"recursive", func(m Model) tea.Cmd { return m.execKubectlExplainRecursive("pods", "v1", "") }},
+		{"tree", func(m Model) tea.Cmd { return m.execKubectlExplainTree("pods", "v1", "spec") }},
+		{"treeDesc", func(m Model) tea.Cmd { return m.execKubectlExplainTreeDesc("pods", "v1", "spec") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			argvPath := fakeKubectl(t, "sleep 60 &\nwait")
+			m := explainExecModel(t)
+			cmd := tc.run(m)
+			require.NotNil(t, cmd)
+
+			done := make(chan tea.Msg, 1)
+			go func() { done <- cmd() }()
+
+			// The stub writes its argv first, so the file appearing means the
+			// process is really running. Closing the view before that would
+			// only prove that a cancelled context never spawns one.
+			require.Eventually(t, func() bool {
+				_, err := os.Stat(argvPath)
+				return err == nil
+			}, 10*time.Second, 20*time.Millisecond, "the stub kubectl never started")
+
+			closedAt := time.Now()
+			m.exitExplainView()
+
+			select {
+			case <-done:
+				// Measured from the close, and well under explainFetchTimeout,
+				// so a fetch that ignored cancellation and merely ran out its
+				// deadline cannot pass this. The allowance covers
+				// cmd.WaitDelay, which is what unblocks the read while the
+				// backgrounded sleep still holds the pipe.
+				assert.Less(t, time.Since(closedAt), explainFetchTimeout/2,
+					"closing the API Explorer must end the fetch, not leave it to the deadline")
+			case <-time.After(explainFetchTimeout / 2):
+				t.Fatal("closing the API Explorer did not stop the kubectl process")
+			}
+		})
+	}
+}
+
+// An auth failure prints whatever the credential plugin had to say. That text
+// must not reach the log; the target and the exit status are what identify the
+// failure.
+func TestExplainFailureLogsNoCommandOutput(t *testing.T) {
+	fakeKubectl(t, `echo "token=s3cret-from-the-credential-plugin" >&2
+exit 1`)
+	buf := captureLogger(t)
+	m := explainExecModel(t)
+
+	msg := m.execKubectlExplain("pods", "v1", "spec")()
+
+	got, ok := msg.(explainLoadedMsg)
+	require.True(t, ok)
+	require.Error(t, got.err)
+	assert.NotContains(t, buf.String(), "s3cret-from-the-credential-plugin")
+	assert.Contains(t, buf.String(), "pods.spec", "the log still names the target that failed")
+}
+
+// Switching tabs is the other way out of the API Explorer, and the reply of a
+// fetch started on the old tab has no tab of its own to go back to.
+func TestExplainFetchesStopOnTabSwitch(t *testing.T) {
+	argvPath := fakeKubectl(t, "sleep 60 &\nwait")
+	m := explainExecModel(t)
+	m.tabs = []TabState{{}, {}}
+	cmd := m.execKubectlExplain("pods", "v1", "spec")
+	require.NotNil(t, cmd)
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(argvPath)
+		return err == nil
+	}, 10*time.Second, 20*time.Millisecond, "the stub kubectl never started")
+
+	switchedAt := time.Now()
+	m.loadTab(1)
+
+	select {
+	case <-done:
+		assert.Less(t, time.Since(switchedAt), explainFetchTimeout/2,
+			"switching tabs must end the fetch, not leave it to the deadline")
+	case <-time.After(explainFetchTimeout / 2):
+		t.Fatal("switching tabs did not stop the kubectl process")
+	}
+}
+
+// A session that was never opened still runs under m.reqCtx, so no explain
+// call is ever left unbounded.
+func TestExplainRequestCtxFallsBackToTheRequestContext(t *testing.T) {
+	m := basePush80Model()
+	m.reqCtx = t.Context()
+	m.cancelExplainSession()
+
+	assert.Equal(t, m.reqCtx, m.explainRequestCtx())
+}

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -396,6 +396,28 @@ func (m Model) execKubectlNodeShell() tea.Cmd {
 	return runInteractiveShellExec(cmd, title, "Node shell", true)
 }
 
+// explainFetchTimeout bounds one kubectl explain call, so an unreachable
+// cluster or a credential plugin waiting on input cannot hold a scheduler
+// worker for the rest of the session.
+const explainFetchTimeout = 15 * time.Second
+
+// explainWaitDelay is how long to wait for the output pipes to close after the
+// process is killed. Killing kubectl does not close a pipe a grandchild still
+// holds (a credential plugin, say), and CombinedOutput reads to EOF, so
+// without this the worker stays blocked on a process already dead.
+const explainWaitDelay = 2 * time.Second
+
+// newExplainCmd builds one bounded kubectl explain. The context ends the
+// process when the user leaves the API Explorer; the deadline ends a cluster
+// that never answers.
+func newExplainCmd(ctx context.Context, kubectlPath, kubeconfigPaths string, args []string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
+	cmd.WaitDelay = explainWaitDelay
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
+	logExecCmd("Running kubectl command", cmd)
+	return cmd
+}
+
 func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cmd {
 	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
@@ -420,17 +442,23 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 		title = title + " > " + strings.ReplaceAll(fieldPath, ".", " > ")
 	}
 
+	reqCtx := m.explainRequestCtx()
+
 	return m.trackBgTask(scheduler.KindSubprocess, "Explain: "+target, kctx, func() tea.Msg {
+		ctx, cancel := context.WithTimeout(reqCtx, explainFetchTimeout)
+		defer cancel()
+
 		args := []string{"explain", target, "--context", m.kubectlContext(kctx)}
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
-		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
-		logExecCmd("Running kubectl command", cmd)
+		cmd := newExplainCmd(ctx, kubectlPath, kubeconfigPaths, args)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
-			logger.Error("kubectl explain failed", "cmd", cmd.String(), "error", cmdErr, "output", string(output))
+			// The output stays out of the log: on an auth failure it carries
+			// whatever the credential plugin printed. It still reaches the
+			// view, where the user asked for it.
+			logger.Error("kubectl explain failed", "target", target, "apiVersion", apiVersion, "error", cmdErr)
 			return explainLoadedMsg{
 				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
 			}
@@ -457,14 +485,17 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 	kctx := m.effectiveContext()
 	kubeconfigPaths := m.client.KubeconfigPathForContext(kctx)
 
+	reqCtx := m.explainRequestCtx()
+
 	return m.trackBgTask(scheduler.KindSubprocess, "Explain (recursive): "+resource, kctx, func() tea.Msg {
+		ctx, cancel := context.WithTimeout(reqCtx, explainFetchTimeout)
+		defer cancel()
+
 		args := []string{"explain", resource, "--recursive", "--context", m.kubectlContext(kctx)}
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
-		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
-		logExecCmd("Running kubectl command", cmd)
+		cmd := newExplainCmd(ctx, kubectlPath, kubeconfigPaths, args)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
 			return explainRecursiveMsg{
@@ -496,14 +527,17 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 		target = resource + "." + fieldPath
 	}
 
+	reqCtx := m.explainRequestCtx()
+
 	return m.trackBgTask(scheduler.KindSubprocess, "Explain (tree): "+target, kctx, func() tea.Msg {
+		ctx, cancel := context.WithTimeout(reqCtx, explainFetchTimeout)
+		defer cancel()
+
 		args := []string{"explain", target, "--recursive", "--context", m.kubectlContext(kctx)}
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
-		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
-		logExecCmd("Running kubectl command", cmd)
+		cmd := newExplainCmd(ctx, kubectlPath, kubeconfigPaths, args)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
 			return explainTreeLoadedMsg{
@@ -546,14 +580,17 @@ func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath strin
 		target = resource + "." + parentPath
 	}
 
+	reqCtx := m.explainRequestCtx()
+
 	return m.trackBgTask(scheduler.KindSubprocess, "Explain (descriptions): "+target, kctx, func() tea.Msg {
+		ctx, cancel := context.WithTimeout(reqCtx, explainFetchTimeout)
+		defer cancel()
+
 		args := []string{"explain", target, "--context", m.kubectlContext(kctx)}
 		if apiVersion != "" {
 			args = append(args, "--api-version", apiVersion)
 		}
-		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
-		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
-		logExecCmd("Running kubectl command", cmd)
+		cmd := newExplainCmd(ctx, kubectlPath, kubeconfigPaths, args)
 		output, cmdErr := cmd.CombinedOutput()
 		msg := ident
 		if cmdErr != nil {

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -407,6 +407,13 @@ const explainFetchTimeout = 15 * time.Second
 // without this the worker stays blocked on a process already dead.
 const explainWaitDelay = 2 * time.Second
 
+// logExplainFailure records a failed kubectl explain. The output stays out of
+// the log: on an auth failure it carries whatever the credential plugin
+// printed. It still reaches the view, where the user asked for it.
+func logExplainFailure(target, apiVersion string, cmdErr error) {
+	logger.Error("kubectl explain failed", "target", target, "apiVersion", apiVersion, "error", cmdErr)
+}
+
 // newExplainCmd builds one bounded kubectl explain. The context ends the
 // process when the user leaves the API Explorer; the deadline ends a cluster
 // that never answers.
@@ -455,10 +462,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 		cmd := newExplainCmd(ctx, kubectlPath, kubeconfigPaths, args)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
-			// The output stays out of the log: on an auth failure it carries
-			// whatever the credential plugin printed. It still reaches the
-			// view, where the user asked for it.
-			logger.Error("kubectl explain failed", "target", target, "apiVersion", apiVersion, "error", cmdErr)
+			logExplainFailure(target, apiVersion, cmdErr)
 			return explainLoadedMsg{
 				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
 			}
@@ -498,6 +502,7 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 		cmd := newExplainCmd(ctx, kubectlPath, kubeconfigPaths, args)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
+			logExplainFailure(resource, apiVersion, cmdErr)
 			return explainRecursiveMsg{
 				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
 			}
@@ -540,6 +545,7 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 		cmd := newExplainCmd(ctx, kubectlPath, kubeconfigPaths, args)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
+			logExplainFailure(target, apiVersion, cmdErr)
 			return explainTreeLoadedMsg{
 				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
 			}
@@ -594,6 +600,7 @@ func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath strin
 		output, cmdErr := cmd.CombinedOutput()
 		msg := ident
 		if cmdErr != nil {
+			logExplainFailure(target, apiVersion, cmdErr)
 			msg.err = fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output)))
 			return msg
 		}

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -456,6 +456,10 @@ func (m *Model) saveCurrentTab() {
 // it returns a tea.Cmd that fetches the tab's data; otherwise it returns nil.
 func (m *Model) loadTab(idx int) tea.Cmd {
 	m.wheel.dead = true // switching/reloading a tab empties the wheel momentum queue (#524)
+	// The explain fetches in flight belong to the tab being left, and their
+	// replies carry no tab of their own. Stop the processes here too, not just
+	// on q/esc, or a tab switch leaves them running to their deadline.
+	m.cancelExplainSession()
 	t := m.tabs[idx]
 	needsLoad := t.needsLoad
 	m.activeTab = idx

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -456,9 +456,8 @@ func (m *Model) saveCurrentTab() {
 // it returns a tea.Cmd that fetches the tab's data; otherwise it returns nil.
 func (m *Model) loadTab(idx int) tea.Cmd {
 	m.wheel.dead = true // switching/reloading a tab empties the wheel momentum queue (#524)
-	// The explain fetches in flight belong to the tab being left, and their
-	// replies carry no tab of their own. Stop the processes here too, not just
-	// on q/esc, or a tab switch leaves them running to their deadline.
+	// The explain fetches in flight belong to the tab being left. Stop them
+	// here too, or a tab switch leaves them running to their deadline.
 	m.cancelExplainSession()
 	t := m.tabs[idx]
 	needsLoad := t.needsLoad
@@ -532,6 +531,11 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 
 	// Restore per-tab view mode and log state.
 	m.mode = t.mode
+	// A tab restored with the API Explorer open needs its own session, or
+	// closing the view could not stop the fetches it starts next.
+	if m.mode == modeExplain {
+		m.beginExplainSession()
+	}
 	m.logView.rawLines = append([]string(nil), t.logLines...)
 	m.logView.rawSev = nil
 	m.logView.filterQuery = t.logFilterQuery

--- a/internal/app/update_explain.go
+++ b/internal/app/update_explain.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
@@ -63,6 +64,7 @@ func (m Model) openExplainBrowser() (tea.Model, tea.Cmd) {
 	}
 
 	m.loading = true
+	m.beginExplainSession()
 	m.explainReturnMode = modeExplorer
 	m.explainPendingField = ""
 	m.explainAncestors = nil
@@ -90,6 +92,7 @@ func (m Model) openExplainAtObjectPath(objPath []string, returnMode viewMode) (t
 	}
 	parentPath, field := explainTarget(objPath)
 	m.loading = true
+	m.beginExplainSession()
 	m.explainReturnMode = returnMode
 	m.explainPendingField = field
 	m.explainAncestors = nil
@@ -97,6 +100,53 @@ func (m Model) openExplainAtObjectPath(objPath []string, returnMode viewMode) (t
 	m.explainAPIVersion = apiVersion
 	m.setStatusMessage("Loading API Explorer...", false)
 	return m, m.execKubectlExplain(resource, apiVersion, parentPath)
+}
+
+// explainSessionState is the cancellation scope shared by every kubectl
+// explain of one API Explorer visit. It is set when the Explorer opens and
+// cancelled when it closes, so leaving the view stops the subprocesses instead
+// of leaving them to their deadlines. Deliberately outside the per-tab
+// snapshot: the fetches belong to the process, not to the tab that started
+// them.
+type explainSessionState struct {
+	explainCtx    context.Context
+	explainCancel context.CancelFunc
+}
+
+// beginExplainSession starts a fresh cancellation scope for the API Explorer.
+// Every explain fetch of this session hangs off it, so closing the view ends
+// them all. Any earlier session is cancelled first, which also releases its
+// child of m.reqCtx.
+func (m *Model) beginExplainSession() {
+	m.cancelExplainSession()
+	base := m.reqCtx
+	if base == nil {
+		base = context.Background()
+	}
+	m.explainCtx, m.explainCancel = context.WithCancel(base)
+}
+
+// cancelExplainSession stops the explain fetches still running, if any.
+func (m *Model) cancelExplainSession() {
+	if m.explainCancel != nil {
+		m.explainCancel()
+	}
+	m.explainCtx, m.explainCancel = nil, nil
+}
+
+// explainRequestCtx is the parent context for one explain fetch. It falls back
+// to m.reqCtx when no session is open, so a fetch is never left unbounded. A
+// session already cancelled falls back too: cancelAndReset kills the session as
+// a child of the old m.reqCtx, and every later fetch of that visit would fail
+// on the spot if it kept using it.
+func (m Model) explainRequestCtx() context.Context {
+	if m.explainCtx != nil && m.explainCtx.Err() == nil {
+		return m.explainCtx
+	}
+	if m.reqCtx != nil {
+		return m.reqCtx
+	}
+	return context.Background()
 }
 
 // explainTarget converts an object path into the kubectl-explain schema path of
@@ -192,6 +242,7 @@ func (m Model) explainGoBack() (tea.Model, tea.Cmd) {
 // Explorer was opened from (the explorer by default; the YAML viewer or
 // Object Explorer when opened from there via the I key).
 func (m *Model) exitExplainView() {
+	m.cancelExplainSession()
 	m.mode = m.explainReturnMode
 	m.explainReturnMode = modeExplorer
 	m.explainAncestors = nil


### PR DESCRIPTION
## Summary

The four `execKubectlExplain*` calls in the API Explorer ran `exec.Command` with no context, so nothing stopped them when the user left the view or the cluster stopped answering. `CombinedOutput` reads to EOF, so a grandchild that outlives the kill kept the scheduler worker blocked - a credential plugin is the real case, and it turned CI red on PR #588 before `cmd.WaitDelay` went in. One of the four also logged the raw output, which on an auth failure holds whatever that plugin printed.

They now follow the pattern `internal/app/commands_fielddoc.go` established:

- `exec.CommandContext` under an API-Explorer-scoped context, plus a 15 second deadline for a cluster that never answers.
- `cmd.WaitDelay`, so a grandchild holding the output pipe cannot block the worker after the kill.
- The failure log carries the target and the exit status. The output still reaches the view, where the user asked for it.

The new `explainSessionState` opens with the Explorer and is cancelled on `q`/`esc` and in `loadTab`, so leaving the view or switching tabs ends the subprocesses instead of leaving them to their deadline.

## Test plan

- [x] `TestExplainFetchesStopWhenTheViewCloses` - a 4-case table over the exec functions. The stub kubectl backgrounds a 60 second sleep that keeps holding the output pipe, which is what a credential plugin does. Each case measures from the close and allows half the deadline, so a fetch that ignored cancellation cannot pass. Each finishes in ~2.4s.
- [x] `TestExplainFetchesStopOnTabSwitch` - the same bar for the other way out of the view.
- [x] `TestExplainFailureLogsNoCommandOutput` - a stub that prints a token to stderr and exits 1; the log names the target but not the token.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues), `go test ./...`, `go test -race ./...`

## Notes

`go-reviewer` and `security-reviewer` passes applied; no CRITICAL or HIGH findings left. The reviewer also found a pre-existing gap - the explain replies carry no generation guard, so a reply already in flight at the moment of a tab switch can still land on the wrong tab. Filed as TASK-876, out of scope here.