### PR TITLE
fix: drop API Explorer replies from an older session (TASK-876)

### DIFF
--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -429,7 +429,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
-			return explainLoadedMsg{err: fmt.Errorf("kubectl not found: %w", err)}
+			return explainLoadedMsg{gen: m.explainGen, err: fmt.Errorf("kubectl not found: %w", err)}
 		}
 	}
 
@@ -450,6 +450,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 	}
 
 	reqCtx := m.explainRequestCtx()
+	gen := m.explainGen
 
 	return m.trackBgTask(scheduler.KindSubprocess, "Explain: "+target, kctx, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(reqCtx, explainFetchTimeout)
@@ -464,6 +465,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 		if cmdErr != nil {
 			logExplainFailure(target, apiVersion, cmdErr)
 			return explainLoadedMsg{
+				gen: gen,
 				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
 			}
 		}
@@ -474,6 +476,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 			description: desc,
 			title:       title,
 			path:        fieldPath,
+			gen:         gen,
 		}
 	})
 }
@@ -482,7 +485,7 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
-			return explainRecursiveMsg{err: fmt.Errorf("kubectl not found: %w", err)}
+			return explainRecursiveMsg{gen: m.explainGen, err: fmt.Errorf("kubectl not found: %w", err)}
 		}
 	}
 
@@ -490,6 +493,7 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 	kubeconfigPaths := m.client.KubeconfigPathForContext(kctx)
 
 	reqCtx := m.explainRequestCtx()
+	gen := m.explainGen
 
 	return m.trackBgTask(scheduler.KindSubprocess, "Explain (recursive): "+resource, kctx, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(reqCtx, explainFetchTimeout)
@@ -504,12 +508,13 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 		if cmdErr != nil {
 			logExplainFailure(resource, apiVersion, cmdErr)
 			return explainRecursiveMsg{
+				gen: gen,
 				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
 			}
 		}
 
 		matches := parseRecursiveExplainForSearch(string(output), query)
-		return explainRecursiveMsg{matches: matches, query: query}
+		return explainRecursiveMsg{matches: matches, query: query, gen: gen}
 	})
 }
 
@@ -520,7 +525,7 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {
 		return func() tea.Msg {
-			return explainTreeLoadedMsg{err: fmt.Errorf("kubectl not found: %w", err)}
+			return explainTreeLoadedMsg{gen: m.explainGen, err: fmt.Errorf("kubectl not found: %w", err)}
 		}
 	}
 
@@ -533,6 +538,7 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 	}
 
 	reqCtx := m.explainRequestCtx()
+	gen := m.explainGen
 
 	return m.trackBgTask(scheduler.KindSubprocess, "Explain (tree): "+target, kctx, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(reqCtx, explainFetchTimeout)
@@ -547,6 +553,7 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 		if cmdErr != nil {
 			logExplainFailure(target, apiVersion, cmdErr)
 			return explainTreeLoadedMsg{
+				gen: gen,
 				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
 			}
 		}
@@ -557,7 +564,7 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 				fields[i].Path = fieldPath + "." + fields[i].Path
 			}
 		}
-		return explainTreeLoadedMsg{fields: fields, path: fieldPath}
+		return explainTreeLoadedMsg{fields: fields, path: fieldPath, gen: gen}
 	})
 }
 
@@ -568,7 +575,9 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 // lazily as the cursor visits each level.
 func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath string) tea.Cmd {
 	kctx := m.effectiveContext()
-	ident := explainTreeDescMsg{resource: resource, apiVersion: apiVersion, kctx: kctx, parent: parentPath}
+	ident := explainTreeDescMsg{
+		resource: resource, apiVersion: apiVersion, kctx: kctx, parent: parentPath, gen: m.explainGen,
+	}
 
 	kubectlPath, err := k8s.KubectlPath()
 	if err != nil {

--- a/internal/app/explain_gen_test.go
+++ b/internal/app/explain_gen_test.go
@@ -56,7 +56,32 @@ func TestExplainLoaded_StaleGenerationDoesNotHijackNewTab(t *testing.T) {
 	assert.Equal(t, modeExplorer, rm.mode, "a reply from the tab left behind must not open the Explorer here")
 	assert.Empty(t, rm.explainFields, "the new tab's schema must stay untouched")
 	assert.Empty(t, rm.explainTitle)
-	assert.False(t, rm.loading, "dropping the reply must still stop the spinner it started")
+	assert.False(t, rm.loading, "leaving the tab must stop the spinner of the fetch it abandoned")
+}
+
+func TestExplainLoaded_StaleReplyLeavesTheNewSpinnerUp(t *testing.T) {
+	m := explainGenTabsModel(t)
+	stale := m.explainGen
+
+	// The user leaves the Explorer and opens it again straight away. The
+	// first fetch answers while the second is still running.
+	m.exitExplainView()
+	m.beginExplainSession()
+	m.loading = true
+
+	result, _ := m.Update(explainLoadedMsg{gen: stale, path: "spec"})
+	rm := result.(Model)
+
+	assert.True(t, rm.loading, "a stale reply must not take down the spinner of the fetch that replaced it")
+}
+
+func TestExitExplainView_StopsTheSpinner(t *testing.T) {
+	m := explainGenTabsModel(t)
+	m.loading = true
+
+	m.exitExplainView()
+
+	assert.False(t, m.loading, "the abandoned fetch will never answer, so nothing else clears it")
 }
 
 func TestExplainLoaded_CurrentGenerationApplies(t *testing.T) {
@@ -124,7 +149,8 @@ func TestExplainTreeDesc_StaleGenerationDropped(t *testing.T) {
 	m.explainAPIVersion = "apps/v1"
 	m.explainTreeAll = []model.ExplainField{{Name: "replicas", Type: "<integer>", Path: "spec.replicas"}}
 	m.explainFields = m.explainTreeAll
-	m.explainTreeDescInflight = map[string]struct{}{"spec": {}}
+	// The stale batch's own marker, still waiting to be released.
+	m.explainTreeDescInflight = map[string]uint64{"spec": stale}
 
 	result, _ := m.Update(explainTreeDescMsg{
 		gen:        stale,
@@ -140,4 +166,30 @@ func TestExplainTreeDesc_StaleGenerationDropped(t *testing.T) {
 	assert.NotContains(t, rm.explainTreeDescFetched, "spec", "and must not mark the level described")
 	assert.NotContains(t, rm.explainTreeDescInflight, "spec",
 		"but the level must be released, or it can never be described again")
+}
+
+func TestExplainTreeDesc_StaleBatchKeepsALiveMarkerForTheSameLevel(t *testing.T) {
+	m := explainGenTabsModel(t)
+	stale := m.explainGen
+
+	// The new session asked for the same level, so its marker sits under the
+	// same key. Releasing it here would let a second subprocess start.
+	m.beginExplainSession()
+	m.explainTree = true
+	m.explainTreeAll = []model.ExplainField{{Name: "replicas", Type: "<integer>", Path: "spec.replicas"}}
+	m.explainFields = m.explainTreeAll
+	m.explainTreeDescInflight = map[string]uint64{"spec": m.explainGen}
+
+	result, _ := m.Update(explainTreeDescMsg{
+		gen:        stale,
+		resource:   "deployments",
+		apiVersion: "apps/v1",
+		kctx:       m.effectiveContext(),
+		parent:     "spec",
+		fields:     []model.ExplainField{{Name: "replicas", Path: "spec.replicas", Description: "stale text"}},
+	})
+	rm := result.(Model)
+
+	assert.Contains(t, rm.explainTreeDescInflight, "spec", "the live fetch's marker must survive")
+	assert.Empty(t, rm.explainTreeAll[0].Description)
 }

--- a/internal/app/explain_gen_test.go
+++ b/internal/app/explain_gen_test.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// The API Explorer fetches answer asynchronously. A reply that was already in
+// flight when the user switched tabs must not drop the new tab into the
+// Explorer with the old tab's schema (TASK-876).
+
+// explainGenTabsModel returns a two-tab model with the API Explorer open on
+// tab 0 and a live explain session.
+func explainGenTabsModel(t *testing.T) Model {
+	t.Helper()
+	m := basePush80Model()
+	m.tabs = []TabState{{nav: m.nav}, {nav: m.nav}}
+	m.mode = modeExplain
+	m.explainResource = "deployments"
+	m.explainAPIVersion = "apps/v1"
+	m.explainPath = "spec"
+	m.explainFields = []model.ExplainField{
+		{Name: "replicas", Type: "<integer>", Path: "spec.replicas"},
+	}
+	m.beginExplainSession()
+	require.NotZero(t, m.explainGen, "opening the Explorer must start a generation")
+	return m
+}
+
+// switchToSecondTab leaves tab 0 for tab 1, which is a plain explorer view.
+func switchToSecondTab(m *Model) {
+	m.saveCurrentTab()
+	m.tabs[1].mode = modeExplorer
+	_ = m.loadTab(1)
+}
+
+func TestExplainLoaded_StaleGenerationDoesNotHijackNewTab(t *testing.T) {
+	m := explainGenTabsModel(t)
+	stale := m.explainGen
+
+	switchToSecondTab(&m)
+	require.Equal(t, modeExplorer, m.mode)
+
+	result, _ := m.Update(explainLoadedMsg{
+		gen:    stale,
+		fields: []model.ExplainField{{Name: "template", Type: "<PodTemplateSpec>", Path: "spec.template"}},
+		title:  "deployments (apps/v1)",
+		path:   "spec",
+	})
+	rm := result.(Model)
+
+	assert.Equal(t, modeExplorer, rm.mode, "a reply from the tab left behind must not open the Explorer here")
+	assert.Empty(t, rm.explainFields, "the new tab's schema must stay untouched")
+	assert.Empty(t, rm.explainTitle)
+	assert.False(t, rm.loading, "dropping the reply must still stop the spinner it started")
+}
+
+func TestExplainLoaded_CurrentGenerationApplies(t *testing.T) {
+	m := explainGenTabsModel(t)
+
+	result, _ := m.Update(explainLoadedMsg{
+		gen:    m.explainGen,
+		fields: []model.ExplainField{{Name: "template", Type: "<PodTemplateSpec>", Path: "spec.template"}},
+		title:  "deployments (apps/v1)",
+		path:   "spec",
+	})
+	rm := result.(Model)
+
+	assert.Equal(t, modeExplain, rm.mode)
+	assert.Len(t, rm.explainFields, 1)
+	assert.Equal(t, "template", rm.explainFields[0].Name)
+}
+
+func TestExplainRecursive_StaleGenerationDropped(t *testing.T) {
+	m := explainGenTabsModel(t)
+	stale := m.explainGen
+
+	switchToSecondTab(&m)
+
+	result, _ := m.Update(explainRecursiveMsg{
+		gen:     stale,
+		matches: []model.ExplainField{{Name: "containers", Path: "spec.template.spec.containers"}},
+		query:   "containers",
+	})
+	rm := result.(Model)
+
+	assert.Equal(t, overlayNone, rm.overlay, "a stale recursive reply must not open the search overlay")
+	assert.Empty(t, rm.explainRecursiveResults)
+}
+
+func TestExplainTreeLoaded_StaleGenerationDropped(t *testing.T) {
+	m := explainGenTabsModel(t)
+	m.explainTreeWanted = true
+	stale := m.explainGen
+
+	switchToSecondTab(&m)
+	m.explainTreeWanted = true // the new tab wants a tree of its own
+
+	result, _ := m.Update(explainTreeLoadedMsg{
+		gen:    stale,
+		fields: []model.ExplainField{{Name: "replicas", Type: "<integer>", Path: "spec.replicas"}},
+		path:   m.explainPath,
+	})
+	rm := result.(Model)
+
+	assert.False(t, rm.explainTree, "a stale tree reply must not switch the new tab into tree mode")
+	assert.Empty(t, rm.explainTreeAll)
+}
+
+func TestExplainTreeDesc_StaleGenerationDropped(t *testing.T) {
+	m := explainGenTabsModel(t)
+	stale := m.explainGen
+
+	// Tab 1 is in tree mode for the same resource, so only the generation
+	// tells the two requests apart.
+	switchToSecondTab(&m)
+	m.mode = modeExplain
+	m.explainTree = true
+	m.explainResource = "deployments"
+	m.explainAPIVersion = "apps/v1"
+	m.explainTreeAll = []model.ExplainField{{Name: "replicas", Type: "<integer>", Path: "spec.replicas"}}
+	m.explainFields = m.explainTreeAll
+	m.explainTreeDescInflight = map[string]struct{}{"spec": {}}
+
+	result, _ := m.Update(explainTreeDescMsg{
+		gen:        stale,
+		resource:   "deployments",
+		apiVersion: "apps/v1",
+		kctx:       m.effectiveContext(),
+		parent:     "spec",
+		fields:     []model.ExplainField{{Name: "replicas", Path: "spec.replicas", Description: "stale text"}},
+	})
+	rm := result.(Model)
+
+	assert.Empty(t, rm.explainTreeAll[0].Description, "a stale description batch must not be merged")
+	assert.NotContains(t, rm.explainTreeDescFetched, "spec", "and must not mark the level described")
+	assert.NotContains(t, rm.explainTreeDescInflight, "spec",
+		"but the level must be released, or it can never be described again")
+}

--- a/internal/app/explain_session.go
+++ b/internal/app/explain_session.go
@@ -1,0 +1,65 @@
+package app
+
+import "context"
+
+// The API Explorer's cancellation scope and its generation counter. Split out
+// of update_explain.go to keep that file under the length cap.
+
+// explainSessionState is the cancellation scope shared by every kubectl
+// explain of one API Explorer visit. It is set when the Explorer opens and
+// cancelled when it closes, so leaving the view stops the subprocesses instead
+// of leaving them to their deadlines. Deliberately outside the per-tab
+// snapshot: the fetches belong to the process, not to the tab that started
+// them.
+type explainSessionState struct {
+	explainCtx    context.Context
+	explainCancel context.CancelFunc
+
+	// explainGen numbers the sessions. Every explain fetch stamps the
+	// generation it was started for, and the reply handlers drop anything
+	// older, so a fetch answered after the user left the view - or switched
+	// to another tab - cannot apply to what is on screen now. Per-tab
+	// requestGen cannot do this job: each tab counts on its own, so two tabs
+	// share generation numbers.
+	explainGen uint64
+}
+
+// beginExplainSession starts a fresh cancellation scope for the API Explorer.
+// Every explain fetch of this session hangs off it, so closing the view ends
+// them all. Any earlier session is cancelled first, which also releases its
+// child of m.reqCtx.
+func (m *Model) beginExplainSession() {
+	m.cancelExplainSession()
+	base := m.reqCtx
+	if base == nil {
+		base = context.Background()
+	}
+	m.explainCtx, m.explainCancel = context.WithCancel(base)
+}
+
+// cancelExplainSession stops the explain fetches still running, if any. The
+// generation moves on even when there was no session to cancel, so a reply
+// already on its way back is stale from here on. beginExplainSession calls
+// this first, which is where a new session gets its number.
+func (m *Model) cancelExplainSession() {
+	if m.explainCancel != nil {
+		m.explainCancel()
+	}
+	m.explainCtx, m.explainCancel = nil, nil
+	m.explainGen++
+}
+
+// explainRequestCtx is the parent context for one explain fetch. It falls back
+// to m.reqCtx when no session is open, so a fetch is never left unbounded. A
+// session already cancelled falls back too: cancelAndReset kills the session as
+// a child of the old m.reqCtx, and every later fetch of that visit would fail
+// on the spot if it kept using it.
+func (m Model) explainRequestCtx() context.Context {
+	if m.explainCtx != nil && m.explainCtx.Err() == nil {
+		return m.explainCtx
+	}
+	if m.reqCtx != nil {
+		return m.reqCtx
+	}
+	return context.Background()
+}

--- a/internal/app/explain_tree.go
+++ b/internal/app/explain_tree.go
@@ -20,6 +20,7 @@ import (
 type explainTreeLoadedMsg struct {
 	fields []model.ExplainField
 	path   string
+	gen    uint64 // explain session, see explainLoadedMsg
 	err    error
 }
 
@@ -34,6 +35,7 @@ type explainTreeDescMsg struct {
 	kctx       string
 	parent     string
 	fields     []model.ExplainField
+	gen        uint64 // explain session, see explainLoadedMsg
 	err        error
 }
 
@@ -109,7 +111,10 @@ func (m *Model) resetExplainTree() {
 // aside for the toggle-off restore. The cursor follows the flat selection
 // onto the matching tree row.
 func (m Model) updateExplainTreeLoaded(msg explainTreeLoadedMsg) (tea.Model, tea.Cmd) {
-	m.loading = false
+	m.loading = false // see updateExplainLoaded
+	if msg.gen != m.explainGen {
+		return m, nil
+	}
 	// Dropped silently when the user canceled tree mode while the fetch was
 	// in flight (every live tree load has explainTreeWanted set).
 	if !m.explainTreeWanted {
@@ -172,7 +177,14 @@ func seedExplainDescriptions(dst, src []model.ExplainField) {
 // retrying on every cursor move would spawn a kubectl process per keypress;
 // the cache resets with the next tree load.
 func (m Model) updateExplainTreeDescLoaded(msg explainTreeDescMsg) tea.Model {
+	// The level is no longer loading whatever session asked for it. The
+	// in-flight map outlives a session (only resetExplainTree clears it), so
+	// skipping this on a stale batch would block that level from ever being
+	// described again.
 	delete(m.explainTreeDescInflight, msg.parent)
+	if msg.gen != m.explainGen {
+		return m
+	}
 	if !m.explainTree || msg.resource != m.explainResource ||
 		msg.apiVersion != m.explainAPIVersion || msg.kctx != m.effectiveContext() {
 		return m

--- a/internal/app/explain_tree.go
+++ b/internal/app/explain_tree.go
@@ -54,7 +54,7 @@ type explainTreeState struct {
 	// explain of the cursor row's parent path) and caches which levels are
 	// done / in flight for the life of the tree.
 	explainTreeDescFetched  map[string]struct{} // levels whose descriptions are merged (or failed)
-	explainTreeDescInflight map[string]struct{} // levels with a fetch currently in flight
+	explainTreeDescInflight map[string]uint64   // levels with a fetch in flight, mapped to its explain generation
 }
 
 // toggleExplainTree flips the API Explorer between the flat field list and
@@ -111,10 +111,10 @@ func (m *Model) resetExplainTree() {
 // aside for the toggle-off restore. The cursor follows the flat selection
 // onto the matching tree row.
 func (m Model) updateExplainTreeLoaded(msg explainTreeLoadedMsg) (tea.Model, tea.Cmd) {
-	m.loading = false // see updateExplainLoaded
 	if msg.gen != m.explainGen {
 		return m, nil
 	}
+	m.loading = false
 	// Dropped silently when the user canceled tree mode while the fetch was
 	// in flight (every live tree load has explainTreeWanted set).
 	if !m.explainTreeWanted {
@@ -177,11 +177,15 @@ func seedExplainDescriptions(dst, src []model.ExplainField) {
 // retrying on every cursor move would spawn a kubectl process per keypress;
 // the cache resets with the next tree load.
 func (m Model) updateExplainTreeDescLoaded(msg explainTreeDescMsg) tea.Model {
-	// The level is no longer loading whatever session asked for it. The
-	// in-flight map outlives a session (only resetExplainTree clears it), so
-	// skipping this on a stale batch would block that level from ever being
-	// described again.
-	delete(m.explainTreeDescInflight, msg.parent)
+	// Release the marker this batch was fetched under. The map outlives a
+	// session (only resetExplainTree clears it), so a stale batch that kept
+	// its marker would block that level from ever being described again.
+	// Matching on the generation as well leaves a live fetch for the same
+	// level alone, which would otherwise be free to start a second
+	// subprocess.
+	if g, ok := m.explainTreeDescInflight[msg.parent]; ok && g == msg.gen {
+		delete(m.explainTreeDescInflight, msg.parent)
+	}
 	if msg.gen != m.explainGen {
 		return m
 	}
@@ -217,9 +221,9 @@ func (m *Model) maybeFetchExplainTreeDesc() tea.Cmd {
 		return nil
 	}
 	if m.explainTreeDescInflight == nil {
-		m.explainTreeDescInflight = make(map[string]struct{})
+		m.explainTreeDescInflight = make(map[string]uint64)
 	}
-	m.explainTreeDescInflight[parent] = struct{}{}
+	m.explainTreeDescInflight[parent] = m.explainGen
 	return m.execKubectlExplainTreeDesc(m.explainResource, m.explainAPIVersion, parent)
 }
 

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -619,12 +619,15 @@ type previewEventsLoadedMsg struct {
 	gen    uint64
 }
 
-// explainLoadedMsg carries the parsed output of kubectl explain.
+// explainLoadedMsg carries the parsed output of kubectl explain. gen is the
+// explain session it was started for; handlers drop a reply whose gen no
+// longer matches m.explainGen. See explainSessionState.
 type explainLoadedMsg struct {
 	fields      []model.ExplainField
 	description string // resource/field-level description
 	title       string // e.g., "deployments.v1.apps"
 	path        string // current field path
+	gen         uint64
 	err         error
 }
 
@@ -645,6 +648,7 @@ type logSaveAllMsg struct {
 type explainRecursiveMsg struct {
 	matches []model.ExplainField // matching fields with full paths
 	query   string
+	gen     uint64 // explain session, see explainLoadedMsg
 	err     error
 }
 

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -456,9 +456,9 @@ func (m *Model) saveCurrentTab() {
 // it returns a tea.Cmd that fetches the tab's data; otherwise it returns nil.
 func (m *Model) loadTab(idx int) tea.Cmd {
 	m.wheel.dead = true // switching/reloading a tab empties the wheel momentum queue (#524)
-	// The explain fetches in flight belong to the tab being left. Stop them
-	// here too, or a tab switch leaves them running to their deadline.
+	// Stop the explain fetches of the tab being left, and their spinner too.
 	m.cancelExplainSession()
+	m.loading = false
 	t := m.tabs[idx]
 	needsLoad := t.needsLoad
 	m.activeTab = idx

--- a/internal/app/update_describe_msgs.go
+++ b/internal/app/update_describe_msgs.go
@@ -85,7 +85,13 @@ func (m Model) updateExplainMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) updateExplainLoaded(msg explainLoadedMsg) (tea.Model, tea.Cmd) {
+	// The spinner is cleared even for a reply this view no longer wants -
+	// the fetch it belongs to is over either way, and m.loading is not
+	// per-tab, so leaving it set hangs a spinner on the screen forever.
 	m.loading = false
+	if msg.gen != m.explainGen {
+		return m, nil
+	}
 	if msg.err != nil {
 		m.setErrorFromErr("Explain failed: ", msg.err)
 		return m, scheduleStatusClear()
@@ -127,7 +133,10 @@ func (m *Model) applyExplainPendingField() {
 }
 
 func (m Model) updateExplainRecursive(msg explainRecursiveMsg) (tea.Model, tea.Cmd) {
-	m.loading = false
+	m.loading = false // see updateExplainLoaded
+	if msg.gen != m.explainGen {
+		return m, nil
+	}
 	if msg.err != nil {
 		m.setErrorFromErr("Recursive search failed: ", msg.err)
 		return m, scheduleStatusClear()

--- a/internal/app/update_describe_msgs.go
+++ b/internal/app/update_describe_msgs.go
@@ -85,13 +85,14 @@ func (m Model) updateExplainMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) updateExplainLoaded(msg explainLoadedMsg) (tea.Model, tea.Cmd) {
-	// The spinner is cleared even for a reply this view no longer wants -
-	// the fetch it belongs to is over either way, and m.loading is not
-	// per-tab, so leaving it set hangs a spinner on the screen forever.
-	m.loading = false
+	// Only the reply the view is waiting for stops the spinner. A stale one
+	// must leave it alone, or it hides the spinner of the fetch that
+	// replaced it. The paths that abandon a fetch - leaving the view,
+	// switching tabs - clear m.loading themselves.
 	if msg.gen != m.explainGen {
 		return m, nil
 	}
+	m.loading = false
 	if msg.err != nil {
 		m.setErrorFromErr("Explain failed: ", msg.err)
 		return m, scheduleStatusClear()
@@ -133,10 +134,10 @@ func (m *Model) applyExplainPendingField() {
 }
 
 func (m Model) updateExplainRecursive(msg explainRecursiveMsg) (tea.Model, tea.Cmd) {
-	m.loading = false // see updateExplainLoaded
 	if msg.gen != m.explainGen {
 		return m, nil
 	}
+	m.loading = false
 	if msg.err != nil {
 		m.setErrorFromErr("Recursive search failed: ", msg.err)
 		return m, scheduleStatusClear()

--- a/internal/app/update_explain.go
+++ b/internal/app/update_explain.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"strconv"
 	"strings"
 
@@ -100,53 +99,6 @@ func (m Model) openExplainAtObjectPath(objPath []string, returnMode viewMode) (t
 	m.explainAPIVersion = apiVersion
 	m.setStatusMessage("Loading API Explorer...", false)
 	return m, m.execKubectlExplain(resource, apiVersion, parentPath)
-}
-
-// explainSessionState is the cancellation scope shared by every kubectl
-// explain of one API Explorer visit. It is set when the Explorer opens and
-// cancelled when it closes, so leaving the view stops the subprocesses instead
-// of leaving them to their deadlines. Deliberately outside the per-tab
-// snapshot: the fetches belong to the process, not to the tab that started
-// them.
-type explainSessionState struct {
-	explainCtx    context.Context
-	explainCancel context.CancelFunc
-}
-
-// beginExplainSession starts a fresh cancellation scope for the API Explorer.
-// Every explain fetch of this session hangs off it, so closing the view ends
-// them all. Any earlier session is cancelled first, which also releases its
-// child of m.reqCtx.
-func (m *Model) beginExplainSession() {
-	m.cancelExplainSession()
-	base := m.reqCtx
-	if base == nil {
-		base = context.Background()
-	}
-	m.explainCtx, m.explainCancel = context.WithCancel(base)
-}
-
-// cancelExplainSession stops the explain fetches still running, if any.
-func (m *Model) cancelExplainSession() {
-	if m.explainCancel != nil {
-		m.explainCancel()
-	}
-	m.explainCtx, m.explainCancel = nil, nil
-}
-
-// explainRequestCtx is the parent context for one explain fetch. It falls back
-// to m.reqCtx when no session is open, so a fetch is never left unbounded. A
-// session already cancelled falls back too: cancelAndReset kills the session as
-// a child of the old m.reqCtx, and every later fetch of that visit would fail
-// on the spot if it kept using it.
-func (m Model) explainRequestCtx() context.Context {
-	if m.explainCtx != nil && m.explainCtx.Err() == nil {
-		return m.explainCtx
-	}
-	if m.reqCtx != nil {
-		return m.reqCtx
-	}
-	return context.Background()
 }
 
 // explainTarget converts an object path into the kubectl-explain schema path of

--- a/internal/app/update_explain.go
+++ b/internal/app/update_explain.go
@@ -195,6 +195,9 @@ func (m Model) explainGoBack() (tea.Model, tea.Cmd) {
 // Object Explorer when opened from there via the I key).
 func (m *Model) exitExplainView() {
 	m.cancelExplainSession()
+	// The fetches just abandoned will never answer, and m.loading is not
+	// per-tab, so nothing else would take the spinner down.
+	m.loading = false
 	m.mode = m.explainReturnMode
 	m.explainReturnMode = modeExplorer
 	m.explainAncestors = nil


### PR DESCRIPTION
## Summary

The four API Explorer reply messages carried no generation, so a `kubectl explain` started on one tab and answered after a tab switch applied to whatever model was current. `updateExplainLoaded` sets `m.mode = modeExplain`, so an in-flight reply could drop the user into the API Explorer on the new tab with another resource's schema.

- `explainSessionState` gains `explainGen`, bumped by `cancelExplainSession`. Each explain command stamps the generation it was started for; each handler drops a reply that no longer matches.
- The counter is process-wide on purpose. Per-tab `requestGen` cannot do this job: each tab counts on its own, so the numbers collide across tabs.
- Bookkeeping runs before the check. `m.loading` is not per-tab, so a dropped reply must still stop the spinner it started, and a dropped description batch must still release its in-flight marker - that map outlives a session, so keeping the marker would block the schema level from ever being described again.
- `update_explain.go` passed the 800-line cap, so the session block moved to `explain_session.go`.

Found by the `go-reviewer` pass on TASK-869. Pre-existing, not caused by that change.

## Test plan

- [x] 5 new tests in `internal/app/explain_gen_test.go`: a stale reply of each of the four kinds is dropped, a current-generation reply still applies
- [x] `go test ./...`
- [x] `go test -race ./internal/app/ -run 'Explain|Tab'`
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./internal/app/...`
- [ ] Manual: open the API Explorer, switch tabs before the schema loads, confirm the new tab stays put

## Out of scope

A tab left mid-fetch does not re-fire the explain when you switch back. Pre-existing - TASK-869 already killed the subprocess on switch.