### PR TITLE
fix: resume the API Explorer schema load on tab restore (TASK-878)

### DIFF
--- a/internal/app/explain_gen_test.go
+++ b/internal/app/explain_gen_test.go
@@ -193,3 +193,64 @@ func TestExplainTreeDesc_StaleBatchKeepsALiveMarkerForTheSameLevel(t *testing.T)
 	assert.Contains(t, rm.explainTreeDescInflight, "spec", "the live fetch's marker must survive")
 	assert.Empty(t, rm.explainTreeAll[0].Description)
 }
+
+// A tab left with the API Explorer still loading comes back to an empty view:
+// the switch cancels the fetch and the generation guard drops its reply, so
+// nothing fills the level (TASK-878).
+
+// explainLoadingTabsModel returns a two-tab model whose tab 0 has the API
+// Explorer open with a fetch in flight and no fields yet.
+func explainLoadingTabsModel() Model {
+	m := basePush80Model()
+	m.tabs = []TabState{{nav: m.nav}, {nav: m.nav, mode: modeExplorer}}
+	m.mode = modeExplain
+	m.explainResource = "deployments"
+	m.explainAPIVersion = "apps/v1"
+	m.explainPath = "spec"
+	m.explainFields = nil
+	m.loading = true
+	m.beginExplainSession()
+	return m
+}
+
+func TestLoadTab_ResumesAnExplainLeftUnfinished(t *testing.T) {
+	m := explainLoadingTabsModel()
+
+	m.saveCurrentTab()
+	_ = m.loadTab(1)
+	require.False(t, m.loading, "the abandoned fetch takes its spinner with it")
+
+	m.saveCurrentTab()
+	cmd := m.loadTab(0)
+
+	require.Equal(t, modeExplain, m.mode)
+	assert.NotNil(t, cmd, "returning to the tab must re-issue the schema fetch")
+	assert.True(t, m.loading, "and show that it is loading again")
+}
+
+func TestLoadTab_DoesNotRefetchAnExplainThatAlreadyLoaded(t *testing.T) {
+	m := explainLoadingTabsModel()
+	m.explainFields = []model.ExplainField{{Name: "replicas", Path: "spec.replicas"}}
+	m.loading = false
+
+	m.saveCurrentTab()
+	_ = m.loadTab(1)
+	m.saveCurrentTab()
+	cmd := m.loadTab(0)
+
+	assert.Nil(t, cmd, "the level is already on screen, so nothing needs fetching")
+	assert.False(t, m.loading)
+}
+
+func TestLoadTab_LeavesANonExplainTabAlone(t *testing.T) {
+	m := explainLoadingTabsModel()
+	m.mode = modeExplorer
+
+	m.saveCurrentTab()
+	_ = m.loadTab(1)
+	m.saveCurrentTab()
+	cmd := m.loadTab(0)
+
+	assert.Nil(t, cmd)
+	assert.False(t, m.loading)
+}

--- a/internal/app/explain_gen_test.go
+++ b/internal/app/explain_gen_test.go
@@ -231,6 +231,7 @@ func TestLoadTab_ResumesAnExplainLeftUnfinished(t *testing.T) {
 func TestLoadTab_DoesNotRefetchAnExplainThatAlreadyLoaded(t *testing.T) {
 	m := explainLoadingTabsModel()
 	m.explainFields = []model.ExplainField{{Name: "replicas", Path: "spec.replicas"}}
+	m.explainTitle = "deployments (apps/v1) > spec"
 	m.loading = false
 
 	m.saveCurrentTab()
@@ -253,4 +254,32 @@ func TestLoadTab_LeavesANonExplainTabAlone(t *testing.T) {
 
 	assert.Nil(t, cmd)
 	assert.False(t, m.loading)
+}
+
+// kubectl explain of a primitive field answers with a description and no
+// FIELDS section, so a level that loaded holds zero fields. Deciding from the
+// field list would refetch it on every visit and flash a spinner over a level
+// that is already right.
+func TestLoadTab_DoesNotRefetchALevelThatLoadedWithNoFields(t *testing.T) {
+	m := explainLoadingTabsModel()
+
+	// The reply for spec.replicas: a description, no fields.
+	mdl, _ := m.updateExplainLoaded(explainLoadedMsg{
+		gen:         m.explainGen,
+		description: "Number of desired pods.",
+		title:       "deployments (apps/v1) > spec > replicas",
+		path:        "spec.replicas",
+	})
+	m = mdl.(Model)
+	require.Empty(t, m.explainFields, "a primitive field has no FIELDS section")
+	require.NotEmpty(t, m.explainTitle, "but the reply still names the level")
+
+	m.saveCurrentTab()
+	_ = m.loadTab(1)
+	m.saveCurrentTab()
+	cmd := m.loadTab(0)
+
+	assert.Nil(t, cmd, "the level arrived, so revisiting the tab must not refetch it")
+	assert.False(t, m.loading, "and must not flash a spinner over it")
+	assert.Equal(t, "Number of desired pods.", m.explainDesc, "the description stays on screen")
 }

--- a/internal/app/explain_session.go
+++ b/internal/app/explain_session.go
@@ -54,11 +54,18 @@ func (m *Model) cancelExplainSession() {
 }
 
 // resumeExplainFetch re-issues the schema load of a tab that comes back with
-// the API Explorer open but nothing in it. Switching away cancels the fetch
+// the API Explorer open but no level in it. Switching away cancels the fetch
 // and the generation guard drops its reply, so the level the tab was waiting
 // for never arrives on its own. Nil when there is nothing to resume.
+//
+// An empty title is what marks a level as never delivered. The field list
+// cannot answer that: kubectl explain of a primitive field returns a
+// description and no FIELDS section, so a level that loaded perfectly well
+// holds zero fields, and keying off the list would refetch it on every visit.
+// Only a reply sets the title, exitExplainView clears it, and it is part of
+// the per-tab snapshot.
 func (m *Model) resumeExplainFetch() tea.Cmd {
-	if m.mode != modeExplain || len(m.explainFields) > 0 || m.explainResource == "" {
+	if m.mode != modeExplain || m.explainTitle != "" || m.explainResource == "" {
 		return nil
 	}
 	m.loading = true

--- a/internal/app/explain_session.go
+++ b/internal/app/explain_session.go
@@ -1,6 +1,10 @@
 package app
 
-import "context"
+import (
+	"context"
+
+	tea "charm.land/bubbletea/v2"
+)
 
 // The API Explorer's cancellation scope and its generation counter. Split out
 // of update_explain.go to keep that file under the length cap.
@@ -47,6 +51,18 @@ func (m *Model) cancelExplainSession() {
 	}
 	m.explainCtx, m.explainCancel = nil, nil
 	m.explainGen++
+}
+
+// resumeExplainFetch re-issues the schema load of a tab that comes back with
+// the API Explorer open but nothing in it. Switching away cancels the fetch
+// and the generation guard drops its reply, so the level the tab was waiting
+// for never arrives on its own. Nil when there is nothing to resume.
+func (m *Model) resumeExplainFetch() tea.Cmd {
+	if m.mode != modeExplain || len(m.explainFields) > 0 || m.explainResource == "" {
+		return nil
+	}
+	m.loading = true
+	return m.execKubectlExplain(m.explainResource, m.explainAPIVersion, m.explainPath)
 }
 
 // explainRequestCtx is the parent context for one explain fetch. It falls back

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -452,8 +452,8 @@ func (m *Model) saveCurrentTab() {
 }
 
 // loadTab restores Model fields from the given tab index.
-// If the tab was restored from a session and has not been loaded yet (needsLoad),
-// it returns a tea.Cmd that fetches the tab's data; otherwise it returns nil.
+// It returns a tea.Cmd that fetches the tab's data when the tab was restored
+// from a session (needsLoad), and one that resumes an unfinished API Explorer.
 func (m *Model) loadTab(idx int) tea.Cmd {
 	m.wheel.dead = true // switching/reloading a tab empties the wheel momentum queue (#524)
 	// Stop the explain fetches of the tab being left, and their spinner too.
@@ -650,7 +650,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 			m.setCursor(0)
 			m.loading = true
 			m.pendingTarget, m.pendingTargetNamespace = t.cursorName, t.cursorNamespace // quit-time row
-			return tea.Batch(securitySeedCmd, m.loadResources(false))
+			return tea.Batch(securitySeedCmd, m.resumeExplainFetch(), m.loadResources(false))
 		case model.LevelResourceTypes:
 			// At resource types level: left = contexts, middle = resource types.
 			m.leftItemsHistory = nil
@@ -659,14 +659,14 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 			m.itemCache[m.navKey()] = m.middleItems
 			m.clearRight()
 			m.clampCursor()
-			return tea.Batch(securitySeedCmd, m.loadPreview())
+			return tea.Batch(securitySeedCmd, m.resumeExplainFetch(), m.loadPreview())
 		default:
 			// Clusters level or unknown: just load contexts.
 			m.loading = true
-			return tea.Batch(securitySeedCmd, m.refreshCurrentLevel())
+			return tea.Batch(securitySeedCmd, m.resumeExplainFetch(), m.refreshCurrentLevel())
 		}
 	}
-	return nil
+	return m.resumeExplainFetch()
 }
 
 // moveActiveTab reorders the active tab one slot in the given direction

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -112,10 +112,14 @@ func (m Model) handleTabSwitchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool
 			}
 			m.saveCurrentTab()
 			next := (m.activeTab + 1) % len(m.tabs)
-			if cmd := m.loadTab(next); cmd != nil {
-				return m, cmd, true
-			}
+			cmd := m.loadTab(next)
+			// The log preview is a Model-level stream, so it has to be
+			// settled on every switch, including one that came back with
+			// work of its own.
 			m, logCmd := m.maybeRestartOrCancelPreviewLog()
+			if cmd != nil {
+				return m, tea.Batch(cmd, logCmd), true
+			}
 			return m, tea.Batch(m.postTabSwitchCmd(), logCmd), true
 		}
 	case kb.PrevTab:
@@ -125,10 +129,14 @@ func (m Model) handleTabSwitchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool
 			}
 			m.saveCurrentTab()
 			prev := (m.activeTab - 1 + len(m.tabs)) % len(m.tabs)
-			if cmd := m.loadTab(prev); cmd != nil {
-				return m, cmd, true
-			}
+			cmd := m.loadTab(prev)
+			// The log preview is a Model-level stream, so it has to be
+			// settled on every switch, including one that came back with
+			// work of its own.
 			m, logCmd := m.maybeRestartOrCancelPreviewLog()
+			if cmd != nil {
+				return m, tea.Batch(cmd, logCmd), true
+			}
 			return m, tea.Batch(m.postTabSwitchCmd(), logCmd), true
 		}
 	case kb.MoveTabLeft:


### PR DESCRIPTION
## Summary

A tab left with the API Explorer still loading came back empty and stayed that way. `loadTab` cancels the fetches of the tab being left (TASK-869) and the generation guard drops their replies (TASK-876), but nothing re-issued them.

- `resumeExplainFetch` re-issues the schema load for a tab restored in `modeExplain` with no fields, and raises the spinner again. `loadTab` returns it on every path.
- The tab switch keys now settle the log preview before returning, not only on the path where `loadTab` had no work of its own. That stream is Model-level, so a switch that skipped it left it pointed at the tab the user had left. This also closes the same gap for session-restored tabs, where it predates this change.

## Test plan

- [x] 3 new tests: an unfinished Explorer resumes, a loaded one does not refetch, a non-Explorer tab is left alone
- [x] Confirmed red first: without the fix `TestLoadTab_ResumesAnExplainLeftUnfinished` fails on the nil command
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./internal/...`

## Follow-up

TASK-879: the resume decides from `len(explainFields)`, which reads "has anything loaded" rather than "is a fetch pending". A drill interrupted by a tab switch is still lost. The proper fix is a per-tab pending marker, which needs `tabs.go` split first - it sits at exactly the 800-line cap.