### PR TITLE
fix: route port-forward and apply argv through the demo helper (TASK-875)

### DIFF
--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -147,7 +147,7 @@ func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
 		if ns != "" {
 			args = append(args, "-n", ns)
 		}
-		cmd := exec.Command(kubectlPath, args...)
+		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 		logExecCmd("Running kubectl command", cmd)
 		output, err := cmd.CombinedOutput()

--- a/internal/k8s/kubectl_path_guard_test.go
+++ b/internal/k8s/kubectl_path_guard_test.go
@@ -333,3 +333,115 @@ func moduleRoot(t *testing.T) string {
 		dir = parent
 	}
 }
+
+// In demo mode KubectlPath returns lfk's own executable, so a call site that
+// spawns it with unwrapped kubectl argv re-enters the root command and opens
+// a second TUI instead of the demo kubectl emulation. Two call sites were
+// missed when the wrapping was rolled out (TASK-865, then TASK-875), because
+// only the binary lookup was guarded, not the arguments. This guards the
+// arguments.
+//
+// The check is per function, not per call: some call sites wrap the slice a
+// few lines earlier and pass the wrapped variable. A function that mentions
+// DemoKubectlArgs anywhere is therefore accepted. That is loose on purpose -
+// it catches every site that forgot the helper altogether, which is the
+// mistake that has actually happened, without failing on the assign-then-use
+// shape.
+func TestKubectlExecArgsGoThroughDemoHelper(t *testing.T) {
+	root := moduleRoot(t)
+
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return fmt.Errorf("parsing %s: %w", path, parseErr)
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if !kubectlSpawnsInFunc(fn) || mentionsDemoKubectlArgs(fn) {
+				continue
+			}
+			offenders = append(offenders, fmt.Sprintf("%s: %s", rel, fn.Name.Name))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking module root: %v", err)
+	}
+	sort.Strings(offenders)
+	if len(offenders) > 0 {
+		t.Errorf("these functions spawn the kubectl path without k8s.DemoKubectlArgs;"+
+			" wrap the argument slice or demo mode re-enters lfk itself:\n%s",
+			strings.Join(offenders, "\n"))
+	}
+}
+
+// kubectlSpawnsInFunc reports whether fn calls exec.Command or
+// exec.CommandContext with the resolved kubectl path as the binary.
+func kubectlSpawnsInFunc(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "exec" {
+			return true
+		}
+		nameIdx, ok := execNameResolvers[sel.Sel.Name]
+		if !ok || sel.Sel.Name == "LookPath" || len(call.Args) <= nameIdx {
+			return true
+		}
+		if ident, ok := call.Args[nameIdx].(*ast.Ident); ok && strings.Contains(ident.Name, "kubectlPath") {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// mentionsDemoKubectlArgs reports whether fn calls the helper anywhere, in
+// either its own package (DemoKubectlArgs) or through k8s.
+func mentionsDemoKubectlArgs(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.Ident:
+			if v.Name == "DemoKubectlArgs" {
+				found = true
+			}
+		case *ast.SelectorExpr:
+			if v.Sel.Name == "DemoKubectlArgs" {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -108,7 +108,7 @@ func (m *PortForwardManager) Start(kubectlPath, kubeconfigPaths, resourceKind, r
 	args := []string{"port-forward", target, portMapping, "-n", namespace, "--context", kubectlContext}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx, kubectlPath, args...)
+	cmd := exec.CommandContext(ctx, kubectlPath, DemoKubectlArgs(args)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/internal/k8s/portforward_demo_test.go
+++ b/internal/k8s/portforward_demo_test.go
@@ -1,0 +1,74 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// In demo mode KubectlPath returns this process's own executable, so a call
+// site that does not wrap its arguments re-enters lfk with kubectl-shaped
+// argv. The root command parses "port-forward pod/p 8080:80 --context ..."
+// as its own flags and opens a second TUI. Every exec of the kubectl path
+// must go through DemoKubectlArgs (TASK-875).
+func TestPortForwardStart_RoutesArgsThroughTheDemoHelper(t *testing.T) {
+	SetDemoMode(true)
+	defer SetDemoMode(false)
+
+	// The fake stands in for the re-exec'd lfk binary: it records the argv it
+	// was given, then fails so the manager settles instead of running on.
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fake-kubectl")
+	argvFile := filepath.Join(dir, "argv")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argvFile + "\nexit 1\n"
+	require.NoError(t, os.WriteFile(fake, []byte(script), 0o700))
+
+	mgr := NewPortForwardManager()
+	_, err := mgr.Start(fake, "/dev/null", "Pod", "p", "ns", "ctx", "ctx", "8080", "80")
+	require.NoError(t, err)
+
+	var argv []string
+	require.Eventually(t, func() bool {
+		b, readErr := os.ReadFile(argvFile)
+		if readErr != nil {
+			return false
+		}
+		argv = strings.Fields(strings.TrimSpace(string(b)))
+		return len(argv) > 0
+	}, portForwardSettleTimeout, 20*time.Millisecond, "the fake binary should have recorded its arguments")
+
+	require.NotEmpty(t, argv)
+	assert.Equal(t, "__demo-kubectl", argv[0],
+		"demo mode must route into the demo kubectl, which refuses port-forward by name")
+	assert.Equal(t, "port-forward", argv[1], "the kubectl verb must follow the subcommand unchanged")
+}
+
+func TestPortForwardStart_LeavesArgsAloneOutsideDemoMode(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fake-kubectl")
+	argvFile := filepath.Join(dir, "argv")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argvFile + "\nexit 1\n"
+	require.NoError(t, os.WriteFile(fake, []byte(script), 0o700))
+
+	mgr := NewPortForwardManager()
+	_, err := mgr.Start(fake, "/dev/null", "Pod", "p", "ns", "ctx", "ctx", "8080", "80")
+	require.NoError(t, err)
+
+	var argv []string
+	require.Eventually(t, func() bool {
+		b, readErr := os.ReadFile(argvFile)
+		if readErr != nil {
+			return false
+		}
+		argv = strings.Fields(strings.TrimSpace(string(b)))
+		return len(argv) > 0
+	}, portForwardSettleTimeout, 20*time.Millisecond)
+
+	require.NotEmpty(t, argv)
+	assert.Equal(t, "port-forward", argv[0], "a real kubectl must be called exactly as before")
+}


### PR DESCRIPTION
## Summary

In demo mode `KubectlPath` returns lfk's own executable, so a call site that spawns it with bare kubectl argv re-enters the root command. It parses `port-forward pod/p 8080:80 --context demo` as its own flags and opens a second TUI, instead of reaching the demo kubectl, which refuses the verb by name.

- `internal/k8s/portforward.go` now wraps its arguments. The path is reachable: nothing else turns port-forward away in demo mode, so the task's "check whether this is dead first" question resolves to live.
- Sweeping the other kubectl exec sites turned up `kubectl apply` (`internal/app/commands_apply.go`) with the same gap. Fixed too.
- The wrapping had no guard. The existing one covers the binary lookup, not the arguments, which is how both sites were missed here and on #594. `TestKubectlExecArgsGoThroughDemoHelper` walks the module and reports any function that spawns the kubectl path without the helper. It checks per function rather than per call, so the sites that wrap the slice a few lines earlier still pass.

`commandbar_execute.go` looked unwrapped but wraps one line before the exec. No change.

## Test plan

- [x] `portforward_demo_test.go`: a fake binary records its argv; demo mode must lead with `__demo-kubectl`, plain mode must not. Confirmed red first (`argv[0]` was `port-forward`).
- [x] The new guard proved to catch both regressions, by reverting each wrap in turn
- [x] `go build ./...`, `go vet ./...`, `go test -count=1 -race ./...`, `golangci-lint run ./...`