### PR TITLE
fix: measure emoji icons the way the terminal does (#604)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -125,6 +125,15 @@ choose between `nerdfont` and `unicode`:
 If detection guesses wrong for your setup, set `icons: nerdfont` (or the mode
 you want) in your config, or export `LFK_ICONS=nerdfont` in your shell.
 
+### Emoji width
+
+In `icons: emoji`, some emoji are two columns wide only because of a trailing
+variation selector (`U+FE0F`). A terminal shows that extra width only when it
+supports grapheme clustering (mode 2027) — kitty, WezTerm and Ghostty do,
+Konsole does not. lfk asks the terminal at startup and drops the selector when
+the answer says no, so those icons render in their narrow monochrome form and
+the columns stay aligned. Nothing to configure.
+
 ## Appearance
 
 Visual settings, grouped. The flat keys of the same name (`colorscheme`, `icons`, `no_color`, `transparent_background`, `min_contrast_ratio`, `dim_overlay`, `row_status_tint`) are deprecated aliases; when both a flat key and its `appearance` equivalent are set, `appearance` wins. The `theme` object (custom color overrides) and per-cluster overrides remain top-level.

--- a/internal/app/security_source_entries.go
+++ b/internal/app/security_source_entries.go
@@ -38,7 +38,7 @@ func buildSecuritySourceEntries(mgr *security.Manager, availability map[string]b
 		return []model.SecuritySourceEntry{{
 			DisplayName: "(probing sources...)",
 			SourceName:  "",
-			Icon:        model.Icon{Unicode: "…", Simple: "[..]", NerdFont: "\U000f04bd"},
+			Icon:        model.Icon{Unicode: "…", Simple: "[..]", Emoji: "⌛", NerdFont: "\U000f04bd"},
 			Count:       -1,
 		}}
 	}
@@ -46,15 +46,15 @@ func buildSecuritySourceEntries(mgr *security.Manager, availability map[string]b
 		display string
 		icon    model.Icon
 	}{
-		"heuristic":      {"Heuristic", model.Icon{Unicode: "◉", Simple: "[He]", NerdFont: "\U000f0483"}},
-		"advisor":        {"Advisor", model.Icon{Unicode: "◌", Simple: "[Ad]", NerdFont: "\U000f0483"}},
-		"rbac":           {"RBAC", model.Icon{Unicode: "◒", Simple: "[Rb]", NerdFont: "\U000f0483"}},
-		"trivy-operator": {"Trivy", model.Icon{Unicode: "◈", Simple: "[Tr]", NerdFont: "\U000f0483"}},
-		"policy-report":  {"Kyverno", model.Icon{Unicode: "◇", Simple: "[Ky]", NerdFont: "\U000f0483"}},
-		"falco":          {"Falco", model.Icon{Unicode: "◎", Simple: "[Fa]", NerdFont: "\U000f0483"}},
-		"kube-bench":     {"CIS", model.Icon{Unicode: "◆", Simple: "[CI]", NerdFont: "\U000f0483"}},
-		"gatekeeper":     {"Gatekeeper", model.Icon{Unicode: "◔", Simple: "[Gk]", NerdFont: "\U000f0483"}},
-		"kubescape":      {"Kubescape", model.Icon{Unicode: "◐", Simple: "[Ks]", NerdFont: "\U000f0483"}},
+		"heuristic":      {"Heuristic", model.Icon{Unicode: "◉", Simple: "[He]", Emoji: "🧠", NerdFont: "\U000f0483"}},
+		"advisor":        {"Advisor", model.Icon{Unicode: "◌", Simple: "[Ad]", Emoji: "💡", NerdFont: "\U000f0483"}},
+		"rbac":           {"RBAC", model.Icon{Unicode: "◒", Simple: "[Rb]", Emoji: "🔑", NerdFont: "\U000f0483"}},
+		"trivy-operator": {"Trivy", model.Icon{Unicode: "◈", Simple: "[Tr]", Emoji: "🔍", NerdFont: "\U000f0483"}},
+		"policy-report":  {"Kyverno", model.Icon{Unicode: "◇", Simple: "[Ky]", Emoji: "📃", NerdFont: "\U000f0483"}},
+		"falco":          {"Falco", model.Icon{Unicode: "◎", Simple: "[Fa]", Emoji: "🦅", NerdFont: "\U000f0483"}},
+		"kube-bench":     {"CIS", model.Icon{Unicode: "◆", Simple: "[CI]", Emoji: "✅", NerdFont: "\U000f0483"}},
+		"gatekeeper":     {"Gatekeeper", model.Icon{Unicode: "◔", Simple: "[Gk]", Emoji: "🚦", NerdFont: "\U000f0483"}},
+		"kubescape":      {"Kubescape", model.Icon{Unicode: "◐", Simple: "[Ks]", Emoji: "🔬", NerdFont: "\U000f0483"}},
 	}
 	var entries []model.SecuritySourceEntry
 	for _, src := range mgr.Sources() {
@@ -64,7 +64,7 @@ func buildSecuritySourceEntries(mgr *security.Manager, availability map[string]b
 		meta, known := displayByName[src.Name()]
 		if !known {
 			meta.display = src.Name()
-			meta.icon = model.Icon{Unicode: "●", Simple: "[Se]", NerdFont: "\U000f0483"}
+			meta.icon = model.Icon{Unicode: "●", Simple: "[Se]", Emoji: "🔎", NerdFont: "\U000f0483"}
 		}
 		entries = append(entries, model.SecuritySourceEntry{
 			DisplayName: meta.display,

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/creack/pty"
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -75,6 +76,8 @@ func (m Model) updateImpl(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateFocus(msg)
 	case tea.BlurMsg:
 		return m.updateBlur(msg)
+	case tea.ModeReportMsg:
+		return m.updateModeReport(msg)
 	case spinner.TickMsg:
 		return m.updateTick(msg)
 	case stderrCapturedMsg:
@@ -562,4 +565,23 @@ func (m Model) updateTick(msg spinner.TickMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, cmd
+}
+
+// updateModeReport records the terminal's answer to the mode 2027 query. Bubble
+// Tea sends the query at startup and switches its renderer to grapheme width on
+// any answer; a terminal that does not know the mode stays on wcwidth. lfk's
+// layout measures with lipgloss, which always counts grapheme clusters, so the
+// icons have to be normalized to whichever measure the renderer settled on
+// (#604).
+func (m Model) updateModeReport(msg tea.ModeReportMsg) (tea.Model, tea.Cmd) {
+	if msg.Mode != ansi.ModeUnicodeCore {
+		return m, nil
+	}
+	switch msg.Value {
+	case ansi.ModeSet, ansi.ModeReset, ansi.ModePermanentlySet:
+		ui.UnicodeCoreActive = true
+	default:
+		ui.UnicodeCoreActive = false
+	}
+	return m, nil
 }

--- a/internal/app/update_mode_report_test.go
+++ b/internal/app/update_mode_report_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// The mode 2027 report is what tells lfk which width the renderer settled on.
+// Reading it wrong puts the icon normalization out of step with the renderer,
+// which is the misalignment of #604 in reverse.
+func TestUpdateModeReport_UnicodeCore(t *testing.T) {
+	tests := []struct {
+		name  string
+		value ansi.ModeSetting
+		want  bool
+	}{
+		// Bubble Tea switches its renderer to grapheme width on any of these:
+		// the terminal answering at all is what proves it knows the mode.
+		{"set", ansi.ModeSet, true},
+		{"reset", ansi.ModeReset, true},
+		{"permanently set", ansi.ModePermanentlySet, true},
+		// No grapheme clustering to be had, so the renderer stays on wcwidth.
+		{"permanently reset", ansi.ModePermanentlyReset, false},
+		{"not recognized", ansi.ModeNotRecognized, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := ui.UnicodeCoreActive
+			defer func() { ui.UnicodeCoreActive = old }()
+			ui.UnicodeCoreActive = !tc.want // start from the wrong answer
+
+			m := Model{}
+			mdl, cmd := m.updateModeReport(tea.ModeReportMsg{
+				Mode:  ansi.ModeUnicodeCore,
+				Value: tc.value,
+			})
+
+			assert.Equal(t, tc.want, ui.UnicodeCoreActive)
+			assert.Nil(t, cmd, "the next render picks the change up; nothing to schedule")
+			assert.IsType(t, Model{}, mdl)
+		})
+	}
+}
+
+func TestUpdateModeReport_LeavesOtherModesAlone(t *testing.T) {
+	for _, active := range []bool{true, false} {
+		old := ui.UnicodeCoreActive
+		ui.UnicodeCoreActive = active
+
+		m := Model{}
+		_, cmd := m.updateModeReport(tea.ModeReportMsg{
+			Mode:  ansi.ModeSynchronizedOutput,
+			Value: ansi.ModeReset,
+		})
+
+		assert.Equal(t, active, ui.UnicodeCoreActive,
+			"a report about another mode says nothing about grapheme clustering")
+		assert.Nil(t, cmd)
+		ui.UnicodeCoreActive = old
+	}
+}

--- a/internal/model/icons_width_test.go
+++ b/internal/model/icons_width_test.go
@@ -1,0 +1,137 @@
+package model_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// An emoji whose base codepoint is one column wide becomes two with the
+// variation selector U+FE0F. Terminals disagree about honouring that: lipgloss,
+// which lfk lays out with, always counts the pair as two columns, while a
+// terminal that has not announced grapheme clustering draws one. The row then
+// ends a column short and the panel border lands early (issue #604).
+//
+// lfk resolves this at render time by dropping the selector when the terminal
+// measures with wcwidth, so both measures agree. This guard pins the property
+// that makes that work: with the selector gone, the two width methods must
+// return the same number for every icon in the tables. An icon that still
+// disagrees would drift on some terminal no matter what the renderer does.
+const variationSelector16 = "\ufe0f"
+
+func TestEmojiIconWidthsAgreeOnceTheSelectorIsDropped(t *testing.T) {
+	var disagree []string
+
+	for _, g := range collectEmojiIcons(t) {
+		bare := strings.ReplaceAll(g.glyph, variationSelector16, "")
+		wc := ansi.WcWidth.StringWidth(bare)
+		grapheme := ansi.GraphemeWidth.StringWidth(bare)
+		if wc != grapheme {
+			disagree = append(disagree,
+				g.String()+" wcwidth="+strconv.Itoa(wc)+" graphemewidth="+strconv.Itoa(grapheme))
+		}
+	}
+
+	sort.Strings(disagree)
+	if len(disagree) > 0 {
+		t.Errorf("these icons measure differently under the two width methods even without"+
+			" U+FE0F, so no render-time normalization can keep them aligned:\n%s",
+			strings.Join(disagree, "\n"))
+	}
+}
+
+type emojiIcon struct {
+	file  string
+	line  int
+	glyph string
+}
+
+func (e emojiIcon) String() string {
+	cps := make([]string, 0, utf8.RuneCountInString(e.glyph))
+	for _, r := range e.glyph {
+		cps = append(cps, "U+"+strings.ToUpper(strconv.FormatInt(int64(r), 16)))
+	}
+	return e.file + ":" + strconv.Itoa(e.line) + " " + e.glyph + " (" + strings.Join(cps, " ") + ")"
+}
+
+// collectEmojiIcons returns every Emoji field value assigned in a composite
+// literal anywhere in the module's production code, so a new icon table is
+// covered without anyone remembering to register it here.
+func collectEmojiIcons(t *testing.T) []emojiIcon {
+	t.Helper()
+	root := moduleRootForIcons(t)
+
+	var out []emojiIcon
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", ".git", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			kv, ok := n.(*ast.KeyValueExpr)
+			if !ok {
+				return true
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "Emoji" {
+				return true
+			}
+			lit, ok := kv.Value.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			glyph, unquoteErr := strconv.Unquote(lit.Value)
+			if unquoteErr != nil || glyph == "" {
+				return true
+			}
+			out = append(out, emojiIcon{file: rel, line: fset.Position(lit.Pos()).Line, glyph: glyph})
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking module root: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("no emoji icons found; the walk or the field name is wrong")
+	}
+	return out
+}
+
+func moduleRootForIcons(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate this test file")
+	}
+	// internal/model/icons_width_test.go -> module root
+	return filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+}

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -482,7 +482,7 @@ func FormatItem(item model.Item, width int) string {
 	name := NormalStyle.Render(displayName)
 
 	// Prepend icon if present (resolved based on IconMode).
-	icon := resolveIcon(item.Icon)
+	icon := iconCell(item.Icon)
 	if icon != "" {
 		name = IconStyle.Render(icon+" ") + name
 	}
@@ -509,7 +509,7 @@ func FormatItem(item model.Item, width int) string {
 		}
 		if ActiveHighlightQuery != "" {
 			name = NormalStyle.Render(highlightName(displayName, ActiveHighlightQuery))
-			if icon := resolveIcon(item.Icon); icon != "" {
+			if icon := iconCell(item.Icon); icon != "" {
 				name = IconStyle.Render(icon+" ") + name
 			}
 		}
@@ -606,7 +606,7 @@ func FormatItemPlain(item model.Item, width int) string {
 	name := displayName
 
 	// Prepend icon if present (plain text, no IconStyle; resolved based on IconMode).
-	icon := resolveIcon(item.Icon)
+	icon := iconCell(item.Icon)
 	if icon != "" {
 		name = icon + " " + name
 	}

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -307,7 +307,7 @@ func styledNameCell(item model.Item, nameW int, nameOverride *lipgloss.Style) st
 	if badgeW > 0 {
 		badgeReserve = badgeW + 1 // separator space
 	}
-	if resolvedIcon := resolveIcon(item.Icon); resolvedIcon != "" {
+	if resolvedIcon := iconCell(item.Icon); resolvedIcon != "" {
 		iconSt := IconStyle
 		if isDimmed {
 			iconSt = DimStyle

--- a/internal/ui/explorer_highlight.go
+++ b/internal/ui/explorer_highlight.go
@@ -127,7 +127,7 @@ const iconCellWidth = 2
 
 // emojiVariationSelector asks for emoji presentation, which is what makes a
 // one-column base codepoint two columns wide.
-const emojiVariationSelector = "️"
+const emojiVariationSelector = "\ufe0f"
 
 // iconCell returns the icon glyph for the active IconMode, laid out so every
 // row of a column starts its name in the same place. Only emoji mode gets the

--- a/internal/ui/explorer_highlight.go
+++ b/internal/ui/explorer_highlight.go
@@ -112,6 +112,52 @@ func VimScrollOff(scroll, cursor, numEntries, height, scrollOff int, displayLine
 	return startEntry
 }
 
+// UnicodeCoreActive reports whether the terminal measures text by grapheme
+// cluster, which it announces by answering the mode 2027 query. Bubble Tea
+// sends that query at startup and switches its renderer to grapheme width only
+// when an answer comes back; until then the renderer measures with wcwidth.
+// lfk's own layout goes through lipgloss, which always measures by grapheme
+// cluster, so the renderer and the layout agree only while this is set.
+var UnicodeCoreActive bool
+
+// iconCellWidth is the column budget an emoji icon is rendered into. Emoji
+// differ in width once the variation selector is gone, so without a fixed cell
+// a one-column glyph would start its name where a two-column glyph's name ends.
+const iconCellWidth = 2
+
+// emojiVariationSelector asks for emoji presentation, which is what makes a
+// one-column base codepoint two columns wide.
+const emojiVariationSelector = "️"
+
+// iconCell returns the icon glyph for the active IconMode, laid out so every
+// row of a column starts its name in the same place. Only emoji mode gets the
+// fixed cell: the other modes have glyphs of a single known width and their
+// spacing is already settled.
+func iconCell(icon model.Icon) string {
+	glyph := resolveIcon(icon)
+	if glyph == "" || IconMode != "emoji" {
+		return glyph
+	}
+	glyph = normalizeEmojiWidth(glyph)
+	if pad := iconCellWidth - lipgloss.Width(glyph); pad > 0 {
+		glyph += strings.Repeat(" ", pad)
+	}
+	return glyph
+}
+
+// normalizeEmojiWidth drops the variation selector when the terminal does not
+// measure by grapheme cluster. lipgloss counts a base codepoint plus the
+// selector as two columns; a terminal measuring with wcwidth draws one, so the
+// row ends a column short and the panel border lands early. Without the
+// selector both measures say one column, the glyph renders in text
+// presentation, and the row stays aligned (#604).
+func normalizeEmojiWidth(glyph string) string {
+	if UnicodeCoreActive {
+		return glyph
+	}
+	return strings.ReplaceAll(glyph, emojiVariationSelector, "")
+}
+
 // resolveIcon returns the glyph for the active IconMode, or empty string for
 // "none" and zero-value icons. Unknown IconMode values fall back to Unicode.
 func resolveIcon(icon model.Icon) string {
@@ -126,6 +172,12 @@ func resolveIcon(icon model.Icon) string {
 	case "simple":
 		return icon.Simple
 	case "emoji":
+		// An icon with no emoji of its own falls back to its unicode glyph.
+		// Returning nothing would drop the icon column for that row alone,
+		// which starts its name a column short of every neighbour (#604).
+		if icon.Emoji == "" {
+			return icon.Unicode
+		}
 		return icon.Emoji
 	default: // "unicode" and any unexpected value
 		return icon.Unicode

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -550,7 +550,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 		}
 
 		displayName := item.Name
-		if icon := resolveIcon(item.Icon); icon != "" {
+		if icon := iconCell(item.Icon); icon != "" {
 			displayName = icon + " " + item.Name
 		}
 

--- a/internal/ui/explorer_table_format.go
+++ b/internal/ui/explorer_table_format.go
@@ -103,7 +103,7 @@ func FormatItemNameOnly(item model.Item, width int) string {
 		deprecationW = lipgloss.Width(deprecationSuffix)
 	}
 
-	resolvedIcon := resolveIcon(item.Icon)
+	resolvedIcon := iconCell(item.Icon)
 	if resolvedIcon != "" {
 		icon := IconStyle.Render(resolvedIcon + " ")
 		iconW := lipgloss.Width(icon)
@@ -128,7 +128,7 @@ func FormatItemNameOnlyPlain(item model.Item, width int) string {
 		deprecationW = lipgloss.Width(deprecationSuffix)
 	}
 
-	resolvedIcon := resolveIcon(item.Icon)
+	resolvedIcon := iconCell(item.Icon)
 	if resolvedIcon != "" {
 		icon := resolvedIcon + " "
 		iconW := lipgloss.Width(icon)

--- a/internal/ui/explorer_test.go
+++ b/internal/ui/explorer_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/janosmiko/lfk/internal/model"
@@ -692,5 +693,66 @@ func TestResolveIconAllModes(t *testing.T) {
 				t.Errorf("resolveIcon in %q = %q, want %q", tc.mode, got, tc.want)
 			}
 		})
+	}
+}
+
+// Emoji mode must not leave a row without an icon. A blank where every
+// neighbour has a glyph starts the name a column short, which is how the
+// Security sources rendered before they were given emoji of their own (#604).
+func TestResolveIconEmojiFallsBackToUnicode(t *testing.T) {
+	old := IconMode
+	IconMode = "emoji"
+	defer func() { IconMode = old }()
+
+	assert.Equal(t, "◉", resolveIcon(model.Icon{Unicode: "◉", Simple: "[He]"}),
+		"an icon with no emoji falls back to its unicode glyph")
+	assert.Equal(t, "🧠", resolveIcon(model.Icon{Unicode: "◉", Emoji: "🧠"}),
+		"an icon with an emoji still uses it")
+	assert.Equal(t, "", resolveIcon(model.Icon{}), "an empty icon stays empty")
+}
+
+// The bug in #604: a selector-dependent emoji measured two columns in lipgloss
+// and one in a terminal that had not announced grapheme clustering, so the row
+// ended a column short and the panel border landed early.
+func TestIconCellKeepsOneWidthAcrossGlyphs(t *testing.T) {
+	oldMode, oldCore := IconMode, UnicodeCoreActive
+	IconMode = "emoji"
+	defer func() { IconMode, UnicodeCoreActive = oldMode, oldCore }()
+
+	// Endpoints and Pods: one needs the selector to be two columns, one does not.
+	selectorDependent := model.Icon{Unicode: "→", Emoji: "➡️"}
+	intrinsicallyWide := model.Icon{Unicode: "□", Emoji: "📦"}
+
+	t.Run("terminal measures with wcwidth", func(t *testing.T) {
+		UnicodeCoreActive = false
+		a, b := iconCell(selectorDependent), iconCell(intrinsicallyWide)
+
+		assert.NotContains(t, a, "️",
+			"the selector must go, or lipgloss counts two columns where the terminal draws one")
+		assert.Equal(t, iconCellWidth, lipgloss.Width(a))
+		assert.Equal(t, iconCellWidth, lipgloss.Width(b))
+		assert.Equal(t, ansi.WcWidth.StringWidth(a), ansi.GraphemeWidth.StringWidth(a),
+			"both width methods must agree, whichever one the renderer picked")
+	})
+
+	t.Run("terminal announced grapheme clustering", func(t *testing.T) {
+		UnicodeCoreActive = true
+		a := iconCell(selectorDependent)
+
+		assert.Contains(t, a, "️", "the emoji keeps its colour presentation here")
+		assert.Equal(t, iconCellWidth, lipgloss.Width(a))
+	})
+}
+
+// Other icon modes have glyphs of one known width and settled spacing, so the
+// emoji cell must not reach them.
+func TestIconCellLeavesOtherModesAlone(t *testing.T) {
+	oldMode := IconMode
+	defer func() { IconMode = oldMode }()
+
+	icon := model.Icon{Unicode: "→", Simple: "[EP]", Emoji: "➡️"}
+	for mode, want := range map[string]string{"unicode": "→", "simple": "[EP]", "none": ""} {
+		IconMode = mode
+		assert.Equal(t, want, iconCell(icon), "mode %q", mode)
 	}
 }

--- a/internal/ui/explorer_test.go
+++ b/internal/ui/explorer_test.go
@@ -706,7 +706,7 @@ func TestResolveIconEmojiFallsBackToUnicode(t *testing.T) {
 
 	assert.Equal(t, "◉", resolveIcon(model.Icon{Unicode: "◉", Simple: "[He]"}),
 		"an icon with no emoji falls back to its unicode glyph")
-	assert.Equal(t, "🧠", resolveIcon(model.Icon{Unicode: "◉", Emoji: "🧠"}),
+	assert.Equal(t, "\U0001f9e0", resolveIcon(model.Icon{Unicode: "◉", Emoji: "\U0001f9e0"}),
 		"an icon with an emoji still uses it")
 	assert.Equal(t, "", resolveIcon(model.Icon{}), "an empty icon stays empty")
 }
@@ -720,14 +720,14 @@ func TestIconCellKeepsOneWidthAcrossGlyphs(t *testing.T) {
 	defer func() { IconMode, UnicodeCoreActive = oldMode, oldCore }()
 
 	// Endpoints and Pods: one needs the selector to be two columns, one does not.
-	selectorDependent := model.Icon{Unicode: "→", Emoji: "➡️"}
-	intrinsicallyWide := model.Icon{Unicode: "□", Emoji: "📦"}
+	selectorDependent := model.Icon{Unicode: "→", Emoji: "\u27a1\ufe0f"} // right arrow + selector
+	intrinsicallyWide := model.Icon{Unicode: "□", Emoji: "\U0001f4e6"}   // package
 
 	t.Run("terminal measures with wcwidth", func(t *testing.T) {
 		UnicodeCoreActive = false
 		a, b := iconCell(selectorDependent), iconCell(intrinsicallyWide)
 
-		assert.NotContains(t, a, "️",
+		assert.NotContains(t, a, "\ufe0f",
 			"the selector must go, or lipgloss counts two columns where the terminal draws one")
 		assert.Equal(t, iconCellWidth, lipgloss.Width(a))
 		assert.Equal(t, iconCellWidth, lipgloss.Width(b))
@@ -739,7 +739,7 @@ func TestIconCellKeepsOneWidthAcrossGlyphs(t *testing.T) {
 		UnicodeCoreActive = true
 		a := iconCell(selectorDependent)
 
-		assert.Contains(t, a, "️", "the emoji keeps its colour presentation here")
+		assert.Contains(t, a, "\ufe0f", "the emoji keeps its colour presentation here")
 		assert.Equal(t, iconCellWidth, lipgloss.Width(a))
 	})
 }
@@ -750,7 +750,7 @@ func TestIconCellLeavesOtherModesAlone(t *testing.T) {
 	oldMode := IconMode
 	defer func() { IconMode = oldMode }()
 
-	icon := model.Icon{Unicode: "→", Simple: "[EP]", Emoji: "➡️"}
+	icon := model.Icon{Unicode: "→", Simple: "[EP]", Emoji: "\u27a1\ufe0f"}
 	for mode, want := range map[string]string{"unicode": "→", "simple": "[EP]", "none": ""} {
 		IconMode = mode
 		assert.Equal(t, want, iconCell(icon), "mode %q", mode)


### PR DESCRIPTION
Fixes #604.

## Cause

17 of the icons are two columns wide only because of a trailing `U+FE0F`. Two measures disagree about that pair:

| glyph | WcWidth | GraphemeWidth |
|---|---|---|
| `➡️` | 1 | 2 |
| `➡` | 1 | 1 |
| `📦` | 2 | 2 |

Bubble Tea asks the terminal about grapheme clustering (mode 2027) and switches its renderer to `GraphemeWidth` only if an answer arrives; otherwise the renderer stays on `WcWidth`. lfk's layout goes through lipgloss, which hardcodes `ansi.StringWidth`, that is `GraphemeWidth`, in `Width`, `align`, `borders`, `join`, `position` and `whitespace`. So on a terminal that does not answer, lfk padded for two columns where the renderer drew one, and the row ended a column short.

That is why kitty, WezTerm and Ghostty were fine and Konsole was not, and why it started with the v2 migration.

## Fix

- Watch `tea.ModeReportMsg` for `ansi.ModeUnicodeCore` and record it.
- Drop the variation selector while the renderer is on wcwidth, so both measures return the same number. The icons keep their codepoints; on those terminals they render in the narrow monochrome form the terminal was already drawing.
- Lay every icon into a fixed two-column cell, so a row whose glyph is one column still starts its name where its neighbours do.

Swapping the 17 glyphs for intrinsically wide ones was the first attempt and is not in this PR. It hid the mismatch rather than fixing it, and left the next added icon free to reintroduce it.

## Also fixed

The Security sources (Advisor, Heuristic, RBAC, Trivy, Kyverno, Falco, CIS, Gatekeeper, Kubescape) had no `Emoji` field, so emoji mode drew no icon and their names started a column short of every other section - visible in the reporter's screenshot. They have emoji now, and an icon without one falls back to its unicode glyph instead of rendering blank.

## Test plan

- [x] Guard over the icon tables: fails if an icon measures differently under the two width methods once the selector is gone
- [x] `iconCell` holds one width across a selector-dependent and an intrinsically wide glyph, in both terminal modes
- [x] Emoji mode falls back to the unicode glyph when no emoji is set
- [x] Other icon modes are untouched
- [x] `go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `-race` on the touched packages, `golangci-lint run ./...`
- [ ] Needs a look on Konsole and on a 2027 terminal