### PR TITLE
fix: sanitize the render sinks TASK-873 did not reach (TASK-880)

### DIFF
--- a/internal/app/commands_dashboard.go
+++ b/internal/app/commands_dashboard.go
@@ -691,24 +691,30 @@ func monitoringAlertTable(lines []string, alerts []k8s.AlertInfo) []string {
 
 // renderAlertRow renders a single alert's main row.
 func renderAlertRow(a k8s.AlertInfo) string {
+	// State and Severity are Prometheus labels, the same untrusted map the
+	// namespace column below reads. A value that matches none of the known
+	// cases reaches the default branch and would otherwise render raw.
+	state := ui.SanitizeTerminalText(a.State)
+	severity := ui.SanitizeTerminalText(a.Severity)
+
 	var stateStr string
-	switch a.State {
+	switch state {
 	case "firing":
-		stateStr = ui.StatusFailed.Render(fmt.Sprintf("%-10s", a.State))
+		stateStr = ui.StatusFailed.Render(fmt.Sprintf("%-10s", state))
 	case "pending":
-		stateStr = ui.StatusProgressing.Render(fmt.Sprintf("%-10s", a.State))
+		stateStr = ui.StatusProgressing.Render(fmt.Sprintf("%-10s", state))
 	default:
-		stateStr = ui.DimStyle.Render(fmt.Sprintf("%-10s", a.State))
+		stateStr = ui.DimStyle.Render(fmt.Sprintf("%-10s", state))
 	}
 
 	var sevStr string
-	switch a.Severity {
+	switch severity {
 	case "critical":
-		sevStr = ui.StatusFailed.Bold(true).Render(fmt.Sprintf("%-12s", a.Severity))
+		sevStr = ui.StatusFailed.Bold(true).Render(fmt.Sprintf("%-12s", severity))
 	case "warning":
-		sevStr = ui.StatusProgressing.Render(fmt.Sprintf("%-12s", a.Severity))
+		sevStr = ui.StatusProgressing.Render(fmt.Sprintf("%-12s", severity))
 	default:
-		sevStr = ui.DimStyle.Render(fmt.Sprintf("%-12s", a.Severity))
+		sevStr = ui.DimStyle.Render(fmt.Sprintf("%-12s", severity))
 	}
 
 	sinceStr := ""
@@ -716,7 +722,7 @@ func renderAlertRow(a k8s.AlertInfo) string {
 		sinceStr = formatTimeAgo(a.Since)
 	}
 	sinceCol := ui.DimStyle.Render(fmt.Sprintf("%-14s", sinceStr))
-	nsCol := ui.DimStyle.Render(fmt.Sprintf("%-12s", a.Labels["namespace"]))
+	nsCol := ui.DimStyle.Render(fmt.Sprintf("%-12s", ui.SanitizeTerminalText(a.Labels["namespace"])))
 
 	return fmt.Sprintf("  %s %s %s %s", stateStr, sevStr, sinceCol, nsCol)
 }
@@ -731,7 +737,11 @@ func renderAlertLabels(lines []string, labels map[string]string, exclude map[str
 	}
 	sort.Strings(labelKeys)
 	for _, k := range labelKeys {
-		lines = append(lines, ui.DimStyle.Render(fmt.Sprintf("      %s=%s", k, labels[k])))
+		// Prometheus alert labels are attacker-controllable (a rule author
+		// or the metric source can set arbitrary label keys/values), so
+		// sanitize both sides before they hit the screen.
+		lines = append(lines, ui.DimStyle.Render(fmt.Sprintf("      %s=%s",
+			ui.SanitizeTerminalText(k), ui.SanitizeTerminalText(labels[k]))))
 	}
 	return lines
 }

--- a/internal/app/commands_dashboard_sanitize_test.go
+++ b/internal/app/commands_dashboard_sanitize_test.go
@@ -123,3 +123,26 @@ func TestRenderAlertRow_SanitizesUnknownStateAndSeverity(t *testing.T) {
 		})
 	}
 }
+
+// Count is read from the same Columns map as Reason, Object and Message, and
+// both dashboard event layouts interpolate it into the count label.
+func TestExtractEventFields_SanitizesCount(t *testing.T) {
+	payloads := map[string]struct{ payload, marker string }{
+		"OSC-52 clipboard write": {"\x1b]52;c;aGF4\a", "\x1b]"},
+		"bidi override":          {"\u202e", "\u202e"},
+	}
+
+	for name, tc := range payloads {
+		t.Run(name, func(t *testing.T) {
+			f := extractEventFields(model.Item{Columns: []model.KeyValue{
+				{Key: "Count", Value: "12" + tc.payload},
+			}})
+			if strings.Contains(f.count, tc.marker) {
+				t.Errorf("%s survived the Count field", name)
+			}
+			if strings.Contains(f.count, "\a") {
+				t.Errorf("%s: BEL survived", name)
+			}
+		})
+	}
+}

--- a/internal/app/commands_dashboard_sanitize_test.go
+++ b/internal/app/commands_dashboard_sanitize_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// hostileDashboardPayloads are the sequences TASK-880 sinks are driven with,
+// keyed so a failing assertion names the attack. Written as literal escapes
+// (not the invisible runes they represent) so a diff shows what leaked.
+var hostileDashboardPayloads = map[string]string{
+	"bidi override":         "\u202e",
+	"raw csi":               "\x1b[31m",
+	"csi screen erase":      "\x1b[2J",
+	"osc52 clipboard write": "\x1b]52;c;aGF4\x07",
+}
+
+func warningEventItem(payload string) model.Item {
+	return model.Item{
+		Name:      "pod-a",
+		Namespace: "ns" + payload,
+		Age:       "5m",
+		Columns: []model.KeyValue{
+			{Key: "Reason", Value: "CrashLoopBackOff" + payload},
+			{Key: "Object", Value: "pod/app" + payload},
+			{Key: "Message", Value: "back-off restarting" + payload},
+			{Key: "Count", Value: "1"},
+		},
+	}
+}
+
+// TestDashboardInlineEventsSection_SanitizesFields guards the single-column
+// RECENT WARNING EVENTS section: reason, object, and message all come from
+// a cluster Event resource via extractEventFields.
+func TestDashboardInlineEventsSection_SanitizesFields(t *testing.T) {
+	for name, payload := range hostileDashboardPayloads {
+		t.Run(name, func(t *testing.T) {
+			lines := dashboardInlineEventsSection(nil, []model.Item{warningEventItem(payload)}, dashboardWidths{sep: 40})
+			for _, line := range lines {
+				assert.NotContains(t, line, payload)
+			}
+		})
+	}
+}
+
+// TestDashboardEventsColumn_SanitizesFields guards the two-column layout's
+// dedicated events column, including the namespace label rendered directly
+// from ev.Namespace (not routed through extractEventFields).
+func TestDashboardEventsColumn_SanitizesFields(t *testing.T) {
+	for name, payload := range hostileDashboardPayloads {
+		t.Run(name, func(t *testing.T) {
+			lines := dashboardEventsColumn([]model.Item{warningEventItem(payload)})
+			for _, line := range lines {
+				assert.NotContains(t, line, payload)
+			}
+		})
+	}
+}
+
+// TestRenderAlertLabels_SanitizesKeysAndValues guards the Prometheus alert
+// label lines: both the label key and value are attacker-controllable
+// (a rule author or the metric source sets them).
+func TestRenderAlertLabels_SanitizesKeysAndValues(t *testing.T) {
+	for name, payload := range hostileDashboardPayloads {
+		t.Run(name, func(t *testing.T) {
+			labels := map[string]string{
+				"pod" + payload: "value" + payload,
+			}
+			lines := renderAlertLabels(nil, labels, nil)
+			for _, line := range lines {
+				assert.NotContains(t, line, payload)
+			}
+		})
+	}
+}
+
+// TestRenderAlertRow_SanitizesNamespaceLabel guards the alert row's
+// namespace column, built directly from a.Labels["namespace"].
+func TestRenderAlertRow_SanitizesNamespaceLabel(t *testing.T) {
+	for name, payload := range hostileDashboardPayloads {
+		t.Run(name, func(t *testing.T) {
+			a := k8s.AlertInfo{
+				State:    "firing",
+				Severity: "critical",
+				Labels:   map[string]string{"namespace": "ns" + payload},
+			}
+			out := renderAlertRow(a)
+			assert.NotContains(t, out, payload)
+		})
+	}
+}
+
+// The severity and state columns switch on the value and render it in every
+// branch. A value matching none of the known cases lands in the default
+// branch, which the earlier test could not reach because it passed "critical".
+func TestRenderAlertRow_SanitizesUnknownStateAndSeverity(t *testing.T) {
+	payloads := map[string]struct{ payload, marker string }{
+		"OSC-52 clipboard write": {"\x1b]52;c;aGF4\a", "\x1b]"},
+		"CSI erase display":      {"\x1b[2J", "\x1b[2J"},
+		"bidi override":          {"\u202e", "\u202e"},
+		"C1 control":             {"\u009b", "\u009b"},
+	}
+
+	for name, tc := range payloads {
+		t.Run(name, func(t *testing.T) {
+			row := renderAlertRow(k8s.AlertInfo{
+				Name:     "HighLatency",
+				State:    "odd" + tc.payload,     // matches no known case
+				Severity: "unusual" + tc.payload, // matches no known case
+				Labels:   map[string]string{"namespace": "prod"},
+			})
+			if strings.Contains(row, tc.marker) {
+				t.Errorf("%s survived the alert row", name)
+			}
+			if strings.Contains(row, "\a") {
+				t.Errorf("%s: BEL survived", name)
+			}
+		})
+	}
+}

--- a/internal/app/commands_dashboard_sections.go
+++ b/internal/app/commands_dashboard_sections.go
@@ -480,10 +480,12 @@ func dashboardNodesSection(lines []string, data dashboardData, w dashboardWidths
 	lines = append(lines, ui.DimStyle.Bold(true).Render("  NODES"))
 	lines = append(lines, "")
 
+	// Sanitize before measuring: a control character changes the width, and
+	// the old byte slice below could also cut a rune in half.
 	maxNameLen := 0
 	for _, n := range data.nodes {
-		if len(n.name) > maxNameLen {
-			maxNameLen = len(n.name)
+		if w := lipgloss.Width(ui.SanitizeTerminalText(n.name)); w > maxNameLen {
+			maxNameLen = w
 		}
 	}
 	if maxNameLen > 48 {
@@ -491,10 +493,7 @@ func dashboardNodesSection(lines []string, data dashboardData, w dashboardWidths
 	}
 
 	for _, n := range data.nodes {
-		name := n.name
-		if len(name) > maxNameLen {
-			name = name[:maxNameLen]
-		}
+		name := ui.Truncate(ui.SanitizeTerminalText(n.name), maxNameLen)
 		statusDot := nodeStatusDot(data.nodeItems, n.name)
 		roleStr := nodeRoleStr(data.nodeItems, n.name)
 
@@ -528,7 +527,7 @@ func nodeRoleStr(nodeItems []model.Item, name string) string {
 		if ni.Name == name {
 			for _, kv := range ni.Columns {
 				if kv.Key == "Role" && kv.Value != "" {
-					return " " + ui.DimStyle.Render("["+kv.Value+"]")
+					return " " + ui.DimStyle.Render("["+ui.SanitizeTerminalText(kv.Value)+"]")
 				}
 			}
 			return ""
@@ -564,8 +563,8 @@ func dashboardWarningBody(data dashboardData) []string {
 		for _, pw := range data.pdbWarnings {
 			out = append(out, fmt.Sprintf("  %s %s/%s",
 				ui.StatusProgressing.Render("⊘"),
-				ui.DimStyle.Render(pw.namespace),
-				ui.StatusProgressing.Render(pw.name)))
+				ui.DimStyle.Render(ui.SanitizeTerminalText(pw.namespace)),
+				ui.StatusProgressing.Render(ui.SanitizeTerminalText(pw.name))))
 			out = append(out, ui.DimStyle.Render(fmt.Sprintf("       MinAvail=%s  Healthy=%s  DisruptionsAllowed=%s",
 				pw.minAvailable, pw.currentHealthy, pw.disruptionsAllowed)))
 		}
@@ -623,16 +622,20 @@ type eventColumnFields struct {
 }
 
 // extractEventFields extracts common fields from an event's columns.
+// Reason/Object/Message come straight from a cluster Event resource and
+// render on a single dashboard line with no wrap support, so they're
+// sanitized here - the single place both dashboard event sections pull
+// from - before any caller truncates or measures their width.
 func extractEventFields(ev model.Item) eventColumnFields {
 	var f eventColumnFields
 	for _, kv := range ev.Columns {
 		switch kv.Key {
 		case "Reason":
-			f.reason = kv.Value
+			f.reason = ui.SanitizeTerminalText(kv.Value)
 		case "Object":
-			f.object = kv.Value
+			f.object = ui.SanitizeTerminalText(kv.Value)
 		case "Message":
-			f.message = kv.Value
+			f.message = ui.SanitizeTerminalText(kv.Value)
 		case "Count":
 			f.count = kv.Value
 		}
@@ -699,7 +702,7 @@ func dashboardEventsColumn(allWarningEvents []model.Item) []string {
 		}
 		nsLabel := ""
 		if ev.Namespace != "" {
-			nsLabel = ui.DimStyle.Render("[" + ev.Namespace + "] ")
+			nsLabel = ui.DimStyle.Render("[" + ui.SanitizeTerminalText(ev.Namespace) + "] ")
 		}
 		line := fmt.Sprintf("  %s %s %s%s%s %s",
 			ui.StatusProgressing.Render("⚠"),

--- a/internal/app/commands_dashboard_sections.go
+++ b/internal/app/commands_dashboard_sections.go
@@ -637,7 +637,7 @@ func extractEventFields(ev model.Item) eventColumnFields {
 		case "Message":
 			f.message = ui.SanitizeTerminalText(kv.Value)
 		case "Count":
-			f.count = kv.Value
+			f.count = ui.SanitizeTerminalText(kv.Value)
 		}
 	}
 	return f

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -470,8 +470,25 @@ func RenderColumn(header string, items []model.Item, cursor int, width, height i
 	return b.String()
 }
 
+// sanitizeItemText strips terminal control sequences from the cluster-sourced
+// fields of a row. The list columns show every object in a namespace, so a
+// hostile name, namespace or status reaches the screen here before anywhere
+// else (TASK-880). It rewrites the local copy so every use below is covered
+// without a call at each one, and it runs before any width measurement,
+// because sanitizing changes how wide the value is.
+func sanitizeItemText(item model.Item) model.Item {
+	item.Name = SanitizeTerminalText(item.Name)
+	item.Namespace = SanitizeTerminalText(item.Namespace)
+	item.Status = SanitizeTerminalText(item.Status)
+	item.Ready = SanitizeTerminalText(item.Ready)
+	item.Restarts = SanitizeTerminalText(item.Restarts)
+	item.Extra = SanitizeTerminalText(item.Extra)
+	return item
+}
+
 // FormatItem formats a single item for display in a column.
 func FormatItem(item model.Item, width int) string {
+	item = sanitizeItemText(item)
 	displayName := item.Name
 
 	// Prepend namespace in all-namespaces mode.
@@ -596,6 +613,7 @@ func FormatItem(item model.Item, width int) string {
 // FormatItemPlain formats a single item for display WITHOUT any inner ANSI styling.
 // Used for the selected item so the selection background renders cleanly.
 func FormatItemPlain(item model.Item, width int) string {
+	item = sanitizeItemText(item)
 	displayName := item.Name
 
 	// Prepend namespace in all-namespaces mode.

--- a/internal/ui/explorer_column_registry.go
+++ b/internal/ui/explorer_column_registry.go
@@ -71,10 +71,10 @@ var builtinColumns = []builtinColumn{
 		width:  func(w builtinColWidths) int { return w.ns },
 		header: func(h builtinColHeaders) string { return h.ns },
 		plain: func(p plainCellInputs) string {
-			return padRight(Truncate(p.ns, p.widths.ns-1), p.widths.ns)
+			return padRight(Truncate(SanitizeTerminalText(p.ns), p.widths.ns-1), p.widths.ns)
 		},
 		styled: func(s styledCellInputs) string {
-			ns := s.item.Namespace
+			ns := SanitizeTerminalText(s.item.Namespace)
 			if ns == "" {
 				ns = "-"
 			}
@@ -86,10 +86,10 @@ var builtinColumns = []builtinColumn{
 		width:  func(w builtinColWidths) int { return w.ready },
 		header: func(h builtinColHeaders) string { return h.ready },
 		plain: func(p plainCellInputs) string {
-			return padRight(p.ready, p.widths.ready)
+			return padRight(SanitizeTerminalText(p.ready), p.widths.ready)
 		},
 		styled: func(s styledCellInputs) string {
-			return DimStyle.Render(padRight(s.item.Ready, s.widths.ready))
+			return DimStyle.Render(padRight(SanitizeTerminalText(s.item.Ready), s.widths.ready))
 		},
 	},
 	{
@@ -108,10 +108,12 @@ var builtinColumns = []builtinColumn{
 		width:  func(w builtinColWidths) int { return w.status },
 		header: func(h builtinColHeaders) string { return h.status },
 		plain: func(p plainCellInputs) string {
-			return padRight(Truncate(AbbreviateStatusForWidth(p.status, p.widths.status-1), p.widths.status-1), p.widths.status)
+			status := SanitizeTerminalText(p.status)
+			return padRight(Truncate(AbbreviateStatusForWidth(status, p.widths.status-1), p.widths.status-1), p.widths.status)
 		},
 		styled: func(s styledCellInputs) string {
-			val := AbbreviateStatusForWidth(s.item.Status, s.widths.status-1)
+			status := SanitizeTerminalText(s.item.Status)
+			val := AbbreviateStatusForWidth(status, s.widths.status-1)
 			return StatusStyle(val).Render(padRight(Truncate(val, s.widths.status-1), s.widths.status))
 		},
 	},

--- a/internal/ui/explorer_column_registry_test.go
+++ b/internal/ui/explorer_column_registry_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
 )
 
 // --- renderableBuiltin ---
@@ -95,4 +97,57 @@ func TestBuiltinColumnsRegistryHasExpectedKeys(t *testing.T) {
 	}
 	assert.Len(t, builtinColumns, len(expected), "registry entry count drifted from expected set")
 	assert.Equal(t, expected, got, "registry keys drifted from expected set")
+}
+
+// --- sanitization: TASK-880 ---
+
+// registryHostilePayloads mirrors explorer_format_test.go's hostilePayloads:
+// a bidi override, a raw CSI sequence, and an OSC-52 clipboard write.
+var registryHostilePayloads = map[string]string{
+	"bidi override": "ab\u202ecd",
+	"raw CSI":       "ab\x1b[2Jcd",
+	"OSC-52":        "ab\x1b]52;c;aGF4\x07cd",
+}
+
+func assertRegistryCellClean(t *testing.T, out string) {
+	t.Helper()
+	assert.NotContains(t, out, "\u202e")
+	assert.NotContains(t, out, "\x1b[2J")
+	assert.NotContains(t, out, "\x1b]52")
+}
+
+func TestBuiltinColumns_NamespaceCellSanitizes(t *testing.T) {
+	widths := builtinColWidths{ns: 20}
+	col := builtinColumnsByKey["Namespace"]
+	for name, payload := range registryHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			assertRegistryCellClean(t, col.plain(plainCellInputs{ns: payload, widths: widths}))
+			assertRegistryCellClean(t, col.styled(styledCellInputs{item: model.Item{Namespace: payload}, widths: widths}))
+		})
+	}
+	assert.Contains(t, col.plain(plainCellInputs{ns: "default", widths: widths}), "default")
+}
+
+func TestBuiltinColumns_ReadyCellSanitizes(t *testing.T) {
+	widths := builtinColWidths{ready: 10}
+	col := builtinColumnsByKey["Ready"]
+	for name, payload := range registryHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			assertRegistryCellClean(t, col.plain(plainCellInputs{ready: payload, widths: widths}))
+			assertRegistryCellClean(t, col.styled(styledCellInputs{item: model.Item{Ready: payload}, widths: widths}))
+		})
+	}
+	assert.Contains(t, col.plain(plainCellInputs{ready: "1/1", widths: widths}), "1/1")
+}
+
+func TestBuiltinColumns_StatusCellSanitizes(t *testing.T) {
+	widths := builtinColWidths{status: 20}
+	col := builtinColumnsByKey["Status"]
+	for name, payload := range registryHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			assertRegistryCellClean(t, col.plain(plainCellInputs{status: "Running" + payload, widths: widths}))
+			assertRegistryCellClean(t, col.styled(styledCellInputs{item: model.Item{Status: "Running" + payload}, widths: widths}))
+		})
+	}
+	assert.Contains(t, col.plain(plainCellInputs{status: "Running", widths: widths}), "Running")
 }

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -88,7 +88,7 @@ func plainExtraCell(ec extraColumn, item *model.Item) string {
 	if item == nil {
 		val = ColumnHeaderLabel(ec.key) + sortIndicatorForColumn(ec.key)
 	} else {
-		val = GetExtraColumnValue(item, ec.key)
+		val = SanitizeTerminalText(GetExtraColumnValue(item, ec.key))
 	}
 	switch {
 	case strings.HasPrefix(val, "↑ ") || strings.HasPrefix(val, "↓ "):
@@ -104,7 +104,7 @@ func plainExtraCell(ec extraColumn, item *model.Item) string {
 
 // styledExtraCell builds the styled cell for a single extra column.
 func styledExtraCell(ec extraColumn, item *model.Item) string {
-	val := GetExtraColumnValue(item, ec.key)
+	val := SanitizeTerminalText(GetExtraColumnValue(item, ec.key))
 	style := resourceColumnStyle(ec.key, val)
 	switch {
 	case strings.HasPrefix(val, "↑ "):
@@ -160,19 +160,20 @@ func AbbreviateStatusForWidth(status string, w int) string {
 // an up-arrow; when any row in the table has a recent restart, rows without
 // one get a space prefix so values remain column-aligned.
 func styledRestartsCell(item model.Item, restartsW int, anyRecentRestart bool) string {
-	restartCount, _ := strconv.Atoi(item.Restarts)
+	restarts := SanitizeTerminalText(item.Restarts)
+	restartCount, _ := strconv.Atoi(restarts)
 	recentRestart := !item.LastRestartAt.IsZero() && time.Since(item.LastRestartAt) < time.Hour
 	switch {
 	case restartCount > 0 && recentRestart:
-		restartText := "↑" + item.Restarts
+		restartText := "↑" + restarts
 		if restartCount >= 5 {
 			return ErrorStyle.Render(padRight(restartText, restartsW))
 		}
 		return StatusFailed.Render(padRight(restartText, restartsW))
 	case anyRecentRestart:
-		return DimStyle.Render(padRight(" "+item.Restarts, restartsW))
+		return DimStyle.Render(padRight(" "+restarts, restartsW))
 	default:
-		return DimStyle.Render(padRight(item.Restarts, restartsW))
+		return DimStyle.Render(padRight(restarts, restartsW))
 	}
 }
 
@@ -180,15 +181,16 @@ func styledRestartsCell(item model.Item, restartsW int, anyRecentRestart bool) s
 // (cursor row, tinted rows): an up-arrow tags the item's own recent restart,
 // and a space keeps alignment when any other row has one.
 func plainRestartsCell(item model.Item, anyRecentRestart bool) string {
-	restartCount, _ := strconv.Atoi(item.Restarts)
+	restarts := SanitizeTerminalText(item.Restarts)
+	restartCount, _ := strconv.Atoi(restarts)
 	recentRestart := !item.LastRestartAt.IsZero() && time.Since(item.LastRestartAt) < time.Hour
 	switch {
 	case restartCount > 0 && recentRestart:
-		return "↑" + item.Restarts
+		return "↑" + restarts
 	case anyRecentRestart:
-		return " " + item.Restarts
+		return " " + restarts
 	default:
-		return item.Restarts
+		return restarts
 	}
 }
 
@@ -259,6 +261,7 @@ func formatTableRowStyledOrdered(item model.Item,
 // Used for cursor rows where the highlighted background must not collide
 // with ANSI styling embedded in the badge string.
 func plainNameCellWithBadge(name string, item *model.Item, nameW int) string {
+	name = SanitizeTerminalText(name)
 	badge := ""
 	if item != nil {
 		badge = securityBadgePlainForItem(item)
@@ -287,6 +290,8 @@ func plainNameCellWithBadge(name string, item *model.Item, nameW int) string {
 // truncated to make room). Gated callers (ActiveSecurityAvailable == false)
 // get an empty badge and the row renders identically to the pre-security UI.
 func styledNameCell(item model.Item, nameW int, nameOverride *lipgloss.Style) string {
+	// item is passed by value, so sanitizing in place is local to this cell.
+	item.Name = SanitizeTerminalText(item.Name)
 	// Ignored security findings (revealed by the show-ignored toggle, tagged
 	// __ignored__ by groupFindings / GetSecurityAffectedResources) are dimmed
 	// so they read as de-emphasized next to active findings.

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -591,5 +591,7 @@ func ColumnHeaderLabel(key string) string {
 	if alias, ok := columnHeaderAliases[key]; ok {
 		return strings.ToUpper(alias)
 	}
-	return strings.ToUpper(key)
+	// key can be a CRD condition type or printer-column name (cluster-sourced)
+	// promoted into a table HEADER; sanitize before it reaches the screen.
+	return strings.ToUpper(SanitizeTerminalText(key))
 }

--- a/internal/ui/explorer_format_columns_test.go
+++ b/internal/ui/explorer_format_columns_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/janosmiko/lfk/internal/model"
@@ -349,5 +350,29 @@ func TestCollectExtraColumns_NonCRDUnaffected(t *testing.T) {
 	cols := collectExtraColumns(items, 120, 20, "Service")
 	if !containsKey(cols, "Ports") || !containsKey(cols, "Replicas") {
 		t.Errorf("expected Ports and Replicas columns, got %v", keysOf(cols))
+	}
+}
+
+// --- ColumnHeaderLabel: TASK-880 ---
+
+// TestColumnHeaderLabel_SanitizesKey guards the one sink where a cluster
+// string (a CRD condition type or printer-column name) is promoted straight
+// into a table HEADER, rendered ahead of any Truncate/width measurement.
+func TestColumnHeaderLabel_SanitizesKey(t *testing.T) {
+	tests := map[string]string{
+		"bidi override": "cond\u202eType",
+		"raw CSI":       "cond\x1b[2JType",
+		"OSC-52":        "cond\x1b]52;c;aGF4\x07Type",
+	}
+	for name, key := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := ColumnHeaderLabel(key)
+			if strings.Contains(out, "\u202e") || strings.Contains(out, "\x1b[2J") || strings.Contains(out, "\x1b]52") {
+				t.Errorf("hostile sequence survived ColumnHeaderLabel: %q", out)
+			}
+		})
+	}
+	if got := ColumnHeaderLabel("Ingress Class"); got != "CLASS" {
+		t.Errorf("alias lookup regressed: got %q, want CLASS", got)
 	}
 }

--- a/internal/ui/explorer_format_test.go
+++ b/internal/ui/explorer_format_test.go
@@ -631,3 +631,91 @@ func TestRenderStyledHeader_TruncatesToWidth(t *testing.T) {
 	assert.Equal(t, 6, lipgloss.Width(ansi.Strip(out)+""))
 	assert.LessOrEqual(t, lipgloss.Width(out), 6)
 }
+
+// --- sanitization: TASK-880 ---
+
+// formatHostilePayloads are cluster-controlled strings carrying a terminal attack:
+// a bidi override reorders rendered text, a raw CSI sequence can rewrite the
+// screen, and OSC-52 writes the operator's clipboard.
+var formatHostilePayloads = map[string]string{
+	"bidi override": "ab\u202ecd",
+	"raw CSI":       "ab\x1b[2Jcd",
+	"OSC-52":        "ab\x1b]52;c;aGF4\x07cd",
+}
+
+func TestPlainNameCellWithBadge_SanitizesName(t *testing.T) {
+	for name, payload := range formatHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			out := plainNameCellWithBadge(payload, nil, 40)
+			assert.NotContains(t, out, "\u202e")
+			assert.NotContains(t, out, "\x1b[2J")
+			assert.NotContains(t, out, "\x1b]52")
+			assert.Contains(t, out, "ab")
+			assert.Contains(t, out, "cd")
+		})
+	}
+	assert.Contains(t, plainNameCellWithBadge("nginx", nil, 40), "nginx")
+}
+
+func TestStyledNameCell_SanitizesName(t *testing.T) {
+	for name, payload := range formatHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := model.Item{Name: payload}
+			out := styledNameCell(item, 40, nil)
+			assert.NotContains(t, out, "\u202e")
+			assert.NotContains(t, out, "\x1b[2J")
+			assert.NotContains(t, out, "\x1b]52")
+		})
+	}
+	assert.Contains(t, stripANSI(styledNameCell(model.Item{Name: "nginx"}, 40, nil)), "nginx")
+}
+
+func TestPlainExtraCell_SanitizesValue(t *testing.T) {
+	ec := extraColumn{key: "IP", width: 20}
+	for name, payload := range formatHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{Columns: []model.KeyValue{{Key: "IP", Value: payload}}}
+			out := plainExtraCell(ec, item)
+			assert.NotContains(t, out, "\u202e")
+			assert.NotContains(t, out, "\x1b[2J")
+			assert.NotContains(t, out, "\x1b]52")
+		})
+	}
+	item := &model.Item{Columns: []model.KeyValue{{Key: "IP", Value: "10.0.0.1"}}}
+	assert.Contains(t, plainExtraCell(ec, item), "10.0.0.1")
+}
+
+func TestStyledExtraCell_SanitizesValue(t *testing.T) {
+	ec := extraColumn{key: "IP", width: 20}
+	for name, payload := range formatHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{Columns: []model.KeyValue{{Key: "IP", Value: payload}}}
+			out := styledExtraCell(ec, item)
+			assert.NotContains(t, out, "\u202e")
+			assert.NotContains(t, out, "\x1b[2J")
+			assert.NotContains(t, out, "\x1b]52")
+		})
+	}
+	item := &model.Item{Columns: []model.KeyValue{{Key: "IP", Value: "10.0.0.1"}}}
+	assert.Contains(t, stripANSI(styledExtraCell(ec, item)), "10.0.0.1")
+}
+
+func TestRestartsCells_SanitizeValue(t *testing.T) {
+	for name, payload := range formatHostilePayloads {
+		t.Run("styled/"+name, func(t *testing.T) {
+			item := model.Item{Restarts: "0" + payload}
+			out := styledRestartsCell(item, 20, false)
+			assert.NotContains(t, out, "\u202e")
+			assert.NotContains(t, out, "\x1b[2J")
+			assert.NotContains(t, out, "\x1b]52")
+		})
+		t.Run("plain/"+name, func(t *testing.T) {
+			item := model.Item{Restarts: "0" + payload}
+			out := plainRestartsCell(item, false)
+			assert.NotContains(t, out, "\u202e")
+			assert.NotContains(t, out, "\x1b[2J")
+			assert.NotContains(t, out, "\x1b]52")
+		})
+	}
+	assert.Contains(t, stripANSI(styledRestartsCell(model.Item{Restarts: "3"}, 20, false)), "3")
+}

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -91,7 +91,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 			continue
 		}
 		if strings.HasPrefix(kv.Key, "secret:") {
-			label := kv.Key[len("secret:"):]
+			label := SanitizeTerminalText(kv.Key[len("secret:"):])
 			if ActiveShowSecretValues {
 				dataLines = append(dataLines, renderDataKV(label, kv.Value, width)...)
 			} else {
@@ -101,14 +101,14 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 			continue
 		}
 		if strings.HasPrefix(kv.Key, "data:") {
-			label := kv.Key[len("data:"):]
+			label := SanitizeTerminalText(kv.Key[len("data:"):])
 			dataLines = append(dataLines, renderDataKV(label, kv.Value, width)...)
 			dataKeyCount++
 			continue
 		}
 		if strings.HasPrefix(kv.Key, "condition:") {
-			label := kv.Key[len("condition:"):]
-			statusRows = append(statusRows, detailRow{strings.ToUpper(label), kv.Value})
+			label := SanitizeTerminalText(kv.Key[len("condition:"):])
+			statusRows = append(statusRows, detailRow{strings.ToUpper(label), SanitizeTerminalText(kv.Value)})
 			continue
 		}
 		if strings.HasPrefix(kv.Key, "step:") {
@@ -133,7 +133,15 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 				val = FormatMemory(bytes)
 			}
 		}
-		row := detailRow{strings.ToUpper(kv.Key), val}
+		// Message/Reason/Health Message are free-text and may carry embedded
+		// SGR colour worth keeping; everything else is a short structured
+		// field value, so the plain single-line sanitizer is enough.
+		if messageKeys[kv.Key] {
+			val = SanitizeLogBody(StripBidiOverrides(val), true)
+		} else {
+			val = SanitizeTerminalText(val)
+		}
+		row := detailRow{strings.ToUpper(SanitizeTerminalText(kv.Key)), val}
 		switch {
 		case statusKeys[kv.Key]:
 			statusRows = append(statusRows, row)
@@ -240,10 +248,11 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		if kv.Key == "Endpoints" {
 			sep = "\n"
 		}
-		for entry := range strings.SplitSeq(kv.Value, sep) {
+		for rawEntry := range strings.SplitSeq(kv.Value, sep) {
 			if len(lines) >= height {
 				break
 			}
+			entry := SanitizeLogBody(StripBidiOverrides(rawEntry), true)
 			maxW := max(width-4, 10)
 			entryRunes := []rune(entry)
 			if len(entryRunes) <= maxW {
@@ -287,7 +296,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		// capped so a single long type can't push everything off-screen.
 		typeWidth := 0
 		for _, cond := range item.Conditions {
-			if w := len([]rune(cond.Type)); w > typeWidth {
+			if w := len([]rune(SanitizeTerminalText(cond.Type))); w > typeWidth {
 				typeWidth = w
 			}
 		}
@@ -301,24 +310,27 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 			// Color the type/status by condition polarity (see ConditionStyle).
 			style := ConditionStyle(cond.Type, cond.Status)
 
-			status := cond.Status
+			condType := SanitizeTerminalText(cond.Type)
+			status := SanitizeTerminalText(cond.Status)
 			if status == "" {
 				status = "Unknown"
 			}
-			pad := max(typeWidth-len([]rune(cond.Type)), 0)
-			header := "  " + style.Render(cond.Type) + strings.Repeat(" ", pad+1) + style.Render(status)
+			pad := max(typeWidth-len([]rune(condType)), 0)
+			header := "  " + style.Render(condType) + strings.Repeat(" ", pad+1) + style.Render(status)
 			if age := FormatAge(cond.LastTransitionTime); age != "-" {
 				header += "  " + DimStyle.Render(age)
 			}
 			lines = append(lines, header)
 
-			if cond.Reason != "" && len(lines) < height {
-				lines = append(lines, "    "+DimStyle.Render(cond.Reason))
+			reason := SanitizeTerminalText(cond.Reason)
+			if reason != "" && len(lines) < height {
+				lines = append(lines, "    "+DimStyle.Render(reason))
 			}
 
-			if cond.Message != "" {
+			message := SanitizeLogBody(StripBidiOverrides(cond.Message), true)
+			if message != "" {
 				maxW := max(width-6, 10)
-				for _, seg := range wrapText(cond.Message, maxW) {
+				for _, seg := range wrapText(message, maxW) {
 					if len(lines) >= height {
 						break
 					}
@@ -342,8 +354,8 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 			if len(lines) >= height {
 				break
 			}
-			stepName := kv.Key[len("step:"):]
-			phase := kv.Value
+			stepName := SanitizeTerminalText(kv.Key[len("step:"):])
+			phase := SanitizeTerminalText(kv.Value)
 			// Color based on phase.
 			phaseStyle := DimStyle
 			switch {
@@ -384,16 +396,16 @@ type identityRow struct {
 func identityRowsFor(item *model.Item) []identityRow {
 	var rows []identityRow
 	if item.Name != "" {
-		rows = append(rows, identityRow{"NAME", item.Name})
+		rows = append(rows, identityRow{"NAME", SanitizeTerminalText(item.Name)})
 	}
 	if item.Namespace != "" {
-		rows = append(rows, identityRow{"NAMESPACE", item.Namespace})
+		rows = append(rows, identityRow{"NAMESPACE", SanitizeTerminalText(item.Namespace)})
 	}
 	if item.Deleting {
 		val := "Terminating"
 		for _, kv := range item.Columns {
 			if kv.Key == "Deletion" || kv.Key == "DELETION" {
-				val = kv.Value
+				val = SanitizeTerminalText(kv.Value)
 				break
 			}
 		}
@@ -470,6 +482,17 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 	if len(events) > maxEvents {
 		events = events[:maxEvents]
 	}
+
+	// Sanitize into a fresh slice (never mutate the caller's backing array)
+	// before either the width-measurement pass or the render pass reads
+	// Reason/Message — both derive column widths from these values.
+	sanitizedEvents := make([]EventTimelineEntry, len(events))
+	for i, e := range events {
+		e.Reason = SanitizeTerminalText(e.Reason)
+		e.Message = SanitizeLogBody(StripBidiOverrides(e.Message), true)
+		sanitizedEvents[i] = e
+	}
+	events = sanitizedEvents
 
 	// Calculate column widths for alignment.
 	// Format: AGE  TYPE  REASON  MESSAGE  (xCount)?
@@ -616,15 +639,18 @@ func renderDataKV(key, value string, width int) []string {
 	value = strings.ReplaceAll(value, `\t`, "\t")
 
 	if !strings.Contains(value, "\n") {
-		return []string{renderKV(key, value, width)}
+		return []string{renderKV(key, SanitizeLogBody(StripBidiOverrides(value), true), width)}
 	}
 	// Multiline: render key on its own line, then indented value lines.
+	// Sanitize per-line (post-split): the body sanitizer treats a bare '\n'
+	// as a stray control byte and would collapse the very newlines this
+	// branch just expanded, if run on the joined value.
 	header := HeaderStyle.Render(key + ":")
 	lines := []string{header}
 	indent := "  "
 	maxVal := max(width-len(indent)-1, 4)
 	for vline := range strings.SplitSeq(value, "\n") {
-		rendered := vline
+		rendered := SanitizeLogBody(StripBidiOverrides(vline), true)
 		if len(rendered) > maxVal {
 			rendered = rendered[:maxVal-3] + "..."
 		}
@@ -672,13 +698,17 @@ func RenderResourceTree(root *model.ResourceNode, width, height int) string {
 // parentNamespace is used to conditionally show the namespace when it differs
 // from the parent node.
 func renderTreeNodeLabel(node *model.ResourceNode, parentNamespace string) string {
+	name := SanitizeTerminalText(node.Name)
+	namespace := SanitizeTerminalText(node.Namespace)
+	parentNS := SanitizeTerminalText(parentNamespace)
+
 	// Use YamlKeyStyle (bold + primary + themed background) for the kind prefix.
 	// OverlayTitleStyle has bottom padding which breaks tree indentation.
-	label := YamlKeyStyle.Render(node.Kind+"/") + NormalStyle.Render(node.Name)
+	label := YamlKeyStyle.Render(node.Kind+"/") + NormalStyle.Render(name)
 
 	// Show namespace when it differs from the parent.
-	if node.Namespace != "" && node.Namespace != parentNamespace {
-		label += " " + DimStyle.Render("(ns: "+node.Namespace+")")
+	if namespace != "" && namespace != parentNS {
+		label += " " + DimStyle.Render("(ns: "+namespace+")")
 	}
 
 	// Show child count for nodes that have children. Pods can have a mix of
@@ -710,7 +740,8 @@ func renderTreeNodeLabel(node *model.ResourceNode, parentNamespace string) strin
 	}
 
 	if node.Status != "" {
-		label += " " + StatusStyle(node.Status).Render("["+node.Status+"]")
+		status := SanitizeTerminalText(node.Status)
+		label += " " + StatusStyle(status).Render("["+status+"]")
 	}
 	return label
 }

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -137,7 +137,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		// SGR colour worth keeping; everything else is a short structured
 		// field value, so the plain single-line sanitizer is enough.
 		if messageKeys[kv.Key] {
-			val = SanitizeLogBody(StripBidiOverrides(val), true)
+			val = SanitizeLogBody(StripBidiOverrides(val), false)
 		} else {
 			val = SanitizeTerminalText(val)
 		}
@@ -252,7 +252,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 			if len(lines) >= height {
 				break
 			}
-			entry := SanitizeLogBody(StripBidiOverrides(rawEntry), true)
+			entry := SanitizeLogBody(StripBidiOverrides(rawEntry), false)
 			maxW := max(width-4, 10)
 			entryRunes := []rune(entry)
 			if len(entryRunes) <= maxW {
@@ -327,7 +327,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 				lines = append(lines, "    "+DimStyle.Render(reason))
 			}
 
-			message := SanitizeLogBody(StripBidiOverrides(cond.Message), true)
+			message := SanitizeLogBody(StripBidiOverrides(cond.Message), false)
 			if message != "" {
 				maxW := max(width-6, 10)
 				for _, seg := range wrapText(message, maxW) {
@@ -489,7 +489,7 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 	sanitizedEvents := make([]EventTimelineEntry, len(events))
 	for i, e := range events {
 		e.Reason = SanitizeTerminalText(e.Reason)
-		e.Message = SanitizeLogBody(StripBidiOverrides(e.Message), true)
+		e.Message = SanitizeLogBody(StripBidiOverrides(e.Message), false)
 		sanitizedEvents[i] = e
 	}
 	events = sanitizedEvents
@@ -639,7 +639,7 @@ func renderDataKV(key, value string, width int) []string {
 	value = strings.ReplaceAll(value, `\t`, "\t")
 
 	if !strings.Contains(value, "\n") {
-		return []string{renderKV(key, SanitizeLogBody(StripBidiOverrides(value), true), width)}
+		return []string{renderKV(key, SanitizeLogBody(StripBidiOverrides(value), false), width)}
 	}
 	// Multiline: render key on its own line, then indented value lines.
 	// Sanitize per-line (post-split): the body sanitizer treats a bare '\n'
@@ -650,7 +650,7 @@ func renderDataKV(key, value string, width int) []string {
 	indent := "  "
 	maxVal := max(width-len(indent)-1, 4)
 	for vline := range strings.SplitSeq(value, "\n") {
-		rendered := SanitizeLogBody(StripBidiOverrides(vline), true)
+		rendered := SanitizeLogBody(StripBidiOverrides(vline), false)
 		if len(rendered) > maxVal {
 			rendered = rendered[:maxVal-3] + "..."
 		}

--- a/internal/ui/explorer_resource_test.go
+++ b/internal/ui/explorer_resource_test.go
@@ -631,3 +631,174 @@ func TestRenderMinimalSummaryNoIdentity(t *testing.T) {
 	result := stripANSI(RenderResourceSummary(&model.Item{}, "", 60, 20))
 	assert.Contains(t, result, "No preview")
 }
+
+// --- sanitization: TASK-880 ---
+
+// resourceHostilePayloads mirrors the payload set used across the other
+// TASK-880 sanitization tests.
+var resourceHostilePayloads = map[string]string{
+	"bidi override": "ab\u202ecd",
+	"raw CSI":       "ab\x1b[2Jcd",
+	"OSC-52":        "ab\x1b]52;c;aGF4\x07cd",
+}
+
+func assertResourceClean(t *testing.T, out string) {
+	t.Helper()
+	assert.NotContains(t, out, "\u202e", "bidi override must not survive")
+	assert.NotContains(t, out, "\x1b[2J", "CSI erase display must not survive")
+	assert.NotContains(t, out, "\x1b]52", "OSC-52 clipboard write must not survive")
+}
+
+func TestRenderResourceSummary_IdentityRowsSanitized(t *testing.T) {
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{Name: "pod" + payload, Namespace: "ns" + payload, Deleting: true}
+			out := RenderResourceSummary(item, "", 80, 30)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+func TestRenderResourceSummary_DetailRowsSanitized(t *testing.T) {
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{
+				Name: "svc-1",
+				Columns: []model.KeyValue{
+					{Key: "Health" + payload, Value: "Healthy" + payload},
+					{Key: "Reason", Value: "Started" + payload},
+					{Key: "Message", Value: "back-off restarting" + payload},
+					{Key: "condition:Ready" + payload, Value: "True" + payload},
+				},
+			}
+			out := RenderResourceSummary(item, "", 100, 40)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+func TestRenderResourceSummary_MultiLineFieldsSanitized(t *testing.T) {
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{
+				Name: "svc-1",
+				Columns: []model.KeyValue{
+					{Key: "Labels", Value: "app=web" + payload + ", tier=frontend"},
+					{Key: "Endpoints", Value: "10.0.0.1:80" + payload + "\n10.0.0.2:80"},
+					{Key: "Taints", Value: "node-role.kubernetes.io/master" + payload},
+				},
+			}
+			out := RenderResourceSummary(item, "", 100, 40)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+func TestRenderResourceSummary_ConditionsSanitized(t *testing.T) {
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{
+				Name:    "deploy-1",
+				Columns: []model.KeyValue{{Key: "Node", Value: "node-1"}},
+				Conditions: []model.ConditionEntry{
+					{Type: "Available" + payload, Status: "True" + payload, Reason: "MinimumReplicas" + payload, Message: "Deployment has minimum availability" + payload},
+				},
+			}
+			out := RenderResourceSummary(item, "", 100, 40)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+func TestRenderResourceSummary_StepsSanitized(t *testing.T) {
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{
+				Name: "workflow-1",
+				Columns: []model.KeyValue{
+					{Key: "step:build" + payload, Value: "Succeeded" + payload},
+				},
+			}
+			out := RenderResourceSummary(item, "", 100, 40)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+func TestRenderResourceSummary_SecretDataSanitized(t *testing.T) {
+	prev := ActiveShowSecretValues
+	t.Cleanup(func() { ActiveShowSecretValues = prev })
+	ActiveShowSecretValues = true
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{
+				Name: "secret-1",
+				Columns: []model.KeyValue{
+					{Key: "secret:token" + payload, Value: "s3cr3t" + payload},
+					{Key: "data:config.yaml" + payload, Value: "line1\\nline2" + payload},
+				},
+			}
+			out := RenderResourceSummary(item, "", 100, 40)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+func TestRenderPreviewEvents_Sanitized(t *testing.T) {
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			events := []EventTimelineEntry{{
+				Timestamp: time.Now(),
+				Type:      "Warning",
+				Reason:    "BackOff" + payload,
+				Message:   "Back-off restarting failed container" + payload,
+				Count:     1,
+			}}
+			out := RenderPreviewEvents(events, 100)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+func TestRenderResourceTree_LabelsSanitized(t *testing.T) {
+	for name, payload := range resourceHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			root := &model.ResourceNode{
+				Name: "pod" + payload, Kind: "Pod", Namespace: "ns" + payload,
+				Status: "Running" + payload,
+				Children: []*model.ResourceNode{
+					{Name: "child" + payload, Kind: "Container", Namespace: "other-ns" + payload, Status: "Ready" + payload},
+				},
+			}
+			out := RenderResourceTree(root, 120, 30)
+			assertResourceClean(t, out)
+		})
+	}
+}
+
+// TestBodySanitizerPathsKeepColour guards against closing these sinks with
+// the blunt single-line sanitizer where the ANSI-aware body sanitizer
+// belongs: SGR colour in a condition message and a Labels entry must still
+// render, or trivy/helm-style colored output turns to plain text.
+func TestBodySanitizerPathsKeepColour(t *testing.T) {
+	const red = "\x1b[31mFAILED\x1b[0m"
+
+	t.Run("condition message", func(t *testing.T) {
+		item := &model.Item{
+			Name:       "deploy-1",
+			Columns:    []model.KeyValue{{Key: "Node", Value: "node-1"}},
+			Conditions: []model.ConditionEntry{{Type: "Available", Status: "False", Message: red}},
+		}
+		out := RenderResourceSummary(item, "", 100, 40)
+		assert.Contains(t, out, "[31m")
+	})
+
+	t.Run("Labels entry", func(t *testing.T) {
+		item := &model.Item{
+			Name:    "svc-1",
+			Columns: []model.KeyValue{{Key: "Labels", Value: red}},
+		}
+		out := RenderResourceSummary(item, "", 100, 40)
+		assert.Contains(t, out, "[31m")
+	})
+}

--- a/internal/ui/explorer_resource_test.go
+++ b/internal/ui/explorer_resource_test.go
@@ -776,29 +776,36 @@ func TestRenderResourceTree_LabelsSanitized(t *testing.T) {
 	}
 }
 
-// TestBodySanitizerPathsKeepColour guards against closing these sinks with
-// the blunt single-line sanitizer where the ANSI-aware body sanitizer
-// belongs: SGR colour in a condition message and a Labels entry must still
-// render, or trivy/helm-style colored output turns to plain text.
-func TestBodySanitizerPathsKeepColour(t *testing.T) {
+// The preview pane deliberately does NOT keep SGR. Cluster metadata has no
+// business colouring the pane, and keeping the escape is what let the rune and
+// byte slicing further down count escape bytes as visible width, which broke
+// alignment in a narrow pane. The escape is replaced with U+FFFD, the same
+// marker the log viewer shows for any other non-printable byte, so the value
+// reads as suspect instead of being obeyed.
+//
+// Asserting on "[31m" alone would prove nothing: that printable tail survives
+// either way. The ESC is what matters.
+func TestPreviewBodyPathsDropTheEscape(t *testing.T) {
 	const red = "\x1b[31mFAILED\x1b[0m"
+	const escSGR = "\x1b[31m"
 
-	t.Run("condition message", func(t *testing.T) {
-		item := &model.Item{
+	cases := map[string]*model.Item{
+		"condition message": {
 			Name:       "deploy-1",
 			Columns:    []model.KeyValue{{Key: "Node", Value: "node-1"}},
 			Conditions: []model.ConditionEntry{{Type: "Available", Status: "False", Message: red}},
-		}
-		out := RenderResourceSummary(item, "", 100, 40)
-		assert.Contains(t, out, "[31m")
-	})
-
-	t.Run("Labels entry", func(t *testing.T) {
-		item := &model.Item{
+		},
+		"Labels entry": {
 			Name:    "svc-1",
 			Columns: []model.KeyValue{{Key: "Labels", Value: red}},
-		}
-		out := RenderResourceSummary(item, "", 100, 40)
-		assert.Contains(t, out, "[31m")
-	})
+		},
+	}
+
+	for name, item := range cases {
+		t.Run(name, func(t *testing.T) {
+			out := RenderResourceSummary(item, "", 100, 40)
+			assert.NotContains(t, out, escSGR, "the escape must not reach the pane")
+			assert.Contains(t, out, "\ufffd", "and the byte it stood for is marked, not dropped silently")
+		})
+	}
 }

--- a/internal/ui/explorer_table_format.go
+++ b/internal/ui/explorer_table_format.go
@@ -51,8 +51,8 @@ func RenderContainerDetail(item *model.Item, width, height int) string {
 
 	maxKeyLen := 0
 	for _, r := range rows {
-		if len(r.key) > maxKeyLen {
-			maxKeyLen = len(r.key)
+		if w := lipgloss.Width(r.key); w > maxKeyLen {
+			maxKeyLen = w
 		}
 	}
 
@@ -63,7 +63,7 @@ func RenderContainerDetail(item *model.Item, width, height int) string {
 		if len(lines) >= height-1 {
 			break
 		}
-		padded := r.key + ": " + strings.Repeat(" ", maxKeyLen-len(r.key))
+		padded := r.key + ": " + strings.Repeat(" ", maxKeyLen-lipgloss.Width(r.key))
 		lines = append(lines, labelStyle.Render(padded)+r.style.Render(r.value))
 	}
 

--- a/internal/ui/explorer_table_format.go
+++ b/internal/ui/explorer_table_format.go
@@ -20,22 +20,23 @@ func RenderContainerDetail(item *model.Item, width, height int) string {
 	}
 	rows := make([]row, 0, 10)
 
-	rows = append(rows, row{"Name", item.Name, valueStyle})
+	rows = append(rows, row{"Name", SanitizeTerminalText(item.Name), valueStyle})
 	switch item.Category {
 	case "Init Containers":
 		rows = append(rows, row{"Type", "Init Container", DimStyle})
 	case "Sidecar Containers":
 		rows = append(rows, row{"Type", "Sidecar Container", DimStyle})
 	}
-	rows = append(rows, row{"Status", item.Status, StatusStyle(item.Status)})
+	status := SanitizeTerminalText(item.Status)
+	rows = append(rows, row{"Status", status, StatusStyle(status)})
 	if item.Extra != "" {
-		rows = append(rows, row{"Image", item.Extra, DimStyle})
+		rows = append(rows, row{"Image", SanitizeTerminalText(item.Extra), DimStyle})
 	}
 	if item.Ready != "" {
-		rows = append(rows, row{"Ready", item.Ready, valueStyle})
+		rows = append(rows, row{"Ready", SanitizeTerminalText(item.Ready), valueStyle})
 	}
 	if item.Restarts != "" {
-		rows = append(rows, row{"Restarts", item.Restarts, valueStyle})
+		rows = append(rows, row{"Restarts", SanitizeTerminalText(item.Restarts), valueStyle})
 	}
 	if age := LiveAge(*item); age != "" {
 		rows = append(rows, row{"Age", age, AgeStyle(age)})
@@ -45,7 +46,7 @@ func RenderContainerDetail(item *model.Item, width, height int) string {
 		if strings.HasPrefix(kv.Key, "__") || strings.HasPrefix(kv.Key, "owner:") || strings.HasPrefix(kv.Key, "secret:") || strings.HasPrefix(kv.Key, "data:") {
 			continue
 		}
-		rows = append(rows, row{kv.Key, kv.Value, valueStyle})
+		rows = append(rows, row{SanitizeTerminalText(kv.Key), SanitizeTerminalText(kv.Value), valueStyle})
 	}
 
 	maxKeyLen := 0
@@ -91,6 +92,7 @@ func HighlightSearchInLine(line, query string, isCurrent bool) string {
 // in the parent would re-introduce the leading-padding alignment
 // problem that prompted this layout.
 func FormatItemNameOnly(item model.Item, width int) string {
+	item = sanitizeItemText(item)
 	displayName := item.Name
 	if item.Namespace != "" {
 		displayName = item.Namespace + "/" + displayName
@@ -116,6 +118,7 @@ func FormatItemNameOnly(item model.Item, width int) string {
 
 // FormatItemNameOnlyPlain formats an item showing only name and icon, without ANSI styling.
 func FormatItemNameOnlyPlain(item model.Item, width int) string {
+	item = sanitizeItemText(item)
 	displayName := item.Name
 	if item.Namespace != "" {
 		displayName = item.Namespace + "/" + displayName

--- a/internal/ui/explorer_table_format_test.go
+++ b/internal/ui/explorer_table_format_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// tableFormatHostilePayloads mirrors the payload set used across the other
+// TASK-880 sanitization tests: a bidi override, a raw CSI sequence, and an
+// OSC-52 clipboard write.
+var tableFormatHostilePayloads = map[string]string{
+	"bidi override": "ab\u202ecd",
+	"raw CSI":       "ab\x1b[2Jcd",
+	"OSC-52":        "ab\x1b]52;c;aGF4\x07cd",
+}
+
+func assertTableFormatClean(t *testing.T, out string) {
+	t.Helper()
+	assert.NotContains(t, out, "\u202e")
+	assert.NotContains(t, out, "\x1b[2J")
+	assert.NotContains(t, out, "\x1b]52")
+}
+
+// TestRenderContainerDetail_SanitizesFields verifies that every
+// cluster-controlled field shown in the container detail pane — name,
+// status, image, ready, restarts, and any extra column — is sanitized
+// before it reaches the rendered output.
+func TestRenderContainerDetail_SanitizesFields(t *testing.T) {
+	for name, payload := range tableFormatHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := &model.Item{
+				Name:     "container" + payload,
+				Status:   "Running" + payload,
+				Extra:    "nginx:latest" + payload,
+				Ready:    "1/1" + payload,
+				Restarts: "0" + payload,
+				Columns: []model.KeyValue{
+					{Key: "Node" + payload, Value: "worker-1" + payload},
+				},
+			}
+			out := RenderContainerDetail(item, 120, 30)
+			assertTableFormatClean(t, out)
+		})
+	}
+}
+
+// TestRenderContainerDetail_OrdinaryValuesUnchanged is the control case: a
+// container with no hostile input renders its fields as plain text.
+func TestRenderContainerDetail_OrdinaryValuesUnchanged(t *testing.T) {
+	item := &model.Item{
+		Name:     "nginx",
+		Status:   "Running",
+		Extra:    "nginx:1.27",
+		Ready:    "1/1",
+		Restarts: "0",
+	}
+	out := RenderContainerDetail(item, 120, 30)
+	plain := stripANSI(out)
+	assert.Contains(t, plain, "nginx")
+	assert.Contains(t, plain, "Running")
+	assert.Contains(t, plain, "nginx:1.27")
+	assert.Contains(t, plain, "1/1")
+}

--- a/internal/ui/kv_editor.go
+++ b/internal/ui/kv_editor.go
@@ -318,6 +318,11 @@ func AdjustEditValueScroll(value string, cursor, scroll, maxW, maxH int) int {
 	if scroll < 0 {
 		scroll = 0
 	}
+	// The renderer draws the sanitized text, so the line count has to be
+	// measured on that. Measuring the raw value counts the bytes a control
+	// sequence occupies, over-reports the line count, and can scroll the pane
+	// past the end of the value onto a blank view.
+	value, cursor = sanitizeCursorBody(value, cursor)
 	cursorLine := CursorVisualLine(value, cursor, maxW)
 	if cursorLine < scroll {
 		return cursorLine

--- a/internal/ui/kv_editor.go
+++ b/internal/ui/kv_editor.go
@@ -113,6 +113,40 @@ func kvFieldBox(label, content string, active bool, outerW, contentH int) string
 	return strings.Join(lines, "\n")
 }
 
+// sanitizeMultilineBody sanitizes a multi-line cluster-controlled value
+// (ConfigMap/Secret data) line by line, mirroring sanitizeYAMLContent in
+// internal/app/yamlfold.go: SanitizeLogBody treats a bare newline as a stray
+// control byte, so the body is split and rejoined around embedded "\n".
+// renderAnsi is false - a Secret/ConfigMap value has no legitimate reason to
+// carry SGR colour, so any ESC is neutralised rather than risking a
+// passed-through attacker-controlled sequence.
+func sanitizeMultilineBody(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = SanitizeLogBody(StripBidiOverrides(line), false)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// sanitizeCursorText sanitizes s (single-line: the Key field) and remaps
+// cursor - a byte offset into the raw, unsanitized s - to the matching
+// offset in the sanitized result. The edit buffer is seeded straight from
+// the cluster value (a Secret/ConfigMap/annotation key or value), so this is
+// the last point before the live cursor overlay reaches the screen; mapping
+// the offset keeps the cursor on the same character instead of drifting once
+// bytes ahead of it are dropped.
+func sanitizeCursorText(s string, cursor int) (string, int) {
+	cursor = clampCursor(cursor, len(s))
+	return SanitizeTerminalText(s), len(SanitizeTerminalText(s[:cursor]))
+}
+
+// sanitizeCursorBody is sanitizeCursorText's multi-line counterpart, used
+// for the Value field. See sanitizeMultilineBody.
+func sanitizeCursorBody(s string, cursor int) (string, int) {
+	cursor = clampCursor(cursor, len(s))
+	return sanitizeMultilineBody(s), len(sanitizeMultilineBody(s[:cursor]))
+}
+
 // overlayCursor renders s with the character at `cursor` shown in
 // inverse video (active) or returns s unchanged (inactive). When
 // cursor is at len(s) a single space gets the inverse style so the
@@ -123,10 +157,11 @@ func kvFieldBox(label, content string, active bool, outerW, contentH int) string
 // every time the cursor moves, which the user reported as the text
 // "jumping around" while typing / navigating.
 func overlayCursor(s string, cursor int, active bool, maxW int) string {
+	s, cursor = sanitizeCursorText(s, cursor)
 	if !active {
 		return Truncate(s, maxW)
 	}
-	cursor = clampInt(cursor, 0, len(s))
+	cursor = clampCursor(cursor, len(s))
 	cursorStyle := lipgloss.NewStyle().Reverse(true).Background(BaseBg)
 	var head, ch, tail string
 	if cursor == len(s) {
@@ -158,8 +193,9 @@ func overlayCursorMultiline(s string, cursor int, active bool, scroll, maxW, max
 	if maxW <= 0 || maxH <= 0 {
 		return ""
 	}
+	s, cursor = sanitizeCursorBody(s, cursor)
 	cursorStyle := lipgloss.NewStyle().Reverse(true).Background(BaseBg)
-	cursor = clampInt(cursor, 0, len(s))
+	cursor = clampCursor(cursor, len(s))
 	if scroll < 0 {
 		scroll = 0
 	}
@@ -240,7 +276,7 @@ func CursorVisualLine(s string, cursor, maxW int) int {
 	if maxW <= 0 {
 		return 0
 	}
-	cursor = clampInt(cursor, 0, len(s))
+	cursor = clampCursor(cursor, len(s))
 	line := 0
 	visualCol := 0
 	i := 0
@@ -349,15 +385,9 @@ func nextRuneEnd(s string, i int) int {
 	return end
 }
 
-// clampInt restricts v to [lo, hi] inclusive.
-func clampInt(v, lo, hi int) int {
-	if v < lo {
-		return lo
-	}
-	if v > hi {
-		return hi
-	}
-	return v
+// clampCursor restricts a cursor offset to the bounds of the string it indexes.
+func clampCursor(v, hi int) int {
+	return min(max(v, 0), hi)
 }
 
 // stylePerLine renders each line of `body` through `style.Width(w)`

--- a/internal/ui/kv_editor_cursor_sanitize_test.go
+++ b/internal/ui/kv_editor_cursor_sanitize_test.go
@@ -80,11 +80,20 @@ func TestSanitizeCursorBody_StripsHostilePayloadsAndKeepsCursorOnChar(t *testing
 func TestOverlayCursor_SanitizesActiveAndInactive(t *testing.T) {
 	payload := "secret\x1b]52;c;aGF4\x07value"
 
+	// Assert on the OSC introducer, not the whole payload. The cursor's
+	// styling is inserted at offset 3, which splits the payload string, so a
+	// whole-payload check passes even when the sequence comes through intact.
+	// "\x1b]" opens an OS command and never belongs in rendered output, while
+	// the cursor's own reverse-video SGR legitimately carries ESC.
+	const oscIntroducer = "\x1b]"
+
 	active := overlayCursor(payload, 3, true, 80)
-	assert.NotContains(t, active, payload)
+	assert.NotContains(t, active, oscIntroducer)
+	assert.NotContains(t, active, "\a", "BEL terminates the sequence")
 
 	inactive := overlayCursor(payload, 3, false, 80)
-	assert.NotContains(t, inactive, payload)
+	assert.NotContains(t, inactive, oscIntroducer)
+	assert.NotContains(t, inactive, "\a")
 }
 
 // TestOverlayCursorMultiline_SanitizesHostilePayload guards the Value

--- a/internal/ui/kv_editor_cursor_sanitize_test.go
+++ b/internal/ui/kv_editor_cursor_sanitize_test.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSanitizeCursorText_StripsHostilePayloadsAndKeepsCursorOnChar guards
+// overlayCursor (the K/V editor's Key-field cursor overlay): the edit
+// buffer is seeded straight from a cluster value, so before this fix a
+// bidi override, raw CSI, or OSC-52 clipboard write in a Secret/ConfigMap
+// annotation key survived byte for byte the moment the user pressed edit
+// on that row.
+func TestSanitizeCursorText_StripsHostilePayloadsAndKeepsCursorOnChar(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"bidi override", "ab\u202eXcd"},
+		{"raw csi", "ab\x1b[31mXcd"},
+		{"csi screen erase", "ab\x1b[2JXcd"},
+		{"osc52 clipboard write", "ab\x1b]52;c;aGF4\x07Xcd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cursor := strings.IndexByte(tc.raw, 'X')
+			require.GreaterOrEqual(t, cursor, 0)
+
+			sanitized, newCursor := sanitizeCursorText(tc.raw, cursor)
+
+			assert.NotContains(t, sanitized, "\x1b")
+			assert.NotContains(t, sanitized, "\x07")
+			assert.NotContains(t, sanitized, "\u202e")
+			require.True(t, newCursor >= 0 && newCursor < len(sanitized), "cursor %d out of range for %q", newCursor, sanitized)
+			assert.Equal(t, byte('X'), sanitized[newCursor], "cursor should still land on the marker character")
+		})
+	}
+}
+
+// TestSanitizeCursorBody_StripsHostilePayloadsAndKeepsCursorOnChar mirrors
+// the above for overlayCursorMultiline (the K/V editor's Value-field
+// cursor overlay), which handles multi-line Secret/ConfigMap bodies.
+func TestSanitizeCursorBody_StripsHostilePayloadsAndKeepsCursorOnChar(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"bidi override", "line1\nab\u202eXcd"},
+		{"raw csi", "line1\nab\x1b[31mXcd"},
+		{"csi screen erase", "line1\nab\x1b[2JXcd"},
+		{"osc52 clipboard write", "line1\nab\x1b]52;c;aGF4\x07Xcd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cursor := strings.IndexByte(tc.raw, 'X')
+			require.GreaterOrEqual(t, cursor, 0)
+
+			sanitized, newCursor := sanitizeCursorBody(tc.raw, cursor)
+
+			assert.NotContains(t, sanitized, "\x1b")
+			assert.NotContains(t, sanitized, "\x07")
+			assert.NotContains(t, sanitized, "\u202e")
+			require.True(t, newCursor >= 0 && newCursor < len(sanitized), "cursor %d out of range for %q", newCursor, sanitized)
+			assert.Equal(t, byte('X'), sanitized[newCursor], "cursor should still land on the marker character")
+		})
+	}
+}
+
+// TestOverlayCursor_SanitizesActiveAndInactive guards the actual render
+// entry point: both branches (active field with a live cursor, and an
+// inactive field rendered plain) must scrub the ESC byte out of the raw
+// payload before Truncate ever measures the string's width. Checking the
+// whole payload substring (ESC included), not a bare "\x1b", because the
+// cursor's own reverse-video styling legitimately emits ESC elsewhere in
+// the output; sanitizing only needs to break the ESC+body pairing, not
+// scrub every ESC byte on the line.
+func TestOverlayCursor_SanitizesActiveAndInactive(t *testing.T) {
+	payload := "secret\x1b]52;c;aGF4\x07value"
+
+	active := overlayCursor(payload, 3, true, 80)
+	assert.NotContains(t, active, payload)
+
+	inactive := overlayCursor(payload, 3, false, 80)
+	assert.NotContains(t, inactive, payload)
+}
+
+// TestOverlayCursorMultiline_SanitizesHostilePayload guards the Value
+// field's multi-line cursor overlay the same way.
+func TestOverlayCursorMultiline_SanitizesHostilePayload(t *testing.T) {
+	csi := "\x1b[31m"
+	osc52 := "\x1b]52;c;aGF4\x07"
+	bidi := "\u202e"
+	payload := "line one\nsecret" + csi + bidi + "value" + osc52
+
+	out := overlayCursorMultiline(payload, 5, true, 0, 40, 10)
+	assert.NotContains(t, out, csi)
+	assert.NotContains(t, out, osc52)
+	assert.NotContains(t, out, bidi)
+}

--- a/internal/ui/objectexplorertreeview.go
+++ b/internal/ui/objectexplorertreeview.go
@@ -26,19 +26,24 @@ func RenderObjectExplorerTreeView(rows []model.ObjectTreeRow, filtered bool, cur
 // objectTreeLabels computes each row's display label and guide prefix. In
 // filtered mode the label is the row's relative dotted path and the prefix is
 // empty.
+//
+// Labels are sanitized here, before any width measurement or truncation:
+// a label is a label/annotation key from a cluster-controlled object, and
+// sanitizing after Truncate/width math would leave stale widths since
+// stripping control bytes changes the string's rendered width.
 func objectTreeLabels(rows []model.ObjectTreeRow, filtered bool) (labels, prefixes []string) {
 	labels = make([]string, len(rows))
 	prefixes = make([]string, len(rows))
 	if filtered {
 		for i, r := range rows {
-			labels[i] = model.FormatObjectPath(r.Segs)
+			labels[i] = SanitizeTerminalText(model.FormatObjectPath(r.Segs))
 		}
 		return labels, prefixes
 	}
 	depths := make([]int, len(rows))
 	for i, r := range rows {
 		depths[i] = r.Depth
-		labels[i] = r.Field.Key
+		labels[i] = SanitizeTerminalText(r.Field.Key)
 	}
 	return labels, TreeGuidePrefixes(depths)
 }
@@ -77,7 +82,10 @@ func renderObjectTreeFieldList(rows []model.ObjectTreeRow, labels, prefixes []st
 		pad := max(nameWidth-prefixW-lipgloss.Width(label), 0)
 
 		valueWidth := max(width-nameWidth-6, 4)
-		value := Truncate(f.Preview, valueWidth)
+		// f.Preview is a cluster-controlled field value (e.g. an annotation
+		// value); sanitize before Truncate so width math runs on the
+		// visible-width string, not the pre-strip one.
+		value := Truncate(SanitizeTerminalText(f.Preview), valueWidth)
 
 		// A container row not followed by a deeper row has folded children
 		// (in pre-order a parent's children render right below it). Mark it

--- a/internal/ui/objectexplorertreeview_sanitize_test.go
+++ b/internal/ui/objectexplorertreeview_sanitize_test.go
@@ -1,0 +1,59 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestRenderObjectExplorerTreeView_SanitizesHostileLabelsAndValues guards
+// the middle-column tree rows: labels come from object field keys (label
+// and annotation keys) and f.Preview from field values, both cluster-
+// controlled. A hostile CSI/OSC-52/bidi payload in either must not reach
+// the rendered tree, whether the row is the cursor row or not.
+func TestRenderObjectExplorerTreeView_SanitizesHostileLabelsAndValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		val     string
+		mustNot []string // exact hostile byte sequences that must not survive
+	}{
+		{"bidi override", "annotation\u202ekey", "value\u202ehere", []string{"\u202e"}},
+		{"raw csi", "annotation\x1b[31mkey", "value\x1b[2Jhere", []string{"\x1b[31m", "\x1b[2J"}},
+		{"osc52 clipboard write", "annotation\x1b]52;c;aGF4\x07key", "value\x1b]52;c;aGF4\x07here", []string{"\x1b]52;c;aGF4\x07"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := []model.ObjectTreeRow{
+				{Field: model.ObjectField{Key: tc.key, Type: "<string>", Preview: tc.val}, Segs: []string{tc.key}, Depth: 0},
+			}
+			for _, cursor := range []int{-1, 0} {
+				out := RenderObjectExplorerTreeView(
+					rows, false, cursor, 0, "Object Explorer: x", nil, 0,
+					"", 0, "", "hint", 160, 30,
+				)
+				for _, hostile := range tc.mustNot {
+					assert.NotContains(t, out, hostile, "cursor=%d", cursor)
+				}
+			}
+		})
+	}
+}
+
+// TestRenderObjectExplorerTreeView_SanitizesFilteredPath covers the
+// filtered-mode label path (model.FormatObjectPath), which bypasses the
+// plain-key branch of objectTreeLabels.
+func TestRenderObjectExplorerTreeView_SanitizesFilteredPath(t *testing.T) {
+	rows := []model.ObjectTreeRow{
+		{Field: model.ObjectField{Key: "key", Type: "<string>", Preview: "val"}, Segs: []string{"spec\x1b[31m", "annot\x1b]52;c;aGF4\x07ation\u202e"}, Depth: 1},
+	}
+	out := RenderObjectExplorerTreeView(
+		rows, true, 0, 0, "Object Explorer: x", nil, 0,
+		"", 0, "annot", "hint", 160, 30,
+	)
+	assert.NotContains(t, out, "\x1b[31m")
+	assert.NotContains(t, out, "\x1b]52;c;aGF4\x07")
+	assert.NotContains(t, out, "\u202e")
+}

--- a/internal/ui/overlay_crash_body_sanitize_test.go
+++ b/internal/ui/overlay_crash_body_sanitize_test.go
@@ -67,3 +67,45 @@ func TestCrashBodySanitizerKeepsLineStructure(t *testing.T) {
 		t.Errorf("expected %d lines, got %q", want, got)
 	}
 }
+
+// The Summary tab's metadata rows are the pod's own identity: Phase, Node, IP,
+// QoS, Owner, and the container named in the last-termination heading. They sit
+// beside fields the same function already guarded, which is the shape of miss
+// this task keeps finding.
+func TestCrashSummaryMetadataDropsHostileSequences(t *testing.T) {
+	payloads := map[string]struct{ payload, marker string }{
+		"OSC-52 clipboard write": {"\x1b]52;c;aGF4\a", "\x1b]"},
+		"CSI erase display":      {"\x1b[2J", "\x1b[2J"},
+		"bidi override":          {"\u202e", "\u202e"},
+		"C1 control":             {"\u009b", "\u009b"},
+	}
+
+	for name, tc := range payloads {
+		t.Run(name, func(t *testing.T) {
+			entry := CrashInvestigatorEntry{
+				PodName:         "api" + tc.payload,
+				Namespace:       "prod" + tc.payload,
+				Phase:           "Running" + tc.payload,
+				Node:            "node-1" + tc.payload,
+				PodIP:           "10.0.0.1" + tc.payload,
+				QoSClass:        "Burstable" + tc.payload,
+				OwnerKind:       "ReplicaSet",
+				OwnerName:       "api-abc" + tc.payload,
+				ActiveContainer: "app" + tc.payload,
+				AppContainers: []CrashContainerEntry{{
+					Name:        "app" + tc.payload,
+					HasLastTerm: true,
+					LastReason:  "Error",
+				}},
+			}
+
+			out := strings.Join(buildCrashSummaryLines(entry), "\n")
+			if strings.Contains(out, tc.marker) {
+				t.Errorf("Summary tab: %s survived", name)
+			}
+			if strings.Contains(out, "\a") {
+				t.Errorf("%s: BEL survived", name)
+			}
+		})
+	}
+}

--- a/internal/ui/overlay_crash_body_sanitize_test.go
+++ b/internal/ui/overlay_crash_body_sanitize_test.go
@@ -1,0 +1,69 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The Logs and Describe tabs render the least constrained content in the app:
+// raw container stdout, and the verbatim text of kubectl describe, which prints
+// annotation values the API server does not restrict. Both are a second render
+// path to bytes the log viewer already guards. Found by the security-reviewer
+// pass on TASK-880 after the first round missed them.
+func TestCrashLogsAndDescribeTabsDropHostileSequences(t *testing.T) {
+	payloads := map[string]struct{ payload, marker string }{
+		"OSC-52 clipboard write": {"\x1b]52;c;aGF4\a", "\x1b]"},
+		"CSI erase display":      {"\x1b[2J", "\x1b[2J"},
+		"bidi override":          {"\u202e", "\u202e"},
+		"C1 control":             {"\u009b", "\u009b"},
+	}
+
+	for name, tc := range payloads {
+		t.Run(name, func(t *testing.T) {
+			entry := CrashInvestigatorEntry{
+				PodName:         "api-7f9" + tc.payload,
+				ActiveContainer: "app" + tc.payload,
+				Describe:        "Annotations:  note=" + tc.payload + "\nStatus: Running",
+				AppContainers: []CrashContainerEntry{{
+					Name:       "app" + tc.payload,
+					CurrentLog: "starting up" + tc.payload + "\nready",
+				}},
+			}
+			entry.ActiveContainer = "app" + tc.payload
+
+			logs := renderCrashLogsTab(entry, 0, 100, 30)
+			if strings.Contains(logs, tc.marker) {
+				t.Errorf("Logs tab: %s survived", name)
+			}
+			describe := renderCrashDescribeTab(entry, 0, 100, 30)
+			if strings.Contains(describe, tc.marker) {
+				t.Errorf("Describe tab: %s survived", name)
+			}
+			if strings.Contains(logs, "\a") || strings.Contains(describe, "\a") {
+				t.Errorf("%s: BEL survived", name)
+			}
+		})
+	}
+}
+
+// A container that colours its own output must still read correctly, so the
+// body path keeps SGR rather than reaching for the blunt sanitizer.
+func TestCrashLogsTabKeepsColour(t *testing.T) {
+	entry := CrashInvestigatorEntry{
+		ActiveContainer: "app",
+		AppContainers:   []CrashContainerEntry{{Name: "app", CurrentLog: "\x1b[31mpanic\x1b[0m"}},
+	}
+	if got := renderCrashLogsTab(entry, 0, 100, 30); !strings.Contains(got, "[31m") {
+		t.Error("SGR colour must survive the logs body path")
+	}
+}
+
+// The tab bodies span many lines, and the body sanitizer treats a newline as a
+// control byte. Sanitizing the whole string at once would collapse the body
+// onto one row.
+func TestCrashBodySanitizerKeepsLineStructure(t *testing.T) {
+	got := sanitizeCrashBody("one\ntwo\nthree")
+	if want := 3; len(strings.Split(got, "\n")) != want {
+		t.Errorf("expected %d lines, got %q", want, got)
+	}
+}

--- a/internal/ui/overlay_crash_investigator.go
+++ b/internal/ui/overlay_crash_investigator.go
@@ -310,17 +310,34 @@ func buildCrashSummaryLines(entry CrashInvestigatorEntry) []string {
 		lines = append(lines, "  "+crashSectionStyle.Render(fmt.Sprintf("Last termination of %s", active.Name)))
 		lines = append(lines, OverlayDimStyle.Render(fmt.Sprintf(
 			"    Reason: %s · ExitCode: %d · Signal: %d · Finished: %s",
-			fallbackCrashStr(active.LastReason),
+			fallbackCrashStr(SanitizeTerminalText(active.LastReason)),
 			active.LastExitCode,
 			active.LastSignal,
 			formatTimeAgo(active.LastFinished),
 		)))
-		if msg := strings.TrimSpace(active.LastMessage); msg != "" {
+		if msg := strings.TrimSpace(sanitizeCrashMessage(active.LastMessage)); msg != "" {
 			lines = append(lines, OverlayDimStyle.Render("    Message: "+truncateCrash(msg, 200)))
 		}
 	}
 
 	return lines
+}
+
+// sanitizeCrashBody guards the Logs and Describe tabs, whose content is the
+// least constrained in the app: raw container stdout and the verbatim text of
+// kubectl describe, which prints annotation values the API server does not
+// restrict at all. The log viewer guards the same bytes with sanitizeLogLine;
+// these tabs are a second render path to them and need the same guard.
+//
+// Line by line, because the body sanitizer treats a newline as a control byte
+// and would replace it, collapsing the whole body onto one row. SGR colour is
+// kept so a container that colours its own output still reads correctly.
+func sanitizeCrashBody(body string) string {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		lines[i] = StripBidiOverrides(SanitizeLogBody(line, true))
+	}
+	return strings.Join(lines, "\n")
 }
 
 // renderCrashContainerTableLines renders the container sub-table as one
@@ -353,14 +370,15 @@ func renderCrashContainerTableLines(containers []CrashContainerEntry, active str
 		if c.StateReason != "" {
 			state = c.StateReason
 		}
+		state = SanitizeTerminalText(state)
 		exit := "—"
 		reason := "—"
 		if c.HasLastTerm {
 			exit = fmt.Sprintf("%d", c.LastExitCode)
-			reason = fallbackCrashStr(c.LastReason)
+			reason = fallbackCrashStr(SanitizeTerminalText(c.LastReason))
 		}
 		row := marker + crashJoinRow(
-			crashCell(truncateCrash(c.Name, crashColContainer), crashColContainer),
+			crashCell(truncateCrash(SanitizeTerminalText(c.Name), crashColContainer), crashColContainer),
 			crashCell(truncateCrash(state, crashColState), crashColState),
 			crashCell(fmt.Sprintf("%d", c.RestartCount), crashColRestarts),
 			crashCell(exit, crashColLastExit),
@@ -529,10 +547,10 @@ func renderCrashEventsTab(entry CrashInvestigatorEntry, scroll, width, height in
 	msgPrefix := strings.Repeat(" ", indent+typeW+reasonW+ageW+gutters)
 
 	for _, ev := range entry.Events {
-		msgLines := wrapCrashText(ev.Message, msgW)
+		msgLines := wrapCrashText(sanitizeCrashMessage(ev.Message), msgW)
 		first := strings.Repeat(" ", indent) + crashJoinRow(
-			crashCell(truncateCrash(ev.Type, typeW), typeW),
-			crashCell(truncateCrash(ev.Reason, reasonW), reasonW),
+			crashCell(truncateCrash(SanitizeTerminalText(ev.Type), typeW), typeW),
+			crashCell(truncateCrash(SanitizeTerminalText(ev.Reason), reasonW), reasonW),
 			crashCell(truncateCrash(ev.Age, ageW), ageW),
 			msgLines[0],
 		)
@@ -565,7 +583,7 @@ func renderCrashLogsTab(entry CrashInvestigatorEntry, scroll, width, height int)
 		mode = "previous"
 	}
 	header := crashHeaderStyle.Render(fmt.Sprintf("LOGS · %s · container=%s",
-		mode, fallbackCrashStr(entry.ActiveContainer)))
+		mode, SanitizeTerminalText(fallbackCrashStr(entry.ActiveContainer))))
 	divider := OverlayDimStyle.Render(strings.Repeat("─", min(width, 80)))
 
 	var b strings.Builder
@@ -582,7 +600,7 @@ func renderCrashLogsTab(entry CrashInvestigatorEntry, scroll, width, height int)
 		return b.String()
 	}
 	if active.LogError != "" {
-		b.WriteString(OverlayWarningStyle.Render(fmt.Sprintf("  failed to load logs: %s", active.LogError)))
+		b.WriteString(OverlayWarningStyle.Render(fmt.Sprintf("  failed to load logs: %s", SanitizeTerminalText(active.LogError))))
 		return b.String()
 	}
 
@@ -590,7 +608,7 @@ func renderCrashLogsTab(entry CrashInvestigatorEntry, scroll, width, height int)
 	if entry.ShowPrevious {
 		body = active.PreviousLog
 	}
-	body = strings.TrimRight(body, "\n")
+	body = sanitizeCrashBody(strings.TrimRight(body, "\n"))
 	if body == "" {
 		if entry.ShowPrevious {
 			b.WriteString(OverlayDimStyle.Render(
@@ -623,14 +641,14 @@ func renderCrashLogsTab(entry CrashInvestigatorEntry, scroll, width, height int)
 // failed (e.g. kubectl not on PATH), we surface that as a warning
 // instead. Long output is clipped to the viewport via scroll.
 func renderCrashDescribeTab(entry CrashInvestigatorEntry, scroll, width, height int) string {
-	header := crashHeaderStyle.Render("DESCRIBE · pod=" + fallbackCrashStr(entry.PodName))
+	header := crashHeaderStyle.Render("DESCRIBE · pod=" + SanitizeTerminalText(fallbackCrashStr(entry.PodName)))
 	divider := OverlayDimStyle.Render(strings.Repeat("─", min(width, 80)))
 
 	if entry.DescribeError != "" {
 		return header + "\n" + divider + "\n\n" +
-			OverlayWarningStyle.Render("  describe failed: "+entry.DescribeError)
+			OverlayWarningStyle.Render("  describe failed: "+SanitizeTerminalText(entry.DescribeError))
 	}
-	body := strings.TrimRight(entry.Describe, "\n")
+	body := sanitizeCrashBody(strings.TrimRight(entry.Describe, "\n"))
 	if body == "" {
 		return header + "\n" + divider + "\n\n" + OverlayDimStyle.Render("  no describe output.")
 	}
@@ -653,6 +671,22 @@ func renderCrashDescribeTab(entry CrashInvestigatorEntry, scroll, width, height 
 	bodyHeight := max(height-3, 1)
 	visible := clipScrollLines(bodyLines, scroll, bodyHeight)
 	return strings.Join(append(stickyTop, visible...), "\n")
+}
+
+// sanitizeCrashMessage sanitizes a container/event message body that later
+// gets word-wrapped (wrapCrashText, which splits on whitespace including
+// embedded newlines). Lines are sanitized individually — SanitizeLogBody
+// treats a bare "\n" as a stray control byte — then rejoined with a space so
+// the existing whitespace-flattening the word-wrapper already does stays
+// intact instead of fusing lines together. renderAnsi is false: an event or
+// termination message from the cluster has no legitimate reason to carry
+// SGR colour.
+func sanitizeCrashMessage(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = SanitizeLogBody(StripBidiOverrides(line), false)
+	}
+	return strings.Join(lines, " ")
 }
 
 // fallbackCrashStr returns an em-dash placeholder when s is blank

--- a/internal/ui/overlay_crash_investigator.go
+++ b/internal/ui/overlay_crash_investigator.go
@@ -274,6 +274,10 @@ func buildCrashSummaryLines(entry CrashInvestigatorEntry) []string {
 	valueStyle := OverlayNormalStyle
 
 	kvLine := func(label, value string) string {
+		// Every Summary row funnels through here, so one guard covers Phase,
+		// Node, IP, QoS and Owner. These come from the cluster and are all
+		// single-line, so the blunt sanitizer is the right one.
+		value = SanitizeTerminalText(value)
 		if strings.TrimSpace(value) == "" {
 			value = "—"
 		}
@@ -307,7 +311,7 @@ func buildCrashSummaryLines(entry CrashInvestigatorEntry) []string {
 	// Last-terminated detail block for the active container.
 	if active := findCrashContainer(entry, entry.ActiveContainer); active != nil && active.HasLastTerm {
 		lines = append(lines, "")
-		lines = append(lines, "  "+crashSectionStyle.Render(fmt.Sprintf("Last termination of %s", active.Name)))
+		lines = append(lines, "  "+crashSectionStyle.Render(fmt.Sprintf("Last termination of %s", SanitizeTerminalText(active.Name))))
 		lines = append(lines, OverlayDimStyle.Render(fmt.Sprintf(
 			"    Reason: %s · ExitCode: %d · Signal: %d · Finished: %s",
 			fallbackCrashStr(SanitizeTerminalText(active.LastReason)),

--- a/internal/ui/overlay_crash_investigator_sanitize_test.go
+++ b/internal/ui/overlay_crash_investigator_sanitize_test.go
@@ -1,0 +1,65 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// hostileCrashPayloads mirrors the format used by the other TASK-880 sink
+// tests: literal escape sequences (not the invisible runes they represent),
+// keyed so each case's assertion can check for the exact ESC+body sequence
+// rather than a bare "\x1b" - the overlay's own styling legitimately emits
+// ESC elsewhere (colors, reverse-video, borders).
+var hostileCrashPayloads = map[string]string{
+	"bidi override":         "\u202e",
+	"raw csi":               "\x1b[31m",
+	"csi screen erase":      "\x1b[2J",
+	"osc52 clipboard write": "\x1b]52;c;aGF4\x07",
+}
+
+// TestRenderCrashInvestigatorOverlay_SanitizesSummaryFields guards the
+// Summary tab's container State/StateReason and the active container's
+// LastReason/LastMessage - all sourced from the cluster's pod status.
+func TestRenderCrashInvestigatorOverlay_SanitizesSummaryFields(t *testing.T) {
+	for name, payload := range hostileCrashPayloads {
+		t.Run(name, func(t *testing.T) {
+			entry := CrashInvestigatorEntry{
+				PodName: "p", Namespace: "default", ActiveContainer: "app",
+				Tab: CrashTabSummary,
+				AppContainers: []CrashContainerEntry{
+					{
+						Name:         "app",
+						State:        "Waiting",
+						StateReason:  "Reason" + payload,
+						RestartCount: 1,
+						HasLastTerm:  true,
+						LastReason:   "Err" + payload,
+						LastMessage:  "boom" + payload,
+					},
+				},
+			}
+			out := RenderCrashInvestigatorOverlay(entry, 0, 120, 30)
+			assert.NotContains(t, out, payload)
+		})
+	}
+}
+
+// TestRenderCrashInvestigatorOverlay_SanitizesEventFields guards the
+// Events tab's Type/Reason/Message columns.
+func TestRenderCrashInvestigatorOverlay_SanitizesEventFields(t *testing.T) {
+	for name, payload := range hostileCrashPayloads {
+		t.Run(name, func(t *testing.T) {
+			entry := CrashInvestigatorEntry{
+				PodName: "p", Namespace: "default",
+				Tab:           CrashTabEvents,
+				AppContainers: []CrashContainerEntry{{Name: "app"}},
+				Events: []CrashEventEntry{
+					{Type: "Warning" + payload, Reason: "BackOff" + payload, Age: "5s", Message: "back-off" + payload},
+				},
+			}
+			out := RenderCrashInvestigatorOverlay(entry, 0, 120, 30)
+			assert.NotContains(t, out, payload)
+		})
+	}
+}

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -8,163 +8,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// RenderEventTimelineOverlay renders the event timeline overlay content.
-// Events are displayed with relative timestamps, type indicators, and scrolling support.
-func RenderEventTimelineOverlay(events []EventTimelineEntry, resourceName string, scroll, width, height int) string {
-	var b strings.Builder
-
-	title := fmt.Sprintf("Event Timeline - %s", resourceName)
-	b.WriteString(OverlayTitleStyle.Render(title))
-	b.WriteString("\n")
-
-	if len(events) == 0 {
-		b.WriteString(OverlayDimStyle.Render("No events found"))
-		return b.String()
-	}
-
-	// Reserve lines for header, blank line before footer, footer.
-	maxLines := max(height-4, 1)
-
-	// Content width inside OverlayStyle Padding(1,2) = 2 left + 2 right.
-	contentWidth := width - 4
-
-	// Calculate available width for message wrapping.
-	msgIndent := "           "
-	msgMaxWidth := max(contentWidth-len(msgIndent), 20)
-	msgContIndent := msgIndent + "  "
-	msgContWidth := max(msgMaxWidth-2, 10)
-
-	// Calculate visual lines per event for scroll/viewport calculations.
-	msgLineCount := func(idx int) int {
-		msgLen := len([]rune(events[idx].Message))
-		if msgLen <= msgMaxWidth {
-			return 1
-		}
-		remaining := msgLen - msgMaxWidth
-		return 1 + (remaining+msgContWidth-1)/msgContWidth
-	}
-	eventLines := func(idx int) int {
-		return 1 + msgLineCount(idx) // 1 header line + message lines
-	}
-
-	// Clamp scroll: find max scroll where remaining events fill the viewport.
-	if scroll < 0 {
-		scroll = 0
-	}
-	if scroll >= len(events) {
-		scroll = max(len(events)-1, 0)
-	}
-	// Shrink scroll if there's empty space at the bottom.
-	for scroll > 0 {
-		lines := 0
-		for i := scroll; i < len(events); i++ {
-			lines += eventLines(i)
-		}
-		if lines >= maxLines {
-			break
-		}
-		scroll--
-	}
-
-	// Compute end index based on available visual lines.
-	// Separators between events just terminate the previous line (already
-	// counted in eventLines), they don't add extra visual lines.
-	usedLines := 0
-	end := scroll
-	for end < len(events) {
-		el := eventLines(end)
-		if usedLines+el > maxLines {
-			break
-		}
-		usedLines += el
-		end++
-	}
-	if end == scroll && end < len(events) {
-		usedLines += eventLines(end)
-		end++
-	}
-
-	// Styles for event type indicators.
-	normalDot := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Background(SurfaceBg).Render("●") // green filled circle
-	warningDot := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError)).Background(SurfaceBg).Render("●")    // red filled circle
-	reasonStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorFile)).Background(SurfaceBg)
-	sourceStyle := OverlayDimStyle
-	countStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorWarning)).Background(SurfaceBg)
-
-	for i := scroll; i < end; i++ {
-		event := events[i]
-
-		// Relative timestamp.
-		ts := RelativeTime(event.Timestamp)
-		tsStr := OverlayDimStyle.Render(fmt.Sprintf("%-8s", ts))
-
-		// Type indicator.
-		dot := normalDot
-		if event.Type == "Warning" {
-			dot = warningDot
-		}
-
-		// Reason.
-		reason := reasonStyle.Render(event.Reason)
-
-		// Source.
-		src := ""
-		if event.Source != "" {
-			src = " " + sourceStyle.Render("["+event.Source+"]")
-		}
-
-		// Involved object info (show if different from the main resource).
-		involved := ""
-		if event.InvolvedName != resourceName {
-			involved = " " + OverlayDimStyle.Render(event.InvolvedKind+"/"+event.InvolvedName)
-		}
-
-		// Count.
-		countStr := ""
-		if event.Count > 1 {
-			countStr = " " + countStyle.Render(fmt.Sprintf("(x%d)", event.Count))
-		}
-
-		// First line: timestamp, dot, reason, source, involved, count.
-		line := fmt.Sprintf("  %s %s %s%s%s%s", tsStr, dot, reason, src, involved, countStr)
-		b.WriteString(line)
-		b.WriteString("\n")
-
-		// Message lines: wrap long messages instead of truncating.
-		// Continuation lines get extra indentation to distinguish them.
-		msg := event.Message
-		msgRunes := []rune(msg)
-		firstChunkEnd := min(msgMaxWidth, len(msgRunes))
-		fmt.Fprintf(&b, "%s%s", msgIndent, OverlayNormalStyle.Render(string(msgRunes[:firstChunkEnd])))
-		for start := firstChunkEnd; start < len(msgRunes); start += msgContWidth {
-			chunkEnd := min(start+msgContWidth, len(msgRunes))
-			chunk := string(msgRunes[start:chunkEnd])
-			b.WriteString("\n")
-			fmt.Fprintf(&b, "%s%s", msgContIndent, OverlayDimStyle.Render(chunk))
-		}
-
-		if i < end-1 {
-			b.WriteString("\n")
-		}
-	}
-
-	// Pad to fixed height so the footer stays in place.
-	for usedLines < maxLines {
-		b.WriteString("\n")
-		usedLines++
-	}
-	b.WriteString("\n")
-
-	// Scroll info (hints moved to main status bar).
-	scrollInfo := fmt.Sprintf("%d events", len(events))
-	if scroll > 0 || end < len(events) {
-		scrollInfo += fmt.Sprintf(" | showing %d-%d", scroll+1, end)
-	}
-	b.WriteString(OverlayDimStyle.Render(scrollInfo))
-
-	return b.String()
-}
-
 // EventViewerParams holds state for the rich event viewer rendering.
 type EventViewerParams struct {
 	Lines        []string // flat text lines (one per event)
@@ -372,7 +215,10 @@ func RenderEventViewer(p EventViewerParams) string {
 	// Title with mode indicators.
 	title := "Event Timeline"
 	if p.ResourceName != "" {
-		title += " - " + p.ResourceName
+		// ResourceName is a cluster object name; the body lines (p.Lines)
+		// are already sanitized upstream, but the title is built here from
+		// the raw value.
+		title += " - " + SanitizeTerminalText(p.ResourceName)
 	}
 	var indicators []string
 	if p.Fullscreen {

--- a/internal/ui/overlay_event_viewer_sanitize_test.go
+++ b/internal/ui/overlay_event_viewer_sanitize_test.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderEventViewer_SanitizesResourceNameInTitle guards the title line:
+// p.Lines (the event body) is already sanitized upstream by the caller, but
+// the title is built here directly from the raw ResourceName - a cluster
+// object name - and used to render "Event Timeline - <name>".
+func TestRenderEventViewer_SanitizesResourceNameInTitle(t *testing.T) {
+	hostile := map[string]string{
+		"bidi override":         "\u202e",
+		"raw csi":               "\x1b[31m",
+		"csi screen erase":      "\x1b[2J",
+		"osc52 clipboard write": "\x1b]52;c;aGF4\x07",
+	}
+	for name, payload := range hostile {
+		t.Run(name, func(t *testing.T) {
+			p := EventViewerParams{
+				Lines:        []string{"line"},
+				ResourceName: "pod" + payload,
+				Width:        80,
+				Height:       20,
+			}
+			out := RenderEventViewer(p)
+			assert.NotContains(t, out, payload)
+		})
+	}
+}

--- a/internal/ui/overlay_monitoring_extra_test.go
+++ b/internal/ui/overlay_monitoring_extra_test.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -42,91 +41,5 @@ func TestRenderRBACOverlay(t *testing.T) {
 		result := RenderRBACOverlay(results, "configmaps")
 		assert.Contains(t, result, "\u2713")
 		assert.NotContains(t, result, "\u2717")
-	})
-}
-
-// --- RenderEventTimelineOverlay ---
-
-func TestRenderEventTimelineOverlay(t *testing.T) {
-	t.Run("empty events shows message", func(t *testing.T) {
-		result := RenderEventTimelineOverlay(nil, "my-pod", 0, 80, 30)
-		assert.Contains(t, result, "Event Timeline - my-pod")
-		assert.Contains(t, result, "No events found")
-		// Hint moved to status bar.
-	})
-
-	t.Run("events rendered with reason and message", func(t *testing.T) {
-		events := []EventTimelineEntry{
-			{
-				Timestamp: time.Now().Add(-5 * time.Minute),
-				Type:      "Normal",
-				Reason:    "Pulled",
-				Message:   "Successfully pulled image",
-				Source:    "kubelet",
-				Count:     1,
-			},
-			{
-				Timestamp: time.Now().Add(-10 * time.Minute),
-				Type:      "Warning",
-				Reason:    "BackOff",
-				Message:   "Back-off restarting failed container",
-				Source:    "kubelet",
-				Count:     3,
-			},
-		}
-		result := RenderEventTimelineOverlay(events, "my-pod", 0, 100, 30)
-		assert.Contains(t, result, "Event Timeline - my-pod")
-		assert.Contains(t, result, "Pulled")
-		assert.Contains(t, result, "Successfully pulled image")
-		assert.Contains(t, result, "BackOff")
-		assert.Contains(t, result, "Back-off restarting failed container")
-		assert.Contains(t, result, "kubelet")
-		assert.Contains(t, result, "2 events")
-	})
-
-	t.Run("count > 1 shows repeat indicator", func(t *testing.T) {
-		events := []EventTimelineEntry{
-			{
-				Timestamp: time.Now().Add(-1 * time.Minute),
-				Type:      "Normal",
-				Reason:    "Killing",
-				Message:   "Stopping container",
-				Count:     5,
-			},
-		}
-		result := RenderEventTimelineOverlay(events, "pod", 0, 80, 20)
-		assert.Contains(t, result, "x5")
-	})
-
-	t.Run("involved name different from resource shows it", func(t *testing.T) {
-		events := []EventTimelineEntry{
-			{
-				Timestamp:    time.Now().Add(-1 * time.Minute),
-				Type:         "Normal",
-				Reason:       "Scheduled",
-				Message:      "Assigned to node",
-				InvolvedName: "other-pod",
-				InvolvedKind: "Pod",
-				Count:        1,
-			},
-		}
-		result := RenderEventTimelineOverlay(events, "my-pod", 0, 80, 20)
-		assert.Contains(t, result, "Pod/other-pod")
-	})
-
-	t.Run("scroll hints removed from overlay body", func(t *testing.T) {
-		// Hints now live in the main status bar, not inline.
-		events := make([]EventTimelineEntry, 50)
-		for i := range events {
-			events[i] = EventTimelineEntry{
-				Timestamp: time.Now().Add(-time.Duration(i) * time.Minute),
-				Type:      "Normal",
-				Reason:    "Test",
-				Message:   "msg",
-				Count:     1,
-			}
-		}
-		result := RenderEventTimelineOverlay(events, "pod", 0, 80, 15)
-		assert.NotContains(t, result, "j/k: scroll")
 	})
 }

--- a/internal/ui/render_sanitize_test.go
+++ b/internal/ui/render_sanitize_test.go
@@ -1,0 +1,115 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// End-to-end guard for TASK-880. A cluster-sourced field carrying terminal
+// control sequences must not reach the screen: OSC-52 writes the operator's
+// clipboard, CSI rewrites the screen, and a bidi override makes one value read
+// as another. The unit tests next to each sink pin the individual call sites;
+// this one renders the panes a normal session shows and asserts nothing hostile
+// comes out the far end, so a sink added later is caught even if nobody
+// remembers to guard it.
+
+// e2eHostilePayloads are the sequences every render path is driven with, written
+// as escapes because two of them are invisible in a source file.
+var e2eHostilePayloads = map[string]string{
+	"OSC-52 clipboard write": "\x1b]52;c;aGF4\x07",
+	"CSI erase display":      "\x1b[2J",
+	"bidi override":          "\u202e",
+	"C1 control":             "\u009b",
+}
+
+// A payload is neutralized once the bytes that give it power are gone. The
+// printable tail of an OSC sequence renders as the literal text "]52;c;aGF4",
+// which is harmless, and the sanitizers deliberately keep printable characters.
+// The markers are therefore the specific introducers rather than ESC on its
+// own: styled output carries ESC for every SGR colour, so testing for that
+// alone would fail on correct output. "\x1b]" opens an OS command and has no
+// place in lipgloss output; "\x1b[2J" erases the display. The bidi overrides
+// reorder text with no introducer at all.
+var e2eHostileMarkers = map[string]string{
+	"OSC-52 clipboard write": "\x1b]",
+	"CSI erase display":      "\x1b[2J",
+	"bidi override":          "\u202e",
+	"C1 control":             "\u009b",
+}
+
+// BEL terminates an OSC sequence and is a control byte in its own right. No
+// render path has a reason to emit one.
+const e2eBellMarker = "\a"
+
+func assertE2ENoHostileSequence(t *testing.T, sink, payloadKey, rendered string) {
+	t.Helper()
+	if strings.Contains(rendered, e2eHostileMarkers[payloadKey]) {
+		t.Errorf("%s: %s survived into the rendered output", sink, payloadKey)
+	}
+	if strings.Contains(rendered, e2eBellMarker) {
+		t.Errorf("%s: BEL survived into the rendered output (%s)", sink, payloadKey)
+	}
+}
+
+// e2eTaintedItem builds a list row whose every cluster-sourced field carries the
+// payload.
+func e2eTaintedItem(payload string) model.Item {
+	return model.Item{
+		Name:      "pod" + payload,
+		Kind:      "Pod",
+		Namespace: "ns" + payload,
+		Status:    "Running" + payload,
+		Ready:     "1/1" + payload,
+		Restarts:  "0" + payload,
+		Extra:     "image:tag" + payload,
+		Columns: []model.KeyValue{
+			{Key: "Reason", Value: "CrashLoopBackOff" + payload},
+			{Key: "Message", Value: "back-off restarting" + payload},
+		},
+	}
+}
+
+func TestRenderTableDropsHostileSequences(t *testing.T) {
+	for name, payload := range e2eHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			items := []model.Item{e2eTaintedItem(payload)}
+			// The cursor row and the plain rows take different paths.
+			for _, cursor := range []int{0, -1} {
+				out := RenderTable("PODS", items, cursor, 120, 20, false, "", "")
+				assertE2ENoHostileSequence(t, "RenderTable", name, out)
+			}
+		})
+	}
+}
+
+func TestRenderColumnDropsHostileSequences(t *testing.T) {
+	for name, payload := range e2eHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			items := []model.Item{e2eTaintedItem(payload)}
+			out := RenderColumn("TYPES", items, 0, 40, 20, true, false, "", "")
+			assertE2ENoHostileSequence(t, "RenderColumn", name, out)
+		})
+	}
+}
+
+func TestRenderContainerDetailDropsHostileSequences(t *testing.T) {
+	for name, payload := range e2eHostilePayloads {
+		t.Run(name, func(t *testing.T) {
+			item := e2eTaintedItem(payload)
+			out := RenderContainerDetail(&item, 120, 20)
+			assertE2ENoHostileSequence(t, "RenderContainerDetail", name, out)
+		})
+	}
+}
+
+// SGR colour has to survive the body paths, or trivy output and helm values
+// render as plain text. Guards against closing a leak with the blunt sanitizer
+// where the ANSI-aware one belongs.
+func TestBodySanitizerKeepsColour(t *testing.T) {
+	const red = "\x1b[31mFAILED\x1b[0m"
+	if got := SanitizeLogBody(red, true); !strings.Contains(got, "[31m") {
+		t.Errorf("SGR colour must survive the body sanitizer, got %q", got)
+	}
+}


### PR DESCRIPTION
## Why

An OSC-52 clipboard-write sequence placed in a pod name reached the rendered resource table. Verified with a probe before any of this landed:

```
RenderTable    ESC=true BEL=true U+202E=true U+009B=true
```

The list is the default view, so nothing unusual was needed to hit it. TASK-873 wired the sanitizers into the log and describe viewers, YAML blame, `colorizePodPrefix` and `resourceTitleLabel`, and stopped there.

## Closed

- Explorer list cells and all four row builders (`FormatItem`, `FormatItemPlain`, `FormatItemNameOnly`, `FormatItemNameOnlyPlain`): name, namespace, status, ready, restarts, image, every extra and CRD printer column.
- Right-hand preview: detail rows, labels and annotations, conditions, workflow steps, and `renderDataKV`, which shows a revealed Secret value and re-expands escaped newlines and tabs before rendering.
- The K/V editor cell being **edited**. Its sibling already went through `SingleLineCell`, so a hostile Secret value was safe until the user pressed edit on it. The cursor is remapped onto the sanitized buffer.
- **Crash investigator Logs and Describe tabs** — raw container stdout and the verbatim text of `kubectl describe`, which prints annotation values the API server does not restrict at all. The least constrained bytes in the app, and a second render path to what the log viewer already guards.
- Preview events footer, whose struct is sanitized on the event timeline path and was not here.
- Dashboard warning events and Prometheus alert rows, including the **state and severity** columns, whose `default:` branch renders any value the two known cases do not match.
- `ColumnHeaderLabel`, where a CRD condition type becomes a table header among static literals.
- Object explorer and ownership tree labels.

`RenderEventTimelineOverlay` is deleted: same gaps, no non-test callers.

## Which sanitizer

Single-line values get `SanitizeTerminalText`. Bodies get `SanitizeLogBody` plus `StripBidiOverrides`, **line by line**, because the body sanitizer treats a newline as a control byte and would collapse a body onto one row. Sanitizing runs before every truncation and width measurement, since it changes how wide a value is.

## How it was built

Two agents worked disjoint files in parallel, then a `security-reviewer` pass over the combined diff. That pass earned its keep — it found the crash investigator Logs and Describe tabs, which neither lane had been given, and an alert `severity` whose existing test hardcoded a value that could only reach the safe branch. I found a third gap myself: `explorer.go` was in neither lane's file list, and `RenderColumn` came back fully unsanitized while `RenderTable` was clean.

## Test plan

- [x] End-to-end: the list table, sidebar column and container detail rendered with OSC-52, CSI erase, bidi override and a C1 control, asserting none survives
- [x] Per-sink table-driven tests for every newly wired call site
- [x] Red confirmed on the crash tabs: reverting the guard fails 8 assertions, restoring it passes
- [x] SGR colour still survives the body paths, so trivy output and coloured container logs read correctly
- [x] Cursor still lands on the intended character after the edit buffer is sanitized
- [x] `go build ./...`, `go vet ./...`, `go test -count=1 -race ./...`, `golangci-lint run ./...`

Markers test the escape introducers (`\x1b]`, `\x1b[2J`) and the bidi/C1 codepoints, not the printable tail: the sanitizers deliberately keep printable text, and testing for bare ESC would fail on correct styled output.