### PR TITLE
fix: measure wrapCrashText by display width (TASK-882)

### DIFF
--- a/internal/ui/overlay_crash_investigator.go
+++ b/internal/ui/overlay_crash_investigator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // CrashTab is the active tab in the crash investigator overlay.
@@ -459,18 +460,24 @@ func wrapCrashText(s string, width int) []string {
 	}
 	var out []string
 	var cur strings.Builder
+	curWidth := 0
 	flush := func() {
 		out = append(out, cur.String())
 		cur.Reset()
+		curWidth = 0
 	}
 	for word := range strings.FieldsSeq(s) {
-		// Hard-break tokens longer than the column.
+		// Hard-break tokens longer than the column. Cut by display width
+		// (ansi.Truncate/TruncateLeft) rather than byte offset, so a
+		// multibyte rune or an SGR sequence (the Logs/Describe tabs pass
+		// renderAnsi=true) is never split across the wrap boundary.
 		for lipgloss.Width(word) > width {
-			room := width - cur.Len()
-			if cur.Len() > 0 && room > 1 {
+			room := width - curWidth
+			if curWidth > 0 && room > 1 {
 				cur.WriteByte(' ')
+				curWidth++
 				room--
-			} else if cur.Len() > 0 {
+			} else if curWidth > 0 {
 				flush()
 				room = width
 			}
@@ -478,19 +485,22 @@ func wrapCrashText(s string, width int) []string {
 				flush()
 				room = width
 			}
-			cur.WriteString(word[:room])
-			word = word[room:]
+			chunk := ansi.Truncate(word, room, "")
+			cur.WriteString(chunk)
+			word = ansi.TruncateLeft(word, room, "")
 			flush()
 		}
 		next := word
-		if cur.Len() > 0 {
+		if curWidth > 0 {
 			next = " " + word
 		}
-		if cur.Len()+lipgloss.Width(next) > width {
+		if curWidth+lipgloss.Width(next) > width {
 			flush()
 			cur.WriteString(word)
+			curWidth = lipgloss.Width(word)
 		} else {
 			cur.WriteString(next)
+			curWidth += lipgloss.Width(next)
 		}
 	}
 	if cur.Len() > 0 || len(out) == 0 {

--- a/internal/ui/overlay_crash_wrap_test.go
+++ b/internal/ui/overlay_crash_wrap_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWrapCrashText_ColoredLineMatchesPlainColumn asserts that an SGR-colored
+// line wraps at the same column as the equivalent plain line. Before the
+// fix, wrapCrashText compared lipgloss.Width (display columns) against
+// strings.Builder.Len (bytes), so a colored word's escape bytes counted
+// against the column budget and pushed the wrap point earlier.
+func TestWrapCrashText_ColoredLineMatchesPlainColumn(t *testing.T) {
+	plain := "alpha bravo charlie delta echo foxtrot golf"
+	colored := "\x1b[31malpha\x1b[0m bravo \x1b[32mcharlie\x1b[0m delta echo foxtrot golf"
+
+	plainLines := wrapCrashText(plain, 20)
+	coloredLines := wrapCrashText(colored, 20)
+
+	require.Equal(t, len(plainLines), len(coloredLines))
+	for i := range plainLines {
+		assert.Equal(t, ansi.Strip(plainLines[i]), ansi.Strip(coloredLines[i]))
+		assert.LessOrEqual(t, lipgloss.Width(coloredLines[i]), 20)
+	}
+}
+
+// TestWrapCrashText_MultibyteWithinBounds asserts multibyte runes are
+// measured by display width, not byte length, when a run of them has to
+// be hard-broken (a single unbroken token with no whitespace to wrap
+// on). Byte-slicing a 3-byte-per-rune, width-2 rune at a budget that
+// isn't a multiple of 3 cuts inside the rune's encoding and yields an
+// invalid UTF-8 fragment — a defect a plain width<=N bound can't see,
+// since a byte cut can only ever undershoot the display-width budget.
+func TestWrapCrashText_MultibyteWithinBounds(t *testing.T) {
+	word := strings.Repeat("あ", 10) // 3 bytes / 2 cols each, no spaces to wrap on
+
+	for _, l := range wrapCrashText(word, 4) {
+		assert.True(t, utf8.ValidString(l), "line %q is not valid UTF-8 (rune split across a wrap boundary)", l)
+		assert.LessOrEqual(t, lipgloss.Width(l), 4, "line %q exceeds width budget", l)
+	}
+}
+
+// incompleteEscapeAtEnd matches an SGR escape sequence that was cut off
+// before its terminating letter: a trailing ESC, "ESC[", or
+// "ESC[<digits/semicolons>" with nothing after it. A complete sequence
+// always ends in a letter (e.g. "m"), which this pattern excludes.
+var incompleteEscapeAtEnd = regexp.MustCompile(`\x1b(\[[0-9;]*)?$`)
+
+// TestWrapCrashText_HardBreakNeverSplitsSGR asserts a single word longer
+// than the column width, that carries SGR sequences, is hard-broken
+// without ever cutting inside the escape sequence itself. Every lipgloss
+// color emits ESC, so checking for ESC's mere presence proves nothing;
+// this checks each wrapped line does not end mid-sequence.
+func TestWrapCrashText_HardBreakNeverSplitsSGR(t *testing.T) {
+	huge := "\x1b[35m" + strings.Repeat("x", 40) + "\x1b[0m"
+
+	for _, l := range wrapCrashText(huge, 3) {
+		assert.LessOrEqual(t, lipgloss.Width(l), 3, "line %q exceeds width budget", l)
+		assert.False(t, incompleteEscapeAtEnd.MatchString(l), "line %q ends mid-escape-sequence", l)
+	}
+}


### PR DESCRIPTION
`wrapCrashText` wrapped a line by comparing `lipgloss.Width(word)` against `cur.Len()`, which counts bytes. The two disagree for any multibyte character, and for the SGR colour the crash investigator's Logs and Describe tabs keep on purpose, so a coloured or non-ASCII log line wrapped at the wrong column.

The mix predates TASK-880, but it matters more now: those two tabs pass `renderAnsi=true` so a container that colours its own output still reads correctly, which means escape bytes are legitimately present in the string being wrapped. The preview pane took the other road in TASK-880 and drops the escape, so it is not affected.

## Changes

- Track the accumulated width in a `curWidth` int updated through `lipgloss.Width`, instead of reading the buffer's byte length.
- Hard-break an overlong word with `ansi.Truncate` / `ansi.TruncateLeft` rather than slicing bytes. Both re-emit the escape codes present in the token, so no SGR sequence is ever split.

## Tests

Three tests, each proven to fail on the old byte-length code:

- a coloured line wraps at the same column as the equivalent plain line (3 lines vs 4 on the old code)
- a run of `あ` at width 4 stays valid UTF-8 (the old code cut mid-rune)
- a hard break never leaves a line ending inside an escape (the old code produced a bare `\x1b[3`)

Two of these were vacuous in the first draft: they passed on the broken code because the inputs never pushed byte count and display width far enough apart. Rewritten until each one went red against the reverted file.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` 0 issues, `go test -count=1 -race ./...` green across 25 packages. `overlay_crash_investigator.go` at 728 of the 800-line cap.

Closes TASK-882.
