### PR TITLE
feat: add a tainted-string type for cluster-sourced fields (TASK-874)

### DIFF
--- a/internal/app/recompose_theme_test.go
+++ b/internal/app/recompose_theme_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // themeA and themeB differ only in their Base background, which is enough for
@@ -45,7 +47,7 @@ func TestRecomposeThemedContentRerendersCachedPreviews(t *testing.T) {
 			memUsed: 256, memReq: 512, memLim: 1024,
 		},
 		previewEventsData: []ui.EventTimelineEntry{
-			{Timestamp: time.Time{}, Type: "Warning", Reason: "BackOff", Message: "boom", InvolvedName: "p", InvolvedKind: "Pod"},
+			{Timestamp: time.Time{}, Type: tainted.Wrap("Warning"), Reason: tainted.Wrap("BackOff"), Message: tainted.Wrap("boom"), InvolvedName: tainted.Wrap("p"), InvolvedKind: tainted.Wrap("Pod")},
 		},
 		monitoringData: map[string]monitoringData{
 			"ctx": {alerts: []k8s.AlertInfo{{Name: "HighCPU", State: "firing", Severity: "critical"}}},

--- a/internal/app/renderoverlay_test.go
+++ b/internal/app/renderoverlay_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // baseOverlayModel returns a minimal Model for overlay rendering tests.
@@ -309,13 +311,13 @@ func TestRenderOverlayEventTimeline(t *testing.T) {
 	m.eventTimelineData = []k8s.EventInfo{
 		{
 			Timestamp:    time.Now(),
-			Type:         "Normal",
-			Reason:       "Created",
-			Message:      "Created container nginx",
-			Source:       "kubelet",
+			Type:         tainted.Wrap("Normal"),
+			Reason:       tainted.Wrap("Created"),
+			Message:      tainted.Wrap("Created container nginx"),
+			Source:       tainted.Wrap("kubelet"),
 			Count:        1,
-			InvolvedName: "my-pod",
-			InvolvedKind: "Pod",
+			InvolvedName: tainted.Wrap("my-pod"),
+			InvolvedKind: tainted.Wrap("Pod"),
 		},
 	}
 	m.actionCtx = actionContext{name: "my-pod"}

--- a/internal/app/update_msg_extra_test.go
+++ b/internal/app/update_msg_extra_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // --- helpers ---
@@ -1107,7 +1109,7 @@ func TestUpdateEventTimelineSuccess(t *testing.T) {
 	m.loading = true
 
 	events := []k8s.EventInfo{
-		{Reason: "Pulled", Message: "Container image pulled"},
+		{Reason: tainted.Wrap("Pulled"), Message: tainted.Wrap("Container image pulled")},
 	}
 	result, cmd := m.Update(eventTimelineMsg{events: events})
 	mdl := result.(Model)

--- a/internal/app/update_msg_test.go
+++ b/internal/app/update_msg_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // --- Update: tea.WindowSizeMsg ---
@@ -971,7 +973,7 @@ func TestPush3UpdatePreviewEventsLoadedMsg(t *testing.T) {
 	m.requestGen = 5
 	msg := previewEventsLoadedMsg{
 		events: []k8s.EventInfo{
-			{Type: "Normal", Reason: "Scheduled", Message: "pod assigned", Source: "scheduler"},
+			{Type: tainted.Wrap("Normal"), Reason: tainted.Wrap("Scheduled"), Message: tainted.Wrap("pod assigned"), Source: tainted.Wrap("scheduler")},
 		},
 		gen: 5,
 	}
@@ -2579,7 +2581,7 @@ func TestCovUpdateFinalizerSearch(t *testing.T) {
 func TestCovUpdateEventTimeline(t *testing.T) {
 	m := baseModelUpdate()
 	result, _ := m.Update(eventTimelineMsg{
-		events: []k8s.EventInfo{{Message: "event 1"}, {Message: "event 2"}},
+		events: []k8s.EventInfo{{Message: tainted.Wrap("event 1")}, {Message: tainted.Wrap("event 2")}},
 	})
 	rm := result.(Model)
 	assert.Equal(t, overlayEventTimeline, rm.overlay)
@@ -2588,7 +2590,7 @@ func TestCovUpdateEventTimeline(t *testing.T) {
 func TestCovUpdatePreviewEvents(t *testing.T) {
 	m := baseModelUpdate()
 	result, _ := m.Update(previewEventsLoadedMsg{
-		events: []k8s.EventInfo{{Message: "evt-1"}},
+		events: []k8s.EventInfo{{Message: tainted.Wrap("evt-1")}},
 	})
 	_ = result
 }

--- a/internal/app/update_nav_pckeys_test.go
+++ b/internal/app/update_nav_pckeys_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // PC-style navigation keys (Home/End/PgUp/PgDown) should behave the same as
@@ -551,9 +553,9 @@ func eventTimelineModel() Model {
 	events := make([]k8s.EventInfo, n)
 	for i := range n {
 		events[i] = k8s.EventInfo{
-			Type:    "Normal",
-			Reason:  "Scheduled",
-			Message: "event message",
+			Type:    tainted.Wrap("Normal"),
+			Reason:  tainted.Wrap("Scheduled"),
+			Message: tainted.Wrap("event message"),
 		}
 	}
 	m := Model{

--- a/internal/app/update_overlays_events.go
+++ b/internal/app/update_overlays_events.go
@@ -43,13 +43,10 @@ func padColumn(s string, width int) string {
 // for cursor navigation. Each event becomes a single line with format:
 // {age}  {type}  {reason}  {message}
 //
-// Type, Reason, Message, and Source are cluster-controlled - any principal
-// that can create an Event in the namespace sets them - so they are
-// sanitized here, the single place raw k8s.EventInfo values turn into
-// displayed text for this viewer. SanitizeTerminalText, not the ANSI-aware
-// body sanitizer, because these are short table-cell values with no
-// legitimate reason to carry colour or tabs (matches how resourceTitleLabel
-// treats kind/namespace/name).
+// Type, Reason, Message, and Source are tainted.String, so the compiler
+// requires the unwrap below. Line, not the ANSI-aware Body, because these are
+// short table-cell values with no legitimate reason to carry colour or tabs
+// (matches how resourceTitleLabel treats kind/namespace/name).
 func (m *Model) buildEventTimelineLines() []string {
 	lines := make([]string, 0, len(m.eventTimelineData))
 	for _, e := range m.eventTimelineData {
@@ -58,12 +55,12 @@ func (m *Model) buildEventTimelineLines() []string {
 		if e.Count > 1 {
 			countStr = fmt.Sprintf(" (x%d)", e.Count)
 		}
-		typ := padColumn(ui.SanitizeTerminalText(e.Type), eventTimelineTypeWidth)
-		reason := padColumn(ui.SanitizeTerminalText(e.Reason), eventTimelineReasonWidth)
-		message := ui.SanitizeTerminalText(e.Message)
+		typ := padColumn(e.Type.Line(), eventTimelineTypeWidth)
+		reason := padColumn(e.Reason.Line(), eventTimelineReasonWidth)
+		message := e.Message.Line()
 		src := ""
-		if e.Source != "" {
-			src = " [" + ui.SanitizeTerminalText(e.Source) + "]"
+		if !e.Source.IsEmpty() {
+			src = " [" + e.Source.Line() + "]"
 		}
 		line := fmt.Sprintf("%-8s %s %s %s%s%s",
 			ts, typ, reason, message, countStr, src)

--- a/internal/app/update_overlays_events_test.go
+++ b/internal/app/update_overlays_events_test.go
@@ -10,15 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/k8s"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 func newEventModel(numEvents int) Model {
 	events := make([]k8s.EventInfo, numEvents)
 	for i := range events {
 		events[i] = k8s.EventInfo{
-			Type:    "Normal",
-			Reason:  "Scheduled",
-			Message: "event message",
+			Type:    tainted.Wrap("Normal"),
+			Reason:  tainted.Wrap("Scheduled"),
+			Message: tainted.Wrap("event message"),
 		}
 	}
 	m := Model{
@@ -55,10 +57,10 @@ func TestBuildEventTimelineLinesEmpty(t *testing.T) {
 func TestBuildEventTimelineLinesSanitizesControlBytes(t *testing.T) {
 	m := Model{
 		eventTimelineData: []k8s.EventInfo{{
-			Type:    "Warning",
-			Reason:  "Hacked\x9b31m",
-			Message: "\x1b]52;c;SGVsbG8=\x07payload",
-			Source:  "evil\x9c",
+			Type:    tainted.Wrap("Warning"),
+			Reason:  tainted.Wrap("Hacked\x9b31m"),
+			Message: tainted.Wrap("\x1b]52;c;SGVsbG8=\x07payload"),
+			Source:  tainted.Wrap("evil\x9c"),
 		}},
 	}
 	lines := m.buildEventTimelineLines()
@@ -77,9 +79,9 @@ func TestBuildEventTimelineLinesSanitizesControlBytes(t *testing.T) {
 func TestBuildEventTimelineLinesSanitizesType(t *testing.T) {
 	m := Model{
 		eventTimelineData: []k8s.EventInfo{{
-			Type:    "\x9d52;c;SGVsbG8=\x9c",
-			Reason:  "Scheduled",
-			Message: "ok",
+			Type:    tainted.Wrap("\x9d52;c;SGVsbG8=\x9c"),
+			Reason:  tainted.Wrap("Scheduled"),
+			Message: tainted.Wrap("ok"),
 		}},
 	}
 	lines := m.buildEventTimelineLines()
@@ -89,9 +91,9 @@ func TestBuildEventTimelineLinesSanitizesType(t *testing.T) {
 
 	m2 := Model{
 		eventTimelineData: []k8s.EventInfo{{
-			Type:    "\x9b31m",
-			Reason:  "Scheduled",
-			Message: "ok",
+			Type:    tainted.Wrap("\x9b31m"),
+			Reason:  tainted.Wrap("Scheduled"),
+			Message: tainted.Wrap("ok"),
 		}},
 	}
 	lines2 := m2.buildEventTimelineLines()
@@ -104,9 +106,9 @@ func TestBuildEventTimelineLinesSanitizesType(t *testing.T) {
 func TestBuildEventTimelineLinesOrdinaryTypeUnaffected(t *testing.T) {
 	m := Model{
 		eventTimelineData: []k8s.EventInfo{{
-			Type:    "Warning",
-			Reason:  "Scheduled",
-			Message: "ok",
+			Type:    tainted.Wrap("Warning"),
+			Reason:  tainted.Wrap("Scheduled"),
+			Message: tainted.Wrap("ok"),
 		}},
 	}
 	lines := m.buildEventTimelineLines()
@@ -123,8 +125,8 @@ func TestBuildEventTimelineLinesOrdinaryTypeUnaffected(t *testing.T) {
 func TestBuildEventTimelineLinesWideUnicodeColumnsAligned(t *testing.T) {
 	m := Model{
 		eventTimelineData: []k8s.EventInfo{
-			{Type: "Normal", Reason: "Scheduled", Message: "ascii message"},
-			{Type: "普通", Reason: "スケジュール済み", Message: "wide message"},
+			{Type: tainted.Wrap("Normal"), Reason: tainted.Wrap("Scheduled"), Message: tainted.Wrap("ascii message")},
+			{Type: tainted.Wrap("普通"), Reason: tainted.Wrap("スケジュール済み"), Message: tainted.Wrap("wide message")},
 		},
 	}
 	lines := m.buildEventTimelineLines()
@@ -146,9 +148,9 @@ func TestBuildEventTimelineLinesWideUnicodeColumnsAligned(t *testing.T) {
 func TestBuildEventTimelineLinesTruncatesOverlongTypeAndReason(t *testing.T) {
 	m := Model{
 		eventTimelineData: []k8s.EventInfo{{
-			Type:    "VeryLongEventTypeNameThatOverflows",
-			Reason:  "AnEvenLongerReasonStringThatDefinitelyExceedsTwentyColumns",
-			Message: "the message",
+			Type:    tainted.Wrap("VeryLongEventTypeNameThatOverflows"),
+			Reason:  tainted.Wrap("AnEvenLongerReasonStringThatDefinitelyExceedsTwentyColumns"),
+			Message: tainted.Wrap("the message"),
 		}},
 	}
 	lines := m.buildEventTimelineLines()

--- a/internal/k8s/client_fakeclient_test.go
+++ b/internal/k8s/client_fakeclient_test.go
@@ -1989,9 +1989,9 @@ func TestGetResourceEvents(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, events, 2)
 	// Most recent first.
-	assert.Equal(t, "BackOff", events[0].Reason)
-	assert.Equal(t, "ScalingReplicaSet", events[1].Reason)
-	assert.Equal(t, "deployment-controller", events[1].Source)
+	assert.Equal(t, "BackOff", events[0].Reason.Raw())
+	assert.Equal(t, "ScalingReplicaSet", events[1].Reason.Raw())
+	assert.Equal(t, "deployment-controller", events[1].Source.Raw())
 }
 
 func TestGetResourceEvents_NoEvents(t *testing.T) {
@@ -2058,7 +2058,7 @@ func TestGetResourceEvents_ReportingComponentFallback(t *testing.T) {
 	events, err := c.GetResourceEvents(t.Context(), "", "default", "my-pod", "Pod")
 	require.NoError(t, err)
 	assert.Len(t, events, 1)
-	assert.Equal(t, "kubelet", events[0].Source)
+	assert.Equal(t, "kubelet", events[0].Source.Raw())
 }
 
 // --- GetPodsUsingPVC ---

--- a/internal/k8s/client_rbac.go
+++ b/internal/k8s/client_rbac.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // CheckRBAC checks what verbs the current user can perform on the given resource.
@@ -415,15 +417,20 @@ func computeQuotaPercent(_, hardStr, usedStr string) float64 {
 }
 
 // EventInfo holds a single Kubernetes event with its key fields.
+//
+// Every text field is tainted: any principal that can create an Event in the
+// namespace chooses Type, Reason, Message and Source, and the involved
+// object's name and kind come from the same object graph. Unwrap with Line
+// for a table cell, Body for a wrapped message pane.
 type EventInfo struct {
 	Timestamp    time.Time
-	Type         string // "Normal" or "Warning"
-	Reason       string
-	Message      string
-	Source       string // e.g. "kubelet", "scheduler"
+	Type         tainted.String // "Normal" or "Warning"
+	Reason       tainted.String
+	Message      tainted.String
+	Source       tainted.String // e.g. "kubelet", "scheduler"
 	Count        int32
-	InvolvedName string
-	InvolvedKind string
+	InvolvedName tainted.String
+	InvolvedKind tainted.String
 }
 
 // GetResourceEvents fetches events related to the named resource and its owned
@@ -508,13 +515,13 @@ func (c *Client) GetResourceEvents(ctx context.Context, kubeCtx, namespace, name
 
 		events = append(events, EventInfo{
 			Timestamp:    ts,
-			Type:         eventType,
-			Reason:       reason,
-			Message:      message,
-			Source:       source,
+			Type:         tainted.Wrap(eventType),
+			Reason:       tainted.Wrap(reason),
+			Message:      tainted.Wrap(message),
+			Source:       tainted.Wrap(source),
 			Count:        int32(countVal),
-			InvolvedName: involvedName,
-			InvolvedKind: involvedKind,
+			InvolvedName: tainted.Wrap(involvedName),
+			InvolvedKind: tainted.Wrap(involvedKind),
 		})
 	}
 

--- a/internal/k8s/eventinfo_tainted_test.go
+++ b/internal/k8s/eventinfo_tainted_test.go
@@ -1,0 +1,26 @@
+package k8s_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/tainted"
+)
+
+// TestEventInfoHasNoRawStringFields fails when any text field on EventInfo is
+// a plain string. Every one of them is cluster-controlled - any principal that
+// can create an Event in a watched namespace sets Type, Reason, Message and
+// Source - so a plain string here is a sink that a reviewer has to remember to
+// sanitize. This is the guard that catches a NEW field, which is how the leak
+// recurred: sibling fields in one Sprintf, three of them sanitized.
+func TestEventInfoHasNoRawStringFields(t *testing.T) {
+	taintedType := reflect.TypeFor[tainted.String]()
+
+	for f := range reflect.TypeFor[k8s.EventInfo]().Fields() {
+		assert.NotEqual(t, reflect.String, f.Type.Kind(),
+			"EventInfo.%s is a raw string; cluster-controlled text must be %s", f.Name, taintedType)
+	}
+}

--- a/internal/tainted/sanitize.go
+++ b/internal/tainted/sanitize.go
@@ -1,0 +1,218 @@
+package tainted
+
+// The sanitizers below were moved verbatim from internal/ui so that
+// internal/k8s and internal/model - which must not import internal/ui - can
+// reach them through tainted.String. internal/ui re-exports each one, so its
+// existing call sites are unchanged.
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// SanitizeTerminalText strips the control characters described above from any
+// cluster-controlled string before it reaches the screen. Exported so every
+// such string passes through one implementation: the YAML blame gutter shows
+// field manager names, which a non-core apiserver can set to anything.
+//
+// It also drops the bidi embedding, override, and isolate characters
+// (U+202A-U+202E, U+2066-U+2069). Those reorder the text that follows them,
+// so a hostile name can make one value read as another on screen. The plain
+// direction marks U+200E and U+200F stay, because they only hint at direction
+// and legitimate right-to-left text uses them.
+func SanitizeTerminalText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) || isBidiOverride(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// StripBidiOverrides removes only the bidi embedding/override/isolate
+// characters SanitizeTerminalText drops (see its doc comment), leaving
+// everything else - including ESC, tabs, and SGR sequences - untouched.
+// For sinks that need SanitizeLogBody's ANSI/tab handling but still must
+// guard against a hostile value reordering the rendered text.
+func StripBidiOverrides(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isBidiOverride(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func isBidiOverride(r rune) bool {
+	return (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069)
+}
+
+// logTabWidth is the column step used when expanding tab characters in
+// log lines. 8 matches the default tab stop on virtually every terminal,
+// so the post-expansion text aligns the way a user pasting the same line
+// into their shell would expect.
+const logTabWidth = 8
+
+// SanitizeLogBody is the exported entry point to sanitizeLogLine for sinks
+// outside this file (describe content, command-bar output) that render a
+// BODY rather than a name or title: unlike SanitizeTerminalText, it keeps
+// SGR colour sequences and expands tabs instead of dropping them. See
+// sanitizeLogLine for the full behaviour.
+func SanitizeLogBody(s string, renderAnsi bool) string {
+	return sanitizeLogLine(s, renderAnsi)
+}
+
+// sanitizeLogLine replaces non-printable control bytes (NUL, DEL, the C0
+// control range minus tab, and the C1 range U+0080-U+009F) with the
+// Unicode replacement character and expands tab characters to spaces
+// using a logTabWidth-column tab stop. Binary data from processes like
+// MySQL handshakes contains bytes that break terminal width calculations
+// and corrupt the viewer layout; C1 controls (raw or UTF-8-encoded, e.g.
+// U+009B "CSI") let a log line hijack the terminal on emulators that
+// honour 8-bit C1 (VTE, Linux console).
+//
+// Tab expansion is required because lipgloss.Width treats '\t' as
+// zero-width while the terminal renders it as a jump to the next tab
+// stop. The viewer's contentWidth-overflow guard (in RenderLogViewer)
+// uses lipgloss.Width to decide when to truncate; without expansion,
+// tab-bearing lines slip through with an undercounted width, get
+// re-wrapped internally by lipgloss, and push the bottom border off the
+// visible area. Reported on dragonfly-operator (controller-runtime/zap)
+// logs in particular - those use tabs to separate timestamp / level /
+// logger / message.
+//
+// When renderAnsi is true, valid CSI SGR sequences (ESC [ params m — the
+// ones that set colour, bold, underline, etc.) are preserved verbatim so
+// log producers that emit ANSI colours render as intended. Non-SGR CSI
+// sequences (cursor movement, screen erase) remain unsafe for an inline
+// viewer and are still replaced. A bare ESC with no valid CSI introducer
+// is replaced too; leaving it would cause terminals to wait for a
+// follow-up byte and mis-interpret subsequent output.
+//
+// C1 detection is decode-aware, not a raw byte-range check: a byte-level
+// test for 0x80-0x9F would also catch UTF-8 continuation bytes of
+// ordinary non-ASCII runes (many common accented Latin, CJK, emoji, and
+// box-drawing characters have a continuation byte in that range) and
+// mangle them. Every non-ASCII byte is instead decoded to its full rune;
+// only a rune that actually equals U+0080-U+009F is replaced, whether it
+// arrived as a raw invalid byte or a valid two-byte UTF-8 encoding (e.g.
+// 0xC2 0x9B for U+009B). Anything else - including genuinely invalid
+// UTF-8 outside the C1 range - copies through as before.
+func sanitizeLogLine(s string, renderAnsi bool) string {
+	// Fast path: no control bytes, tabs needing expansion, or non-ASCII
+	// bytes means no work to do. Any byte >= 0x80 must go through the
+	// slow path because it might decode to a C1 control character.
+	needsSanitize := false
+	for i := range len(s) {
+		c := s[i]
+		if c < 32 || c == 127 || c >= 0x80 {
+			needsSanitize = true
+			break
+		}
+	}
+	if !needsSanitize {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	col := 0
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if renderAnsi && c == 0x1b {
+			if end := parseSGRSequence(s, i); end > i {
+				// SGR sequences are zero-width; do not advance col.
+				b.WriteString(s[i:end])
+				i = end
+				continue
+			}
+		}
+		if c == '\t' {
+			n := logTabWidth - col%logTabWidth
+			for range n {
+				b.WriteByte(' ')
+			}
+			col += n
+			i++
+			continue
+		}
+		if c < 0x80 {
+			if c >= 32 && c != 127 {
+				b.WriteByte(c)
+				col++
+			} else {
+				// Control byte (< 32 and not tab, or DEL).
+				b.WriteRune('\ufffd')
+			}
+			i++
+			continue
+		}
+		// Non-ASCII byte: decode the full rune so a C1 control encoded
+		// as two valid UTF-8 bytes is judged by its decoded value, not
+		// by the raw continuation byte (see the C1 detection note
+		// above).
+		r, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case r == utf8.RuneError && size <= 1:
+			// Invalid UTF-8. A lone byte in the C1 range is still a
+			// control character regardless of encoding; anything else
+			// invalid passes through unchanged, matching legacy
+			// behaviour for non-UTF-8 binary payloads. Column tracking
+			// mirrors the old approximation: only a would-be leading
+			// byte (>= 0xC0) counts as one cell.
+			if c >= 0x80 && c <= 0x9f {
+				b.WriteRune('\ufffd')
+			} else {
+				b.WriteByte(c)
+				if c >= 0xC0 {
+					col++
+				}
+			}
+			i++
+		case r >= 0x80 && r <= 0x9f:
+			// Valid UTF-8 encoding of a C1 control character.
+			b.WriteRune('\ufffd')
+			i += size
+		default:
+			// Ordinary multi-byte rune: copy through untouched.
+			b.WriteString(s[i : i+size])
+			col++
+			i += size
+		}
+	}
+	return b.String()
+}
+
+// parseSGRSequence returns the index after a valid ESC [ ... m sequence
+// starting at s[i], or i if no valid sequence is present. Only SGR
+// (Select Graphic Rendition) finals are accepted because they set
+// colour and text attributes without moving the cursor or clearing the
+// screen — preserving them is safe in an inline viewer, whereas other
+// CSI finals would corrupt the layout.
+func parseSGRSequence(s string, i int) int {
+	if i+1 >= len(s) || s[i] != 0x1b || s[i+1] != '[' {
+		return i
+	}
+	j := i + 2
+	// Parameter bytes: 0x30-0x3F (digits and ; : < = > ?).
+	for j < len(s) && s[j] >= 0x30 && s[j] <= 0x3F {
+		j++
+	}
+	// Intermediate bytes: 0x20-0x2F (space and ! " # $ % & ' ( ) * + , - . /).
+	for j < len(s) && s[j] >= 0x20 && s[j] <= 0x2F {
+		j++
+	}
+	// SGR final byte is lowercase 'm'. Anything else is a CSI we can't
+	// safely forward to an inline viewer.
+	if j < len(s) && s[j] == 'm' {
+		return j + 1
+	}
+	return i
+}

--- a/internal/tainted/sanitize.go
+++ b/internal/tainted/sanitize.go
@@ -201,16 +201,18 @@ func parseSGRSequence(s string, i int) int {
 		return i
 	}
 	j := i + 2
-	// Parameter bytes: 0x30-0x3F (digits and ; : < = > ?).
-	for j < len(s) && s[j] >= 0x30 && s[j] <= 0x3F {
+	// Parameter bytes: digits, ';' and ':' only (truecolour uses both
+	// separators). This deliberately excludes the private markers < = > ?
+	// and the CSI intermediate bytes 0x20-0x2F: CSI > Ps ; Ps m is
+	// XTMODKEYS, which reprograms xterm's keyboard-modifier reporting, so
+	// forwarding a private marker let a cluster-controlled line change
+	// terminal state after rendering (TASK-885).
+	for j < len(s) && (s[j] == ';' || s[j] == ':' || (s[j] >= '0' && s[j] <= '9')) {
 		j++
 	}
-	// Intermediate bytes: 0x20-0x2F (space and ! " # $ % & ' ( ) * + , - . /).
-	for j < len(s) && s[j] >= 0x20 && s[j] <= 0x2F {
-		j++
-	}
-	// SGR final byte is lowercase 'm'. Anything else is a CSI we can't
-	// safely forward to an inline viewer.
+	// SGR final byte is lowercase 'm'. Anything else - including a private
+	// marker or intermediate byte that stopped the loop above - is a CSI
+	// we can't safely forward to an inline viewer.
 	if j < len(s) && s[j] == 'm' {
 		return j + 1
 	}

--- a/internal/tainted/sanitize_test.go
+++ b/internal/tainted/sanitize_test.go
@@ -1,0 +1,60 @@
+package tainted_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/tainted"
+)
+
+// TestSGRParameterBytesRejectPrivateMarkersAndIntermediates is TASK-885: the
+// CSI parameter scan in parseSGRSequence accepted the whole 0x30-0x3F range,
+// which includes the private markers < = > ?. CSI > Ps ; Ps m is XTMODKEYS -
+// xterm reads it as a request to change keyboard modifier reporting - so a
+// cluster-controlled log line carrying that marker altered terminal state
+// after rendering. This asserts each private marker, plus a CSI intermediate
+// byte, is rejected rather than forwarded.
+func TestSGRParameterBytesRejectPrivateMarkersAndIntermediates(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"private marker <", "pre\x1b[<4;2mpost"},
+		{"private marker =", "pre\x1b[=4;2mpost"},
+		{"private marker >", "pre\x1b[>4;2mpost"},
+		{"private marker ?", "pre\x1b[?4;2mpost"},
+		{"intermediate byte", "pre\x1b[ mpost"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tainted.Wrap(tc.payload).Body(true)
+			assert.NotContains(t, out, "\x1b[", "payload %q should not survive as a CSI sequence", tc.payload)
+		})
+	}
+}
+
+// TestSGRParameterBytesKeepLegitimateColour guards the reason the parameter
+// forwarding exists at all: plain SGR colour, including both truecolour
+// separator forms, resets, and combined attributes, must still render when
+// renderAnsi is true.
+func TestSGRParameterBytesKeepLegitimateColour(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{"8-colour", "pre\x1b[31mpost", "\x1b[31m"},
+		{"256-colour", "pre\x1b[38;5;196mpost", "\x1b[38;5;196m"},
+		{"truecolour semicolon", "pre\x1b[38;2;255;0;0mpost", "\x1b[38;2;255;0;0m"},
+		{"truecolour colon", "pre\x1b[38:2:255:0:0mpost", "\x1b[38:2:255:0:0m"},
+		{"reset", "pre\x1b[0mpost", "\x1b[0m"},
+		{"combined attributes", "pre\x1b[1;4;31mpost", "\x1b[1;4;31m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tainted.Wrap(tc.payload).Body(true)
+			assert.Contains(t, out, tc.want, "payload %q should keep its SGR sequence", tc.payload)
+		})
+	}
+}

--- a/internal/tainted/tainted.go
+++ b/internal/tainted/tainted.go
@@ -1,0 +1,114 @@
+// Package tainted carries cluster-sourced strings in a wrapper that cannot
+// reach the terminal without an explicit, named sanitizer call.
+//
+// Everything lfk renders comes from the cluster, so any principal able to
+// create an object in a watched namespace controls those strings. A raw
+// escape sequence on the terminal means OSC-52 clipboard writes, screen
+// rewrites via CSI, and text reordering via bidi overrides. Reviews caught
+// this four times and still missed sibling fields in the same Sprintf, so
+// the guarantee is moved into the type system instead.
+//
+// The package is a leaf: it imports nothing from lfk, so internal/k8s,
+// internal/model and internal/ui can all use it without an import cycle.
+// The sanitizer implementations live here (see sanitize.go) rather than in
+// internal/ui for the same reason; internal/ui re-exports them.
+package tainted
+
+import (
+	"fmt"
+	"strings"
+)
+
+// unsanitizedMarker is what a String renders as when it reaches fmt without
+// an unwrap. It is deliberately loud and greppable: a leak becomes a visible
+// bug report rather than silent terminal control.
+const unsanitizedMarker = "[tainted:unsanitized]"
+
+// String holds a cluster-controlled value. The payload is unexported, so the
+// value cannot be concatenated, compared to a literal, or passed where a
+// plain string is expected. Reaching the payload requires choosing one of
+// the two unwraps below, which is the point: the choice between the
+// single-line and the body sanitizer is a real decision that a default would
+// hide.
+type String struct {
+	raw string
+}
+
+// Wrap marks a value as cluster-controlled. Call it at the boundary where
+// the value enters lfk - the API response decode - not at the render site.
+func Wrap(s string) String {
+	return String{raw: s}
+}
+
+// WrapAll wraps a slice in place-equivalent order.
+func WrapAll(ss []string) []String {
+	out := make([]String, len(ss))
+	for i, s := range ss {
+		out[i] = Wrap(s)
+	}
+	return out
+}
+
+// Line unwraps for a single-line sink: a table cell, a title, a status
+// message. Drops C0/C1 controls and bidi overrides entirely; no ANSI or tab
+// survives, because a short cell has no legitimate use for either.
+func (t String) Line() string {
+	return SanitizeTerminalText(t.raw)
+}
+
+// Body unwraps for a multi-line sink: a log body, a describe pane, command
+// output. Strips bidi overrides, then keeps SGR colour sequences when
+// renderAnsi is set and expands tabs. Use Line for anything that lands in a
+// single cell.
+func (t String) Body(renderAnsi bool) string {
+	return SanitizeLogBody(StripBidiOverrides(t.raw), renderAnsi)
+}
+
+// Is reports whether the payload equals a trusted literal. For branching on
+// known API enum values (Event Type "Warning", a condition status) without
+// unwrapping. The argument is a constant in lfk's own source, never another
+// cluster value.
+func (t String) Is(literal string) bool {
+	return t.raw == literal
+}
+
+// IsEmpty reports whether the payload is empty, so "render this row only if
+// the field is set" needs no unwrap.
+func (t String) IsEmpty() bool {
+	return t.raw == ""
+}
+
+// Compare orders two payloads like strings.Compare, for sorting without
+// unwrapping.
+func (t String) Compare(other String) int {
+	return strings.Compare(t.raw, other.raw)
+}
+
+// Contains reports whether the payload contains sub, for filter matching
+// without unwrapping.
+func (t String) Contains(sub string) bool {
+	return strings.Contains(t.raw, sub)
+}
+
+// Raw returns the payload unsanitized. It exists for the non-render paths
+// that need the exact bytes the cluster sent: sending a value back to the
+// API server, a map key, a file write. Never pass the result to anything
+// that reaches the terminal - use Line or Body. Every call is a deliberate
+// exception and should be greppable as such.
+func (t String) Raw() string {
+	return t.raw
+}
+
+// Format makes String print the marker under every verb, so a String that
+// slips into a Sprintf leaks nothing. Implementing fmt.Formatter rather than
+// only fmt.Stringer matters: %v, %q, %d and %#v all route here, whereas a
+// bare String method leaves %#v printing the struct with its payload.
+func (t String) Format(f fmt.State, _ rune) {
+	_, _ = f.Write([]byte(unsanitizedMarker))
+}
+
+// String satisfies fmt.Stringer for the paths that call it directly rather
+// than going through fmt.
+func (t String) String() string {
+	return unsanitizedMarker
+}

--- a/internal/tainted/tainted_test.go
+++ b/internal/tainted/tainted_test.go
@@ -1,0 +1,99 @@
+package tainted_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/tainted"
+)
+
+// hostile carries every escape class the threat model cares about: OSC-52
+// clipboard write, a CSI screen erase, and a bidi override that reorders the
+// text after it.
+const hostile = "ok\x1b]52;c;aGF4\x07\x1b[2Jsafe‮txet"
+
+// TestFormatVerbsNeverEmitPayload is the core guarantee: a String that
+// reaches fmt without an unwrap must emit the marker, not the payload. It
+// covers %v and %#v specifically because a plain String() method leaves
+// those printing the struct with its payload intact.
+func TestFormatVerbsNeverEmitPayload(t *testing.T) {
+	v := tainted.Wrap(hostile)
+	for _, verb := range []string{"%s", "%v", "%q", "%d", "%#v", "%+v"} {
+		out := fmt.Sprintf(verb, v)
+		assert.NotContains(t, out, "\x1b", "verb %s emitted a raw ESC", verb)
+		assert.NotContains(t, out, "‮", "verb %s emitted a bidi override", verb)
+		assert.Contains(t, out, "[tainted:unsanitized]", "verb %s should emit the marker", verb)
+	}
+}
+
+// TestFormatInsideStructNeverEmitsPayload covers the failure that actually
+// shipped four times: a sibling field printed raw in the same Sprintf as
+// sanitized ones. Printing the whole struct must not leak either.
+func TestFormatInsideStructNeverEmitsPayload(t *testing.T) {
+	s := struct {
+		Reason  tainted.String
+		Message tainted.String
+	}{tainted.Wrap(hostile), tainted.Wrap(hostile)}
+
+	// %d is in the list on purpose: a String with only a Stringer method
+	// survives %v but leaks the payload through fmt's wrong-verb reporting.
+	for _, verb := range []string{"%v", "%+v", "%d"} {
+		out := fmt.Sprintf(verb, s)
+		assert.NotContains(t, out, "\x1b", "verb %s leaked an ESC from a struct field", verb)
+		assert.NotContains(t, out, "‮", "verb %s leaked a bidi override from a struct field", verb)
+	}
+}
+
+func TestStringerEmitsMarker(t *testing.T) {
+	assert.Equal(t, "[tainted:unsanitized]", tainted.Wrap(hostile).String())
+}
+
+// TestLineStripsEverySinkUnsafeRune checks the single-line unwrap drops
+// controls, ESC and bidi overrides while keeping ordinary text.
+func TestLineStripsEverySinkUnsafeRune(t *testing.T) {
+	out := tainted.Wrap(hostile).Line()
+	assert.NotContains(t, out, "\x1b")
+	assert.NotContains(t, out, "‮")
+	assert.NotContains(t, out, "\x07")
+	assert.Contains(t, out, "safe")
+}
+
+// TestBodyStripsBidiAndKeepsSGR checks the body unwrap makes the other
+// trade-off: colour survives, reordering does not.
+func TestBodyStripsBidiAndKeepsSGR(t *testing.T) {
+	out := tainted.Wrap("\x1b[32mgreen\x1b[0m‮flip").Body(true)
+	assert.Contains(t, out, "\x1b[32m", "SGR colour should survive the body unwrap")
+	assert.NotContains(t, out, "‮", "bidi override must not survive the body unwrap")
+
+	plain := tainted.Wrap("\x1b[2Jerase").Body(false)
+	assert.NotContains(t, plain, "\x1b", "a non-SGR CSI must not survive even with renderAnsi off")
+}
+
+// TestNonRenderAccessorsAvoidUnwrapping documents that branching, sorting
+// and filtering do not need a sanitizer, so nobody reaches for Raw to do
+// them.
+func TestNonRenderAccessorsAvoidUnwrapping(t *testing.T) {
+	warn := tainted.Wrap("Warning")
+	assert.True(t, warn.Is("Warning"))
+	assert.False(t, warn.Is("Normal"))
+	assert.False(t, warn.IsEmpty())
+	assert.True(t, tainted.Wrap("").IsEmpty())
+	assert.True(t, warn.Contains("arn"))
+	assert.Negative(t, tainted.Wrap("a").Compare(tainted.Wrap("b")))
+}
+
+func TestRawReturnsPayloadVerbatim(t *testing.T) {
+	assert.Equal(t, hostile, tainted.Wrap(hostile).Raw())
+}
+
+func TestWrapAllPreservesOrder(t *testing.T) {
+	got := tainted.WrapAll([]string{"a", "b", "c"})
+	var b strings.Builder
+	for _, v := range got {
+		b.WriteString(v.Raw())
+	}
+	assert.Equal(t, "abc", b.String())
+}

--- a/internal/tainted/tainted_test.go
+++ b/internal/tainted/tainted_test.go
@@ -13,7 +13,7 @@ import (
 // hostile carries every escape class the threat model cares about: OSC-52
 // clipboard write, a CSI screen erase, and a bidi override that reorders the
 // text after it.
-const hostile = "ok\x1b]52;c;aGF4\x07\x1b[2Jsafe‮txet"
+const hostile = "ok\x1b]52;c;aGF4\x07\x1b[2Jsafe\u202etxet"
 
 // TestFormatVerbsNeverEmitPayload is the core guarantee: a String that
 // reaches fmt without an unwrap must emit the marker, not the payload. It
@@ -24,7 +24,7 @@ func TestFormatVerbsNeverEmitPayload(t *testing.T) {
 	for _, verb := range []string{"%s", "%v", "%q", "%d", "%#v", "%+v"} {
 		out := fmt.Sprintf(verb, v)
 		assert.NotContains(t, out, "\x1b", "verb %s emitted a raw ESC", verb)
-		assert.NotContains(t, out, "‮", "verb %s emitted a bidi override", verb)
+		assert.NotContains(t, out, "\u202e", "verb %s emitted a bidi override", verb)
 		assert.Contains(t, out, "[tainted:unsanitized]", "verb %s should emit the marker", verb)
 	}
 }
@@ -43,7 +43,7 @@ func TestFormatInsideStructNeverEmitsPayload(t *testing.T) {
 	for _, verb := range []string{"%v", "%+v", "%d"} {
 		out := fmt.Sprintf(verb, s)
 		assert.NotContains(t, out, "\x1b", "verb %s leaked an ESC from a struct field", verb)
-		assert.NotContains(t, out, "‮", "verb %s leaked a bidi override from a struct field", verb)
+		assert.NotContains(t, out, "\u202e", "verb %s leaked a bidi override from a struct field", verb)
 	}
 }
 
@@ -56,7 +56,7 @@ func TestStringerEmitsMarker(t *testing.T) {
 func TestLineStripsEverySinkUnsafeRune(t *testing.T) {
 	out := tainted.Wrap(hostile).Line()
 	assert.NotContains(t, out, "\x1b")
-	assert.NotContains(t, out, "‮")
+	assert.NotContains(t, out, "\u202e")
 	assert.NotContains(t, out, "\x07")
 	assert.Contains(t, out, "safe")
 }
@@ -64,9 +64,9 @@ func TestLineStripsEverySinkUnsafeRune(t *testing.T) {
 // TestBodyStripsBidiAndKeepsSGR checks the body unwrap makes the other
 // trade-off: colour survives, reordering does not.
 func TestBodyStripsBidiAndKeepsSGR(t *testing.T) {
-	out := tainted.Wrap("\x1b[32mgreen\x1b[0m‮flip").Body(true)
+	out := tainted.Wrap("\x1b[32mgreen\x1b[0m\u202eflip").Body(true)
 	assert.Contains(t, out, "\x1b[32m", "SGR colour should survive the body unwrap")
-	assert.NotContains(t, out, "‮", "bidi override must not survive the body unwrap")
+	assert.NotContains(t, out, "\u202e", "bidi override must not survive the body unwrap")
 
 	plain := tainted.Wrap("\x1b[2Jerase").Body(false)
 	assert.NotContains(t, plain, "\x1b", "a non-SGR CSI must not survive even with renderAnsi off")

--- a/internal/ui/eventtimelineentry_tainted_test.go
+++ b/internal/ui/eventtimelineentry_tainted_test.go
@@ -1,0 +1,20 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEventTimelineEntryHasNoRawStringFields is the internal/ui mirror of the
+// k8s.EventInfo guard. The two structs are copies of each other so internal/ui
+// need not import internal/k8s, which means a field added to one and mirrored
+// into the other as a plain string would reopen the leak on the render side
+// only. Guard both ends.
+func TestEventTimelineEntryHasNoRawStringFields(t *testing.T) {
+	for f := range reflect.TypeFor[EventTimelineEntry]().Fields() {
+		assert.NotEqual(t, reflect.String, f.Type.Kind(),
+			"EventTimelineEntry.%s is a raw string; cluster-controlled text must be tainted.String", f.Name)
+	}
+}

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -483,32 +483,42 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 		events = events[:maxEvents]
 	}
 
-	// Sanitize into a fresh slice (never mutate the caller's backing array)
-	// before either the width-measurement pass or the render pass reads
-	// Reason/Message — both derive column widths from these values.
-	sanitizedEvents := make([]EventTimelineEntry, len(events))
-	for i, e := range events {
-		e.Reason = SanitizeTerminalText(e.Reason)
-		e.Message = SanitizeLogBody(StripBidiOverrides(e.Message), false)
-		sanitizedEvents[i] = e
+	// Unwrap into plain strings once, up front: the width-measurement pass
+	// and the render pass both read Reason/Message, and both must see the
+	// same sanitized text or the computed column widths will not match what
+	// is drawn.
+	type renderEvent struct {
+		age     string
+		reason  string
+		message string
+		warning bool
+		count   int32
 	}
-	events = sanitizedEvents
+	rendered := make([]renderEvent, len(events))
+	for i, e := range events {
+		rendered[i] = renderEvent{
+			age:     RelativeTime(e.Timestamp),
+			reason:  e.Reason.Line(),
+			message: e.Message.Body(false),
+			warning: e.Type.Is("Warning"),
+			count:   e.Count,
+		}
+	}
 
 	// Calculate column widths for alignment.
 	// Format: AGE  TYPE  REASON  MESSAGE  (xCount)?
 	maxAgeW := 0
 	maxReasonW := 0
 	maxCountW := 0
-	for _, e := range events {
-		ageStr := RelativeTime(e.Timestamp)
-		if len(ageStr) > maxAgeW {
-			maxAgeW = len(ageStr)
+	for _, e := range rendered {
+		if len(e.age) > maxAgeW {
+			maxAgeW = len(e.age)
 		}
-		if len(e.Reason) > maxReasonW {
-			maxReasonW = len(e.Reason)
+		if len(e.reason) > maxReasonW {
+			maxReasonW = len(e.reason)
 		}
-		if e.Count > 1 {
-			countStr := fmt.Sprintf(" (x%d)", e.Count)
+		if e.count > 1 {
+			countStr := fmt.Sprintf(" (x%d)", e.count)
 			if len(countStr) > maxCountW {
 				maxCountW = len(countStr)
 			}
@@ -531,31 +541,28 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 	// clipped off the screen.
 	msgWidth := max(width-maxAgeW-3-maxReasonW-4-maxCountW, 20) // 3 for " ● ", 4 for spacing
 
-	for _, e := range events {
-		ageStr := RelativeTime(e.Timestamp)
-
+	for _, e := range rendered {
 		// Type indicator and styling.
 		var dot, reasonStr string
-		switch e.Type {
-		case "Warning":
+		if e.warning {
 			dot = errorStyle.Render("\u25cf")
-			reasonStr = errorStyle.Bold(true).Render(fmt.Sprintf("%-*s", maxReasonW, truncateStr(e.Reason, maxReasonW)))
-		default:
+			reasonStr = errorStyle.Bold(true).Render(fmt.Sprintf("%-*s", maxReasonW, truncateStr(e.reason, maxReasonW)))
+		} else {
 			dot = normalStyle.Render("\u25cf")
-			reasonStr = reasonStyle.Render(fmt.Sprintf("%-*s", maxReasonW, truncateStr(e.Reason, maxReasonW)))
+			reasonStr = reasonStyle.Render(fmt.Sprintf("%-*s", maxReasonW, truncateStr(e.reason, maxReasonW)))
 		}
 
 		// Age.
-		ageFormatted := dimStyle.Render(fmt.Sprintf("%-*s", maxAgeW, ageStr))
+		ageFormatted := dimStyle.Render(fmt.Sprintf("%-*s", maxAgeW, e.age))
 
 		// Count suffix.
 		countStr := ""
-		if e.Count > 1 {
-			countStr = warningStyle.Render(fmt.Sprintf(" (x%d)", e.Count))
+		if e.count > 1 {
+			countStr = warningStyle.Render(fmt.Sprintf(" (x%d)", e.count))
 		}
 
 		// Message - wrap long messages rather than truncate.
-		msg := e.Message
+		msg := e.message
 		if len(msg) > msgWidth {
 			msg = msg[:msgWidth-3] + "..."
 		}

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -511,11 +511,11 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 	maxReasonW := 0
 	maxCountW := 0
 	for _, e := range rendered {
-		if len(e.age) > maxAgeW {
-			maxAgeW = len(e.age)
+		if w := lipgloss.Width(e.age); w > maxAgeW {
+			maxAgeW = w
 		}
-		if len(e.reason) > maxReasonW {
-			maxReasonW = len(e.reason)
+		if w := lipgloss.Width(e.reason); w > maxReasonW {
+			maxReasonW = w
 		}
 		if e.count > 1 {
 			countStr := fmt.Sprintf(" (x%d)", e.count)
@@ -544,12 +544,15 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 	for _, e := range rendered {
 		// Type indicator and styling.
 		var dot, reasonStr string
+		// padRight/Truncate measure visual columns, matching maxReasonW
+		// above; truncateStr and fmt's "%-*s" both count runes, which
+		// mismeasures a wide (e.g. CJK) or multibyte Reason.
 		if e.warning {
 			dot = errorStyle.Render("\u25cf")
-			reasonStr = errorStyle.Bold(true).Render(fmt.Sprintf("%-*s", maxReasonW, truncateStr(e.reason, maxReasonW)))
+			reasonStr = errorStyle.Bold(true).Render(padRight(Truncate(e.reason, maxReasonW), maxReasonW))
 		} else {
 			dot = normalStyle.Render("\u25cf")
-			reasonStr = reasonStyle.Render(fmt.Sprintf("%-*s", maxReasonW, truncateStr(e.reason, maxReasonW)))
+			reasonStr = reasonStyle.Render(padRight(Truncate(e.reason, maxReasonW), maxReasonW))
 		}
 
 		// Age.

--- a/internal/ui/explorer_resource_test.go
+++ b/internal/ui/explorer_resource_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // --- renderKV ---
@@ -235,16 +237,16 @@ func TestRenderPreviewEvents(t *testing.T) {
 		events := []EventTimelineEntry{
 			{
 				Timestamp: time.Now().Add(-5 * time.Minute),
-				Type:      "Normal",
-				Reason:    "Scheduled",
-				Message:   "Successfully assigned pod to node",
+				Type:      tainted.Wrap("Normal"),
+				Reason:    tainted.Wrap("Scheduled"),
+				Message:   tainted.Wrap("Successfully assigned pod to node"),
 				Count:     1,
 			},
 			{
 				Timestamp: time.Now().Add(-3 * time.Minute),
-				Type:      "Warning",
-				Reason:    "BackOff",
-				Message:   "Back-off restarting failed container",
+				Type:      tainted.Wrap("Warning"),
+				Reason:    tainted.Wrap("BackOff"),
+				Message:   tainted.Wrap("Back-off restarting failed container"),
 				Count:     5,
 			},
 		}
@@ -259,9 +261,9 @@ func TestRenderPreviewEvents(t *testing.T) {
 		events := []EventTimelineEntry{
 			{
 				Timestamp: time.Now(),
-				Type:      "Normal",
-				Reason:    "Pulled",
-				Message:   "Pulled image",
+				Type:      tainted.Wrap("Normal"),
+				Reason:    tainted.Wrap("Pulled"),
+				Message:   tainted.Wrap("Pulled image"),
 				Count:     1,
 			},
 		}
@@ -291,9 +293,9 @@ func TestRenderPreviewEvents(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				events := []EventTimelineEntry{{
 					Timestamp: now.Add(-2 * time.Hour),
-					Type:      "Warning",
-					Reason:    "FailedMount",
-					Message:   tc.msg,
+					Type:      tainted.Wrap("Warning"),
+					Reason:    tainted.Wrap("FailedMount"),
+					Message:   tainted.Wrap(tc.msg),
 					Count:     tc.count,
 				}}
 				result := RenderPreviewEvents(events, tc.width)
@@ -749,9 +751,9 @@ func TestRenderPreviewEvents_Sanitized(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			events := []EventTimelineEntry{{
 				Timestamp: time.Now(),
-				Type:      "Warning",
-				Reason:    "BackOff" + payload,
-				Message:   "Back-off restarting failed container" + payload,
+				Type:      tainted.Wrap("Warning"),
+				Reason:    tainted.Wrap("BackOff" + payload),
+				Message:   tainted.Wrap("Back-off restarting failed container" + payload),
 				Count:     1,
 			}}
 			out := RenderPreviewEvents(events, 100)

--- a/internal/ui/explorer_resource_test.go
+++ b/internal/ui/explorer_resource_test.go
@@ -310,6 +310,31 @@ func TestRenderPreviewEvents(t *testing.T) {
 			})
 		}
 	})
+
+	// Regression (TASK-874 CodeRabbit review): the reason-column width was
+	// measured with len(), which counts bytes. A CJK Reason has 3 bytes but
+	// 2 display cells per rune, so the byte count wildly overstates the
+	// column's visual width. That fed both the %-*s pad (rune-counted) and
+	// the byte-slicing truncateStr helper, which cut the string mid-rune
+	// and produced invalid UTF-8.
+	t.Run("multibyte reason column stays within width with valid UTF-8", func(t *testing.T) {
+		events := []EventTimelineEntry{{
+			Timestamp: time.Now().Add(-2 * time.Hour),
+			Type:      tainted.Wrap("Warning"),
+			Reason:    tainted.Wrap(strings.Repeat("日", 30)),
+			Message:   tainted.Wrap("volume mount failed"),
+			Count:     1,
+		}}
+		result := RenderPreviewEvents(events, 80)
+		for line := range strings.SplitSeq(result, "\n") {
+			if line == "" {
+				continue
+			}
+			assert.True(t, utf8.ValidString(line), "line must stay valid UTF-8: %q", line)
+			assert.LessOrEqual(t, lipgloss.Width(line), 80,
+				"event line exceeds width=80: %q (visible width %d)", line, lipgloss.Width(line))
+		}
+	})
 }
 
 // --- RenderResourceSummary ---

--- a/internal/ui/listsummary.go
+++ b/internal/ui/listsummary.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // SummaryBucket is one value group within a summary dimension (e.g. 12 "Healthy").
@@ -282,47 +283,19 @@ func sanitizeSummaryValue(s string) string {
 	return SanitizeTerminalText(s)
 }
 
-// SanitizeTerminalText strips the control characters described above from any
-// cluster-controlled string before it reaches the screen. Exported so every
-// such string passes through one implementation: the YAML blame gutter shows
-// field manager names, which a non-core apiserver can set to anything.
-//
-// It also drops the bidi embedding, override, and isolate characters
-// (U+202A-U+202E, U+2066-U+2069). Those reorder the text that follows them,
-// so a hostile name can make one value read as another on screen. The plain
-// direction marks U+200E and U+200F stay, because they only hint at direction
-// and legitimate right-to-left text uses them.
+// SanitizeTerminalText strips control characters and bidi overrides from a
+// cluster-controlled string before it reaches a single-line sink. Re-exported
+// from internal/tainted, which owns the implementation so the k8s and model
+// packages can reach it without importing internal/ui.
 func SanitizeTerminalText(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
-		if r < 0x20 || (r >= 0x7f && r <= 0x9f) || isBidiOverride(r) {
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
+	return tainted.SanitizeTerminalText(s)
 }
 
 // StripBidiOverrides removes only the bidi embedding/override/isolate
-// characters SanitizeTerminalText drops (see its doc comment), leaving
-// everything else - including ESC, tabs, and SGR sequences - untouched.
-// For sinks that need SanitizeLogBody's ANSI/tab handling but still must
-// guard against a hostile value reordering the rendered text.
+// characters, leaving ESC, tabs, and SGR sequences untouched. Re-exported
+// from internal/tainted.
 func StripBidiOverrides(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
-		if isBidiOverride(r) {
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
-}
-
-func isBidiOverride(r rune) bool {
-	return (r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069)
+	return tainted.StripBidiOverrides(s)
 }
 
 const summaryBarCells = 14

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // LogSearchHighlightStyle highlights matched substrings in log lines.
@@ -612,166 +613,16 @@ func StripPodPrefix(line string) string {
 	return after
 }
 
-// logTabWidth is the column step used when expanding tab characters in
-// log lines. 8 matches the default tab stop on virtually every terminal,
-// so the post-expansion text aligns the way a user pasting the same line
-// into their shell would expect.
-const logTabWidth = 8
-
-// SanitizeLogBody is the exported entry point to sanitizeLogLine for sinks
-// outside this file (describe content, command-bar output) that render a
-// BODY rather than a name or title: unlike SanitizeTerminalText, it keeps
-// SGR colour sequences and expands tabs instead of dropping them. See
-// sanitizeLogLine for the full behaviour.
+// SanitizeLogBody sanitizes a cluster-controlled multi-line body (log lines,
+// describe content, command-bar output): unlike SanitizeTerminalText it keeps
+// SGR colour sequences and expands tabs instead of dropping them.
+// Re-exported from internal/tainted, which owns the implementation.
 func SanitizeLogBody(s string, renderAnsi bool) string {
-	return sanitizeLogLine(s, renderAnsi)
+	return tainted.SanitizeLogBody(s, renderAnsi)
 }
 
-// sanitizeLogLine replaces non-printable control bytes (NUL, DEL, the C0
-// control range minus tab, and the C1 range U+0080-U+009F) with the
-// Unicode replacement character and expands tab characters to spaces
-// using a logTabWidth-column tab stop. Binary data from processes like
-// MySQL handshakes contains bytes that break terminal width calculations
-// and corrupt the viewer layout; C1 controls (raw or UTF-8-encoded, e.g.
-// U+009B "CSI") let a log line hijack the terminal on emulators that
-// honour 8-bit C1 (VTE, Linux console).
-//
-// Tab expansion is required because lipgloss.Width treats '\t' as
-// zero-width while the terminal renders it as a jump to the next tab
-// stop. The viewer's contentWidth-overflow guard (in RenderLogViewer)
-// uses lipgloss.Width to decide when to truncate; without expansion,
-// tab-bearing lines slip through with an undercounted width, get
-// re-wrapped internally by lipgloss, and push the bottom border off the
-// visible area. Reported on dragonfly-operator (controller-runtime/zap)
-// logs in particular - those use tabs to separate timestamp / level /
-// logger / message.
-//
-// When renderAnsi is true, valid CSI SGR sequences (ESC [ params m — the
-// ones that set colour, bold, underline, etc.) are preserved verbatim so
-// log producers that emit ANSI colours render as intended. Non-SGR CSI
-// sequences (cursor movement, screen erase) remain unsafe for an inline
-// viewer and are still replaced. A bare ESC with no valid CSI introducer
-// is replaced too; leaving it would cause terminals to wait for a
-// follow-up byte and mis-interpret subsequent output.
-//
-// C1 detection is decode-aware, not a raw byte-range check: a byte-level
-// test for 0x80-0x9F would also catch UTF-8 continuation bytes of
-// ordinary non-ASCII runes (many common accented Latin, CJK, emoji, and
-// box-drawing characters have a continuation byte in that range) and
-// mangle them. Every non-ASCII byte is instead decoded to its full rune;
-// only a rune that actually equals U+0080-U+009F is replaced, whether it
-// arrived as a raw invalid byte or a valid two-byte UTF-8 encoding (e.g.
-// 0xC2 0x9B for U+009B). Anything else - including genuinely invalid
-// UTF-8 outside the C1 range - copies through as before.
+// sanitizeLogLine is the package-internal alias kept for the log viewer's own
+// call sites and tests.
 func sanitizeLogLine(s string, renderAnsi bool) string {
-	// Fast path: no control bytes, tabs needing expansion, or non-ASCII
-	// bytes means no work to do. Any byte >= 0x80 must go through the
-	// slow path because it might decode to a C1 control character.
-	needsSanitize := false
-	for i := range len(s) {
-		c := s[i]
-		if c < 32 || c == 127 || c >= 0x80 {
-			needsSanitize = true
-			break
-		}
-	}
-	if !needsSanitize {
-		return s
-	}
-
-	var b strings.Builder
-	b.Grow(len(s))
-	col := 0
-	i := 0
-	for i < len(s) {
-		c := s[i]
-		if renderAnsi && c == 0x1b {
-			if end := parseSGRSequence(s, i); end > i {
-				// SGR sequences are zero-width; do not advance col.
-				b.WriteString(s[i:end])
-				i = end
-				continue
-			}
-		}
-		if c == '\t' {
-			n := logTabWidth - col%logTabWidth
-			for range n {
-				b.WriteByte(' ')
-			}
-			col += n
-			i++
-			continue
-		}
-		if c < 0x80 {
-			if c >= 32 && c != 127 {
-				b.WriteByte(c)
-				col++
-			} else {
-				// Control byte (< 32 and not tab, or DEL).
-				b.WriteRune('\ufffd')
-			}
-			i++
-			continue
-		}
-		// Non-ASCII byte: decode the full rune so a C1 control encoded
-		// as two valid UTF-8 bytes is judged by its decoded value, not
-		// by the raw continuation byte (see the C1 detection note
-		// above).
-		r, size := utf8.DecodeRuneInString(s[i:])
-		switch {
-		case r == utf8.RuneError && size <= 1:
-			// Invalid UTF-8. A lone byte in the C1 range is still a
-			// control character regardless of encoding; anything else
-			// invalid passes through unchanged, matching legacy
-			// behaviour for non-UTF-8 binary payloads. Column tracking
-			// mirrors the old approximation: only a would-be leading
-			// byte (>= 0xC0) counts as one cell.
-			if c >= 0x80 && c <= 0x9f {
-				b.WriteRune('\ufffd')
-			} else {
-				b.WriteByte(c)
-				if c >= 0xC0 {
-					col++
-				}
-			}
-			i++
-		case r >= 0x80 && r <= 0x9f:
-			// Valid UTF-8 encoding of a C1 control character.
-			b.WriteRune('\ufffd')
-			i += size
-		default:
-			// Ordinary multi-byte rune: copy through untouched.
-			b.WriteString(s[i : i+size])
-			col++
-			i += size
-		}
-	}
-	return b.String()
-}
-
-// parseSGRSequence returns the index after a valid ESC [ ... m sequence
-// starting at s[i], or i if no valid sequence is present. Only SGR
-// (Select Graphic Rendition) finals are accepted because they set
-// colour and text attributes without moving the cursor or clearing the
-// screen — preserving them is safe in an inline viewer, whereas other
-// CSI finals would corrupt the layout.
-func parseSGRSequence(s string, i int) int {
-	if i+1 >= len(s) || s[i] != 0x1b || s[i+1] != '[' {
-		return i
-	}
-	j := i + 2
-	// Parameter bytes: 0x30-0x3F (digits and ; : < = > ?).
-	for j < len(s) && s[j] >= 0x30 && s[j] <= 0x3F {
-		j++
-	}
-	// Intermediate bytes: 0x20-0x2F (space and ! " # $ % & ' ( ) * + , - . /).
-	for j < len(s) && s[j] >= 0x20 && s[j] <= 0x2F {
-		j++
-	}
-	// SGR final byte is lowercase 'm'. Anything else is a CSI we can't
-	// safely forward to an inline viewer.
-	if j < len(s) && s[j] == 'm' {
-		return j + 1
-	}
-	return i
+	return tainted.SanitizeLogBody(s, renderAnsi)
 }

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"time"
+
+	"github.com/janosmiko/lfk/internal/tainted"
 )
 
 // overlayNsScroll is the persistent scroll position for the namespace overlay.
@@ -91,15 +93,17 @@ type QuotaResourceEntry struct {
 }
 
 // EventTimelineEntry holds event data for rendering in the timeline overlay.
+// It mirrors k8s.EventInfo so internal/ui does not depend on the k8s package,
+// and keeps the same tainted fields - see k8s.EventInfo for why.
 type EventTimelineEntry struct {
 	Timestamp    time.Time
-	Type         string // "Normal" or "Warning"
-	Reason       string
-	Message      string
-	Source       string
+	Type         tainted.String // "Normal" or "Warning"
+	Reason       tainted.String
+	Message      tainted.String
+	Source       tainted.String
 	Count        int32
-	InvolvedName string
-	InvolvedKind string
+	InvolvedName tainted.String
+	InvolvedKind tainted.String
 }
 
 // AlertEntry holds alert data for rendering in the overlay, decoupled from the k8s package.


### PR DESCRIPTION
Terminal escape injection through cluster-controlled strings has recurred four times. TASK-873 closed six sinks across three review rounds, each round finding more. TASK-880 then found ten that TASK-873 had missed, including a field printed raw in the same `fmt.Sprintf` where three sibling fields had just been sanitized. TASK-855 shipped one more this week with the threat spelled out in its brief.

The failure is field-level, so a lint rule or a "does this function sanitize" test passes on the code while it still leaks. This makes the next one a compile error instead.

## The type

New leaf package `internal/tainted`, stdlib imports only, so `k8s`, `model` and `ui` can all use it.

`type String struct{ raw string }` - a struct, not a named string. That distinction is the whole design: `type Tainted string` still satisfies `%s`, still concatenates, and still passes where a `string` is wanted, so it buys nothing. The struct cannot concatenate, cannot compare to a literal, and cannot pass as a `string`.

It implements `fmt.Formatter`, so `%s %v %q %d %x %#v %+v`, width and precision flags, and the zero value all emit `[tainted:unsanitized]` rather than the payload.

Two unwraps, no default, so the choice between the sanitizers is forced:

| Method | Applies |
|---|---|
| `.Line()` | `SanitizeTerminalText` - single-line values |
| `.Body(renderAnsi)` | `StripBidiOverrides` + `SanitizeLogBody` - multi-line bodies |

Non-render needs are served by `Is()`, `IsEmpty()`, `Compare()` and `Contains()`, which is why `.Raw()` has **zero production call sites** - the 6 that exist are all test assertions.

## The sanitizers moved down a layer

The three implementations moved out of `internal/ui` into `tainted`, and `ui` re-exports them, so its existing call sites and tests are untouched. `logviewer.go` 777 to 628, `listsummary.go` 457 to 430.

This was the riskiest part of the change, since roughly 200 existing sinks now reach the sanitizers through a delegation. A security review diffed the relocated implementations against `main` line by line - byte-identical apart from comment placement - then set up a throwaway `main` worktree and pushed six payloads (OSC-52, CSI erase, raw C1, bidi override, tab, SGR) through all three functions on both branches. Byte-for-byte identical output in every case. The re-exports are one-line delegations, not reimplementations.

## Scope

`k8s.EventInfo` and its mirror `ui.EventTimelineEntry` - Type, Reason, Message, Source, InvolvedName, InvolvedKind - converted end to end, from the producer in `client_rbac.go` through both render sinks. Reviewers traced all six fields and found no early unwrap.

Deliberately left out: object names and namespaces, Secret and ConfigMap values, label and annotation values. Those flow through `model.Item` and the whole explorer column pipeline, hundreds of sites. A partial conversion there would leave gaps the type system then blesses, which is worse than the status quo. **They remain plain strings relying on manual sanitizer calls, the same residual risk as before this PR.**

## Proof it works

Removing a real sanitizer call now breaks the build:

```
internal/ui/explorer_resource.go:501:13: cannot use e.Reason (variable of struct type
  tainted.String) as string value in struct literal
internal/app/update_overlays_events.go:58:20: cannot use e.Type (variable of struct type
  tainted.String) as string value in argument to padColumn
```

One shape still compiles, and is documented rather than hidden: assigning the field and passing it straight to a verb, `message := e.Message` then `%s`. It does not leak - it renders `[tainted:unsanitized]` and turns `TestBuildEventTimelineLines` red. A reviewer probed nine more such shapes (map ranged, slice element, `fmt.Errorf`, `errors.New`, struct embedding, assertion to `fmt.Stringer` through `any`, width and precision flags, zero value, `%x`) and every one emits only the marker.

So: compile error where the value crosses into a string parameter, loud marker plus a red test where it goes straight to a verb. Never silent.

## Tests

The two guard tests are the durable part. Both iterate struct fields with `reflect.TypeFor[T]().Fields()` rather than a hardcoded list, so a newly added raw field fails rather than slipping through.

Every test was proven red by name before being made green, and a reviewer independently re-verified three by reverting the method each covers.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` 0 issues, `go test -count=1 -race ./...` exit 0 with 26 of 26 packages `ok`. Largest touched file 778 of the 800-line cap.

## Follow-ups, not fixed here

- `json.Marshal` on a struct holding a `tainted.String` silently drops the field, since `raw` is unexported. No leak and no call site does this today, but it is a trap worth knowing.
- `InvolvedName` and `InvolvedKind` are wrapped and carried through, then never rendered. Dead fields.
- **TASK-884** is the related one worth attention: `setStatusMessage` never sanitizes, so any caller interpolating a cluster string leaks into the status bar. `handleOrphansLoaded` has that bug today.

Closes TASK-874.
