### PR TITLE
docs: correct the orphan overview keybinding (TASK-883)

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -115,7 +115,7 @@ Your chosen sort is remembered per resource kind and per cluster context, and pe
 
 ### Cluster-wide overview
 
-Press **`Shift+O`** anywhere in the explorer (or type `:orphans` with no arguments in the command bar) to open the cluster-wide orphan overview overlay. Inside the overlay:
+Press **`Shift+Z`** anywhere in the explorer (or type `:orphans` with no arguments in the command bar) to open the cluster-wide orphan overview overlay. Inside the overlay:
 
 | Key | Action |
 | --- | ------ |
@@ -124,7 +124,7 @@ Press **`Shift+O`** anywhere in the explorer (or type `:orphans` with no argumen
 | `/` | Filter by namespace + name |
 | `Enter` | Jump to the highlighted resource (namespace switches automatically) |
 | `R` | Re-scan the cluster |
-| `Esc` / `q` / `Shift+O` | Close the overlay |
+| `Esc` / `q` / `Shift+Z` | Close the overlay |
 
 ### Per-kind presets
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -452,14 +452,14 @@ session affinity, etc.), press `v` (Describe).
 
 ### Cluster-wide overview
 
-Press **`Shift+O`** anywhere in the explorer (or type `:orphans` in the command bar) to open the orphan overview overlay. It scans the cluster and lists every orphan in one table grouped by kind:
+Press **`Shift+Z`** anywhere in the explorer (or type `:orphans` in the command bar) to open the orphan overview overlay. It scans the cluster and lists every orphan in one table grouped by kind:
 
 - `Tab` / `Shift+Tab` cycle through every kind filter chip (All plus all supported orphan kinds rendered in the strip)
 - `s` toggles strict / lenient — strict (default) hides items referenced by workload templates (e.g. CronJob between firings, scaled-to-zero Deployment); lenient surfaces them
 - `/` filters by namespace + name
 - `Enter` jumps straight to the highlighted resource (the namespace switches automatically)
 - `R` re-scans the cluster
-- `Esc`, `q`, or `Shift+O` close the overlay
+- `Esc`, `q`, or `Shift+Z` close the overlay
 
 Partial-RBAC denials surface as a warning banner at the top of the overlay; whatever could be listed is still shown.
 

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -148,7 +148,7 @@ category, and every entry maps to a constant in `app_types.go`.
 | `overlayAutoSync`        | ArgoCD app                      | Toggle auto-sync settings.                                      |
 | `overlaySyncWave`        | action menu → `W` on Application | Per-Application ArgoCD sync wave timeline.                      |
 | `overlayBackgroundTasks` | `` ` ``, `:scheduler`           | In-flight + recent background tasks.                            |
-| `overlayOrphans`         | `Shift+O`, `:orphans`           | Cluster-wide orphan resource overview.                          |
+| `overlayOrphans`         | `Shift+Z`, `:orphans`           | Cluster-wide orphan resource overview.                          |
 | `overlayLocalClusters`   | `Ctrl+N` at LevelClusters       | Manage kind/k3d/minikube clusters.                              |
 | `overlayTrafficCapture`  | action menu → `c` on Pod / Service | Live packet capture (kubectl-debug, kubeshark).                |
 


### PR DESCRIPTION
The docs disagreed with each other about the orphan overview's keybinding. `README.md` said `Shift+Z`; `docs/usage.md`, `docs/keybindings.md` and `docs/views-and-overlays.md` said `Shift+O` in five places.

The code is the truth: `OrphanOverlay: "Z"` at `internal/ui/config_keybindings.go:246`. So the README was right and the three docs files were stale.

## Changes

Five references corrected across `docs/keybindings.md`, `docs/usage.md` and `docs/views-and-overlays.md`. Docs only, no code.

## Where the confusion came from

`O` is a real orphan hotkey, just for a different thing: every orphan **filter preset** in the `.` overlay binds to `O`, documented at `docs/keybindings.md:131`. That is unchanged and correct. The two got conflated.

Found while wiring TASK-855, which sits in the same shift-letter family of cluster-wide overviews. Left out of that PR to keep it in scope.

Closes TASK-883.
