### PR TITLE
fix: sanitize every status-bar message at its shared sink (TASK-884)

### DIFF
--- a/internal/app/commands_orphans_test.go
+++ b/internal/app/commands_orphans_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -129,6 +130,34 @@ func TestHandleOrphansLoaded_ReappliesActiveFilter(t *testing.T) {
 	assert.Equal(t, "naked", updated.middleItems[0].Name)
 	assert.Contains(t, updated.statusMessage, "Unmounted",
 		"status bar should announce the post-scan match count")
+}
+
+// TestHandleOrphansLoaded_SanitizesPartialErrorIntoStatusBar covers the
+// end-to-end path a security review proved leaky: msg.err.Error() is
+// interpolated straight into setStatusMessage with no sanitizing in
+// between, so a hostile scan error (a namespace/secret name an attacker
+// controls can end up embedded in an apiserver error string) put its raw
+// escape on screen. The fix lives in setStatusMessage itself, so this test
+// exercises the caller, not the sink, to prove the fix reaches this far.
+func TestHandleOrphansLoaded_SanitizesPartialErrorIntoStatusBar(t *testing.T) {
+	m := newTestModel()
+	key := orphanCacheKey{kubeContext: "test", namespace: ""}
+	m.nav.Context = "test"
+
+	require.NotNil(t, m.cmdLoadOrphans(key))
+	gen := m.orphanLoadInflight[key].gen
+
+	hostile := errors.New("listing pvcs: \x1b]52;c;SGVsbG8=\a forbidden \u202e")
+	msg := orphansLoadedMsg{key: key, gen: gen, err: hostile}
+
+	updated, cmd := m.handleOrphansLoaded(msg)
+	require.NotNil(t, cmd, "a partial result still schedules the status clear")
+
+	for _, bad := range []string{"\x1b]", "\a", "\u202e"} {
+		assert.NotContains(t, updated.statusMessage, bad, "status message leaked an escape")
+	}
+	assert.Contains(t, updated.statusMessage, "listing pvcs")
+	assert.Contains(t, updated.statusMessage, "forbidden")
 }
 
 func TestInvalidateOrphanCacheForNamespace(t *testing.T) {

--- a/internal/app/tabs.go
+++ b/internal/app/tabs.go
@@ -190,12 +190,24 @@ func (m *Model) sanitizeMessage(s string) string {
 	return s
 }
 
-// setStatusMessage sets a temporary status bar message.
-// All messages are appended to the application log buffer with appropriate level.
-func (m *Model) setStatusMessage(msg string, isErr bool) {
+// setStatusMessageText is the only place that writes m.statusMessage. Both
+// setStatusMessage and setErrorFromErr route through it so a hostile string
+// - a cluster-controlled resource name, apiserver error text - cannot reach
+// the status bar via a second, forgotten direct write. Sanitizing here,
+// before the caller-specific log entry is built below, keeps that order
+// (sanitize before truncate/measure) automatic for both callers.
+func (m *Model) setStatusMessageText(msg string, isErr bool) string {
+	msg = ui.SanitizeTerminalText(msg)
 	m.statusMessage = msg
 	m.statusMessageErr = isErr
 	m.statusMessageExp = time.Now().Add(5 * time.Second)
+	return msg
+}
+
+// setStatusMessage sets a temporary status bar message.
+// All messages are appended to the application log buffer with appropriate level.
+func (m *Model) setStatusMessage(msg string, isErr bool) {
+	msg = m.setStatusMessageText(msg, isErr)
 
 	level := "INF"
 	if isErr {
@@ -215,9 +227,7 @@ func (m *Model) setStatusMessage(msg string, isErr bool) {
 // full untruncated error to the error log overlay.
 func (m *Model) setErrorFromErr(prefix string, err error) {
 	// Show truncated version in status bar.
-	m.statusMessage = prefix + m.sanitizeError(err)
-	m.statusMessageErr = true
-	m.statusMessageExp = time.Now().Add(5 * time.Second)
+	m.setStatusMessageText(prefix+m.sanitizeError(err), true)
 
 	// Log the full untruncated error to the error log.
 	full := fullErrorMessage(err)

--- a/internal/app/tabs_test.go
+++ b/internal/app/tabs_test.go
@@ -685,6 +685,23 @@ func TestSetStatusMessage_SanitizesErrorLog(t *testing.T) {
 	assert.NotContains(t, m.errorLog[1].Message, "\u202e")
 }
 
+// TestSetStatusMessage_SanitizesStatusMessage guards the sink itself, not
+// just its errorLog side effect: appendErrorLogEntry already sanitized the
+// log copy, but setStatusMessage stored the raw msg into m.statusMessage,
+// which is what the status bar actually renders. An OSC-52 payload landing
+// here reaches the terminal with its introducer and terminator intact.
+func TestSetStatusMessage_SanitizesStatusMessage(t *testing.T) {
+	m := Model{}
+
+	m.setStatusMessage("Orphan scan: partial result (listing pvcs: \x1b]52;c;SGVsbG8=\a forbidden \u202e)", true)
+
+	for _, bad := range []string{"\x1b]", "\a", "\u202e"} {
+		assert.NotContains(t, m.statusMessage, bad, "status message leaked an escape")
+	}
+	assert.Contains(t, m.statusMessage, "listing pvcs")
+	assert.Contains(t, m.statusMessage, "forbidden")
+}
+
 // TestSetStatusMessage_OrdinaryContentUnaffected guards against sanitizing
 // legitimate non-ASCII status messages into mush.
 func TestSetStatusMessage_OrdinaryContentUnaffected(t *testing.T) {
@@ -1025,6 +1042,23 @@ func TestSetErrorFromErr_SanitizesErrorLog(t *testing.T) {
 	require.Len(t, m.errorLog, 1)
 	assert.NotContains(t, m.errorLog[0].Message, "\x9d")
 	assert.NotContains(t, m.errorLog[0].Message, "\x9c")
+}
+
+// TestSetErrorFromErr_SanitizesStatusMessage guards the second direct writer
+// of m.statusMessage. setStatusMessage sanitizes at its own sink, but
+// setErrorFromErr wrote m.statusMessage itself via sanitizeError, which only
+// folds newlines and truncates - it never strips escapes. A second direct
+// writer left unsanitized is not a sink fix, it is a caller fix wearing a
+// sink's clothes.
+func TestSetErrorFromErr_SanitizesStatusMessage(t *testing.T) {
+	m := Model{width: 100}
+	m.setErrorFromErr("scan: ", errors.New("listing pvcs: \x1b]52;c;SGVsbG8=\a forbidden \u202e"))
+
+	for _, bad := range []string{"\x1b]", "\a", "\u202e"} {
+		assert.NotContains(t, m.statusMessage, bad, "status message leaked an escape")
+	}
+	assert.Contains(t, m.statusMessage, "listing pvcs")
+	assert.Contains(t, m.statusMessage, "forbidden")
 }
 
 // --- setStatusMessage log capping ---


### PR DESCRIPTION
`setStatusMessage` never sanitized. It folded newlines and truncated, nothing more. So any caller interpolating a cluster-sourced string put terminal escapes straight into the status bar - and lfk renders whatever the cluster says, so an attacker who can create objects in a watched namespace controls those strings.

Found while reviewing TASK-855. That task fixed its own caller; `handleOrphansLoaded` had the identical bug and still does on `main`. A security reviewer proved it: an OSC-52 payload wrapped in a scan error reached the far end with its `\x1b]` introducer and `\a` terminator intact.

Fixing callers one at a time is what turned TASK-873 into a sixteen-site chase across three review rounds. This fixes the sink instead, which covers every caller including the unaudited ones.

## Changes

There is now exactly one function that stores non-empty content into `m.statusMessage`, and it sanitizes with `ui.SanitizeTerminalText` before storing - before any truncation or width measurement, since sanitizing changes a string's width.

Both entry points route through it:

| Path | Before | After |
|---|---|---|
| `setStatusMessage` | stored raw | routes through the sanitizing writer |
| `setErrorFromErr` | wrote `m.statusMessage` **directly**, bypassing everything | routes through the same writer |

`setErrorFromErr` is the reason this needed a second pass. A sink fix with a second path writing the same field directly is not a sink fix - the next person reads `setStatusMessage`, sees the sanitizer, and reasonably concludes the field is safe.

Full census of direct writers, so the claim is checkable: one writes content (the sanitizing writer), and three only ever clear to `""` (`status_clear.go:18`, `update_dispatch_msgs.go:117`, `update_keys.go:16`). No fourth path.

## No visible regression

Sanitizing at the sink strips SGR from every status message, so the risk was a caller that legitimately passes colour. Surveyed all **444** non-test `setStatusMessage` call sites: none pass a styled or `.Render()`ed string. Nothing loses colour.

## Tests

Both proven red against the unfixed code, by name:

- `TestSetStatusMessage_SanitizesStatusMessage` asserts on `m.statusMessage` itself, not just the error-log copy.
- `TestSetErrorFromErr_SanitizesStatusMessage` - failure on the unfixed line was `"scan: listing pvcs: \x1b]52;c;SGVsbG8=\a forbidden ‮" should not contain "\x1b]"`.
- `TestHandleOrphansLoaded_SanitizesPartialErrorIntoStatusBar` drives the actual reported vulnerable caller end to end.

Assertions target `"\x1b]"`, `"\a"` and `"‮"` rather than a bare `"\x1b"` - every lipgloss colour emits ESC, so a bare check can never fail.

## Based on #608

This targets `fix/task-879-explain-pending-marker` rather than `main`, and GitHub will retarget it automatically when #608 merges.

The reason is the file-length cap. On `main`, `internal/app/tabs.go` is exactly 800 lines, so adding this fix pushes it to 810 and fails revive. #608 splits that file and leaves it at 279, so the fix lands with room to spare and needs no split of its own. The first attempt here did split `tabs.go` independently, which would have collided head-on with #608's split of the same file - that was undone.

Closes TASK-884.
