### PR TITLE
fix: stop the orphan scanner claiming orphans when a referencing list failed (TASK-886)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -461,7 +461,7 @@ Press **`Shift+Z`** anywhere in the explorer (or type `:orphans` in the command 
 - `R` re-scans the cluster
 - `Esc`, `q`, or `Shift+Z` close the overlay
 
-Partial-RBAC denials surface as a warning banner at the top of the overlay; whatever could be listed is still shown.
+Partial-RBAC denials surface as a warning banner at the top of the overlay. A kind is shown only if every list its orphan check depends on loaded; a kind whose answer would depend on a denied list is omitted rather than risking a false "unused".
 
 ### Per-kind filter presets
 

--- a/internal/k8s/orphan_detector.go
+++ b/internal/k8s/orphan_detector.go
@@ -101,57 +101,201 @@ type orphanLists struct {
 // the pipeline runs unaffected.
 func fetchOrphanLists(ctx context.Context, cs kubernetes.Interface, namespace string) (orphanLists, []error) {
 	var errs []error
-	collect := func(name string, err error) {
+	// client-go's generated List() always returns an allocated,
+	// empty-Items list even when the request errors - it never hands
+	// back a nil pointer. Nil the pointer ourselves on failure so a
+	// listing error reads as "no data available" instead of a
+	// zero-item list, which every downstream orphan check would
+	// otherwise mistake for "verified nothing references this".
+	collect := func(name string, err error) bool {
 		if err != nil {
 			errs = append(errs, fmt.Errorf("listing %s: %w", name, err))
+			return true
 		}
+		return false
 	}
 	opts := metav1.ListOptions{}
 	out := orphanLists{}
 	var err error
 	out.pods, err = cs.CoreV1().Pods(namespace).List(ctx, opts)
-	collect("pods", err)
+	if collect("pods", err) {
+		out.pods = nil
+	}
 	out.ingresses, err = cs.NetworkingV1().Ingresses(namespace).List(ctx, opts)
-	collect("ingresses", err)
+	if collect("ingresses", err) {
+		out.ingresses = nil
+	}
 	out.serviceAccounts, err = cs.CoreV1().ServiceAccounts(namespace).List(ctx, opts)
-	collect("service accounts", err)
+	if collect("service accounts", err) {
+		out.serviceAccounts = nil
+	}
 	out.secrets, err = cs.CoreV1().Secrets(namespace).List(ctx, opts)
-	collect("secrets", err)
+	if collect("secrets", err) {
+		out.secrets = nil
+	}
 	out.configMaps, err = cs.CoreV1().ConfigMaps(namespace).List(ctx, opts)
-	collect("configmaps", err)
+	if collect("configmaps", err) {
+		out.configMaps = nil
+	}
 	out.services, err = cs.CoreV1().Services(namespace).List(ctx, opts)
-	collect("services", err)
+	if collect("services", err) {
+		out.services = nil
+	}
 	out.pvcs, err = cs.CoreV1().PersistentVolumeClaims(namespace).List(ctx, opts)
-	collect("pvcs", err)
+	if collect("pvcs", err) {
+		out.pvcs = nil
+	}
 	out.hpas, err = cs.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(ctx, opts)
-	collect("hpas", err)
+	if collect("hpas", err) {
+		out.hpas = nil
+	}
 	out.pdbs, err = cs.PolicyV1().PodDisruptionBudgets(namespace).List(ctx, opts)
-	collect("pdbs", err)
+	if collect("pdbs", err) {
+		out.pdbs = nil
+	}
 	out.netpols, err = cs.NetworkingV1().NetworkPolicies(namespace).List(ctx, opts)
-	collect("networkpolicies", err)
+	if collect("networkpolicies", err) {
+		out.netpols = nil
+	}
 	out.deployments, err = cs.AppsV1().Deployments(namespace).List(ctx, opts)
-	collect("deployments", err)
+	if collect("deployments", err) {
+		out.deployments = nil
+	}
 	out.statefulSets, err = cs.AppsV1().StatefulSets(namespace).List(ctx, opts)
-	collect("statefulsets", err)
+	if collect("statefulsets", err) {
+		out.statefulSets = nil
+	}
 	out.daemonSets, err = cs.AppsV1().DaemonSets(namespace).List(ctx, opts)
-	collect("daemonsets", err)
+	if collect("daemonsets", err) {
+		out.daemonSets = nil
+	}
 	out.jobs, err = cs.BatchV1().Jobs(namespace).List(ctx, opts)
-	collect("jobs", err)
+	if collect("jobs", err) {
+		out.jobs = nil
+	}
 	out.cronJobs, err = cs.BatchV1().CronJobs(namespace).List(ctx, opts)
-	collect("cronjobs", err)
+	if collect("cronjobs", err) {
+		out.cronJobs = nil
+	}
 	out.roles, err = cs.RbacV1().Roles(namespace).List(ctx, opts)
-	collect("roles", err)
+	if collect("roles", err) {
+		out.roles = nil
+	}
 	out.roleBindings, err = cs.RbacV1().RoleBindings(namespace).List(ctx, opts)
-	collect("rolebindings", err)
+	if collect("rolebindings", err) {
+		out.roleBindings = nil
+	}
 	// ClusterRole(Binding)s are cluster-scoped — list cluster-wide
 	// regardless of the namespace parameter so a namespace-scoped run
 	// can still validate that a RoleBinding's roleRef pointing at a
 	// ClusterRole resolves.
 	out.clusterRoles, err = cs.RbacV1().ClusterRoles().List(ctx, opts)
-	collect("clusterroles", err)
+	if collect("clusterroles", err) {
+		out.clusterRoles = nil
+	}
 	out.clusterRoleBindings, err = cs.RbacV1().ClusterRoleBindings().List(ctx, opts)
-	collect("clusterrolebindings", err)
+	if collect("clusterrolebindings", err) {
+		out.clusterRoleBindings = nil
+	}
 	return out, errs
+}
+
+// orphanDeps flags, per orphan kind, whether every list its "is
+// anything referencing this" answer depends on was actually read. A
+// false flag means that kind's report is unsound this scan and must be
+// omitted entirely — a failed list must not silently read as "nothing
+// references this resource" next to a bulk-delete action.
+type orphanDeps struct {
+	secrets             bool
+	configMaps          bool
+	pvcs                bool
+	hpas                bool
+	pdbs                bool
+	netpols             bool
+	roles               bool
+	clusterRoles        bool
+	roleBindings        bool
+	clusterRoleBindings bool
+}
+
+// computeOrphanDeps derives orphanDeps from which lists in `l` failed
+// (nil pointer — see fetchOrphanLists). The dependency shape mirrors
+// buildRefSet/buildWorkloadIndex/collectTemplatePodLabels/buildRBACIndex
+// below: whatever those builders read from is what the corresponding
+// kind depends on.
+func computeOrphanDeps(l orphanLists) orphanDeps {
+	podsOK := l.pods != nil
+	workloadTemplatesOK := l.deployments != nil && l.statefulSets != nil &&
+		l.daemonSets != nil && l.jobs != nil && l.cronJobs != nil
+	return orphanDeps{
+		// buildRefSet walks Pods, Ingress TLS, ServiceAccounts, and
+		// every workload's PodTemplate for Secret references.
+		secrets: podsOK && l.ingresses != nil && l.serviceAccounts != nil && workloadTemplatesOK,
+		// ConfigMap/PVC references only ever come from a PodSpec
+		// (volumes/env) — Ingress and ServiceAccount never touch them.
+		configMaps: podsOK && workloadTemplatesOK,
+		pvcs:       podsOK && workloadTemplatesOK,
+		// buildWorkloadIndex only resolves Deployment/StatefulSet/
+		// DaemonSet scaleTargetRefs (Jobs/CronJobs aren't valid HPA
+		// targets, so they aren't a dependency here).
+		hpas: l.deployments != nil && l.statefulSets != nil && l.daemonSets != nil,
+		// PDB/NetworkPolicy selector matching walks live Pods plus every
+		// workload's PodTemplate labels.
+		pdbs:    podsOK && workloadTemplatesOK,
+		netpols: podsOK && workloadTemplatesOK,
+		// RBAC is a mutual dependency web: Role/ClusterRole "bound"
+		// status is computed from the binding lists; RoleBinding/
+		// ClusterRoleBinding roleRef validity is computed from the
+		// Role/ClusterRole lists. See buildRBACIndex.
+		roles:               l.roleBindings != nil,
+		clusterRoles:        l.roleBindings != nil && l.clusterRoleBindings != nil,
+		roleBindings:        l.roles != nil && l.clusterRoles != nil,
+		clusterRoleBindings: l.clusterRoles != nil,
+	}
+}
+
+// detectRBACOrphans runs all four RBAC orphan checks. Split out of
+// DetectOrphans to keep that function's cyclomatic complexity down —
+// the four dependency-gated loops here mirror the mutual-dependency web
+// documented in computeOrphanDeps.
+func detectRBACOrphans(
+	deps orphanDeps,
+	roles *rbacv1.RoleList, clusterRoles *rbacv1.ClusterRoleList,
+	roleBindings *rbacv1.RoleBindingList, clusterRoleBindings *rbacv1.ClusterRoleBindingList,
+) (rolesOut, clusterRolesOut, roleBindingsOut, clusterRoleBindingsOut []OrphanItem) {
+	rbacIdx := buildRBACIndex(
+		safeRoleItems(roles), safeClusterRoleItems(clusterRoles),
+		safeRoleBindingItems(roleBindings), safeClusterRoleBindingItems(clusterRoleBindings),
+	)
+	if deps.roles {
+		for _, r := range safeRoleItems(roles) {
+			if item, ok := roleOrphan(r, rbacIdx); ok {
+				rolesOut = append(rolesOut, item)
+			}
+		}
+	}
+	if deps.clusterRoles {
+		for _, cr := range safeClusterRoleItems(clusterRoles) {
+			if item, ok := clusterRoleOrphan(cr, rbacIdx); ok {
+				clusterRolesOut = append(clusterRolesOut, item)
+			}
+		}
+	}
+	if deps.roleBindings {
+		for _, rb := range safeRoleBindingItems(roleBindings) {
+			if item, ok := roleBindingOrphan(rb, rbacIdx); ok {
+				roleBindingsOut = append(roleBindingsOut, item)
+			}
+		}
+	}
+	if deps.clusterRoleBindings {
+		for _, crb := range safeClusterRoleBindingItems(clusterRoleBindings) {
+			if item, ok := clusterRoleBindingOrphan(crb, rbacIdx); ok {
+				clusterRoleBindingsOut = append(clusterRoleBindingsOut, item)
+			}
+		}
+	}
+	return rolesOut, clusterRolesOut, roleBindingsOut, clusterRoleBindingsOut
 }
 
 func (c *Client) DetectOrphans(ctx context.Context, kubeContext, namespace string) (OrphanReport, error) {
@@ -162,6 +306,7 @@ func (c *Client) DetectOrphans(ctx context.Context, kubeContext, namespace strin
 
 	report := OrphanReport{}
 	lists, errs := fetchOrphanLists(ctx, cs, namespace)
+	deps := computeOrphanDeps(lists)
 	pods := lists.pods
 	ingresses := lists.ingresses
 	serviceAccounts := lists.serviceAccounts
@@ -208,14 +353,18 @@ func (c *Client) DetectOrphans(ctx context.Context, kubeContext, namespace strin
 			report.Pods = append(report.Pods, item)
 		}
 	}
-	for _, s := range safeSecretItems(secrets) {
-		if item, ok := secretOrphan(s, lenientRefs, strictRefs); ok {
-			report.Secrets = append(report.Secrets, item)
+	if deps.secrets {
+		for _, s := range safeSecretItems(secrets) {
+			if item, ok := secretOrphan(s, lenientRefs, strictRefs); ok {
+				report.Secrets = append(report.Secrets, item)
+			}
 		}
 	}
-	for _, cm := range safeCMItems(configMaps) {
-		if item, ok := configMapOrphan(cm, lenientRefs, strictRefs); ok {
-			report.ConfigMaps = append(report.ConfigMaps, item)
+	if deps.configMaps {
+		for _, cm := range safeCMItems(configMaps) {
+			if item, ok := configMapOrphan(cm, lenientRefs, strictRefs); ok {
+				report.ConfigMaps = append(report.ConfigMaps, item)
+			}
 		}
 	}
 	for _, svc := range safeSvcItems(services) {
@@ -228,9 +377,11 @@ func (c *Client) DetectOrphans(ctx context.Context, kubeContext, namespace strin
 			report.Services = append(report.Services, item)
 		}
 	}
-	for _, p := range safePVCItems(pvcs) {
-		if item, ok := pvcOrphan(p, lenientRefs, strictRefs); ok {
-			report.PVCs = append(report.PVCs, item)
+	if deps.pvcs {
+		for _, p := range safePVCItems(pvcs) {
+			if item, ok := pvcOrphan(p, lenientRefs, strictRefs); ok {
+				report.PVCs = append(report.PVCs, item)
+			}
 		}
 	}
 
@@ -246,48 +397,29 @@ func (c *Client) DetectOrphans(ctx context.Context, kubeContext, namespace strin
 	livePods := safePodItems(pods)
 	templatePodLabels := collectTemplatePodLabels(strictInputs)
 
-	for _, h := range safeHPAItems(hpas) {
-		if item, ok := hpaOrphan(h, wlIdx); ok {
-			report.HPAs = append(report.HPAs, item)
+	if deps.hpas {
+		for _, h := range safeHPAItems(hpas) {
+			if item, ok := hpaOrphan(h, wlIdx); ok {
+				report.HPAs = append(report.HPAs, item)
+			}
 		}
 	}
-	for _, b := range safePDBItems(pdbs) {
-		if item, ok := pdbOrphan(b, livePods, templatePodLabels); ok {
-			report.PDBs = append(report.PDBs, item)
+	if deps.pdbs {
+		for _, b := range safePDBItems(pdbs) {
+			if item, ok := pdbOrphan(b, livePods, templatePodLabels); ok {
+				report.PDBs = append(report.PDBs, item)
+			}
 		}
 	}
-	for _, n := range safeNetPolItems(netpols) {
-		if item, ok := netpolOrphan(n, livePods, templatePodLabels); ok {
-			report.NetworkPolicies = append(report.NetworkPolicies, item)
+	if deps.netpols {
+		for _, n := range safeNetPolItems(netpols) {
+			if item, ok := netpolOrphan(n, livePods, templatePodLabels); ok {
+				report.NetworkPolicies = append(report.NetworkPolicies, item)
+			}
 		}
 	}
 
-	// RBAC orphans — Roles/ClusterRoles unbound by any binding;
-	// (Cluster)RoleBindings with empty subjects or a missing roleRef.
-	rbacIdx := buildRBACIndex(
-		safeRoleItems(roles), safeClusterRoleItems(clusterRoles),
-		safeRoleBindingItems(roleBindings), safeClusterRoleBindingItems(clusterRoleBindings),
-	)
-	for _, r := range safeRoleItems(roles) {
-		if item, ok := roleOrphan(r, rbacIdx); ok {
-			report.Roles = append(report.Roles, item)
-		}
-	}
-	for _, cr := range safeClusterRoleItems(clusterRoles) {
-		if item, ok := clusterRoleOrphan(cr, rbacIdx); ok {
-			report.ClusterRoles = append(report.ClusterRoles, item)
-		}
-	}
-	for _, rb := range safeRoleBindingItems(roleBindings) {
-		if item, ok := roleBindingOrphan(rb, rbacIdx); ok {
-			report.RoleBindings = append(report.RoleBindings, item)
-		}
-	}
-	for _, crb := range safeClusterRoleBindingItems(clusterRoleBindings) {
-		if item, ok := clusterRoleBindingOrphan(crb, rbacIdx); ok {
-			report.ClusterRoleBindings = append(report.ClusterRoleBindings, item)
-		}
-	}
+	report.Roles, report.ClusterRoles, report.RoleBindings, report.ClusterRoleBindings = detectRBACOrphans(deps, roles, clusterRoles, roleBindings, clusterRoleBindings)
 
 	sortOrphans(report.Pods)
 	sortOrphans(report.Secrets)

--- a/internal/k8s/orphan_detector_gating_test.go
+++ b/internal/k8s/orphan_detector_gating_test.go
@@ -1,0 +1,210 @@
+package k8s
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// orphanKindItems maps a report field name to its slice, so gating
+// cases below can be data rather than a chain of if/else per kind.
+func orphanKindItems(kind string, r OrphanReport) []OrphanItem {
+	switch kind {
+	case "Pods":
+		return r.Pods
+	case "Secrets":
+		return r.Secrets
+	case "ConfigMaps":
+		return r.ConfigMaps
+	case "Services":
+		return r.Services
+	case "PVCs":
+		return r.PVCs
+	case "HPAs":
+		return r.HPAs
+	case "PDBs":
+		return r.PDBs
+	case "NetworkPolicies":
+		return r.NetworkPolicies
+	case "Roles":
+		return r.Roles
+	case "ClusterRoles":
+		return r.ClusterRoles
+	case "RoleBindings":
+		return r.RoleBindings
+	case "ClusterRoleBindings":
+		return r.ClusterRoleBindings
+	}
+	return nil
+}
+
+// orphanGateCase exercises one gated kind's dependency in isolation:
+// fail exactly one list it depends on, and assert both that the target
+// kind reports nothing and that a kind NOT depending on the failed list
+// still reports normally. The second assertion is the one that catches
+// a fix that suppresses everything rather than the specific dependency.
+type orphanGateCase struct {
+	name string
+	// failList is the fake-clientset resource name to fail "list" on.
+	failList string
+	objs     []runtime.Object
+
+	suppressedKind string // must report zero items
+	unaffectedKind string // must still report normally
+	unaffectedName string // the object name expected in unaffectedKind
+}
+
+// TestDetectOrphans_GatedKindsSkipOnDependencyFailure covers the 8
+// gated kinds not already exercised by
+// TestDetectOrphans_IngressListFailureSkipsSecrets (Secrets) and
+// TestDetectOrphans_RoleBindingListFailureSkipsRoleAndClusterRole
+// (Roles, ClusterRoles). Each case fails a list unique to the target
+// kind's dependency where the dependency map allows one, so the case
+// discriminates rather than proving suppression by failing every list
+// at once.
+func TestDetectOrphans_GatedKindsSkipOnDependencyFailure(t *testing.T) {
+	badHPA := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "bad-hpa"},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: "missing"},
+		},
+	}
+	unboundRole := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "leftover-role"}}
+	unboundClusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "leftover-cr"}}
+	emptySubjectsCRB := func(name string) *rbacv1.ClusterRoleBinding {
+		return &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "does-not-matter"},
+		}
+	}
+
+	cases := []orphanGateCase{
+		{
+			name:     "ConfigMaps depend on the Job PodTemplate list",
+			failList: "jobs",
+			objs: []runtime.Object{
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "stale-cm"}},
+				badHPA,
+			},
+			suppressedKind: "ConfigMaps",
+			unaffectedKind: "HPAs", // HPA's dependency doesn't include Jobs.
+			unaffectedName: "bad-hpa",
+		},
+		{
+			name:     "PVCs depend on the CronJob PodTemplate list",
+			failList: "cronjobs",
+			objs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "stale-pvc"}},
+				badHPA,
+			},
+			suppressedKind: "PVCs",
+			unaffectedKind: "HPAs", // HPA's dependency doesn't include CronJobs.
+			unaffectedName: "bad-hpa",
+		},
+		{
+			name:     "HPAs depend on the StatefulSet list",
+			failList: "statefulsets",
+			objs: []runtime.Object{
+				badHPA,
+				unboundRole,
+			},
+			suppressedKind: "HPAs",
+			unaffectedKind: "Roles", // Role bound-status depends on RoleBindings, not StatefulSets.
+			unaffectedName: "leftover-role",
+		},
+		{
+			name:     "PDBs depend on the DaemonSet PodTemplate list",
+			failList: "daemonsets",
+			objs: []runtime.Object{
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "stale-pdb"},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "deleted"}},
+					},
+				},
+				unboundClusterRole,
+			},
+			suppressedKind: "PDBs",
+			unaffectedKind: "ClusterRoles", // ClusterRole bound-status depends on binding lists, not DaemonSets.
+			unaffectedName: "leftover-cr",
+		},
+		{
+			name:     "NetworkPolicies depend on the live Pod list",
+			failList: "pods",
+			objs: []runtime.Object{
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "stale-np"},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "deleted"}},
+					},
+				},
+				emptySubjectsCRB("empty-crb"),
+			},
+			suppressedKind: "NetworkPolicies",
+			unaffectedKind: "ClusterRoleBindings", // Doesn't depend on the Pod list at all.
+			unaffectedName: "empty-crb",
+		},
+		{
+			name:     "RoleBindings depend on the Role list (reverse of the Role/ClusterRole case)",
+			failList: "roles",
+			objs: []runtime.Object{
+				&rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "empty-rb"},
+					RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "does-not-matter"},
+				},
+				emptySubjectsCRB("empty-crb2"),
+			},
+			suppressedKind: "RoleBindings",
+			unaffectedKind: "ClusterRoleBindings", // Depends on ClusterRoles only, not Roles.
+			unaffectedName: "empty-crb2",
+		},
+		{
+			name:     "ClusterRoleBindings depend on the ClusterRole list (reverse of the Role/ClusterRole case)",
+			failList: "clusterroles",
+			objs: []runtime.Object{
+				emptySubjectsCRB("empty-crb3"),
+				unboundRole,
+			},
+			suppressedKind: "ClusterRoleBindings",
+			unaffectedKind: "Roles", // Role bound-status depends on RoleBindings, not ClusterRoles.
+			unaffectedName: "leftover-role",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := k8sfake.NewSimpleClientset(tc.objs...)
+			cs.PrependReactor("list", tc.failList, func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("forbidden")
+			})
+
+			c := newFakeClient(cs, nil)
+			report, err := c.DetectOrphans(t.Context(), "", "")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.failList)
+			assert.Empty(t, orphanKindItems(tc.suppressedKind, report),
+				"%s must be omitted when its dependency (%s) fails to load", tc.suppressedKind, tc.failList)
+
+			unaffected := orphanKindItems(tc.unaffectedKind, report)
+			require.NotEmpty(t, unaffected,
+				"%s doesn't depend on %s and must still report", tc.unaffectedKind, tc.failList)
+			names := make([]string, 0, len(unaffected))
+			for _, item := range unaffected {
+				names = append(names, item.Name)
+			}
+			assert.Contains(t, names, tc.unaffectedName)
+		})
+	}
+}

--- a/internal/k8s/orphan_detector_test.go
+++ b/internal/k8s/orphan_detector_test.go
@@ -605,3 +605,66 @@ func TestDetectOrphans_PartialDenial(t *testing.T) {
 	require.Len(t, report.Pods, 1)
 	assert.Equal(t, "naked", report.Pods[0].Name)
 }
+
+// TestDetectOrphans_IngressListFailureSkipsSecrets guards against the
+// referencing-list version of the partial-scan bug: a Secret is only
+// referenced via an Ingress's spec.tls[].secretName, so if the Ingress
+// list fails, the detector cannot know the Secret is in use. Reporting
+// it as an orphan anyway would be a false positive next to a bulk-delete
+// action. ConfigMaps don't depend on the Ingress list at all, so a
+// ConfigMap with the same "unmounted" shape must still be reported —
+// this is the boundary between "too narrow" (only guard the kind whose
+// own list failed) and "too broad" (drop the whole report).
+func TestDetectOrphans_IngressListFailureSkipsSecrets(t *testing.T) {
+	tlsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "tls-cert"}}
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "web"},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{{SecretName: "tls-cert"}},
+		},
+	}
+	unmountedCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "stale-config"}}
+
+	cs := k8sfake.NewSimpleClientset(tlsSecret, ingress, unmountedCM)
+	cs.PrependReactor("list", "ingresses", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+
+	c := newFakeClient(cs, nil)
+	report, err := c.DetectOrphans(t.Context(), "", "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ingresses")
+	assert.Empty(t, report.Secrets,
+		"tls-cert is referenced only via the unreadable Ingress list; it must not be reported as orphan")
+	require.Len(t, report.ConfigMaps, 1,
+		"ConfigMaps don't depend on the Ingress list and must still be reported")
+	assert.Equal(t, "stale-config", report.ConfigMaps[0].Name)
+}
+
+// TestDetectOrphans_RoleBindingListFailureSkipsRoleAndClusterRole covers
+// the RBAC group's mutual dependency: a Role's orphan status depends on
+// whether any RoleBinding references it, and a ClusterRole's depends on
+// both binding kinds. If the RoleBinding list fails, both Role and
+// ClusterRole answers become unsound and must be omitted — but
+// RoleBinding's own report (which depends on the Role/ClusterRole
+// lists, not on itself) is unaffected by this particular failure.
+func TestDetectOrphans_RoleBindingListFailureSkipsRoleAndClusterRole(t *testing.T) {
+	boundRole := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "deployer"}}
+	boundClusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "viewer"}}
+
+	cs := k8sfake.NewSimpleClientset(boundRole, boundClusterRole)
+	cs.PrependReactor("list", "rolebindings", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+
+	c := newFakeClient(cs, nil)
+	report, err := c.DetectOrphans(t.Context(), "", "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rolebindings")
+	assert.Empty(t, report.Roles,
+		"a Role's bound/unbound status depends on the unreadable RoleBinding list")
+	assert.Empty(t, report.ClusterRoles,
+		"a ClusterRole's bound/unbound status also depends on the unreadable RoleBinding list")
+}


### PR DESCRIPTION
The orphan scanner decides an object is unused by checking whether anything references it. That answer is only sound if every referencing list was actually read.

Until now, a failed list was collected into a partial-result banner while the rows were still shown as orphans. So if the Pod list failed, a ConfigMap referenced only by Pods appeared orphaned. The banner said the scan was partial; the table said the object was unused. **The table is what people act on, and this view offers bulk deletion.**

Found while verifying CodeRabbit's review of #609, which caught the same class in the Undeliverable view: a failed EndpointSlice list made every Service look endpoint-less.

## Why a failed list looked empty

client-go's `List()` allocates its result struct before it can fail, so it **never** returns a nil pointer (`client-go@v0.36.3/gentype/type.go:171-186`). A failed list arrived as an allocated struct with zero items - indistinguishable from a genuinely empty cluster. That also made the existing `safe*Items` nil guards dead code.

`fetchOrphanLists` now nils each list pointer when its call errored, so the two are distinguishable. Same approach TASK-855 took, already on main.

## Which kinds depend on which lists

`orphanDeps` / `computeOrphanDeps` encode the map; `DetectOrphans` gates each kind on its flag. Every row was verified against the source in review:

| Kind | Depends on |
|---|---|
| Pods | nothing - owner refs and the mirror annotation are self-contained |
| Secrets | pods, ingresses, serviceAccounts, and all five workload kinds |
| ConfigMaps, PVCs | pods and the five workload kinds. Ingresses and ServiceAccounts write only to `rs.secrets`, so they are genuinely irrelevant here |
| Services | nothing pre-fetched - `GetServiceEndpoints` lists per service and already skips that item on error |
| HPAs | deployments, statefulSets, daemonSets. `buildWorkloadIndex` never reads jobs or cronJobs |
| PDBs, NetworkPolicies | pods and the five workload kinds, via `collectTemplatePodLabels` |
| RBAC | a mutual web: Roles need RoleBindings; ClusterRoles need both binding lists; RoleBindings need Roles and ClusterRoles; ClusterRoleBindings need ClusterRoles |

The partial-scan error still surfaces, so the banner explains what was omitted.

**Blast radius is scoped, deliberately.** Discarding the whole report on any error would punish anyone with partial RBAC for no reason. Worst case here is both binding lists failing, which silences the four RBAC kinds and nothing else. A failed Pod list does not touch RBAC, and vice versa.

`detectRBACOrphans` was extracted to keep `DetectOrphans` under gocyclo 30 - a pure move plus the gating, confirmed in review.

## Tests

All **10** gated kinds have a failure-injection case. Each asserts two things: the dependent kind produces no rows, **and** a kind that does not depend on the failed list still reports normally. Without that second assertion a fix that suppresses everything would pass.

The failed list per case is chosen to be discriminating rather than convenient - ConfigMaps via jobs, PVCs via cronjobs, RoleBindings via roles (the reverse direction from the ClusterRoles case), and so on.

Verified by checking out the pre-fix `orphan_detector.go` and running the suite: **10 failures**, each showing the false-positive row it now prevents, for example `Should be empty, but was [{default stale-cm ConfigMap unmounted false}]`. Green with the fix restored.

A first review passed this as ready to merge with the coverage at 2 of 10 kinds, the rest verified by code inspection. That was not enough for a gate whose job is preventing a wrong delete, so the remaining 8 were covered before opening this.

## Docs

`docs/usage.md:464` claimed that under partial RBAC denial "whatever could be listed is still shown". This change deliberately makes that false, so it now states the omission rule.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` 0 issues, `go test -count=1 -race ./...` exit 0 across 26 packages. `orphan_detector.go` 571 lines, new gating test file 210.

Closes TASK-886.
