### PR TITLE
fix: stop a bare sync status posing as Application child health (TASK-888)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 - **StatefulSets / DaemonSets / Jobs** show their Pods directly
 - **CronJobs** show their Jobs
 - **Services** show Pods matching the service selector
-- **ArgoCD Applications** show managed resources (from status or label discovery)
+- **ArgoCD Applications** show managed resources (from status or label discovery); child health shows as `Unknown` unless the cluster sets `resourceHealthSource: resourceHealth`
 - **Helm Releases** show managed resources (via `app.kubernetes.io/instance` label)
 - **Pods** show their Containers
 - **ConfigMaps / Secrets / Ingresses / PVCs** show details preview (no children)

--- a/internal/k8s/client_fakeclient_extra_test.go
+++ b/internal/k8s/client_fakeclient_extra_test.go
@@ -1203,10 +1203,15 @@ func TestGetArgoManagedResources_WithStatusResources(t *testing.T) {
 	items, err := c.getArgoManagedResources(t.Context(), dc, "", "argocd", "my-app")
 	require.NoError(t, err)
 	assert.Len(t, items, 2)
-	// First should have combined status.
 	for _, item := range items {
-		if item.Name == "my-deploy" {
+		switch item.Name {
+		case "my-deploy":
+			// Health present: combined status, unchanged.
 			assert.Equal(t, "Healthy/Synced", item.Status)
+		case "my-svc":
+			// Health absent (ArgoCD's appTree default): must not read as
+			// healthy just because it's a bare "Synced".
+			assert.Equal(t, "Unknown/Synced", item.Status)
 		}
 	}
 }

--- a/internal/k8s/gitops_argo.go
+++ b/internal/k8s/gitops_argo.go
@@ -67,6 +67,14 @@ func argoStatusResourcesToItems(resources []any) []model.Item {
 			healthStatus, _ = health["status"].(string)
 		}
 
+		// resourceHealthSource: appTree (ArgoCD's default) never writes a
+		// "health" key here, so a bare sync status would read as healthy.
+		// "Unknown" is a real ArgoCD health value, so it is the honest label.
+		healthKnown := healthStatus != ""
+		if !healthKnown {
+			healthStatus = "Unknown"
+		}
+
 		status := healthStatus
 		if syncStatus != "" && healthStatus != "" {
 			status = healthStatus + "/" + syncStatus
@@ -94,6 +102,12 @@ func argoStatusResourcesToItems(resources []any) []model.Item {
 				{Key: "KIND", Value: kind},
 				{Key: "APIVERSION", Value: apiVersion},
 			},
+		}
+		if !healthKnown {
+			ti.Columns = append(ti.Columns, model.KeyValue{
+				Key:   "Health Message",
+				Value: "ArgoCD is not persisting per-resource health on this cluster (resourceHealthSource: appTree)",
+			})
 		}
 		items = append(items, ti)
 	}

--- a/internal/k8s/gitops_argo_test.go
+++ b/internal/k8s/gitops_argo_test.go
@@ -1,0 +1,85 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// argoStatusResourcesToItems: health persistence shapes.
+//
+// ArgoCD's default resourceHealthSource ("appTree") never writes a "health"
+// key into status.resources, so a bare sync status ("Synced") read as a full
+// verdict when health is simply unknown. These tests pin the two real
+// cluster shapes: health absent (the default) and health present (clusters
+// with resourceHealthSource: resourceHealth), so the working path can never
+// silently regress while the unknown-health path gets fixed.
+
+// TestArgoStatusResourcesToItems_MissingHealth_IsLabeledUnknown guards the
+// bug: with no "health" key, the child's rendered status must say the health
+// is unknown, not read as "Synced" (which implies healthy).
+func TestArgoStatusResourcesToItems_MissingHealth_IsLabeledUnknown(t *testing.T) {
+	resources := []any{
+		map[string]any{
+			"group": "external-secrets.io", "kind": "ExternalSecret",
+			"name": "light-avalara", "namespace": "apps",
+			"status": "Synced", "version": "v1",
+		},
+	}
+
+	items := argoStatusResourcesToItems(resources)
+
+	require.Len(t, items, 1)
+	assert.Equal(t, "Unknown/Synced", items[0].Status,
+		"missing health must not render as a bare, healthy-looking sync status")
+}
+
+// TestArgoStatusResourcesToItems_MissingHealth_ExplainsWhy guards the
+// requirement that the details panel can say why health is unknown: a
+// clusters running the appTree default. The row itself stays untouched.
+func TestArgoStatusResourcesToItems_MissingHealth_ExplainsWhy(t *testing.T) {
+	resources := []any{
+		map[string]any{
+			"group": "external-secrets.io", "kind": "ExternalSecret",
+			"name": "light-avalara", "namespace": "apps",
+			"status": "Synced", "version": "v1",
+		},
+	}
+
+	items := argoStatusResourcesToItems(resources)
+
+	require.Len(t, items, 1)
+	var found bool
+	for _, kv := range items[0].Columns {
+		if kv.Key == "Health Message" {
+			found = true
+			assert.Contains(t, kv.Value, "resourceHealthSource")
+		}
+	}
+	assert.True(t, found, "details panel must explain why health is unknown")
+}
+
+// TestArgoStatusResourcesToItems_PresentHealth_Unchanged is the regression
+// guard: when ArgoCD does persist health (resourceHealthSource:
+// resourceHealth), the existing "Degraded/Synced" form must stay exactly as
+// it is, with no explanatory Health Message column added.
+func TestArgoStatusResourcesToItems_PresentHealth_Unchanged(t *testing.T) {
+	resources := []any{
+		map[string]any{
+			"group": "apps", "kind": "Deployment",
+			"name": "my-deploy", "namespace": "default",
+			"status": "Synced", "version": "v1",
+			"health": map[string]any{"status": "Degraded"},
+		},
+	}
+
+	items := argoStatusResourcesToItems(resources)
+
+	require.Len(t, items, 1)
+	assert.Equal(t, "Degraded/Synced", items[0].Status)
+	for _, kv := range items[0].Columns {
+		assert.NotEqual(t, "Health Message", kv.Key,
+			"health-present path must not gain the unknown-health explanation")
+	}
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -544,7 +544,7 @@ func statusSeverity(status string) statusSev {
 var phraseSeverityWords = map[string]statusSev{
 	"failed": sevFailed, "failing": sevFailed, "error": sevFailed,
 	"errored": sevFailed, "degraded": sevFailed, "unhealthy": sevFailed,
-	"pending": sevProgressing, "waiting": sevProgressing, "creating": sevProgressing,
+	"pending": sevProgressing, "waiting": sevProgressing, "creating": sevProgressing, "unknown": sevProgressing,
 	"initializing": sevProgressing, "starting": sevProgressing, "setting": sevProgressing,
 	"upgrading": sevProgressing, "provisioning": sevProgressing, "progressing": sevProgressing,
 	"progress": sevProgressing, "reconciling": sevProgressing, "restarting": sevProgressing,

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -206,6 +206,18 @@ func TestStatusSeverity_FreeFormPhrases(t *testing.T) {
 	}
 }
 
+// --- statusSeverity: unknown health must not read as healthy ---
+
+// ArgoCD's "Unknown" health value combined with a sync status (e.g. a child
+// resource whose health was never persisted, TASK-888) must not classify as
+// sevRunning -- that would color the same green as a real "Healthy/Synced"
+// row and mislead a reader into thinking health is good.
+func TestStatusSeverity_UnknownHealthIsNotColoredHealthy(t *testing.T) {
+	assert.Equal(t, sevProgressing, statusSeverity("Unknown/Synced"))
+	assert.Equal(t, sevProgressing, statusSeverity("Unknown/OutOfSync"))
+	assert.NotEqual(t, StatusStyle("Unknown/Synced").GetForeground(), StatusStyle("Healthy/Synced").GetForeground())
+}
+
 // --- FillLinesBg ---
 
 // TestFillLinesBgReestablishesBgAfterShortReset guards issue #293's recurrence


### PR DESCRIPTION
Drilling into an ArgoCD Application listed its child resources with a bare green `Synced`, so a Degraded child read as healthy.

## What was actually wrong

Not the code. `argoStatusResourcesToItems` already read `res["health"]["status"]` and rendered `health/sync`. The data was not there.

Verified directly against a live cluster:

- `status.resourceHealthSource` is `appTree`, and with that setting ArgoCD **does not persist per-resource health into the Application CR at all**. Every entry carries only `group`, `kind`, `name`, `namespace`, `status`, `version`.
- Confirmed on a Degraded app *and* a Healthy one, so it is cluster-wide, not a symptom of the degradation.
- The application-controller has no health-persistence flag set, so this is the **ArgoCD default**. Any default install behaves this way, which makes it the common case rather than an edge case.
- The web UI reads child health from the app-tree cache via the ArgoCD API. lfk does not use that API, and adding it was explicitly out of scope here.

So the old output was worse than showing nothing: it presented a sync status as though it were a full verdict.

## The change

| Health in the CR | Rendered |
|---|---|
| absent | `Unknown/Synced` |
| present | `Degraded/Synced` - unchanged |

`Unknown` is a real ArgoCD health status, not an invented placeholder, so it is the honest label rather than a `-` or `?`.

**Colour was the actual harm and is handled through the existing mechanism.** `Synced` alone lands in the healthy-green `sevRunning` bucket via `statusSeverity` / `phraseSeverityWords`. Adding `"unknown": sevProgressing` to that word map puts `Unknown/Synced` in the amber progressing bucket instead, so it can never read as green. No new colour path was invented. (`internal/ui/styles.go` is at exactly the 800-line cap, so this extends an existing map line rather than adding one.)

**The reason is discoverable.** A `Health Message` column carries `ArgoCD is not persisting per-resource health on this cluster (resourceHealthSource: appTree)`, reusing the details-panel `messageKeys` bucket that already renders that key. It is added only when health is absent, never otherwise, and it stays out of the row.

## Tests

Three proven red on the unfixed code:

- `TestArgoStatusResourcesToItems_MissingHealth_IsLabeledUnknown` - `expected: "Unknown/Synced" actual: "Synced"`
- `TestArgoStatusResourcesToItems_MissingHealth_ExplainsWhy` - no `Health Message` column found
- `TestStatusSeverity_UnknownHealthIsNotColoredHealthy` - `expected: 6 actual: 0` on the RGBA foreground compare

Plus `TestArgoStatusResourcesToItems_PresentHealth_Unchanged`, which passes either way by design - it exists to catch a regression in the working path, not to prove this fix.

A pre-existing test had an unexercised no-health fixture; it now asserts `Unknown/Synced`.

**Also verified against the real thing.** The captured `status.resources` from the cluster that produced the bug was fed through the fixed function: all five ExternalSecrets render `Unknown/Synced` with the message attached.

## Docs

One line on the README's Applications bullet noting that child health needs `resourceHealthSource: resourceHealth` on the ArgoCD side. `docs/usage.md` and `docs/views-and-overlays.md` do not describe this drill-down, so they were left alone.

## Not fixed here

Two things found in the same investigation, both out of scope:

- The app's destination is a **different cluster** (`spec.destination.name: tixx-baseus-dev-argocd-poc`). lfk is connected to the management cluster, where the `ExternalSecret` CRD is not installed - that is the cause of the `Warning: unknown resource type: ExternalSecret` in the drill-down.
- Getting real child health needs either the destination cluster's own objects or the ArgoCD API. Both are larger than this change.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` 0 issues, `go test -count=1 -race ./...` exit 0 across 26 packages.

Closes TASK-888.
