### PR TITLE
fix: resolve CronJob logs through its newest Job's pods

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -219,10 +219,18 @@ func (m Model) loadPodsForLogAction() tea.Cmd {
 	kubeconfigPaths := m.client.KubeconfigPathForContext(kctx)
 
 	return func() tea.Msg {
-		// Get the selector for this parent resource.
-		selector := kubectlGetPodSelector(kubectlPath, kubeconfigPaths, ns, kind, name, m.kubectlContext(kctx))
-		if selector == "" {
-			return podLogSelectMsg{err: fmt.Errorf("could not determine pod selector for %s/%s", kind, name)}
+		var selector string
+		if kind == "CronJob" {
+			resolved, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if !ok {
+				return podLogSelectMsg{err: errCronJobNoRuns}
+			}
+			selector = resolved
+		} else {
+			selector = kubectlGetPodSelector(kubectlPath, kubeconfigPaths, ns, kind, name, m.kubectlContext(kctx))
+			if selector == "" {
+				return podLogSelectMsg{err: fmt.Errorf("could not determine pod selector for %s/%s", kind, name)}
+			}
 		}
 
 		// Fetch pods matching the selector.

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -221,9 +221,9 @@ func (m Model) loadPodsForLogAction() tea.Cmd {
 	return func() tea.Msg {
 		var selector string
 		if kind == "CronJob" {
-			resolved, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
-			if !ok {
-				return podLogSelectMsg{err: errCronJobNoRuns}
+			resolved, err := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if err != nil {
+				return podLogSelectMsg{err: err}
 			}
 			selector = resolved
 		} else {

--- a/internal/app/commands_logs.go
+++ b/internal/app/commands_logs.go
@@ -135,10 +135,10 @@ func (m *Model) startLogStream() tea.Cmd {
 		}
 		switch kind {
 		case "CronJob":
-			selector, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
-			if !ok {
+			selector, err := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if err != nil {
 				select {
-				case ch <- cronJobNoRunsSentinel + name:
+				case ch <- cronJobSentinelLine(name, err):
 				case <-ctx.Done():
 				}
 				return
@@ -410,9 +410,9 @@ func (m *Model) fetchOlderLogs() tea.Cmd {
 		var args []string //nolint:prealloc
 		switch kind {
 		case "CronJob":
-			selector, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
-			if !ok {
-				return logHistoryMsg{err: errCronJobNoRuns, prevTotal: prevTotal}
+			selector, err := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if err != nil {
+				return logHistoryMsg{err: err, prevTotal: prevTotal}
 			}
 			args = []string{
 				"logs", "-l", selector, "--all-containers=true", "--prefix",
@@ -542,9 +542,9 @@ func (m *Model) saveAllLogs() tea.Cmd {
 		var args []string
 		switch kind {
 		case "CronJob":
-			selector, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
-			if !ok {
-				return logSaveAllMsg{err: errCronJobNoRuns}
+			selector, err := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if err != nil {
+				return logSaveAllMsg{err: err}
 			}
 			args = []string{
 				"logs", "-l", selector, "--all-containers=true", "--prefix",

--- a/internal/app/commands_logs.go
+++ b/internal/app/commands_logs.go
@@ -10,14 +10,12 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
-	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -136,7 +134,20 @@ func (m *Model) startLogStream() tea.Cmd {
 			followFlag = "--previous"
 		}
 		switch kind {
-		case "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "Service":
+		case "CronJob":
+			selector, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if !ok {
+				select {
+				case ch <- cronJobNoRunsSentinel + name:
+				case <-ctx.Done():
+				}
+				return
+			}
+			args = []string{
+				"logs", "-l", selector, "--all-containers=true", "--prefix", followFlag,
+				"--max-log-requests=20", "--ignore-errors", "-n", ns, "--context", m.kubectlContext(kctx),
+			}
+		case "Deployment", "StatefulSet", "DaemonSet", "Job", "Service":
 			// Try to get the pod selector via kubectl so we can follow ALL pods.
 			// kubectl logs deployment/<name> only follows a single pod.
 			selector := kubectlGetPodSelector(kubectlPath, kubeconfigPaths, ns, kind, name, m.kubectlContext(kctx))
@@ -366,225 +377,6 @@ func (m Model) waitForLogLineIfIdle() tea.Cmd {
 	return m.readLogChannel(ch)
 }
 
-// startMultiLogStream spawns one kubectl logs process per selected item and
-// merges their output into a single log channel. This supports streaming logs
-// from multiple pods or parent resources simultaneously.
-func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
-	kubectlPath, err := k8s.KubectlPath()
-	if err != nil {
-		return m, func() tea.Msg { return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)} }
-	}
-
-	// Initialize log viewer state.
-	m.mode = modeLogs
-	m.resetLogBuffer()
-	m.logView.scroll = 0
-	m.logView.follow = true
-	m.logView.wrap = false
-	m.logView.lineNumbers = true
-	m.logView.timestamps = ui.ConfigLogShowTimestamps
-	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
-	m.logView.previewVisible = ui.ConfigLogShowPreview
-	m.logView.previous = false
-	m.logView.isMulti = true
-	m.logView.multiItems = items
-	m.logView.title = fmt.Sprintf("Logs: %d resources", len(items))
-	m.logView.tailLines = ui.ConfigLogTailLines
-	m.logView.hasMoreHistory = false // too complex to deduplicate across multiple streams
-	m.logView.loadingHistory = false
-	m.logView.cursor = 0 // will track end as lines stream in with follow mode
-	m.logView.visualMode = false
-	m.logView.visualStart = 0
-
-	ctx, cancel := context.WithCancel(context.Background())
-	m.logView.cancel = cancel
-	ch := make(chan string, 256)
-	m.logView.ch = ch
-
-	kctx := m.nav.Context
-	ns := m.resolveNamespace()
-
-	var wg sync.WaitGroup
-	for _, item := range items {
-		itemCtx := kctx
-		if item.ClusterName != "" {
-			itemCtx = item.ClusterName
-		}
-		itemNs := ns
-		if item.Namespace != "" {
-			itemNs = item.Namespace
-		}
-
-		kind := item.Kind
-		if kind == "" {
-			kind = m.nav.ResourceType.Kind
-		}
-
-		followFlag := "-f"
-		if m.logView.previous {
-			followFlag = "--previous"
-		}
-		var args []string
-		switch kind {
-		case "Pod":
-			args = []string{
-				"logs", item.Name, "--all-containers=true", "--prefix", followFlag,
-				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
-			}
-		default:
-			resourceRef := strings.ToLower(kind) + "/" + item.Name
-			args = []string{
-				"logs", resourceRef, "--all-containers=true", "--prefix", followFlag,
-				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
-			}
-		}
-
-		// Add --tail for initial loading.
-		if m.logView.tailLines > 0 {
-			args = append(args, fmt.Sprintf("--tail=%d", m.logView.tailLines))
-		}
-
-		args = append(args, "--timestamps")
-
-		m.addLogEntry("DBG", "kubectl "+strings.Join(args, " "))
-
-		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
-		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(itemCtx))
-		logger.Info("Starting multi-log kubectl",
-			"item", item.Name,
-			"context", itemCtx,
-			"cmd", cmd.String(),
-			"kubeconfig", m.client.KubeconfigPathForContext(itemCtx))
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			logger.Error("Failed to create stdout pipe for multi-log", "item", item.Name, "error", err)
-			continue
-		}
-		cmd.Stderr = cmd.Stdout
-
-		if err := cmd.Start(); err != nil {
-			logger.Error("Failed to start kubectl logs for multi-log", "item", item.Name, "error", err)
-			continue
-		}
-
-		wg.Go(func() {
-			defer cmd.Wait() //nolint:errcheck
-			scanner := bufio.NewScanner(stdout)
-			scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
-			for scanner.Scan() {
-				select {
-				case ch <- scanner.Text():
-				case <-ctx.Done():
-					return
-				}
-			}
-		})
-	}
-
-	// Close the channel once all goroutines finish.
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-
-	return m, m.waitForLogLine()
-}
-
-// restartMultiLogStream restarts a multi-log stream using stored items,
-// preserving current viewer settings (used when toggling timestamps).
-func (m Model) restartMultiLogStream() (Model, tea.Cmd) {
-	kubectlPath, err := k8s.KubectlPath()
-	if err != nil {
-		return m, func() tea.Msg { return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)} }
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	m.logView.cancel = cancel
-	ch := make(chan string, 256)
-	m.logView.ch = ch
-
-	kctx := m.nav.Context
-	ns := m.resolveNamespace()
-	items := m.logView.multiItems
-
-	var wg sync.WaitGroup
-	for _, item := range items {
-		itemCtx := kctx
-		if item.ClusterName != "" {
-			itemCtx = item.ClusterName
-		}
-		itemNs := ns
-		if item.Namespace != "" {
-			itemNs = item.Namespace
-		}
-
-		kind := item.Kind
-		if kind == "" {
-			kind = m.nav.ResourceType.Kind
-		}
-
-		followFlag := "-f"
-		if m.logView.previous {
-			followFlag = "--previous"
-		}
-		var args []string
-		switch kind {
-		case "Pod":
-			args = []string{
-				"logs", item.Name, "--all-containers=true", "--prefix", followFlag,
-				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
-			}
-		default:
-			resourceRef := strings.ToLower(kind) + "/" + item.Name
-			args = []string{
-				"logs", resourceRef, "--all-containers=true", "--prefix", followFlag,
-				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
-			}
-		}
-
-		// Add --tail for initial loading.
-		if m.logView.tailLines > 0 {
-			args = append(args, fmt.Sprintf("--tail=%d", m.logView.tailLines))
-		}
-
-		args = append(args, "--timestamps")
-
-		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
-		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(itemCtx))
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			logger.Error("Failed to open kubectl logs stdout pipe (multi-pod)", "error", err, "pod", item.Name, "namespace", itemNs, "context", itemCtx)
-			continue
-		}
-		cmd.Stderr = cmd.Stdout
-
-		if err := cmd.Start(); err != nil {
-			logger.Error("Failed to start kubectl logs (multi-pod)", "error", err, "pod", item.Name, "namespace", itemNs, "context", itemCtx, "cmd", cmd.String())
-			continue
-		}
-
-		wg.Go(func() {
-			defer cmd.Wait() //nolint:errcheck
-			scanner := bufio.NewScanner(stdout)
-			scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
-			for scanner.Scan() {
-				select {
-				case ch <- scanner.Text():
-				case <-ctx.Done():
-					return
-				}
-			}
-		})
-	}
-
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-
-	return m, m.waitForLogLine()
-}
-
 // --- Log history and persistence ---
 
 // fetchOlderLogs fetches an additional batch of older log lines using a
@@ -617,7 +409,16 @@ func (m *Model) fetchOlderLogs() tea.Cmd {
 
 		var args []string //nolint:prealloc
 		switch kind {
-		case "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "Service":
+		case "CronJob":
+			selector, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if !ok {
+				return logHistoryMsg{err: errCronJobNoRuns, prevTotal: prevTotal}
+			}
+			args = []string{
+				"logs", "-l", selector, "--all-containers=true", "--prefix",
+				"--max-log-requests=20", "-n", ns, "--context", m.kubectlContext(kctx),
+			}
+		case "Deployment", "StatefulSet", "DaemonSet", "Job", "Service":
 			selector := kubectlGetPodSelector(kubectlPath, kubeconfigPaths, ns, kind, name, m.kubectlContext(kctx))
 			if selector != "" {
 				args = []string{
@@ -740,7 +541,16 @@ func (m *Model) saveAllLogs() tea.Cmd {
 	return m.trackBgTask(scheduler.KindSubprocess, "Save all logs: "+kind+"/"+name, bgtaskTarget(kctx, ns), func() tea.Msg {
 		var args []string
 		switch kind {
-		case "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "Service":
+		case "CronJob":
+			selector, ok := resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, m.kubectlContext(kctx))
+			if !ok {
+				return logSaveAllMsg{err: errCronJobNoRuns}
+			}
+			args = []string{
+				"logs", "-l", selector, "--all-containers=true", "--prefix",
+				"--max-log-requests=20", "--timestamps", "-n", ns, "--context", m.kubectlContext(kctx),
+			}
+		case "Deployment", "StatefulSet", "DaemonSet", "Job", "Service":
 			selector := kubectlGetPodSelector(kubectlPath, kubeconfigPaths, ns, kind, name, m.kubectlContext(kctx))
 			if selector != "" {
 				args = []string{

--- a/internal/app/commands_logs_cronjob.go
+++ b/internal/app/commands_logs_cronjob.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// cronJobNoRunsSentinel is a marker line updateLogLine turns into a status
+// message instead of a log line - kubectl has no selector for *v1.CronJob.
+const cronJobNoRunsSentinel = "\x00lfk:cronjob-no-runs\x00"
+
+var errCronJobNoRuns = errors.New("no runs yet")
+
+// resolveCronJobPodSelector resolves a CronJob to the pod selector for its
+// newest owned Job. *v1.CronJob has no pod selector of its own. ok is false
+// when the CronJob has never run or its newest Job's pods are already gone.
+func resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, kctx string) (selector string, ok bool) {
+	jobName, jobUID, found := latestOwnedJob(kubectlPath, kubeconfigPaths, ns, name, kctx)
+	if !found {
+		return "", false
+	}
+	// Prefixed label first, then the unprefixed pair older clusters still use.
+	for _, candidate := range []string{
+		"batch.kubernetes.io/job-name=" + jobName + ",batch.kubernetes.io/controller-uid=" + jobUID,
+		"job-name=" + jobName + ",controller-uid=" + jobUID,
+	} {
+		if podSelectorHasPods(kubectlPath, kubeconfigPaths, ns, kctx, candidate) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// latestOwnedJob returns the name and UID of the most recently created Job
+// whose ownerReferences point at the named CronJob.
+func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) (jobName, jobUID string, found bool) {
+	getArgs := []string{"get", "jobs", "-n", ns, "--context", kctx, "-o", "json"}
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
+	logExecCmd("Running kubectl command", cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		logger.Error("Failed to list jobs for CronJob", "cronjob", cronJobName, "error", err)
+		return "", "", false
+	}
+
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name              string    `json:"name"`
+				UID               string    `json:"uid"`
+				CreationTimestamp time.Time `json:"creationTimestamp"`
+				OwnerReferences   []struct {
+					Kind string `json:"kind"`
+					Name string `json:"name"`
+				} `json:"ownerReferences"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(out, &list); err != nil {
+		logger.Error("Failed to parse kubectl jobs output", "error", err)
+		return "", "", false
+	}
+
+	var latestTS time.Time
+	for _, item := range list.Items {
+		owned := false
+		for _, ref := range item.Metadata.OwnerReferences {
+			if ref.Kind == "CronJob" && ref.Name == cronJobName {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			continue
+		}
+		if !found || item.Metadata.CreationTimestamp.After(latestTS) {
+			jobName = item.Metadata.Name
+			jobUID = item.Metadata.UID
+			latestTS = item.Metadata.CreationTimestamp
+			found = true
+		}
+	}
+	return jobName, jobUID, found
+}
+
+// podSelectorHasPods reports whether at least one pod currently matches
+// selector, so a candidate label-key convention can be verified before it is
+// handed to `kubectl logs -l`.
+func podSelectorHasPods(kubectlPath, kubeconfigPaths, ns, kctx, selector string) bool {
+	getArgs := []string{"get", "pods", "-l", selector, "-n", ns, "--context", kctx, "-o", "name"}
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
+	logExecCmd("Running kubectl command", cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		logger.Error("Failed to check pods for selector", "selector", selector, "error", err)
+		return false
+	}
+	return len(strings.TrimSpace(string(out))) > 0
+}

--- a/internal/app/commands_logs_cronjob.go
+++ b/internal/app/commands_logs_cronjob.go
@@ -3,60 +3,89 @@ package app
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/janosmiko/lfk/internal/k8s"
-	"github.com/janosmiko/lfk/internal/logger"
 )
 
 // cronJobNoRunsSentinel is a marker line updateLogLine turns into a status
 // message instead of a log line - kubectl has no selector for *v1.CronJob.
 const cronJobNoRunsSentinel = "\x00lfk:cronjob-no-runs\x00"
 
+// cronJobErrorSentinel carries a real kubectl failure (RBAC, expired creds,
+// apiserver outage) the same way - it must never collapse into "no runs yet".
+const cronJobErrorSentinel = "\x00lfk:cronjob-error\x00"
+
 var errCronJobNoRuns = errors.New("no runs yet")
 
 var errCronJobUIDMissing = errors.New("cronjob uid missing")
 
-// resolveCronJobPodSelector resolves a CronJob to the pod selector for its
-// newest owned Job. *v1.CronJob has no pod selector of its own. ok is false
-// when the CronJob has never run or its newest Job's pods are already gone.
-func resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, kctx string) (selector string, ok bool) {
-	jobName, jobUID, found := latestOwnedJob(kubectlPath, kubeconfigPaths, ns, name, kctx)
-	if !found {
-		return "", false
+// runKubectlJSON runs cmd and returns its stdout, folding stderr into the
+// error so an RBAC denial or apiserver message reaches the user instead of
+// the bare "exit status 1" exec.Output leaves behind.
+func runKubectlJSON(cmd *exec.Cmd) ([]byte, error) {
+	out, err := cmd.Output()
+	if err == nil {
+		return out, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return nil, err
+}
+
+// cronJobSentinelLine picks the marker updateLogLine turns into a status
+// message, distinguishing a genuine empty result from a real kubectl failure.
+func cronJobSentinelLine(cronJobName string, err error) string {
+	if errors.Is(err, errCronJobNoRuns) {
+		return cronJobNoRunsSentinel + cronJobName
+	}
+	return cronJobErrorSentinel + err.Error()
+}
+
+// resolveCronJobPodSelector returns errCronJobNoRuns only for a genuine empty
+// result. Any other error is a real kubectl failure, not "no runs yet".
+func resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, kctx string) (selector string, err error) {
+	jobName, jobUID, err := latestOwnedJob(kubectlPath, kubeconfigPaths, ns, name, kctx)
+	if err != nil {
+		return "", err
 	}
 	// Prefixed label first, then the unprefixed pair older clusters still use.
 	for _, candidate := range []string{
 		"batch.kubernetes.io/job-name=" + jobName + ",batch.kubernetes.io/controller-uid=" + jobUID,
 		"job-name=" + jobName + ",controller-uid=" + jobUID,
 	} {
-		if podSelectorHasPods(kubectlPath, kubeconfigPaths, ns, kctx, candidate) {
-			return candidate, true
+		has, err := podSelectorHasPods(kubectlPath, kubeconfigPaths, ns, kctx, candidate)
+		if err != nil {
+			return "", fmt.Errorf("check pods for %s: %w", candidate, err)
+		}
+		if has {
+			return candidate, nil
 		}
 	}
-	return "", false
+	return "", errCronJobNoRuns
 }
 
 // latestOwnedJob matches ownership by UID - an orphaned Job keeps the OLD
 // CronJob's UID, so name matching would leak its run to a same-named replacement.
-func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) (jobName, jobUID string, found bool) {
+func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) (jobName, jobUID string, err error) {
 	cronJobUID, err := getCronJobUID(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx)
 	if err != nil {
-		logger.Error("Failed to read CronJob UID", "cronjob", cronJobName, "error", err)
-		return "", "", false
+		return "", "", fmt.Errorf("get cronjob %s: %w", cronJobName, err)
 	}
 
 	getArgs := []string{"get", "jobs", "-n", ns, "--context", kctx, "-o", "json"}
 	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 	logExecCmd("Running kubectl command", cmd)
-	out, err := cmd.Output()
-	if err != nil {
-		logger.Error("Failed to list jobs for CronJob", "cronjob", cronJobName, "error", err)
-		return "", "", false
+	out, cmdErr := runKubectlJSON(cmd)
+	if cmdErr != nil {
+		return "", "", fmt.Errorf("list jobs: %w", cmdErr)
 	}
 
 	var list struct {
@@ -73,11 +102,11 @@ func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) 
 		} `json:"items"`
 	}
 	if err := json.Unmarshal(out, &list); err != nil {
-		logger.Error("Failed to parse kubectl jobs output", "error", err)
-		return "", "", false
+		return "", "", fmt.Errorf("parse jobs list: %w", err)
 	}
 
 	var latestTS time.Time
+	found := false
 	for _, item := range list.Items {
 		owned := false
 		for _, ref := range item.Metadata.OwnerReferences {
@@ -101,7 +130,10 @@ func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) 
 			found = true
 		}
 	}
-	return jobName, jobUID, found
+	if !found {
+		return "", "", errCronJobNoRuns
+	}
+	return jobName, jobUID, nil
 }
 
 // getCronJobUID reads the live CronJob's UID via kubectl, so ownership can be
@@ -111,7 +143,7 @@ func getCronJobUID(kubectlPath, kubeconfigPaths, ns, name, kctx string) (string,
 	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 	logExecCmd("Running kubectl command", cmd)
-	out, err := cmd.Output()
+	out, err := runKubectlJSON(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -133,15 +165,14 @@ func getCronJobUID(kubectlPath, kubeconfigPaths, ns, name, kctx string) (string,
 // podSelectorHasPods reports whether at least one pod currently matches
 // selector, so a candidate label-key convention can be verified before it is
 // handed to `kubectl logs -l`.
-func podSelectorHasPods(kubectlPath, kubeconfigPaths, ns, kctx, selector string) bool {
+func podSelectorHasPods(kubectlPath, kubeconfigPaths, ns, kctx, selector string) (bool, error) {
 	getArgs := []string{"get", "pods", "-l", selector, "-n", ns, "--context", kctx, "-o", "name"}
 	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
 	logExecCmd("Running kubectl command", cmd)
-	out, err := cmd.Output()
+	out, err := runKubectlJSON(cmd)
 	if err != nil {
-		logger.Error("Failed to check pods for selector", "selector", selector, "error", err)
-		return false
+		return false, err
 	}
-	return len(strings.TrimSpace(string(out))) > 0
+	return len(strings.TrimSpace(string(out))) > 0, nil
 }

--- a/internal/app/commands_logs_cronjob.go
+++ b/internal/app/commands_logs_cronjob.go
@@ -18,6 +18,8 @@ const cronJobNoRunsSentinel = "\x00lfk:cronjob-no-runs\x00"
 
 var errCronJobNoRuns = errors.New("no runs yet")
 
+var errCronJobUIDMissing = errors.New("cronjob uid missing")
+
 // resolveCronJobPodSelector resolves a CronJob to the pod selector for its
 // newest owned Job. *v1.CronJob has no pod selector of its own. ok is false
 // when the CronJob has never run or its newest Job's pods are already gone.
@@ -38,9 +40,15 @@ func resolveCronJobPodSelector(kubectlPath, kubeconfigPaths, ns, name, kctx stri
 	return "", false
 }
 
-// latestOwnedJob returns the name and UID of the most recently created Job
-// whose ownerReferences point at the named CronJob.
+// latestOwnedJob matches ownership by UID - an orphaned Job keeps the OLD
+// CronJob's UID, so name matching would leak its run to a same-named replacement.
 func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) (jobName, jobUID string, found bool) {
+	cronJobUID, err := getCronJobUID(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx)
+	if err != nil {
+		logger.Error("Failed to read CronJob UID", "cronjob", cronJobName, "error", err)
+		return "", "", false
+	}
+
 	getArgs := []string{"get", "jobs", "-n", ns, "--context", kctx, "-o", "json"}
 	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
 	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
@@ -59,7 +67,7 @@ func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) 
 				CreationTimestamp time.Time `json:"creationTimestamp"`
 				OwnerReferences   []struct {
 					Kind string `json:"kind"`
-					Name string `json:"name"`
+					UID  string `json:"uid"`
 				} `json:"ownerReferences"`
 			} `json:"metadata"`
 		} `json:"items"`
@@ -73,7 +81,7 @@ func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) 
 	for _, item := range list.Items {
 		owned := false
 		for _, ref := range item.Metadata.OwnerReferences {
-			if ref.Kind == "CronJob" && ref.Name == cronJobName {
+			if ref.Kind == "CronJob" && ref.UID == cronJobUID {
 				owned = true
 				break
 			}
@@ -81,7 +89,12 @@ func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) 
 		if !owned {
 			continue
 		}
-		if !found || item.Metadata.CreationTimestamp.After(latestTS) {
+		// On an exact timestamp tie, the higher Job name wins so the pick
+		// stays deterministic regardless of API return order.
+		newer := !found ||
+			item.Metadata.CreationTimestamp.After(latestTS) ||
+			(item.Metadata.CreationTimestamp.Equal(latestTS) && item.Metadata.Name > jobName)
+		if newer {
 			jobName = item.Metadata.Name
 			jobUID = item.Metadata.UID
 			latestTS = item.Metadata.CreationTimestamp
@@ -89,6 +102,32 @@ func latestOwnedJob(kubectlPath, kubeconfigPaths, ns, cronJobName, kctx string) 
 		}
 	}
 	return jobName, jobUID, found
+}
+
+// getCronJobUID reads the live CronJob's UID via kubectl, so ownership can be
+// matched by UID rather than name (see latestOwnedJob).
+func getCronJobUID(kubectlPath, kubeconfigPaths, ns, name, kctx string) (string, error) {
+	getArgs := []string{"get", "cronjob", name, "-n", ns, "--context", kctx, "-o", "json"}
+	cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(getArgs)...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPaths)
+	logExecCmd("Running kubectl command", cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	var obj struct {
+		Metadata struct {
+			UID string `json:"uid"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &obj); err != nil {
+		return "", err
+	}
+	if obj.Metadata.UID == "" {
+		return "", errCronJobUIDMissing
+	}
+	return obj.Metadata.UID, nil
 }
 
 // podSelectorHasPods reports whether at least one pod currently matches

--- a/internal/app/commands_logs_cronjob_test.go
+++ b/internal/app/commands_logs_cronjob_test.go
@@ -1,0 +1,192 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cronJobFakeJobsList = `
+if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+cat <<'EOF'
+{"items":[
+  {"metadata":{"name":"my-cron-100","uid":"uid-100","creationTimestamp":"2026-08-10T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron"}]}},
+  {"metadata":{"name":"my-cron-200","uid":"uid-200","creationTimestamp":"2026-08-11T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron"}]}}
+]}
+EOF
+fi
+`
+
+// --- resolveCronJobPodSelector ---
+
+func TestResolveCronJobPodSelector_PicksNewestJobAndPrefixedLabel(t *testing.T) {
+	fakeKubectl(t, cronJobFakeJobsList+`
+if [ "$1" = "get" ] && [ "$2" = "pods" ]; then
+  case "$*" in
+    *"-l batch.kubernetes.io/job-name=my-cron-200,batch.kubernetes.io/controller-uid=uid-200"*) echo "pod/my-cron-200-xyz" ;;
+  esac
+fi
+`)
+	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.True(t, ok)
+	assert.Equal(t, "batch.kubernetes.io/job-name=my-cron-200,batch.kubernetes.io/controller-uid=uid-200", selector)
+}
+
+func TestResolveCronJobPodSelector_FallsBackToLegacyLabels(t *testing.T) {
+	fakeKubectl(t, cronJobFakeJobsList+`
+if [ "$1" = "get" ] && [ "$2" = "pods" ]; then
+  case "$*" in
+    *"-l job-name=my-cron-200,controller-uid=uid-200"*) echo "pod/my-cron-200-xyz" ;;
+  esac
+fi
+`)
+	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.True(t, ok)
+	assert.Equal(t, "job-name=my-cron-200,controller-uid=uid-200", selector)
+}
+
+func TestResolveCronJobPodSelector_NoOwnedJobs(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo '{"items":[]}'
+fi
+`)
+	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	assert.False(t, ok)
+	assert.Empty(t, selector)
+}
+
+func TestResolveCronJobPodSelector_JobExistsButPodsCleanedUp(t *testing.T) {
+	fakeKubectl(t, cronJobFakeJobsList)
+	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	assert.False(t, ok)
+	assert.Empty(t, selector)
+}
+
+// --- startLogStream / kind=CronJob ---
+
+func TestStartLogStream_CronJob_UsesNewestJobSelector(t *testing.T) {
+	argvPath := fakeKubectl(t, cronJobFakeJobsList+`
+if [ "$1" = "get" ] && [ "$2" = "pods" ]; then
+  case "$*" in
+    *"-l batch.kubernetes.io/job-name=my-cron-200,batch.kubernetes.io/controller-uid=uid-200"*) echo "pod/my-cron-200-xyz" ;;
+  esac
+elif [ "$1" = "logs" ]; then
+  echo "hello from job pod"
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
+
+	cmd := m.startLogStream()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	logMsg, ok := msg.(logLineMsg)
+	require.True(t, ok)
+	assert.False(t, logMsg.done)
+	assert.Equal(t, "hello from job pod", logMsg.line)
+
+	argv, err := os.ReadFile(argvPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(argv), "-l\nbatch.kubernetes.io/job-name=my-cron-200,batch.kubernetes.io/controller-uid=uid-200")
+	assert.NotContains(t, string(argv), "cronjob/my-cron")
+}
+
+func TestStartLogStream_CronJob_NoRuns_SendsSentinelInsteadOfKubectlLogs(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo '{"items":[]}'
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
+
+	cmd := m.startLogStream()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	logMsg, ok := msg.(logLineMsg)
+	require.True(t, ok)
+	assert.Equal(t, cronJobNoRunsSentinel+"my-cron", logMsg.line)
+
+	mdl, _ := m.updateLogLine(logMsg)
+	rm := mdl.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.Contains(t, rm.statusMessage, "No runs yet for CronJob my-cron")
+}
+
+// --- fetchOlderLogs / saveAllLogs no-runs handling ---
+
+func TestFetchOlderLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo '{"items":[]}'
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
+	m.scheduler.StartWorkers()
+	defer m.scheduler.StopWorkers()
+
+	cmd := m.fetchOlderLogs()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	historyMsg, ok := msg.(logHistoryMsg)
+	require.True(t, ok)
+	require.ErrorIs(t, historyMsg.err, errCronJobNoRuns)
+
+	mdl, _ := m.updateLogHistory(historyMsg)
+	assert.True(t, mdl.statusMessageErr)
+	assert.Contains(t, mdl.statusMessage, "No runs yet for CronJob my-cron")
+}
+
+func TestSaveAllLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo '{"items":[]}'
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
+	m.scheduler.StartWorkers()
+	defer m.scheduler.StopWorkers()
+
+	cmd := m.saveAllLogs()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	saveMsg, ok := msg.(logSaveAllMsg)
+	require.True(t, ok)
+	require.ErrorIs(t, saveMsg.err, errCronJobNoRuns)
+
+	mdl, _ := m.updateLogSaveAll(saveMsg)
+	rm := mdl.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.Contains(t, rm.statusMessage, "No runs yet for CronJob my-cron")
+}
+
+// --- Job (non-CronJob) must keep working through the existing selector path ---
+
+func TestStartLogStream_Job_StillUsesKubectlGetPodSelector(t *testing.T) {
+	argvPath := fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "job/my-job" ]; then
+  echo '{"spec":{"selector":{"matchLabels":{"batch.kubernetes.io/controller-uid":"job-uid"}}}}'
+elif [ "$1" = "logs" ]; then
+  echo "job log line"
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-job", "default", "Job", model.ResourceTypeEntry{})
+
+	cmd := m.startLogStream()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	logMsg, ok := msg.(logLineMsg)
+	require.True(t, ok)
+	assert.Equal(t, "job log line", logMsg.line)
+
+	argv, err := os.ReadFile(argvPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(argv), "-l\nbatch.kubernetes.io/controller-uid=job-uid")
+}

--- a/internal/app/commands_logs_cronjob_test.go
+++ b/internal/app/commands_logs_cronjob_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -34,7 +35,7 @@ elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
 fi
 `
 
-// --- resolveCronJobPodSelector / latestOwnedJob ---
+// --- resolveCronJobPodSelector / latestOwnedJob: genuine empty result ---
 
 func TestResolveCronJobPodSelector_PicksNewestJobAndPrefixedLabel(t *testing.T) {
 	fakeKubectl(t, cronJobFakeJobsList+`
@@ -44,8 +45,8 @@ if [ "$1" = "get" ] && [ "$2" = "pods" ]; then
   esac
 fi
 `)
-	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
-	require.True(t, ok)
+	selector, err := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.NoError(t, err)
 	assert.Equal(t, "batch.kubernetes.io/job-name=my-cron-200,batch.kubernetes.io/controller-uid=uid-200", selector)
 }
 
@@ -57,23 +58,63 @@ if [ "$1" = "get" ] && [ "$2" = "pods" ]; then
   esac
 fi
 `)
-	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
-	require.True(t, ok)
+	selector, err := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.NoError(t, err)
 	assert.Equal(t, "job-name=my-cron-200,controller-uid=uid-200", selector)
 }
 
 func TestResolveCronJobPodSelector_NoOwnedJobs(t *testing.T) {
 	fakeKubectl(t, cronJobFakeNoJobs)
-	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
-	assert.False(t, ok)
+	selector, err := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.ErrorIs(t, err, errCronJobNoRuns)
 	assert.Empty(t, selector)
 }
 
 func TestResolveCronJobPodSelector_JobExistsButPodsCleanedUp(t *testing.T) {
 	fakeKubectl(t, cronJobFakeJobsList)
-	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
-	assert.False(t, ok)
+	selector, err := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.ErrorIs(t, err, errCronJobNoRuns)
 	assert.Empty(t, selector)
+}
+
+// --- resolveCronJobPodSelector: real kubectl failures must not read as "no runs yet" ---
+
+func TestResolveCronJobPodSelector_GetCronJobFails_ReturnsRealError(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ]; then
+  echo "Error from server (Forbidden): cronjobs.batch is forbidden" >&2
+  exit 1
+fi
+`)
+	_, err := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errCronJobNoRuns), "an RBAC-style failure must not collapse into errCronJobNoRuns")
+}
+
+func TestResolveCronJobPodSelector_GetJobsFails_ReturnsRealError(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ]; then
+  echo '{"metadata":{"uid":"cron-uid-1"}}'
+elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo "Error from server: etcdserver: request timed out" >&2
+  exit 1
+fi
+`)
+	_, err := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errCronJobNoRuns), "an apiserver outage must not collapse into errCronJobNoRuns")
+}
+
+func TestResolveCronJobPodSelector_GetPodsFails_ReturnsRealError(t *testing.T) {
+	fakeKubectl(t, cronJobFakeJobsList+`
+if [ "$1" = "get" ] && [ "$2" = "pods" ]; then
+  echo "Unable to connect to the server: dial tcp: i/o timeout" >&2
+  exit 1
+fi
+`)
+	_, err := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errCronJobNoRuns), "a pod-list failure must not collapse into errCronJobNoRuns")
 }
 
 // The fixture's third Job has the latest creationTimestamp but a different
@@ -81,8 +122,8 @@ func TestResolveCronJobPodSelector_JobExistsButPodsCleanedUp(t *testing.T) {
 // that Job would win the pick instead of my-cron-200.
 func TestLatestOwnedJob_IgnoresJobOwnedByDifferentCronJob(t *testing.T) {
 	fakeKubectl(t, cronJobFakeJobsList)
-	jobName, jobUID, found := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
-	require.True(t, found)
+	jobName, jobUID, err := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
+	require.NoError(t, err)
 	assert.Equal(t, "my-cron-200", jobName)
 	assert.Equal(t, "uid-200", jobUID)
 }
@@ -98,8 +139,8 @@ elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
   echo '{"items":[{"metadata":{"name":"my-cron-100","uid":"uid-100","creationTimestamp":"2026-08-10T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron","uid":"cron-uid-OLD"}]}}]}'
 fi
 `)
-	_, _, found := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
-	assert.False(t, found, "an orphaned Job's UID must not match the replacement CronJob's UID")
+	_, _, err := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
+	assert.ErrorIs(t, err, errCronJobNoRuns, "an orphaned Job's UID must not match the replacement CronJob's UID")
 }
 
 // Two Jobs sharing an exact creationTimestamp must resolve deterministically
@@ -115,8 +156,8 @@ elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
   ]}'
 fi
 `)
-	jobName, jobUID, found := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
-	require.True(t, found)
+	jobName, jobUID, err := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
+	require.NoError(t, err)
 	assert.Equal(t, "my-cron-200", jobName)
 	assert.Equal(t, "uid-200", jobUID)
 }
@@ -168,7 +209,31 @@ func TestStartLogStream_CronJob_NoRuns_SendsSentinelInsteadOfKubectlLogs(t *test
 	assert.Contains(t, rm.statusMessage, "No runs yet for CronJob my-cron")
 }
 
-// --- fetchOlderLogs / saveAllLogs no-runs handling ---
+func TestStartLogStream_CronJob_KubectlFailure_SurfacesRealError(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ]; then
+  echo "Error from server (Forbidden): cronjobs.batch is forbidden" >&2
+  exit 1
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
+
+	cmd := m.startLogStream()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	logMsg, ok := msg.(logLineMsg)
+	require.True(t, ok)
+	assert.NotEqual(t, cronJobNoRunsSentinel+"my-cron", logMsg.line, "a real kubectl failure must not read as the no-runs marker")
+
+	mdl, _ := m.updateLogLine(logMsg)
+	rm := mdl.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.NotContains(t, rm.statusMessage, "No runs yet")
+	assert.Contains(t, rm.statusMessage, "Forbidden")
+}
+
+// --- fetchOlderLogs / saveAllLogs: no-runs vs real failure ---
 
 func TestFetchOlderLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
 	fakeKubectl(t, cronJobFakeNoJobs)
@@ -189,6 +254,31 @@ func TestFetchOlderLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
 	assert.Contains(t, mdl.statusMessage, "No runs yet for CronJob my-cron")
 }
 
+func TestFetchOlderLogs_CronJob_KubectlFailure_SurfacesRealError(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ]; then
+  echo "Unable to connect to the server: dial tcp: i/o timeout" >&2
+  exit 1
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
+	m.scheduler.StartWorkers()
+	defer m.scheduler.StopWorkers()
+
+	cmd := m.fetchOlderLogs()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	historyMsg, ok := msg.(logHistoryMsg)
+	require.True(t, ok)
+	require.Error(t, historyMsg.err)
+	assert.False(t, errors.Is(historyMsg.err, errCronJobNoRuns))
+
+	mdl, _ := m.updateLogHistory(historyMsg)
+	assert.True(t, mdl.statusMessageErr)
+	assert.NotContains(t, mdl.statusMessage, "No runs yet")
+}
+
 func TestSaveAllLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
 	fakeKubectl(t, cronJobFakeNoJobs)
 	m := baseModelWithFakeClient()
@@ -207,6 +297,80 @@ func TestSaveAllLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
 	rm := mdl.(Model)
 	assert.True(t, rm.statusMessageErr)
 	assert.Contains(t, rm.statusMessage, "No runs yet for CronJob my-cron")
+}
+
+func TestSaveAllLogs_CronJob_KubectlFailure_SurfacesRealError(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ]; then
+  echo "Error from server (Forbidden): cronjobs.batch is forbidden" >&2
+  exit 1
+fi
+`)
+	m := baseModelWithFakeClient()
+	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
+	m.scheduler.StartWorkers()
+	defer m.scheduler.StopWorkers()
+
+	cmd := m.saveAllLogs()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	saveMsg, ok := msg.(logSaveAllMsg)
+	require.True(t, ok)
+	require.Error(t, saveMsg.err)
+	assert.False(t, errors.Is(saveMsg.err, errCronJobNoRuns))
+
+	mdl, _ := m.updateLogSaveAll(saveMsg)
+	rm := mdl.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.NotContains(t, rm.statusMessage, "No runs yet")
+}
+
+// --- background-tab CronJob stream must not leak the sentinel into a log buffer ---
+
+func TestUpdateLogLine_BackgroundTab_CronJobNoRuns_SetsStatusNotBuffer(t *testing.T) {
+	bgCh := make(chan string)
+	activeCh := make(chan string)
+	m := Model{
+		mode:      modeLogs,
+		width:     80,
+		height:    40,
+		activeTab: 0,
+		tabs: []TabState{
+			{}, // active tab
+			{logCh: bgCh},
+		},
+		logView: logViewState{ch: activeCh},
+	}
+
+	ret, _ := m.updateLogLine(logLineMsg{line: cronJobNoRunsSentinel + "my-cron", ch: bgCh})
+	rm := ret.(Model)
+
+	assert.Empty(t, rm.tabs[1].logLines, "the sentinel must never reach a tab's log buffer")
+	assert.True(t, rm.statusMessageErr)
+	assert.Contains(t, rm.statusMessage, "No runs yet for CronJob my-cron")
+}
+
+func TestUpdateLogLine_BackgroundTab_CronJobError_SetsStatusNotBuffer(t *testing.T) {
+	bgCh := make(chan string)
+	activeCh := make(chan string)
+	m := Model{
+		mode:      modeLogs,
+		width:     80,
+		height:    40,
+		activeTab: 0,
+		tabs: []TabState{
+			{},
+			{logCh: bgCh},
+		},
+		logView: logViewState{ch: activeCh},
+	}
+
+	ret, _ := m.updateLogLine(logLineMsg{line: cronJobErrorSentinel + "boom", ch: bgCh})
+	rm := ret.(Model)
+
+	assert.Empty(t, rm.tabs[1].logLines, "the sentinel must never reach a tab's log buffer")
+	assert.True(t, rm.statusMessageErr)
+	assert.Contains(t, rm.statusMessage, "boom")
 }
 
 // --- Job (non-CronJob) must keep working through the existing selector path ---

--- a/internal/app/commands_logs_cronjob_test.go
+++ b/internal/app/commands_logs_cronjob_test.go
@@ -9,18 +9,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The third Job here has the latest timestamp but a different owner UID -
+// it must never win the pick, proving the ownership filter still runs.
 const cronJobFakeJobsList = `
-if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ] && [ "$3" = "my-cron" ]; then
+  echo '{"metadata":{"uid":"cron-uid-1"}}'
+elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
 cat <<'EOF'
 {"items":[
-  {"metadata":{"name":"my-cron-100","uid":"uid-100","creationTimestamp":"2026-08-10T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron"}]}},
-  {"metadata":{"name":"my-cron-200","uid":"uid-200","creationTimestamp":"2026-08-11T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron"}]}}
+  {"metadata":{"name":"my-cron-100","uid":"uid-100","creationTimestamp":"2026-08-10T00:00:00Z","ownerReferences":[{"kind":"CronJob","uid":"cron-uid-1"}]}},
+  {"metadata":{"name":"my-cron-200","uid":"uid-200","creationTimestamp":"2026-08-11T00:00:00Z","ownerReferences":[{"kind":"CronJob","uid":"cron-uid-1"}]}},
+  {"metadata":{"name":"other-cron-999","uid":"uid-999","creationTimestamp":"2026-08-12T00:00:00Z","ownerReferences":[{"kind":"CronJob","uid":"cron-uid-OTHER"}]}}
 ]}
 EOF
 fi
 `
 
-// --- resolveCronJobPodSelector ---
+// cronJobFakeNoJobs answers `get cronjob my-cron` but returns an empty Jobs list.
+const cronJobFakeNoJobs = `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ] && [ "$3" = "my-cron" ]; then
+  echo '{"metadata":{"uid":"cron-uid-1"}}'
+elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo '{"items":[]}'
+fi
+`
+
+// --- resolveCronJobPodSelector / latestOwnedJob ---
 
 func TestResolveCronJobPodSelector_PicksNewestJobAndPrefixedLabel(t *testing.T) {
 	fakeKubectl(t, cronJobFakeJobsList+`
@@ -49,11 +63,7 @@ fi
 }
 
 func TestResolveCronJobPodSelector_NoOwnedJobs(t *testing.T) {
-	fakeKubectl(t, `
-if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
-  echo '{"items":[]}'
-fi
-`)
+	fakeKubectl(t, cronJobFakeNoJobs)
 	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
 	assert.False(t, ok)
 	assert.Empty(t, selector)
@@ -64,6 +74,51 @@ func TestResolveCronJobPodSelector_JobExistsButPodsCleanedUp(t *testing.T) {
 	selector, ok := resolveCronJobPodSelector("kubectl", "", "default", "my-cron", "test-ctx")
 	assert.False(t, ok)
 	assert.Empty(t, selector)
+}
+
+// The fixture's third Job has the latest creationTimestamp but a different
+// owner UID. Deleting the `!owned { continue }` filter makes this test fail:
+// that Job would win the pick instead of my-cron-200.
+func TestLatestOwnedJob_IgnoresJobOwnedByDifferentCronJob(t *testing.T) {
+	fakeKubectl(t, cronJobFakeJobsList)
+	jobName, jobUID, found := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
+	require.True(t, found)
+	assert.Equal(t, "my-cron-200", jobName)
+	assert.Equal(t, "uid-200", jobUID)
+}
+
+// A Job left behind by a deleted CronJob still carries the OLD CronJob's UID
+// in its ownerReferences. A replacement CronJob with the same name but a new
+// UID must not inherit that orphaned Job's run.
+func TestLatestOwnedJob_OrphanedJobSameNameDifferentUID_NotMatched(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ] && [ "$3" = "my-cron" ]; then
+  echo '{"metadata":{"uid":"cron-uid-NEW"}}'
+elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo '{"items":[{"metadata":{"name":"my-cron-100","uid":"uid-100","creationTimestamp":"2026-08-10T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron","uid":"cron-uid-OLD"}]}}]}'
+fi
+`)
+	_, _, found := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
+	assert.False(t, found, "an orphaned Job's UID must not match the replacement CronJob's UID")
+}
+
+// Two Jobs sharing an exact creationTimestamp must resolve deterministically
+// (higher name wins) rather than by whatever order the API returned them in.
+func TestLatestOwnedJob_TiebreakOnEqualTimestamp(t *testing.T) {
+	fakeKubectl(t, `
+if [ "$1" = "get" ] && [ "$2" = "cronjob" ] && [ "$3" = "my-cron" ]; then
+  echo '{"metadata":{"uid":"cron-uid-1"}}'
+elif [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
+  echo '{"items":[
+    {"metadata":{"name":"my-cron-100","uid":"uid-100","creationTimestamp":"2026-08-11T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron","uid":"cron-uid-1"}]}},
+    {"metadata":{"name":"my-cron-200","uid":"uid-200","creationTimestamp":"2026-08-11T00:00:00Z","ownerReferences":[{"kind":"CronJob","name":"my-cron","uid":"cron-uid-1"}]}}
+  ]}'
+fi
+`)
+	jobName, jobUID, found := latestOwnedJob("kubectl", "", "default", "my-cron", "test-ctx")
+	require.True(t, found)
+	assert.Equal(t, "my-cron-200", jobName)
+	assert.Equal(t, "uid-200", jobUID)
 }
 
 // --- startLogStream / kind=CronJob ---
@@ -96,11 +151,7 @@ fi
 }
 
 func TestStartLogStream_CronJob_NoRuns_SendsSentinelInsteadOfKubectlLogs(t *testing.T) {
-	fakeKubectl(t, `
-if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
-  echo '{"items":[]}'
-fi
-`)
+	fakeKubectl(t, cronJobFakeNoJobs)
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
 
@@ -120,11 +171,7 @@ fi
 // --- fetchOlderLogs / saveAllLogs no-runs handling ---
 
 func TestFetchOlderLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
-	fakeKubectl(t, `
-if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
-  echo '{"items":[]}'
-fi
-`)
+	fakeKubectl(t, cronJobFakeNoJobs)
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
 	m.scheduler.StartWorkers()
@@ -143,11 +190,7 @@ fi
 }
 
 func TestSaveAllLogs_CronJob_NoRuns_ReturnsSentinelError(t *testing.T) {
-	fakeKubectl(t, `
-if [ "$1" = "get" ] && [ "$2" = "jobs" ]; then
-  echo '{"items":[]}'
-fi
-`)
+	fakeKubectl(t, cronJobFakeNoJobs)
 	m := baseModelWithFakeClient()
 	m = withActionCtx(m, "my-cron", "default", "CronJob", model.ResourceTypeEntry{})
 	m.scheduler.StartWorkers()

--- a/internal/app/commands_logs_multi.go
+++ b/internal/app/commands_logs_multi.go
@@ -1,0 +1,236 @@
+package app
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// startMultiLogStream spawns one kubectl logs process per selected item and
+// merges their output into a single log channel. This supports streaming logs
+// from multiple pods or parent resources simultaneously.
+func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
+	kubectlPath, err := k8s.KubectlPath()
+	if err != nil {
+		return m, func() tea.Msg { return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)} }
+	}
+
+	// Initialize log viewer state.
+	m.mode = modeLogs
+	m.resetLogBuffer()
+	m.logView.scroll = 0
+	m.logView.follow = true
+	m.logView.wrap = false
+	m.logView.lineNumbers = true
+	m.logView.timestamps = ui.ConfigLogShowTimestamps
+	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
+	m.logView.previewVisible = ui.ConfigLogShowPreview
+	m.logView.previous = false
+	m.logView.isMulti = true
+	m.logView.multiItems = items
+	m.logView.title = fmt.Sprintf("Logs: %d resources", len(items))
+	m.logView.tailLines = ui.ConfigLogTailLines
+	m.logView.hasMoreHistory = false // too complex to deduplicate across multiple streams
+	m.logView.loadingHistory = false
+	m.logView.cursor = 0 // will track end as lines stream in with follow mode
+	m.logView.visualMode = false
+	m.logView.visualStart = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.logView.cancel = cancel
+	ch := make(chan string, 256)
+	m.logView.ch = ch
+
+	kctx := m.nav.Context
+	ns := m.resolveNamespace()
+
+	var wg sync.WaitGroup
+	for _, item := range items {
+		itemCtx := kctx
+		if item.ClusterName != "" {
+			itemCtx = item.ClusterName
+		}
+		itemNs := ns
+		if item.Namespace != "" {
+			itemNs = item.Namespace
+		}
+
+		kind := item.Kind
+		if kind == "" {
+			kind = m.nav.ResourceType.Kind
+		}
+
+		followFlag := "-f"
+		if m.logView.previous {
+			followFlag = "--previous"
+		}
+		var args []string
+		switch kind {
+		case "Pod":
+			args = []string{
+				"logs", item.Name, "--all-containers=true", "--prefix", followFlag,
+				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
+			}
+		default:
+			resourceRef := strings.ToLower(kind) + "/" + item.Name
+			args = []string{
+				"logs", resourceRef, "--all-containers=true", "--prefix", followFlag,
+				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
+			}
+		}
+
+		// Add --tail for initial loading.
+		if m.logView.tailLines > 0 {
+			args = append(args, fmt.Sprintf("--tail=%d", m.logView.tailLines))
+		}
+
+		args = append(args, "--timestamps")
+
+		m.addLogEntry("DBG", "kubectl "+strings.Join(args, " "))
+
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(itemCtx))
+		logger.Info("Starting multi-log kubectl",
+			"item", item.Name,
+			"context", itemCtx,
+			"cmd", cmd.String(),
+			"kubeconfig", m.client.KubeconfigPathForContext(itemCtx))
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			logger.Error("Failed to create stdout pipe for multi-log", "item", item.Name, "error", err)
+			continue
+		}
+		cmd.Stderr = cmd.Stdout
+
+		if err := cmd.Start(); err != nil {
+			logger.Error("Failed to start kubectl logs for multi-log", "item", item.Name, "error", err)
+			continue
+		}
+
+		wg.Go(func() {
+			defer cmd.Wait() //nolint:errcheck
+			scanner := bufio.NewScanner(stdout)
+			scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+			for scanner.Scan() {
+				select {
+				case ch <- scanner.Text():
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+	}
+
+	// Close the channel once all goroutines finish.
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	return m, m.waitForLogLine()
+}
+
+// restartMultiLogStream restarts a multi-log stream using stored items,
+// preserving current viewer settings (used when toggling timestamps).
+func (m Model) restartMultiLogStream() (Model, tea.Cmd) {
+	kubectlPath, err := k8s.KubectlPath()
+	if err != nil {
+		return m, func() tea.Msg { return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)} }
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.logView.cancel = cancel
+	ch := make(chan string, 256)
+	m.logView.ch = ch
+
+	kctx := m.nav.Context
+	ns := m.resolveNamespace()
+	items := m.logView.multiItems
+
+	var wg sync.WaitGroup
+	for _, item := range items {
+		itemCtx := kctx
+		if item.ClusterName != "" {
+			itemCtx = item.ClusterName
+		}
+		itemNs := ns
+		if item.Namespace != "" {
+			itemNs = item.Namespace
+		}
+
+		kind := item.Kind
+		if kind == "" {
+			kind = m.nav.ResourceType.Kind
+		}
+
+		followFlag := "-f"
+		if m.logView.previous {
+			followFlag = "--previous"
+		}
+		var args []string
+		switch kind {
+		case "Pod":
+			args = []string{
+				"logs", item.Name, "--all-containers=true", "--prefix", followFlag,
+				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
+			}
+		default:
+			resourceRef := strings.ToLower(kind) + "/" + item.Name
+			args = []string{
+				"logs", resourceRef, "--all-containers=true", "--prefix", followFlag,
+				"--max-log-requests=20", "-n", itemNs, "--context", m.kubectlContext(itemCtx),
+			}
+		}
+
+		// Add --tail for initial loading.
+		if m.logView.tailLines > 0 {
+			args = append(args, fmt.Sprintf("--tail=%d", m.logView.tailLines))
+		}
+
+		args = append(args, "--timestamps")
+
+		cmd := exec.CommandContext(ctx, kubectlPath, k8s.DemoKubectlArgs(args)...)
+		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(itemCtx))
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			logger.Error("Failed to open kubectl logs stdout pipe (multi-pod)", "error", err, "pod", item.Name, "namespace", itemNs, "context", itemCtx)
+			continue
+		}
+		cmd.Stderr = cmd.Stdout
+
+		if err := cmd.Start(); err != nil {
+			logger.Error("Failed to start kubectl logs (multi-pod)", "error", err, "pod", item.Name, "namespace", itemNs, "context", itemCtx, "cmd", cmd.String())
+			continue
+		}
+
+		wg.Go(func() {
+			defer cmd.Wait() //nolint:errcheck
+			scanner := bufio.NewScanner(stdout)
+			scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+			for scanner.Scan() {
+				select {
+				case ch <- scanner.Text():
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	return m, m.waitForLogLine()
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -524,8 +524,8 @@ func (m Model) updateEditorResultMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		mdl, cmd := m.updateLogStreamRestart(msg)
 		return mdl, cmd, true
 	case logHistoryMsg:
-		mdl := m.updateLogHistory(msg)
-		return mdl, nil, true
+		mdl, cmd := m.updateLogHistory(msg)
+		return mdl, cmd, true
 	case logSaveAllMsg:
 		mdl, cmd := m.updateLogSaveAll(msg)
 		return mdl, cmd, true

--- a/internal/app/update_exec_log_msgs.go
+++ b/internal/app/update_exec_log_msgs.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -99,6 +102,10 @@ func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+	}
+	if name, ok := strings.CutPrefix(msg.line, cronJobNoRunsSentinel); ok {
+		m.setStatusMessage(fmt.Sprintf("No runs yet for CronJob %s", name), true)
+		return m, tea.Batch(m.waitForLogLine(), scheduleStatusClear())
 	}
 	if msg.done {
 		// When following all containers of a single Pod, the stream ends as
@@ -221,14 +228,18 @@ func (m Model) updateLogStreamRestart(msg logStreamRestartMsg) (tea.Model, tea.C
 	return m, cmd
 }
 
-func (m Model) updateLogHistory(msg logHistoryMsg) Model {
+func (m Model) updateLogHistory(msg logHistoryMsg) (Model, tea.Cmd) {
 	m.logView.loadingHistory = false
 	if msg.err != nil {
 		m.logView.hasMoreHistory = false
-		return m
+		if errors.Is(msg.err, errCronJobNoRuns) {
+			m.setStatusMessage("No runs yet for CronJob "+m.actionCtx.name, true)
+			return m, scheduleStatusClear()
+		}
+		return m, nil
 	}
 	if m.mode != modeLogs {
-		return m
+		return m, nil
 	}
 
 	// The fetched history is the last <tail> lines of the resource; the current
@@ -238,7 +249,7 @@ func (m Model) updateLogHistory(msg logHistoryMsg) Model {
 
 	if len(newOlderLines) == 0 {
 		m.logView.hasMoreHistory = false
-		return m
+		return m, nil
 	}
 
 	// Prepend and adjust scroll to maintain view position — unless the user
@@ -272,10 +283,14 @@ func (m Model) updateLogHistory(msg logHistoryMsg) Model {
 		m.logView.hasMoreHistory = false
 	}
 
-	return m
+	return m, nil
 }
 
 func (m Model) updateLogSaveAll(msg logSaveAllMsg) (tea.Model, tea.Cmd) {
+	if errors.Is(msg.err, errCronJobNoRuns) {
+		m.setStatusMessage("No runs yet for CronJob "+m.actionCtx.name, true)
+		return m, scheduleStatusClear()
+	}
 	if msg.err != nil {
 		m.setErrorFromErr("Log save failed: ", msg.err)
 		return m, scheduleStatusClear()

--- a/internal/app/update_exec_log_msgs.go
+++ b/internal/app/update_exec_log_msgs.go
@@ -65,6 +65,21 @@ func (m Model) updateExecPTYStart(msg execPTYStartMsg) (tea.Model, tea.Cmd) {
 	return m, m.scheduleExecTick()
 }
 
+// applyCronJobSentinelLine turns a CronJob no-runs/error marker into a status
+// message, false for an ordinary line. Called before either branch of
+// updateLogLine buffers a line, so the raw marker never reaches a log buffer.
+func (m *Model) applyCronJobSentinelLine(line string) bool {
+	if name, ok := strings.CutPrefix(line, cronJobNoRunsSentinel); ok {
+		m.setStatusMessage(fmt.Sprintf("No runs yet for CronJob %s", name), true)
+		return true
+	}
+	if errMsg, ok := strings.CutPrefix(line, cronJobErrorSentinel); ok {
+		m.setStatusMessage("Failed to resolve CronJob logs: "+errMsg, true)
+		return true
+	}
+	return false
+}
+
 func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 	// The reader that produced this message has exited (it does one receive then
 	// returns). Mark the channel idle; the branches below re-arm exactly one
@@ -83,6 +98,9 @@ func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 		for i := range m.tabs {
 			if m.tabs[i].logCh == msg.ch {
 				if !msg.done {
+					if m.applyCronJobSentinelLine(msg.line) {
+						return m, tea.Batch(m.readLogChannel(msg.ch), scheduleStatusClear())
+					}
 					m.tabs[i].logLines = append(m.tabs[i].logLines, msg.line)
 					// Bound the background tab's buffer; shift its saved
 					// offsets so restoring the tab lands on the same content.
@@ -103,8 +121,7 @@ func (m Model) updateLogLine(msg logLineMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
-	if name, ok := strings.CutPrefix(msg.line, cronJobNoRunsSentinel); ok {
-		m.setStatusMessage(fmt.Sprintf("No runs yet for CronJob %s", name), true)
+	if m.applyCronJobSentinelLine(msg.line) {
 		return m, tea.Batch(m.waitForLogLine(), scheduleStatusClear())
 	}
 	if msg.done {
@@ -232,8 +249,12 @@ func (m Model) updateLogHistory(msg logHistoryMsg) (Model, tea.Cmd) {
 	m.logView.loadingHistory = false
 	if msg.err != nil {
 		m.logView.hasMoreHistory = false
-		if errors.Is(msg.err, errCronJobNoRuns) {
+		switch {
+		case errors.Is(msg.err, errCronJobNoRuns):
 			m.setStatusMessage("No runs yet for CronJob "+m.actionCtx.name, true)
+			return m, scheduleStatusClear()
+		case m.actionCtx.kind == "CronJob":
+			m.setErrorFromErr("Failed to resolve CronJob logs: ", msg.err)
 			return m, scheduleStatusClear()
 		}
 		return m, nil

--- a/internal/app/update_pod_msgs.go
+++ b/internal/app/update_pod_msgs.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 
 	tea "charm.land/bubbletea/v2"
@@ -47,7 +48,11 @@ func (m Model) updatePodSelect(msg podSelectMsg) (tea.Model, tea.Cmd) {
 func (m Model) updatePodLogSelect(msg podLogSelectMsg) (tea.Model, tea.Cmd) {
 	m.loading = false
 	if msg.err != nil {
-		m.setErrorFromErr("Error: ", msg.err)
+		if errors.Is(msg.err, errCronJobNoRuns) {
+			m.setStatusMessage("No runs yet for CronJob "+m.actionCtx.name, true)
+		} else {
+			m.setErrorFromErr("Error: ", msg.err)
+		}
 		m.pendingAction = ""
 		// If in log mode, restart the previous log stream on error.
 		if m.mode == modeLogs && m.logView.savedPodName != "" {


### PR DESCRIPTION
Tail Logs and Logs on a CronJob have never worked. `kubectlGetPodSelector` returned an empty selector for kind CronJob by design, which forced the fallback `kubectl logs cronjob/<name>`, and kubectl rejects that outright:

```
error: cannot get the logs from *v1.CronJob: selector for *v1.CronJob not implemented
```

Verified against a live CronJob before the fix: `spec.selector` is absent and the fallback errors exactly as above. Both log actions offered something the code could not deliver.

A CronJob now resolves to the pods of its newest owned Job. **Most recent Job only** - "logs" on a scheduled task means the last run, and aggregating every historical Job would mix runs with no marker between them. Jobs are untouched, they already carry `spec.selector` and resolve through the existing path.

Older clusters use unprefixed `job-name` / `controller-uid`, so the prefixed pair is tried first and the legacy pair second. A CronJob that has never run, or whose Jobs were cleaned up, reports "no runs yet" through the status bar rather than opening an empty viewer or leaking a raw kubectl error.

**Ownership is matched by UID, not name.** Review caught the first version matching `ownerReferences[].name`, which silently attributes an orphaned Job's logs to a same-named replacement: delete a CronJob with `--cascade=orphan`, create a new one under the same name, open its logs before its first run, and you would read the deleted CronJob's output under the new resource's name. The UID comes from a live `kubectl get cronjob`; a failed read returns "no runs yet" rather than falling back to names, and an empty UID is rejected outright.

`startMultiLogStream` / `restartMultiLogStream` moved to `commands_logs_multi.go` unchanged, to bring `commands_logs.go` under the 800-line cap. Diffed byte-for-byte against the parent commit.

Log Top stays out: it was removed from Job and CronJob in the change that found this, because batch output has none of the HTTP access-log shape it parses.

## Test plan

Every test proven red before the fix, per test by name.

- [x] `TestStartLogStream_CronJob_UsesNewestJobSelector` - red with the reported bug reproduced verbatim: argv was `logs cronjob/my-cron --all-containers=true`, no `-l`
- [x] `TestLatestOwnedJob_IgnoresJobOwnedByDifferentCronJob` - red: `found=false`
- [x] `TestLatestOwnedJob_OrphanedJobSameNameDifferentUID_NotMatched` - red: old code matched the orphan by name
- [x] `TestLatestOwnedJob_TiebreakOnEqualTimestamp` - red: `want my-cron-200, got my-cron-100`
- [x] `go build ./...`, `go test ./...` (all packages), `golangci-lint run ./...` - 0 issues
- [ ] Manual, and the gap that matters: **no live cluster.** The selector logic and the legacy-label fallback were checked against fake `kubectl` scripts, not a real CronJob to Job to Pod chain

`TestStartLogStream_Job_StillUsesKubectlGetPodSelector` passes on unfixed code too. That is correct - the Job path was never broken, so it guards against future breakage rather than proving this fix.

Known and out of scope: multi-select log streaming still has no CronJob branch and would build the same rejected `logs cronjob/<name>`.

Closes TASK-892.
