### PR TITLE
fix: key saved templates by namespace, not just name

### DIFF
--- a/internal/app/commands_export_template.go
+++ b/internal/app/commands_export_template.go
@@ -24,7 +24,7 @@ func (m Model) exportTemplateCmd() (Model, tea.Cmd) {
 		m.setStatusMessage("Export Template: security findings have no manifest to export", true)
 		return m, scheduleStatusClear()
 	}
-	fetch, name, kind, ok := m.resolveTemplateSource()
+	fetch, name, kind, namespace, ok := m.resolveTemplateSource()
 	if !ok {
 		m.setStatusMessage("Export Template: nothing selected to export", true)
 		return m, scheduleStatusClear()
@@ -37,30 +37,30 @@ func (m Model) exportTemplateCmd() (Model, tea.Cmd) {
 			if err != nil {
 				return exportTemplateReadyMsg{err: fmt.Errorf("fetching resource: %w", err)}
 			}
-			return exportTemplateReadyMsg{name: name, kind: kind, raw: doc}
+			return exportTemplateReadyMsg{name: name, kind: kind, namespace: namespace, raw: doc}
 		})
 }
 
-// resolveTemplateSource returns a YAML fetcher for the row under the cursor,
-// plus its name and kind. A container row resolves to its parent Pod: a
-// container has no manifest of its own.
-func (m Model) resolveTemplateSource() (fetch func(context.Context) (string, error), name, kind string, ok bool) {
+// resolveTemplateSource resolves a container row to its parent Pod: a
+// container has no manifest of its own. namespace is "" for a cluster-scoped
+// resource.
+func (m Model) resolveTemplateSource() (fetch func(context.Context) (string, error), name, kind, namespace string, ok bool) {
 	kctx := m.effectiveContext()
 	ns := m.resolveNamespace()
 
 	if m.nav.Level == model.LevelContainers {
 		podName := m.nav.OwnedName
 		if podName == "" {
-			return nil, "", "", false
+			return nil, "", "", "", false
 		}
 		return func(ctx context.Context) (string, error) {
 			return m.client.GetPodYAML(ctx, kctx, ns, podName)
-		}, podName, "Pod", true
+		}, podName, "Pod", ns, true
 	}
 
 	sel := m.selectedMiddleItem()
 	if sel == nil {
-		return nil, "", "", false
+		return nil, "", "", "", false
 	}
 	itemNs := ns
 	if sel.Namespace != "" {
@@ -74,24 +74,32 @@ func (m Model) resolveTemplateSource() (fetch func(context.Context) (string, err
 	switch m.nav.Level {
 	case model.LevelResources:
 		rt := m.nav.ResourceType
+		fetchNs := ""
+		if rt.Namespaced {
+			fetchNs = itemNs
+		}
 		return func(ctx context.Context) (string, error) {
 			return m.client.GetResourceYAML(ctx, itemCtx, itemNs, rt, sel.Name)
-		}, sel.Name, rt.Kind, true
+		}, sel.Name, rt.Kind, fetchNs, true
 	case model.LevelOwned:
 		if sel.Kind == "Pod" {
 			return func(ctx context.Context) (string, error) {
 				return m.client.GetPodYAML(ctx, itemCtx, itemNs, sel.Name)
-			}, sel.Name, "Pod", true
+			}, sel.Name, "Pod", itemNs, true
 		}
 		rt, resolved := m.resolveOwnedResourceType(sel)
 		if !resolved {
-			return nil, "", "", false
+			return nil, "", "", "", false
+		}
+		fetchNs := ""
+		if rt.Namespaced {
+			fetchNs = itemNs
 		}
 		return func(ctx context.Context) (string, error) {
 			return m.client.GetResourceYAML(ctx, itemCtx, itemNs, rt, sel.Name)
-		}, sel.Name, rt.Kind, true
+		}, sel.Name, rt.Kind, fetchNs, true
 	}
-	return nil, "", "", false
+	return nil, "", "", "", false
 }
 
 // updateExportTemplateReady opens the destination picker once the manifest has
@@ -101,6 +109,6 @@ func (m Model) updateExportTemplateReady(msg exportTemplateReadyMsg) (tea.Model,
 		m.setErrorFromErr("Export template failed: ", msg.err)
 		return m, scheduleStatusClear()
 	}
-	m.openExportTemplatePicker(msg.name, msg.kind, msg.raw)
+	m.openExportTemplatePicker(msg.name, msg.kind, msg.namespace, msg.raw)
 	return m, nil
 }

--- a/internal/app/export_strip_overlay_test.go
+++ b/internal/app/export_strip_overlay_test.go
@@ -29,7 +29,7 @@ func openedExportPicker(t *testing.T) Model {
 	// Toggling a category persists; keep it out of the developer's real state dir.
 	t.Setenv("LFK_STATE_DIR", t.TempDir())
 	m := basePush80Model()
-	m.openExportTemplatePicker("settings", "ConfigMap", exportPickerYAML)
+	m.openExportTemplatePicker("settings", "ConfigMap", "prod", exportPickerYAML)
 	require.Equal(t, overlayExportTemplate, m.overlay)
 	return m
 }

--- a/internal/app/export_strip_prefs_test.go
+++ b/internal/app/export_strip_prefs_test.go
@@ -73,7 +73,7 @@ func TestExportStripPrefs_ToggleSurvivesANewExport(t *testing.T) {
 	require.False(t, m.exportTemplatePicker.strip[k8s.TemplateNamespace])
 
 	next := basePush80Model()
-	next.openExportTemplatePicker("settings", "ConfigMap", exportPickerYAML)
+	next.openExportTemplatePicker("settings", "ConfigMap", "prod", exportPickerYAML)
 
 	assert.False(t, next.exportTemplatePicker.strip[k8s.TemplateNamespace])
 	assert.Contains(t, next.exportTemplatePicker.manifest, "namespace: prod")

--- a/internal/app/export_template.go
+++ b/internal/app/export_template.go
@@ -201,11 +201,11 @@ func (m Model) applyExportTemplatePicker() (tea.Model, tea.Cmd) {
 // collision the filename scheme cannot resolve on its own — same namespace
 // and name, saved from two different clusters.
 func (m Model) applyExportToTemplateList(state exportTemplateState) (tea.Model, tea.Cmd) {
-	path, ok := templateSavePath(state.namespace, state.name)
-	if !ok {
+	path, pathErr := templateSavePath(state.namespace, state.name)
+	if pathErr != nil {
 		m.closeExportTemplatePicker()
 		return m, func() tea.Msg {
-			return actionResultMsg{err: fmt.Errorf("saving template: %w", errInvalidTemplateName)}
+			return actionResultMsg{err: fmt.Errorf("saving template: %w", pathErr)}
 		}
 	}
 	if _, err := os.Stat(path); err == nil {

--- a/internal/app/export_template.go
+++ b/internal/app/export_template.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -62,6 +63,8 @@ type exportTemplateState struct {
 	cursor int
 	name   string
 	kind   string
+	// namespace is "" for a cluster-scoped resource.
+	namespace string
 	// raw is the fetched document. Kept so a category toggle in the field
 	// picker can re-strip it rather than trying to unpick the stripped copy.
 	raw         string
@@ -97,13 +100,14 @@ func (s exportTemplateState) redactionNote() string {
 	return ""
 }
 
-func (m *Model) openExportTemplatePicker(name, kind, raw string) {
+func (m *Model) openExportTemplatePicker(name, kind, namespace, raw string) {
 	m.exportTemplatePicker = exportTemplateState{
-		active: true,
-		name:   name,
-		kind:   kind,
-		raw:    raw,
-		strip:  loadExportStripPrefs(),
+		active:    true,
+		name:      name,
+		kind:      kind,
+		namespace: namespace,
+		raw:       raw,
+		strip:     loadExportStripPrefs(),
 	}
 	m.exportTemplatePicker.restrip()
 	m.previousOverlay = overlayNone
@@ -159,13 +163,17 @@ func (m Model) handleExportTemplateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 }
 
 // applyExportTemplatePicker delivers the captured manifest to the highlighted
-// destination and closes the picker.
+// destination. The template-list destination may detour through a confirm
+// overlay, so it alone keeps the picker state alive and closes it itself.
 func (m Model) applyExportTemplatePicker() (tea.Model, tea.Cmd) {
 	state := m.exportTemplatePicker
 	if !state.active || state.cursor >= len(exportDestinations) {
 		return m, nil
 	}
 	dest := exportDestinations[state.cursor]
+	if dest == exportDestTemplateList {
+		return m.applyExportToTemplateList(state)
+	}
 	m.closeExportTemplatePicker()
 
 	switch dest {
@@ -185,16 +193,40 @@ func (m Model) applyExportTemplatePicker() (tea.Model, tea.Cmd) {
 			}
 			return exportDoneMsg{path: abs, note: note}
 		}
-	case exportDestTemplateList:
-		name, manifest, note := state.name, state.manifest, state.redactionNote()
-		return m, func() tea.Msg {
-			if err := saveUserTemplate(name, manifest); err != nil {
-				return actionResultMsg{err: fmt.Errorf("saving template: %w", err)}
-			}
-			return actionResultMsg{message: "Saved template " + name + note}
-		}
 	}
 	return m, nil
+}
+
+// applyExportToTemplateList confirms first on an existing file: the
+// collision the filename scheme cannot resolve on its own — same namespace
+// and name, saved from two different clusters.
+func (m Model) applyExportToTemplateList(state exportTemplateState) (tea.Model, tea.Cmd) {
+	path, ok := templateSavePath(state.namespace, state.name)
+	if !ok {
+		m.closeExportTemplatePicker()
+		return m, func() tea.Msg {
+			return actionResultMsg{err: fmt.Errorf("saving template: %w", errInvalidTemplateName)}
+		}
+	}
+	if _, err := os.Stat(path); err == nil {
+		m.confirmAction = path
+		m.pendingAction = overwriteTemplateAction
+		m.confirmTitle = "Confirm Overwrite"
+		m.confirmQuestion = fmt.Sprintf("Overwrite the saved template %s?", state.name)
+		// A stale blast/deps fetch belongs to a cluster delete, not this file save.
+		m.blast.reset()
+		m.deps.reset()
+		m.overlay = overlayConfirm
+		return m, nil
+	}
+	namespace, name, manifest, note := state.namespace, state.name, state.manifest, state.redactionNote()
+	m.closeExportTemplatePicker()
+	return m, func() tea.Msg {
+		if err := saveUserTemplate(namespace, name, manifest); err != nil {
+			return actionResultMsg{err: fmt.Errorf("saving template: %w", err)}
+		}
+		return actionResultMsg{message: "Saved template " + name + note}
+	}
 }
 
 // templateExportFilename builds "<kind>_<name>.template.yaml" in the working

--- a/internal/app/export_template_test.go
+++ b/internal/app/export_template_test.go
@@ -143,9 +143,9 @@ func TestConfirmOverlayKey_CancelledOverwriteKeepsFile(t *testing.T) {
 	saved, err := os.ReadFile(filepath.Join(dir, "staging__web.yaml"))
 	require.NoError(t, err)
 	assert.Equal(t, "kind: Pod # old\n", string(saved), "cancelling keeps the existing file")
-	assert.Equal(t, overlayNone, got.overlay)
 	assert.Empty(t, got.pendingAction)
-	assert.False(t, got.exportTemplatePicker.active)
+	assert.Equal(t, overlayExportTemplate, got.overlay, "declining the overwrite returns to the destinations")
+	assert.True(t, got.exportTemplatePicker.active, "the export stays staged, so clipboard and file need no re-export")
 }
 
 // TestApplyExportTemplatePicker_FileWritesStrippedManifest covers AC #5's file

--- a/internal/app/export_template_test.go
+++ b/internal/app/export_template_test.go
@@ -120,14 +120,21 @@ func TestConfirmOverlayKey_AcceptedOverwriteReplacesFile(t *testing.T) {
 	retTeaModel, _ := m.applyExportTemplatePicker()
 	m = retTeaModel.(Model)
 
-	got := pressConfirmKey(m, "y")
+	got, cmd := pressConfirmKeyWithCmd(m, "y")
+
+	assert.Equal(t, overlayNone, got.overlay)
+	assert.False(t, got.exportTemplatePicker.active)
+	// The write is deferred so a slow fsync cannot stall key handling, so the
+	// file only exists once the command has run.
+	require.NotNil(t, cmd, "the overwrite must be committed through a command")
+	msg, ok := cmd().(actionResultMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	assert.Contains(t, msg.message, "Saved template web")
 
 	saved, err := os.ReadFile(filepath.Join(dir, "staging__web.yaml"))
 	require.NoError(t, err)
 	assert.Equal(t, strippedManifest, string(saved), "the confirmed overwrite replaces the old content")
-	assert.Equal(t, overlayNone, got.overlay)
-	assert.False(t, got.exportTemplatePicker.active)
-	assert.Contains(t, got.statusMessage, "Saved template web")
 }
 
 func TestConfirmOverlayKey_CancelledOverwriteKeepsFile(t *testing.T) {

--- a/internal/app/export_template_test.go
+++ b/internal/app/export_template_test.go
@@ -18,7 +18,7 @@ const strippedManifest = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: web\n"
 func pickerModel(t *testing.T) Model {
 	t.Helper()
 	m := basePush80Model()
-	m.openExportTemplatePicker("web", "Pod", strippedManifest)
+	m.openExportTemplatePicker("web", "Pod", "staging", strippedManifest)
 	return m
 }
 
@@ -27,7 +27,7 @@ func pickerModel(t *testing.T) Model {
 func secretPickerModel(t *testing.T) Model {
 	t.Helper()
 	m := basePush80Model()
-	m.openExportTemplatePicker("db-creds", "Secret", "kind: Secret\ndata:\n  password: \"hunter2\"\n")
+	m.openExportTemplatePicker("db-creds", "Secret", "staging", "kind: Secret\ndata:\n  password: \"hunter2\"\n")
 	return m
 }
 
@@ -84,9 +84,68 @@ func TestApplyExportTemplatePicker_TemplateListSavesFile(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, msg.err)
 
-	saved, err := os.ReadFile(filepath.Join(dir, "web.yaml"))
+	saved, err := os.ReadFile(filepath.Join(dir, "staging__web.yaml"))
 	require.NoError(t, err)
 	assert.Equal(t, strippedManifest, string(saved))
+}
+
+// TestApplyExportTemplatePicker_ExistingFileOpensConfirm is the residual
+// collision the filename scheme cannot resolve on its own: the same
+// namespace and name, saved a second time (e.g. from a different cluster).
+func TestApplyExportTemplatePicker_ExistingFileOpensConfirm(t *testing.T) {
+	dir := withTempConfigDir(t)
+	writeTemplateFile(t, dir, "staging__web.yaml", "kind: Pod # old\n")
+	m := pickerModel(t)
+	m.exportTemplatePicker.cursor = indexOfDestination(t, exportDestTemplateList)
+
+	ret, cmd := m.applyExportTemplatePicker()
+	got := ret.(Model)
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, overlayConfirm, got.overlay)
+	assert.Equal(t, overwriteTemplateAction, got.pendingAction)
+	assert.Contains(t, got.confirmQuestion, "web")
+	assert.True(t, got.exportTemplatePicker.active, "the picker state survives to commit on confirm")
+
+	saved, err := os.ReadFile(filepath.Join(dir, "staging__web.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "kind: Pod # old\n", string(saved), "nothing is written before the confirm")
+}
+
+func TestConfirmOverlayKey_AcceptedOverwriteReplacesFile(t *testing.T) {
+	dir := withTempConfigDir(t)
+	writeTemplateFile(t, dir, "staging__web.yaml", "kind: Pod # old\n")
+	m := pickerModel(t)
+	m.exportTemplatePicker.cursor = indexOfDestination(t, exportDestTemplateList)
+	retTeaModel, _ := m.applyExportTemplatePicker()
+	m = retTeaModel.(Model)
+
+	got := pressConfirmKey(m, "y")
+
+	saved, err := os.ReadFile(filepath.Join(dir, "staging__web.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, strippedManifest, string(saved), "the confirmed overwrite replaces the old content")
+	assert.Equal(t, overlayNone, got.overlay)
+	assert.False(t, got.exportTemplatePicker.active)
+	assert.Contains(t, got.statusMessage, "Saved template web")
+}
+
+func TestConfirmOverlayKey_CancelledOverwriteKeepsFile(t *testing.T) {
+	dir := withTempConfigDir(t)
+	writeTemplateFile(t, dir, "staging__web.yaml", "kind: Pod # old\n")
+	m := pickerModel(t)
+	m.exportTemplatePicker.cursor = indexOfDestination(t, exportDestTemplateList)
+	retTeaModel, _ := m.applyExportTemplatePicker()
+	m = retTeaModel.(Model)
+
+	got := pressConfirmKey(m, "n")
+
+	saved, err := os.ReadFile(filepath.Join(dir, "staging__web.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "kind: Pod # old\n", string(saved), "cancelling keeps the existing file")
+	assert.Equal(t, overlayNone, got.overlay)
+	assert.Empty(t, got.pendingAction)
+	assert.False(t, got.exportTemplatePicker.active)
 }
 
 // TestApplyExportTemplatePicker_FileWritesStrippedManifest covers AC #5's file
@@ -121,7 +180,7 @@ func TestHandleExportTemplateKey_ShortcutAppliesThatDestination(t *testing.T) {
 	assert.False(t, ret.(Model).exportTemplatePicker.active)
 	cmd()
 
-	assert.FileExists(t, filepath.Join(dir, "web.yaml"))
+	assert.FileExists(t, filepath.Join(dir, "staging__web.yaml"))
 }
 
 func TestHandleExportTemplateKey_EscCloses(t *testing.T) {

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -258,6 +258,8 @@ type yamlClipboardMsg struct {
 type exportTemplateReadyMsg struct {
 	name string
 	kind string
+	// namespace is "" for a cluster-scoped resource.
+	namespace string
 	// raw is the fetched document, stripped when the picker opens so a later
 	// category toggle can re-strip it.
 	raw string

--- a/internal/app/template_delete_test.go
+++ b/internal/app/template_delete_test.go
@@ -26,8 +26,13 @@ func pressTemplateDeleteKey(m Model) Model {
 }
 
 func pressConfirmKey(m Model, key string) Model {
-	mdl, _ := m.handleConfirmOverlayKey(tea.KeyPressMsg{Code: rune(key[0]), Text: key})
-	return mdl.(Model)
+	got, _ := pressConfirmKeyWithCmd(m, key)
+	return got
+}
+
+func pressConfirmKeyWithCmd(m Model, key string) (Model, tea.Cmd) {
+	mdl, cmd := m.handleConfirmOverlayKey(tea.KeyPressMsg{Code: rune(key[0]), Text: key})
+	return mdl.(Model), cmd
 }
 
 func TestDeleteUserTemplate_RemovesFile(t *testing.T) {

--- a/internal/app/template_overwrite.go
+++ b/internal/app/template_overwrite.go
@@ -24,11 +24,25 @@ func (m Model) commitTemplateOverwrite() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) clearTemplateOverwriteConfirm() Model {
+	m = m.clearOverwriteConfirmFields()
+	m.closeExportTemplatePicker()
+	m.overlay = overlayNone
+	return m
+}
+
+// cancelTemplateOverwrite returns to the destination picker with the export
+// still staged, so declining the overwrite leaves clipboard and file reachable
+// without exporting again.
+func (m Model) cancelTemplateOverwrite() Model {
+	m = m.clearOverwriteConfirmFields()
+	m.overlay = overlayExportTemplate
+	return m
+}
+
+func (m Model) clearOverwriteConfirmFields() Model {
 	m.confirmAction = ""
 	m.pendingAction = ""
 	m.confirmTitle = ""
 	m.confirmQuestion = ""
-	m.closeExportTemplatePicker()
-	m.overlay = overlayNone
 	return m
 }

--- a/internal/app/template_overwrite.go
+++ b/internal/app/template_overwrite.go
@@ -1,0 +1,34 @@
+// Package app — template_overwrite.go
+// Confirms before Export Template replaces an existing saved template file.
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+// overwriteTemplateAction is the pendingAction label that routes the
+// confirmation back here. Absent from mutatingActions like
+// deleteTemplateAction: the file is local configuration.
+const overwriteTemplateAction = "Overwrite Template"
+
+func (m Model) commitTemplateOverwrite() (tea.Model, tea.Cmd) {
+	state := m.exportTemplatePicker
+	namespace, name, manifest, note := state.namespace, state.name, state.manifest, state.redactionNote()
+	m = m.clearTemplateOverwriteConfirm()
+	if err := saveUserTemplate(namespace, name, manifest); err != nil {
+		m.setStatusMessage("Failed to save template "+name+": "+err.Error(), true)
+		return m, scheduleStatusClear()
+	}
+	m.setStatusMessage("Saved template "+name+note, false)
+	return m, scheduleStatusClear()
+}
+
+func (m Model) clearTemplateOverwriteConfirm() Model {
+	m.confirmAction = ""
+	m.pendingAction = ""
+	m.confirmTitle = ""
+	m.confirmQuestion = ""
+	m.closeExportTemplatePicker()
+	m.overlay = overlayNone
+	return m
+}

--- a/internal/app/template_overwrite.go
+++ b/internal/app/template_overwrite.go
@@ -3,6 +3,8 @@
 package app
 
 import (
+	"fmt"
+
 	tea "charm.land/bubbletea/v2"
 )
 
@@ -11,16 +13,19 @@ import (
 // deleteTemplateAction: the file is local configuration.
 const overwriteTemplateAction = "Overwrite Template"
 
+// commitTemplateOverwrite hands the write to a command rather than doing it
+// here: saveUserTemplate fsyncs the file and the directory, and this runs
+// inside key handling, where a slow filesystem would stall the whole UI.
 func (m Model) commitTemplateOverwrite() (tea.Model, tea.Cmd) {
 	state := m.exportTemplatePicker
 	namespace, name, manifest, note := state.namespace, state.name, state.manifest, state.redactionNote()
 	m = m.clearTemplateOverwriteConfirm()
-	if err := saveUserTemplate(namespace, name, manifest); err != nil {
-		m.setStatusMessage("Failed to save template "+name+": "+err.Error(), true)
-		return m, scheduleStatusClear()
+	return m, func() tea.Msg {
+		if err := saveUserTemplate(namespace, name, manifest); err != nil {
+			return actionResultMsg{err: fmt.Errorf("saving template: %w", err)}
+		}
+		return actionResultMsg{message: "Saved template " + name + note}
 	}
-	m.setStatusMessage("Saved template "+name+note, false)
-	return m, scheduleStatusClear()
 }
 
 func (m Model) clearTemplateOverwriteConfirm() Model {

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -123,7 +123,7 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 			return m.clearTemplateDeleteConfirm(), nil
 		}
 		if m.pendingAction == overwriteTemplateAction {
-			return m.clearTemplateOverwriteConfirm(), nil
+			return m.cancelTemplateOverwrite(), nil
 		}
 		// A cancelled taint-apply returns to the still-alive editor so
 		// the staged marks are not lost.

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -26,6 +26,9 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		if m.pendingAction == deleteTemplateAction {
 			return m.commitTemplateDelete()
 		}
+		if m.pendingAction == overwriteTemplateAction {
+			return m.commitTemplateOverwrite()
+		}
 		// Read-only safety net: if RO was toggled on while a confirm overlay
 		// was already showing, refuse to commit the mutation.
 		if m.pendingActionBlockedByReadOnly() {
@@ -118,6 +121,9 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 	case "n", "N", "esc", "q":
 		if m.pendingAction == deleteTemplateAction {
 			return m.clearTemplateDeleteConfirm(), nil
+		}
+		if m.pendingAction == overwriteTemplateAction {
+			return m.clearTemplateOverwriteConfirm(), nil
 		}
 		// A cancelled taint-apply returns to the still-alive editor so
 		// the staged marks are not lost.

--- a/internal/app/user_templates.go
+++ b/internal/app/user_templates.go
@@ -212,16 +212,16 @@ func templateFileBase(namespace, name string) (string, bool) {
 // templateSavePath resolves where saveUserTemplate would write namespace and
 // name, without touching the filesystem — the export picker checks this path
 // for an existing file before it commits to an overwrite.
-func templateSavePath(namespace, name string) (string, bool) {
+func templateSavePath(namespace, name string) (string, error) {
 	dir := userTemplateDir()
 	if dir == "" {
-		return "", false
+		return "", errTemplateDirUnavailable
 	}
 	base, ok := templateFileBase(namespace, name)
 	if !ok {
-		return "", false
+		return "", errInvalidTemplateName
 	}
-	return filepath.Join(dir, base+".yaml"), true
+	return filepath.Join(dir, base+".yaml"), nil
 }
 
 // saveUserTemplate writes manifest to <template dir>/<namespace>__<name>.yaml

--- a/internal/app/user_templates.go
+++ b/internal/app/user_templates.go
@@ -144,12 +144,18 @@ func templateBaseFromPath(path string) string {
 	return strings.TrimSuffix(base, filepath.Ext(base))
 }
 
-// templateNameFromPath maps a file to the name the picker shows for it. "_"
-// is illegal in a DNS-1123 object name or namespace, so splitting on the
-// LAST "__" is unambiguous. A basename with none is unchanged.
+// templateNameFromPath maps a file to the name the picker shows for it. "_" is
+// illegal in a DNS-1123 object name or namespace, so splitting on the LAST "__"
+// is unambiguous for a file lfk wrote. A hand-authored name is under no such
+// rule, so `my__template.yaml` does read as namespace `my` - wrong, but it only
+// affects the two columns the picker draws.
+//
+// A split that leaves nothing after the separator falls back to the whole
+// basename: a file the user can see in the directory must not vanish from the
+// list that claims to show it.
 func templateNameFromPath(path string) string {
 	base := templateBaseFromPath(path)
-	if idx := strings.LastIndex(base, "__"); idx >= 0 {
+	if idx := strings.LastIndex(base, "__"); idx >= 0 && idx+2 < len(base) {
 		return base[idx+2:]
 	}
 	return base

--- a/internal/app/user_templates.go
+++ b/internal/app/user_templates.go
@@ -49,6 +49,11 @@ var errTemplateNotFound = errors.New("template not found")
 // resource name being saved.
 var errTemplateDirUnavailable = errors.New("template directory unavailable")
 
+// clusterScopedSegment stands in for a namespace on a cluster-scoped save.
+// The cluster context is deliberately left out of the file name: EKS
+// contexts are ARNs containing ":" and "/".
+const clusterScopedSegment = "_cluster"
+
 func userTemplateDir() string {
 	dir, err := paths.ConfigDir()
 	if err != nil {
@@ -116,10 +121,11 @@ func readUserTemplate(path string) (model.ResourceTemplate, bool) {
 	if name == "" {
 		return model.ResourceTemplate{}, false
 	}
+	namespace := ui.SanitizeTerminalText(templateNamespaceFromPath(path))
 	kind, _ := obj["kind"].(string)
 	return model.ResourceTemplate{
 		Name:        name,
-		Description: ui.SanitizeTerminalText(kind),
+		Description: templateDescription(ui.SanitizeTerminalText(kind), namespace),
 		Category:    userTemplateCategory,
 		YAML:        string(data),
 		Path:        path,
@@ -133,10 +139,43 @@ func decodeFirstDocument(data []byte, obj *map[string]any) bool {
 	return dec.Decode(obj) == nil
 }
 
-// templateNameFromPath maps a file to the name the picker shows for it.
-func templateNameFromPath(path string) string {
+func templateBaseFromPath(path string) string {
 	base := filepath.Base(path)
 	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+// templateNameFromPath maps a file to the name the picker shows for it. "_"
+// is illegal in a DNS-1123 object name or namespace, so splitting on the
+// LAST "__" is unambiguous. A basename with none is unchanged.
+func templateNameFromPath(path string) string {
+	base := templateBaseFromPath(path)
+	if idx := strings.LastIndex(base, "__"); idx >= 0 {
+		return base[idx+2:]
+	}
+	return base
+}
+
+// templateNamespaceFromPath recovers the namespace saveUserTemplate encoded
+// into the file name, or "" for a hand-authored file or a cluster-scoped save.
+func templateNamespaceFromPath(path string) string {
+	base := templateBaseFromPath(path)
+	idx := strings.LastIndex(base, "__")
+	if idx < 0 {
+		return ""
+	}
+	if ns := base[:idx]; ns != clusterScopedSegment {
+		return ns
+	}
+	return ""
+}
+
+// templateDescription matches the "<namespace>/<name>" order used elsewhere
+// in the app (e.g. explorer.go) for the picker's Description column.
+func templateDescription(kind, namespace string) string {
+	if namespace == "" {
+		return kind
+	}
+	return namespace + "/" + kind
 }
 
 func isYAMLFile(name string) bool {
@@ -147,23 +186,54 @@ func isYAMLFile(name string) bool {
 	return false
 }
 
-// saveUserTemplate writes manifest to <template dir>/<name>.yaml, replacing any
-// file already under that name. The name is a resource name read from the
-// cluster, so it is sanitized and confined to a single path element before it
-// reaches the filesystem.
-func saveUserTemplate(name, manifest string) error {
+// templateFileBase sanitizes namespace and name before they reach the
+// filesystem: both are resource identifiers read from the cluster.
+func templateFileBase(namespace, name string) (string, bool) {
+	cleanName := ui.SanitizeTerminalText(name)
+	if !isSafeTemplateName(cleanName) {
+		return "", false
+	}
+	nsSegment := clusterScopedSegment
+	if namespace != "" {
+		nsSegment = ui.SanitizeTerminalText(namespace)
+		if !isSafeTemplateName(nsSegment) {
+			return "", false
+		}
+	}
+	return nsSegment + "__" + cleanName, true
+}
+
+// templateSavePath resolves where saveUserTemplate would write namespace and
+// name, without touching the filesystem — the export picker checks this path
+// for an existing file before it commits to an overwrite.
+func templateSavePath(namespace, name string) (string, bool) {
+	dir := userTemplateDir()
+	if dir == "" {
+		return "", false
+	}
+	base, ok := templateFileBase(namespace, name)
+	if !ok {
+		return "", false
+	}
+	return filepath.Join(dir, base+".yaml"), true
+}
+
+// saveUserTemplate writes manifest to <template dir>/<namespace>__<name>.yaml
+// (or _cluster__<name>.yaml for a cluster-scoped resource), replacing any
+// file already at that path.
+func saveUserTemplate(namespace, name, manifest string) error {
 	dir := userTemplateDir()
 	if dir == "" {
 		return errTemplateDirUnavailable
 	}
-	clean := ui.SanitizeTerminalText(name)
-	if !isSafeTemplateName(clean) {
+	base, ok := templateFileBase(namespace, name)
+	if !ok {
 		return errInvalidTemplateName
 	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	return writeFileDurable(filepath.Join(dir, clean+".yaml"), []byte(manifest))
+	return writeFileDurable(filepath.Join(dir, base+".yaml"), []byte(manifest))
 }
 
 // deleteUserTemplate removes one template file by path. Deleting by name would

--- a/internal/app/user_templates_test.go
+++ b/internal/app/user_templates_test.go
@@ -30,9 +30,9 @@ func writeTemplateFile(t *testing.T, dir, filename, body string) {
 func TestSaveUserTemplate_RoundTrips(t *testing.T) {
 	dir := withTempConfigDir(t)
 
-	require.NoError(t, saveUserTemplate("web", "apiVersion: apps/v1\nkind: Deployment\n"))
+	require.NoError(t, saveUserTemplate("staging", "web", "apiVersion: apps/v1\nkind: Deployment\n"))
 
-	assert.FileExists(t, filepath.Join(dir, "web.yaml"))
+	assert.FileExists(t, filepath.Join(dir, "staging__web.yaml"))
 
 	got := loadUserTemplates()
 	require.Len(t, got, 1)
@@ -40,6 +40,43 @@ func TestSaveUserTemplate_RoundTrips(t *testing.T) {
 	assert.Equal(t, userTemplateCategory, got[0].Category)
 	assert.Equal(t, "apiVersion: apps/v1\nkind: Deployment\n", got[0].YAML)
 	assert.Contains(t, got[0].Description, "Deployment")
+	assert.Contains(t, got[0].Description, "staging")
+}
+
+// TestSaveUserTemplate_DifferentNamespacesSameNameBothSurvive is the bug this
+// naming scheme fixes: an nginx in staging and an nginx in prod used to write
+// the same file and silently overwrite each other.
+func TestSaveUserTemplate_DifferentNamespacesSameNameBothSurvive(t *testing.T) {
+	dir := withTempConfigDir(t)
+
+	require.NoError(t, saveUserTemplate("staging", "nginx", "kind: Deployment\nmetadata:\n  namespace: staging\n"))
+	require.NoError(t, saveUserTemplate("prod", "nginx", "kind: Deployment\nmetadata:\n  namespace: prod\n"))
+
+	assert.FileExists(t, filepath.Join(dir, "staging__nginx.yaml"))
+	assert.FileExists(t, filepath.Join(dir, "prod__nginx.yaml"))
+
+	got := loadUserTemplates()
+	require.Len(t, got, 2)
+	for _, tmpl := range got {
+		assert.Equal(t, "nginx", tmpl.Name)
+	}
+	assert.Contains(t, got[0].Description+got[1].Description, "staging")
+	assert.Contains(t, got[0].Description+got[1].Description, "prod")
+}
+
+// TestSaveUserTemplate_ClusterScoped covers a resource with no namespace:
+// the file name carries the "_cluster" marker instead of one.
+func TestSaveUserTemplate_ClusterScoped(t *testing.T) {
+	dir := withTempConfigDir(t)
+
+	require.NoError(t, saveUserTemplate("", "worker-1", "kind: Node\n"))
+
+	assert.FileExists(t, filepath.Join(dir, "_cluster__worker-1.yaml"))
+
+	got := loadUserTemplates()
+	require.Len(t, got, 1)
+	assert.Equal(t, "worker-1", got[0].Name)
+	assert.Equal(t, "Node", got[0].Description, "no namespace segment for a cluster-scoped save")
 }
 
 // TestLoadUserTemplates_ReadsHandAuthoredFile is the point of the directory:
@@ -57,8 +94,8 @@ func TestLoadUserTemplates_ReadsHandAuthoredFile(t *testing.T) {
 func TestSaveUserTemplate_ReplacesSameName(t *testing.T) {
 	dir := withTempConfigDir(t)
 
-	require.NoError(t, saveUserTemplate("web", "kind: Pod\n"))
-	require.NoError(t, saveUserTemplate("web", "kind: Deployment\n"))
+	require.NoError(t, saveUserTemplate("staging", "web", "kind: Pod\n"))
+	require.NoError(t, saveUserTemplate("staging", "web", "kind: Deployment\n"))
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -117,7 +154,7 @@ func TestLoadUserTemplates_SanitizesUserSuppliedText(t *testing.T) {
 func TestSaveUserTemplate_LeavesNoTempFile(t *testing.T) {
 	dir := withTempConfigDir(t)
 
-	require.NoError(t, saveUserTemplate("web", "kind: Pod\n"))
+	require.NoError(t, saveUserTemplate("staging", "web", "kind: Pod\n"))
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -125,7 +162,7 @@ func TestSaveUserTemplate_LeavesNoTempFile(t *testing.T) {
 	for _, e := range entries {
 		names = append(names, e.Name())
 	}
-	assert.Equal(t, []string{"web.yaml"}, names)
+	assert.Equal(t, []string{"staging__web.yaml"}, names)
 }
 
 // TestSaveUserTemplate_RejectsPathEscape keeps a resource name from steering
@@ -134,10 +171,21 @@ func TestSaveUserTemplate_RejectsPathEscape(t *testing.T) {
 	dir := withTempConfigDir(t)
 
 	for _, name := range []string{"../escape", "sub/web", "..", ""} {
-		assert.Error(t, saveUserTemplate(name, "kind: Pod\n"), "name %q must be rejected", name)
+		assert.Error(t, saveUserTemplate("staging", name, "kind: Pod\n"), "name %q must be rejected", name)
 	}
 	assert.NoDirExists(t, filepath.Join(dir, "sub"))
 	assert.NoFileExists(t, filepath.Join(filepath.Dir(dir), "escape.yaml"))
+}
+
+// TestSaveUserTemplate_RejectsNamespacePathEscape is the same guard on the
+// namespace segment: it reaches the file name too.
+func TestSaveUserTemplate_RejectsNamespacePathEscape(t *testing.T) {
+	dir := withTempConfigDir(t)
+
+	for _, namespace := range []string{"../escape", "sub/web", ".."} {
+		assert.Error(t, saveUserTemplate(namespace, "web", "kind: Pod\n"), "namespace %q must be rejected", namespace)
+	}
+	assert.NoDirExists(t, filepath.Join(dir, "sub"))
 }
 
 // TestSaveUserTemplate_ConfigDirUnavailableIsDistinctError guards against
@@ -150,7 +198,7 @@ func TestSaveUserTemplate_ConfigDirUnavailableIsDistinctError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", "")
 
-	err := saveUserTemplate("web", "kind: Pod\n")
+	err := saveUserTemplate("staging", "web", "kind: Pod\n")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errTemplateDirUnavailable)
 	assert.NotErrorIs(t, err, errInvalidTemplateName)

--- a/internal/app/user_templates_test.go
+++ b/internal/app/user_templates_test.go
@@ -238,3 +238,25 @@ func TestLoadUserTemplates_TrailingSeparatorKeepsWholeBaseName(t *testing.T) {
 	require.Len(t, got, 1, "the row must not disappear")
 	assert.Equal(t, "web__", got[0].Name)
 }
+
+// A missing config directory and a rejected name are different failures, and
+// the caller reports whichever it is told, so the two must not collapse.
+func TestTemplateSavePath_DistinguishesFailures(t *testing.T) {
+	t.Run("directory unavailable", func(t *testing.T) {
+		t.Setenv("LFK_CONFIG_DIR", "")
+		t.Setenv("HOME", "")
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		_, err := templateSavePath("staging", "web")
+
+		require.ErrorIs(t, err, errTemplateDirUnavailable)
+	})
+
+	t.Run("invalid name", func(t *testing.T) {
+		withTempConfigDir(t)
+
+		_, err := templateSavePath("staging", "../escape")
+
+		require.ErrorIs(t, err, errInvalidTemplateName)
+	})
+}

--- a/internal/app/user_templates_test.go
+++ b/internal/app/user_templates_test.go
@@ -226,3 +226,15 @@ func TestMergedTemplates_UserFirstAndNeverShadows(t *testing.T) {
 	assert.True(t, builtinKept, "the built-in Pod template must still be listed")
 	assert.Len(t, merged, len(model.BuiltinTemplates())+1)
 }
+
+// A file whose name ends in the separator has nothing after it to use as a
+// name. Dropping the row would hide a file the user can see in the directory.
+func TestLoadUserTemplates_TrailingSeparatorKeepsWholeBaseName(t *testing.T) {
+	dir := withTempConfigDir(t)
+	writeTemplateFile(t, dir, "web__.yaml", "kind: Pod\n")
+
+	got := loadUserTemplates()
+
+	require.Len(t, got, 1, "the row must not disappear")
+	assert.Equal(t, "web__", got[0].Name)
+}


### PR DESCRIPTION
> Builds on the `Path` field #619 added to `ResourceTemplate`. #619 is merged, so this targets `main` and carries only its own three commits.

`saveUserTemplate` wrote `<ConfigDir>/templates/<metadata.name>.yaml`. Two objects with the same name in different namespaces or clusters wrote the same file, and the second overwrote the first with no warning. A Deployment called `nginx` in staging and one in prod is a plausible pair.

The file name now carries the namespace: `<namespace>__<name>.yaml`, or `_cluster__<name>.yaml` for a cluster-scoped kind. A **double underscore** separates them because `_` is illegal in a DNS-1123 object name and namespace, so the split back is unambiguous for any file lfk wrote. The picker still shows the object name and gains the namespace beside the Kind in its description column.

Two decisions worth stating, because neither is the obvious one:

- **The cluster context is deliberately not in the file name.** EKS contexts are ARNs containing `:` and `/`. Encoding those into a path has no clean escape.
- **So the residual collision gets a confirmation instead.** The same namespace and name in two different clusters now asks before replacing the file. Qualified naming removes the common case, the prompt covers the rest.

Declining that prompt returns to the destination picker with the export still staged, so saying no to an overwrite leaves clipboard and file reachable without exporting again. The delete confirm already returned to its opener; this now matches.

**Backward compatible.** A hand-authored file with no `__` keeps its whole base name, which matters because users keep these in dotfiles. `deleteUserTemplate` needed no change - it deletes by `Path`.

## Test plan

Every test proven red before its fix, per test by name.

- [x] `TestSaveUserTemplate_DifferentNamespacesSameNameBothSurvive` - red: 1 of 2 files existed
- [x] `TestSaveUserTemplate_ClusterScoped` - red: `worker-1.yaml` not found
- [x] `TestApplyExportTemplatePicker_ExistingFileOpensConfirm`, `TestConfirmOverlayKey_AcceptedOverwriteReplacesFile` - red: no confirm, no cmd, no save
- [x] `TestConfirmOverlayKey_CancelledOverwriteKeepsFile` - red on the return path: `declining the overwrite returns to the destinations`, `the export stays staged`
- [x] `TestLoadUserTemplates_TrailingSeparatorKeepsWholeBaseName` - red: `"[]" should have 1 item(s), but has 0`
- [x] `go build ./...`, `go test ./...` (all packages), `golangci-lint run ./...` - 0 issues
- [ ] Manual: save two same-named objects from different namespaces, then save one twice to hit the confirm

**Known limit, documented in the code rather than fixed:** the `__` split also applies to hand-authored names, which are under no DNS-1123 rule. A file called `my__template.yaml` reads as namespace `my`. It affects only the two columns the picker draws - no data loss, no path escape. A file ending in the separator (`web__.yaml`) used to vanish from the picker entirely, because an empty name is dropped; it now falls back to the whole base name.

Review confirmed the path composition is safe: namespace and name are sanitized and validated **separately** before joining, so neither half can carry a separator into the result, and the overwrite check and the write share one function so they cannot disagree about the target.

Closes TASK-890.
