### PR TITLE
fix: report a status message when every multi-log stream fails to start

### DIFF
--- a/internal/app/commands_logs_multi.go
+++ b/internal/app/commands_logs_multi.go
@@ -25,6 +25,8 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 		return m, func() tea.Msg { return actionResultMsg{err: fmt.Errorf("kubectl not found: %w", err)} }
 	}
 
+	previousMode := m.mode
+
 	// Initialize log viewer state.
 	m.mode = modeLogs
 	m.resetLogBuffer()
@@ -55,6 +57,8 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 	ns := m.resolveNamespace()
 
 	var wg sync.WaitGroup
+	started := 0
+	var lastErr error
 	for _, item := range items {
 		itemCtx := kctx
 		if item.ClusterName != "" {
@@ -108,15 +112,18 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
 			logger.Error("Failed to create stdout pipe for multi-log", "item", item.Name, "error", err)
+			lastErr = err
 			continue
 		}
 		cmd.Stderr = cmd.Stdout
 
 		if err := cmd.Start(); err != nil {
 			logger.Error("Failed to start kubectl logs for multi-log", "item", item.Name, "error", err)
+			lastErr = err
 			continue
 		}
 
+		started++
 		wg.Go(func() {
 			defer cmd.Wait() //nolint:errcheck
 			scanner := bufio.NewScanner(stdout)
@@ -136,6 +143,17 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 		wg.Wait()
 		close(ch)
 	}()
+
+	if started == 0 {
+		cancel()
+		m.mode = previousMode
+		msg := fmt.Sprintf("Failed to start logs for %d resources", len(items))
+		if lastErr != nil {
+			msg = fmt.Sprintf("%s: %v", msg, lastErr)
+		}
+		m.setStatusMessage(msg, true)
+		return m, scheduleStatusClear()
+	}
 
 	return m, m.waitForLogLine()
 }

--- a/internal/app/commands_logs_multi_test.go
+++ b/internal/app/commands_logs_multi_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartMultiLogStream_AllFail_ReportsStatusAndKeepsMode(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeExplorer
+	t.Setenv("KUBECTL_BIN", "/nonexistent/kubectl")
+
+	items := []model.Item{
+		{Name: "pod-1", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-2", Namespace: "default", Kind: "Pod"},
+		{Name: "pod-3", Namespace: "default", Kind: "Pod"},
+	}
+
+	updated, cmd := m.startMultiLogStream(items)
+	mdl, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Equal(t, modeExplorer, mdl.mode, "must not enter the log viewer when every stream fails")
+	assert.True(t, mdl.statusMessageErr)
+	assert.Contains(t, mdl.statusMessage, "3")
+	require.NotNil(t, cmd)
+}

--- a/internal/app/commands_logs_multi_test.go
+++ b/internal/app/commands_logs_multi_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/janosmiko/lfk/internal/model"
@@ -25,6 +26,7 @@ func TestStartMultiLogStream_AllFail_ReportsStatusAndKeepsMode(t *testing.T) {
 
 	assert.Equal(t, modeExplorer, mdl.mode, "must not enter the log viewer when every stream fails")
 	assert.True(t, mdl.statusMessageErr)
-	assert.Contains(t, mdl.statusMessage, "3")
+	assert.True(t, strings.HasPrefix(mdl.statusMessage, "Failed to start logs for 3 resources:"),
+		"the count and the appended cause both belong in the message, got %q", mdl.statusMessage)
 	require.NotNil(t, cmd)
 }


### PR DESCRIPTION
> `commands_logs_multi.go` arrived in #620, which is merged, so this targets `main` and carries only its own commit.

`startMultiLogStream` skipped an item on a pipe or start failure with only a `logger` call. When every item failed, `wg.Wait()` returned at once, `close(ch)` fired, and the consumer received `logLineMsg{done: true}`. The user got an empty log viewer and no reason for it.

It now counts the streams that actually started. At zero it cancels the context, restores the view mode the model was in before the call, and reports through `setStatusMessage` with the item count and the last start error. A partial failure is untouched: the viewer still opens with the streams that did start.

No synchronisation was needed. The counter is written only in the calling goroutine, before any per-item goroutine is spawned, and read once after the loop - confirmed by review and by a clean `-race` run.

This predates #620, which only moved the function to `commands_logs_multi.go` unchanged. It was raised by CodeRabbit there and kept out to hold that PR's scope.

## Test plan

- [x] `TestStartMultiLogStream_AllFail_ReportsStatusAndKeepsMode` - proven red: mode stayed `modeLogs` instead of `modeExplorer`, `statusMessageErr` was false, `statusMessage` empty
- [x] `go build ./...`, `go test ./...` (all packages), `go test -race ./internal/app/` clean, `golangci-lint run ./...` - 0 issues
- [ ] Manual: select several pods, break `kubectl` on PATH, run the bulk Logs action

**One test, and that is the honest ceiling here.** Two more were written for the other acceptance criteria - partial failure still opens the viewer, all-success unchanged - and both passed against the unfixed baseline, so they were deleted rather than kept as decorative guards. Review reached the same conclusion independently: the `continue`-on-error loop body is unchanged by this commit, so no non-vacuous test of the partial path is constructible from this diff.

Closes TASK-895.
