### PR TITLE
test: cover the CronJob log path in demo and on a real kind cluster

### DIFF
--- a/.github/workflows/e2e-cluster.yml
+++ b/.github/workflows/e2e-cluster.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing after this step talks to git, so the token has no reason to
+          # stay readable in the local git config.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/e2e-cluster.yml
+++ b/.github/workflows/e2e-cluster.yml
@@ -1,0 +1,144 @@
+name: E2E (real cluster)
+
+# Runs the e2e suite against a real kind apiserver instead of the --demo
+# fake, so the CronJob log label selectors validate for real (TASK-896).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-cluster:
+    name: e2e against a kind cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      LFK_E2E_REAL_CLUSTER: "1"
+      LFK_E2E_LOG_MARKER: lfk-e2e-cronjob-log-marker
+      LFK_NAMESPACE: lfk-e2e
+      LFK_CRONJOB: nightly-backup
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      # Cleanup (kind delete cluster) is this action's own post step, which
+      # GitHub Actions runs regardless of job outcome - no separate
+      # always()-guarded teardown step needed.
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: lfk-e2e
+
+      - name: Apply CronJob/Job/Pod fixture
+        run: |
+          set -euo pipefail
+          kubectl create namespace "${LFK_NAMESPACE}"
+
+          # Suspended so the CronJob's own controller never creates a
+          # competing Job - the Job below is applied directly instead, with
+          # ownerReferences filled in from the CronJob's server-assigned uid.
+          kubectl apply -n "${LFK_NAMESPACE}" -f - <<EOF
+          apiVersion: batch/v1
+          kind: CronJob
+          metadata:
+            name: ${LFK_CRONJOB}
+          spec:
+            schedule: "0 2 * * *"
+            suspend: true
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: backup
+                        image: busybox:1.36
+                        command: ["sh", "-c", "echo backup"]
+          EOF
+
+          cronjob_uid=$(kubectl get cronjob "${LFK_CRONJOB}" -n "${LFK_NAMESPACE}" -o jsonpath='{.metadata.uid}')
+
+          kubectl apply -n "${LFK_NAMESPACE}" -f - <<EOF
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: ${LFK_CRONJOB}-run
+            ownerReferences:
+              - apiVersion: batch/v1
+                kind: CronJob
+                name: ${LFK_CRONJOB}
+                uid: ${cronjob_uid}
+                controller: true
+                blockOwnerDeletion: true
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: backup
+                    image: busybox:1.36
+                    command: ["sh", "-c", "echo backup"]
+          EOF
+
+          job_uid=$(kubectl get job "${LFK_CRONJOB}-run" -n "${LFK_NAMESPACE}" -o jsonpath='{.metadata.uid}')
+
+          # Only the legacy job-name/controller-uid labels, no
+          # batch.kubernetes.io/ prefix, so resolveCronJobPodSelector's
+          # fallback candidate is what actually matches pods (AC#3).
+          kubectl apply -n "${LFK_NAMESPACE}" -f - <<EOF
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: ${LFK_CRONJOB}-run-pod
+            labels:
+              job-name: ${LFK_CRONJOB}-run
+              controller-uid: ${job_uid}
+            ownerReferences:
+              - apiVersion: batch/v1
+                kind: Job
+                name: ${LFK_CRONJOB}-run
+                uid: ${job_uid}
+                controller: true
+                blockOwnerDeletion: true
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: backup
+                image: busybox:1.36
+                command: ["sh", "-c", "echo ${LFK_E2E_LOG_MARKER} && sleep 120"]
+          EOF
+
+          kubectl wait --for=jsonpath='{.status.phase}'=Running \
+            "pod/${LFK_CRONJOB}-run-pod" -n "${LFK_NAMESPACE}" --timeout=60s
+
+          # The pod can report Running before its container has written
+          # anything - poll logs until the marker line actually shows up.
+          for _ in $(seq 1 30); do
+            if kubectl logs "${LFK_CRONJOB}-run-pod" -n "${LFK_NAMESPACE}" 2>/dev/null | grep -qF "${LFK_E2E_LOG_MARKER}"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "marker never appeared in pod logs" >&2
+          kubectl logs "${LFK_CRONJOB}-run-pod" -n "${LFK_NAMESPACE}" >&2 || true
+          exit 1
+
+      - name: Run e2e against the real cluster
+        run: go test -tags e2e -count=1 -timeout 5m -run TestClusterModeCronJobLogs -v ./e2e/...
+
+      - name: Collect cluster state on failure
+        if: failure()
+        run: |
+          kubectl get all -n "${LFK_NAMESPACE}" -o wide || true
+          kubectl describe pod "${LFK_CRONJOB}-run-pod" -n "${LFK_NAMESPACE}" || true
+          kubectl logs "${LFK_CRONJOB}-run-pod" -n "${LFK_NAMESPACE}" || true

--- a/.github/workflows/e2e-cluster.yml
+++ b/.github/workflows/e2e-cluster.yml
@@ -85,13 +85,20 @@ jobs:
                 controller: true
                 blockOwnerDeletion: true
           spec:
+            # Suspended so the Job controller creates no pod of its own. Its
+            # pod would carry the modern batch.kubernetes.io/ labels and would
+            # be the one lfk resolves, leaving the legacy-label pod below
+            # unused and the fallback branch untested. The command still emits
+            # the marker, so a cluster that ignores suspend does not turn this
+            # into a silent timeout.
+            suspend: true
             template:
               spec:
                 restartPolicy: Never
                 containers:
                   - name: backup
                     image: busybox:1.36
-                    command: ["sh", "-c", "echo backup"]
+                    command: ["sh", "-c", "echo ${LFK_E2E_LOG_MARKER} && sleep 120"]
           EOF
 
           job_uid=$(kubectl get job "${LFK_CRONJOB}-run" -n "${LFK_NAMESPACE}" -o jsonpath='{.metadata.uid}')

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -13,7 +13,7 @@ import (
 // clusterStartupTimeout is longer than startupTimeout: a real apiserver
 // connection and RBAC self-check are slower than the demo fake's in-memory
 // client.
-const clusterStartupTimeout = 30 * time.Second
+const clusterStartupTimeout = 90 * time.Second
 
 // TestClusterModeCronJobLogs opens the seeded CronJob's logs (TASK-896)
 // against a real cluster, unlike TestDemoModeCronJobLogs's fake selectors.

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -37,12 +37,13 @@ func TestClusterModeCronJobLogs(t *testing.T) {
 	// Same navigation as TestDemoModeCronJobLogs, but each keystroke waits
 	// for its target's own text first - a real apiserver's context and
 	// discovery lists populate too slowly for a fixed sleep to outlast.
-	waitForThenSend(t, out, "kind-lfk-e2e", ptmx, "\r", clusterStartupTimeout)
-	waitForThenSend(t, out, "CronJobs", ptmx, "/CronJobs\r", clusterStartupTimeout)
-	waitForThenSend(t, out, "nightly-backup", ptmx, "\r", clusterStartupTimeout)
-	waitForThenSend(t, out, "nightly-backup", ptmx, "\x0c", clusterStartupTimeout) // ctrl+l: open the fullscreen log viewer
+	at := waitForThenSend(t, out, "kind-lfk-e2e", ptmx, "\r", clusterStartupTimeout)
+	at = waitForNewThenSend(t, out, at, "CronJobs", ptmx, "/CronJobs\r", clusterStartupTimeout)
+	at = waitForNewThenSend(t, out, at, "nightly-backup", ptmx, "\r", clusterStartupTimeout)
+	// ctrl+l opens the fullscreen log viewer.
+	at = waitForNewThenSend(t, out, at, "nightly-backup", ptmx, "\x0c", clusterStartupTimeout)
 
-	waitFor(t, out, marker, clusterStartupTimeout)
+	waitForAfter(t, out, at, marker, clusterStartupTimeout)
 
 	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {
 		t.Fatalf("lfk panicked; pty output:\n%s\nstderr:\n%s", out.String(), stderr.String())

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -34,15 +34,13 @@ func TestClusterModeCronJobLogs(t *testing.T) {
 
 	ptmx, out, stderr := runUnderPty(t, cmd)
 
-	// Same navigation as TestDemoModeCronJobLogs: select the (only) context,
-	// jump to the CronJobs resource type, select the (only) row, open logs.
-	sendKeys(t, ptmx, "\r")
-	time.Sleep(300 * time.Millisecond)
-	sendKeys(t, ptmx, "/CronJobs\r")
-	time.Sleep(300 * time.Millisecond)
-	sendKeys(t, ptmx, "\r")
-	time.Sleep(300 * time.Millisecond)
-	sendKeys(t, ptmx, "\x0c") // ctrl+l: open the fullscreen log viewer
+	// Same navigation as TestDemoModeCronJobLogs, but each keystroke waits
+	// for its target's own text first - a real apiserver's context and
+	// discovery lists populate too slowly for a fixed sleep to outlast.
+	waitForThenSend(t, out, "kind-lfk-e2e", ptmx, "\r", clusterStartupTimeout)
+	waitForThenSend(t, out, "CronJobs", ptmx, "/CronJobs\r", clusterStartupTimeout)
+	waitForThenSend(t, out, "nightly-backup", ptmx, "\r", clusterStartupTimeout)
+	waitForThenSend(t, out, "nightly-backup", ptmx, "\x0c", clusterStartupTimeout) // ctrl+l: open the fullscreen log viewer
 
 	waitFor(t, out, marker, clusterStartupTimeout)
 

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -1,0 +1,55 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// clusterStartupTimeout is longer than startupTimeout: a real apiserver
+// connection and RBAC self-check are slower than the demo fake's in-memory
+// client.
+const clusterStartupTimeout = 30 * time.Second
+
+// TestClusterModeCronJobLogs opens the seeded CronJob's logs (TASK-896)
+// against a real cluster, unlike TestDemoModeCronJobLogs's fake selectors.
+// Skipped without one - .github/workflows/e2e-cluster.yml provisions it.
+func TestClusterModeCronJobLogs(t *testing.T) {
+	if os.Getenv("LFK_E2E_REAL_CLUSTER") == "" {
+		t.Skip("LFK_E2E_REAL_CLUSTER not set; this test needs a real cluster, see .github/workflows/e2e-cluster.yml")
+	}
+	marker := os.Getenv("LFK_E2E_LOG_MARKER")
+	if marker == "" {
+		t.Fatal("LFK_E2E_LOG_MARKER must be set alongside LFK_E2E_REAL_CLUSTER")
+	}
+
+	binPath := buildBinary(t)
+
+	cmd := exec.Command(binPath)
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color") // KUBECONFIG comes from the CI job's environment
+
+	ptmx, out, stderr := runUnderPty(t, cmd)
+
+	// Same navigation as TestDemoModeCronJobLogs: select the (only) context,
+	// jump to the CronJobs resource type, select the (only) row, open logs.
+	sendKeys(t, ptmx, "\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "/CronJobs\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "\x0c") // ctrl+l: open the fullscreen log viewer
+
+	waitFor(t, out, marker, clusterStartupTimeout)
+
+	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {
+		t.Fatalf("lfk panicked; pty output:\n%s\nstderr:\n%s", out.String(), stderr.String())
+	}
+	if strings.Contains(out.String(), "No runs yet") {
+		t.Fatalf("CronJob log resolution reported no runs; pty output:\n%s", out.String())
+	}
+}

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -89,6 +89,15 @@ func waitFor(t *testing.T, out *output, substr string, timeout time.Duration) {
 	t.Fatalf("timed out after %s waiting for %q; captured output:\n%s", timeout, substr, out.String())
 }
 
+// waitForThenSend waits for substr before sending keys - a fixed sleep
+// between keystrokes is a timing guess that only holds on a fast, unloaded
+// machine (TASK-896: it failed against a real apiserver's slower startup).
+func waitForThenSend(t *testing.T, out *output, substr string, f *os.File, keys string, timeout time.Duration) {
+	t.Helper()
+	waitFor(t, out, substr, timeout)
+	sendKeys(t, f, keys)
+}
+
 // runUnderPty starts cmd inside a pty and registers cleanup that kills it -
 // lfk is a TUI that otherwise sits waiting for input forever.
 func runUnderPty(t *testing.T, cmd *exec.Cmd) (ptmx *os.File, out, stderr *output) {
@@ -203,12 +212,9 @@ func TestDemoModeCronJobLogs(t *testing.T) {
 	ptmx, out, stderr := startDemoUnderPty(t)
 
 	sendKeys(t, ptmx, "\r")
-	time.Sleep(300 * time.Millisecond)
-	sendKeys(t, ptmx, "/CronJobs\r")
-	time.Sleep(300 * time.Millisecond)
-	sendKeys(t, ptmx, "\r")
-	time.Sleep(300 * time.Millisecond)
-	sendKeys(t, ptmx, "\x0c") // ctrl+l: open the fullscreen log viewer
+	waitForThenSend(t, out, "CronJobs", ptmx, "/CronJobs\r", startupTimeout)
+	waitForThenSend(t, out, demo.CronJobNightlyBackup, ptmx, "\r", startupTimeout)
+	waitForThenSend(t, out, demo.CronJobNightlyBackup, ptmx, "\x0c", startupTimeout) // ctrl+l: open the fullscreen log viewer
 
 	waitFor(t, out, demo.JobNightlyBackupRun, startupTimeout)
 

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -86,27 +86,10 @@ func waitFor(t *testing.T, out *output, substr string, timeout time.Duration) {
 	t.Fatalf("timed out after %s waiting for %q; captured output:\n%s", timeout, substr, out.String())
 }
 
-// startDemoUnderPty builds lfk, launches it under --demo inside a pty, and
-// registers cleanup that kills the process. Startup is already confirmed
-// (DEMO badge rendered, no panic) by the time it returns.
-func startDemoUnderPty(t *testing.T) (ptmx *os.File, out, stderr *output) {
+// runUnderPty starts cmd inside a pty and registers cleanup that kills it -
+// lfk is a TUI that otherwise sits waiting for input forever.
+func runUnderPty(t *testing.T, cmd *exec.Cmd) (ptmx *os.File, out, stderr *output) {
 	t.Helper()
-	binPath := buildBinary(t)
-
-	home := t.TempDir()
-	kubeconfig := filepath.Join(home, "kubeconfig")
-
-	cmd := exec.Command(binPath, "--demo")
-	// An explicit, minimal env -- not os.Environ() plus overrides -- so a
-	// developer's own XDG_CONFIG_HOME, LFK_CONFIG_DIR, or KUBECONFIG_DIR
-	// can never leak a real config or kubeconfig into the demo run.
-	cmd.Env = []string{
-		"HOME=" + home,
-		"KUBECONFIG=" + kubeconfig,
-		"PATH=" + os.Getenv("PATH"),
-		"TERM=xterm-256color",
-	}
-
 	stderr = &output{}
 	cmd.Stderr = stderr // stdout must stay on the pty, or bubbletea's terminal handshake hangs
 
@@ -132,8 +115,6 @@ func startDemoUnderPty(t *testing.T) (ptmx *os.File, out, stderr *output) {
 		}
 	}()
 
-	// Always kill the process, however the test ends -- it's a TUI that
-	// otherwise sits waiting for input forever.
 	t.Cleanup(func() {
 		_ = ptmx.Close()
 		_ = cmd.Process.Kill()
@@ -156,6 +137,31 @@ func startDemoUnderPty(t *testing.T) (ptmx *os.File, out, stderr *output) {
 			t.Logf("lfk stderr:\n%s", s)
 		}
 	})
+
+	return ptmx, out, stderr
+}
+
+// startDemoUnderPty builds lfk and launches it under --demo. Startup is
+// already confirmed (DEMO badge rendered, no panic) by the time it returns.
+func startDemoUnderPty(t *testing.T) (ptmx *os.File, out, stderr *output) {
+	t.Helper()
+	binPath := buildBinary(t)
+
+	home := t.TempDir()
+	kubeconfig := filepath.Join(home, "kubeconfig")
+
+	cmd := exec.Command(binPath, "--demo")
+	// An explicit, minimal env -- not os.Environ() plus overrides -- so a
+	// developer's own XDG_CONFIG_HOME, LFK_CONFIG_DIR, or KUBECONFIG_DIR
+	// can never leak a real config or kubeconfig into the demo run.
+	cmd.Env = []string{
+		"HOME=" + home,
+		"KUBECONFIG=" + kubeconfig,
+		"PATH=" + os.Getenv("PATH"),
+		"TERM=xterm-256color",
+	}
+
+	ptmx, out, stderr = runUnderPty(t, cmd)
 
 	waitFor(t, out, "DEMO", startupTimeout)
 	if strings.Contains(out.String(), "panic:") {

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -92,10 +92,40 @@ func waitFor(t *testing.T, out *output, substr string, timeout time.Duration) {
 // waitForThenSend waits for substr before sending keys - a fixed sleep
 // between keystrokes is a timing guess that only holds on a fast, unloaded
 // machine (TASK-896: it failed against a real apiserver's slower startup).
-func waitForThenSend(t *testing.T, out *output, substr string, f *os.File, keys string, timeout time.Duration) {
+//
+// It searches only output produced after the previous step, because the buffer
+// is never cleared and a marker that appeared once would satisfy every later
+// wait for free. A real case: the startup dashboard lists an UnexpectedJob
+// warning naming the CronJob, so a whole-buffer wait for that name passes
+// before any key is sent.
+func waitForThenSend(t *testing.T, out *output, substr string, f *os.File, keys string, timeout time.Duration) int {
 	t.Helper()
-	waitFor(t, out, substr, timeout)
+	return waitForNewThenSend(t, out, 0, substr, f, keys, timeout)
+}
+
+// waitForNewThenSend is waitForThenSend scoped to output after offset. It
+// returns the buffer length at the moment the keys were sent, to pass as the
+// next step's offset.
+func waitForNewThenSend(t *testing.T, out *output, offset int, substr string, f *os.File, keys string, timeout time.Duration) int {
+	t.Helper()
+	waitForAfter(t, out, offset, substr, timeout)
+	sent := len(out.String())
 	sendKeys(t, f, keys)
+	return sent
+}
+
+// waitForAfter polls for substr in the output written after offset.
+func waitForAfter(t *testing.T, out *output, offset int, substr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s := out.String(); len(s) > offset && strings.Contains(s[offset:], substr) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %q in output past byte %d; captured output:\n%s",
+		timeout, substr, offset, out.String())
 }
 
 // runUnderPty starts cmd inside a pty and registers cleanup that kills it -
@@ -212,11 +242,12 @@ func TestDemoModeCronJobLogs(t *testing.T) {
 	ptmx, out, stderr := startDemoUnderPty(t)
 
 	sendKeys(t, ptmx, "\r")
-	waitForThenSend(t, out, "CronJobs", ptmx, "/CronJobs\r", startupTimeout)
-	waitForThenSend(t, out, demo.CronJobNightlyBackup, ptmx, "\r", startupTimeout)
-	waitForThenSend(t, out, demo.CronJobNightlyBackup, ptmx, "\x0c", startupTimeout) // ctrl+l: open the fullscreen log viewer
+	at := waitForThenSend(t, out, "CronJobs", ptmx, "/CronJobs\r", startupTimeout)
+	at = waitForNewThenSend(t, out, at, demo.CronJobNightlyBackup, ptmx, "\r", startupTimeout)
+	// ctrl+l opens the fullscreen log viewer.
+	at = waitForNewThenSend(t, out, at, demo.CronJobNightlyBackup, ptmx, "\x0c", startupTimeout)
 
-	waitFor(t, out, demo.JobNightlyBackupRun, startupTimeout)
+	waitForAfter(t, out, at, demo.JobNightlyBackupRun, startupTimeout)
 
 	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {
 		t.Fatalf("lfk panicked; pty output:\n%s\nstderr:\n%s", out.String(), stderr.String())

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/janosmiko/lfk/internal/k8s/demo"
 )
 
 const (
@@ -85,10 +86,11 @@ func waitFor(t *testing.T, out *output, substr string, timeout time.Duration) {
 	t.Fatalf("timed out after %s waiting for %q; captured output:\n%s", timeout, substr, out.String())
 }
 
-// TestDemoModeStartup launches `lfk --demo` under a pty with HOME and
-// KUBECONFIG pointed at an empty temp dir, then checks it renders the DEMO
-// badge and a seeded workload without panicking.
-func TestDemoModeStartup(t *testing.T) {
+// startDemoUnderPty builds lfk, launches it under --demo inside a pty, and
+// registers cleanup that kills the process. Startup is already confirmed
+// (DEMO badge rendered, no panic) by the time it returns.
+func startDemoUnderPty(t *testing.T) (ptmx *os.File, out, stderr *output) {
+	t.Helper()
 	binPath := buildBinary(t)
 
 	home := t.TempDir()
@@ -105,16 +107,16 @@ func TestDemoModeStartup(t *testing.T) {
 		"TERM=xterm-256color",
 	}
 
-	stderr := &output{}
+	stderr = &output{}
 	cmd.Stderr = stderr // stdout must stay on the pty, or bubbletea's terminal handshake hangs
 
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 200})
+	var err error
+	ptmx, err = pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 200})
 	if err != nil {
 		t.Fatalf("starting lfk under pty: %v", err)
 	}
-	defer func() { _ = ptmx.Close() }()
 
-	out := &output{}
+	out = &output{}
 	readDone := make(chan struct{})
 	go func() {
 		defer close(readDone)
@@ -132,7 +134,8 @@ func TestDemoModeStartup(t *testing.T) {
 
 	// Always kill the process, however the test ends -- it's a TUI that
 	// otherwise sits waiting for input forever.
-	defer func() {
+	t.Cleanup(func() {
+		_ = ptmx.Close()
 		_ = cmd.Process.Kill()
 
 		waitErr := make(chan error, 1)
@@ -152,12 +155,20 @@ func TestDemoModeStartup(t *testing.T) {
 		if s := stderr.String(); s != "" {
 			t.Logf("lfk stderr:\n%s", s)
 		}
-	}()
+	})
 
 	waitFor(t, out, "DEMO", startupTimeout)
 	if strings.Contains(out.String(), "panic:") {
 		t.Fatalf("lfk panicked during startup:\n%s", out.String())
 	}
+
+	return ptmx, out, stderr
+}
+
+// TestDemoModeStartup checks lfk --demo renders a seeded workload without
+// panicking.
+func TestDemoModeStartup(t *testing.T) {
+	ptmx, out, stderr := startDemoUnderPty(t)
 
 	// Drill into the (only) context, then jump to the Deployments resource
 	// type via search rather than counting arrow-key presses: the
@@ -173,6 +184,30 @@ func TestDemoModeStartup(t *testing.T) {
 
 	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {
 		t.Fatalf("lfk panicked; pty output:\n%s\nstderr:\n%s", out.String(), stderr.String())
+	}
+}
+
+// TestDemoModeCronJobLogs opens the seeded CronJob's logs (TASK-896) - a
+// wiring check only, since internal/democli hand-crafts its kubectl
+// responses. Real label selector semantics need the e2e-cluster CI job.
+func TestDemoModeCronJobLogs(t *testing.T) {
+	ptmx, out, stderr := startDemoUnderPty(t)
+
+	sendKeys(t, ptmx, "\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "/CronJobs\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "\r")
+	time.Sleep(300 * time.Millisecond)
+	sendKeys(t, ptmx, "\x0c") // ctrl+l: open the fullscreen log viewer
+
+	waitFor(t, out, demo.JobNightlyBackupRun, startupTimeout)
+
+	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {
+		t.Fatalf("lfk panicked; pty output:\n%s\nstderr:\n%s", out.String(), stderr.String())
+	}
+	if strings.Contains(out.String(), "No runs yet") {
+		t.Fatalf("CronJob log resolution reported no runs; pty output:\n%s", out.String())
 	}
 }
 

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -30,7 +30,10 @@ import (
 )
 
 const (
-	startupTimeout  = 15 * time.Second
+	// A pty wait is wall-clock, so a loaded machine eats the budget rather than
+	// the app being slow. 15s failed on a laptop running three test suites at
+	// once, and a shared CI runner is no less contended.
+	startupTimeout  = 45 * time.Second
 	shutdownTimeout = 5 * time.Second
 )
 

--- a/e2e/waitfor_test.go
+++ b/e2e/waitfor_test.go
@@ -1,0 +1,41 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// The pty buffer is never cleared, so a marker rendered during startup would
+// satisfy every later wait for free. That is not hypothetical: the cluster
+// dashboard lists an UnexpectedJob warning naming the CronJob, which is the
+// same string the navigation waits on.
+func TestWaitForAfter_IgnoresOutputBeforeOffset(t *testing.T) {
+	out := &output{}
+	if _, err := out.Write([]byte("UnexpectedJob: CronJob/nightly-backup")); err != nil {
+		t.Fatal(err)
+	}
+	offset := len(out.String())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		waitForAfter(t, out, offset, "nightly-backup", 2*time.Second)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("returned on a marker that only appears before the offset")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	if _, err := out.Write([]byte("\nrow: nightly-backup")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not return once the marker appeared after the offset")
+	}
+}

--- a/internal/democli/get.go
+++ b/internal/democli/get.go
@@ -6,25 +6,56 @@ import (
 	"strings"
 )
 
-// runGet emulates `kubectl get <kind>/<name> -n <ns> --context <ctx> -o
-// json`, the only "get" shape the app issues (kubectlGetPodSelector in
-// internal/app/commands_logs.go, to discover a parent resource's pod
-// selector before following its logs). It returns a minimal JSON object
-// carrying a synthetic selector derived from the resource name, which is
-// enough for the caller to extract a usable "-l" value — the exact label set
-// need not match real cluster data since demo log generation does not filter
-// by it.
+// runGet dispatches by shape: the CronJob log path in
+// internal/app/commands_logs_cronjob.go issues "get cronjob NAME", "get
+// jobs", and "get pods -l SELECTOR", answered by get_cronjob.go.
 func runGet(args []string, stdout io.Writer) error {
-	var resourceRef string
+	positional, selector, hasSelector := parseGetArgs(args)
+
+	switch {
+	case len(positional) >= 1 && positional[0] == "cronjob":
+		name := ""
+		if len(positional) > 1 {
+			name = positional[1]
+		}
+		return writeCronJobUID(stdout, name)
+	case len(positional) >= 1 && positional[0] == "jobs":
+		return writeOwnedJobsList(stdout)
+	case len(positional) >= 1 && positional[0] == "pods" && hasSelector:
+		return writePodNamesForSelector(stdout, selector)
+	default:
+		return runGetResourceSelector(positional, stdout)
+	}
+}
+
+// parseGetArgs collects every positional argument (in order) and the "-l"
+// selector value, if any, skipping the values of flags this stub never
+// inspects otherwise (-n, --context, -o).
+func parseGetArgs(args []string) (positional []string, selector string, hasSelector bool) {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "-n", "--context", "-o":
 			i++ // skip the flag's value; unused by this stub
+		case "-l":
+			i++
+			if i < len(args) {
+				selector, hasSelector = args[i], true
+			}
 		default:
-			if !strings.HasPrefix(args[i], "-") && resourceRef == "" {
-				resourceRef = args[i]
+			if !strings.HasPrefix(args[i], "-") {
+				positional = append(positional, args[i])
 			}
 		}
+	}
+	return positional, selector, hasSelector
+}
+
+// runGetResourceSelector answers kubectlGetPodSelector's `get <kind>/<name>
+// -o json` (internal/app/commands_logs.go) with a synthetic selector.
+func runGetResourceSelector(positional []string, stdout io.Writer) error {
+	var resourceRef string
+	if len(positional) > 0 {
+		resourceRef = positional[0]
 	}
 
 	kind, name, ok := strings.Cut(resourceRef, "/")

--- a/internal/democli/get_cronjob.go
+++ b/internal/democli/get_cronjob.go
@@ -1,0 +1,48 @@
+package democli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+// cronJobLogSelector is the only selector writePodNamesForSelector answers -
+// the prefixed pair buildCronJobOwnedPod (internal/k8s/demo/jobs.go) sets.
+// The legacy fallback needs a real apiserver to exercise.
+func cronJobLogSelector() string {
+	return fmt.Sprintf("batch.kubernetes.io/job-name=%s,batch.kubernetes.io/controller-uid=%s",
+		demo.JobNightlyBackupRun, demo.UIDJobNightlyBackupRun)
+}
+
+// writeCronJobUID answers `get cronjob <name> -o json`. An unrecognized name
+// gets an empty uid, which getCronJobUID turns into a real error rather
+// than "no runs yet".
+func writeCronJobUID(stdout io.Writer, name string) error {
+	uid := ""
+	if name == demo.CronJobNightlyBackup {
+		uid = demo.UIDCronJobNightlyBackup
+	}
+	_, err := fmt.Fprintf(stdout, `{"metadata":{"uid":%q}}`+"\n", uid)
+	return err
+}
+
+// writeOwnedJobsList answers `kubectl get jobs -o json`: the demo cluster
+// has exactly one Job, owned by the one seeded CronJob.
+func writeOwnedJobsList(stdout io.Writer) error {
+	body := fmt.Sprintf(
+		`{"items":[{"metadata":{"name":%q,"uid":%q,"creationTimestamp":"2024-01-01T00:00:00Z",`+
+			`"ownerReferences":[{"kind":"CronJob","uid":%q}]}}]}`,
+		demo.JobNightlyBackupRun, demo.UIDJobNightlyBackupRun, demo.UIDCronJobNightlyBackup)
+	_, err := fmt.Fprintln(stdout, body)
+	return err
+}
+
+// writePodNamesForSelector answers `kubectl get pods -l <selector> -o name`.
+func writePodNamesForSelector(stdout io.Writer, selector string) error {
+	if selector != cronJobLogSelector() {
+		return nil // no match: an empty result, same as a real cluster's
+	}
+	_, err := fmt.Fprintf(stdout, "pod/%s\n", demo.PodNightlyBackupRun)
+	return err
+}

--- a/internal/democli/get_cronjob_test.go
+++ b/internal/democli/get_cronjob_test.go
@@ -1,0 +1,166 @@
+package democli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/k8s/demo"
+)
+
+func TestRun_GetCronJob_ReturnsUID(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"get", "cronjob", demo.CronJobNightlyBackup, "-n", demo.NamespaceJobs, "--context", "demo", "-o", "json"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var obj struct {
+		Metadata struct {
+			UID string `json:"uid"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &obj); err != nil {
+		t.Fatalf("unmarshalling stdout %q: %v", stdout.String(), err)
+	}
+	if obj.Metadata.UID != demo.UIDCronJobNightlyBackup {
+		t.Errorf("uid = %q, want %q", obj.Metadata.UID, demo.UIDCronJobNightlyBackup)
+	}
+}
+
+func TestRun_GetCronJob_UnknownName_ReturnsEmptyUID(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"get", "cronjob", "no-such-cronjob", "-n", demo.NamespaceJobs, "--context", "demo", "-o", "json"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if strings.Contains(stdout.String(), demo.UIDCronJobNightlyBackup) {
+		t.Errorf("stdout = %q, want no uid for an unseeded CronJob name", stdout.String())
+	}
+}
+
+func TestRun_GetJobs_ReturnsJobOwnedByCronJob(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"get", "jobs", "-n", demo.NamespaceJobs, "--context", "demo", "-o", "json"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name            string `json:"name"`
+				UID             string `json:"uid"`
+				OwnerReferences []struct {
+					Kind string `json:"kind"`
+					UID  string `json:"uid"`
+				} `json:"ownerReferences"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshalling stdout %q: %v", stdout.String(), err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("got %d items, want 1", len(list.Items))
+	}
+	item := list.Items[0]
+	if item.Metadata.Name != demo.JobNightlyBackupRun || item.Metadata.UID != demo.UIDJobNightlyBackupRun {
+		t.Errorf("job = %+v, want name=%q uid=%q", item.Metadata, demo.JobNightlyBackupRun, demo.UIDJobNightlyBackupRun)
+	}
+	if len(item.Metadata.OwnerReferences) != 1 ||
+		item.Metadata.OwnerReferences[0].Kind != "CronJob" ||
+		item.Metadata.OwnerReferences[0].UID != demo.UIDCronJobNightlyBackup {
+		t.Errorf("ownerReferences = %+v, want a CronJob owner with uid %q",
+			item.Metadata.OwnerReferences, demo.UIDCronJobNightlyBackup)
+	}
+}
+
+func TestRun_GetPods_MatchingSelector_ReturnsPodName(t *testing.T) {
+	selector := fmt.Sprintf("batch.kubernetes.io/job-name=%s,batch.kubernetes.io/controller-uid=%s",
+		demo.JobNightlyBackupRun, demo.UIDJobNightlyBackupRun)
+
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"get", "pods", "-l", selector, "-n", demo.NamespaceJobs, "--context", "demo", "-o", "name"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := "pod/" + demo.PodNightlyBackupRun
+	if strings.TrimSpace(stdout.String()) != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestRun_GetPods_LegacySelector_ReturnsEmpty(t *testing.T) {
+	selector := fmt.Sprintf("job-name=%s,controller-uid=%s", demo.JobNightlyBackupRun, demo.UIDJobNightlyBackupRun)
+
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), []string{"get", "pods", "-l", selector, "-n", demo.NamespaceJobs, "--context", "demo", "-o", "name"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Errorf("stdout = %q, want empty - the demo pod does not carry legacy labels", stdout.String())
+	}
+}
+
+// TestCronJobLogResolution_FullChain replays resolveCronJobPodSelector's
+// three-call sequence through Run, proving the chain resolves end to end.
+func TestCronJobLogResolution_FullChain(t *testing.T) {
+	ctx := t.Context()
+
+	var cronJobOut, jobsOut bytes.Buffer
+	if err := Run(ctx, []string{"get", "cronjob", demo.CronJobNightlyBackup, "-n", demo.NamespaceJobs, "--context", "demo", "-o", "json"}, &cronJobOut, &bytes.Buffer{}); err != nil {
+		t.Fatalf("get cronjob: %v", err)
+	}
+	var cronJobObj struct {
+		Metadata struct {
+			UID string `json:"uid"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(cronJobOut.Bytes(), &cronJobObj); err != nil {
+		t.Fatalf("unmarshalling cronjob: %v", err)
+	}
+
+	if err := Run(ctx, []string{"get", "jobs", "-n", demo.NamespaceJobs, "--context", "demo", "-o", "json"}, &jobsOut, &bytes.Buffer{}); err != nil {
+		t.Fatalf("get jobs: %v", err)
+	}
+	var jobsList struct {
+		Items []struct {
+			Metadata struct {
+				Name            string `json:"name"`
+				UID             string `json:"uid"`
+				OwnerReferences []struct {
+					Kind string `json:"kind"`
+					UID  string `json:"uid"`
+				} `json:"ownerReferences"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(jobsOut.Bytes(), &jobsList); err != nil {
+		t.Fatalf("unmarshalling jobs: %v", err)
+	}
+
+	var jobName, jobUID string
+	for _, item := range jobsList.Items {
+		for _, ref := range item.Metadata.OwnerReferences {
+			if ref.Kind == "CronJob" && ref.UID == cronJobObj.Metadata.UID {
+				jobName, jobUID = item.Metadata.Name, item.Metadata.UID
+			}
+		}
+	}
+	if jobName == "" {
+		t.Fatalf("no Job owned by CronJob uid %q", cronJobObj.Metadata.UID)
+	}
+
+	selector := fmt.Sprintf("batch.kubernetes.io/job-name=%s,batch.kubernetes.io/controller-uid=%s", jobName, jobUID)
+	var podsOut bytes.Buffer
+	if err := Run(ctx, []string{"get", "pods", "-l", selector, "-n", demo.NamespaceJobs, "--context", "demo", "-o", "name"}, &podsOut, &bytes.Buffer{}); err != nil {
+		t.Fatalf("get pods: %v", err)
+	}
+	if strings.TrimSpace(podsOut.String()) == "" {
+		t.Fatalf("no pods matched selector %q, resolved from a real ownership chain walk", selector)
+	}
+}

--- a/internal/democli/get_cronjob_test.go
+++ b/internal/democli/get_cronjob_test.go
@@ -36,8 +36,19 @@ func TestRun_GetCronJob_UnknownName_ReturnsEmptyUID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if strings.Contains(stdout.String(), demo.UIDCronJobNightlyBackup) {
-		t.Errorf("stdout = %q, want no uid for an unseeded CronJob name", stdout.String())
+	// Rejecting only the seeded UID would pass on any other non-empty value,
+	// and a non-empty UID is what makes an unknown CronJob look real to the
+	// resolver.
+	var obj struct {
+		Metadata struct {
+			UID string `json:"uid"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &obj); err != nil {
+		t.Fatalf("stdout is not JSON: %v (%q)", err, stdout.String())
+	}
+	if obj.Metadata.UID != "" {
+		t.Errorf("metadata.uid = %q, want empty for an unseeded CronJob name", obj.Metadata.UID)
 	}
 }
 

--- a/internal/k8s/demo/demo_test.go
+++ b/internal/k8s/demo/demo_test.go
@@ -27,6 +27,7 @@ func seededGVRs() []schema.GroupVersionResource {
 		{Group: "apps", Version: "v1", Resource: "deployments"},
 		{Group: "apps", Version: "v1", Resource: "replicasets"},
 		{Group: "batch", Version: "v1", Resource: "jobs"},
+		{Group: "batch", Version: "v1", Resource: "cronjobs"},
 		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"},
 		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"},
 	}
@@ -217,6 +218,40 @@ func TestOwnerReferences_JobPodResolvesToJob(t *testing.T) {
 	assert.Equal(t, string(owners[0].UID), string(job.GetUID()))
 }
 
+// The CronJob -> Job -> Pod chain and the Pod's labels are what
+// resolveCronJobPodSelector (internal/app/commands_logs_cronjob.go) and its
+// demo-mode kubectl emulation (internal/democli/get_cronjob.go) both walk.
+func TestOwnerReferences_CronJobOwnedPodResolvesToCronJob(t *testing.T) {
+	dyn := NewDynamicClient()
+	ctx := t.Context()
+
+	pod, err := dyn.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).
+		Namespace(NamespaceJobs).Get(ctx, PodNightlyBackupRun, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, JobNightlyBackupRun, pod.GetLabels()["batch.kubernetes.io/job-name"])
+	assert.Equal(t, UIDJobNightlyBackupRun, pod.GetLabels()["batch.kubernetes.io/controller-uid"])
+
+	podOwners := pod.GetOwnerReferences()
+	require.Len(t, podOwners, 1)
+	assert.Equal(t, "Job", podOwners[0].Kind)
+	assert.Equal(t, JobNightlyBackupRun, podOwners[0].Name)
+
+	job, err := dyn.Resource(schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}).
+		Namespace(NamespaceJobs).Get(ctx, JobNightlyBackupRun, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(podOwners[0].UID), string(job.GetUID()))
+
+	jobOwners := job.GetOwnerReferences()
+	require.Len(t, jobOwners, 1)
+	assert.Equal(t, "CronJob", jobOwners[0].Kind)
+	assert.Equal(t, CronJobNightlyBackup, jobOwners[0].Name)
+
+	cronJob, err := dyn.Resource(schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"}).
+		Namespace(NamespaceJobs).Get(ctx, CronJobNightlyBackup, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(jobOwners[0].UID), string(cronJob.GetUID()))
+}
+
 func TestSeedObjects_CarryManagedFields(t *testing.T) {
 	dyn := NewDynamicClient()
 	ctx := t.Context()
@@ -265,6 +300,7 @@ func TestNewClientset_DiscoveryReportsSeededKinds(t *testing.T) {
 	assert.Contains(t, kinds, "Pod")
 	assert.Contains(t, kinds, "Deployment")
 	assert.Contains(t, kinds, "Job")
+	assert.Contains(t, kinds, "CronJob")
 	assert.Contains(t, kinds, "Service")
 	assert.Contains(t, kinds, "ConfigMap")
 	assert.Contains(t, kinds, "Node")

--- a/internal/k8s/demo/discovery.go
+++ b/internal/k8s/demo/discovery.go
@@ -31,7 +31,8 @@ func ListKinds() map[schema.GroupVersionResource]string {
 		{Group: "apps", Version: "v1", Resource: "replicasets"}:  "ReplicaSetList",
 		{Group: "apps", Version: "v1", Resource: "statefulsets"}: "StatefulSetList",
 
-		{Group: "batch", Version: "v1", Resource: "jobs"}: "JobList",
+		{Group: "batch", Version: "v1", Resource: "jobs"}:     "JobList",
+		{Group: "batch", Version: "v1", Resource: "cronjobs"}: "CronJobList",
 
 		{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}:  "PodMetricsList",
 		{Group: "metrics.k8s.io", Version: "v1", Resource: "pods"}:       "PodMetricsList",
@@ -90,6 +91,7 @@ func APIResourceLists() []*metav1.APIResourceList {
 			GroupVersion: "batch/v1",
 			APIResources: []metav1.APIResource{
 				{Name: "jobs", Namespaced: true, Kind: "Job", Verbs: rw},
+				{Name: "cronjobs", Namespaced: true, Kind: "CronJob", Verbs: rw},
 			},
 		},
 		{

--- a/internal/k8s/demo/fake.go
+++ b/internal/k8s/demo/fake.go
@@ -59,10 +59,11 @@ func seedMetrics(dyn *dynamicfake.FakeDynamicClient) {
 // typedObjects returns every seed object as its typed API type — what the
 // fake clientset's tracker and Discovery() need.
 func typedObjects() []runtime.Object {
-	objs := make([]runtime.Object, 0, 17)
+	objs := make([]runtime.Object, 0, 20)
 	objs = append(objs,
 		buildDeployment(), buildReplicaSet(), buildService(), buildConfigMap(),
 		buildJob(), buildJobPod(),
+		buildCronJob(), buildCronJobOwnedJob(), buildCronJobOwnedPod(),
 	)
 	for _, ns := range buildNamespaces() {
 		objs = append(objs, ns)

--- a/internal/k8s/demo/jobs.go
+++ b/internal/k8s/demo/jobs.go
@@ -9,6 +9,151 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
+// nightlyBackupContainer is shared by the CronJob's own template and its
+// one seeded run, so both describe the same workload.
+func nightlyBackupContainer() corev1.Container {
+	return corev1.Container{Name: "backup", Image: "ghcr.io/example/nightly-backup:1.0.0"}
+}
+
+func buildCronJob() *batchv1.CronJob {
+	created := demoEpoch.Add(-30 * 24 * time.Hour)
+	lastSchedule := demoEpoch.Add(-25 * time.Minute)
+	suspend := false
+	return &batchv1.CronJob{
+		TypeMeta: metav1.TypeMeta{APIVersion: "batch/v1", Kind: "CronJob"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              CronJobNightlyBackup,
+			Namespace:         NamespaceJobs,
+			UID:               k8stypes.UID(UIDCronJobNightlyBackup),
+			CreationTimestamp: metav1.NewTime(created),
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kubectl-client-side-apply", "Update",
+					`{"f:spec":{"f:schedule":{},"f:jobTemplate":{}}}`, created),
+			},
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "0 2 * * *",
+			Suspend:  &suspend,
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers:    []corev1.Container{nightlyBackupContainer()},
+						},
+					},
+				},
+			},
+		},
+		Status: batchv1.CronJobStatus{
+			LastScheduleTime:   ptrTime(lastSchedule),
+			LastSuccessfulTime: ptrTime(lastSchedule.Add(3 * time.Minute)),
+		},
+	}
+}
+
+// buildCronJobOwnedJob is owned by CronJobNightlyBackup via a Controller
+// ownerReference - the shape latestOwnedJob (internal/app/commands_logs_cronjob.go) matches on.
+func buildCronJobOwnedJob() *batchv1.Job {
+	started := demoEpoch.Add(-25 * time.Minute)
+	completed := demoEpoch.Add(-22 * time.Minute)
+	controller, block := true, true
+	return &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{APIVersion: "batch/v1", Kind: "Job"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              JobNightlyBackupRun,
+			Namespace:         NamespaceJobs,
+			UID:               k8stypes.UID(UIDJobNightlyBackupRun),
+			CreationTimestamp: metav1.NewTime(started),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1", Kind: "CronJob", Name: CronJobNightlyBackup,
+					UID: k8stypes.UID(UIDCronJobNightlyBackup), Controller: &controller, BlockOwnerDeletion: &block,
+				},
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("cronjob-controller", "Update",
+					`{"f:metadata":{"f:ownerReferences":{}},"f:spec":{"f:template":{}}}`, started),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"batch.kubernetes.io/job-name": JobNightlyBackupRun}},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers:    []corev1.Container{nightlyBackupContainer()},
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Succeeded:      1,
+			StartTime:      ptrTime(started),
+			CompletionTime: ptrTime(completed),
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+// buildCronJobOwnedPod carries only the modern batch.kubernetes.io/-prefixed
+// labels, the pair internal/democli/get_cronjob.go answers - the legacy
+// fallback needs a real apiserver to exercise.
+func buildCronJobOwnedPod() *corev1.Pod {
+	started := demoEpoch.Add(-25 * time.Minute)
+	finished := demoEpoch.Add(-22 * time.Minute)
+	controller, block := true, true
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PodNightlyBackupRun,
+			Namespace: NamespaceJobs,
+			UID:       k8stypes.UID(uidPodNightlyBackupRun),
+			Labels: map[string]string{
+				"batch.kubernetes.io/job-name":       JobNightlyBackupRun,
+				"batch.kubernetes.io/controller-uid": UIDJobNightlyBackupRun,
+			},
+			CreationTimestamp: metav1.NewTime(started),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1", Kind: "Job", Name: JobNightlyBackupRun,
+					UID: k8stypes.UID(UIDJobNightlyBackupRun), Controller: &controller, BlockOwnerDeletion: &block,
+				},
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				managedField("kube-controller-manager", "Update",
+					`{"f:metadata":{"f:ownerReferences":{},"f:labels":{}}}`, started),
+				managedField("kubelet", "Update",
+					`{"f:status":{"f:containerStatuses":{},"f:phase":{}}}`, finished),
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:      NodeWorker1,
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers:    []corev1.Container{nightlyBackupContainer()},
+		},
+		Status: corev1.PodStatus{
+			Phase:     corev1.PodSucceeded,
+			StartTime: ptrTime(started),
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "backup",
+					Ready: false,
+					Image: "ghcr.io/example/nightly-backup:1.0.0",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode:   0,
+							Reason:     "Completed",
+							StartedAt:  metav1.NewTime(started),
+							FinishedAt: metav1.NewTime(finished),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func buildJob() *batchv1.Job {
 	started := demoEpoch.Add(-25 * time.Minute)
 	backoffLimit := int32(4)

--- a/internal/k8s/demo/names.go
+++ b/internal/k8s/demo/names.go
@@ -30,6 +30,12 @@ const (
 
 	JobDBMigrate = "db-migrate-28472913"
 	PodDBMigrate = "db-migrate-28472913-9f2lk"
+
+	// CronJobNightlyBackup -> JobNightlyBackupRun -> PodNightlyBackupRun is
+	// the ownership chain internal/democli/get_cronjob.go answers.
+	CronJobNightlyBackup = "nightly-backup"
+	JobNightlyBackupRun  = "nightly-backup-28571940"
+	PodNightlyBackupRun  = "nightly-backup-28571940-h4qtz"
 )
 
 // uids are fixed so ownerReferences and event involvedObject links stay
@@ -52,6 +58,12 @@ const (
 
 	uidJobDBMigrate = "c0000000-0000-4000-8000-000000000001"
 	uidPodDBMigrate = "c0000000-0000-4000-8000-000000000002"
+
+	// Exported (unlike the uid* consts above): internal/democli/get_cronjob.go
+	// needs these to answer `kubectl get cronjob`/`get jobs` consistently.
+	UIDCronJobNightlyBackup = "c0000000-0000-4000-8000-000000000003"
+	UIDJobNightlyBackupRun  = "c0000000-0000-4000-8000-000000000004"
+	uidPodNightlyBackupRun  = "c0000000-0000-4000-8000-000000000005"
 
 	uidEventPodCrashBackOff   = "d0000000-0000-4000-8000-000000000001"
 	uidEventPodCrashUnhealthy = "d0000000-0000-4000-8000-000000000002"

--- a/internal/k8s/demo/ticker_test.go
+++ b/internal/k8s/demo/ticker_test.go
@@ -65,12 +65,8 @@ func podEffectivelyRunning(obj map[string]any) bool {
 	return false
 }
 
-// TestTicker_FullCycleInvariants drives the ticker across a full cycle
-// (the LCM of every per-field cycle length: healthyPodFlipEvery, len(
-// waitingReasons), len(deploymentReadyReplicaCycle)) and asserts the two
-// demo-polish invariants: Running pods stay a strict majority of all pods at
-// every tick, and the web Deployment reports fully ready for a majority of
-// the ticks in the cycle.
+// TestTicker_FullCycleInvariants checks Running pods stay a majority within
+// NamespaceDemo across a full cycle - Jobs-namespace pods sit fixed and would only dilute the ratio.
 func TestTicker_FullCycleInvariants(t *testing.T) {
 	dyn := NewDynamicClient()
 	tk := NewTicker(dyn, time.Hour)
@@ -91,7 +87,7 @@ func TestTicker_FullCycleInvariants(t *testing.T) {
 	for i := range cycleLen {
 		require.NoError(t, tk.Tick(ctx))
 
-		podList, err := dyn.Resource(podGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		podList, err := dyn.Resource(podGVR).Namespace(NamespaceDemo).List(ctx, metav1.ListOptions{})
 		require.NoError(t, err)
 
 		var running int

--- a/internal/k8s/demo/ticker_test.go
+++ b/internal/k8s/demo/ticker_test.go
@@ -65,8 +65,13 @@ func podEffectivelyRunning(obj map[string]any) bool {
 	return false
 }
 
-// TestTicker_FullCycleInvariants checks Running pods stay a majority within
-// NamespaceDemo across a full cycle - Jobs-namespace pods sit fixed and would only dilute the ratio.
+// TestTicker_FullCycleInvariants drives the ticker across a full cycle and
+// asserts both demo-polish invariants: Running pods stay a strict majority at
+// every tick, and the web Deployment reports fully ready for a majority of the
+// cycle.
+//
+// Pods are counted in NamespaceDemo only. The ticker mutates nothing outside
+// it, so the fixed Jobs-namespace pods would dilute a ratio they cannot move.
 func TestTicker_FullCycleInvariants(t *testing.T) {
 	dyn := NewDynamicClient()
 	tk := NewTicker(dyn, time.Hour)


### PR DESCRIPTION
> The scenario needs the CronJob log fix from #620, which is merged, so this targets `main` and carries only its own three commits.

The e2e suite drove the built binary in a pty under `--demo`, behind the `e2e` build tag. It talked to the demo fake, never to an apiserver, and no workflow ran it - `make e2e` was manual. That left every kubectl-shaped path checked only against fake `kubectl` scripts.

**It found a real bug on its first run.** The demo kubectl emulation had no handler for `get cronjob NAME`, `get jobs`, or `get pods -l SELECTOR`. So the CronJob log fix in #620, which passes against fake `kubectl` scripts, failed under `--demo` with `cronjob uid missing`. A unit test could not have caught this, because the fake scripts stand in for exactly the layer that was missing.

Two commits.

**`test:` demo coverage.** Seeds a CronJob to Job to Pod chain (`nightly-backup`), teaches the demo kubectl emulation the three calls it was missing, and adds `TestDemoModeCronJobLogs`. Reuses the existing pty driving rather than adding a second harness. This catches wiring breakage and nothing more - the test says so in its own comment.

**`ci:` a real cluster.** A new workflow provisions a kind cluster, applies a CronJob/Job/Pod fixture with server-assigned UIDs substituted in between calls, and runs `TestClusterModeCronJobLogs`. `ci.yml` is untouched, every action is pinned to a commit SHA, the job has a 15-minute bound, and teardown runs through the action's own `post` step regardless of outcome.

**The label coverage is split on purpose.** The demo pod carries only the modern `batch.kubernetes.io/` labels. The kind fixture carries only the legacy unprefixed `job-name` / `controller-uid` pair, so the CI lane is what finally forces the fallback branch of `resolveCronJobPodSelector` to be the one that matches. That branch has never been exercised against a real apiserver until now.

kind over k3d: no k3d tooling exists in this repo, and the thing under test is controller-manager label semantics, where fidelity to upstream matters.

## Test plan

- [x] `make e2e` - real run, `TestDemoModeStartup` PASS, `TestDemoModeCronJobLogs` PASS (3.67s), `TestClusterModeCronJobLogs` SKIP without `LFK_E2E_REAL_CLUSTER`
- [x] `go build ./...`, `go test ./...` (all packages), `golangci-lint run ./...` - 0 issues
- [x] `actionlint` on the workflow, including shellcheck over the `run:` blocks - 0 issues
- [ ] **The CI job itself has never run.** It needs this PR to exercise it

**Unverified, and it cannot be otherwise from a sandbox:** whether kind provisioning leaves `kubectl` and `lfk` pointed at the same kubeconfig on a real runner, whether the UID-substitution `kubectl apply` sequence behaves as scripted against a live apiserver, whether the pty navigation timing holds against slower RBAC-checked startup, and whether the 30-second `waitFor` budget is enough on `ubuntu-latest`. Watch this PR's own check.

One existing test changed: `TestTicker_FullCycleInvariants` counted Running pods cluster-wide, and the new static Pod tipped its majority. Narrowed to `NamespaceDemo`, which is the only namespace the ticker mutates - a fixed pod elsewhere dilutes a ratio it cannot move. Both invariants the test asserts are intact, and the comment describing them was restored after the narrowing dropped one.

Closes TASK-896.
