### PR TITLE
feat(logviewer): add config setting for log wrap

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -212,6 +212,7 @@ log_path: /tmp/lfk.log
 #   show_timestamps: false  # log line timestamps hidden on open
 #   preview_live: false     # right-pane live-log preview on explorer open (L to toggle)
 #   max_lines: 50000        # max retained log lines per tab (oldest dropped); clamped [1000, 1000000]
+#   wrap: false             # log lines wrapped on open (toggle: >)
 
 # ─── Viewer Defaults ─────────────────────────────────────────────────────────
 # Startup defaults for the fullscreen YAML / diff / describe viewers. A toggle

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -172,6 +172,7 @@ log_viewer:
   show_prefixes: true
   show_timestamps: false
   preview_live: false
+  wrap: false
 ```
 
 | Field | Type | Default | Description |
@@ -184,6 +185,7 @@ log_viewer:
 | `show_timestamps` | bool | `false` | Startup default for log line timestamps. Runtime toggle: `toggle_timestamps` (`s`). |
 | `preview_live` | bool | `false` | Startup default for the right-pane live-log preview. When true the explorer opens with live logs streaming in the right pane for the selected pod. Runtime toggle: `toggle_preview_logs` (`L`). |
 | `max_lines` | int | `50000` | Max streamed log lines retained per tab; once exceeded, the oldest lines are dropped so a long-running follow stays bounded in memory. Clamped to `[1000, 1000000]`. |
+| `wrap` | bool | `true` | Startup default for log line wrapping. Runtime toggle: `toggle_wrap` (`>`). |
 
 The deprecated flat keys `log_tail_lines`, `log_tail_lines_short`, and `log_render_ansi` are still accepted as aliases; when both a flat key and its `log_viewer` equivalent are set, `log_viewer` wins.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -185,7 +185,7 @@ log_viewer:
 | `show_timestamps` | bool | `false` | Startup default for log line timestamps. Runtime toggle: `toggle_timestamps` (`s`). |
 | `preview_live` | bool | `false` | Startup default for the right-pane live-log preview. When true the explorer opens with live logs streaming in the right pane for the selected pod. Runtime toggle: `toggle_preview_logs` (`L`). |
 | `max_lines` | int | `50000` | Max streamed log lines retained per tab; once exceeded, the oldest lines are dropped so a long-running follow stays bounded in memory. Clamped to `[1000, 1000000]`. |
-| `wrap` | bool | `true` | Startup default for log line wrapping. Runtime toggle: `toggle_wrap` (`>`). |
+| `wrap` | bool | `false` | Startup default for log line wrapping. Runtime toggle: `toggle_wrap` (`>`). |
 
 The deprecated flat keys `log_tail_lines`, `log_tail_lines_short`, and `log_render_ansi` are still accepted as aliases; when both a flat key and its `log_viewer` equivalent are set, `log_viewer` wins.
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -762,6 +762,11 @@
           "type": "integer",
           "description": "Maximum streamed log lines retained per tab; once exceeded, the oldest lines are dropped so a long-running follow does not grow memory without bound. Clamped to [1000, 1000000].",
           "default": 50000
+        },
+        "wrap": {
+          "type": "boolean",
+          "description": "Startup default for log line wrapping (runtime toggle: >). Set true to start with wrapped lines.",
+          "default": false
         }
       }
     },

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -74,6 +74,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 			previewVisible: ui.ConfigLogShowPreview,
 			hidePrefixes:   !ui.ConfigLogShowPrefixes,
 			timestamps:     ui.ConfigLogShowTimestamps,
+			wrap:           ui.ConfigLogWrap,
 		},
 		pinnedState:             pinnedSt,
 		pinnedSummariesState:    pinnedSummariesSt,

--- a/internal/app/commands_logs_multi.go
+++ b/internal/app/commands_logs_multi.go
@@ -37,7 +37,6 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 	m.logView.timestamps = ui.ConfigLogShowTimestamps
 	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
 	m.logView.previewVisible = ui.ConfigLogShowPreview
-	m.logView.wrap = ui.ConfigLogWrap
 	m.logView.previous = false
 	m.logView.isMulti = true
 	m.logView.multiItems = items

--- a/internal/app/commands_logs_multi.go
+++ b/internal/app/commands_logs_multi.go
@@ -32,11 +32,12 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 	m.resetLogBuffer()
 	m.logView.scroll = 0
 	m.logView.follow = true
-	m.logView.wrap = false
+	m.logView.wrap = ui.ConfigLogWrap
 	m.logView.lineNumbers = true
 	m.logView.timestamps = ui.ConfigLogShowTimestamps
 	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
 	m.logView.previewVisible = ui.ConfigLogShowPreview
+	m.logView.wrap = ui.ConfigLogWrap
 	m.logView.previous = false
 	m.logView.isMulti = true
 	m.logView.multiItems = items

--- a/internal/app/tab_log_wrap_test.go
+++ b/internal/app/tab_log_wrap_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// log_viewer.wrap seeds a new log viewer, but a tab switch must give the tab
+// its own toggle back. Restoring from the global default instead of the
+// snapshot dropped the user's `>` toggle on every switch.
+func TestLoadTab_RestoresPerTabLogWrap(t *testing.T) {
+	prev := ui.ConfigLogWrap
+	t.Cleanup(func() { ui.ConfigLogWrap = prev })
+	ui.ConfigLogWrap = false
+
+	m := &Model{tabs: []TabState{{}, {}}}
+	m.mode = modeLogs
+	m.logView.wrap = true // the user pressed > on tab 0
+	m.saveCurrentTab()
+
+	m.loadTab(1)
+	require.False(t, m.logView.wrap, "tab 1 never toggled wrap, so it stays unwrapped")
+
+	m.loadTab(0)
+	assert.True(t, m.logView.wrap, "switching back to tab 0 keeps the wrap toggle")
+}

--- a/internal/app/tab_state.go
+++ b/internal/app/tab_state.go
@@ -286,7 +286,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.logView.scroll = t.logScroll
 	m.logView.wrapTopSkip = t.logWrapTopSkip
 	m.logView.follow = t.logFollow
-	m.logView.wrap = t.logWrap
+	m.logView.wrap = ui.ConfigLogWrap
 	m.logView.lineNumbers = t.logLineNumbers
 	m.logView.timestamps = t.logTimestamps
 	m.logView.previous = t.logPrevious

--- a/internal/app/tab_state.go
+++ b/internal/app/tab_state.go
@@ -286,7 +286,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.logView.scroll = t.logScroll
 	m.logView.wrapTopSkip = t.logWrapTopSkip
 	m.logView.follow = t.logFollow
-	m.logView.wrap = ui.ConfigLogWrap
+	m.logView.wrap = t.logWrap
 	m.logView.lineNumbers = t.logLineNumbers
 	m.logView.timestamps = t.logTimestamps
 	m.logView.previous = t.logPrevious

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -80,7 +80,7 @@ func (m Model) executeActionLogsWithTail(pendingLabel string, tailLines int) (te
 	m.resetLogBuffer()
 	m.logView.scroll = 0
 	m.logView.follow = true
-	m.logView.wrap = false
+	m.logView.wrap = ui.ConfigLogWrap
 	m.logView.lineNumbers = true
 	m.logView.timestamps = ui.ConfigLogShowTimestamps
 	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes

--- a/internal/app/update_actions_logtop.go
+++ b/internal/app/update_actions_logtop.go
@@ -24,7 +24,7 @@ func (m Model) executeActionLogTop() (tea.Model, tea.Cmd) {
 	m.resetLogBuffer()
 	m.logView.scroll = 0
 	m.logView.follow = true
-	m.logView.wrap = false
+	m.logView.wrap = ui.ConfigLogWrap
 	m.logView.timestamps = true // Log Top needs timestamps for REQ/s calculation
 	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
 	m.logView.previous = false

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -336,6 +336,7 @@ func applyLogViewerConfig(cfg configFile) {
 	applyBoolPtr(lv.ShowPrefixes, &ConfigLogShowPrefixes)
 	applyBoolPtr(lv.ShowTimestamps, &ConfigLogShowTimestamps)
 	applyBoolPtr(lv.PreviewLive, &ConfigLogPreviewLive)
+	applyBoolPtr(lv.Wrap, &ConfigLogWrap)
 	applyLogMaxLines(lv.MaxLines)
 }
 

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -386,6 +386,8 @@ type LogViewerConfig struct {
 	// (runtime toggle: L). When true the explorer opens with live logs streaming
 	// in the right pane for the selected pod. Default false.
 	PreviewLive *bool `json:"preview_live" yaml:"preview_live"`
+	// Wrap: startup default for line wrapping (runtime toggle: >). Default false.
+	Wrap *bool `json:"wrap" yaml:"wrap"`
 }
 
 // YAMLViewerConfig is the on-disk schema for the yaml_viewer section. Every

--- a/internal/ui/config_log_viewer_test.go
+++ b/internal/ui/config_log_viewer_test.go
@@ -17,6 +17,7 @@ func snapshotLogViewerGlobals(t *testing.T) {
 	prevPrefixes := ConfigLogShowPrefixes
 	prevTimestamps := ConfigLogShowTimestamps
 	prevMaxLines := ConfigLogMaxLines
+	prevWrap := ConfigLogWrap
 	t.Cleanup(func() {
 		ConfigLogTailLines = prevTail
 		ConfigLogTailLinesShort = prevShort
@@ -25,6 +26,7 @@ func snapshotLogViewerGlobals(t *testing.T) {
 		ConfigLogShowPrefixes = prevPrefixes
 		ConfigLogShowTimestamps = prevTimestamps
 		ConfigLogMaxLines = prevMaxLines
+		ConfigLogWrap = prevWrap
 	})
 	// Reset to compiled defaults before each test.
 	ConfigLogTailLines = 100
@@ -34,6 +36,7 @@ func snapshotLogViewerGlobals(t *testing.T) {
 	ConfigLogShowPrefixes = true
 	ConfigLogShowTimestamps = false
 	ConfigLogMaxLines = LogMaxLinesDefault
+	ConfigLogWrap = false
 }
 
 // TestLogViewer_GroupAppliesAllFields verifies the canonical log_viewer group
@@ -48,6 +51,7 @@ func TestLogViewer_GroupAppliesAllFields(t *testing.T) {
   show_preview: false
   show_prefixes: false
   show_timestamps: true
+  wrap: false
 `)
 	LoadConfig(path)
 
@@ -57,6 +61,7 @@ func TestLogViewer_GroupAppliesAllFields(t *testing.T) {
 	assert.False(t, ConfigLogShowPreview, "show_preview")
 	assert.False(t, ConfigLogShowPrefixes, "show_prefixes")
 	assert.True(t, ConfigLogShowTimestamps, "show_timestamps")
+	assert.False(t, ConfigLogWrap, "wrap")
 }
 
 // TestLogViewer_MaxLinesAppliesAndClamps verifies the buffer cap is wired and

--- a/internal/ui/config_log_viewer_test.go
+++ b/internal/ui/config_log_viewer_test.go
@@ -51,7 +51,7 @@ func TestLogViewer_GroupAppliesAllFields(t *testing.T) {
   show_preview: false
   show_prefixes: false
   show_timestamps: true
-  wrap: false
+  wrap: true
 `)
 	LoadConfig(path)
 
@@ -61,7 +61,7 @@ func TestLogViewer_GroupAppliesAllFields(t *testing.T) {
 	assert.False(t, ConfigLogShowPreview, "show_preview")
 	assert.False(t, ConfigLogShowPrefixes, "show_prefixes")
 	assert.True(t, ConfigLogShowTimestamps, "show_timestamps")
-	assert.False(t, ConfigLogWrap, "wrap")
+	assert.True(t, ConfigLogWrap, "wrap")
 }
 
 // TestLogViewer_MaxLinesAppliesAndClamps verifies the buffer cap is wired and

--- a/internal/ui/config_viewers.go
+++ b/internal/ui/config_viewers.go
@@ -23,6 +23,10 @@ var ConfigLogShowTimestamps = false
 // logs streaming in the right pane for the selected pod. Default false.
 var ConfigLogPreviewLive = false
 
+// ConfigLogWrap is the startup default for log line wrapping.
+// Default false (unwrapped). Toggle with >.
+var ConfigLogWrap = false
+
 // ConfigYAMLViewerWrap is the startup default for YAML viewer line wrapping
 // (runtime toggle: z). Default false.
 var ConfigYAMLViewerWrap = false

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -42,6 +42,7 @@ log_viewer:
   show_timestamps: true
   max_lines: 12345
   preview_live: true
+  wrap: false
 yaml_viewer:
   wrap: true
 diff_viewer:
@@ -221,6 +222,7 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	assert.True(t, ConfigLogShowTimestamps, "log_viewer.show_timestamps")
 	assert.Equal(t, 12345, ConfigLogMaxLines, "log_viewer.max_lines")
 	assert.True(t, ConfigLogPreviewLive, "log_viewer.preview_live")
+	assert.False(t, ConfigLogWrap, "log_viewer.wrap")
 	assert.True(t, ConfigYAMLViewerWrap, "yaml_viewer.wrap")
 	assert.True(t, ConfigDiffViewerWrap, "diff_viewer.wrap")
 	assert.False(t, ConfigDiffViewerLineNumbers, "diff_viewer.line_numbers")

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -42,7 +42,7 @@ log_viewer:
   show_timestamps: true
   max_lines: 12345
   preview_live: true
-  wrap: false
+  wrap: true
 yaml_viewer:
   wrap: true
 diff_viewer:
@@ -222,7 +222,7 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	assert.True(t, ConfigLogShowTimestamps, "log_viewer.show_timestamps")
 	assert.Equal(t, 12345, ConfigLogMaxLines, "log_viewer.max_lines")
 	assert.True(t, ConfigLogPreviewLive, "log_viewer.preview_live")
-	assert.False(t, ConfigLogWrap, "log_viewer.wrap")
+	assert.True(t, ConfigLogWrap, "log_viewer.wrap")
 	assert.True(t, ConfigYAMLViewerWrap, "yaml_viewer.wrap")
 	assert.True(t, ConfigDiffViewerWrap, "diff_viewer.wrap")
 	assert.False(t, ConfigDiffViewerLineNumbers, "diff_viewer.line_numbers")


### PR DESCRIPTION
## Summary

Add a new configuration setting `logViewer.wrapLines` that controls whether log lines are automatically wrapped in the log viewer. 

## Type of change

- [x] feat: new user-facing feature
- [ ] fix: bug break
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Changes

- Add `LogViewer.WrapLines` boolean field to the config 
- Add the setting to config.schema.json, config-reference.md, and config-example.yaml
- Update `config_wiring_test.go` to cover the new field

## Testing

- [x] `go build` succeeds
- [x] `go test` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / docs updated when user-visible behavior or config changed
- [x] keybindings.md and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)