### PR TITLE
chore: bump Go to 1.26.6 for stdlib security fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are welcome! Here is how to get started.
 
 ## Prerequisites
 
-- Go 1.26.5 or later
+- Go 1.26.6 or later
 - Access to a Kubernetes cluster (for testing)
 - `kubectl` configured and working
 - `golangci-lint`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS builder
 
 RUN apk add --no-cache git
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,14 +18,14 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib;
 
-        # go.mod requires 1.26.5 (security). nixpkgs/master currently ships an
-        # older go_1_26; override the source to the official 1.26.5 tarball
-        # until nixpkgs catches up, then delete this block.
-        go_1_26_5 = pkgs.go_1_26.overrideAttrs (_: rec {
-          version = "1.26.5";
+        # go.mod requires 1.26.6 (security). nixpkgs/master still ships an
+        # older go_1_26, so point the source at the official 1.26.6 tarball.
+        # Delete this block once nixpkgs catches up.
+        go_1_26_6 = pkgs.go_1_26.overrideAttrs (_: rec {
+          version = "1.26.6";
           src = pkgs.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            hash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
+            hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
           };
         });
 
@@ -40,7 +40,7 @@
       in
       {
         packages = {
-          default = (pkgs.buildGoModule.override { go = go_1_26_5; }) {
+          default = (pkgs.buildGoModule.override { go = go_1_26_6; }) {
             pname = "lfk";
             inherit version;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/janosmiko/lfk
 
-go 1.26.5
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
## Why

`govulncheck` fails on every open branch since the Go 1.26.6 advisories landed. Five reach our code:

| Advisory | Package |
|---|---|
| GO-2026-6089 | `net/http` (ReadHeaderTimeout on unencrypted HTTP/2 check) |
| GO-2026-5972 | `encoding/asn1` (recursion depth) |
| GO-2026-5026 | `golang.org/x/net/idna` via `net/http` (Punycode labels) |
| +2 more | standard library |

All are fixed in the 1.26.6 standard library. Nothing in our own code is at fault.

## Changes

- `go.mod`: `go 1.26.5` -> `go 1.26.6`. Every workflow reads `go-version-file: go.mod`, so this covers all of CI.
- `flake.nix`: the toolchain is pinned by source tarball, so the version, the hash, and the binding name move together.
- `CONTRIBUTING.md`: the stated minimum Go version.

`vendorHash` is unchanged. The dependency tree did not move, and this was verified rather than assumed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` - 0 issues
- [x] `govulncheck ./...` - No vulnerabilities found
- [x] `go test ./internal/...`
- [x] `nix build .#` succeeds with the existing `vendorHash`