### PR TITLE
fix(test): make the suite pass the way packagers build it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
         run: |
           go test -coverprofile=coverage.out -json ./... > test-report.json
 
+      # Packagers build with a version injected and expand packages one by one.
+      # Plain `go test ./...` passes both ways, so it misses those breaks (#627).
+      - name: Test as a packager builds
+        run: |
+          go test -ldflags "-X github.com/janosmiko/lfk/internal/version.Version=v9.9.9" ./...
+          go test ./e2e
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:

--- a/e2e/doc.go
+++ b/e2e/doc.go
@@ -1,0 +1,4 @@
+// Package e2e holds the cluster-backed tests, all behind the `e2e` build tag.
+// This file carries no tag so `go test ./e2e` skips instead of failing to
+// build, which packagers hit when they expand packages one by one (#627).
+package e2e

--- a/internal/k8s/fieldmanager_test.go
+++ b/internal/k8s/fieldmanager_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+
+	"github.com/janosmiko/lfk/internal/version"
 )
 
 func TestBuildFieldManager(t *testing.T) {
@@ -120,6 +122,7 @@ func TestFieldManager_DefaultsToTheOSUser(t *testing.T) {
 func TestUserAgent_NamesTheToolAndVersion(t *testing.T) {
 	got := UserAgent()
 
-	assert.True(t, strings.HasPrefix(got, "lfk/"), "got %q", got)
-	assert.Contains(t, got, "dev")
+	// Packagers inject the version with -ldflags, so "dev" only holds for a
+	// plain `go build`. Assert against the version compiled in.
+	assert.True(t, strings.HasPrefix(got, "lfk/"+version.Short()+" "), "got %q", got)
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -6,7 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFull_DefaultValues(t *testing.T) {
+// Set the placeholders rather than trusting them: a packager build injects
+// real values with -ldflags, so the compiled-in defaults are not "dev".
+func TestFull_PlaceholderValues(t *testing.T) {
+	origVersion := Version
+	origCommit := GitCommit
+	origDate := BuildDate
+
+	t.Cleanup(func() {
+		Version = origVersion
+		GitCommit = origCommit
+		BuildDate = origDate
+	})
+
+	Version = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+
 	got := Full()
 	expected := "lfk dev (commit: unknown, built: unknown)"
 
@@ -34,7 +50,15 @@ func TestFull_CustomValues(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func TestShort_DefaultValue(t *testing.T) {
+func TestShort_PlaceholderValue(t *testing.T) {
+	origVersion := Version
+
+	t.Cleanup(func() {
+		Version = origVersion
+	})
+
+	Version = "dev"
+
 	got := Short()
 
 	assert.Equal(t, "dev", got)


### PR DESCRIPTION
Fixes #627. Reported by @michnicki, whose diagnosis and suggested fix were both correct.

## What was broken

Two failures that only show up when the suite is built the way a packager builds it. Plain `go test ./...` passes through both, so CI stayed green across v0.17.0 and v0.17.1.

1. `TestUserAgent_NamesTheToolAndVersion` asserted `Contains(got, "dev")`, the compiled-in default of `version.Version`. Packagers override it with `-ldflags`, so the assertion could only hold for a plain `go build`.
2. The `e2e` package held only `//go:build e2e` files. An explicit `go test ./e2e` failed with `build constraints exclude all Go files ... [setup failed]`. `go test ./...` skipped it without a word. Setups that expand packages one by one, such as the nixpkgs checkPhase, hit the failure.

## What changed

- `internal/k8s/fieldmanager_test.go` asserts the prefix `lfk/<version.Short()> `, so it tracks whatever version is compiled in.
- `e2e/doc.go` is new and carries no build tag, so the package always has one buildable file and `go test ./e2e` skips.
- `.github/workflows/ci.yml` gains a step that runs the suite both ways, so neither can regress unseen.

## Test plan

- [x] `go test -run TestUserAgent ./internal/k8s/` passes
- [x] `go test -run TestUserAgent -ldflags "-X github.com/janosmiko/lfk/internal/version.Version=v0.17.1" ./internal/k8s/` passes (failed before)
- [x] `go test ./e2e` skips instead of failing to build (failed before)
- [x] `go vet -tags e2e ./e2e` still compiles the tagged tests
- [x] `go test -race` clean on the touched package, both version paths
- [x] `golangci-lint run internal/k8s/... e2e/...` reports 0 issues

## Not in scope

`TestNoUnguardedExternalBinaryLookup` fails on `main` as well. Its scanner walks a git-ignored agent worktree under `.claude/worktrees/` and reports that copy's `exec.Command` calls. Separate fix.