### PR TITLE
docs: doc-audit fixes and README reshape

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,1 +1,2 @@
 github: janosmiko
+buy_me_a_coffee: janosmiko

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to lfk
 
-Contributions are welcome! Here is how to get started.
+Setup, build, and release steps for `lfk` contributors.
 
 ## Prerequisites
 
@@ -69,7 +69,12 @@ Typical flow:
 
 1. Land conventional commits on `main` (`feat:`, `fix:`, `perf:`, `refactor:`, etc.).
 2. The `release-please` workflow opens or updates a Release PR with the next version, an updated `flake.nix` `baseVersion`, and a `CHANGELOG.md` entry.
-3. If `go.sum` changed since the last release, check out the Release PR locally and run `make refresh-vendor-hash` so `vendorHash` matches the new vendored module set, then push the change to the PR branch. (`verify-flake-build` in `release.yml` will catch a stale hash if you forget.)
+3. If `go.sum` changed since the last release:
+   1. Check out the Release PR locally.
+   2. Run `make refresh-vendor-hash` so `vendorHash` matches the new vendored module set.
+   3. Push the change to the PR branch.
+
+   (`verify-flake-build` in `release.yml` catches a stale hash if you forget this step.)
 4. Merge the Release PR. release-please tags the merge commit (e.g. `v0.9.33`), and `release.yml` takes over to publish the release.
 
-For emergency manual releases (skipping the bot), `make bump-version VERSION=X.Y.Z` and `make release VERSION=X.Y.Z` remain available; the `verify-flake-version` job in `release.yml` is the safety net that prevents a tag/`flake.nix` mismatch.
+For emergency manual releases (skipping the bot), `make bump-version VERSION=X.Y.Z` and `make release VERSION=X.Y.Z` remain available. The `verify-flake-version` job in `release.yml` is the safety net that prevents a tag/`flake.nix` mismatch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Setup, build, and release steps for `lfk` contributors.
 - `kubectl` configured and working
 - `golangci-lint`
 
-## Development Setup
+## Development setup
 
 ```bash
 # Clone the repository
@@ -27,7 +27,7 @@ make build
 ./lfk
 ```
 
-## Building and Testing
+## Building and testing
 
 ```bash
 # Build
@@ -43,7 +43,7 @@ go test -race ./...
 golangci-lint run
 ```
 
-## Project Structure
+## Project structure
 
 - `main.go` - Entry point, initializes the Kubernetes client, loads config, and starts the Bubbletea program
 - `internal/app/` - Core application logic: the Bubbletea model, update loop, async commands, and bookmarks
@@ -52,7 +52,7 @@ golangci-lint run
 - `internal/ui/` - All rendering: columns, overlays, styles, themes, help screen, and log viewer
 - `internal/logger/` - Application logging
 
-## Submitting Changes
+## Submitting changes
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/my-feature`)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 | Pods | <img src="./docs/imgs/pods.png" alt="Pods" width="600"> |
 | Pods fullscreen | <img src="./docs/imgs/pods-fullscreen.png" alt="Pods fullscreen" width="600"> |
 | Pod action menu | <img src="./docs/imgs/pods-actions.png" alt="Pod actions" width="600"> |
-| Cluster dashboard | <img src="./docs/imgs/cluster-dashboard.png" alt="Cluster dashboard" width="600"> |
+| Cluster Dashboard | <img src="./docs/imgs/cluster-dashboard.png" alt="Cluster Dashboard" width="600"> |
 | Object Explorer | <img src="./docs/imgs/object-explorer.png" alt="Object Explorer" width="600"> |
 | API Explorer | <img src="./docs/imgs/api-explorer.png" alt="API Explorer" width="600"> |
 
@@ -106,8 +106,8 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 | Feature | |
 | --- | --- |
-| YAML viewer | <img src="./docs/imgs/yaml-preview.png" alt="YAML viewer" width="600"> |
-| Log viewer | <img src="./docs/imgs/log-viewer.png" alt="Log viewer" width="600"> |
+| YAML Viewer | <img src="./docs/imgs/yaml-preview.png" alt="YAML Viewer" width="600"> |
+| Log Viewer | <img src="./docs/imgs/log-viewer.png" alt="Log Viewer" width="600"> |
 | Log Top | <img src="./docs/imgs/log-top.png" alt="Log Top" width="600"> |
 
 ### Integrations
@@ -123,7 +123,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 | Feature | |
 | --- | --- |
-| Security dashboard | <img src="./docs/imgs/security-heuristics.png" alt="Built-in security heuristics" width="600"> |
+| Security Dashboard | <img src="./docs/imgs/security-heuristics.png" alt="Built-in security heuristics" width="600"> |
 | Crash Investigator | <img src="./docs/imgs/crash-investigator.png" alt="Crash Investigator" width="600"> |
 | Pod Startup Analysis | <img src="./docs/imgs/startup-analysis.png" alt="Pod Startup Analysis" width="600"> |
 | Can-I RBAC permissions browser | <img src="./docs/imgs/can-i.png" alt="Can-I viewer" width="600"> |
@@ -167,7 +167,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 - Multi-tab workspace with `t` / `]` / `[`: [keybindings.md](docs/keybindings.md#tabs)
 - Merged kubeconfig from `~/.kube/config`, `~/.kube/config.d/*`, and `KUBECONFIG_DIR`: [usage.md](docs/usage.md#kubeconfig-directory)
 - Union view merging several clusters into one table: [union-context.md](docs/union-context.md)
-- Cluster dashboard on entering a context: [config-reference.md](docs/config-reference.md#top-level-fields)
+- Cluster Dashboard on entering a context: [config-reference.md](docs/config-reference.md#top-level-fields)
 - Monitoring dashboard with Prometheus and Alertmanager alerts, `@`: [config-reference.md](docs/config-reference.md#monitoring)
 - Local kind, k3d, and minikube clusters with `Ctrl+N`: [keybindings.md](docs/keybindings.md#local-clusters-manager)
 - Named sessions with `C`: [keybindings.md](docs/keybindings.md#named-sessions)
@@ -188,7 +188,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 - Multi-select with `Space`, range with `Ctrl+Space`, then bulk delete, scale, or restart: [keybindings.md](docs/keybindings.md#multi-selection)
 - Custom shell actions per resource type: [config-reference.md](docs/config-reference.md#custom-actions)
 - Port forwarding, with active forwards listed under the Networking group: [keybindings.md](docs/keybindings.md#action-menu-items)
-- Right-sizing advisor with `x` -> `z`: [keybindings.md](docs/keybindings.md#right-sizing-advisor)
+- Right-sizing Advisor with `x` -> `z`: [keybindings.md](docs/keybindings.md#right-sizing-advisor)
 - Network policy visualizer with `x` -> `N`, Cilium aware: [keybindings.md](docs/keybindings.md#network-policy-visualizer)
 - Traffic capture with `c` on a Pod or Service: [usage.md](docs/usage.md#traffic-capture)
 
@@ -205,7 +205,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 ### Viewers
 
 - YAML preview in the right column, details summary with `Shift+P`
-- Fullscreen YAML viewer with search, folding, and in-place editing: [keybindings.md](docs/keybindings.md#yaml-view)
+- Fullscreen YAML Viewer with search, folding, and in-place editing: [keybindings.md](docs/keybindings.md#yaml-view)
 - Field-manager blame with `m`, writes stamped `lfk:<os-user>`: [config-reference.md](docs/config-reference.md#top-level-fields)
 - Schema side pane with `Ctrl+K`: [features.md](docs/features.md#schema-side-pane)
 - Object Explorer with `O` for the live object: [keybindings.md](docs/keybindings.md#object-explorer)
@@ -255,7 +255,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 - Column visibility and order with `,`, remembered per kind: [keybindings.md](docs/keybindings.md#column-toggle-overlay)
 - Configurable columns globally, per resource type, and per cluster: [config-reference.md](docs/config-reference.md#views)
-- CPU and memory bars on the cluster dashboard: [features.md](docs/features.md#resource-usage-metrics)
+- CPU and memory bars on the Cluster Dashboard: [features.md](docs/features.md#resource-usage-metrics)
 - Node uptime column: [config-reference.md](docs/config-reference.md#node-uptime-column)
 - Namespace resource quota dashboard with `Q`
 - Watch mode auto-refresh with `w`: [usage.md](docs/usage.md#watch-mode-interval)
@@ -296,7 +296,7 @@ Inside the namespace selector:
 
 ## Keybindings
 
-[docs/keybindings.md](docs/keybindings.md) is the complete reference, including the YAML view, log viewer, describe, diff, exec mode, and every sub-mode. Press `F1` in-app for the help screen, `?` for the which-key action panel.
+[docs/keybindings.md](docs/keybindings.md) is the complete reference, including the YAML view, Log Viewer, describe, diff, exec mode, and every sub-mode. Press `F1` in-app for the help screen, `?` for the which-key action panel.
 
 ### Move
 
@@ -359,7 +359,7 @@ Inside the namespace selector:
 | Key | Action |
 |---|---|
 | `x` | Action menu (logs, exec, describe, edit, delete, scale, port-forward) |
-| `v` / `L` / `Ctrl+L` | Describe / live-log preview / fullscreen log viewer |
+| `v` / `L` / `Ctrl+L` | Describe / live-log preview / fullscreen Log Viewer |
 | `D` / `X` | Delete / force delete |
 | `y` / `Y` / `Ctrl+Y` | Copy name / copy-as picker / copy a single field |
 | `Ctrl+P` / `W` | Apply from clipboard / save the manifest to a file |
@@ -429,7 +429,7 @@ Every search and filter input auto-detects the mode from the query string:
 
 All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A multiline paste shows a confirmation dialog.
 
-`Up` / `Down` recall previous queries. `/` and `f` share one history, the log viewer's `/` and the `:` command bar keep their own. All three survive restarts under `$XDG_STATE_HOME/lfk/`: [keybindings.md](docs/keybindings.md#log-viewer).
+`Up` / `Down` recall previous queries. `/` and `f` share one history, the Log Viewer's `/` and the `:` command bar keep their own. All three survive restarts under `$XDG_STATE_HOME/lfk/`: [keybindings.md](docs/keybindings.md#log-viewer).
 
 ## Tips and tricks
 
@@ -458,14 +458,14 @@ All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A mu
 - Peek at Pod or Deployment logs with `L`, open the fullscreen viewer with `Ctrl+L`
 - Make noisy logs readable with `P`: the structured preview parses JSON, logfmt, klog, zap, nginx, envoy, Java, and postgres lines
 - Save logs to a file with `S` (loaded lines) or `Ctrl+S` (full history), the path lands on your clipboard
-- Switch pods or filter containers without leaving the log viewer: press `\`
+- Switch pods or filter containers without leaving the Log Viewer: press `\`
 - Investigate a crash-looping Pod with `x` -> `I`: restart history, events, previous logs, and describe in one tabbed view
 
 ### Inspecting
 
 - Walk any resource's live object with `O`: `r` finds keys recursively, `T` expands an ASCII tree, `y` copies the field path
 - Forget `kubectl explain`, `I` opens the API Explorer and `n` / `N` auto-drill into nested fields
-- In the YAML viewer, press `O` on a line to open the Object Explorer at that attribute, or `I` to see its schema
+- In the YAML Viewer, press `O` on a line to open the Object Explorer at that attribute, or `I` to see its schema
 - `Ctrl+K` opens a side pane with the schema description of the field under the cursor, and keeps it in step as you move
 - Fold YAML sections with `z` (`Z` folds all), edit the resource in your `$EDITOR` with `Ctrl+E`
 - Replay a resource's event history as a timeline with `V`
@@ -488,7 +488,7 @@ All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A mu
 - Spin up a throwaway kind, k3d, or minikube cluster with `Ctrl+N` at the cluster list
 - Capture a Pod's network traffic with `c`: live decode plus pcap export
 - Flip the RBAC question: inside the Can-I browser (`U`), `Tab` opens Who-Can, every subject allowed to run a verb on a resource
-- Get per-container CPU and memory recommendations with `x` -> `z` (Right-sizing advisor, VPA-backed when available)
+- Get per-container CPU and memory recommendations with `x` -> `z` (Right-sizing Advisor, VPA-backed when available)
 - Watch an ArgoCD Application roll out wave by wave: `x` -> `W` opens the Sync Wave Timeline
 - Try a new look without restarting: `T` live-previews 460+ themes
 - Waiting for a rollout? `:nyan` and `:kubetris` are real commands

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # :zap: LFK - Lightning Fast Kubernetes navigator
 
-[![Release](https://img.shields.io/github/v/release/janosmiko/lfk)](https://github.com/janosmiko/lfk/releases) [![CI](https://img.shields.io/github/actions/workflow/status/janosmiko/lfk/ci.yml?branch=main&label=CI)](https://github.com/janosmiko/lfk/actions/workflows/ci.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/janosmiko/lfk)](https://goreportcard.com/report/github.com/janosmiko/lfk) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=janosmiko_lfk&metric=security_rating)](https://sonarcloud.io/dashboard?id=janosmiko_lfk) [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=janosmiko_lfk&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=janosmiko_lfk) [![codecov](https://codecov.io/gh/janosmiko/lfk/graph/badge.svg)](https://codecov.io/gh/janosmiko/lfk) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/janosmiko/lfk/badge)](https://scorecard.dev/viewer/?uri=github.com/janosmiko/lfk) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12677/badge)](https://www.bestpractices.dev/projects/12677)[![Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square&link=https%3A%2F%2Fcloudsmith.com)](https://cloudsmith.com)
+[![Release](https://img.shields.io/github/v/release/janosmiko/lfk)](https://github.com/janosmiko/lfk/releases) [![CI](https://img.shields.io/github/actions/workflow/status/janosmiko/lfk/ci.yml?branch=main&label=CI)](https://github.com/janosmiko/lfk/actions/workflows/ci.yml) [![Stars](https://img.shields.io/github/stars/janosmiko/lfk?style=flat)](https://github.com/janosmiko/lfk) [![Sponsor](https://img.shields.io/badge/sponsor-%E2%9D%A4-db61a2)](https://github.com/sponsors/janosmiko) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=janosmiko_lfk&metric=security_rating)](https://sonarcloud.io/dashboard?id=janosmiko_lfk) [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=janosmiko_lfk&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=janosmiko_lfk) [![codecov](https://codecov.io/gh/janosmiko/lfk/graph/badge.svg)](https://codecov.io/gh/janosmiko/lfk) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/janosmiko/lfk/badge)](https://scorecard.dev/viewer/?uri=github.com/janosmiko/lfk) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12677/badge)](https://www.bestpractices.dev/projects/12677)[![Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square&link=https%3A%2F%2Fcloudsmith.com)](https://cloudsmith.com)
 
 **LFK** is a keyboard-focused, yazi-inspired terminal user interface for navigating and managing Kubernetes clusters. It brings a three-column Miller columns layout with an owner-based resource hierarchy to your terminal.
 
@@ -71,12 +71,18 @@ KUBECONFIG_DIR=/team-a/configs:/team-b/configs lfk
 
 [docs/usage.md](docs/usage.md#command-line-flags) has the full CLI reference and the runtime tuning options: mouse capture, no-color mode, read-only mode, watch-mode interval, discovery cache, and Secret lazy loading.
 
-## Support
+## Sponsor
 
-LFK is a side project I build in my free time, and the tools that go into it (IDE licenses, AI assistants) are not free. If LFK saves you time, consider sponsoring:
+LFK is Apache-2.0 and stays free. I build it in my free time, and the tools it takes to build it are not free.
+
+**Do you use LFK at work? Ask your team to sponsor it.** A company expenses this without noticing, and an individual feels it. Most clusters LFK gets pointed at are company clusters.
 
 - [GitHub Sponsors](https://github.com/sponsors/janosmiko)
 - [Buy Me a Coffee](https://buymeacoffee.com/janosmiko)
+
+Sponsorship pays for the IDE licenses and AI assistants that go into development. More of it buys more hours for LFK.
+
+Money is not the only way to help. Star the repo, file a good bug report, or tell one colleague who lives in `kubectl`.
 
 Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com).
 Cloudsmith is a hosted package management service that stores and serves packages in many formats.
@@ -500,13 +506,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, development setup, bui
 ## License
 
 Apache License 2.0, see [LICENSE](LICENSE).
-
-## Star history
-
-<a href="https://www.star-history.com/?repos=janosmiko%2Flfk&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=janosmiko/lfk&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=janosmiko/lfk&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=janosmiko/lfk&type=date&legend=top-left" />
- </picture>
-</a>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Every contribution is appreciated and helps make LFK sustainable.
 **Thank you for your support!**
 
 Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com).
-Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that enables your organization to create, store and share packages in any format, to any place, with total confidence.
+Cloudsmith is a hosted package management service that stores and serves packages in many formats.
 
 ## Screenshots
 
@@ -264,13 +264,13 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `Enter` | Open full-screen YAML view / navigate into |
 | `z` | Toggle expand/collapse all resource groups / toggle event grouping (Events view) |
 | `p` | Pin/unpin resource type (at resource types level) |
-| `x` | At resource types level: pin/unpin or hide/show the selected resource type (saved per cluster context / union set) |
-| `H` | Toggle rarely used + hidden resource types (CSI internals, webhooks, APF, leases, advanced core); revealed types shown dimmed |
+| `x` | Pin/unpin or hide/show resource type (at resource types level) |
+| `H` | Toggle rarely used + hidden resource types |
 | `0` / `1` / `2` | Jump to clusters / types / resources level |
 | `J` / `K` | Scroll preview pane down/up |
 | `o` | Jump to owner/controller of selected resource |
-| `Backspace` | Jump back through teleport history (owner / port-forward / orphan / finding / mark jumps) |
-| `g`+`p/d/s/n/N/i/j/c/r/D/t/C/S/h/v/V/b` | Goto resource type: Pods / Deployments / Services / Nodes / Namespaces / Ingresses / Jobs / CronJobs / ReplicaSets / DaemonSets / StatefulSets / ConfigMaps / Secrets / HPAs / PVCs / PVs / PDBs (press `g` for which-key popup; add CRDs like ArgoCD via `goto_targets`) |
+| `Backspace` | Jump back through teleport history |
+| `g`+`p/d/s/n/N/i/j/c/r/D/t/C/S/h/v/V/b` | Goto resource type (press `g` for which-key popup) |
 
 ### Views and Modes
 
@@ -292,7 +292,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `Ctrl+K` | Schema side pane for the field under the cursor (YAML viewer, Object Explorer) |
 | `U` | RBAC permissions browser (can-i) |
 | `T` | Open theme selector |
-| `:` | Command bar: resource jumps (`:pod`, `:dep`), built-ins (`:ns`, `:ctx`, `:set`, `:sort`, `:export`), kubectl (`:k get pod`), shell (`:! cmd`) |
+| `:` | Command bar (resource jumps, built-ins, kubectl, shell) |
 | `w` | Toggle watch mode (auto-refresh) |
 | `,` | Column visibility toggle (show/hide and reorder columns) |
 | `>` / `<` | Sort by next / previous column |
@@ -317,7 +317,7 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 | `y` / `Y` | Copy name / open copy-as picker (YAML / JSON / Table) |
 | `Ctrl+Y` | Copy a single field (columns by default, `Tab` for all manifest fields; works with multi-selection) |
 | `Space` | Toggle multi-selection (bulk actions via `x`) |
-| `?` | Which-key action panel: hotkeys actionable right now, descriptions colored by category with a color legend at the bottom (scroll: `Ctrl+D`/`Ctrl+U`, close: `esc`; `?` again switches between category and key order, kept for the session). Also in every fullscreen viewer except exec mode, where it lists what that viewer supports in its current state. `F1` opens full help |
+| `?` | Which-key action panel: hotkeys actionable right now |
 | `m<slot>` / `'<slot>` | Set / jump to bookmark (lowercase = context-aware, uppercase = context-free) |
 | `t` / `]` / `[` | New tab / next / previous |
 | `}` / `{` | Move current tab right / left |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 - Groups: Dashboards, Workloads, Networking, Config, Storage, ArgoCD, Helm, Access Control, Cluster, Custom Resources
 - Discovered CRDs grouped by API group, for example `argoproj.io`, `longhorn.io`
-- Pin a type with `p`: [config-reference.md](docs/config-reference.md#pinned-groups)
+- Pin a type with `p`: [keybindings.md](docs/keybindings.md#navigation)
 - Pin a type's dashboard summary with `x`: [config-reference.md](docs/config-reference.md#top-level-fields)
 - Hide or show a single type with `x`, reveal hidden ones with `H`: [config-reference.md](docs/config-reference.md#top-level-fields)
 - Rarely used types (CSI internals, webhooks, APF, leases) hidden until `H`: [config-reference.md](docs/config-reference.md#top-level-fields)
@@ -196,7 +196,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 - Filter with `f`, search with `/`, in substring, regex, fuzzy, or literal mode
 - Abbreviated jumps such as `pvc`, `hpa`, `deploy`: [config-reference.md](docs/config-reference.md#abbreviations)
-- Command bar `:` for resource jumps, built-ins, kubectl, and shell: [commands.md](docs/commands.md)
+- Command bar `:` for resource jumps, built-ins, kubectl, and shell: [commands.md](docs/commands.md), autocomplete in [features.md](docs/features.md#command-bar-autocomplete)
 - Quick filter presets with `.`: [config-reference.md](docs/config-reference.md#filter-presets)
 - Sorting with `>` / `<` / `=` / `-`, remembered per kind: [keybindings.md](docs/keybindings.md#sorting)
 - Bookmarks with `m<slot>` and `'<slot>`: [keybindings.md](docs/keybindings.md#bookmarks)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 | Pods | <img src="./docs/imgs/pods.png" alt="Pods" width="600"> |
 | Pods fullscreen | <img src="./docs/imgs/pods-fullscreen.png" alt="Pods fullscreen" width="600"> |
 | Pod action menu | <img src="./docs/imgs/pods-actions.png" alt="Pod actions" width="600"> |
-| Cluster Dashboard | <img src="./docs/imgs/cluster-dashboard.png" alt="Cluster Dashboard" width="600"> |
+| Cluster dashboard | <img src="./docs/imgs/cluster-dashboard.png" alt="Cluster dashboard" width="600"> |
 | Object Explorer | <img src="./docs/imgs/object-explorer.png" alt="Object Explorer" width="600"> |
 | API Explorer | <img src="./docs/imgs/api-explorer.png" alt="API Explorer" width="600"> |
 
@@ -106,8 +106,8 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 | Feature | |
 | --- | --- |
-| YAML Viewer | <img src="./docs/imgs/yaml-preview.png" alt="YAML Viewer" width="600"> |
-| Log Viewer | <img src="./docs/imgs/log-viewer.png" alt="Log Viewer" width="600"> |
+| YAML viewer | <img src="./docs/imgs/yaml-preview.png" alt="YAML viewer" width="600"> |
+| Log viewer | <img src="./docs/imgs/log-viewer.png" alt="Log viewer" width="600"> |
 | Log Top | <img src="./docs/imgs/log-top.png" alt="Log Top" width="600"> |
 
 ### Integrations
@@ -261,7 +261,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 - Watch mode auto-refresh with `w`: [usage.md](docs/usage.md#watch-mode-interval)
 - Random startup tips: [config-reference.md](docs/config-reference.md#top-level-fields)
 
-## Navigation Hierarchy
+## Navigation hierarchy
 
 ```
 Clusters (kubeconfig contexts)
@@ -271,9 +271,19 @@ Clusters (kubeconfig contexts)
                     +-- Containers (for Pods)
 ```
 
-Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`, which opens a selector that filters as you type. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection shows all except the marked namespaces, each prefixed with `!`), `A` to reset to all-namespaces mode, or `R` to refresh the list from the cluster. Press `.` to quick-filter straight to the namespace of the resource highlighted behind the overlay.
+Namespaces are **not** a navigation level. The top-right corner shows the current namespace. Press `\` to open the selector, which filters as you type. All-namespaces mode is on by default, and `A` toggles it.
 
-### Owner Resolution
+Inside the namespace selector:
+
+| Key | Action |
+|---|---|
+| `Space` | Include a namespace |
+| `Tab` | Exclude a namespace (shows all except the marked ones, each prefixed with `!`) |
+| `A` | Reset to all-namespaces mode |
+| `R` | Refresh the list from the cluster |
+| `.` | Quick-filter to the namespace of the resource behind the overlay |
+
+### Owner resolution
 
 - **Deployments** show their Pods (resolved through ReplicaSets, flattened)
 - **StatefulSets / DaemonSets / Jobs** show their Pods directly
@@ -406,7 +416,7 @@ abbreviations:
 
 [docs/config-reference.md](docs/config-reference.md) is the full reference, [docs/config-example.yaml](docs/config-example.yaml) a commented example of every field.
 
-### Search Modes
+### Search modes
 
 Every search and filter input auto-detects the mode from the query string:
 
@@ -421,7 +431,7 @@ All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A mu
 
 `Up` / `Down` recall previous queries. `/` and `f` share one history, the log viewer's `/` and the `:` command bar keep their own. All three survive restarts under `$XDG_STATE_HOME/lfk/`: [keybindings.md](docs/keybindings.md#log-viewer).
 
-## Tips and Tricks
+## Tips and tricks
 
 ### Navigating
 
@@ -478,7 +488,7 @@ All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A mu
 - Spin up a throwaway kind, k3d, or minikube cluster with `Ctrl+N` at the cluster list
 - Capture a Pod's network traffic with `c`: live decode plus pcap export
 - Flip the RBAC question: inside the Can-I browser (`U`), `Tab` opens Who-Can, every subject allowed to run a verb on a resource
-- Get per-container CPU and memory recommendations with `x` -> `z` (Right-sizing Advisor, VPA-backed when available)
+- Get per-container CPU and memory recommendations with `x` -> `z` (Right-sizing advisor, VPA-backed when available)
 - Watch an ArgoCD Application roll out wave by wave: `x` -> `W` opens the Sync Wave Timeline
 - Try a new look without restarting: `T` live-previews 460+ themes
 - Waiting for a rollout? `:nyan` and `:kubetris` are real commands
@@ -491,7 +501,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, development setup, bui
 
 Apache License 2.0, see [LICENSE](LICENSE).
 
-## Star History
+## Star history
 
 <a href="https://www.star-history.com/?repos=janosmiko%2Flfk&type=date&legend=top-left">
  <picture>

--- a/README.md
+++ b/README.md
@@ -6,184 +6,30 @@
 
 **LFK** is a keyboard-focused, yazi-inspired terminal user interface for navigating and managing Kubernetes clusters. It brings a three-column Miller columns layout with an owner-based resource hierarchy to your terminal.
 
-## Support
+## Install
 
-LFK is a side project I build in my free time, and the tools that go into it
-(IDE licenses, AI assistants) are not free. If LFK saves you time and you'd like
-to help cover those costs and fund continued development, consider sponsoring:
-
-- [GitHub Sponsors](https://github.com/sponsors/janosmiko)
-- [Buy Me a Coffee](https://buymeacoffee.com/janosmiko)
-
-Every contribution is appreciated and helps make LFK sustainable.
-
-**Thank you for your support!**
-
-Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com).
-Cloudsmith is a hosted package management service that stores and serves packages in many formats.
-
-## Screenshots
-
-### Demo
-
-![Demo](./docs/imgs/demo.gif)
-
-### Themes
-
-![Themes](./docs/imgs/themes.gif)
-
-### Features
-
-| Feature | |
-| --- | --- |
-| Pods | <img src="./docs/imgs/pods.png" alt="Pods" width="600"> |
-| Pods fullscreen | <img src="./docs/imgs/pods-fullscreen.png" alt="Pods fullscreen" width="600"> |
-| Pod action menu | <img src="./docs/imgs/pods-actions.png" alt="Pod actions" width="600"> |
-| Cluster Dashboard | <img src="./docs/imgs/cluster-dashboard.png" alt="Cluster Dashboard" width="600"> |
-| Object Explorer | <img src="./docs/imgs/object-explorer.png" alt="Object Explorer" width="600"> |
-| API Explorer | <img src="./docs/imgs/api-explorer.png" alt="API Explorer" width="600"> |
-| YAML Viewer | <img src="./docs/imgs/yaml-preview.png" alt="YAML Viewer" width="600"> |
-| Log Viewer | <img src="./docs/imgs/log-viewer.png" alt="Log Viewer" width="600"> |
-| Log Top | <img src="./docs/imgs/log-top.png" alt="Log Top" width="600"> |
-| Helm integration | <img src="./docs/imgs/helm-integration.png" alt="Helm integration" width="600"> |
-| ArgoCD integration | <img src="./docs/imgs/argocd-integration.png" alt="ArgoCD integration" width="600"> |
-| ArgoCD AutoSync config | <img src="./docs/imgs/argocd-autosync.png" alt="ArgoCD auto-sync config" width="300"> |
-| Security dashboard | <img src="./docs/imgs/security-heuristics.png" alt="Built-in security heuristics" width="600"> |
-| Trivy integration | <img src="./docs/imgs/trivy-integration.png" alt="Trivy integration" width="600"> |
-| Crash Investigator | <img src="./docs/imgs/crash-investigator.png" alt="Crash Investigator" width="600"> |
-| Pod Startup Analysis | <img src="./docs/imgs/startup-analysis.png" alt="Pod Startup Analysis" width="600"> |
-| Can-I RBAC permissions browser | <img src="./docs/imgs/can-i.png" alt="Can-I viewer" width="600"> |
-| Label and annotation editor | <img src="./docs/imgs/label-annotation-editor.png" alt="Label and annotation editor" width="600"> |
-| Quick filters | <img src="./docs/imgs/quick-filters.png" alt="Quick filters" width="600"> |
-| Column visibility and reordering | <img src="./docs/imgs/column-visibility-reordering.png" alt="Column visibility and reordering" width="600"> |
-| Bookmarks | <img src="./docs/imgs/bookmarks.png" alt="Bookmarks" width="600"> |
-| Multi-tab support | <img src="./docs/imgs/tab-support.png" alt="Multi-tab support" width="600"> |
-| Union view | <img src="./docs/imgs/union-sets.png" alt="Union sets" width="600"> |
-| Local cluster management | <img src="./docs/imgs/local-clusters.png" alt="Local clusters" width="600"> |
-
-## Features
-
-### Navigation and Layout
-
-- **Three-column Miller columns** interface (parent / current / preview)
-- **Owner-based navigation**: Clusters -> Resource Types -> Resources -> Owned Resources -> Containers
-- **Resource groups**: Dashboards, Workloads, Networking, Config, Storage, ArgoCD, Helm, Access Control, Cluster, Custom Resources
-- **Pinned resource types**: Pin individual resource types (built-in or CRD) into a "Pinned" section at the top of the list, below the dashboards. Configurable via `pinned_types` in config (legacy `pinned_groups` also supported) or interactively with `p` key (stored per-context or per named union set)
-- **Pinned dashboard summaries**: Pin any resource type's status summary (Jobs failed/succeeded, Argo app health/sync, any CRD's phase/conditions rollup) as inline rows on the cluster dashboard for a one-page daily health check. Shows Jobs, Deployments, Argo CD Applications, Flux Kustomizations, and cert-manager Certificates by default (CRD-backed defaults appear only when installed); your first pin keeps the defaults you see and adds your type. Toggle from the action menu (`x`) at the resource types level, or set `pinned_summaries` in config (max 10 per scope; stored per-context or per named union set)
-- **CRD categories**: Discovered CRDs are grouped by API group name (e.g., `argoproj.io`, `longhorn.io`, `networking.istio.io`)
-- **Hide rarely used resources**: CSI internals, admission webhooks, APF, leases, runtime classes, and uncategorized core resources are hidden by default. Press `H` to surface them (dimmed) under their categories and an "Advanced" group (resets each launch; set `show_rare_types: true` in config to show them from startup)
-- **Hide individual resource types**: At the resource types level, open the action menu (`x`) on a type to hide or show it. Hidden types are saved per cluster context (or named union set) and stay hidden across restarts. Press `H` to reveal hidden types dimmed so you can un-hide them
-- **Expandable/collapsible resource groups** with `z`
-- **Layout cycle** with `Shift+F` — hide sidebar, then fullscreen middle column, then restore
-- **Vim-style keybindings** throughout (fully customizable via config)
-- **Mouse support**: Click to navigate, scroll wheel scrolls the pane under the pointer, `Ctrl+Option+Y` toggles mouse capture, Shift+Drag for native terminal text selection
-
-### Cluster Management
-
-- **Multi-tab support**: Open multiple views side by side
-- **Multi-cluster/multi-context support** via merged kubeconfig loading
-- **Merged kubeconfig loading**: `~/.kube/config`, `~/.kube/config.d/*` (recursive, symlinks followed), and `KUBECONFIG_DIR` env var. The `KUBECONFIG` env var is exclusive like kubectl — when set it replaces `~/.kube/config` and the default `config.d/` scan (explicit `--kubeconfig-dir`/`KUBECONFIG_DIR` still merge); opt out with `kubeconfig_exclusive: false`.
-- **Union view**: Merge resources from multiple clusters into a single table with a `Context` column identifying the source, via `--union-context` (repeatable) or a named `--union-set` from config. See [Union View](docs/union-context.md).
-- **Cluster dashboard** when entering a context (configurable)
-- **Monitoring dashboard** with active Prometheus/Alertmanager alerts (`@` key), configurable endpoints per cluster
-- **API Explorer** for interactively browsing resource structure (`I` key) with recursive field browser and an ASCII-art tree view (`T`, sticky across navigation; `Space` folds branches)
-- **Object Explorer** for drilling into the selected resource's live object (`O` key); arrays expand into indexed elements, so recursive status trees (e.g. `.status.steps[].steps[]`) are walkable; live-refreshes under watch mode (`w` to pause, `R` to refresh manually); `T` toggles a tree view that expands the whole subtree with ASCII-art guides, `Space` folds branches
-- **Schema side pane** (`Ctrl+K`) shows the cluster's own description of the field under the cursor, in a bordered pane beside the YAML viewer and Object Explorer; it follows the cursor, reads the connected cluster so CRDs resolve like built-in kinds, and caches what it reads
-- **Namespace selector** overlay with type-to-filter
-- **All-namespaces mode** (enabled by default)
-- **Local cluster management** — create, list, and delete `kind` clusters; create, list, start, stop, and delete `k3d` and `minikube` clusters (kind has no native start/stop) from inside lfk via the `Ctrl+N` manager overlay.
-
-### Resource Operations
-
-- **Read-only mode**: Lock a session against destructive actions (delete, edit, scale, restart, exec, port-forward, drain, etc.). Enable with `--read-only`, the `read_only: true` config field, per-context `clusters.<name>.read_only`, or the in-app `Ctrl+R` toggle (toggles the highlighted row's `[RO]` marker at the cluster picker; toggles the current tab inside a context). A `[RO]` badge in the title bar marks active sessions. See [Read-Only Mode](docs/usage.md#read-only-mode).
-- **Security dashboard**: Aggregated findings from Trivy, Kyverno, Kubescape, Falco, Gatekeeper, plus two built-in zero-dependency scanners: a heuristic Pod-spec scanner and an Advisor source with reliability recommendations (missing PDBs, quotas, probes, requests — dashboard-only, never on the SEC badge). Auto-detects installed sources, shows a per-resource SEC badge, and probes lazily on first use. Enable/disable globally or per cluster via `security.enabled` / `clusters.<name>.security`. See [Security Dashboard](docs/security.md).
-- **Permission-aware actions**: Actions your RBAC refuses are dropped from the action menu for Pod, Deployment, StatefulSet, DaemonSet and ReplicaSet, decided by one bulk `SelfSubjectAccessReview` pass per context, namespace and kind, and cached under the same three. Fails open when the review errors or times out. See [Permission-Aware Actions](docs/usage.md#permission-aware-actions).
-- **Context-aware action menus**: logs, exec, attach, debug, scale, restart, delete, describe, edit, events, port-forward, vuln scan, PVC resize
-- **Selectable delete cascade**: Both delete confirmations show the propagation policy and cycle it with `Tab` — `Background` (delete now, garbage collector removes dependents), `Foreground` (keep the object until dependents are gone), `Orphan` (leave dependents running), and `None` (send no policy, letting the API server decide; regular delete only, since force delete runs through `kubectl`). Applies to bulk delete too. The default is `Background`, sent explicitly, so deleting a Job no longer falls through to the API server's legacy `Orphan` default and leaves its pods running; picking `None` opts back into that server-side default deliberately. Change the default with `delete_propagation_policy`. See [Delete confirm dialog](docs/keybindings.md#delete-confirm-dialog).
-- **Cost of a destructive action, in three rows**: The delete, drain, and scale dialogs answer what happens before you confirm, as `Scope` (what else stops existing), `Availability` (what stops serving), and `Risk` (what refuses the action, or what it leaves with no owner). Every row is built from the selected cascade policy, so `Tab` rewrites all three in place and no two rows can disagree. `Scope` walks `ownerReferences`, so a deep chain such as Deployment to ReplicaSet to Pod is counted in full. Under `Orphan` the `Risk` row names the real cost, which is objects left with no controller to manage them. A row with nothing to say is left out, so deleting a bare pod stays a small box. See [Delete confirm dialog](docs/keybindings.md#delete-confirm-dialog).
-- **Custom user-defined actions**: Define custom shell commands per resource type in config
-- **Multi-select with bulk actions**: Select multiple resources with Space, range-select with Ctrl+Space, perform bulk delete, scale, restart, and ArgoCD bulk sync/refresh
-- **Resource sorting** by name, age, or status, remembered per resource kind for the session
-- **Filter and search**: Filter with `f`, search with `/` -- supports substring, regex (auto-detected), and fuzzy (`~` prefix) modes
-- **Abbreviated search**: Type `pvc`, `hpa`, `deploy` etc. to jump to resource types
-- **Command bar** (`:`) with vertical dropdown autocomplete: resource jumps (`:pod`, `:dep`), built-in commands (`:ns`, `:ctx`, `:set`, `:sort`, `:export`), kubectl with `:k`/`:kubectl` prefix and flag/namespace completion, shell commands (`:!`). Value positions (namespace, context, resource name, option, column, format) accept fuzzy matches; command names stay on prefix.
-- **Watch mode**: Auto-refresh resources every 2 seconds (enabled by default)
-- **Owner/controller navigation**: Jump to the owner of any resource with `o`
-- **Events view** with warnings-only filter toggle and duplicate-event grouping (`z`)
-- **Crash Investigator** — per-Pod tabbed view combining restart history, pod-scoped events, previous/current container logs, and container-scoped `describe` — accessible from the Pod action menu (`x` → `I`). Refresh with `Shift+R`.
-- **Traffic capture** — per-pod packet capture (kubectl-debug or kubeshark, auto-detected) with live decode and pcap export. Press `c` on a Pod or Service.
-
-### Preview and Editing
-
-- **YAML preview** in the right column with syntax highlighting
-- **Full-screen YAML viewer** with scrollable output, search, section folding (`Tab`/`z`), and in-place editing
-- **Field-manager blame** (`m`) in the YAML viewer: who and when last wrote the line under the cursor, from `.metadata.managedFields`
-- **Your name on your own writes**: lfk stamps the field manager `lfk:<os-user>`, so blame shows the person and not just the tool. Override or shorten it to plain `lfk` with the `field_manager` config field
-- **Resource details** summary in split preview (toggle with `Shift+P`)
-- **List status summary** band pinned at the bottom of the children pane (like the resource-usage footer) when hovering a resource type in the resource-type list — always shows the resource count, plus a colored status rollup for kinds with a health signal (ArgoCD Application health/sync, Pod phase, workload ready ratios, Node readiness, Namespace/PV/PVC phase, Flux & cert-manager Ready) — plus a generic `.status.phase` or `.status.conditions` rollup for any other kind that surfaces one — so you can confirm a whole list is healthy without drilling in
-- **Inline log viewer** with streaming, search, live text filter (`f`: plain/`~`fuzzy/regex/`\`literal), severity filter (`i`/`o`: step the minimum level shown — INFO+/WARN+/ERROR+), line numbers, word wrap, follow mode (`F`), timestamps toggle, previous container logs, container filter, tail-first loading, line jump, structured preview pane (`P`: parses the selected line as JSON or logfmt, falls back to plain text), and automatic reconnect across init-container transitions (stays attached as each init container finishes and the next one starts)
-- **Log Top** — aggregate a resource's logs by parsed attributes (method, host, path, status, service, or JSON/logfmt keys) showing request counts, REQ/s, ERR%, 4xx/5xx counts, avg/max latency, and p50/p95/p99 percentiles (when duration data is present). Columns auto-fit the terminal width (wider = more columns, up to all of REQ, REQ/s, ERR%, P50/P95/P99, ERR, 4XX, 5XX, AVG, MAX, %); `,` toggles/reorders columns. Auto-detects Traefik JSON, ingress-nginx, Envoy, NCSA common/combined access logs (nginx, Apache, Traefik default), JSON, and logfmt. Launch from the resource action menu ("Log Top") or press `T` in the open log viewer. In view: `g` group by, `p` profile, `,` columns (show/hide and reorder), `enter` drill down, sort key to re-sort, `esc` back.
-- **Inline describe view** with scrollable output
-- **Secret viewing/editing** with decode toggle (`Ctrl+S`) and dedicated editor (`e`)
-- **Embedded terminal** (PTY mode) for exec and shell with tab switching — PTY keeps running in background when switching tabs
-
-### Resource Management
-
-- **Resource templates**: Create resources from 25+ built-in templates plus your own (`a`, `/` to search); includes a Custom Resource template as a starting point. Drop manifests in `~/.config/lfk/templates/` or save one there with `x` -> `T` Export Template. `d` in the picker deletes one of your saved templates after a confirmation; built-ins cannot be deleted
-- **Export as template**: `x` -> `T` Export Template strips a live object down to an appliable manifest (no `status`, `uid`, `resourceVersion`, `nodeName`, `clusterIP`, finalizers, `pod-template-hash`, Helm ownership markers, injected token volume, ...) and sends it to the clipboard, a file, or the template list. `s` on the destination picker opens the field picker: tick which categories the export removes (namespace, labels, annotations, Helm ownership, vendor runtime annotations, Secret values); correctness fields show as locked rows. Choices persist. Secret values are blanked by default (keys and `type` kept). Allowed in read-only mode
-- **Port forwarding** from the action menu (with local port setting and browser open); manage active forwards via the Networking group
-- **Network policy visualizer**: Visualize a NetworkPolicy's ingress/egress rules (`x` → `N` on a NetworkPolicy), or list every policy affecting a Pod or Service (`x` → "Network Policies" on the resource) — including which backing pods a policy covers. Supports CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy (entities, FQDNs, deny rules, L7 indicators) when the Cilium CRDs are installed. The dialog scrolls with the mouse wheel and is searchable (`/`, `n`/`N`)
-- **Clipboard support**: Copy resource name (`y`), open copy-as picker (`Y`: YAML / JSON / Table), copy a single field via a filterable picker (`Ctrl+Y`: visible columns by default, `Tab` for all manifest fields — e.g. a node's external IP), paste/apply from clipboard (`Ctrl+P`), paste into search/filter boxes (`Cmd+V` / `Ctrl+Shift+V`)
-- **Bookmarks**: Save favorite resource paths (including the active list filter) for quick navigation
-- **Orphan detection**: Press `Shift+Z` (or run bare `:orphans`) to open the cluster-wide orphan overview across 11 kinds — Pods, Secrets, ConfigMaps, Services, PVCs, HPAs, PDBs, NetworkPolicies, Roles, ClusterRoles, RoleBindings, ClusterRoleBindings. Per-list filters are still available via the filter-preset overlay (`.`) on each kind, or jump straight to a filtered view with `:orphans <kind>` (e.g., `:orphans secrets`). A strict / lenient toggle (`s`) flips between "truly unused" and "currently idle but referenced by workload templates" (e.g. CronJob between firings). Auto-excludes Helm release Secrets, ServiceAccount tokens, owner-managed resources, and `kube-root-ca.crt`.
-- **Session persistence**: Remembers last context/namespace/resource, the active list filter, and the highlighted row across restarts. **Named sessions** save the whole multi-tab workspace under a name and switch between them from the session manager (`C` or `:sessions`); the active session is auto-saved on quit and reopened on start, so working in one never clobbers another. Start on a specific one with `lfk --session <name>` (or `LFK_SESSION`). Navigate before the restore finishes and lfk drops the saved row rather than pulling your cursor back
-
-### Integrations
-
-- **ArgoCD integration**: Browse Applications, sync, terminate sync, refresh, view managed resources
-- **Argo Workflows integration**: Suspend/resume, stop/terminate, resubmit Workflows; submit from WorkflowTemplates; suspend/resume CronWorkflows
-- **Helm integration**: Browse releases, view managed resources, uninstall
-- **HPA scaling**: Press `S` on a HorizontalPodAutoscaler to edit its min/max replica bounds and scale its target workload (Deployment / StatefulSet / ReplicaSet) in one overlay
-- **KEDA integration**: Pause/unpause ScaledObjects and ScaledJobs
-- **External Secrets integration**: Force refresh ExternalSecrets, ClusterExternalSecrets, and PushSecrets
-- **CRD discovery**: Automatically discovers installed CRDs and groups them by API group
-
-### Customization
-
-- **460+ built-in color schemes** from [ghostty themes](https://github.com/ghostty-org/ghostty): Tokyonight, Catppuccin, Dracula, Nord, Rose Pine, Gruvbox, and many more. Transparent background support.
-- **Runtime theme switching**: Press `T` to preview and switch themes without restarting
-- **Auto dark/light mode**: configure a dark and a light scheme; lfk switches automatically when the OS appearance changes (requires CSI 996/2031 terminal support: Ghostty, kitty, Contour, …)
-- **Custom color themes** via config file (Tokyonight theme by default)
-- **Configurable keybindings** for direct actions, including `Ctrl+Shift` chords that stay distinct from plain `Ctrl` (requires Kitty keyboard protocol or xterm `modifyOtherKeys`: Ghostty, kitty, WezTerm, foot, xterm — not macOS Terminal.app; see [Ctrl+Shift chords](docs/keybindings.md#ctrlshift-chords))
-- **Configurable search abbreviations**
-- **Configurable filter presets** per resource type (extend built-in quick filters with `.`)
-- **Configurable icon modes**: `auto` (default, detects Nerd Font-capable terminals like Ghostty/Kitty/WezTerm), `unicode`, `nerdfont` (Material Design Icons), `simple` (ASCII labels), `emoji`, or `none`. Override at runtime with the `LFK_ICONS` environment variable. Also decides how the which-key panel and help screen draw keys: Nerd Font keycaps (`󰘴 D`), Unicode symbols (`⌃D`), or names (`ctrl+d`).
-- **Configurable table columns** (global, per-resource-type, and per-cluster)
-- **Column visibility toggle** overlay to show/hide and reorder columns at runtime (`,` key)
-- **Startup tips**: Random tips on startup to help discover features (configurable via `tips: false`)
-- **Status-aware coloring**: Running=green, Pending=yellow, Failed=red — also applied to CRD printer-column values: recognized status words (Active, Failed, Pending, ...) get their severity color, and True/False values follow the column's polarity (Established=False red, Failed=False green)
-- **Row status tint**: failed/progressing rows stay visible even when the Status column is hidden — `foreground` (default) colors the row's Name cell in the status color when Status is hidden, `background` adds a muted status-colored row background, `off` disables it. Set via `appearance.row_status_tint`
-- **Resource usage metrics**: CPU/MEM with color-coded bars in dashboard
-- **Node uptime column**: time since each node last booted, to spot restarts. Requires Prometheus as the monitoring source and node_exporter (the Kubernetes API does not expose boot time)
-
-## Installation
+Pick your platform:
 
 ```bash
 # Homebrew (macOS / Linux)
 brew install janosmiko/tap/lfk
 
-# Windows: Scoop
+# Scoop (Windows)
 scoop bucket add janosmiko https://github.com/janosmiko/scoop-bucket && scoop install lfk
-# or: winget install janosmiko.lfk
-# or: choco install lfk
 
-# Linux: Arch / AUR
+# Winget (Windows)
+winget install janosmiko.lfk
+
+# Chocolatey (Windows)
+choco install lfk
+
+# AUR (Arch)
 yay -S lfk-bin
 
-# Linux: Debian / Ubuntu (Cloudsmith APT)
+# APT (Debian / Ubuntu)
 curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.deb.sh' | sudo -E bash && sudo apt update && sudo apt install lfk
 
-# Linux: Fedora / RHEL (Cloudsmith DNF)
+# DNF (Fedora / RHEL)
 curl -1sLf 'https://dl.cloudsmith.io/public/janosmiko/lfk/setup.rpm.sh' | sudo -E bash && sudo dnf install lfk
 
 # Go
@@ -193,19 +39,22 @@ go install github.com/janosmiko/lfk@latest
 nix run github:janosmiko/lfk
 ```
 
-`kubectl` is required and must be configured. `helm` and `trivy` are optional (Helm management, image vulnerability scanning). No cluster yet? `lfk --demo` runs against a built-in fake cluster instead.
+Then run it:
 
-> See [docs/installation.md](docs/installation.md) for Windows, Docker, NixOS/home-manager flake input, building from source, and the full list of optional CLI dependencies.
+```bash
+lfk
+lfk --demo
+```
+
+`lfk` uses `~/.kube/config` and `~/.kube/config.d/*`. `lfk --demo` runs against a built-in fake cluster, so no kubeconfig is needed.
+
+`kubectl` is required and must be configured. `helm` and `trivy` are optional, for Helm management and image vulnerability scanning.
+
+[docs/installation.md](docs/installation.md) covers Docker, NixOS and home-manager, binary releases, building from source, and the full list of optional CLI dependencies.
 
 ## Usage
 
 ```bash
-# Use default kubeconfig (~/.kube/config + ~/.kube/config.d/*)
-lfk
-
-# Try it without a cluster (no kubeconfig required)
-lfk --demo
-
 # Start in a specific context / namespace
 lfk --context my-cluster -n kube-system
 
@@ -220,7 +69,197 @@ KUBECONFIG_DIR=/path/to/configs/ lfk
 KUBECONFIG_DIR=/team-a/configs:/team-b/configs lfk
 ```
 
-> See [docs/usage.md](docs/usage.md) for the full CLI reference and runtime tuning options: mouse capture, no-color mode, read-only mode, watch-mode interval, discovery cache (`KUBECACHEDIR`), and Secret lazy loading.
+[docs/usage.md](docs/usage.md#command-line-flags) has the full CLI reference and the runtime tuning options: mouse capture, no-color mode, read-only mode, watch-mode interval, discovery cache, and Secret lazy loading.
+
+## Support
+
+LFK is a side project I build in my free time, and the tools that go into it (IDE licenses, AI assistants) are not free. If LFK saves you time, consider sponsoring:
+
+- [GitHub Sponsors](https://github.com/sponsors/janosmiko)
+- [Buy Me a Coffee](https://buymeacoffee.com/janosmiko)
+
+Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is a hosted package management service that stores and serves packages in many formats.
+
+## Screenshots
+
+### Demo
+
+![Demo](./docs/imgs/demo.gif)
+
+### Themes
+
+![Themes](./docs/imgs/themes.gif)
+
+### Explorer
+
+| Feature | |
+| --- | --- |
+| Pods | <img src="./docs/imgs/pods.png" alt="Pods" width="600"> |
+| Pods fullscreen | <img src="./docs/imgs/pods-fullscreen.png" alt="Pods fullscreen" width="600"> |
+| Pod action menu | <img src="./docs/imgs/pods-actions.png" alt="Pod actions" width="600"> |
+| Cluster Dashboard | <img src="./docs/imgs/cluster-dashboard.png" alt="Cluster Dashboard" width="600"> |
+| Object Explorer | <img src="./docs/imgs/object-explorer.png" alt="Object Explorer" width="600"> |
+| API Explorer | <img src="./docs/imgs/api-explorer.png" alt="API Explorer" width="600"> |
+
+### Viewers
+
+| Feature | |
+| --- | --- |
+| YAML Viewer | <img src="./docs/imgs/yaml-preview.png" alt="YAML Viewer" width="600"> |
+| Log Viewer | <img src="./docs/imgs/log-viewer.png" alt="Log Viewer" width="600"> |
+| Log Top | <img src="./docs/imgs/log-top.png" alt="Log Top" width="600"> |
+
+### Integrations
+
+| Feature | |
+| --- | --- |
+| Helm integration | <img src="./docs/imgs/helm-integration.png" alt="Helm integration" width="600"> |
+| ArgoCD integration | <img src="./docs/imgs/argocd-integration.png" alt="ArgoCD integration" width="600"> |
+| ArgoCD AutoSync config | <img src="./docs/imgs/argocd-autosync.png" alt="ArgoCD auto-sync config" width="300"> |
+| Trivy integration | <img src="./docs/imgs/trivy-integration.png" alt="Trivy integration" width="600"> |
+
+### Analysis
+
+| Feature | |
+| --- | --- |
+| Security dashboard | <img src="./docs/imgs/security-heuristics.png" alt="Built-in security heuristics" width="600"> |
+| Crash Investigator | <img src="./docs/imgs/crash-investigator.png" alt="Crash Investigator" width="600"> |
+| Pod Startup Analysis | <img src="./docs/imgs/startup-analysis.png" alt="Pod Startup Analysis" width="600"> |
+| Can-I RBAC permissions browser | <img src="./docs/imgs/can-i.png" alt="Can-I viewer" width="600"> |
+
+### Workspace
+
+| Feature | |
+| --- | --- |
+| Label and annotation editor | <img src="./docs/imgs/label-annotation-editor.png" alt="Label and annotation editor" width="600"> |
+| Quick filters | <img src="./docs/imgs/quick-filters.png" alt="Quick filters" width="600"> |
+| Column visibility and reordering | <img src="./docs/imgs/column-visibility-reordering.png" alt="Column visibility and reordering" width="600"> |
+| Bookmarks | <img src="./docs/imgs/bookmarks.png" alt="Bookmarks" width="600"> |
+| Multi-tab support | <img src="./docs/imgs/tab-support.png" alt="Multi-tab support" width="600"> |
+| Union view | <img src="./docs/imgs/union-sets.png" alt="Union sets" width="600"> |
+| Local cluster management | <img src="./docs/imgs/local-clusters.png" alt="Local clusters" width="600"> |
+
+## Features
+
+### Navigation
+
+- Three-column Miller columns layout: parent, current, preview
+- Owner-based hierarchy: Clusters -> Resource Types -> Resources -> Owned Resources -> Containers
+- Jump to a resource's owner with `o`, back with `Backspace`
+- Teleport between levels with `0` / `1` / `2`
+- Cycle the layout with `F`, expand or collapse groups with `z`
+- Vim keybindings throughout, remappable, including `Ctrl+Shift` chords: [keybindings.md](docs/keybindings.md#ctrlshift-chords)
+- Mouse click, scroll, and `Ctrl+Option+Y` to release capture: [usage.md](docs/usage.md#mouse-support)
+
+### Resource type list
+
+- Groups: Dashboards, Workloads, Networking, Config, Storage, ArgoCD, Helm, Access Control, Cluster, Custom Resources
+- Discovered CRDs grouped by API group, for example `argoproj.io`, `longhorn.io`
+- Pin a type with `p`: [config-reference.md](docs/config-reference.md#pinned-groups)
+- Pin a type's dashboard summary with `x`: [config-reference.md](docs/config-reference.md#top-level-fields)
+- Hide or show a single type with `x`, reveal hidden ones with `H`: [config-reference.md](docs/config-reference.md#top-level-fields)
+- Rarely used types (CSI internals, webhooks, APF, leases) hidden until `H`: [config-reference.md](docs/config-reference.md#top-level-fields)
+- Status summary band under the hovered type: [features.md](docs/features.md#list-status-summary)
+
+### Clusters and contexts
+
+- Multi-tab workspace with `t` / `]` / `[`: [keybindings.md](docs/keybindings.md#tabs)
+- Merged kubeconfig from `~/.kube/config`, `~/.kube/config.d/*`, and `KUBECONFIG_DIR`: [usage.md](docs/usage.md#kubeconfig-directory)
+- Union view merging several clusters into one table: [union-context.md](docs/union-context.md)
+- Cluster dashboard on entering a context: [config-reference.md](docs/config-reference.md#top-level-fields)
+- Monitoring dashboard with Prometheus and Alertmanager alerts, `@`: [config-reference.md](docs/config-reference.md#monitoring)
+- Local kind, k3d, and minikube clusters with `Ctrl+N`: [keybindings.md](docs/keybindings.md#local-clusters-manager)
+- Named sessions with `C`: [keybindings.md](docs/keybindings.md#named-sessions)
+- Context, namespace, filter, and cursor row restored on start: [config-reference.md](docs/config-reference.md#session-persistence)
+
+### Safety
+
+- Read-only mode via `--read-only` or `Ctrl+R`: [usage.md](docs/usage.md#read-only-mode)
+- Actions your RBAC refuses are dropped from the action menu: [usage.md](docs/usage.md#permission-aware-actions)
+- Security dashboard and SEC badges from Trivy, Kyverno, Kubescape, Falco, Gatekeeper, and three built-in scanners: [security.md](docs/security.md)
+- Delete cascade picker, `Tab` cycles Background / Foreground / Orphan / None: [keybindings.md](docs/keybindings.md#delete-confirm-dialog)
+- Scope, Availability, and Risk rows on the delete, drain, and scale dialogs: [keybindings.md](docs/keybindings.md#delete-confirm-dialog)
+- RBAC browser with `U`, reverse lookup with `Tab`: [keybindings.md](docs/keybindings.md#can-i-browser)
+
+### Resource actions
+
+- Action menu `x`: logs, exec, attach, debug, scale, restart, delete, describe, edit, events, port-forward, vuln scan, PVC resize: [keybindings.md](docs/keybindings.md#action-menu-items)
+- Multi-select with `Space`, range with `Ctrl+Space`, then bulk delete, scale, or restart: [keybindings.md](docs/keybindings.md#multi-selection)
+- Custom shell actions per resource type: [config-reference.md](docs/config-reference.md#custom-actions)
+- Port forwarding, with active forwards listed under the Networking group: [keybindings.md](docs/keybindings.md#action-menu-items)
+- Right-sizing advisor with `x` -> `z`: [keybindings.md](docs/keybindings.md#right-sizing-advisor)
+- Network policy visualizer with `x` -> `N`, Cilium aware: [keybindings.md](docs/keybindings.md#network-policy-visualizer)
+- Traffic capture with `c` on a Pod or Service: [usage.md](docs/usage.md#traffic-capture)
+
+### Finding things
+
+- Filter with `f`, search with `/`, in substring, regex, fuzzy, or literal mode
+- Abbreviated jumps such as `pvc`, `hpa`, `deploy`: [config-reference.md](docs/config-reference.md#abbreviations)
+- Command bar `:` for resource jumps, built-ins, kubectl, and shell: [commands.md](docs/commands.md)
+- Quick filter presets with `.`: [config-reference.md](docs/config-reference.md#filter-presets)
+- Sorting with `>` / `<` / `=` / `-`, remembered per kind: [keybindings.md](docs/keybindings.md#sorting)
+- Bookmarks with `m<slot>` and `'<slot>`: [keybindings.md](docs/keybindings.md#bookmarks)
+- Orphan detection with `Shift+Z` across 11 kinds: [usage.md](docs/usage.md#orphan-detection)
+
+### Viewers
+
+- YAML preview in the right column, details summary with `Shift+P`
+- Fullscreen YAML viewer with search, folding, and in-place editing: [keybindings.md](docs/keybindings.md#yaml-view)
+- Field-manager blame with `m`, writes stamped `lfk:<os-user>`: [config-reference.md](docs/config-reference.md#top-level-fields)
+- Schema side pane with `Ctrl+K`: [features.md](docs/features.md#schema-side-pane)
+- Object Explorer with `O` for the live object: [keybindings.md](docs/keybindings.md#object-explorer)
+- API Explorer with `I` for the resource schema: [keybindings.md](docs/keybindings.md#api-explorer)
+- Describe with `v`, relationship map with `M`, events with `V` plus warnings-only and grouping toggles: [keybindings.md](docs/keybindings.md#actions)
+
+### Logs and shells
+
+- Live-log preview pane with `L`, fullscreen viewer with `Ctrl+L`: [keybindings.md](docs/keybindings.md#log-viewer)
+- Text filter `f`, severity filter `i` / `o`, structured preview `P`: [keybindings.md](docs/keybindings.md#log-viewer)
+- Log Top aggregates access logs into a metrics table, `T`: [keybindings.md](docs/keybindings.md#log-top)
+- Crash Investigator with `x` -> `I`: [keybindings.md](docs/keybindings.md#crash-investigator-overlay)
+- Embedded terminal for exec and shell, `Ctrl+T` cycles the mode: [features.md](docs/features.md#embedded-terminal)
+- Node shell with `x` -> `s`: [usage.md](docs/usage.md#node-shell)
+
+### Creating and copying
+
+- Resource templates with `a`, built-ins plus your own: [features.md](docs/features.md#resource-templates)
+- Export a live object as a template with `x` -> `T`: [features.md](docs/features.md#export-as-template)
+- Copy name `y`, copy-as picker `Y`, single field `Ctrl+Y`: [keybindings.md](docs/keybindings.md#clipboard)
+- Apply a manifest from the clipboard with `Ctrl+P`: [keybindings.md](docs/keybindings.md#clipboard)
+- Save the selected manifest to a file with `W`
+- Decode Secrets with `Ctrl+S`, edit them decoded with `e`: [keybindings.md](docs/keybindings.md#secret-actions)
+- Finalizer search and removal with `Ctrl+G`
+
+### Integrations
+
+- Argo CD: browse Applications, sync, terminate, refresh: [features.md](docs/features.md#argo-cd)
+- Argo Workflows: suspend, resume, stop, resubmit, submit from a template: [features.md](docs/features.md#argo-workflows)
+- Helm: browse releases, values, diff, upgrade, rollback, uninstall: [keybindings.md](docs/keybindings.md#helm-release-actions)
+- HPA scaling overlay with `S`: [keybindings.md](docs/keybindings.md#horizontalpodautoscaler-actions)
+- KEDA: pause and unpause ScaledObjects and ScaledJobs: [features.md](docs/features.md#keda)
+- External Secrets: force refresh: [features.md](docs/features.md#external-secrets)
+- CRD discovery, grouped by API group
+
+### Appearance
+
+- 460+ built-in color schemes from [ghostty themes](https://github.com/ghostty-org/ghostty), `T` switches live: [config-reference.md](docs/config-reference.md#color-schemes)
+- Auto dark and light switching with the OS appearance: [config-reference.md](docs/config-reference.md#auto-darklight-mode)
+- Custom theme colors, Tokyonight by default: [config-reference.md](docs/config-reference.md#theme)
+- Icon modes: auto, unicode, nerdfont, simple, emoji, none: [config-reference.md](docs/config-reference.md#icon-mode-auto-detection)
+- Status colors on rows and CRD printer columns: [features.md](docs/features.md#status-colors)
+- Row status tint when the Status column is hidden: [config-reference.md](docs/config-reference.md#row-status-tint)
+- Transparent background: [config-reference.md](docs/config-reference.md#appearance)
+
+### Tables and metrics
+
+- Column visibility and order with `,`, remembered per kind: [keybindings.md](docs/keybindings.md#column-toggle-overlay)
+- Configurable columns globally, per resource type, and per cluster: [config-reference.md](docs/config-reference.md#views)
+- CPU and memory bars on the cluster dashboard: [features.md](docs/features.md#resource-usage-metrics)
+- Node uptime column: [config-reference.md](docs/config-reference.md#node-uptime-column)
+- Namespace resource quota dashboard with `Q`
+- Watch mode auto-refresh with `w`: [usage.md](docs/usage.md#watch-mode-interval)
+- Random startup tips: [config-reference.md](docs/config-reference.md#top-level-fields)
 
 ## Navigation Hierarchy
 
@@ -232,7 +271,7 @@ Clusters (kubeconfig contexts)
                     +-- Containers (for Pods)
 ```
 
-Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection — shows all except the marked namespaces, each prefixed with `!`), `A` to reset to all-namespaces mode, or `R` to refresh the list from the cluster. Press `.` to quick-filter straight to the namespace of the resource highlighted behind the overlay.
+Namespaces are **not** a navigation level. The current namespace is shown in the top-right corner and can be changed by pressing `\`, which opens a selector that filters as you type. All-namespaces mode is enabled by default (toggle with `A`). Inside the namespace selector, press `Space` to include namespaces, `Tab` to exclude them (negative selection shows all except the marked namespaces, each prefixed with `!`), `A` to reset to all-namespaces mode, or `R` to refresh the list from the cluster. Press `.` to quick-filter straight to the namespace of the resource highlighted behind the overlay.
 
 ### Owner Resolution
 
@@ -247,125 +286,129 @@ Namespaces are **not** a navigation level. The current namespace is shown in the
 
 ## Keybindings
 
-> For the complete keybinding reference (YAML view, log viewer, describe, diff, exec mode, and all sub-modes), see [docs/keybindings.md](docs/keybindings.md). Press `F1` in-app for the built-in help screen, `?` for the which-key action panel.
+[docs/keybindings.md](docs/keybindings.md) is the complete reference, including the YAML view, log viewer, describe, diff, exec mode, and every sub-mode. Press `F1` in-app for the help screen, `?` for the which-key action panel.
 
-### Navigation
-
-| Key | Action |
-|---|---|
-| `h` / `Left` | Navigate to parent level |
-| `l` / `Right` | Navigate into selected item |
-| `j` / `Down` | Move cursor down |
-| `k` / `Up` | Move cursor up |
-| `gg` / `Home` | Jump to top of list |
-| `G` / `End` | Jump to bottom of list |
-| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page scroll down/up |
-| `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Full-page scroll down/up |
-| `Enter` | Open full-screen YAML view / navigate into |
-| `z` | Toggle expand/collapse all resource groups / toggle event grouping (Events view) |
-| `p` | Pin/unpin resource type (at resource types level) |
-| `x` | Pin/unpin or hide/show resource type (at resource types level) |
-| `H` | Toggle rarely used + hidden resource types |
-| `0` / `1` / `2` | Jump to clusters / types / resources level |
-| `J` / `K` | Scroll preview pane down/up |
-| `o` | Jump to owner/controller of selected resource |
-| `Backspace` | Jump back through teleport history |
-| `g`+`p/d/s/n/N/i/j/c/r/D/t/C/S/h/v/V/b` | Goto resource type (press `g` for which-key popup) |
-
-### Views and Modes
+### Move
 
 | Key | Action |
 |---|---|
-| `F1` | Toggle help screen (`?` too, where no which-key panel exists: overlays and exec mode) |
-| `f` | Filter items in current view |
-| `/` | Search and jump to match |
-| `n` / `N` | Next / previous search match |
-| `P` | Toggle between details and YAML preview |
-| `M` | Toggle resource relationship map |
-| `F` | Cycle layout: hide sidebar -> fullscreen -> normal |
+| `h` / `l` | Parent level / into the selected item |
+| `j` / `k` | Cursor down / up |
+| `gg` / `G` | Top / bottom of list |
+| `Ctrl+D` / `Ctrl+U` | Half-page scroll down / up |
+| `Ctrl+F` / `Ctrl+B` | Full-page scroll down / up |
+| `J` / `K` | Scroll the preview pane down / up |
+| `Enter` | Fullscreen YAML view, or navigate into |
+
+### Jump
+
+| Key | Action |
+|---|---|
+| `0` / `1` / `2` | Clusters / resource types / resources level |
+| `o` | Owner or controller of the selected resource |
+| `Backspace` | Back through teleport history |
+| `g` + key | Goto resource type (`g` opens the which-key popup) |
+| `m<slot>` / `'<slot>` | Set / jump to bookmark (lowercase context-aware, uppercase context-free) |
+| `\` / `A` | Namespace selector / toggle all-namespaces |
+| `g\` | Previous namespace |
+
+### Resource type list
+
+| Key | Action |
+|---|---|
+| `z` | Expand or collapse all groups (Events view: toggle grouping) |
+| `p` | Pin or unpin the selected type |
+| `x` | Pin, hide, or show the selected type |
+| `H` | Reveal rarely used and hidden types |
+
+### Search and filter
+
+| Key | Action |
+|---|---|
+| `f` | Filter items in the current view |
+| `/` | Search and jump to a match |
+| `n` / `N` | Next / previous match |
 | `.` | Quick filter presets |
-| `!` | Error log (V/v select, y copy, f fullscreen) |
-| `Ctrl+S` | Toggle secret value visibility |
-| `Ctrl+G` | Finalizer search and remove |
-| `I` | API Explorer (browse resource structure interactively) |
-| `O` | Object Explorer (browse the selected resource's live object as a drill-in tree) |
-| `Ctrl+K` | Schema side pane for the field under the cursor (YAML viewer, Object Explorer) |
+| `,` | Column visibility and order |
+| `>` / `<` / `=` / `-` | Sort by next / previous column, flip direction, reset |
+
+### Views
+
+| Key | Action |
+|---|---|
+| `F1` / `?` | Help screen / which-key action panel |
+| `P` | Details summary or YAML preview |
+| `M` | Resource relationship map |
+| `F` | Cycle layout: hide sidebar, fullscreen, restore |
+| `I` / `O` | API Explorer / Object Explorer |
+| `Ctrl+K` | Schema side pane for the field under the cursor |
 | `U` | RBAC permissions browser (can-i) |
-| `T` | Open theme selector |
-| `:` | Command bar (resource jumps, built-ins, kubectl, shell) |
-| `w` | Toggle watch mode (auto-refresh) |
-| `,` | Column visibility toggle (show/hide and reorder columns) |
-| `>` / `<` | Sort by next / previous column |
-| `=` | Toggle sort direction (ascending/descending) |
-| `-` | Reset sort to default (Name ascending) |
-| `W` | Save resource to file / toggle warnings-only (Events) |
-| `Ctrl+T` | Cycle terminal mode (pty / exec / mux — mux skipped without tmux/zellij) |
-| `@` | Cycle Cluster / Monitoring dashboard |
-| `Q` | Namespace resource quota dashboard |
 
 ### Actions
 
 | Key | Action |
 |---|---|
-| `x` | Action menu (logs, exec, describe, edit, delete, scale, port-forward, etc.) |
-| `\` / `A` | Namespace selector / toggle all-namespaces |
-| `g\` | Jump to previous namespace (swap back and forth) |
-| `L` | Toggle live-log preview pane (right pane, streaming tail; pod and container rows) |
-| `Ctrl+L` | Open fullscreen log viewer |
-| `v` | Describe resource |
+| `x` | Action menu (logs, exec, describe, edit, delete, scale, port-forward) |
+| `v` / `L` / `Ctrl+L` | Describe / live-log preview / fullscreen log viewer |
 | `D` / `X` | Delete / force delete |
-| `y` / `Y` | Copy name / open copy-as picker (YAML / JSON / Table) |
-| `Ctrl+Y` | Copy a single field (columns by default, `Tab` for all manifest fields; works with multi-selection) |
+| `y` / `Y` / `Ctrl+Y` | Copy name / copy-as picker / copy a single field |
+| `Ctrl+P` / `W` | Apply from clipboard / save the manifest to a file |
 | `Space` | Toggle multi-selection (bulk actions via `x`) |
-| `?` | Which-key action panel: hotkeys actionable right now |
-| `m<slot>` / `'<slot>` | Set / jump to bookmark (lowercase = context-aware, uppercase = context-free) |
-| `t` / `]` / `[` | New tab / next / previous |
-| `}` / `{` | Move current tab right / left |
+| `Ctrl+S` / `Ctrl+G` | Secret value visibility / finalizer search and remove |
 
-All views (YAML, logs, describe, diff, exec) use vim-style navigation (`j`/`k`, `gg`/`G`, `Ctrl+D`/`Ctrl+U`, `/` search, `v`/`V` visual selection). See [docs/keybindings.md](docs/keybindings.md) for the full reference.
+### Tools
 
-> For the complete command bar reference (built-in commands, shell/kubectl execution, resource jumps), see [docs/commands.md](docs/commands.md).
+| Key | Action |
+|---|---|
+| `:` | Command bar (resource jumps, built-ins, kubectl, shell) |
+| `T` | Theme selector |
+| `@` / `Q` | Cluster or monitoring dashboard / namespace quotas |
+| `w` | Watch mode (auto-refresh) |
+| `Ctrl+T` | Cycle terminal mode (pty / exec / mux) |
+| `Ctrl+R` | Read-only mode |
+| `!` | Error log |
+| `t` / `]` / `[` / `}` / `{` | New tab / next / previous / move right / move left |
+
+All views (YAML, logs, describe, diff, exec) use vim-style navigation: `j`/`k`, `gg`/`G`, `Ctrl+D`/`Ctrl+U`, `/` search, `v`/`V` visual selection.
+
+[docs/commands.md](docs/commands.md) is the command bar reference: built-in commands, shell and kubectl execution, resource jumps.
 
 ## Configuration
 
-Create `~/.config/lfk/config.yaml` to customize the application. All fields are optional; only the values you specify will override the defaults.
-
-> For the complete configuration reference, see [docs/config-reference.md](docs/config-reference.md) and [docs/config-example.yaml](docs/config-example.yaml).
-
-### Quick Start
+1. Create `~/.config/lfk/config.yaml`.
+2. Add only the keys you want to change. Every other value keeps its default.
+3. Press `T` in-app to browse themes, then put the name you picked in `colorscheme`.
 
 ```yaml
-# Color scheme (press T in-app to browse 460+ themes with live preview)
-# Auto dark/light mode — Ghostty-style "dark:X,light:Y" syntax switches the
-# scheme when the OS appearance changes (CSI 996/2031; Ghostty, kitty >= 0.27, …)
+# Color scheme. "dark:X,light:Y" switches with the OS appearance.
 colorscheme: "dark:catppuccin-mocha,light:catppuccin-latte"
 
-# Use terminal's own background
+# Use the terminal's own background
 transparent_background: true
 
-# Icon mode: "auto" (default, detects Nerd Font terminals like Ghostty/Kitty/WezTerm),
-# "unicode", "nerdfont" (requires Nerd Font in terminal), "simple" (ASCII labels),
-# "emoji", or "none". The LFK_ICONS env var overrides this setting.
+# auto, unicode, nerdfont, simple, emoji, or none. LFK_ICONS overrides it.
 icons: auto
 
 # Disable mouse capture (allows native terminal text selection)
 mouse: false
 
-# Custom keybinding overrides (only specify what you want to change)
+# Keybinding overrides
 keybindings:
   logs: "ctrl+l"
   toggle_preview_logs: "L"
   describe: "v"
   delete: "D"
 
-# Search abbreviations (extend built-in abbreviations for :pod, :dep, etc.)
+# Search abbreviations
 abbreviations:
   myapp: myapplications
 ```
 
+[docs/config-reference.md](docs/config-reference.md) is the full reference, [docs/config-example.yaml](docs/config-example.yaml) a commented example of every field.
+
 ### Search Modes
 
-All search and filter inputs support three modes, auto-detected from the query string:
+Every search and filter input auto-detects the mode from the query string:
 
 | Mode | Syntax | Example |
 |---|---|---|
@@ -374,62 +417,79 @@ All search and filter inputs support three modes, auto-detected from the query s
 | Fuzzy | `~` prefix | `~deplymnt` |
 | Literal | `\` prefix | `\err.*` |
 
-**Clipboard paste**: All search, filter, and command bar inputs accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). Multiline paste shows a confirmation dialog.
+All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A multiline paste shows a confirmation dialog.
 
-**Recall previous queries**: While the `f` filter or `/` search input is open, press `Up` / `Down` to cycle through previous queries. `/` and `f` share one history (the matcher and matched fields are identical between them), kept separate from the `:` command bar. The log viewer's `/` search has its own history because it matches raw log lines (substring/regex over arbitrary text) rather than resource names — pooling it would surface irrelevant entries. All three persist across sessions under `$XDG_STATE_HOME/lfk/` (default `~/.local/state/lfk/`) — `query-history` for explorer `/` and `f`, `log-search-history` for the log viewer's `/`, and `history` for the command bar.
+`Up` / `Down` recall previous queries. `/` and `f` share one history, the log viewer's `/` and the `:` command bar keep their own. All three survive restarts under `$XDG_STATE_HOME/lfk/`: [keybindings.md](docs/keybindings.md#log-viewer).
 
 ## Tips and Tricks
 
-- Peek at Pod/Deployment logs with `L` (live-log preview pane), or open the fullscreen log viewer with `Ctrl+L`
-- Jump straight to a resource type from anywhere: type `:pod`, `:dep`, `:pvc` in the command bar
-- Press `o` on a resource to jump to its owner (e.g. Pod -> Deployment), then `Backspace` to jump back
-- Typos are fine in search: `/~deplymnt` fuzzy-matches `deployments`
-- Multi-select with `Space` (range-select with `Ctrl+Space`), then bulk delete/scale/restart via `x`
-- Set a bookmark with `m<letter>`, jump back with `'<letter>` - lowercase slots are context-aware. Each bookmark shows its saved namespace in the overlay and the jump applies it by default; press Tab to opt out and keep the current scope. An active list filter is saved with the bookmark and reapplied on jump (shown as `> /<filter>` in the slot name)
-- Press `.` for quick filter presets (e.g. only failing Pods); extend them per resource type in config
-- Decode Secret values in the preview with `Ctrl+S`, or edit them decoded with `e`
-- Copy the resource name with `y`; press `Y` to copy as YAML, JSON, or Table
-- Apply a manifest straight from your clipboard with `Ctrl+P`
-- Hunt down unused ConfigMaps, Secrets, PVCs and more with `Shift+Z` (orphan detection)
-- Run kubectl without leaving lfk (`:k get pods -o wide`) or any shell command (`:! curl ...`)
-- Investigate a crash-looping Pod with `x` -> `I`: restart history, events, previous logs, and describe in one tabbed view
-- Lock a session against destructive actions with `Ctrl+R` (read-only mode)
-- Try a new look without restarting: `T` live-previews 460+ themes
-- Resource stuck in Terminating? `Ctrl+G` searches its finalizers and removes them
-- Press `Tab` inside `/` or `f` to broaden matching to labels, annotations, finalizers, and other column values
-- Recall earlier queries with `Up`/`Down` inside `/`, `f`, and the `:` command bar - history persists across restarts
-- See how a resource connects to everything else with `M` (relationship map)
-- Need everything except a few namespaces? In the `\` selector, `Tab` excludes namespaces instead of selecting them
-- Pin your daily-driver resource types with `p` and hide noisy ones via `x` - both remembered per cluster
+### Navigating
+
+- Press `o` on a resource to jump to its owner (Pod -> Deployment), then `Backspace` to jump back
 - Teleport between levels with `0` / `1` / `2` (clusters / resource types / resources)
+- Jump straight to a resource type from anywhere: type `:pod`, `:dep`, `:pvc`
+- Set a bookmark with `m<letter>`, jump back with `'<letter>`, the saved namespace and filter come with it
+- Pin your daily-driver resource types with `p` and hide noisy ones via `x`, both remembered per cluster
+- Need everything except a few namespaces? In the `\` selector, `Tab` excludes namespaces instead of selecting them
+- See how a resource connects to everything else with `M` (relationship map)
+
+### Finding
+
+- Typos are fine in search: `/~deplymnt` fuzzy-matches `deployments`
+- Press `Tab` inside `/` or `f` to broaden matching to labels, annotations, finalizers, and other column values
+- Recall earlier queries with `Up` / `Down` inside `/`, `f`, and the `:` command bar
+- Press `.` for quick filter presets, for example only failing Pods
+- Hunt down unused ConfigMaps, Secrets, PVCs and more with `Shift+Z` (orphan detection)
 - Sort by any column with `>` / `<`, flip direction with `=`, reset with `-`
-- Check firing Prometheus/Alertmanager alerts with `@` and namespace quotas with `Q`
-- Open an Ingress host - or an active port-forward's localhost URL - in your browser with `Ctrl+O`; on a Service, `Ctrl+O` starts a port forward and opens it
-- Save the selected resource manifest to a file with `W`
-- Spin up a throwaway kind/k3d/minikube cluster without leaving lfk: `Ctrl+N` at the cluster list
-- Capture a Pod's network traffic with `c` - live decode plus pcap export (kubectl-debug or kubeshark)
-- Walk any resource's live object with `O` (Object Explorer): `r` finds keys recursively, `T` expands an ASCII tree, `y` copies the field path
-- Forget `kubectl explain` - `I` opens the API Explorer, and `n`/`N` searches auto-drill into nested fields
-- In the YAML viewer, press `O` on a line to jump into the Object Explorer at that attribute, or `I` to see its schema
-- `Ctrl+K` opens a side pane with the schema description of the field under the cursor, and keeps it in step as you move
-- Fold YAML sections with `z` (`Z` folds all); edit the resource in your `$EDITOR` with `Ctrl+E`
-- Every viewer speaks vim: counts (`100j`, `42G`, `5n`), visual selections (`v` / `V` / `Ctrl+V`), and text objects (`viw`) work everywhere
-- Make noisy logs readable with `P` - the structured preview parses JSON, logfmt, klog, zap, nginx, envoy, Java, and postgres lines
-- Save logs to a file with `S` (loaded lines) or `Ctrl+S` (full history) - the path lands on your clipboard
+- Check firing Prometheus or Alertmanager alerts with `@`, and namespace quotas with `Q`
+
+### Logs
+
+- Peek at Pod or Deployment logs with `L`, open the fullscreen viewer with `Ctrl+L`
+- Make noisy logs readable with `P`: the structured preview parses JSON, logfmt, klog, zap, nginx, envoy, Java, and postgres lines
+- Save logs to a file with `S` (loaded lines) or `Ctrl+S` (full history), the path lands on your clipboard
 - Switch pods or filter containers without leaving the log viewer: press `\`
+- Investigate a crash-looping Pod with `x` -> `I`: restart history, events, previous logs, and describe in one tabbed view
+
+### Inspecting
+
+- Walk any resource's live object with `O`: `r` finds keys recursively, `T` expands an ASCII tree, `y` copies the field path
+- Forget `kubectl explain`, `I` opens the API Explorer and `n` / `N` auto-drill into nested fields
+- In the YAML viewer, press `O` on a line to open the Object Explorer at that attribute, or `I` to see its schema
+- `Ctrl+K` opens a side pane with the schema description of the field under the cursor, and keeps it in step as you move
+- Fold YAML sections with `z` (`Z` folds all), edit the resource in your `$EDITOR` with `Ctrl+E`
 - Replay a resource's event history as a timeline with `V`
-- Flip the RBAC question: inside the Can-I browser (`U`), `Tab` opens Who-Can - every subject allowed to run a verb on a resource
-- Get per-container CPU/memory recommendations with `x` -> `z` (Right-sizing Advisor, VPA-backed when available)
+- Every viewer speaks vim: counts (`100j`, `42G`, `5n`), visual selections (`v` / `V` / `Ctrl+V`), and text objects (`viw`)
+
+### Acting
+
+- Multi-select with `Space` (range-select with `Ctrl+Space`), then bulk delete, scale, or restart via `x`
+- Decode Secret values in the preview with `Ctrl+S`, or edit them decoded with `e`
+- Copy the resource name with `y`, press `Y` to copy as YAML, JSON, or Table
+- Apply a manifest straight from your clipboard with `Ctrl+P`
+- Save the selected resource manifest to a file with `W`
+- Resource stuck in Terminating? `Ctrl+G` searches its finalizers and removes them
+- Open an Ingress host, or an active port-forward's localhost URL, with `Ctrl+O`. On a Service it starts a port forward and opens it
+- Run kubectl without leaving lfk (`:k get pods -o wide`) or any shell command (`:! curl ...`)
+
+### Cluster work
+
+- Lock a session against destructive actions with `Ctrl+R` (read-only mode)
+- Spin up a throwaway kind, k3d, or minikube cluster with `Ctrl+N` at the cluster list
+- Capture a Pod's network traffic with `c`: live decode plus pcap export
+- Flip the RBAC question: inside the Can-I browser (`U`), `Tab` opens Who-Can, every subject allowed to run a verb on a resource
+- Get per-container CPU and memory recommendations with `x` -> `z` (Right-sizing Advisor, VPA-backed when available)
 - Watch an ArgoCD Application roll out wave by wave: `x` -> `W` opens the Sync Wave Timeline
+- Try a new look without restarting: `T` live-previews 460+ themes
 - Waiting for a rollout? `:nyan` and `:kubetris` are real commands
 
 ## Contributing
 
-Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, development setup, build/test commands, project layout, and the PR submission flow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, development setup, build and test commands, project layout, and the PR flow.
 
 ## License
 
-Apache License 2.0 - see [LICENSE](LICENSE) for details.
+Apache License 2.0, see [LICENSE](LICENSE).
 
 ## Star History
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-LFK is under active development. Security fixes are applied to the latest
-release on the `main` branch. Older tagged releases are not maintained — please
-upgrade to the latest version to receive security patches.
+Security fixes apply to the latest release on the `main` branch only. Older
+tagged releases are not maintained. Upgrade to the latest version to receive
+patches (LFK is under active development).
 
 | Version          | Supported          |
 | ---------------- | ------------------ |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Security fixes apply to the latest release on the `main` branch only. Older
 tagged releases are not maintained. Upgrade to the latest version to receive
-patches (LFK is under active development).
+patches.
 
 | Version          | Supported          |
 | ---------------- | ------------------ |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,4 +1,4 @@
-# Command Bar Reference
+# Command Bar reference
 
 Press `:` to open the command bar. Input is classified by the first word:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,13 +25,13 @@ Press `:` to open the command bar. Input is classified by the first word:
 | `:orphans [<kind>]` | Open cluster-wide orphan resource overview |
 | `:session save <name>` | Save the current workspace (all tabs) as a named session |
 | `:session delete <name>` &nbsp;·&nbsp; `:session rm <name>` | Delete a named session |
-| `:sessions` &nbsp;·&nbsp; `C` | Open the session manager (enter=switch, s=save current as…, d=delete, /=filter). The active session auto-saves on quit; start on one with `lfk --session <name>` / `LFK_SESSION`. |
+| `:sessions` &nbsp;·&nbsp; `C` | Open the session manager |
 | `:quit` &nbsp;·&nbsp; `:q` &nbsp;·&nbsp; `:q!` | Exit |
 | `:nyan` | Toggle Nyan mode |
 | `:kubetris` | Play Kubetris |
 | `:credits` | Show credits |
-| `:dashboard` | Show Cluster Dashboard
-| `:monitoring`| Show Monitoring Dashboard
+| `:dashboard` | Show Cluster Dashboard |
+| `:monitoring` | Show Monitoring Dashboard |
 
 ### `:sort <column>`
 
@@ -45,7 +45,9 @@ Column names match the table headers (case-sensitive): `Name`, `Namespace`, `Age
 | `linenumbers` / `nolinenumbers` | Line numbers |
 | `timestamps` / `notimestamps` | Timestamps |
 | `follow` / `nofollow` | Auto-scroll to tail |
-| `ansi` / `noansi` | Render ANSI SGR colors from log output. Off replaces ESC bytes with U+FFFD (see config-reference.md `log_viewer.render_ansi`). |
+| `ansi` / `noansi` | Render ANSI SGR colors from log output |
+
+`noansi` replaces ESC bytes with U+FFFD (see `log_viewer.render_ansi` in [config-reference.md](config-reference.md)).
 
 ### `:scheduler`
 
@@ -57,6 +59,10 @@ Scheduler / task queue overlay. Inside:
 - `Esc` / `q` — close
 
 Repeated completed tasks collapse with a `×N` suffix.
+
+### `:sessions`
+
+Session manager: `Enter` switches, `s` saves the current workspace as a new session, `d` deletes, `/` filters. The active session auto-saves on quit. Start on a given session with `lfk --session <name>` or `LFK_SESSION`.
 
 ## Shell commands
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,7 +13,7 @@ Press `:` to open the command bar. Input is classified by the first word:
 
 | Command | Description |
 |---|---|
-| `:namespace <ns>…` &nbsp;·&nbsp; `:ns <ns>…` | Switch namespace(s); no args opens the Namespaces list |
+| `:namespace <ns>…` &nbsp;·&nbsp; `:ns <ns>…` | Switch namespace(s). No args opens the Namespaces list |
 | `:context <ctx>` &nbsp;·&nbsp; `:ctx <ctx>` | Switch kube context |
 | `:sort <column>` | Sort the current list by column name |
 | `:set <option>` | Toggle log viewer option (see below) |
@@ -62,7 +62,16 @@ Repeated completed tasks collapse with a `×N` suffix.
 
 ### `:sessions`
 
-Session manager: `Enter` switches, `s` saves the current workspace as a new session, `d` deletes, `/` filters. The active session auto-saves on quit. Start on a given session with `lfk --session <name>` or `LFK_SESSION`.
+Session manager.
+
+| Key | Action |
+|---|---|
+| `Enter` | Switch to the session |
+| `s` | Save the current workspace as a new session |
+| `d` | Delete the session |
+| `/` | Filter |
+
+The active session auto-saves on quit. Start on a given session with `lfk --session <name>` or `LFK_SESSION`.
 
 ## Shell commands
 
@@ -85,7 +94,7 @@ Session manager: `Enter` switches, `s` saves the current workspace as a new sess
 
 Autocomplete offers subcommands, flags, resource types, and namespaces. Typing `:k` or `:kubectl` alone surfaces the subcommand list. Value positions (namespace, resource name, output format) accept fuzzy matches — exact > prefix > substring > subsequence — while command names themselves stay on prefix.
 
-Namespace suggestions come from a per-context cache warmed when the context is opened and refreshed on a 60s TTL. In-app mutations — `:k create ns`, `:k delete ns`, or a template apply — invalidate the cache immediately so new namespaces appear in completions without waiting for the TTL; changes made outside the TUI (CI, cloud console, `kubectl` in another shell) surface on the next refresh. The existing list stays visible during refreshes so completions never blank out.
+Namespace suggestions come from a per-context cache warmed when the context is opened and refreshed on a 60s TTL. In-app mutations (`:k create ns`, `:k delete ns`, or a template apply) invalidate the cache immediately, so new namespaces appear in completions without waiting for the TTL. Changes made outside the TUI (CI, cloud console, `kubectl` in another shell) surface on the next refresh. The existing list stays visible during refreshes so completions never blank out.
 
 ## Resource jumps
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,4 +1,4 @@
-# Configuration Reference
+# Configuration reference
 
 The configuration file is located at `~/.config/lfk/config.yaml`. All fields are optional — only the values you specify will override the defaults.
 
@@ -12,7 +12,7 @@ A JSON Schema is published at [`docs/config.schema.json`](config.schema.json). A
 
 Prefer a local copy? Point `$schema` at a relative or absolute path instead of the URL.
 
-## Top-Level Fields
+## Top-level fields
 
 | Field | Type | Default | Description |
 |---|---|---|---|
@@ -199,7 +199,7 @@ log_viewer:
 
 The deprecated flat keys `log_tail_lines`, `log_tail_lines_short`, and `log_render_ansi` are still accepted as aliases; when both a flat key and its `log_viewer` equivalent are set, `log_viewer` wins.
 
-## Viewer Defaults
+## Viewer defaults
 
 Startup defaults for the fullscreen YAML / diff / describe viewers, so display toggles you always want don't need re-pressing on every open. Each viewer mirrors the `log_viewer` group.
 
@@ -273,7 +273,7 @@ monitoring:
       services: ["prometheus-server", "prometheus"]
 ```
 
-### Monitoring Entry Fields
+### Monitoring entry fields
 
 Each monitoring entry accepts the following top-level fields:
 
@@ -285,7 +285,7 @@ Each monitoring entry accepts the following top-level fields:
 
 When `node_metrics` is empty, lfk uses Prometheus if a `prometheus` endpoint is configured, otherwise metrics-api. Either way the other source is tried as a fallback, so pod metrics resolve on clusters served only by Prometheus.
 
-### Node Uptime Column
+### Node uptime column
 
 The nodes list shows an `Uptime` column (how long since each node last booted)
 when Prometheus is the configured monitoring source — that is, a `prometheus`
@@ -303,7 +303,7 @@ auto-discovered from the well-known namespaces and services listed below.
 Clusters without node_exporter never show the column. A node missing from the
 query result shows `n/a`, as does every node if Prometheus stops responding.
 
-### Monitoring Endpoint Fields
+### Monitoring endpoint fields
 
 Each endpoint (`prometheus` and `alertmanager`) accepts:
 
@@ -600,7 +600,7 @@ views:
 
 Per-cluster overrides follow the same format under `clusters.<name>.views` and win over global `views` for matching keys.
 
-## Resource Columns (Deprecated)
+## Resource columns (deprecated)
 
 > **Deprecated.** Use [`views`](#views) instead. `resource_columns` is bridged automatically — each entry becomes a `views` entry with the same columns and no `sort_column`. A one-time warning is logged when bridging occurs. When `views` is set for the same Kind, `views` wins.
 
@@ -635,7 +635,7 @@ resource_columns:
 
 Keys are resource Kind names and are case-insensitive (e.g., `Pod`, `pod`, `POD` all work).
 
-## Resource Templates
+## Resource templates
 
 Templates listed in the create-from-template picker (`a`) come from two places: the built-ins, and one YAML file per template in `~/.config/lfk/templates/`.
 
@@ -694,7 +694,7 @@ abbreviations:
   myapp: myapplication.example.com
 ```
 
-### Default Abbreviations
+### Default abbreviations
 
 | Abbreviation | Resource Type |
 |---|---|
@@ -733,7 +733,7 @@ abbreviations:
 | `netpol` | networkpolicy |
 | `rc` | replicationcontroller |
 
-## Custom Actions
+## Custom actions
 
 Define custom shell commands for specific resource types. Custom actions appear in the action menu (`x` key) after the built-in actions.
 
@@ -757,7 +757,7 @@ custom_actions:
       read_only_safe: true
 ```
 
-### Custom Action Fields
+### Custom action fields
 
 | Field | Required | Description |
 |---|---|---|
@@ -769,7 +769,7 @@ custom_actions:
 
 Set `read_only_safe: true` for view-only commands (e.g. `kubectl describe`, `kubectl logs`).
 
-### Template Variables
+### Template variables
 
 Template variables are substituted before execution:
 
@@ -785,7 +785,7 @@ Custom action commands are executed via `sh -c` with `KUBECONFIG` set in the env
 
 Substituted values are shell-quoted before insertion, so cluster data (context names, labels, image strings) containing shell metacharacters is passed literally and cannot inject commands. Quoting is transparent for normal argument use — `ssh {Node}` and `/tmp/{name}.log` work as written.
 
-## Pinned Groups
+## Pinned groups
 
 Pin CRD API groups so they appear right after the built-in categories (Workloads, Networking, etc.) instead of being sorted alphabetically under Custom Resources.
 
@@ -802,7 +802,7 @@ Pinning a type's dashboard summary is a separate action (the action menu's "Pin 
 
 When nothing is pinned anywhere (config or state), the dashboard shows a built-in default set instead: `batch/jobs`, `apps/deployments`, `argoproj.io/applications`, `kustomize.toolkit.fluxcd.io/kustomizations`, `cert-manager.io/certificates`. CRD-backed defaults are silently skipped when the cluster doesn't have the type. Your first interactive pin copies the currently-active defaults into your pinned list, then adds (or removes) the selected type, so the defaults you already see are kept, not replaced. Setting `pinned_summaries` in config is still a full explicit list and replaces the defaults outright. Set `pinned_summaries: []` in config to disable the defaults and show none.
 
-## Union Sets
+## Union sets
 
 Define named groups of clusters that the `--union-set <name>` CLI flag expands into a merged ("union") view. Avoids retyping long `--union-context` lists for the same recurring groups (blue/green/canary, region triplets, etc.). The flag is mutually exclusive with `--union-context` and `--context`.
 
@@ -850,7 +850,7 @@ When a cluster entry has a `color:` set, every row sourced from that cluster get
 
 The colors live inside the `union_sets` definition (not the global `cluster_colors` state file used by the cluster picker) so you can pick deliberate "traffic light" semantics per view — for example, the same kubeconfig context can be tinted blue here and untinted in another set, without affecting how it appears in the cluster picker. The textual `Context` column remains the source of truth for unambiguous reads (sortable, copyable, fits screen-readers); the tile is purely visual shorthand.
 
-## Filter Presets
+## Filter presets
 
 Define custom quick filter presets per resource type. These appear alongside the built-in presets when you press `.` at the resource level.
 
@@ -870,7 +870,7 @@ filter_presets:
         column_value: "1"
 ```
 
-### Filter Preset Fields
+### Filter preset fields
 
 | Field | Required | Description |
 |---|---|---|
@@ -878,7 +878,7 @@ filter_presets:
 | `key` | Yes | Single-character shortcut key (must not conflict with built-in presets) |
 | `match` | Yes | Filter criteria object (all fields are AND-ed) |
 
-### Match Criteria
+### Match criteria
 
 | Field | Description |
 |---|---|
@@ -891,7 +891,7 @@ filter_presets:
 
 `invert: true` flips the final AND result — useful for "anything except X" filters, e.g. `status: Bound` + `invert: true` matches every PVC that is NOT Bound.
 
-### Built-in Presets
+### Built-in presets
 
 Press `.` on any resource list to see the presets available for that kind. The built-ins are:
 
@@ -1006,7 +1006,7 @@ informer_cache: auto
 # informer_cache: off
 ```
 
-## Minimum Contrast Ratio
+## Minimum contrast ratio
 
 `min_contrast_ratio` is a normalized knob in `[0.0, 1.0]` that makes lfk
 automatically adjust foreground colors to be more readable against their
@@ -1071,7 +1071,7 @@ AA); raise toward `0.3` if still too dim.
 min_contrast_ratio: 0.175
 ```
 
-## Terminal Mode
+## Terminal mode
 
 Controls how interactive shells (`exec`, `attach`, `debug`, debug pods,
 node shell) run.
@@ -1124,7 +1124,7 @@ are forwarded to the new pane via inline shell variable assignments,
 since neither tmux nor zellij propagate parent env reliably across
 their spawn APIs.
 
-## PTY Scrollback
+## PTY scrollback
 
 `scrollback_lines` sets the per-tab capacity of the embedded PTY
 scrollback ring buffer (in lines). Only applies to `pty` mode — `exec`
@@ -1158,7 +1158,7 @@ page), `Ctrl+]` `Ctrl+B`/`Ctrl+F` (full page), `Ctrl+]` `g`/`G`
 If the Service isn't found in this namespace, the kubeshark chip is
 omitted from the backend picker.
 
-## Color Schemes
+## Color schemes
 
 Over 460 built-in color schemes are available, generated from [ghostty terminal themes](https://github.com/ghostty-org/ghostty). Sample list:
 
@@ -1168,7 +1168,7 @@ Switch themes at runtime with `T` to browse all available themes interactively w
 
 To regenerate themes from the latest ghostty source, run `make generate-themes`.
 
-## Session Persistence
+## Session persistence
 
 The application automatically saves and restores the last visited context, namespace, and resource type across restarts (per tab, including the active tab). It also restores the active list filter (including the `Tab` broad-match mode) and the highlighted row, so you reopen lfk on the same resource you were looking at. The session state is stored at `~/.local/state/lfk/session.yaml`.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -21,7 +21,7 @@ Prefer a local copy? Point `$schema` at a relative or absolute path instead of t
 | `transparent_background` | bool | `false` | **Deprecated** — use `appearance.transparent_background`. Use the terminal's own background for bars. Selection highlights remain opaque. |
 | `icons` | string | `"auto"` | **Deprecated** — use `appearance.icons`. Icon display mode. One of: `"auto"` (detects Nerd Font terminals; default), `"unicode"`, `"nerdfont"` (Material Design Icons; requires Nerd Font in terminal), `"simple"` (ASCII labels), `"emoji"`, or `"none"`. Unknown values fall back to `"unicode"`. Can be overridden at runtime by the `LFK_ICONS` environment variable. |
 | `log_path` | string | `"~/.local/share/lfk/lfk.log"` | Path to the application log file. |
-| `kubeconfig_dir` | string or list[string] | `"~/.kube/config.d"` | Directory (or list of directories) recursively scanned for kubeconfig files, in addition to `~/.kube/config` (unless `KUBECONFIG` is set, which is exclusive like kubectl). Tilde paths are expanded against `$HOME`. The `--kubeconfig-dir` CLI flag (repeatable) and `KUBECONFIG_DIR` env var (colon-separated) override this; the `--kubeconfig` flag bypasses directory discovery entirely. See [Kubeconfig Directory](usage.md#kubeconfig-directory). |
+| `kubeconfig_dir` | string or list[string] | `"~/.kube/config.d"` | Directory (or list of directories) recursively scanned for kubeconfig files, in addition to `~/.kube/config` (unless `KUBECONFIG` is set). See [Kubeconfig Directory](usage.md#kubeconfig-directory). |
 | `kubeconfig_exclusive` | bool | `true` | When `KUBECONFIG` is set, load only the files it lists (kubectl semantics), skipping `~/.kube/config` and the default `~/.kube/config.d` scan. Set `false` to merge everything like releases before 0.15. Overridden by `--kubeconfig-exclusive` and `LFK_KUBECONFIG_EXCLUSIVE`. |
 | `dashboard` | bool | `true` | Show cluster dashboard when entering a context. Set to `false` to go directly to resource types. |
 | `monitoring` | map[string]object | `{}` | Per-cluster monitoring endpoint configuration. Keys are context names or `"_global"`. See [Monitoring](#monitoring) section. |
@@ -74,12 +74,12 @@ Prefer a local copy? Point `$schema` at a relative or absolute path instead of t
 | `security.enabled` | bool | `true` | Enable the built-in security findings dashboard (Security category + SEC badge). `false` turns the dashboard and all source probing off. Per-context overrides under `clusters.<name>.security` take precedence. See [Security Dashboard](security.md). |
 | `security.hide_badges` | bool | `false` | Hide the per-resource SEC severity badge by default. The dashboard still scans; only the inline row badge is suppressed. Toggle at runtime with the security badge key (`B`). Per-context overrides under `clusters.<name>.security.hide_badges` take precedence. |
 | `security.sources.<name>` | bool | `true` | Enable/disable individual sources (`heuristic`, `advisor`, `rbac`, `trivy`, `kyverno`, `kubescape`, `falco`, `gatekeeper`). A source omitted from the map stays enabled. |
-| `security.ignore_patterns` | list | _(empty)_ | Declarative glob-based ignore rules applied at load. Each entry has `cluster`, `source`, `group`, `namespace` (globs; empty = any), an optional `labels` map (label key -> glob value; all entries must match), and an optional `comment`. A finding is hidden when every non-empty field matches. A `labels` entry is resource-scoped (hides matching resources, never the whole group) and matches when the finding's resource has resolvable labels (heuristic-observed pods and same-pod findings, plus workload labels resolved from the live object for standard kinds when a label pattern is set). See [Security Dashboard](security.md#label-matching) for coverage details. An all-empty entry is dropped. Read-only (not un-ignorable from the UI); the `i` toggle still reveals them. |
+| `security.ignore_patterns` | list | _(empty)_ | Declarative glob-based ignore rules applied at load. See [Security](#security) below for field details. |
 | `security.heuristic.secret_env_include` | list | _(empty)_ | Extra env-var name globs (`*`, `?`; case-insensitive) the heuristic `secret_env` check flags, on top of the built-in credential keywords. An explicit match overrides a built-in exemption. Top-level `security` section only. |
 | `security.heuristic.secret_env_exclude` | list | _(empty)_ | Env-var name globs the heuristic `secret_env` check never flags, on top of the built-in exemptions. Wins over `secret_env_include`. Top-level `security` section only. |
 | `security.heuristic.scan_secrets` | bool | `true` | Allow the heuristic source to list Secret objects, enabling the `legacy_sa_token_secret` and `tls_secret_expiry` checks and Secret-reference verification. `false` means the source never reads Secrets. Top-level `security` section only. |
 | `clusters.<name>.security` | object | _(unset)_ | Per-context security override (`enabled`, `hide_badges`, and/or `sources`). Wins over the global `security` settings for that context. |
-| `secret_lazy_loading` | bool | `false` | When `true`, Secret listing fetches metadata only and decoded values load on hover. Much faster in clusters with many Helm release secrets (each release is a multi-hundred-KB Secret) or large TLS payloads, at the cost of an extra GET per hovered Secret. When `false` (default), Secrets list like every other resource type — full objects are pulled and `data` is eagerly decoded, so the Type column and decoded values are visible immediately. See [Secret lazy loading](#secret-lazy-loading) for trade-offs. |
+| `secret_lazy_loading` | bool | `false` | When `true`, Secret listing fetches metadata only and decoded values load on hover. See [Secret lazy loading](#secret-lazy-loading) for trade-offs. |
 | `informer_cache` | bool or string | `auto` | Selects the list strategy. Accepts `off` (round-trip every list — matches kubectl), `auto` (default; promote a resource type to a shared informer once a list crosses 1000 items, demote when sustained below 500), and `always` (open a watch eagerly on first use). Legacy bool form is still accepted: `true` → `always`, `false` → `off`. See [Informer cache](#informer-cache) for trade-offs. |
 | `min_contrast_ratio` | float | `0.0` | **Deprecated** — use `appearance.min_contrast_ratio`. Normalized readability knob in `[0.0, 1.0]`. When above zero, foreground colors are nudged in HSL lightness space to meet a minimum WCAG contrast ratio against their paired background. See [Minimum Contrast Ratio](#minimum-contrast-ratio). |
 
@@ -152,12 +152,22 @@ appearance:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `colorscheme` | string | `"tokyonight-storm"` | Built-in color scheme name. Dual-mode `"dark:X,light:Y"` supported. |
-| `icons` | string | `"auto"` | Icon display mode (`auto`/`unicode`/`nerdfont`/`simple`/`emoji`/`none`). Also decides how the which-key panel and the help screen's key column draw keys: Nerd Font keycaps (`󰘴 D`), Unicode symbols (`⌃D`), or names (`ctrl+d`). |
+| `icons` | string | `"auto"` | Icon display mode (`auto`/`unicode`/`nerdfont`/`simple`/`emoji`/`none`). |
 | `no_color` | bool | `false` | Strip all colors (monochrome). `NO_COLOR` env var takes precedence. |
 | `transparent_background` | bool | `false` | Use the terminal's own background for bars and surfaces. |
 | `min_contrast_ratio` | float | `0.0` | Readability knob in `[0.0, 1.0]`. See [Minimum Contrast Ratio](#minimum-contrast-ratio). |
 | `dim_overlay` | bool | `true` | Fade the screen behind overlays. No-op when `no_color: true`. |
-| `row_status_tint` | string | `"foreground"` | Emphasize failed/progressing rows as a fallback for when the Status cell is not visible. `foreground`: color the row's **Name** cell in the status color (same color as the Status cell) only when the Status column is hidden — no change while the Status column is shown; when the Name column is also hidden, the whole row is tinted so the signal is not lost. `background`: a muted status-colored background across the whole row, always; the cursor row blends the status color toward the selection color so it stays visible. `off`: only the Status cell is colored. In `no_color` mode the tint degrades to bold (failed) / italic (progressing); a selected failed row uses underline, since the selection is already bold. |
+| `row_status_tint` | string | `"foreground"` | Emphasize failed/progressing rows as a fallback for when the Status cell is not visible. See [Row status tint](#row-status-tint) below. |
+
+`icons` also decides how the which-key panel and the help screen's key column draw keys: Nerd Font keycaps (`󰘴 D`), Unicode symbols (`⌃D`), or names (`ctrl+d`).
+
+### Row status tint
+
+- `foreground`: colors the row's **Name** cell in the status color (same color as the Status cell), only when the Status column is hidden — no change while the Status column is shown. When the Name column is also hidden, the whole row is tinted so the signal is not lost.
+- `background`: a muted status-colored background across the whole row, always. The cursor row blends the status color toward the selection color so it stays visible.
+- `off`: only the Status cell is colored.
+
+In `no_color` mode the tint degrades to bold (failed) / italic (progressing); a selected failed row uses underline, since the selection is already bold.
 
 ## Log Viewer
 
@@ -271,7 +281,9 @@ Each monitoring entry accepts the following top-level fields:
 |---|---|---|---|
 | `prometheus` | object | *(auto-discovery)* | Prometheus endpoint configuration. See endpoint fields below. |
 | `alertmanager` | object | *(auto-discovery)* | Alertmanager endpoint configuration. See endpoint fields below. |
-| `node_metrics` | string | *(auto-detect)* | Metrics source for node **and pod** usage: `"prometheus"` (use Prometheus queries), `"metrics-api"` (use metrics.k8s.io API). When empty, uses Prometheus if a prometheus endpoint is configured, otherwise metrics-api. Either way the other source is tried as a fallback, so pod metrics resolve on clusters served only by Prometheus. |
+| `node_metrics` | string | *(auto-detect)* | Metrics source for node **and pod** usage: `"prometheus"` or `"metrics-api"`. Empty auto-detects. |
+
+When `node_metrics` is empty, lfk uses Prometheus if a `prometheus` endpoint is configured, otherwise metrics-api. Either way the other source is tried as a fallback, so pod metrics resolve on clusters served only by Prometheus.
 
 ### Node Uptime Column
 
@@ -373,6 +385,17 @@ clusters:
       sources:
         trivy: false       # keep the dashboard, drop Trivy on staging only
 ```
+
+Each `ignore_patterns` entry matches on `cluster`, `source`, `group`, `namespace`
+(globs; empty = any), an optional `labels` map (label key -> glob value; all
+entries must match), and an optional `comment`. A finding is hidden when every
+non-empty field matches. A `labels` entry is resource-scoped — it hides
+matching resources, never the whole group — and matches when the finding's
+resource has resolvable labels (heuristic-observed pods and same-pod findings,
+plus workload labels resolved from the live object for standard kinds when a
+label pattern is set). See [Security Dashboard](security.md#label-matching)
+for coverage details. An all-empty entry is dropped. Ignore patterns are
+read-only from config; the `i` toggle still reveals hidden findings.
 
 Precedence: `clusters.<ctx>.security.*` overrides the global `security.*`. The
 interactive per-cluster ignore-list (action menu) and `ignore_patterns` are
@@ -492,17 +515,17 @@ The fullscreen viewers (YAML, diff, describe, log, events) honor the shared `sea
 | `secret_editor` | `e` | Secret/ConfigMap editor |
 | `column_toggle` | `,` | Column visibility toggle |
 | `session_manager` | `C` | Open the session manager (save/switch/delete named workspace sessions). |
-| `toggle_wrap` | `>` | Toggle line wrapping in the YAML, diff, describe, log, and event viewers. Shares the `>` default with `sort_next`, but they apply in separate contexts (viewers vs. resource list). |
+| `toggle_wrap` | `>` | Toggle line wrapping in the YAML, diff, describe, log, and event viewers. |
 | `toggle_line_numbers` | `#` | Toggle line numbers (diff, log viewers). |
-| `toggle_fold` | `z` | Toggle fold on the section/region under the cursor (YAML, diff viewers; also folds tree-view branches in the Object/API Explorers, alongside `Space`). |
+| `toggle_fold` | `z` | Toggle fold on the section/region under the cursor (YAML, diff viewers). |
 | `toggle_fold_all` | `Z` | Toggle all folds (YAML, diff viewers). |
 | `toggle_follow` | `F` | Toggle follow / auto-scroll (log viewer). Moved from `f`, which now opens the log filter. |
 | `severity_up` | `o` | Raise the minimum log severity shown — cycles off → INFO+ → WARN+ → ERROR+ (log viewer). |
-| `severity_down` | `i` | Lower the minimum log severity shown (log viewer). Structured logs use the parsed level; plain-text logs are classified by keyword (error/warn/debug), defaulting to INFO. Shares the `i` default with `label_editor` / `security_ignore_toggle`, but they apply in separate contexts (log viewer vs. resource list). |
+| `severity_down` | `i` | Lower the minimum log severity shown (log viewer). |
 | `toggle_timestamps` | `s` | Toggle timestamps (log viewer). |
 | `toggle_prefixes` | `p` | Toggle `[pod/name/container]` line prefixes (log viewer). |
 | `toggle_unified` | `u` | Toggle unified vs side-by-side layout (diff viewer). |
-| `tree_view` | `T` | Toggle the ASCII-art tree view (Object Explorer, API Explorer). Shares the `T` default with `theme_selector`, but they apply in separate contexts (explorers vs. resource list). |
+| `tree_view` | `T` | Toggle the ASCII-art tree view (Object Explorer, API Explorer). |
 | `field_doc` | `ctrl+k` | Toggle the schema side pane for the field under the cursor (YAML viewer, Object Explorer). |
 | `toggle_preview` | `P` | Toggle the structured preview side panel (log viewer) / details↔YAML preview (explorer). |
 | `toggle_preview_logs` | `L` | Toggle the right-pane live-log preview for the selected pod or container (explorer; deeper levels only). |
@@ -516,6 +539,12 @@ The fullscreen viewers (YAML, diff, describe, log, events) honor the shared `sea
 | `terminal_toggle` | `ctrl+t` | Cycle terminal mode (pty/exec/mux) |
 | `mouse_toggle` | `ctrl+alt+y` | Suspend/resume mouse capture (Ctrl+Option+Y) for native text selection |
 | `toggle_rare` | `H` | Toggle rarely used resource types in the sidebar |
+
+### Keybinding notes
+
+- `toggle_fold` also folds tree-view branches in the Object/API Explorers, alongside `Space`.
+- `severity_up`/`severity_down` read the parsed level on structured logs; plain-text logs are classified by keyword (error/warn/debug), defaulting to INFO.
+- Shared defaults across separate contexts: `>` (`toggle_wrap` in viewers vs. `sort_next` in the resource list), `T` (`tree_view` in explorers vs. `theme_selector` in the resource list), `i` (`severity_down` in the log viewer vs. `label_editor` / `security_ignore_toggle` in the resource list).
 
 ## Views
 
@@ -537,7 +566,7 @@ NAME[:.jsonpath][|flag]*
 | Form | Meaning |
 |---|---|
 | `Name` | Built-in column resolved by the renderer (Name, Age, Ready, REV, etc.) |
-| `Name:.jsonpath` | Custom column — JSONPath evaluated against the source object. Uses `k8s.io/client-go/util/jsonpath` (kubectl-flavored). |
+| `Name:.jsonpath` | Custom column — JSONPath evaluated against the source object. |
 | `Name:.jsonpath\|flag` | Custom column with one or more display flags (stackable with multiple `\|`). |
 
 **Flags** (case-insensitive):
@@ -736,7 +765,9 @@ custom_actions:
 | `command` | Yes | Shell command to execute (supports template variables) |
 | `key` | Yes | Shortcut key in the action menu |
 | `description` | No | Description shown next to the action |
-| `read_only_safe` | No | When `true`, available in read-only mode. Defaults to `false` (treated as mutating). Set `true` for view-only commands (e.g. `kubectl describe`, `kubectl logs`). |
+| `read_only_safe` | No | When `true`, available in read-only mode. Defaults to `false`. |
+
+Set `read_only_safe: true` for view-only commands (e.g. `kubectl describe`, `kubectl logs`).
 
 ### Template Variables
 
@@ -856,7 +887,9 @@ filter_presets:
 | `restarts_gt` | Match pods with restart count greater than this number |
 | `column` | Column key to check (case-insensitive, e.g., "Node", "IP") |
 | `column_value` | Substring match against the column value (case-insensitive) |
-| `invert` | `true` to negate the entire match. Other fields still AND together; the final boolean is flipped. Useful for "anything except X" filters, e.g., `status: Bound` + `invert: true` matches every PVC that is NOT Bound. |
+| `invert` | `true` to negate the entire match (fields still AND together first). |
+
+`invert: true` flips the final AND result — useful for "anything except X" filters, e.g. `status: Bound` + `invert: true` matches every PVC that is NOT Bound.
 
 ### Built-in Presets
 
@@ -864,7 +897,7 @@ Press `.` on any resource list to see the presets available for that kind. The b
 
 | Kind | Presets (key) |
 |---|---|
-| Pod | Failing (`f`), Pending (`p`), Not Ready (`n`), Restarting (`r`), High Restarts (`R`), **Not Running (`x`)** |
+| Pod | Failing (`f`), Pending (`p`), Not Ready (`n`), **Not Running (`x`)** |
 | Deployment / StatefulSet / DaemonSet | Not Ready (`n`), Failing (`f`), **Not Running (`x`)** |
 | Job | Failed (`f`), **Not Running (`x`)** |
 | PersistentVolume | Available (`a`), Released (`r`), Failed (`f`), **Not Bound (`x`)** |
@@ -877,7 +910,7 @@ Press `.` on any resource list to see the presets available for that kind. The b
 | Flux HelmRelease / Kustomization | Suspended (`s`), Not Ready (`n`) |
 | Event | Warnings (`w`) |
 
-The `x` key (Not Running / Not Bound) is the shared "show me anything not in a healthy state" mnemonic across the kinds where it applies — k9s `Ctrl-Z` equivalent. Universal presets `Old (>30d)` (`o`) and `Recent (<1h)` (`h`) are also available on every list.
+The `x` key (Not Running / Not Bound) is the shared "show me anything not in a healthy state" mnemonic across the kinds where it applies — k9s `Ctrl-Z` equivalent. Universal presets `Old (>30d)` (`o`) and `Recent (<1h)` (`h`) are also available on every list. Pod also has Restarting (`r`) and High Restarts (`R`) presets for crash-loop triage.
 
 ## Secret lazy loading
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -897,7 +897,7 @@ Press `.` on any resource list to see the presets available for that kind. The b
 
 | Kind | Presets (key) |
 |---|---|
-| Pod | Failing (`f`), Pending (`p`), Not Ready (`n`), **Not Running (`x`)** |
+| Pod | Failing (`f`), Pending (`p`), Not Ready (`n`), Restarting (`r`), High Restarts (`R`), **Not Running (`x`)** |
 | Deployment / StatefulSet / DaemonSet | Not Ready (`n`), Failing (`f`), **Not Running (`x`)** |
 | Job | Failed (`f`), **Not Running (`x`)** |
 | PersistentVolume | Available (`a`), Released (`r`), Failed (`f`), **Not Bound (`x`)** |
@@ -910,7 +910,7 @@ Press `.` on any resource list to see the presets available for that kind. The b
 | Flux HelmRelease / Kustomization | Suspended (`s`), Not Ready (`n`) |
 | Event | Warnings (`w`) |
 
-The `x` key (Not Running / Not Bound) is the shared "show me anything not in a healthy state" mnemonic across the kinds where it applies — k9s `Ctrl-Z` equivalent. Universal presets `Old (>30d)` (`o`) and `Recent (<1h)` (`h`) are also available on every list. Pod also has Restarting (`r`) and High Restarts (`R`) presets for crash-loop triage.
+The `x` key (Not Running / Not Bound) is the shared "show me anything not in a healthy state" mnemonic across the kinds where it applies — k9s `Ctrl-Z` equivalent. Universal presets `Old (>30d)` (`o`) and `Recent (<1h)` (`h`) are also available on every list.
 
 ## Secret lazy loading
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,53 @@
+# Feature Details
+
+Detail for the README feature list. Features documented elsewhere link straight to their own page.
+
+## List status summary
+
+Hovering a resource type in the resource-type list pins a summary band at the bottom of the children pane, like the resource-usage footer. It always shows the resource count.
+
+Kinds with a health signal add a colored status rollup: ArgoCD Application health and sync, Pod phase, workload ready ratios, Node readiness, Namespace / PV / PVC phase, and Flux and cert-manager Ready. Any other kind that surfaces a `.status.phase` or `.status.conditions` gets a generic rollup, so you can confirm a whole list is healthy without drilling in.
+
+## Schema side pane
+
+`Ctrl+K` opens a bordered pane beside the YAML viewer and the Object Explorer with the cluster's own description of the field under the cursor. It follows the cursor, reads the connected cluster so CRDs resolve like built-in kinds, and caches what it reads.
+
+## Status colors
+
+Running is green, Pending yellow, Failed red. The same rule applies to CRD printer-column values: recognized status words (Active, Failed, Pending, ...) take their severity color, and True/False values follow the column's polarity, so `Established=False` is red and `Failed=False` is green.
+
+## Resource usage metrics
+
+The cluster dashboard shows CPU and memory as color-coded bars.
+
+## Command bar autocomplete
+
+The `:` bar drops a vertical suggestion list under the input. Value positions (namespace, context, resource name, option, column, format) accept fuzzy matches. Command names match on prefix only. kubectl commands complete flags and namespaces.
+
+## Resource templates
+
+`a` opens the create-from-template picker with more than 25 built-in templates plus your own. A Custom Resource template is included as a starting point for CRDs. See [config-reference.md](config-reference.md#resource-templates) for the file rules and [keybindings.md](keybindings.md#action-menu-items) for the picker keys.
+
+## Export as template
+
+`x` -> `T` strips a live object down to a manifest you can apply. On top of the server-set fields listed in [keybindings.md](keybindings.md#action-menu-items), the export also drops `nodeName`, `clusterIP`, and the injected service-account token volume.
+
+## Argo CD
+
+Browse Applications, sync, terminate a running sync, and refresh. With rows multi-selected, `x` also offers bulk sync and bulk refresh. Per-Application keys are in [keybindings.md](keybindings.md#argocd-application-actions).
+
+## Argo Workflows
+
+Suspend and resume Workflows, stop or terminate them, and resubmit them. Submit a new Workflow from a WorkflowTemplate. Suspend and resume CronWorkflows.
+
+## KEDA
+
+Pause and unpause ScaledObjects and ScaledJobs.
+
+## External Secrets
+
+Force a refresh of ExternalSecrets, ClusterExternalSecrets, and PushSecrets.
+
+## Embedded terminal
+
+Exec and shell sessions run in an embedded PTY by default. A session keeps running in the background when you switch tabs, so you can leave it and come back. `Ctrl+T` cycles the mode, see [config-reference.md](config-reference.md#terminal-mode).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,4 +1,4 @@
-# Feature Details
+# Feature details
 
 Detail for the README feature list. Features documented elsewhere link straight to their own page.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ paru -S lfk-bin
 git clone https://aur.archlinux.org/lfk-bin.git && cd lfk-bin && makepkg -si
 ```
 
-The `lfk-bin` package installs the prebuilt binary from the GitHub release. There is no source-build (`lfk` AUR) package; if you want to build from source, use `go install github.com/janosmiko/lfk@latest`.
+The `lfk-bin` package installs the prebuilt binary from the GitHub release. There is no source-build (`lfk` AUR) package. To build from source, use `go install github.com/janosmiko/lfk@latest`.
 
 ### Debian / Ubuntu (Cloudsmith APT)
 
@@ -109,7 +109,11 @@ choco install lfk
 
 ### Manual binary
 
-Download `lfk_<version>_windows_<arch>.zip` from [GitHub Releases](https://github.com/janosmiko/lfk/releases), extract `lfk.exe` into a directory in your `PATH`, and verify with `lfk --version`. Each archive is covered by the same cosign Sigstore bundle as Linux/macOS builds.
+1. Download `lfk_<version>_windows_<arch>.zip` from [GitHub Releases](https://github.com/janosmiko/lfk/releases).
+2. Extract `lfk.exe` into a directory in your `PATH`.
+3. Verify with `lfk --version`.
+
+Each archive is covered by the same cosign Sigstore bundle as Linux/macOS builds.
 
 ## From source
 
@@ -158,7 +162,7 @@ docker run -it --rm \
 lfk --demo
 ```
 
-Runs against a built-in fake cluster; no kubeconfig required. Exec, port-forward, drain, debug, Helm, and vuln scan are unavailable in demo mode.
+Runs against a built-in fake cluster. No kubeconfig required. Exec, port-forward, drain, debug, Helm, and vuln scan are unavailable in demo mode.
 
 ## External Dependencies
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -164,7 +164,7 @@ lfk --demo
 
 Runs against a built-in fake cluster. No kubeconfig required. Exec, port-forward, drain, debug, Helm, and vuln scan are unavailable in demo mode.
 
-## External Dependencies
+## External dependencies
 
 **Required:**
 - `kubectl` - Kubernetes CLI (must be configured and in PATH)

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -24,7 +24,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 
 In the Events list, `z` toggles event grouping instead of expand/collapse.
 
-`x`, at the resource types level, also lets you pin or unpin the selected type's dashboard summary through the action menu. The choice is saved per cluster context, or per union set.
+`x`, at the resource types level, also lets you pin or unpin the selected type's dashboard summary through the action menu. Pin, hide, and summary choices are saved per cluster context, or per union set.
 
 Teleport history records owner, port-forward, orphan, finding, and mark jumps. Hierarchical `h`/`l` navigation does not push a history entry.
 
@@ -876,7 +876,7 @@ The editor picks one of two modes based on the value being edited:
 
 `T`'s tree view shows the whole field subtree with ASCII-art guides, and stays on while drilling in or going back, until you toggle it off again.
 
-`Space` / `z` folding applies only in tree view (configurable via `toggle_fold`).
+`Space` / `z` folding applies only in tree view (`z` is configurable via `toggle_fold`).
 
 ## Can-I Browser
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,4 +1,4 @@
-# Keybindings Reference
+# Keybindings reference
 
 Complete list of all keybindings in `lfk`. All keybindings can be overridden in `~/.config/lfk/config.yaml` under the `keybindings` section. Only `esc`, `ctrl+c`, and `q` (quit) are hardcoded.
 
@@ -28,7 +28,7 @@ In the Events list, `z` toggles event grouping instead of expand/collapse.
 
 Teleport history records owner, port-forward, orphan, finding, and mark jumps. Hierarchical `h`/`l` navigation does not push a history entry.
 
-## Goto Navigation
+## Goto navigation
 
 Vim-style `g`-prefix chords that switch the active resource type while keeping the current context and namespace filter. Press `g` to open the goto which-key popup (configurable via `which_key_enabled` and `which_key_delay_ms`); `esc` or any unmapped key closes it.
 
@@ -67,7 +67,7 @@ looks up `jump_top` + the next keypress. A chord that does not is reported at
 startup and ignored. Rebinding `jump_top` therefore disables the built-in
 chords, which all start with `g`; re-point the ones you use at the new prefix.
 
-## Views and Tools
+## Views and tools
 
 | Key | Action |
 |---|---|
@@ -109,7 +109,7 @@ chords, which all start with `g`; re-point the ones you use at the new prefix.
 
 Your chosen sort is remembered per resource kind and per cluster context, and persists across restarts (stored in `~/.local/state/lfk/sort_memory.yaml`), so leaving a list and returning — or quitting and reopening lfk — keeps your sort instead of resetting. Use `-` (reset) to drop a remembered sort.
 
-## Modes & Settings
+## Modes and settings
 
 | Key | Action |
 |---|---|
@@ -171,7 +171,7 @@ Auto-excluded from Pod "Orphans":
 
 Terminal pods (Succeeded/Failed) older than 1h are still flagged but the reason is `"no owner (terminal)"` to distinguish them from live workloads.
 
-## Search and Filter
+## Search and filter
 
 | Key | Action | Config key |
 |---|---|---|
@@ -776,7 +776,7 @@ overlay interprets it as "reset to defaults for this kind" rather than
 leaving the table empty. To render only built-ins with zero extras, keep
 at least one built-in column checked when you press Enter.
 
-## Inline Editors (Secret / ConfigMap / Labels & Annotations)
+## Inline Editors (Secret / ConfigMap / labels and annotations)
 
 The Secret, ConfigMap, and Labels/Annotations editors use a shared key-value
 overlay. The list view supports vim-like navigation; pressing `e` or `a`
@@ -929,7 +929,7 @@ has access.
 ClusterRoleBindings always count regardless of namespace scope (cluster-wide
 grants apply everywhere); RoleBindings outside the active scope are excluded.
 
-## Can-I Subject Selector
+## Can-I subject selector
 
 | Key | Action |
 |---|---|
@@ -1058,7 +1058,7 @@ Invalid config values are dropped at startup with a warning in the error log.
 
 `Ctrl+C` cancels an in-progress bulk action on the current tab first, rather than closing it. It only cancels a bulk action started on that tab, not one running in another tab.
 
-## Read-Only Mode
+## Read-only mode
 
 | Key | Action |
 |---|---|
@@ -1075,7 +1075,7 @@ mode: X disabled" toast. See [Read-Only Mode](usage.md#read-only-mode)
 for the full precedence rules across the CLI flag, per-context config,
 and global config.
 
-## Cluster Color Coding
+## Cluster color coding
 
 | Key | Action |
 |---|---|
@@ -1213,7 +1213,7 @@ Inside the manager: `enter` switch (auto-saves the one you're leaving), `s` save
 | `q` | Quit application (with confirmation) |
 | `Esc` | Go back one level / close overlay / quit |
 
-## Action Menu Items
+## Action Menu items
 
 The action menu (`x` key) shows context-specific actions based on the resource type.
 
@@ -1238,64 +1238,64 @@ Locked rows offer no choice — keeping them yields a manifest that will not app
 
 The template picker (`a`): `Enter` create, `/` filter, `d` delete the highlighted saved template after a confirmation, `Esc`/`q` close. `d` works on your own templates only — the built-ins have no file behind them.
 
-### Pod Actions
+### Pod actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies whose pod selector matches this pod), `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `V` Events
 
-### Deployment Actions
+### Deployment actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `R` Rollback, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
-### StatefulSet Actions
+### StatefulSet actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
-### DaemonSet Actions
+### DaemonSet actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Restart, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
-### HorizontalPodAutoscaler Actions
+### HorizontalPodAutoscaler actions
 `S` Scale (edit min/max bounds & target replicas), `E` Edit, `D` Delete, `v` Describe, `b` Debug Pod, `V` Events
 
 The Scale overlay edits the HPA's `spec.minReplicas` / `spec.maxReplicas` (the HPA keeps autoscaling within the new range) and, optionally, scales the target workload directly. Fields prefill from the HPA's current values. `j`/`k` (or `↓`/`↑`) move between the three fields; `h`/`-` and `l`/`+` decrement/increment the active field; `←`/`→` move the cursor within the field; digits type a value directly. Target replica changes may be reverted by the HPA on its next reconcile. The same `h`/`-`/`l`/`+` steppers work in the workload Scale overlay.
 
-### Service Actions
+### Service actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec (into pod behind service), `A` Attach (to pod behind service), `p` Port Forward, `O` Port Forward & Open (forward a port and open it in the browser), `c` Capture Traffic, `N` Network Policies (policies affecting the service's backing pods), `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
 
-### Secret Actions
+### Secret actions
 `e` Secret Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
 
-### ConfigMap Actions
+### ConfigMap actions
 `e` ConfigMap Editor, `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
 
-### Node Actions
+### Node actions
 `c` Cordon/Uncordon (toggle schedulability), `n` Drain, `t` Taints (editor: mark taints for removal with `space`, add with `a`, pick a common taint with `p`, apply with `enter`), `s` Shell, `v` Describe, `E` Edit, `b` Debug Pod, `V` Events
 
 Drain streams the eviction progress live: in PTY terminal mode (default on macOS/Linux) the `kubectl drain` output renders in lfk's embedded scrollable terminal; in Exec mode the host terminal is handed over. The same applies to Drain Node on a Karpenter NodeClaim.
 
-### Longhorn Node Actions
+### Longhorn Node actions
 `e` Evict Replicas, `C` Cancel Eviction, `v` Describe, `E` Edit, `D` Delete, `X` Force Delete, `V` Events, `P` Permissions
 
 The Longhorn Nodes list shows a `REPLICAS` column with the count of replicas scheduled on each node. Force Delete disables scheduling, then deletes (the `validator.longhorn.io` webhook rejects deleting a still-schedulable node). Evict Replicas disables scheduling and sets `spec.evictionRequested`, so Longhorn rebuilds each replica on another node before removing it.
 
-### Job Actions
+### Job actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `b` Debug Pod, `V` Events
 
-### CronJob Actions
+### CronJob actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `r` Trigger (create Job), `S` Suspend/Resume (pause/resume schedule), `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events
 
-### ArgoCD Application Actions
+### ArgoCD Application actions
 `s` Sync, `a` Sync (Apply Only), `f` Diff, `R` Refresh, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
 
-### Helm Release Actions
+### Helm Release actions
 `u` Values, `A` All Values, `E` Edit Values, `d` Diff, `U` Upgrade, `R` Rollback, `h` History, `v` Describe, `D` Delete, `b` Debug Pod, `V` Events
 
-### Ingress Actions
+### Ingress actions
 `o` Open in Browser, `v` Describe, `E` Edit, `D` Delete, `b` Debug Pod, `V` Events
 
-### PVC Actions
+### PVC actions
 `g` Go to Pod, `b` Debug Mount, `B` Debug Pod, `v` Describe, `E` Edit, `D` Delete, `V` Events
 
-### Default Actions (all other resources)
+### Default actions (all other resources)
 `v` Describe, `E` Edit, `D` Delete, `l` Labels / Annotations, `P` Permissions, `b` Debug Pod, `V` Events
 
-### Bulk Actions (when items multi-selected)
+### Bulk actions (when items multi-selected)
 `D` Delete, `X` Force Delete, `S` Scale, `r` Restart
 
 ArgoCD Application bulk actions (when Application resources are multi-selected):
@@ -1303,7 +1303,7 @@ ArgoCD Application bulk actions (when Application resources are multi-selected):
 
 Custom actions defined in the config file appear after the built-in actions.
 
-## Configuring Keybindings
+## Configuring keybindings
 
 All keybindings can be overridden in `~/.config/lfk/config.yaml`. Only specify the keys you want to change — defaults apply for everything else.
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -15,12 +15,18 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `Enter` | Open full-screen YAML view / navigate into |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
-| `z` | Toggle expand / collapse all resource groups / toggle event grouping in the Events list |
-| `x` | At resource types level: pin / unpin or hide / show the selected resource type, or pin / unpin its dashboard summary, via the action menu (saved per cluster context / union set) |
+| `z` | Toggle expand / collapse all resource groups |
+| `x` | At resource types level: pin, hide, or show the selected type (action menu) |
 | `0` / `1` / `2` | Jump to clusters / types / resources level |
 | `J` / `K` | Scroll preview pane down / up |
-| `o` / `O` | `o` jumps to the owner/controller of the selected resource; `O` opens the Object Explorer for it |
-| `Backspace` | Jump back through teleport history (owner, port-forward, orphan, finding, and mark jumps push history; hierarchical `h`/`l` navigation does not) |
+| `o` / `O` | Jump to owner/controller / open Object Explorer |
+| `Backspace` | Jump back through teleport history |
+
+In the Events list, `z` toggles event grouping instead of expand/collapse.
+
+`x`, at the resource types level, also lets you pin or unpin the selected type's dashboard summary through the action menu. The choice is saved per cluster context, or per union set.
+
+Teleport history records owner, port-forward, orphan, finding, and mark jumps. Hierarchical `h`/`l` navigation does not push a history entry.
 
 ## Goto Navigation
 
@@ -66,16 +72,14 @@ chords, which all start with `g`; re-point the ones you use at the new prefix.
 | Key | Action |
 |---|---|
 | `F1` | Toggle help screen |
-| `?` | Which-key action panel -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key action panel — see [Which-Key Panel](#which-key-panel) |
 | `P` | Toggle between details summary and YAML preview |
-| | Details pane shows labels, finalizers, annotation count, and resource metadata |
-| | Details view shows deletion timestamp (with warning highlight) for resources being deleted |
 | `L` | Toggle live-log preview pane for selected pod or container (streaming tail in right pane; deeper levels only) |
 | `F` | Cycle layout: hide sidebar -> fullscreen -> restore (dashboards toggle fullscreen) |
 | `M` | Toggle resource relationship map view |
 | `,` | Column visibility toggle (show / hide and reorder columns — see [Column Toggle Overlay](#column-toggle-overlay) below) |
 | `p` | Pin / unpin resource type (at resource types level) |
-| `H` | Toggle rarely used + hidden resource types (CSI internals, webhooks, APF, leases, advanced core); revealed types shown dimmed (rare toggle resets each launch; per-type hides persist) |
+| `H` | Toggle rarely used and hidden resource types |
 | `I` | API Explorer (browse resource structure interactively) |
 | `O` | Object Explorer (browse the selected resource's live object as a drill-in tree) |
 | `U` | RBAC permissions browser (can-i) |
@@ -87,7 +91,13 @@ chords, which all start with `g`; re-point the ones you use at the new prefix.
 | `Ctrl+N` | Open the Local Clusters Manager overlay (only at LevelClusters) |
 | `Q` | Namespace resource quota dashboard |
 | `` ` `` | Scheduler / task queue overlay (Tab toggles running / completed history; `a` toggles show-all entries in completed view) |
-| `:` | Command bar: resource jumps (`:pod`, `:dep`), built-ins (`:ns`, `:ctx`, `:set`, `:sort`, `:export`, `:scheduler`), kubectl (`:k get pod`), shell (`:! cmd`) |
+| `:` | Command bar (resource jumps, built-ins, kubectl, shell) |
+
+`P`'s details summary shows labels, finalizers, annotation count, and other resource metadata, including a highlighted deletion timestamp for resources being deleted.
+
+`H`'s rarely used types are CSI internals, webhooks, APF, leases, and advanced core resources. Revealed types show dimmed. The toggle resets on each launch, but per-type hides persist.
+
+`:`'s resource jumps use the kind name, for example `:pod` or `:dep`. Built-ins include `:ns`, `:ctx`, `:set`, `:sort`, `:export`, and `:scheduler`. `:k` runs kubectl, for example `:k get pod`. `:!` runs a shell command, for example `:! cmd`.
 
 ## Sorting
 
@@ -119,12 +129,16 @@ Press **`Shift+Z`** anywhere in the explorer (or type `:orphans` with no argumen
 
 | Key | Action |
 | --- | ------ |
-| `Tab` / `Shift+Tab` | Cycle kind filter chips (All / Pods / Secrets / CMs / Svcs / PVCs / HPAs / PDBs / NetPols / Roles / RBs) |
-| `s` | Toggle strict / lenient — strict (default) hides items referenced by workload templates; lenient surfaces them |
+| `Tab` / `Shift+Tab` | Cycle kind filter chips |
+| `s` | Toggle strict / lenient filtering |
 | `/` | Filter by namespace + name |
 | `Enter` | Jump to the highlighted resource (namespace switches automatically) |
 | `R` | Re-scan the cluster |
 | `Esc` / `q` / `Shift+Z` | Close the overlay |
+
+The kind filter chips are All, Pods, Secrets, CMs, Svcs, PVCs, HPAs, PDBs, NetPols, Roles, and RBs.
+
+Strict mode (the default) hides items referenced by workload templates. Lenient mode surfaces them.
 
 ### Per-kind presets
 
@@ -276,9 +290,13 @@ Resource-specific actions (exec, scale, restart, secret editor, etc.) are availa
 | Key | Action |
 |---|---|
 | `y` | Copy resource name to clipboard (with multi-selection: newline-joined names of all selected items) |
-| `Y` | Open copy-as picker (YAML/JSON/Table). YAML/JSON support multi-selection (multi-doc YAML joined with `---`, JSON array). Table is a kubectl-style aligned plain-text view of the displayed columns. At LevelClusters and LevelResourceTypes only Table is offered. At LevelContainers, YAML and JSON extract the container spec block from the Pod manifest. |
-| `Ctrl+Y` | Copy a single field. Opens instantly on the visible table columns (Name, Status, extras...) — `Enter` copies the cell value. `Tab` switches to the full manifest field list, where array elements are labeled semantically (`status.addresses[ExternalIP].address` for a node's external IP) so filtering `ExternalIP` finds the address row. With multi-selection the chosen column/field is extracted from every selected item, one value per line; labeled array elements resolve per manifest (not by index), and items missing the field are skipped. Remembers the last-copied entry per resource kind for the session and preselects it next time. |
+| `Y` | Open copy-as picker (YAML / JSON / Table) |
+| `Ctrl+Y` | Copy a single field |
 | `Ctrl+P` | Apply resource from clipboard (`kubectl apply`) |
+
+`Y`'s YAML and JSON formats support multi-selection: multi-doc YAML joined with `---`, or a JSON array. Table is a kubectl-style aligned plain-text view of the displayed columns. At LevelClusters and LevelResourceTypes only Table is offered. At LevelContainers, YAML and JSON extract the container spec block from the Pod manifest.
+
+`Ctrl+Y` opens instantly on the visible table columns (Name, Status, extras). `Enter` copies the cell value. `Tab` switches to the full manifest field list, where array elements are labeled semantically (`status.addresses[ExternalIP].address` for a node's external IP), so filtering `ExternalIP` finds the address row. With multi-selection the chosen column/field is extracted from every selected item, one value per line. Labeled array elements resolve per manifest, not by index, and items missing the field are skipped. `Ctrl+Y` remembers the last-copied entry per resource kind for the session and preselects it next time.
 
 When items are multi-selected (`Space` / `Ctrl+Space` / `Ctrl+A`), `y`, `Y`, and `Ctrl+Y` operate on the selection rather than the cursor row — mirroring the precedence used by `D` (delete) and other bulk actions. `Y` and `Ctrl+Y` are capped at 50 manifests per copy (client-go's default rate limiter serializes the per-item fetches).
 
@@ -374,7 +392,7 @@ suffix in their name.
 | `j` / `k` | Bookmark overlay | Navigate bookmarks |
 | `/` | Bookmark overlay | Filter bookmarks by name |
 | `Enter` | Bookmark overlay | Jump to selected bookmark |
-| `Tab` | Bookmark overlay | Toggle `[KEEP CURRENT NS]` — opt out of loading the bookmark's saved namespace on the next jump |
+| `Tab` | Bookmark overlay | Toggle `[KEEP CURRENT NS]` |
 | `Ctrl+X` | Bookmark overlay | Delete selected bookmark (with confirmation) |
 | `Alt+X` | Bookmark overlay | Delete all bookmarks (with confirmation) |
 
@@ -402,7 +420,7 @@ The in-app screen is a quick reference: one binding per line, keys right-aligned
 
 ## YAML View
 
-> Search (`/`), help (`F1`), match navigation (`n`/`N`), and the display toggles (wrap, fold, line numbers, timestamps, prefixes, unified, preview, follow) shown across the viewers below are rebindable — see [Keybindings](config-reference.md#keybindings). Core cursor navigation (`hjkl`, `g`/`G`, page motions, word-motions) is fixed.
+> Search (`/`), help (`F1`), match navigation (`n`/`N`), and the display toggles (wrap, fold, line numbers, timestamps, prefixes, unified, preview, follow) shown across the viewers below are rebindable — see [Keybindings](config-reference.md#keybindings). Core cursor navigation (`hjkl`, `g`/`G`, page motions, word-motions) is fixed. `123 Ctrl+D` / `123 Ctrl+U` set the scroll step shared by both keys, following vim's `'scroll'` option. The result is clamped to the viewport.
 
 | Key | Action |
 |---|---|
@@ -422,7 +440,7 @@ The in-app screen is a quick reference: one binding per line, keys right-aligned
 | `123G` | Jump to line number |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
-| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
+| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (sets shared Ctrl+D/Ctrl+U step) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
 | `/` | Search in YAML |
 | `n` / `N` | Next / previous search match |
@@ -443,7 +461,7 @@ The in-app screen is a quick reference: one binding per line, keys right-aligned
 | `O` | Switch to the Object Explorer at the attribute under the cursor (keeps position) |
 | `I` | Open the API Explorer at the schema of the attribute under the cursor |
 | `Ctrl+K` | Toggle the schema side pane for the attribute under the cursor (configurable via `field_doc`) |
-| `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` / `Esc` | Back to explorer |
 
@@ -469,7 +487,7 @@ The top breadcrumb shows the resource name and the attribute path under the curs
 | `P` | Open the whole resource in the full YAML viewer |
 | `I` | Open the API Explorer at the selected item's schema |
 | `Ctrl+K` | Toggle the schema side pane for the selected item (configurable via `field_doc`) |
-| `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` | Close the Object Explorer |
 | `Esc` | Clear filter / back one level / close at root |
@@ -491,7 +509,7 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 | `123G` | Jump to line number |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
-| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
+| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (sets shared Ctrl+D/Ctrl+U step) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
 | `/` | Search in content |
 | `n` / `N` | Next / previous search match |
@@ -503,7 +521,7 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 | `y` | Copy line under cursor (or selection in visual mode) |
 | `123y` | Copy number of lines from cursor (count-prefixed yank) |
 | `>` | Toggle line wrapping (configurable via `toggle_wrap`) |
-| `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` / `Esc` | Back to explorer |
 
@@ -526,11 +544,11 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 | `G` / `End` | Jump to bottom |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half page down / up |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Full page down / up |
-| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
+| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (sets shared Ctrl+D/Ctrl+U step) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
 | `F` | Toggle follow mode (auto-scroll to new logs) |
 | `f` | Filter log lines live (`~`fuzzy, regex auto-detected, `\`literal); narrows the view to matching lines |
-| `i` / `o` | Lower / raise the minimum log severity shown — cycles **off → INFO+ → WARN+ → ERROR+** (all source levels merge into these three). Structured logs use the parsed level; plain-text logs are classified by keyword (error/warn/debug), defaulting to INFO. So INFO+ hides debug/trace, WARN+ shows only warn/error lines, ERROR+ only error/failure lines |
+| `i` / `o` | Lower / raise the minimum log severity shown |
 | `>` | Toggle line wrapping (configurable via `toggle_wrap`) |
 | `#` | Toggle line numbers |
 | `s` | Toggle timestamps |
@@ -553,9 +571,11 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 | `y` | Copy line under cursor (or selection in visual mode) |
 | `123y` | Copy number of lines from cursor (count-prefixed yank) |
 | `\` | Switch pod / filter containers (space: select, enter: apply, / to filter) |
-| `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` / `Esc` | Close log viewer |
+
+`i` / `o` cycle the minimum severity through `off`, `INFO+`, `WARN+`, and `ERROR+`. All source levels merge into these three tiers. Structured logs use the parsed level. Plain-text logs are classified by keyword (error/warn/debug), defaulting to INFO. `INFO+` hides debug/trace lines, `WARN+` shows only warn and error lines, and `ERROR+` shows only error and failure lines.
 
 The log viewer's `/` keeps its own persistent history at `$XDG_STATE_HOME/lfk/log-search-history` (default `~/.local/state/lfk/log-search-history`), separate from the explorer's `query-history`. Log search matches raw log lines (substring/regex over arbitrary text) rather than resource names, so pooling the two would surface irrelevant entries on Up/Down in either context.
 
@@ -585,7 +605,7 @@ Log Top aggregates a resource's logs into a table grouped by parsed attributes (
 | `n` / `N` | Next / previous search match |
 | `Tab` | Cycle the dimension `Enter` drills into |
 | `Enter` | Drill into selected group (descends to the next unused dimension, marked `▸` in its column header) |
-| `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `Esc` / `q` | Pop drill level, or return to log viewer |
 
 ## Exec Mode (embedded terminal)
@@ -653,7 +673,7 @@ from `terminal:` in the config.
 | `123G` | Jump to line number |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
-| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
+| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (sets shared Ctrl+D/Ctrl+U step) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
 | `/` | Search in diff |
 | `n` / `N` | Next / previous search match |
@@ -670,7 +690,7 @@ from `terminal:` in the config.
 | `#` | Toggle line numbers |
 | `>` | Toggle line wrapping (configurable via `toggle_wrap`) |
 | `u` | Toggle unified/side-by-side view |
-| `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` / `Esc` | Back to explorer |
 
@@ -696,7 +716,7 @@ Press `V` on a resource (or open the Events list and press `Enter` on an event) 
 | `123G` | Jump to specific line number |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half page down / up |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Full page down / up |
-| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (vim `'scroll'` semantics: sets the sticky step shared between Ctrl+D and Ctrl+U; clamped to viewport) |
+| `123 Ctrl+D` / `123 Ctrl+U` | Scroll N lines (sets shared Ctrl+D/Ctrl+U step) |
 | `123 Ctrl+F` / `123 Ctrl+B` | Page motion scaled by N |
 | `Shift+F` | Toggle fullscreen event viewer (also minimizes back) |
 | `>` | Toggle line wrapping (configurable via `toggle_wrap`) |
@@ -709,7 +729,7 @@ Press `V` on a resource (or open the Events list and press `Enter` on an event) 
 | `viw` / `vaw` / `viW` / `vaW` | Select inner/around word (or WORD) under cursor |
 | `y` | Copy line under cursor (or selection in visual mode) |
 | `123y` | Copy N lines from cursor (count-prefixed yank) |
-| `?` | Which-key panel (fullscreen viewer only) -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel (fullscreen viewer only) — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Open this help, scrolled to the Event Timeline section (`?` too, in the overlay) |
 | `q` / `Esc` | Close overlay (or exit fullscreen back to overlay) |
 
@@ -769,13 +789,17 @@ enters edit mode for the selected (or new) entry.
 | `j` / `k` | Move cursor up / down |
 | `e` | Edit selected key/value |
 | `a` | Add a new key/value entry |
-| `y` | Copy: cursor row's value when nothing is selected, **opens the format picker automatically when 1+ rows are selected** (so you don't silently copy a single value while ignoring the marked bundle) |
-| `Space` | Toggle selection on the current row (cursor auto-advances; works across non-adjacent rows) |
-| `Y` | Always open the format picker; copies selected rows (or the cursor row) as YAML / JSON / dotenv / `key=value` / values-only |
+| `y` | Copy value (opens the format picker if rows are selected) |
+| `Space` | Toggle selection on the current row |
+| `Y` | Open the format picker |
 | `/` | Filter the list by key (typing extends the query, `Enter` applies, `Esc` clears) |
 | `D` | Delete selected entry |
 | `Enter` | Save changes and close (no-op if nothing changed) |
 | `Esc` | Close without saving |
+
+`y` copies the cursor row's value when nothing is selected. It opens the format picker automatically when one or more rows are selected, so you don't silently copy a single value while ignoring the marked bundle.
+
+`Space` auto-advances the cursor after toggling, and works across non-adjacent rows.
 
 The Labels/Annotations editor additionally has a `Tab` binding in the list
 view to switch between the labels pane and the annotations pane. Switching
@@ -783,6 +807,8 @@ tabs clears the multi-row selection (label and annotation namespaces are
 disjoint).
 
 ### Format picker (Shift+Y)
+
+`Y` always opens the picker and copies the selected rows, or the cursor row, as YAML, JSON, dotenv, `key=value`, or values-only.
 
 When the format picker is open, the bottom hint bar swaps to picker controls:
 
@@ -838,15 +864,19 @@ The editor picks one of two modes based on the value being edited:
 | `/` | Search fields |
 | `n` / `N` | Next / previous search match (recursive: auto-drills into children / searches parent) |
 | `r` | Recursive field browser (browse all nested fields with filter) |
-| `T` | Toggle tree view — show the whole field subtree with ASCII-art guides; stays on while drilling/going back until toggled off (configurable via `tree_view`) |
-| `Space` / `z` | Fold / unfold the field subtree under the cursor (tree view; `z` configurable via `toggle_fold`) |
+| `T` | Toggle tree view (configurable via `tree_view`) |
+| `Space` / `z` | Fold / unfold the subtree under the cursor |
 | `gg` / `G` / `Home` / `End` | Jump to top / bottom |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Page down / up (half page) |
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
-| `?` | Which-key panel for this view -- see [Which-Key Panel](#which-key-panel) |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
 | `q` | Close API explorer |
 | `Esc` | Go back one level / close at root |
+
+`T`'s tree view shows the whole field subtree with ASCII-art guides, and stays on while drilling in or going back, until you toggle it off again.
+
+`Space` / `z` folding applies only in tree view (configurable via `toggle_fold`).
 
 ## Can-I Browser
 
@@ -953,7 +983,9 @@ Available strategies (priority order; unavailable ones are skipped):
 The headroom multiplier is the safety-margin factor applied on top of the strategy's raw
 output. Cycle through `1.0`, `1.1`, `1.25`, `1.5`, `1.75`, `2.0` with `<` and `>`.
 Default is `1.25` (the closest preset to lfk's previous hardcoded `1.2` factor —
-existing recommendations stay visually similar after the upgrade).
+existing recommendations stay visually similar after the upgrade). If the active
+value isn't one of the presets, the first press of `<` or `>` snaps to the nearest
+one instead of stepping from it.
 
 | Key | Action |
 |---|---|
@@ -961,7 +993,7 @@ existing recommendations stay visually similar after the upgrade).
 | `r` | Force-refresh (invalidate the cached entry for the active strategy + headroom and re-fetch) |
 | `]` | Cycle to the next available strategy (wraps around) |
 | `[` | Cycle to the previous available strategy (wraps around) |
-| `>` | Cycle to the next headroom multiplier (wraps around; snaps to nearest preset on first press if the active value isn't in the list) |
+| `>` | Cycle to the next headroom multiplier (wraps around) |
 | `<` | Cycle to the previous headroom multiplier (wraps around; same snap behavior as `>`) |
 | `j` / `k` | Scroll up / down |
 | `g` / `G` (or `Home` / `End`) | Jump to top / bottom |
@@ -1022,7 +1054,9 @@ Invalid config values are dropped at startup with a warning in the error log.
 | `[` | Previous tab |
 | `}` | Move current tab right (shift+]) |
 | `{` | Move current tab left (shift+[) |
-| `Ctrl+C` | Close current tab (quit if last tab). Cancels a bulk action first, but only one started on this tab |
+| `Ctrl+C` | Close current tab (quit if last tab) |
+
+`Ctrl+C` cancels an in-progress bulk action on the current tab first, rather than closing it. It only cancels a bulk action started on that tab, not one running in another tab.
 
 ## Read-Only Mode
 
@@ -1194,9 +1228,11 @@ The field picker (`s` from the destination picker) chooses which categories the 
 | Namespace | removed | `metadata.namespace` |
 | Labels | kept | every author-written label |
 | Annotations | kept | every author-written annotation |
-| Helm ownership | removed | `helm.sh/chart`, `meta.helm.sh/*`, `heritage`, `release`, `chart`, and `app.kubernetes.io/managed-by` when its value is `Helm` |
+| Helm ownership | removed | Helm chart / release labels and annotations |
 | Vendor runtime annotations | removed | `cni.projectcalico.org/*`, `field.cattle.io/*`, `management.cattle.io/*` |
 | Secret values | removed | Secret values; keys and `type` kept |
+
+Helm ownership removes `helm.sh/chart`, `meta.helm.sh/*`, `heritage`, `release`, `chart`, and `app.kubernetes.io/managed-by` when its value is `Helm`.
 
 Locked rows offer no choice — keeping them yields a manifest that will not apply: `status` and the server-set metadata (`uid`, `resourceVersion`, `generation`, `creationTimestamp`, `managedFields`, `selfLink`, `ownerReferences`), `last-applied-configuration`, finalizers, and controller-generated labels (`pod-template-hash`, `controller-uid`, `job-name`).
 
@@ -1428,18 +1464,18 @@ keybindings:
 Opened from the Pod action menu (`x` → `I`). Combines events, restart history,
 last logs, and describe for the failing container in one tabbed panel.
 
-| Key            | Action                                                   |
-| -------------- | -------------------------------------------------------- |
-| `Tab` / `S-Tab`| Cycle tabs forward / backward                            |
-| `1` / `2` / `3` / `4` | Jump to Summary / Events / Logs / Describe        |
-| `c`            | Cycle active container (init + app)                       |
-| `p`            | Toggle previous / current logs (Logs tab only)            |
-| `j` / `k`      | Scroll within tab body                                    |
-| `g` / `G`      | Jump to top / bottom of tab body                          |
-| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page down / up                                  |
-| `Ctrl+F` / `Ctrl+B` | Full-page down / up (also `PgDn` / `PgUp`)           |
-| `Shift+R`      | Refresh — re-fetch all sections, preserves cursor state  |
-| `Esc` / `q`    | Close overlay                                             |
+| Key | Action |
+| --- | --- |
+| `Tab` / `S-Tab` | Cycle tabs forward / backward |
+| `1` / `2` / `3` / `4` | Jump to Summary / Events / Logs / Describe |
+| `c` | Cycle active container (init + app) |
+| `p` | Toggle previous / current logs (Logs tab only) |
+| `j` / `k` | Scroll within tab body |
+| `g` / `G` | Jump to top / bottom of tab body |
+| `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page down / up |
+| `Ctrl+F` / `Ctrl+B` | Full-page down / up (also `PgDn` / `PgUp`) |
+| `Shift+R` | Refresh — re-fetch all sections, preserves cursor state |
+| `Esc` / `q` | Close overlay |
 
 ### Sync Wave Timeline (Applications)
 
@@ -1453,7 +1489,7 @@ on the right. `Tab` toggles which pane has focus.
 | --- | --- |
 | `j` / `↓` | Move sidebar cursor down (wraps); resets body cursor + scroll |
 | `k` / `↑` | Move sidebar cursor up (wraps) |
-| `Enter` / `Space` | Toggle phase collapse (sidebar marker `▾`/`▸`; body shows placeholder when collapsed) |
+| `Enter` / `Space` | Toggle phase collapse |
 | `Tab` / `Shift+Tab` | Switch focus to body |
 | `g` / `G` | First / last phase |
 
@@ -1463,7 +1499,7 @@ on the right. `Tab` toggles which pane has focus.
 | --- | --- |
 | `j` / `↓` | Move body cursor down (wave headers + visible resources) |
 | `k` / `↑` | Move body cursor up |
-| `Enter` / `Space` | If on wave header: toggle wave collapse. If on placeholder: toggle phase collapse. If on resource: no-op |
+| `Enter` / `Space` | Toggle wave / phase collapse (no-op on a resource) |
 | `Tab` / `Shift+Tab` | Switch focus to sidebar |
 | `g` / `G` | First / last visible body row |
 | `Ctrl+D` / `Ctrl+U` / `Shift+↓` / `Shift+↑` | Half-page scroll |
@@ -1475,6 +1511,10 @@ on the right. `Tab` toggles which pane has focus.
 | --- | --- |
 | `R` | Refresh |
 | `q` / `Esc` | Close overlay |
+
+In the sidebar, `Enter` / `Space` toggles collapse for the phase under the cursor: the sidebar marker switches between `▾` and `▸`, and the body shows a placeholder for a collapsed phase.
+
+In the body, `Enter` / `Space` depends on the cursor: on a wave header it toggles that wave's collapse, on a placeholder it toggles the phase collapse, and on a resource row it does nothing.
 
 While `Application.status.operationState.phase == "Running"`, the overlay
 auto-refreshes every 3 seconds. A spinner animates in the header during

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,8 +1,8 @@
-# Release Process
+# Release process
 
 Operational reference for the maintainer. The release pipeline is fully automated on tag push (see `.github/workflows/release.yml`). This document covers one-time bootstrap, secret management, and recovery procedures.
 
-## Trigger a Release
+## Trigger a release
 
 Releases are driven by `release-please`:
 
@@ -13,7 +13,7 @@ Releases are driven by `release-please`:
 
 To cut a release manually (skipping `release-please`): `make release VERSION=X.Y.Z` then `git push && git push --tags`.
 
-## External Accounts (one-time bootstrap)
+## External accounts (one-time bootstrap)
 
 | Channel | Account / Repo | Setup |
 |---|---|---|
@@ -25,7 +25,7 @@ To cut a release manually (skipping `release-please`): `make release VERSION=X.Y
 | Snap | snapcraft.io publisher | Snap name `lfk` registered. Classic confinement justification approved. Macaroon in `SNAPCRAFT_STORE_CREDENTIALS` (run `snapcraft export-login --snaps=lfk --acls=package_access,package_push,package_update,package_release - 2>&1 \| tail -n +2`). |
 | Cloudsmith | cloudsmith.io account `janosmiko` | Repository `janosmiko/lfk` with DEB + RPM enabled. API key in `CLOUDSMITH_API_KEY`. |
 
-## GitHub Secrets
+## GitHub secrets
 
 | Secret | Used by | Rotation |
 |---|---|---|

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,6 @@
 # Release Process
 
-Operational reference for the maintainer. The release pipeline is fully automated on tag push (see `.github/workflows/release.yml`); this document covers one-time bootstrap, secret management, and recovery procedures.
+Operational reference for the maintainer. The release pipeline is fully automated on tag push (see `.github/workflows/release.yml`). This document covers one-time bootstrap, secret management, and recovery procedures.
 
 ## Trigger a Release
 
@@ -20,9 +20,9 @@ To cut a release manually (skipping `release-please`): `make release VERSION=X.Y
 | Homebrew | `janosmiko/homebrew-tap` | Existing. PAT in `RELEASE_TAP_TOKEN`. |
 | Scoop | `janosmiko/scoop-bucket` | Empty repo with README + LICENSE. Same PAT. |
 | Winget | Fork of `microsoft/winget-pkgs` at `janosmiko/winget-pkgs` | PAT in `WINGET_TOKEN` with `contents:write` on the fork. |
-| AUR | aur.archlinux.org account `janosmiko` | SSH public key uploaded; `lfk-bin` reserved. Private key in `AUR_SSH_PRIVATE_KEY` (multi-line PEM). |
+| AUR | aur.archlinux.org account `janosmiko` | SSH public key uploaded. `lfk-bin` reserved. Private key in `AUR_SSH_PRIVATE_KEY` (multi-line PEM). |
 | Chocolatey | chocolatey.org publisher `janosmiko` | API key in `CHOCOLATEY_API_KEY`. `lfk` package id reserved. |
-| Snap | snapcraft.io publisher | Snap name `lfk` registered; classic confinement justification approved. Macaroon in `SNAPCRAFT_STORE_CREDENTIALS` (run `snapcraft export-login --snaps=lfk --acls=package_access,package_push,package_update,package_release - 2>&1 \| tail -n +2`). |
+| Snap | snapcraft.io publisher | Snap name `lfk` registered. Classic confinement justification approved. Macaroon in `SNAPCRAFT_STORE_CREDENTIALS` (run `snapcraft export-login --snaps=lfk --acls=package_access,package_push,package_update,package_release - 2>&1 \| tail -n +2`). |
 | Cloudsmith | cloudsmith.io account `janosmiko` | Repository `janosmiko/lfk` with DEB + RPM enabled. API key in `CLOUDSMITH_API_KEY`. |
 
 ## GitHub Secrets
@@ -36,7 +36,7 @@ To cut a release manually (skipping `release-please`): `make release VERSION=X.Y
 | `WINGET_TOKEN` | Winget upstream PR | rotate annually |
 | `AUR_SSH_PRIVATE_KEY` | AUR push | rotate when key compromised |
 | `CHOCOLATEY_API_KEY` | choco push | rotate when key compromised |
-| `SNAPCRAFT_STORE_CREDENTIALS` | snap upload | macaroon expires; rotate every 12 months |
+| `SNAPCRAFT_STORE_CREDENTIALS` | snap upload | macaroon expires, rotate every 12 months |
 | `CLOUDSMITH_API_KEY` | cloudsmith push | rotate annually |
 
 ## Recovery: a single channel's publish failed
@@ -64,10 +64,10 @@ cloudsmith push rpm janosmiko/lfk/any-distro/any-version dist/lfk_<version>_<arc
 
 Run after each release tag completes. Channels with classic Snap or first-time Chocolatey moderation may legitimately be "pending" — that's not a failure.
 
-- [ ] **Homebrew:** `brew update && brew upgrade lfk` on macOS or Linux; `lfk --version` matches.
+- [ ] **Homebrew:** `brew update && brew upgrade lfk` on macOS or Linux. `lfk --version` matches.
 - [ ] **Scoop:** on Windows, `scoop update lfk && lfk --version`.
 - [ ] **Winget:** check `https://github.com/microsoft/winget-pkgs/pulls?q=author%3Ajanosmiko` for the auto-PR. Once merged: `winget upgrade janosmiko.lfk`.
-- [ ] **AUR:** `https://aur.archlinux.org/packages/lfk-bin` shows the new version; `yay -Syu lfk-bin` on Arch.
+- [ ] **AUR:** `https://aur.archlinux.org/packages/lfk-bin` shows the new version. `yay -Syu lfk-bin` on Arch.
 - [ ] **Chocolatey:** `https://chocolatey.org/packages/lfk` shows the new version (may say "Pending" for first submission). `choco upgrade lfk`.
 - [ ] **Snap:** `snap info lfk` shows new version on `stable` track. `snap refresh lfk --classic`.
 - [ ] **Cloudsmith:** `https://cloudsmith.io/~janosmiko/repos/lfk/packages/` lists the new `.deb` and `.rpm`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,14 +8,55 @@ sources, each auto-detected by the operator or CRDs it needs.
 
 | Source | Config key | Requires in cluster | Findings |
 |---|---|---|---|
-| Heuristic | `heuristic` | nothing (built-in) | Pod- and Service-spec hardening issues: privileged, host PID/IPC/network, hostPath + runtime-socket mounts, dangerous capabilities, runAsRoot, allowPrivilegeEscalation, writable root filesystem, seccomp Unconfined, unmasked procMount, unsafe sysctls, hostPort, shared process namespace, plaintext secrets in env, entire Secrets in env (envFrom), default ServiceAccount (+ token automount), missing resource limits, unpinned image tags, leftover ephemeral debug containers, Windows HostProcess containers, Services with externalIPs, namespaces without Pod Security enforcement labels or NetworkPolicies, credential-looking ConfigMap keys, Ingresses without TLS or with catch-all hosts, legacy ServiceAccount token Secrets, expired/expiring TLS certificates, bare pods without a controller (reliability), pods referencing missing ConfigMaps/Secrets (reliability) |
-| Advisor | `advisor` | nothing (built-in) | Reliability recommendations: namespaces without ResourceQuota/LimitRange, multi-replica workloads without a PodDisruptionBudget or topology spread, drain-blocking or orphaned PDBs, single-replica workloads, missing probes or resource requests, identical liveness/readiness probes, liveness without readiness, downtime rollout strategies, OnDelete update strategies, zero termination grace period, emptyDir without sizeLimit, quotas near their limit, HPAs pinned / at their ceiling / lacking target requests, PDB minAvailable above HPA minimums, PDBs without unhealthyPodEvictionPolicy, manifests pinning replicas under an HPA, StatefulSets with missing or non-headless governing Services, Services with zero or one ready endpoint, suspended CronJobs, standalone Jobs without TTL, StatefulSet volumes on non-expandable StorageClasses |
-| RBAC | `rbac` | nothing (built-in) | Privilege-escalation paths in Roles/ClusterRoles and their bindings: wildcard rules, impersonation, bind/escalate verbs, pods/exec + attach + port-forward grants, kubelet API (nodes/proxy), CSR approval, admission-webhook write access, cluster-wide secret reads, and bindings to anonymous users, system:masters, cluster-admin, or the default ServiceAccount. Kubernetes built-ins (bootstrap-labeled or system:-prefixed) are excluded — note this also skips user-created objects deliberately named `system:*`, so the source audits misconfigurations, not active evasion |
+| Heuristic | `heuristic` | nothing (built-in) | Pod/Service hardening issues |
+| Advisor | `advisor` | nothing (built-in) | Reliability recommendations |
+| RBAC | `rbac` | nothing (built-in) | RBAC privilege-escalation paths |
 | Trivy | `trivy` | [Trivy Operator](https://github.com/aquasecurity/trivy-operator) (`VulnerabilityReport`, `ConfigAuditReport` CRDs) | Image vulnerabilities + config-audit misconfigurations |
 | Kyverno | `kyverno` | Policy Reports API (`PolicyReport`, `ClusterPolicyReport` from `wgpolicyk8s.io/v1alpha2`) | Policy violations |
 | Kubescape | `kubescape` | [kubescape-operator](https://github.com/kubescape/kubescape-operator) (`WorkloadConfigurationScan` CRD) | Failed compliance controls |
 | Falco | `falco` | [Falco](https://falco.org) DaemonSet + falcosidekick (pod logs / K8s Events) | Runtime security events |
 | Gatekeeper | `gatekeeper` | [OPA Gatekeeper](https://open-policy-agent.github.io/gatekeeper/) (Constraint CRDs under `constraints.gatekeeper.sh`) | Constraint audit violations |
+
+### Heuristic
+
+Pod- and Service-spec hardening checks: privileged, host PID/IPC/network,
+hostPath + runtime-socket mounts, dangerous capabilities, runAsRoot,
+allowPrivilegeEscalation, writable root filesystem, seccomp Unconfined,
+unmasked procMount, unsafe sysctls, hostPort, shared process namespace,
+plaintext secrets in env, entire Secrets in env (envFrom), default
+ServiceAccount (+ token automount), missing resource limits, unpinned image
+tags, leftover ephemeral debug containers, Windows HostProcess containers,
+Services with externalIPs, namespaces without Pod Security enforcement labels
+or NetworkPolicies, credential-looking ConfigMap keys, Ingresses without TLS
+or with catch-all hosts, legacy ServiceAccount token Secrets, expired/expiring
+TLS certificates, bare pods without a controller (reliability), and pods
+referencing missing ConfigMaps/Secrets (reliability).
+
+### Advisor
+
+Reliability recommendations: namespaces without ResourceQuota/LimitRange,
+multi-replica workloads without a PodDisruptionBudget or topology spread,
+drain-blocking or orphaned PDBs, single-replica workloads, missing probes or
+resource requests, identical liveness/readiness probes, liveness without
+readiness, downtime rollout strategies, OnDelete update strategies, zero
+termination grace period, emptyDir without sizeLimit, quotas near their limit,
+HPAs pinned / at their ceiling / lacking target requests, PDB minAvailable
+above HPA minimums, PDBs without unhealthyPodEvictionPolicy, manifests pinning
+replicas under an HPA, StatefulSets with missing or non-headless governing
+Services, Services with zero or one ready endpoint, suspended CronJobs,
+standalone Jobs without TTL, and StatefulSet volumes on non-expandable
+StorageClasses.
+
+### RBAC
+
+Privilege-escalation paths in Roles/ClusterRoles and their bindings: wildcard
+rules, impersonation, bind/escalate verbs, pods/exec + attach + port-forward
+grants, kubelet API (nodes/proxy), CSR approval, admission-webhook write
+access, cluster-wide secret reads, and bindings to anonymous users,
+system:masters, cluster-admin, or the default ServiceAccount. Kubernetes
+built-ins (bootstrap-labeled or system:-prefixed) are excluded. This also
+skips user-created objects deliberately named `system:*`, so the source
+audits misconfigurations, not active evasion.
 
 **Heuristic, Advisor, and RBAC are always available** — they only need API
 access, so the Security category is never empty unless the dashboard is

--- a/docs/security.md
+++ b/docs/security.md
@@ -73,9 +73,9 @@ their checks instead of failing the source, and the `kube-system`,
 `kube-public`, and `kube-node-lease` namespaces are always excluded.
 
 The heuristic `secret_env` check (plaintext credential-looking env vars) is
-tunable with `security.heuristic.secret_env_include` / `secret_env_exclude` —
+tunable with `security.heuristic.secret_env_include` / `secret_env_exclude`,
 case-insensitive env-var name globs added on top of the built-in keyword and
-exemption lists (exclude wins); the same patterns also drive the
+exemption lists (exclude wins). The same patterns also drive the
 `configmap_secret_keys` check. The Secret-listing checks
 (`legacy_sa_token_secret`, `tls_secret_expiry`, and Secret-reference
 verification) can be turned off with `security.heuristic.scan_secrets: false`
@@ -99,7 +99,7 @@ security:
 
 - `enabled: false` removes the Security category, hides the SEC badge, and runs
   no source probes.
-- `sources.<name>: false` disables one source; any source omitted from the map
+- `sources.<name>: false` disables one source. Any source omitted from the map
   stays enabled. Disabling **every** source leaves the Security category empty
   (same as `enabled: false`).
 
@@ -156,16 +156,16 @@ clusters:
 - **Low priority**: security scans run as a low-priority background task and on a
   dedicated, throttled API client (QPS 10 / burst 20, separate from the
   foreground budget), so a multi-source scan never starves foreground resource
-  lists. The foreground client rate is configurable; see
+  lists. The foreground client rate is configurable, see
   [API client rate limits](config-reference.md#api-client-rate-limits).
 - **Drill-down**: open the Security category, pick a source to list finding
   groups (one per check/CVE), then drill into a group to see affected
-  resources. `Enter` on an affected resource jumps to the real object;
+  resources. `Enter` on an affected resource jumps to the real object.
   `Backspace` jumps back.
 - **Per-resource findings**: the `Security Findings` action (`x` on a resource
   row) opens a finding-group list filtered to that resource **and its owners**
   across all sources — the same set the SEC badge counts (e.g. a Pod row
-  includes its Deployment's trivy CVEs). Rows carry a `Source` column;
+  includes its Deployment's trivy CVEs). Rows carry a `Source` column.
   `Enter` drills into a group's affected resources as usual, and `Backspace`
   jumps back to the originating list.
 
@@ -200,7 +200,7 @@ persists across sessions.
 
 `security.ignore_patterns` in the config file defines glob-based rules applied
 at startup — useful for org-wide accepted findings. Each field is a glob (`*`,
-`?`); an empty field matches anything. A finding is ignored when every non-empty
+`?`). An empty field matches anything. A finding is ignored when every non-empty
 field matches it.
 
 ```yaml
@@ -222,7 +222,7 @@ empty is ignored (it would otherwise hide everything).
 The optional `labels` field matches the target resource's Kubernetes labels —
 the right tool for silencing whole classes of infrastructure pods (CNI, CSI,
 storage) without naming each one. Each entry is a label key mapped to a glob
-value (`*`, `?`); **all** entries must match (AND). `labels` combines with the
+value (`*`, `?`). **All** entries must match (AND). `labels` combines with the
 other fields, so you can still scope by source, namespace, or cluster.
 
 Semantics:
@@ -236,7 +236,7 @@ Semantics:
   object — but only when at least one `labels` pattern is configured, and only
   for the standard workload kinds (Pod, Deployment, ReplicaSet, StatefulSet,
   DaemonSet, Job, CronJob). The lookups run on the throttled security client and
-  are capped per scan; other kinds (and CRDs) resolve to no labels.
+  are capped per scan. Other kinds (and CRDs) resolve to no labels.
 - A resource with no resolvable labels is never hidden by a label pattern.
 - **Cached badges**: labels are not persisted to the on-disk findings cache, so
   on reopen the cached badges paint before the live scan re-stamps labels — a
@@ -263,5 +263,5 @@ security:
 
 > Label ignores hide privileged host-level pods, which is usually the intent for
 > CNI/CSI. Add them deliberately — a compromised infrastructure pod then
-> produces no finding. They are opt-in for exactly this reason; lfk ships no
+> produces no finding. They are opt-in for exactly this reason. lfk ships no
 > default ignores.

--- a/docs/union-context.md
+++ b/docs/union-context.md
@@ -16,7 +16,7 @@ This opens the chosen resource type from namespace `cloud-cd` across all three c
 |------|---------|
 | `--union-context` | A kubeconfig context to include. Repeat it for each cluster, up to 8. |
 | `--union-set` | Name of a union set defined in config — expands into its contexts and namespace. |
-| `--namespace`, `-n` | Required. Union view fetches a single namespace from every cluster; all-namespaces mode is not available. A `union_sets` entry can supply this instead. |
+| `--namespace`, `-n` | Required. Union view fetches a single namespace from every cluster. All-namespaces mode is not available. A `union_sets` entry can supply this instead. |
 
 `--union-context` and `--union-set` cannot be combined with `--context`. Unknown context names are reported at startup.
 
@@ -60,14 +60,14 @@ For the complete schema, available tile colors, and namespace precedence, see [c
 
 - **Drill-down** — selecting a resource follows it into its own cluster, where navigation, dashboards, and actions behave like a normal single-cluster session. Going back returns to the merged table.
 - **Merged-level actions** — read-only actions (logs, describe, YAML, events) always work. Mutating actions are limited to deleting a Pod, restarting a workload (Deployment, StatefulSet, DaemonSet), and port-forwarding (Pod, Service, Deployment, StatefulSet, DaemonSet). Drill into a resource to do anything else.
-- **Dashboards** — the Cluster and Monitoring dashboards list the member clusters instead of aggregating; open a member to see its dashboard.
+- **Dashboards** — the Cluster and Monitoring dashboards list the member clusters instead of aggregating. Open a member to see its dashboard.
 - **Can-I RBAC browser** — `U` checks permissions across every member cluster at once.
 - **Bookmarks and pinned groups** — available for named union sets. Ad-hoc `--union-context` sessions have no saved name, so they cannot pin CRD groups or use context-aware bookmarks.
-- **Sessions** — union view is always started explicitly; lfk never reopens it automatically on the next launch.
+- **Sessions** — union view is always started explicitly. lfk never reopens it automatically on the next launch.
 
 ## Limitations
 
-- **Differing CRDs** — if a resource type exists in one cluster but not another, the missing cluster contributes no rows; this is not an error.
+- **Differing CRDs** — if a resource type exists in one cluster but not another, the missing cluster contributes no rows. This is not an error.
 - **`:ctx`, shell, and kubectl** — `:ctx` is disabled for the whole union session. Shell and `:kubectl` / `:k` commands are blocked in the merged table and work again once you drill into a single cluster.
-- **Reverse Who-Can and orphan scans** — run one cluster at a time; drill in to use them.
+- **Reverse Who-Can and orphan scans** — run one cluster at a time. Drill in to use them.
 - **Drill-down is single-cluster** — owned-resource and container views below a selected resource show only that resource's cluster. There is no merged owned-resources view.

--- a/docs/union-context.md
+++ b/docs/union-context.md
@@ -22,7 +22,7 @@ This opens the chosen resource type from namespace `cloud-cd` across all three c
 
 Configured union sets also appear at the top of the cluster picker under a **Union Sets** heading — pick one to enter union view without passing any flags.
 
-## The Context column
+## The context column
 
 Every merged row carries a **Context** column naming its source cluster. It behaves like any other column: sort by it, reorder it, or hide it from the column toggle (`,`). Rows are sorted by name first and context second, so the same resource lines up across clusters.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,19 +95,24 @@ When `--context` or `--namespace` flags are provided, the saved session state is
 ignored and the app opens directly in the specified context/namespace. The user
 can still change the namespace during the session.
 
-Restoring a session takes two steps: lfk opens the saved resource type as soon
-as the cluster list arrives, then selects the saved row when the resource list
-comes back. Press a key or click during that gap and lfk gives up the saved row,
-so an arriving list cannot pull the cursor away from where you went.
+Restoring a session takes two steps:
+
+1. lfk opens the saved resource type as soon as the cluster list arrives.
+2. lfk selects the saved row when the resource list comes back.
+
+Press a key or click during that gap and lfk gives up the saved row, so an
+arriving list cannot pull the cursor away from where you went.
 
 ## Mouse Support
 
-By default, lfk captures mouse input for click navigation, scroll, and tab
-switching. If you need native terminal text selection (e.g., shift+click to
-select text), you can disable mouse capture:
+Disable mouse capture to get native terminal text selection (for example,
+shift+click):
 
 - **CLI flag:** `lfk --no-mouse`
 - **Config file:** Add `mouse: false` to `~/.config/lfk/config.yaml`
+
+By default, lfk captures mouse input for click navigation, scroll, and tab
+switching.
 
 ### Explorer click semantics
 
@@ -119,7 +124,7 @@ The three-pane explorer maps mouse clicks to navigation actions:
 | Middle pane (different row) | Select that row and load its preview in the right pane |
 | Middle pane (cursored row) | Drill into it (same as `Enter` / Right arrow) |
 | Right pane | Drill into the selected item |
-| Table header row | Sort by that column; click again toggles direction |
+| Table header row | Sort by that column, click again to toggle direction |
 | Right-click on middle pane | Move cursor to the clicked row and open the action menu |
 | Right-click on right pane | Open the action menu for the currently selected item |
 | Right-click on left pane | No-op |
@@ -145,14 +150,14 @@ underneath:
 | Click inside the box on padding/title/border | No-op (use `Esc` or click outside to dismiss) |
 
 Other list overlays (color scheme picker, bookmarks, templates, container /
-pod / log selectors, column toggle, etc.) accept wheel scroll; row-click
-activation is being added incrementally — for now use `Enter` after wheel
+pod / log selectors, column toggle, etc.) accept wheel scroll. Row-click
+activation is being added incrementally. For now, use `Enter` after wheel
 scrolling to the desired row.
 
 Fullscreen overlays (the secret / config-map / label editors, rollback /
 helm-history pickers, the auto-sync dialog, the Can-I browser, and the
 NetworkPolicy viewer) cover the entire screen, so there is no "outside" to
-click; press `Esc` to close them.
+click. Press `Esc` to close them.
 
 > macOS Terminal.app does not support shift+click text selection while mouse
 > capture is active. Use `--no-mouse` or switch to a terminal that handles this
@@ -160,12 +165,12 @@ click; press `Esc` to close them.
 
 ## No-Color Mode
 
-Disable all foreground and background colors while keeping selection and
-other highlights visible via bold, underline, and reverse-video SGR codes.
-Useful for monochrome terminals, piped output, or lower CPU usage.
+Disable all foreground and background colors. Selection and other highlights
+stay visible via bold, underline, and reverse-video SGR codes. Useful for
+monochrome terminals, piped output, or lower CPU usage.
 
 - **CLI flag:** `lfk --no-color`
-- **Environment variable:** `NO_COLOR=1 lfk` (any non-empty value; see
+- **Environment variable:** `NO_COLOR=1 lfk` (any non-empty value, see
   [no-color.org](https://no-color.org/))
 - **Config file:** Add `no_color: true` to `~/.config/lfk/config.yaml`
 
@@ -173,9 +178,8 @@ Precedence: `--no-color` flag > `NO_COLOR` env var > config file.
 
 ## Kubeconfig Directory
 
-By default, lfk discovers additional kubeconfig files from `~/.kube/config.d/`
-(recursively). This can be overridden — and multiple directories can be merged —
-via CLI, environment variable, or config:
+Override or merge the directories lfk scans for kubeconfig files, via CLI,
+environment variable, or config:
 
 - **CLI flag:** `lfk --kubeconfig-dir /path/to/configs/` (repeatable: pass `--kubeconfig-dir` multiple times to merge several directories).
 - **Environment variable:** `KUBECONFIG_DIR=/path/to/configs/ lfk`. Colon-separated for multiple directories on Unix (`KUBECONFIG_DIR=/dir/a:/dir/b`), matching the convention `KUBECONFIG` uses.
@@ -187,7 +191,9 @@ via CLI, environment variable, or config:
     - /team-b/configs
   ```
 
-Precedence (replacement, not merge): `--kubeconfig-dir` flag > `KUBECONFIG_DIR` env var > config file > default `~/.kube/config.d/`. Each entry's tilde (`~/`) is expanded against `$HOME`. lfk validates every directory exists at startup and errors out loudly on a typo. The `--kubeconfig` flag bypasses all directory discovery entirely.
+Precedence (replacement, not merge): `--kubeconfig-dir` flag > `KUBECONFIG_DIR` env var > config file > default `~/.kube/config.d/` (scanned recursively). Each entry's tilde (`~/`) is expanded against `$HOME`.
+
+lfk validates every directory exists at startup and errors out loudly on a typo. The `--kubeconfig` flag bypasses all directory discovery entirely.
 
 ## Read-Only Mode
 
@@ -236,18 +242,21 @@ tab when created and re-evaluate on context switch.
 `Ctrl+R` behavior depends on where you are:
 
 - **At the cluster picker**: flips the `[RO]` marker on the highlighted
-  context row. The toggle is stored as a session override that wins
-  over per-context and global config when entering that context.
-  Persists across back-and-forth navigation to the picker; cleared on
-  process exit. Blocked when `--read-only` is set.
-- **Inside a context**: flips read-only for the current tab and records
-  the choice as a session override for that context, so it survives
-  navigating back to the picker and re-entering, and keeps the picker's
-  `[RO]` marker in sync. Session-scoped — does not write to the config
-  file. Keyed by context, so unlocking one context never leaks read-write
-  state into another. Blocked when `--read-only` is set; the CLI flag is
-  the strongest precedence level and cannot be defeated within the
-  running process.
+  context row.
+  - Stored as a session override that wins over per-context and global
+    config when entering that context.
+  - Persists across back-and-forth navigation to the picker. Cleared on
+    process exit.
+  - Blocked when `--read-only` is set.
+- **Inside a context**: flips read-only for the current tab.
+  - Recorded as a session override for that context, so it survives
+    navigating back to the picker and re-entering, and keeps the
+    picker's `[RO]` marker in sync.
+  - Session-scoped. Does not write to the config file.
+  - Keyed by context, so unlocking one context never leaks read-write
+    state into another.
+  - Blocked when `--read-only` is set. The CLI flag is the strongest
+    precedence level and cannot be defeated within the running process.
 
 ### CLI flag
 
@@ -257,7 +266,7 @@ lfk --context prod --read-only
 ```
 
 `--read-only` is process-wide. `--context` only selects the starting
-context; it does not scope the read-only flag.
+context. It does not scope the read-only flag.
 
 ### Discovery
 
@@ -328,7 +337,7 @@ when a stray `D` would do real damage.
 - **Persistence**: the assignment is saved to
   `$XDG_STATE_HOME/lfk/cluster-colors.yaml` (defaults to
   `~/.local/state/lfk/cluster-colors.yaml`) so colors survive restarts.
-  The file is lfk-managed — don't hand-edit; use the in-app picker.
+  The file is lfk-managed. Don't hand-edit it, use the in-app picker.
   Unknown color names in the file are ignored on load (with a warning
   written to the lfk log) so a typo doesn't poison neighbouring entries.
 
@@ -357,14 +366,14 @@ load. Tune it with:
   `2s`, `1m`, ...)
 - **Config file:** Add `watch_interval: 5s` to `~/.config/lfk/config.yaml`
 
-Values outside `[500ms, 10m]` are clamped to the bounds; invalid values fall
+Values outside `[500ms, 10m]` are clamped to the bounds. Invalid values fall
 back to 2s.
 
 ### Battery / idle throttling
 
 In watch mode, lfk slows its refresh to `background_watch_interval` (default 10s)
 when the terminal window is unfocused, or when a focused window has had no
-keypress for `foreground_idle_timeout` (default 120s; set 0 to disable). It
+keypress for `foreground_idle_timeout` (default 120s, set 0 to disable). It
 snaps back to `watch_interval` and refreshes immediately on focus or keypress.
 The loading spinner only animates while a load is actually in flight.
 
@@ -407,7 +416,7 @@ ENDPOINTS
   192.168.1.8  → pod/foo-7d9-broken  on node-c   (NotReady)
 ```
 
-Ready endpoints render with no status suffix; only `(NotReady)` is shown
+Ready endpoints render with no status suffix. Only `(NotReady)` is shown
 inline so the eye is drawn to the broken ones. A row degrades gracefully
 when `targetRef` (no target pod) or `nodeName` (host-network endpoints)
 is absent. Multiple addresses on a single EndpointSlice entry (dual-stack
@@ -441,7 +450,7 @@ session affinity, etc.), press `v` (Describe).
 
 `lfk` flags Kubernetes resources that have no live consumer or controller, across 11 kinds:
 
-- **Pods without owners** — typically debug / one-off pods that escaped a controller. Static pods (kubelet-managed) are excluded; terminal pods older than an hour are tagged separately.
+- **Pods without owners** — typically debug / one-off pods that escaped a controller. Static pods (kubelet-managed) are excluded. Terminal pods older than an hour are tagged separately.
 - **Secrets / ConfigMaps not mounted** — anything not referenced by a Pod (volumes, env, envFrom, imagePullSecrets), an Ingress (`spec.tls.secretName`), or a ServiceAccount.
 - **Services with no endpoints** — non-Headless, non-ExternalName Services with zero backing addresses.
 - **PersistentVolumeClaims not mounted** — bound but no Pod or workload template references them.
@@ -455,13 +464,13 @@ session affinity, etc.), press `v` (Describe).
 Press **`Shift+Z`** anywhere in the explorer (or type `:orphans` in the command bar) to open the orphan overview overlay. It scans the cluster and lists every orphan in one table grouped by kind:
 
 - `Tab` / `Shift+Tab` cycle through every kind filter chip (All plus all supported orphan kinds rendered in the strip)
-- `s` toggles strict / lenient — strict (default) hides items referenced by workload templates (e.g. CronJob between firings, scaled-to-zero Deployment); lenient surfaces them
+- `s` toggles strict / lenient — strict (default) hides items referenced by workload templates (e.g. CronJob between firings, scaled-to-zero Deployment). Lenient shows them
 - `/` filters by namespace + name
 - `Enter` jumps straight to the highlighted resource (the namespace switches automatically)
 - `R` re-scans the cluster
 - `Esc`, `q`, or `Shift+Z` close the overlay
 
-Partial-RBAC denials surface as a warning banner at the top of the overlay. A kind is shown only if every list its orphan check depends on loaded; a kind whose answer would depend on a denied list is omitted rather than risking a false "unused".
+Partial-RBAC denials surface as a warning banner at the top of the overlay. A kind is shown only if every list its orphan check depends on loaded. A kind whose answer would depend on a denied list is omitted rather than risking a false "unused".
 
 ### Per-kind filter presets
 
@@ -490,17 +499,17 @@ auto-detected:
 | `kubectl debug` | Ephemeral container streaming `tcpdump` | kubectl 1.30+, ephemeral containers enabled, target pod can grant `NET_ADMIN` / `NET_RAW` |
 | kubeshark | Hand-off (port-forward + browser) | `kubeshark-hub` Service in `kubeshark` namespace (override via `kubeshark.namespace`) |
 
-Hardened non-root pods can't grant `NET_ADMIN` / `NET_RAW`; capture fails
+Hardened non-root pods can't grant `NET_ADMIN` / `NET_RAW`. Capture fails
 with a message pointing at kubeshark. Install with
 `helm install kubeshark kubeshark/kubeshark -n kubeshark --create-namespace`.
 
 pcap output: `$XDG_STATE_HOME/lfk/captures/` (default
 `~/.local/state/lfk/captures/`). The full per-phase keymap lives in
-[`docs/keybindings.md`](keybindings.md#traffic-capture-overlay); the
+[`docs/keybindings.md`](keybindings.md#traffic-capture-overlay). The
 load-bearing keys:
 
 - `s` — stop, stay in overlay
-- `Esc` — stop and stay; second `Esc` dismisses + deletes the pcap
+- `Esc` — stop and stay. Second `Esc` dismisses + deletes the pcap
   unless `Y` was pressed
 - `Y` — copy pcap path to system clipboard, marks the capture as saved
 - `e` (from stopped phase) — re-open config to tweak the filter, then
@@ -517,11 +526,13 @@ read-only tunnel to its in-cluster hub.
 
 ## Secret Lazy Loading
 
-On clusters with many Helm releases or large TLS secrets, listing the
-Secrets resource type can transfer tens of megabytes. Enable lazy loading
-to fetch only metadata for the list and defer decoded values to hover:
+Enable lazy loading to fetch only metadata for the Secrets list and defer
+decoded values to hover:
 
 - **Config file:** Add `secret_lazy_loading: true` to `~/.config/lfk/config.yaml`
+
+On clusters with many Helm releases or large TLS secrets, listing the
+Secrets resource type can transfer tens of megabytes.
 
 Trade-off: the Type column is dropped from the list (metadata-only fetch
 doesn't include it) and there's a small per-hover fetch for decoded values
@@ -536,7 +547,7 @@ Both are off by default.
 | Variable | Effect |
 |---|---|
 | `LFK_PPROF_ADDR` | Serves Go `pprof` on the given **loopback** address (e.g. `127.0.0.1:6060`). Non-loopback addresses are refused. |
-| `LFK_MEMSTATS_INTERVAL` | Logs heap and goroutine counts to the app log on each interval (Go duration, e.g. `30s`; clamped to a 1s floor). |
+| `LFK_MEMSTATS_INTERVAL` | Logs heap and goroutine counts to the app log on each interval (Go duration, e.g. `30s`, clamped to a 1s floor). |
 
 ```bash
 # Periodic memory snapshots in the app log (heap_objects, goroutines, ...)
@@ -548,5 +559,5 @@ go tool pprof http://127.0.0.1:6060/debug/pprof/heap
 ```
 
 Reading a suspected leak: rising `heap_objects` with a flat `goroutines`
-count points at an unbounded cache or buffer; a steadily climbing
+count points at an unbounded cache or buffer. A steadily climbing
 `goroutines` count points at a watch or stream that is never stopped.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -103,7 +103,7 @@ Restoring a session takes two steps:
 Press a key or click during that gap and lfk gives up the saved row, so an
 arriving list cannot pull the cursor away from where you went.
 
-## Mouse Support
+## Mouse support
 
 Disable mouse capture to get native terminal text selection (for example,
 shift+click):
@@ -163,7 +163,7 @@ click. Press `Esc` to close them.
 > capture is active. Use `--no-mouse` or switch to a terminal that handles this
 > correctly (iTerm2, Kitty, Alacritty, WezTerm, Ghostty).
 
-## No-Color Mode
+## No-color mode
 
 Disable all foreground and background colors. Selection and other highlights
 stay visible via bold, underline, and reverse-video SGR codes. Useful for
@@ -176,7 +176,7 @@ monochrome terminals, piped output, or lower CPU usage.
 
 Precedence: `--no-color` flag > `NO_COLOR` env var > config file.
 
-## Kubeconfig Directory
+## Kubeconfig directory
 
 Override or merge the directories lfk scans for kubeconfig files, via CLI,
 environment variable, or config:
@@ -195,7 +195,7 @@ Precedence (replacement, not merge): `--kubeconfig-dir` flag > `KUBECONFIG_DIR` 
 
 lfk validates every directory exists at startup and errors out loudly on a typo. The `--kubeconfig` flag bypasses all directory discovery entirely.
 
-## Read-Only Mode
+## Read-only mode
 
 Read-only mode disables every action that changes cluster state — delete,
 edit, scale, restart, rollback, exec, attach, port-forward, drain, cordon,
@@ -273,7 +273,7 @@ context. It does not scope the read-only flag.
 The cluster picker hint bar advertises `Ctrl+R toggle RO` so users
 can find the row toggle without reading docs.
 
-## Permission-Aware Actions
+## Permission-aware actions
 
 Actions the current user cannot run are dropped from the action menu, so a
 delete you are not allowed to make no longer fails after the confirm
@@ -304,7 +304,7 @@ dialog. The gate is the same one read-only mode uses.
 - **Bulk actions**: gated only when every selected row sits in one context
   and namespace. A mixed selection is left to the API server.
 
-## Node Shell
+## Node shell
 
 From the Node action menu (`x` → `s`), lfk launches a privileged debug pod
 that `nsenter`s into PID 1 on the selected node, giving an interactive shell
@@ -317,7 +317,7 @@ is removed when the shell exits.
 
 Node shell is a mutating action and is gated by the read-only check.
 
-## Cluster Color Coding
+## Cluster color coding
 
 Tag any cluster with a background color so the title bar tints the
 moment you enter it — useful for "I am unmistakably in prod" feedback
@@ -356,7 +356,7 @@ bright codes so they look the same regardless of which lfk theme is
 active — useful when none of the theme accent colors fit a particular
 cluster's identity.
 
-## Watch-Mode Interval
+## Watch-mode interval
 
 Watch mode (toggle with `w`) polls the current resource list on an interval.
 The default 2-second interval is a good balance between freshness and API
@@ -381,7 +381,7 @@ Set `watch_throttle: false` to disable this throttling entirely.
 
 Flags: `--background-watch-interval`, `--foreground-idle-timeout`.
 
-## Discovery Cache
+## Discovery cache
 
 API discovery (the list of resource types and CRDs the server exposes) is
 cached on disk under `~/.kube/cache/discovery/<host>/` with a 5-minute TTL.
@@ -399,7 +399,7 @@ discovery round-trips on the API server and reduces startup time.
 - **TTL:** 5 minutes. Stale entries are refetched automatically on the
   next discovery request.
 
-## Endpoint Visibility
+## Endpoint visibility
 
 The right-pane preview for the **Endpoints** and **EndpointSlices** kinds
 shows every endpoint individually, with target pod, node, and ready state:
@@ -524,7 +524,7 @@ listed [Read-Only](#read-only-mode) `port-forward` block applies to the
 user-triggered Port Forward action, not to the kubeshark backend's
 read-only tunnel to its in-cluster hub.
 
-## Secret Lazy Loading
+## Secret lazy loading
 
 Enable lazy loading to fetch only metadata for the Secrets list and defer
 decoded values to hover:

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -1,4 +1,4 @@
-# Views and Overlays
+# Views and overlays
 
 Reference list of every view, fullscreen flag, and overlay lfk renders.
 
@@ -103,7 +103,7 @@ category, and every entry maps to a constant in `app_types.go`.
 | ------------------ | -------------------- | ------------------------------------ |
 | `overlayBookmarks` | `'`, `:bookmarks`    | Saved navigation slots, with filter. |
 
-### Editors / Forms
+### Editors / forms
 
 | Overlay                  | Default trigger                | Purpose                                            |
 | ------------------------ | ------------------------------ | -------------------------------------------------- |

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -41,7 +41,7 @@ Listed in `viewMode` declaration order.
 | ----------------- | ------------------------------------- | ---------------------------------------------------------------------- |
 | `modeExplorer`    | default                               | Three-column resource browser (clusters → resource types → resources). |
 | `modeYAML`        | `Enter` on a resource                 | Full-screen YAML preview with search and copy.                         |
-| `modeHelp`        | `F1`                                  | Searchable, filterable keybinding reference. `?` also opens it in the overlays and exec mode, where no which-key panel claims the key. |
+| `modeHelp`        | `F1`                                  | Searchable, filterable keybinding reference.                           |
 | `modeLogs`        | `L` on a pod / workload               | Log viewer with follow, wrap, search, visual selection.                |
 | `modeDescribe`    | `v` on a resource                     | `kubectl describe`-style detail view.                                  |
 | `modeDiff`        | `d` between two selected resources    | Side-by-side diff (e.g. ArgoCD live vs. desired).                      |
@@ -50,6 +50,9 @@ Listed in `viewMode` declaration order.
 | `modeEventViewer` | event timeline overlay → drill-in     | Full-screen event viewer with grouping.                                |
 | `modeKubetris`    | `:kubetris`                           | Easter-egg game.                                                       |
 | `modeCredits`     | `:credits`                            | Scrolling credits screen.                                              |
+
+> Note: `?` also opens `modeHelp` from the overlays and exec mode, where
+> no which-key panel claims the key.
 
 ## Fullscreen flags inside `modeExplorer`
 
@@ -162,7 +165,13 @@ and follow their own dismissal rules.
 | ------------------ | --------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `overlayErrorLog`  | `!`             | Application error log overlay (lfk's own error buffer). Has its own `errorLogFullscreen` toggle for full-screen mode. |
 | `commandBarActive` | `:`             | Bottom-of-screen `:command [args]` input with autocomplete, history, and ghost-text preview.                          |
-| `fieldDoc.on`      | `Ctrl+K`        | Schema side pane in the YAML viewer and Object Explorer. Shows the cluster's description of the field under the cursor and follows it as the cursor moves. Drawn like the log viewer's structured preview (`RenderLogPreviewPane`) and joined horizontally, so it takes columns rather than rows. `splitFieldDocWidth` sizes it and reports zero on a terminal too narrow for both. |
+| `fieldDoc.on`      | `Ctrl+K`        | Schema side pane in the YAML viewer and Object Explorer.                                                              |
+
+> Note: the field-doc pane shows the cluster's description of the field
+> under the cursor and follows it as the cursor moves. It is drawn like
+> the log viewer's structured preview (`RenderLogPreviewPane`) and joined
+> horizontally, so it takes columns rather than rows. `splitFieldDocWidth`
+> sizes it and reports zero on a terminal too narrow for both.
 
 ## Adding a new view, fullscreen flag, or overlay
 

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -12,12 +12,12 @@ lfk's UI is built from three layered concepts:
   per tab on `TabState.mode` and mirrored to `Model.mode`.
 - **Fullscreen flag** — boolean on `Model` (and sometimes `TabState`)
   that lets a sub-pane take the whole screen *without* leaving
-  `modeExplorer`. Multiple flags can coexist; precedence is decided in
+  `modeExplorer`. Multiple flags can coexist. Precedence is decided in
   `viewExplorerColumns` (see [`internal/app/view.go`](../internal/app/view.go)).
 - **Overlay** — modal panel that floats over the current view. The
   underlying view is dimmed but stays mounted. Overlays own the keyboard
   while open and dismiss back to the view they appeared over. Most are
-  typed via `overlayKind` and mutually exclusive; a few live as
+  typed via `overlayKind` and mutually exclusive. A few live as
   independent boolean fields on `Model` so they can stack on top of an
   `overlayKind` overlay (see [Boolean overlays](#boolean-overlays)).
 
@@ -26,11 +26,11 @@ Source of truth for the enums:
 and `overlayKind`. When those enums change, update this doc and the help
 catalog in
 [`internal/ui/help_sections.go`](../internal/ui/help_sections.go)
-(`internal/ui/help.go` renders that catalog; it holds no per-view rows).
+(`internal/ui/help.go` renders that catalog and holds no per-view rows).
 
 Default trigger keys below come from
-[`internal/ui/config_keybindings.go`](../internal/ui/config_keybindings.go);
-users can rebind any of them — see [keybindings.md](./keybindings.md)
+[`internal/ui/config_keybindings.go`](../internal/ui/config_keybindings.go).
+Users can rebind any of them, see [keybindings.md](./keybindings.md)
 for the full reference.
 
 ## Views (`viewMode`)
@@ -63,7 +63,7 @@ wins.
 
 | Flag                      | Scope    | Default trigger                       | What it shows                                                                                                                |
 | ------------------------- | -------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `fullscreenMiddle`        | per-tab  | `F`                                   | Hides left and right columns; the middle resource list takes the whole screen.                                                |
+| `fullscreenMiddle`        | per-tab  | `F`                                   | Hides left and right columns. The middle resource list takes the whole screen.                                                |
 | `fullscreenDashboard`     | per-tab  | `Enter` on `[Dashboard]`, `@`         | Cluster or monitoring dashboard (see Note below).                                                                            |
 | `errorLogFullscreen`      | global   | inside the error-log overlay (`F`)    | Promotes the error-log overlay to a full-screen log buffer.                                                                   |
 | `eventTimelineFullscreen` | global   | inside the event-timeline overlay     | Promotes the event timeline overlay to a full-screen viewer (also reachable via the `modeEventViewer` drill).                 |
@@ -129,7 +129,7 @@ category, and every entry maps to a constant in `app_types.go`.
 | `overlayConfirm`     | delete / drain                   | y/n confirmation for reversible actions. Delete shows a cascade policy row (`Tab` cycles it). |
 | `overlayConfirmType` | force delete / force finalize    | Requires typing `DELETE` for destructive ops. Force delete shows a cascade policy row (`Tab` cycles it). |
 | `overlayQuitConfirm` | `q`                              | Confirm before exiting lfk.                                   |
-| `overlayShuttingDown`| after confirming quit            | Notice shown while background processes drain; force quits after 10s if it hangs. |
+| `overlayShuttingDown`| after confirming quit            | Notice shown while background processes drain. Force quits after 10s if it hangs. |
 | `overlayPasteConfirm`| paste into search / filter       | Confirm multi-line paste.                                     |
 
 ### Information panels

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,7 +23,7 @@ type Model struct {
 	client  *k8s.Client
 	version string // application version string shown in the title bar
 
-	// demoMode mirrors k8s.Client.IsDemo(); drives the title-bar DEMO badge.
+	// demoMode mirrors k8s.Client.IsDemo(). Drives the title-bar DEMO badge.
 	demoMode bool
 
 	nav model.NavigationState // navigation state
@@ -41,7 +41,7 @@ type Model struct {
 
 	// Cursor memory: maps navigation path to cursor position for back-and-forth navigation.
 	cursorMemory map[string]int
-	filterMemory map[string]savedFilter // per-level committed filter, recalled on back-nav; see saveLevelFilter (#303)
+	filterMemory map[string]savedFilter // per-level committed filter, recalled on back-nav. See saveLevelFilter (#303)
 
 	// Item cache: maps navigation path to loaded items for faster back navigation.
 	itemCache map[string][]model.Item
@@ -60,16 +60,16 @@ type Model struct {
 
 	// Full-screen YAML viewer state (the `y` view): content, scroll/cursor,
 	// search, visual selection, wrap, and collapsible sections. Extracted
-	// from the formerly flat yaml* fields into one cohesive value; see
+	// from the formerly flat yaml* fields into one cohesive value. See
 	// yamlview.go. Note: previewYAML/splitPreview/fullYAMLPreview below are
 	// distinct right-pane preview state and are intentionally not part of it.
 	yamlView yamlViewState
 
-	// Schema side pane (ctrl+k) and its description cache; see fielddoc.go.
+	// Schema side pane (ctrl+k) and its description cache. See fielddoc.go.
 	fieldDoc fieldDocState
 
 	// yamlReturnMode is the mode the full-screen YAML viewer returns to on
-	// q/esc. Defaults to modeExplorer (the zero value); set to
+	// q/esc. Defaults to modeExplorer (the zero value). Set to
 	// modeObjectExplorer when the YAML viewer is opened from the Object Explorer
 	// browser so closing it returns there instead of the explorer.
 	yamlReturnMode viewMode
@@ -80,9 +80,9 @@ type Model struct {
 	yamlPendingPath []string
 
 	// explainReturnMode is the mode the API Explorer returns to on q/esc. Defaults
-	// to modeExplorer; modeYAML or modeObjectExplorer when opened there (I key).
+	// to modeExplorer. modeYAML or modeObjectExplorer when opened there (I key).
 	explainReturnMode   viewMode
-	explainSessionState // embedded - cancellation scope for the explain calls; see update_explain.go.
+	explainSessionState // embedded - cancellation scope for the explain calls. See update_explain.go.
 
 	// explainPendingField, when set, is the field name the API Explorer should
 	// place its cursor on once the level finishes loading. Used to land on a
@@ -125,10 +125,10 @@ type Model struct {
 	copyFormatPicker     copyFormatPickerState      // Y-key copy-as picker — see openCopyFormatPicker
 	exportTemplatePicker exportTemplateState        // Export Template destination picker — see openExportTemplatePicker
 	copyFieldPicker      copyFieldPickerState       // ctrl+y field picker — see updateCopyFieldManifests
-	lastCopyFieldByKind  map[string]copyFieldMemory // last entry copied per kind (ctrl+y preselect; session-only, all tabs)
+	lastCopyFieldByKind  map[string]copyFieldMemory // last entry copied per kind (ctrl+y preselect, session-only, all tabs)
 	taintEditor          taintEditorState           // node taint editor — see openTaintEditor
 
-	namespace string // current namespace (not a navigation level; displayed in top-right)
+	namespace string // current namespace (not a navigation level, displayed in top-right)
 
 	// Terminal dimensions.
 	width, height int
@@ -147,7 +147,7 @@ type Model struct {
 	previewLoading bool
 	// Spinner for loading animation.
 	spinner spinner.Model
-	// spinnerTicking guards the tick loop; armSpinner never stacks a second loop.
+	// spinnerTicking guards the tick loop. armSpinner never stacks a second loop.
 	spinnerTicking bool
 
 	// initialSecuritySeedCmd holds the SEC-badge findings-cache seed command
@@ -185,14 +185,14 @@ type Model struct {
 	selectedNamespaces, savedSelectedNamespaces map[string]bool
 	nsSelectionNegated, savedNsSelectionNegated bool     // nsSelectionNegated: EXCLUDE set
 	nsFilterMode, nsSelectionModified           bool     // nsSelectionModified: Space pressed in current ns overlay session
-	nsFilterEntryItem, nsOverlayContext         string   // filter-entry ns (restored on Esc); context the open overlay lists (in-overlay R refresh)
-	previousNsScope                             *nsScope // scope before the last change; g\ swaps back to it (per-tab)
-	nsOverlayEntryScope                         *nsScope // scope when the ns overlay opened; the pre-edit "previous" recorded on commit
+	nsFilterEntryItem, nsOverlayContext         string   // filter-entry ns (restored on Esc), context the open overlay lists (in-overlay R refresh)
+	previousNsScope                             *nsScope // scope before the last change. g\ swaps back to it (per-tab)
+	nsOverlayEntryScope                         *nsScope // scope when the ns overlay opened. The pre-edit "previous" recorded on commit
 
-	// Fullscreen toggles: middle = hides left and right columns; dashboard
+	// Fullscreen toggles: middle = hides left and right columns. Dashboard
 	// = renders the cluster dashboard full screen.
 	fullscreenMiddle, fullscreenDashboard bool
-	// hideLeftPane hides only the left resource-type sidebar; middle and
+	// hideLeftPane hides only the left resource-type sidebar. Middle and
 	// right preview stay visible. One phase of the kb.Fullscreen cycle.
 	hideLeftPane bool
 
@@ -209,11 +209,11 @@ type Model struct {
 	// pendingTargetNamespace narrows pendingTarget to one ns (empty = name-only).
 	pendingTargetNamespace string
 
-	// pendingG: vim 'gg' -> next 'g' jumps to top; whichKey: popup + leader-panel state.
+	// pendingG: vim 'gg' -> next 'g' jumps to top. whichKey: popup + leader-panel state.
 	pendingG bool
 	whichKey whichKeyState
 
-	// Vim text-object operator pending in visual mode ('i'/'a'); 0 = none.
+	// Vim text-object operator pending in visual mode ('i'/'a'). 0 = none.
 	pendingTextObject byte
 
 	// Vim-style named marks: m<key> sets a mark, '<key> jumps to it.
@@ -223,15 +223,15 @@ type Model struct {
 	// Watch mode: auto-refresh the current view on a timer.
 	watchMode     bool
 	watchInterval time.Duration
-	// focused tracks terminal focus (DECSET-1004); defaults true.
+	// focused tracks terminal focus (DECSET-1004). Defaults true.
 	focused bool
 	// lastInputAt is the time of the most recent key press, for idle detection.
 	lastInputAt time.Time
 	// backgroundWatchInterval is the watch cadence while background or focused-idle.
 	backgroundWatchInterval time.Duration
-	// watchThrottle enables focus/idle throttling; false uses watchInterval always.
+	// watchThrottle enables focus/idle throttling. False uses watchInterval always.
 	watchThrottle bool
-	// foregroundIdleTimeout is the no-input window before a focused window throttles; 0 disables.
+	// foregroundIdleTimeout is the no-input window before a focused window throttles. 0 disables.
 	foregroundIdleTimeout time.Duration
 	// watchTickGen guards the watch-tick chain (see watch_interval.go). A tick
 	// whose gen does not match is a retired chain and is ignored.
@@ -239,14 +239,14 @@ type Model struct {
 
 	// objectExplorerLive controls whether the Object Explorer re-syncs its
 	// browsed object on list refreshes (issue #391). Defaults from
-	// ui.ConfigObjectExplorerLive; runtime toggle is w inside the explorer.
+	// ui.ConfigObjectExplorerLive. Runtime toggle is w inside the explorer.
 	// objectExplorerForceSync forces a single re-sync on the next list refresh
 	// even when live is off, so manual refresh (R) updates the view once.
 	objectExplorerLive, objectExplorerForceSync bool
-	objectExplorerTree                          bool // session tree-view pref (T); seeded from ui.ConfigObjectExplorerTree
+	objectExplorerTree                          bool // session tree-view pref (T). Seeded from ui.ConfigObjectExplorerTree
 
 	// Read-only mode: blocks all mutating actions for the active tab. Mirrors
-	// the active TabState.readOnly; re-evaluated on context switch and tab
+	// the active TabState.readOnly. Re-evaluated on context switch and tab
 	// switch.
 	readOnly bool
 	// cliReadOnly is the value of --read-only at startup. Sticky for the life
@@ -263,9 +263,9 @@ type Model struct {
 	// sticks within a context but never leaks across contexts.
 	contextBadgeOverrides map[string]bool
 
-	// clusterColors: per-context tint assignments set via Ctrl+L; persisted
+	// clusterColors: per-context tint assignments set via Ctrl+L. Persisted
 	// to $XDG_STATE_HOME/lfk/cluster-colors.yaml. Values validated against
-	// ui.ClusterColorNames; absent key = no tint.
+	// ui.ClusterColorNames. Absent key = no tint.
 	clusterColors map[string]string
 
 	// clusterColorOverlay state: cursor position within the picker's color
@@ -282,7 +282,7 @@ type Model struct {
 	// helpers handle paste, ctrl+w, etc. uniformly.
 	clusterColorFilter TextInput
 	// clusterColorFilterMode is true while the user is typing into the
-	// filter input; in this mode every keystroke goes to the input and
+	// filter input. In this mode every keystroke goes to the input and
 	// navigation keys (j/k/enter) are deferred until Enter or Esc exits
 	// filter mode.
 	clusterColorFilterMode bool
@@ -322,14 +322,14 @@ type Model struct {
 	// goroutine is currently blocked on it. Switching into a logs tab used to
 	// arm a fresh reader unconditionally, accumulating duplicate readers (and
 	// out-of-order lines) on every switch. The guard lets tab switches skip
-	// arming when a reader is already outstanding; updateLogLine keeps the
+	// arming when a reader is already outstanding. updateLogLine keeps the
 	// single reader alive. Shared map (reference type) so all by-value Model
-	// copies observe the same state; only touched on the update goroutine.
+	// copies observe the same state. Only touched on the update goroutine.
 	logReaderInFlight map[chan string]bool
 
 	// Full-screen describe viewer state (kubectl-describe output): content,
 	// scroll/cursor, auto-refresh, search, and visual selection. Extracted
-	// from the formerly flat describe* fields into one cohesive value; see
+	// from the formerly flat describe* fields into one cohesive value. See
 	// describeview.go.
 	describeView describeViewState
 
@@ -346,7 +346,7 @@ type Model struct {
 	// Full-screen diff viewer state (resource compare / revision diff):
 	// left/right content, scroll/cursor, unified vs side-by-side, search,
 	// fold regions, and visual selection. Extracted from the formerly flat
-	// diff* fields into one cohesive value; see diffview.go.
+	// diff* fields into one cohesive value. See diffview.go.
 	diffView diffViewState
 
 	// Embedded terminal state (PTY mode).
@@ -357,9 +357,9 @@ type Model struct {
 	execMu           *sync.Mutex    // Protects execTerm access
 	execEscPressed   bool           // Ctrl+] prefix pressed, waiting for follow-up key
 	execScrollback   *scrollback    // Line ring captured from the PTY byte stream for scrollback
-	execScrollOffset int            // 0 = live; >0 = N rows scrolled back into history
+	execScrollOffset int            // 0 = live. >0 = N rows scrolled back into history
 	// execTickGen is the generation token for the 50ms terminal-refresh tick.
-	// Every arm (tab switch, focus, PTY start) takes a fresh generation; the
+	// Every arm (tab switch, focus, PTY start) takes a fresh generation. The
 	// tick handler re-arms only the current generation, so older chains die
 	// instead of accumulating one render loop per tab switch. Shared pointer so
 	// all by-value Model copies see the same counter.
@@ -381,7 +381,7 @@ type Model struct {
 	pasteTargetID pasteTarget // identifies which input to insert into after confirm
 
 	// Request generation counter for stale response detection.
-	// Incremented on every navigation change; async messages carry the gen
+	// Incremented on every navigation change. Async messages carry the gen
 	// they were created with and are discarded if it no longer matches.
 	requestGen uint64
 
@@ -415,7 +415,7 @@ type Model struct {
 	bookmarkSearchMode bookmarkOverlayMode // current interaction mode for bookmark overlay
 	// bookmarkLoadNamespace controls whether the next jump from the bookmark
 	// overlay replays the bookmark's saved namespace scope. Loading is the
-	// default (seeded on open); Tab opts out to keep the tab's current scope,
+	// default (seeded on open). Tab opts out to keep the tab's current scope,
 	// surfaced by a `[KEEP CURRENT NS]` title chip. Reset to the default on
 	// overlay close and consumed after each jump so it never leaks between opens.
 	bookmarkLoadNamespace bool
@@ -446,19 +446,19 @@ type Model struct {
 	suppressBgtasks bool
 
 	// :scheduler overlay state: tasksOverlayShowCompleted (Tab) flips
-	// running ↔ history; tasksOverlayShowAll (`a`, history only) lifts
-	// the sub-second filter; tasksOverlayFrozenHistory pauses the live
+	// running ↔ history. tasksOverlayShowAll (`a`, history only) lifts
+	// the sub-second filter. tasksOverlayFrozenHistory pauses the live
 	// history while scrolled (cleared on scroll-to-top, Tab, `a`, esc).
 	tasksOverlayShowCompleted, tasksOverlayShowAll bool
 	tasksOverlayFrozenHistory                      []ui.BackgroundTaskRow
 
 	// tasksOverlayScroll is the first-visible-row index for the :tasks
-	// overlay. Bumped by j/k (and friends) inside the overlay; reset on
+	// overlay. Bumped by j/k (and friends) inside the overlay. Reset on
 	// open and on Tab mode switch. The renderer clamps this into a
 	// valid range so the handler can bump it blindly.
 	tasksOverlayScroll int
 
-	// dashboardAcc holds the per-(kctx,gen) fan-out accumulator; keyed by dashboardAccKey.
+	// dashboardAcc holds the per-(kctx,gen) fan-out accumulator. Keyed by dashboardAccKey.
 	dashboardAcc map[string]*dashboardAccumulator
 	// Discovered CRDs per context (unsynchronized: only the bubbletea update goroutine writes).
 	discoveredResources map[string][]model.ResourceTypeEntry
@@ -493,7 +493,7 @@ type Model struct {
 	// the user lands back on the view they quit from rather than the type level.
 	sessionResourceTypeAwaitingDiscovery string
 	// sessionResourceNameAwaitingDiscovery is the resource name to land on once
-	// the type-await above resolves; mirrors pendingTarget but only when deferred.
+	// the type-await above resolves. Mirrors pendingTarget but only when deferred.
 	sessionResourceNameAwaitingDiscovery string
 	// pendingSessionList carries the saved filter + cursor through a deferred restore.
 	pendingSessionList pendingSessionListState
@@ -509,7 +509,7 @@ type Model struct {
 
 	// Mouse capture runtime state. mouseAvailable is true when mouse
 	// capture was enabled at startup (no --no-mouse flag and config allows
-	// it); mouseCaptured tracks the current runtime state so the toggle
+	// it). mouseCaptured tracks the current runtime state so the toggle
 	// keybinding can suspend capture for native terminal text selection and
 	// later re-enable it. When mouse was never available the toggle is a
 	// no-op.
@@ -519,12 +519,12 @@ type Model struct {
 
 	// Metrics content: rendered bar graph for the preview column.
 	metricsContent string
-	metricsData    *metricsInputs // raw numbers behind metricsContent; recomposed on theme/resize, nil when none
-	metricsLoading bool           // true while a metrics fetch for the focused resource is in flight; renders a placeholder bar instead of the previous resource's numbers
+	metricsData    *metricsInputs // raw numbers behind metricsContent. Recomposed on theme/resize, nil when none
+	metricsLoading bool           // true while a metrics fetch for the focused resource is in flight. Renders a placeholder bar instead of the previous resource's numbers
 
 	// Preview events content: rendered event timeline for the preview column.
 	previewEventsContent string
-	previewEventsData    []ui.EventTimelineEntry // raw entries behind previewEventsContent; recomposed on theme/resize
+	previewEventsData    []ui.EventTimelineEntry // raw entries behind previewEventsContent. Recomposed on theme/resize
 
 	// Baseline metrics for trend detection (updated every ~60s, not every refresh).
 	prevPodMetrics      map[string]model.PodMetrics
@@ -535,9 +535,9 @@ type Model struct {
 	// Dashboard state for the cluster overview / monitoring previews.
 	dashboardPreview       string                    // rendered cluster dashboard (right column / fullscreen)
 	dashboardEventsPreview string                    // warning events for the two-column layout
-	dashboardData          map[string]dashboardData  // retained per context; recomposed at current width on resize / fullscreen toggle
+	dashboardData          map[string]dashboardData  // retained per context. Recomposed at current width on resize / fullscreen toggle
 	monitoringPreview      string                    // rendered monitoring dashboard
-	monitoringData         map[string]monitoringData // raw alerts retained per context; recomposed on theme change / resize
+	monitoringData         map[string]monitoringData // raw alerts retained per context. Recomposed on theme change / resize
 
 	// Collapsible tree view state for resource types.
 	expandedGroup     string // currently expanded category (accordion behavior)
@@ -563,19 +563,19 @@ type Model struct {
 	schemeFilter          TextInput
 	schemeFilterMode      bool   // true when typing into filter
 	schemeOriginalName    string // scheme name before opening overlay, for cancel restore
-	schemeFilterEntryName string // scheme name selected when filter mode was entered; restored on Esc
+	schemeFilterEntryName string // scheme name selected when filter mode was entered. Restored on Esc
 
-	serviceEndpointsCache map[string]*k8s.ServiceEndpoints // stale-while-revalidate cache for the Service endpoint rollup; see commands_load_preview.go
-	// orphanCache holds the most recent OrphanReport per (kubeContext, namespace); see commands_orphans.go
+	serviceEndpointsCache map[string]*k8s.ServiceEndpoints // stale-while-revalidate cache for the Service endpoint rollup. See commands_load_preview.go
+	// orphanCache holds the most recent OrphanReport per (kubeContext, namespace). See commands_orphans.go
 	orphanCache        map[orphanCacheKey]*k8s.OrphanReport
 	orphanLoadInflight map[orphanCacheKey]orphanInflight
-	orphanGen          uint64 // monotonic counter; bumped per scan so a superseded result is dropped on arrival
+	orphanGen          uint64 // monotonic counter. Bumped per scan so a superseded result is dropped on arrival
 	orphans            orphanState
-	// rightsizingCache stores GetRightsizing results keyed by ctx/ns/kind/name/strategy/headroom; see commands_load_overlays.go
+	// rightsizingCache stores GetRightsizing results keyed by ctx/ns/kind/name/strategy/headroom. See commands_load_overlays.go
 	rightsizingCache map[string]*model.Rightsizing
-	rightsizing      rightsizingState // overlay session state; see rightsizingState in app_types.go
+	rightsizing      rightsizingState // overlay session state. See rightsizingState in app_types.go
 	// secretPreviewCache caches decoded secret data keyed "ctx/ns/name" to skip
-	// redundant API calls on hover-after-refresh; invalidated on successful save.
+	// redundant API calls on hover-after-refresh. Invalidated on successful save.
 	secretPreviewCache map[string]*model.SecretData
 
 	// Secret editor state.
@@ -614,7 +614,7 @@ type Model struct {
 	helmRevisionsLoading bool
 	// editorSearch backs the / search across the K/V editor overlays
 	// (secret, configmap, label). Shared because only one editor is
-	// open at a time; reset on overlay open.
+	// open at a time. Reset on overlay open.
 	editorSearch kvEditorSearchState
 
 	// Label/annotation editor state.
@@ -651,7 +651,7 @@ type Model struct {
 	alertsLineInput string          // digit buffer for 123G jump-to-line
 
 	// Network policy visualizer state. netpolData holds the single-policy
-	// view (Visualize on a NetworkPolicy); netpolsData the multi-policy view
+	// view (Visualize on a NetworkPolicy). netpolsData the multi-policy view
 	// (Network Policies on a Pod/Service). Exactly one is set at a time.
 	netpolData         *k8s.NetworkPolicyInfo
 	netpolsData        *k8s.NetpolsForResource
@@ -672,7 +672,7 @@ type Model struct {
 
 	crashInv           crashInvState // Crash Investigator overlay (per-pod multi-tab diagnostic view).
 	syncWave           syncWaveState // Sync Wave Timeline overlay state (per-ArgoCD-Application).
-	localClusterFields               // Local-cluster manager overlay (Ctrl+N at LevelClusters); see app_types.go.
+	localClusterFields               // Local-cluster manager overlay (Ctrl+N at LevelClusters). See app_types.go.
 
 	// Event timeline overlay state.
 	eventTimelineData         []k8s.EventInfo // event timeline data
@@ -686,7 +686,7 @@ type Model struct {
 	eventTimelineVisualStart  int             // anchor line for visual selection
 	eventTimelineVisualCol    int             // anchor column for char visual mode
 	eventTimelineCursorCol    int             // cursor column for char visual mode
-	eventTimelineScrollOption int             // sticky vim 'scroll' option for [count]<C-d>/<C-u>; 0 = default (half viewport)
+	eventTimelineScrollOption int             // sticky vim 'scroll' option for [count]<C-d>/<C-u>. 0 = default (half viewport)
 	eventTimelineSearchActive bool
 	eventTimelineSearchInput  TextInput
 	eventTimelineSearchQuery  string
@@ -740,9 +740,9 @@ type Model struct {
 	// Session persistence: restores navigation state across restarts.
 	pendingSession                    *SessionState      // loaded session waiting to be applied after contexts load
 	pendingPortForwards               *PortForwardStates // loaded port forwards waiting to be re-established
-	sessionRestored, restoringSession bool               // apply-once guard; restore in flight (session_restore_guard.go)
+	sessionRestored, restoringSession bool               // apply-once guard. Restore in flight (session_restore_guard.go)
 
-	// Jump history: back stack for "teleport" jumps; jump_back pops it. Capped at jumpHistoryCap.
+	// Jump history: back stack for "teleport" jumps. jump_back pops it. Capped at jumpHistoryCap.
 	jumpBackStack []navSnapshot
 
 	// Stack of LevelOwned parents for nested drill-downs (popped by navigateParent).
@@ -768,20 +768,20 @@ type Model struct {
 	explainResource                                string // resource name (e.g., "deployments")
 	explainAPIVersion                              string // api version for kubectl explain (e.g., "apps/v1")
 	explainTitle                                   string
-	explainPending                                 bool // flat-level fetch issued but not yet answered; see resumeExplainFetch
+	explainPending                                 bool // flat-level fetch issued but not yet answered. See resumeExplainFetch
 	explainCursor, explainScroll                   int
 	explainLineInput                               string               // digit buffer for 123G jump-to-line
 	explainSearchActive                            bool                 // true when typing in search bar
 	explainSearchInput                             TextInput            // current search input
 	explainSearchQuery                             string               // persisted search query for n/N navigation
 	explainSearchPrevCursor                        int                  // cursor position before search started
-	explainTreeState                                                    // embedded — tree-mode state; see explain_tree.go
+	explainTreeState                                                    // embedded — tree-mode state. See explain_tree.go
 	explainRecursiveResults                        []model.ExplainField // results from recursive search
 	explainRecursiveCursor, explainRecursiveScroll int
 	explainRecursiveFilter                         TextInput // filter input for recursive search overlay
 	explainRecursiveFilterActive                   bool      // true when typing in filter
 
-	// canIState (embedded, not named) — Can-I/Who-Can RBAC explorer state; see cani_state.go.
+	// canIState (embedded, not named) — Can-I/Who-Can RBAC explorer state. See cani_state.go.
 	canIState
 
 	// Finalizer search overlay state.
@@ -792,7 +792,7 @@ type Model struct {
 	finalizerSearchLoading      bool
 	finalizerSearchFilter       string
 	finalizerSearchFilterActive bool
-	// Column toggle overlay state; see columnToggleState in update_column_toggle.go.
+	// Column toggle overlay state. See columnToggleState in update_column_toggle.go.
 	columnToggleState
 	// Easter egg state (Konami, nyan, credits, kubetris).
 	easterEggState

--- a/internal/app/app_helpers.go
+++ b/internal/app/app_helpers.go
@@ -42,7 +42,7 @@ const namespaceCacheTTL = 60 * time.Second
 
 // activeContext returns the kubectl context that queries on behalf of
 // the current tab should target. It prefers the tab-scoped nav.Context
-// and falls back to the client's current context; returns "" when the
+// and falls back to the client's current context. Returns "" when the
 // client has not been initialised yet (e.g. in pre-startup tests) so
 // callers never panic on a nil client.
 //
@@ -51,7 +51,7 @@ const namespaceCacheTTL = 60 * time.Second
 // caller of activeContext (cache key, GetNamespaces, completion) needs a
 // real cluster, so resolve it to unionContexts[0] here. The union assumes
 // homogeneous clusters, so any one of them is a representative source for
-// namespace listing and similar metadata; if clusters diverge, the user
+// namespace listing and similar metadata. If clusters diverge, the user
 // can drill into a specific cluster and re-run the operation.
 func (m Model) activeContext() string {
 	if m.isUnionSentinel() {
@@ -81,7 +81,7 @@ func (m Model) discoveryContext() string {
 
 // ensureNamespaceCacheFresh returns a command that refreshes the
 // namespace cache for the current context when the entry is missing,
-// empty, or older than namespaceCacheTTL; returns nil otherwise.
+// empty, or older than namespaceCacheTTL. Returns nil otherwise.
 // Context-open paths (drilling into a cluster, `:ctx`, bookmark
 // activation, session restore) batch it so the first `:` open in the
 // newly-opened context has completions ready without waiting for the
@@ -145,7 +145,7 @@ func (m *Model) cancelInFlightRequests() {
 // It also refreshes model.HiddenTypes via applyHiddenTypes, since hidden types
 // must recompute at exactly the same moments as pins. Callers that already call
 // applyPinnedTypes therefore need NOT call applyHiddenTypes separately (doing so
-// is harmless but redundant); a caller that needs only hidden types refreshed
+// is harmless but redundant). A caller that needs only hidden types refreshed
 // may call applyHiddenTypes directly.
 func (m *Model) applyPinnedTypes() {
 	discCtx := m.nav.Context

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -35,10 +35,10 @@ const (
 )
 
 // wheelBurst tracks a single mouse/trackpad wheel burst. Trackpad momentum
-// keeps emitting wheel ticks after the physical gesture ends; those queued
+// keeps emitting wheel ticks after the physical gesture ends. Those queued
 // ticks otherwise "play out" on whatever list is under the pointer once the
 // user has navigated away or moved the pointer (#524). A gesture is a run of
-// ticks less than wheelQuietGap apart; once it is marked dead (a boundary was
+// ticks less than wheelQuietGap apart. Once it is marked dead (a boundary was
 // reached, a left/right navigation happened, or the pointer moved to another
 // pane) the rest of the gesture is dropped until a real pause starts a new one.
 type wheelBurst struct {
@@ -180,7 +180,7 @@ type localClusterRow struct {
 }
 
 // localClusterWizard holds the staged input across wizard sub-screens.
-// Cleared every time the overlay closes; populated as the user advances.
+// Cleared every time the overlay closes. Populated as the user advances.
 type localClusterWizard struct {
 	provider     string
 	providerCur  int
@@ -199,8 +199,8 @@ type localClusterWizard struct {
 // file cap (mirrors whoCanState pattern).
 type localClusterState struct {
 	screen    localClusterScreen
-	gen       uint64             // race-guard token; bumps on every Detect request
-	clusters  []localClusterRow  // unified row list; .state distinguishes Real / InFlight / Failed
+	gen       uint64             // race-guard token. Bumps on every Detect request
+	clusters  []localClusterRow  // unified row list. .state distinguishes Real / InFlight / Failed
 	cursor    int                // selected row in the list view
 	loading   bool               // Detect in flight
 	info      string             // transient info banner ("Creating kind/dev...", "Created kind/dev")
@@ -250,7 +250,7 @@ type crashInvScrollKey struct {
 // crashInvState groups the CrashLoopBackOff-investigator fields together
 // so they live as a single field on Model. Mirrors whoCanState. The
 // scroll map persists per-(tab, container) viewport offsets so switching
-// tabs or containers preserves the reader's position; the renderer is
+// tabs or containers preserves the reader's position. The renderer is
 // responsible for clamping the offset when content shrinks.
 type crashInvState struct {
 	data            *k8s.CrashInvestigation
@@ -304,7 +304,7 @@ type syncWaveState struct {
 // rightsizingState groups the per-session right-sizing overlay fields
 // so they live together on Model without bloating the main struct over
 // the file-length cap. The cache (Model.rightsizingCache) is kept
-// separate because it survives across overlay opens; this struct is
+// separate because it survives across overlay opens. This struct is
 // reset (or its scroll/data swapped) every time the overlay is opened
 // for a different workload.
 //
@@ -397,7 +397,7 @@ const sortColEventLastSeen = "__event_last_seen__"
 
 // UnionContextSentinel is the value stored in nav.Context when the user is at
 // LevelResources in --union-context mode. It is never sent to the Kubernetes
-// API; effectiveContext() resolves it to a real cluster for API calls.
+// API. effectiveContext() resolves it to a real cluster for API calls.
 const UnionContextSentinel = "__union__"
 
 const (
@@ -419,11 +419,11 @@ type actionContext struct {
 	namespace     string // namespace of the target resource (captured at action time)
 	context       string // kubeconfig context name (captured at action time)
 	containerName string // container name (for exec/logs at container level)
-	os            string // pod OS ("windows"/"linux"/""); resolved before exec to pick the shell
+	os            string // pod OS ("windows"/"linux"/""). Resolved before exec to pick the shell
 	image         string // container image (for vuln scan at container level)
 	resourceType  model.ResourceTypeEntry
 	columns       []model.KeyValue // additional item columns (e.g., Node, IP) for custom action templates
-	raw           map[string]any   // full source object; used to prefill scale overlays from spec/status
+	raw           map[string]any   // full source object. Used to prefill scale overlays from spec/status
 }
 
 // hpaScaleState backs the HPA scale overlay. The overlay edits the HPA's
@@ -475,7 +475,7 @@ type TabState struct {
 	yamlContent        string
 	yamlScroll         int
 	yamlCursor         int // cursor position in visible lines (relative to scroll)
-	yamlScrollOption   int // sticky vim 'scroll' option for [count]<C-d>/<C-u>; 0 = default (half viewport)
+	yamlScrollOption   int // sticky vim 'scroll' option for [count]<C-d>/<C-u>. 0 = default (half viewport)
 	yamlSearchText     TextInput
 	yamlMatchLines     []int
 	yamlMatchIdx       int
@@ -576,7 +576,7 @@ type TabState struct {
 	logVisualType     rune // 'V' = line, 'v' = char, 'B' = block
 	logVisualCol      int  // character column of anchor (for char and block modes)
 	logVisualCurCol   int  // current cursor column (for char and block modes)
-	logScrollOption   int  // sticky vim 'scroll' option for [count]<C-d>/<C-u>; 0 = default (half viewport)
+	logScrollOption   int  // sticky vim 'scroll' option for [count]<C-d>/<C-u>. 0 = default (half viewport)
 
 	// Log viewer: parent resource context for pod re-selection.
 	logParentKind   string
@@ -607,7 +607,7 @@ type TabState struct {
 	execDone         *atomic.Bool
 	execMu           *sync.Mutex
 	execScrollback   *scrollback // line ring captured from the PTY byte stream
-	execScrollOffset int         // 0 = live; >0 = N rows scrolled back into history
+	execScrollOffset int         // 0 = live. >0 = N rows scrolled back into history
 
 	// Explain view state (per-tab).
 	explainFields      []model.ExplainField
@@ -616,7 +616,7 @@ type TabState struct {
 	explainResource    string // resource name (e.g., "deployments")
 	explainAPIVersion  string // api version for kubectl explain (e.g., "apps/v1")
 	explainTitle       string
-	explainPending     bool // a flat-level fetch issued but not yet answered; see resumeExplainFetch
+	explainPending     bool // a flat-level fetch issued but not yet answered. See resumeExplainFetch
 	explainCursor      int
 	explainScroll      int
 	explainSearchQuery string // persisted search query for n/N navigation

--- a/internal/app/commandbar_complete.go
+++ b/internal/app/commandbar_complete.go
@@ -494,7 +494,7 @@ func (m *Model) contextNames() []string {
 // command bar opens for a context that isn't cached yet.
 //
 // A stale entry (older than namespaceCacheTTL) is still returned here
-// so completions remain visible while a background refresh runs; the
+// so completions remain visible while a background refresh runs. The
 // refresh is scheduled from handleKeyCommandBar.
 func (m *Model) namespaceNames() []string {
 	return m.cachedNamespaces[m.activeContext()].names

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -54,8 +54,6 @@ func (m Model) kubectlContext(displayName string) string {
 	return m.client.OriginalContextName(displayName)
 }
 
-// executeCommandBarInput is the main entry point for command bar execution.
-// It classifies the input and dispatches to the appropriate handler.
 func (m Model) executeCommandBarInput(input string) (tea.Model, tea.Cmd) {
 	input = strings.TrimSpace(input)
 	if input == "" {
@@ -568,7 +566,7 @@ func (m Model) executeResourceJump(input string) (tea.Model, tea.Cmd) {
 
 // ensureAtResourceTypesLevel navigates parent until reaching
 // model.LevelResourceTypes. Returns the updated model and true on
-// success; if the level drops below that threshold (cluster level)
+// success. If the level drops below that threshold (cluster level)
 // it returns false without mutating the model further.
 func ensureAtResourceTypesLevel(m Model) (Model, bool) {
 	for m.nav.Level > model.LevelResourceTypes {
@@ -723,7 +721,7 @@ func (m Model) executeKubectlCommand(input string) tea.Cmd {
 		// PTY-mode commands don't route through tea.ExecProcess, so the
 		// namespace-cache invalidation that normally arrives via
 		// actionResultMsg won't fire here. That's acceptable because the
-		// user sees the result inline and can refresh manually with R; a
+		// user sees the result inline and can refresh manually with R. A
 		// future improvement could propagate invalidation through
 		// execPTYExitMsg. The affectsNamespaces value is intentionally
 		// dropped to keep the PTY path free of bespoke wiring.
@@ -754,7 +752,7 @@ func (m Model) executeKubectlCommand(input string) tea.Cmd {
 }
 
 // wrapYAMLCmdAsJSON converts the YAML payload of an inner yamlClipboardMsg
-// into JSON. A single-document payload becomes a JSON object; a multi-document
+// into JSON. A single-document payload becomes a JSON object. A multi-document
 // payload (separated by `\n---\n` per copyYAMLToClipboard's joiner) becomes a
 // JSON array. The bulk-fetch wiring, status messages, and error envelope are
 // reused unchanged.

--- a/internal/app/commands_dashboard.go
+++ b/internal/app/commands_dashboard.go
@@ -89,7 +89,7 @@ func (m Model) loadDashboardFor(kctx string) tea.Cmd {
 	// A prior fan-out for this same (context, gen) may still be mid-flight
 	// (e.g. this reload was triggered by a pin toggle before the previous
 	// dashboard load finished). Its accumulator's `expected` count was seeded
-	// from *that* fan-out's total; if this fresh fan-out has a different
+	// from *that* fan-out's total. If this fresh fan-out has a different
 	// total (a different pin count), letting both feed the same accumulator
 	// would mix section data across fan-outs or complete against the wrong
 	// count. Evict it so this fan-out always starts from a clean slate. The
@@ -132,7 +132,7 @@ func (m Model) loadDashboardFor(kctx string) tea.Cmd {
 		{dashboardSectionPDB, func(ctx context.Context) dashboardData { return fetchDashboardPDB(ctx, kctx, client) }},
 		{dashboardSectionNodeMetrics, func(ctx context.Context) dashboardData {
 			// Node metrics needs node items as input. Re-fetch them inside
-			// this section to keep it self-contained; a node-list failure
+			// this section to keep it self-contained. A node-list failure
 			// surfaces as nodeMetricsErr so the dashboard renders an explicit
 			// "metrics unavailable" instead of zeros.
 			nodeItems, err := client.GetResources(ctx, kctx, "", model.ResourceTypeEntry{
@@ -178,7 +178,7 @@ func dashboardAccKey(kctx string, gen uint64) string {
 // handleDashboardPartial accumulates a section result and emits a
 // single dashboardLoadedMsg only after all expected sections have arrived.
 // This avoids flickering the dashboard layout on every watch tick
-// (each tick fires one partial fetch per section; rendering on each one
+// (each tick fires one partial fetch per section. Rendering on each one
 // would repeatedly clear sections that haven't arrived yet).
 //
 // Stale messages (different context or different requestGen) are
@@ -199,7 +199,7 @@ func (m Model) handleDashboardPartial(msg dashboardPartialMsg) (Model, tea.Cmd) 
 	if m.dashboardAcc == nil {
 		// Lazy-init: production app_init.go pre-allocates this map, but
 		// test fixtures with bare Model{} don't. The stale-drop branch
-		// above already guards a nil map; mirror that here so a current
+		// above already guards a nil map. Mirror that here so a current
 		// partial arriving before init can't panic.
 		m.dashboardAcc = make(map[string]*dashboardAccumulator)
 	}
@@ -210,7 +210,7 @@ func (m Model) handleDashboardPartial(msg dashboardPartialMsg) (Model, tea.Cmd) 
 	} else {
 		// A coalesced old fan-out (smaller total) can race a fresh one (larger
 		// total, e.g. a pin added mid-flight) on the same (context, gen).
-		// Awaiting the larger fan-out guarantees a full frame; the smaller
+		// Awaiting the larger fan-out guarantees a full frame. The smaller
 		// fan-out's keys are a subset delivered by surviving coalesced tasks.
 		acc.expected = max(acc.expected, msg.total)
 	}
@@ -344,7 +344,7 @@ func (m Model) composeDashboard(data dashboardData) (content, events string) {
 		if warn := dashboardWarningsColumn(data); len(warn) > 0 {
 			right = append(right, warn...)
 			// Divide warnings from the events below. Size it to match
-			// wrapEventsColumn's wrap width (rightW-4); that helper adds the
+			// wrapEventsColumn's wrap width (rightW-4). That helper adds the
 			// leading "  " pad, so the rule renders as a single full-width line
 			// rather than wrapping.
 			_, rightW := dashboardColumnWidths(content, m.width-2)

--- a/internal/app/commands_dashboard_sections.go
+++ b/internal/app/commands_dashboard_sections.go
@@ -17,7 +17,7 @@ import (
 
 // dashboardSection enumerates the parallel fetches that compose the
 // cluster dashboard. Each section runs as a separate scheduled task so
-// foreground work can preempt mid-flight (Task 26 wires the fan-out).
+// foreground work can preempt mid-flight.
 type dashboardSection int
 
 const (
@@ -31,7 +31,7 @@ const (
 
 // pinnedSummaryResult is one pinned resource type's status rollup, rendered
 // as inline dashboard metric rows below Pods (dashboardPinnedRows). index
-// preserves pin order across the unordered fan-out; notFound flags a pin key
+// preserves pin order across the unordered fan-out. notFound flags a pin key
 // absent from the cluster's discovery (e.g. a CRD not installed here).
 type pinnedSummaryResult struct {
 	index       int
@@ -51,7 +51,7 @@ type dashboardWidths struct {
 	node    int // per-node CPU/Mem bars (two side by side)
 	sep     int // horizontal separator rule
 	label   int // metric-row label column width (for inline label/bar/summary alignment)
-	content int // total content width; inline rows are truncated to it as a safety net
+	content int // total content width. Inline rows are truncated to it as a safety net
 }
 
 // dashboardMetricLines lays out one cluster metric over two lines: the label +
@@ -90,7 +90,7 @@ func (m Model) dashboardContentWidth(twoCol bool) int {
 }
 
 // dashboardWidths derives the metric-row widths from the target content width.
-// Bars are uniform and as wide as the column allows; the summary lives on its
+// Bars are uniform and as wide as the column allows. The summary lives on its
 // own line, so it no longer constrains the bar. maxPinnedLabel is the longest
 // label any pinned row will render (see maxPinnedLabelWidth) - the label
 // column widens to fit it, capped at 14, so a long CRD display name never
@@ -100,7 +100,7 @@ func (m Model) dashboardContentWidth(twoCol bool) int {
 func (m Model) dashboardWidths(twoCol bool, maxPinnedLabel int) dashboardWidths {
 	contentW := m.dashboardContentWidth(twoCol)
 	labelCol := min(max(maxPinnedLabel, 5), 14) // "Nodes" / "Pods" / "CPU" / "Mem" at minimum
-	// Per-node row is `      CPU [bar] NN%   MEM [bar] NN%`; the two bars share
+	// Per-node row is `      CPU [bar] NN%   MEM [bar] NN%`. The two bars share
 	// a fixed 31-col overhead (indents, "CPU"/"MEM" labels, brackets, "%",
 	// gaps), so split the rest between them to reach the same right edge as the
 	// top bars instead of staying noticeably narrower.
@@ -442,7 +442,7 @@ func dashboardHeaderSection(lines []string, data dashboardData, w dashboardWidth
 		lines = append(lines, dashboardMetricLines("Pods", podBar, podSummaryStr(data), w)...)
 	}
 	// No trailing blank here: pinned rows (dashboardPinnedRows) render
-	// directly below Pods inside the same block; composeDashboard adds the
+	// directly below Pods inside the same block. composeDashboard adds the
 	// separating blank after them.
 
 	return lines

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -33,7 +33,7 @@ func (m Model) loadContexts() tea.Cmd {
 // loadContextsReload re-walks every kubeconfig file from disk before
 // listing. Use this only when you have reason to believe the kubeconfig
 // changed externally (kind/k3d/minikube create or delete from inside
-// lfk; explicit user-initiated refresh). Watch-mode auto-refresh and
+// lfk. Explicit user-initiated refresh). Watch-mode auto-refresh and
 // startup use the cheaper loadContexts.
 func (m Model) loadContextsReload() tea.Cmd {
 	return m.trackBgTask(
@@ -156,7 +156,7 @@ func (m Model) loadResources(forPreview bool) tea.Cmd {
 	// not exist` on every sidebar hover whose target rt isn't already in
 	// itemCache.
 	//
-	// Preview hovers serve from cache when fresh; main-list and watch
+	// Preview hovers serve from cache when fresh. Main-list and watch
 	// ticks always refetch so deleted pods don't linger and Age advances.
 	// This mirrors the non-union policy below — see the fresh-cache
 	// shortcut comment.
@@ -260,7 +260,7 @@ func (m Model) loadResources(forPreview bool) tea.Cmd {
 	// Critical first — starve the High preview work that renders pod details.
 	// High keeps the list ahead of Low background (dashboard/metrics/events)
 	// while sharing the general pool fairly with previews.
-	// Security findings reaching here have a cold cache; name the task so it
+	// Security findings reaching here have a cold cache. Name the task so it
 	// reads as the shared security scan (it triggers/awaits the one coalesced
 	// FetchAll that covers every source), not a per-source object listing.
 	listName := "List " + model.DisplayNameFor(rt)
@@ -348,7 +348,7 @@ func (m Model) loadResourceTree() tea.Cmd {
 			return nil
 		}
 		kind = "Pod"
-		// effectiveNamespace returns "" in all-namespaces mode; fall back
+		// effectiveNamespace returns "" in all-namespaces mode. Fall back
 		// to the navigation namespace so the typed Pod GET resolves —
 		// same pattern as loadContainers above.
 		if ns == "" && m.nav.Namespace != "" {
@@ -455,7 +455,7 @@ func (m Model) resolveOwnedResourceType(sel *model.Item) (model.ResourceTypeEntr
 }
 
 func (m Model) loadYAML() tea.Cmd {
-	// Synthetic security items have no YAML; defense in depth alongside
+	// Synthetic security items have no YAML. Defense in depth alongside
 	// the gate in enterFullView so any future caller stays safe.
 	if onSecurityView(&m) {
 		return nil
@@ -736,7 +736,7 @@ func (m Model) scheduleK8sCall(prio scheduler.Priority, kind scheduler.Kind, nam
 		// All three sentinels mean "this submission was intentionally
 		// abandoned" — coalesced by a newer one, context dropped, or
 		// superseded by a newer requestGen via CancelStaleByGen. Return nil
-		// so the UI ignores it; the surviving submission carries the result.
+		// so the UI ignores it. The surviving submission carries the result.
 		if errors.Is(res.Err, scheduler.ErrCoalesced) ||
 			errors.Is(res.Err, scheduler.ErrContextSwitched) ||
 			errors.Is(res.Err, scheduler.ErrSuperseded) {

--- a/internal/app/commands_load_preview.go
+++ b/internal/app/commands_load_preview.go
@@ -178,7 +178,7 @@ func (m Model) loadPreviewResources() tea.Cmd {
 		cmds = append(cmds, eventsCmd)
 	}
 	// loadPreviewSecretData is itself gated on kind and the lazy-loading
-	// config flag; call it unconditionally and let it no-op when not
+	// config flag. Call it unconditionally and let it no-op when not
 	// applicable. Keeping the gate centralised there makes the contract
 	// testable without reaching into tea.Batch internals here.
 	if secretCmd := m.loadPreviewSecretData(); secretCmd != nil {
@@ -386,7 +386,7 @@ func (m Model) loadAlerts() tea.Cmd {
 }
 
 // loadNetworkPolicy fetches and parses a network policy for visualization.
-// Cilium policies may carry multiple specs; a multi-spec policy opens the
+// Cilium policies may carry multiple specs. A multi-spec policy opens the
 // stacked multi-policy view instead of the single view.
 func (m Model) loadNetworkPolicy() tea.Cmd {
 	client := m.client
@@ -480,7 +480,7 @@ func (m Model) loadHelmValues(allValues bool) tea.Cmd {
 		logExecCmd("Running helm command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
-			// Helm chart values commonly embed secrets/passwords; redact
+			// Helm chart values commonly embed secrets/passwords. Redact
 			// the captured output before persisting it to lfk.log.
 			logger.Error("helm get values failed", "cmd", cmd.String(), "error", cmdErr, "output", logger.Redact(string(output)))
 			return helmValuesLoadedMsg{
@@ -547,8 +547,8 @@ func serviceEndpointsCacheKey(ctx, ns, name string) string {
 // network call returns) AND fire a fresh background fetch (so pod
 // churn — restart, rolling update, HPA scale — is always reflected
 // within one watch tick). Pure cache-only would show stale ready
-// state after pod restart; pure fetch-only would flash a blank row
-// every watch tick. Both run in parallel; the fresh response normally
+// state after pod restart. Pure fetch-only would flash a blank row
+// every watch tick. Both run in parallel. The fresh response normally
 // arrives last and overwrites the cache emit.
 //
 // Returns nil when:
@@ -620,7 +620,7 @@ func (m Model) loadPreviewServiceEndpoints() tea.Cmd {
 // isServiceWithoutEndpoints reports whether the selected Service has
 // no backing EndpointSlices to roll up — Headless services
 // (clusterIP=None) and ExternalName services. Both surface their type
-// in the populated "Type" column already; reading it back avoids a
+// in the populated "Type" column already. Reading it back avoids a
 // round-trip to fetch the spec just for the gating check.
 func isServiceWithoutEndpoints(sel *model.Item) bool {
 	for _, kv := range sel.Columns {

--- a/internal/app/commands_logs.go
+++ b/internal/app/commands_logs.go
@@ -216,7 +216,7 @@ func (m *Model) startLogStream() tea.Cmd {
 		// kubectl (with --ignore-errors) keeps re-emitting the same
 		// 'container X is waiting to start' line every retry. We want the
 		// user to see the message once so they know what's happening, but
-		// not a flood. Dedup within this kubectl run; reconnect resets.
+		// not a flood. Dedup within this kubectl run. Reconnect resets.
 		seenTransient := map[string]bool{}
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
@@ -496,7 +496,7 @@ func (m *Model) maybeLoadMoreHistory() tea.Cmd {
 // writeTempLog writes log data to a uniquely-named, owner-only (0600) file in
 // the OS temp dir. pattern is an os.CreateTemp pattern (the "*" is replaced by a
 // random string). Logs frequently carry bearer tokens / connection strings, so
-// the file must not be world-readable; the random suffix plus CreateTemp's
+// the file must not be world-readable. The random suffix plus CreateTemp's
 // O_EXCL also defeat the predictable-path symlink TOCTOU that a fixed /tmp name
 // allowed, and os.TempDir keeps it working on Windows where /tmp does not exist.
 func writeTempLog(pattern string, data []byte) (string, error) {

--- a/internal/app/commands_security.go
+++ b/internal/app/commands_security.go
@@ -34,7 +34,7 @@ func (m Model) invalidateSecurityCache() {
 // those calls go through the kubeconfig's aws exec-credential plugin, which
 // surfaces "SSO session expired" noise when the session has lapsed even
 // though the foreground views work off a cached token. The per-context guard
-// stops a re-probe on every cursor move; refreshSecuritySources clears it on
+// stops a re-probe on every cursor move. refreshSecuritySources clears it on
 // context switch so each cluster is probed once on first Security focus.
 func (m *Model) maybeProbeSecurityOnFocus() tea.Cmd {
 	if m.nav.Level != model.LevelResourceTypes {
@@ -271,10 +271,10 @@ func (m Model) updateSecurityFindingsLoaded(msg securityFindingsLoadedMsg) (Mode
 	// Persist to disk for stale-while-revalidate on the next session — but OFF
 	// the Bubble Tea Update goroutine. Marshaling the full findings set to YAML
 	// and the durable write take multiple seconds on clusters with many
-	// findings; running them inline here froze the UI until the write finished
+	// findings. Running them inline here froze the UI until the write finished
 	// (the findings message lands on the Update loop exactly when a background
 	// scan completes). A fully clean scan with zero findings is still cached (a
-	// valid "nothing found"). Best-effort; a write failure never affects the
+	// valid "nothing found"). Best-effort. A write failure never affects the
 	// session. saveSecurityFindingsCacheForHost serializes concurrent writes.
 	client := m.client
 	ctx, ns, findings := msg.context, msg.namespace, msg.findings
@@ -299,7 +299,7 @@ func (m Model) updateSecurityFindingsSeed(msg securityFindingsSeedMsg) Model {
 		return m
 	}
 	if m.securityIndex != nil {
-		return m // a live scan already won; do not regress to stale data
+		return m // a live scan already won. Do not regress to stale data
 	}
 	if m.nav.Context != "" && msg.context != m.nav.Context {
 		return m
@@ -338,7 +338,7 @@ func (m Model) loadSecurityAffectedResources(forPreview bool) tea.Cmd {
 	rt := m.nav.ResourceType
 	// The per-resource findings view mixes sources, so its sentinel Kind
 	// carries no source. Rebuild a per-source RT from the row's source so
-	// the k8s getters scope the fetch correctly; without a source there is
+	// the k8s getters scope the fetch correctly. Without a source there is
 	// nothing to fetch.
 	if rt.Kind == model.SecurityResourceFindingsKind {
 		if sourceName == "" {

--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -60,12 +60,10 @@ func indexByExtra(items []model.Item, extra string) int {
 	return -1
 }
 
-// cursor returns the cursor position for the current level.
 func (m *Model) cursor() int {
 	return m.cursors[m.nav.Level]
 }
 
-// setCursor sets the cursor for the current level.
 func (m *Model) setCursor(v int) {
 	m.cursors[m.nav.Level] = v
 }
@@ -119,7 +117,7 @@ func (m *Model) restoreCursorToItem(name, namespace, extra, kind string) {
 // Every path that swaps middleItems (full replace, filter-and-replace,
 // append-and-replace, nil-out) must go through this helper so the
 // TableRenderer fingerprint invalidates. Slice reassignment alone is not
-// enough — itemsPtr is only a fast-path; rev is the authoritative signal.
+// enough — itemsPtr is only a fast-path. Rev is the authoritative signal.
 func (m *Model) setMiddleItems(items []model.Item) {
 	m.middleItems = items
 	m.middleItemsRev++
@@ -299,7 +297,7 @@ func (m *Model) middleColumnKind() string {
 // currently rendered in the middle column. Used to resolve view configs
 // keyed by GVR or Kind. At LevelOwned/LevelContainers the parent's GVR
 // does not match the rendered items, so only Kind is populated (matching
-// the kind returned by middleColumnKind); resolution then falls back to
+// the kind returned by middleColumnKind). Resolution then falls back to
 // Kind-only lookup. At shallower levels the full GVR is returned so views
 // keyed by `<group>/<version>/<resource>` resolve.
 func (m *Model) middleColumnRef() ui.ResourceRef {
@@ -525,12 +523,10 @@ func selectionKey(item model.Item) string {
 	return item.SelectionKey()
 }
 
-// isSelected returns true if the given item is in the multi-selection set.
 func (m *Model) isSelected(item model.Item) bool {
 	return m.selectedItems[selectionKey(item)]
 }
 
-// toggleSelection toggles the selection state of an item.
 func (m *Model) toggleSelection(item model.Item) {
 	key := selectionKey(item)
 	if m.selectedItems[key] {
@@ -541,14 +537,12 @@ func (m *Model) toggleSelection(item model.Item) {
 	m.selectionRev++
 }
 
-// clearSelection removes all items from the multi-selection set and resets the region anchor.
 func (m *Model) clearSelection() {
 	m.selectedItems = make(map[string]bool)
 	m.selectionAnchor = -1
 	m.selectionRev++
 }
 
-// hasSelection returns true if any items are selected.
 func (m *Model) hasSelection() bool {
 	return len(m.selectedItems) > 0
 }

--- a/internal/app/discovery_cache.go
+++ b/internal/app/discovery_cache.go
@@ -31,7 +31,7 @@ type discoveryCacheLoadedMsg struct {
 // in a single file) this re-parses the kubeconfig ~1200× and serialises the
 // whole startup behind a multi-second clientcmd loop. Running it as a tea.Cmd
 // lets NewModel return immediately so the first frame renders with seed
-// resources; the cache then lands and overlays the seed list when ready.
+// resources. The cache then lands and overlays the seed list when ready.
 //
 // reqCtx lets a user-initiated quit short-circuit the loop instead of
 // waiting for the full walk to finish. Without this plumbing a Ctrl+C
@@ -107,7 +107,7 @@ type DiscoveryCacheHostState struct {
 // discoveryCacheFilePathForHost returns the per-host cache file path:
 // $KUBECACHEDIR/discovery/<host>/lfk-enriched.yaml (with $KUBECACHEDIR
 // defaulting to ~/.kube/cache). Returns "" for an empty host or an
-// unresolvable home dir; callers treat that as "skip caching".
+// unresolvable home dir. Callers treat that as "skip caching".
 func discoveryCacheFilePathForHost(host string) string {
 	if host == "" {
 		return ""

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -95,7 +95,7 @@ type namespacesLoadedMsg struct {
 	// silent marks this load as a background cache refresh (e.g., fired
 	// by ensureNamespaceCacheFresh on session restore or context open).
 	// The handler must not flip m.loading in this mode because that flag
-	// belongs to the middle-column / resource-types load; clearing it
+	// belongs to the middle-column / resource-types load. Clearing it
 	// asynchronously while discovery is still in flight causes a "No
 	// items" flash between the loader and the populated list.
 	silent bool
@@ -188,7 +188,7 @@ type statusMessageExpiredMsg struct{}
 type startupTipMsg struct{ tip string }
 
 // watchTickMsg triggers a periodic refresh in watch mode. gen identifies the
-// tick chain; a tick whose gen != Model.watchTickGen is from a retired chain.
+// tick chain. A tick whose gen != Model.watchTickGen is from a retired chain.
 type watchTickMsg struct{ gen uint64 }
 
 type previewDebounceTickMsg struct{ gen uint64 }
@@ -205,13 +205,13 @@ type containerSelectMsg struct {
 // dashboardLoadedMsg carries the rendered dashboard content.
 type dashboardLoadedMsg struct {
 	data    dashboardData // composed into preview/events at the current width on receipt
-	content string        // optional pre-rendered override (e.g. "disabled"); used verbatim when non-empty
+	content string        // optional pre-rendered override (e.g. "disabled"). Used verbatim when non-empty
 	context string
 }
 
 // dashboardPartialMsg delivers one section of the dashboard fan-out to the
 // renderer, which accumulates sections per-(kctx, gen). key identifies the
-// section ("nodes", "pods", ..., or "pinned:<group/resource>"); total is the
+// section ("nodes", "pods", ..., or "pinned:<group/resource>"), total is the
 // number of sections this load fanned out to (6 fixed + one per pinned
 // summary), so the accumulator knows when the set is complete. Once all
 // expected sections have arrived, a dashboardLoadedMsg is dispatched for
@@ -310,7 +310,7 @@ type previewLogRestartMsg struct {
 
 // previewLogHistoryMsg carries a batch of older log lines fetched by a one-shot
 // kubectl logs (no -f). podKey correlates the result to the pod that was active
-// when the fetch was issued; stale results are dropped on receipt.
+// when the fetch was issued. Stale results are dropped on receipt.
 type previewLogHistoryMsg struct {
 	podKey string
 	lines  []string
@@ -427,7 +427,7 @@ type rightsizingLoadedMsg struct {
 // update loop freezes the UI on every overlay open.
 //
 // The handler reconciles available + the current strategy: if the
-// sticky strategy is still in the probe result it's kept; otherwise
+// sticky strategy is still in the probe result it's kept. Otherwise
 // the picker re-seeds via pickRightsizingStrategy and a fresh load is
 // dispatched (the in-memory data was for the wrong strategy).
 //
@@ -533,7 +533,7 @@ type templateApplyMsg struct {
 	tmpFile     string
 	context     string
 	ns          string
-	origModTime time.Time // modification time before editor opened; skip apply if unchanged
+	origModTime time.Time // modification time before editor opened. Skip apply if unchanged
 }
 
 // eventTimelineMsg carries event timeline data for the overlay.
@@ -636,7 +636,7 @@ type previewEventsLoadedMsg struct {
 }
 
 // explainLoadedMsg carries the parsed output of kubectl explain. gen is the
-// explain session it was started for; handlers drop a reply whose gen no
+// explain session it was started for. Handlers drop a reply whose gen no
 // longer matches m.explainGen. See explainSessionState.
 type explainLoadedMsg struct {
 	fields      []model.ExplainField
@@ -727,7 +727,7 @@ type previewServiceEndpointsLoadedMsg struct {
 }
 
 // orphanCacheKey identifies a slot in Model.orphanCache. namespace == ""
-// means cluster-wide (the overlay path); a non-empty namespace is the
+// means cluster-wide (the overlay path). A non-empty namespace is the
 // filter-preset path scoped to a single namespace.
 type orphanCacheKey struct {
 	kubeContext string
@@ -735,7 +735,7 @@ type orphanCacheKey struct {
 }
 
 // orphanInflight is the per-key bookkeeping for an in-flight scan.
-// gen lets handleOrphansLoaded drop a superseded result; cancel lets
+// gen lets handleOrphansLoaded drop a superseded result. Cancel lets
 // invalidators stop the scan immediately when the user switches
 // namespace/context or refreshes — without it, a stale scan could
 // repopulate the cache after invalidation.
@@ -769,7 +769,7 @@ type localClustersDetectedMsg struct {
 
 // localClusterCreatedMsg carries the result of a create-cluster wizard
 // submission. Emitted by createLocalClusterCmd after Provider.Create
-// returns; the handler reloads the manager table and contexts list.
+// returns. The handler reloads the manager table and contexts list.
 // gen guards against late results landing after the manager closed —
 // without it a 2-minute create that completes after the user navigated
 // away would silently mutate localClusterState.creating + .info.

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -41,7 +41,7 @@ type objectExplorerState struct {
 	// path with ASCII-art guides instead of the flat current level. treeRows
 	// is the pre-order flattened subtree, rebuilt on every path/root change.
 	// treeCollapsed holds the folded rows (space / toggle_fold), keyed by
-	// their relative segs; cleared whenever the tree re-roots.
+	// their relative segs. Cleared whenever the tree re-roots.
 	tree          bool
 	treeRows      []model.ObjectTreeRow
 	treeCollapsed map[string]struct{}
@@ -94,7 +94,7 @@ func (rt *objectExplorerState) selected() (model.ObjectField, bool) {
 }
 
 // openObjectExplorer enters the Object Explorer for the focused resource.
-// It needs the live object (Item.Raw); synthetic items without one get a
+// It needs the live object (Item.Raw). Synthetic items without one get a
 // status message.
 func (m Model) openObjectExplorer() (tea.Model, tea.Cmd) {
 	if m.nav.Level < model.LevelResources {
@@ -143,7 +143,7 @@ func (m *Model) syncObjectExplorerLive() {
 	}
 	// Live off: leave the snapshot frozen so the view doesn't shift under the
 	// user. A manual refresh (R) sets objectExplorerForceSync to apply one
-	// update anyway; consume it here so it stays a single-shot.
+	// update anyway. Consume it here so it stays a single-shot.
 	if !m.objectExplorerLive && !m.objectExplorerForceSync {
 		return
 	}
@@ -234,7 +234,7 @@ func (m Model) refreshObjectExplorer() (tea.Model, tea.Cmd) {
 }
 
 // exitObjectExplorer resets state and returns to the mode the Object Explorer
-// was opened from (the explorer by default; the YAML viewer when opened via P).
+// was opened from (the explorer by default, the YAML viewer when opened via P).
 func (m *Model) exitObjectExplorer() {
 	m.mode = m.objectExplorerReturnMode
 	m.objectExplorerReturnMode = modeExplorer
@@ -691,7 +691,7 @@ func (m Model) selectedNodeYAML() string {
 	return string(out)
 }
 
-// formatObjectPath renders path segments as a readable dotted path; see
+// formatObjectPath renders path segments as a readable dotted path. See
 // model.FormatObjectPath.
 func formatObjectPath(segs []string) string {
 	return model.FormatObjectPath(segs)

--- a/internal/app/previewlog.go
+++ b/internal/app/previewlog.go
@@ -62,15 +62,15 @@ type previewLogState struct {
 	podKey               string       // ctx/ns/name currently streaming
 	readerInFlight       *atomic.Bool // single-reader guard across model copies
 	err                  string
-	autoReconnectAttempt int // consecutive done-reconnect attempts; reset to 0 on a line
+	autoReconnectAttempt int // consecutive done-reconnect attempts. Reset to 0 on a line
 	// fromBottom is the scroll offset for the preview pane.
-	// 0 = auto-follow (show newest); N = show N rows up from the bottom.
+	// 0 = auto-follow (show newest). N = show N rows up from the bottom.
 	// K scrolls back (fromBottom++), J scrolls forward (fromBottom--).
 	fromBottom int
 
 	// Lazy history loading state.
 	// hasMoreHistory is true when there may be older lines not yet loaded.
-	// Set to true on fresh stream start; cleared when an empty overlap is found
+	// Set to true on fresh stream start. Cleared when an empty overlap is found
 	// or the buffer cap is reached.
 	hasMoreHistory bool
 	// loadingHistory is true while a one-shot history fetch is in flight.
@@ -82,7 +82,7 @@ type previewLogState struct {
 }
 
 // appendPreviewLogLine adds a line to the preview buffer. The buffer may grow
-// beyond previewLogCap when lazy history has been prepended; it is only capped
+// beyond previewLogCap when lazy history has been prepended. It is only capped
 // at previewLogMaxLines to bound total memory. The GC-friendly tail-copy is
 // performed at the higher bound so the dropped head can be collected.
 func (m *Model) appendPreviewLogLine(line string) {
@@ -139,7 +139,7 @@ func (m *Model) cancelPreviewLogStream() {
 // function records the error in previewLog.err and returns a nil cmd.
 func (m Model) startPreviewLogStream(ref podRef, reconnect bool) (Model, tea.Cmd) {
 	// Stop / clear the previous stream before touching kubectl. The full cancel
-	// clears the buffer; the light stop preserves it for reconnects.
+	// clears the buffer. The light stop preserves it for reconnects.
 	if reconnect {
 		m.stopPreviewStream()
 	} else {
@@ -234,7 +234,7 @@ func (m Model) startPreviewLogStream(ref podRef, reconnect bool) (Model, tea.Cmd
 // waitForPreviewLogLine returns a tea.Cmd that reads exactly one line from
 // previewLog.ch. The readerInFlight guard (Swap-on-arm) ensures that only one
 // reader is in flight at a time even when model copies are made during a pod
-// switch; if a reader is already in flight the cmd is a no-op.
+// switch. If a reader is already in flight the cmd is a no-op.
 func (m Model) waitForPreviewLogLine() tea.Cmd {
 	ch := m.previewLog.ch
 	if ch == nil {
@@ -273,7 +273,7 @@ func (m Model) updatePreviewLogLine(msg previewLogLineMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	// The reader that produced this msg has exited; mark it idle so the next
+	// The reader that produced this msg has exited. Mark it idle so the next
 	// arm in waitForPreviewLogLine is not blocked by a stale true value.
 	if m.previewLog.readerInFlight != nil {
 		m.previewLog.readerInFlight.Store(false)
@@ -304,7 +304,7 @@ func (m Model) updatePreviewLogLine(msg previewLogLineMsg) (tea.Model, tea.Cmd) 
 	// fromBottom is a bottom-anchored physical-line offset, so appending a line
 	// would otherwise shift the window toward the newest line. When the user has
 	// scrolled back (fromBottom > 0) advance it by the new line's physical
-	// (wrapped) height so the same lines stay visible; fromBottom == 0 keeps
+	// (wrapped) height so the same lines stay visible. fromBottom == 0 keeps
 	// auto-following the newest line. The single-line measure is O(1).
 	if m.previewLog.fromBottom > 0 {
 		m.previewLog.fromBottom += ui.PreviewLogPhysicalCount([]string{msg.line}, m.previewLogInnerWidth())
@@ -437,7 +437,7 @@ func (r podRef) key() string {
 // be restored when the user returns to the same pod. A copy of the slice is
 // stored (not an alias) so later mutations to the live buffer cannot corrupt
 // the cache. No-op when podKey is empty or the buffer is empty.
-// LRU eviction: the key is moved to most-recent in previewLogCacheOrder; if
+// LRU eviction: the key is moved to most-recent in previewLogCacheOrder. If
 // the cache exceeds previewLogCacheMax the oldest key is dropped.
 func (m *Model) cachePreviewLog() {
 	if m.previewLog.podKey == "" || len(m.previewLog.lines) == 0 {
@@ -605,7 +605,7 @@ func (m Model) selectedPodForLogPreview() (podRef, bool) {
 
 // fetchOlderPreviewLogs returns a tea.Cmd that runs a one-shot kubectl logs
 // --tail=<tail> for ref (no -f), capturing combined output, and emits a
-// previewLogHistoryMsg. The fetch runs in the background; the model correlates
+// previewLogHistoryMsg. The fetch runs in the background. The model correlates
 // the result by podKey to drop stale responses.
 func (m Model) fetchOlderPreviewLogs(ref podRef, tail int) tea.Cmd {
 	kubectlPath, err := k8s.KubectlPath()
@@ -661,7 +661,7 @@ func (m Model) updatePreviewLogHistory(msg previewLogHistoryMsg) tea.Model {
 		return m
 	}
 
-	// The fetched lines are the last <tail> lines of the pod; the current
+	// The fetched lines are the last <tail> lines of the pod. The current
 	// buffer's oldest lines overlap the end of that set, so only the prefix
 	// before the overlap is genuinely older.
 	newOlder := mergeOlderLogLines(m.previewLog.lines, msg.lines)

--- a/internal/app/ptyexec.go
+++ b/internal/app/ptyexec.go
@@ -18,7 +18,7 @@ import (
 )
 
 // execPTYTickMsg triggers a re-render of the embedded terminal.
-// The ptmx field identifies which tab's terminal this tick belongs to; gen is
+// The ptmx field identifies which tab's terminal this tick belongs to, gen is
 // the chain generation, used to drop ticks from superseded tick chains.
 type execPTYTickMsg struct {
 	ptmx *os.File
@@ -211,7 +211,7 @@ func (m Model) execAltScreen() bool {
 
 // execViewportRows reports the number of PTY rows the user can see in
 // the current window — the same value viewExecTerminal uses for its
-// viewH. The handlers and the renderer must agree on this number; if
+// viewH. The handlers and the renderer must agree on this number. If
 // the scroll clamp uses a larger viewport than the renderer, the
 // oldest few lines get trimmed off the top when the user scrolls all
 // the way back.
@@ -233,7 +233,7 @@ func (m Model) execViewportRows() int {
 // execScrollBy adjusts the scrollback offset by delta lines (negative =
 // scroll back into history, positive = scroll forward toward live). The
 // offset is clamped to [0, max(Len - viewH, 0)] — i.e. the oldest line
-// can sit at the top of the viewport, but never further; otherwise the
+// can sit at the top of the viewport, but never further. Otherwise the
 // rendered window slides past the start of scrollback and shows blanks.
 func (m Model) execScrollBy(delta int) Model {
 	if m.execScrollback == nil {

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -14,7 +14,7 @@ import (
 // Keep this list in sync with the action handlers in update_actions.go and
 // the bulk handlers in update_actions.go (executeBulkAction). Adding a new
 // mutating action without listing it here is a silent escape from read-only
-// mode; the readonly_test.go suite asserts membership for every known label.
+// mode. The readonly_test.go suite asserts membership for every known label.
 var mutatingActions = map[string]bool{
 	// Core kubectl mutations.
 	"Delete":               true,
@@ -68,12 +68,12 @@ var mutatingActions = map[string]bool{
 	"Reconcile":     true,
 
 	// Longhorn node mutations. Force Delete (above) disables scheduling then
-	// deletes; Evict Replicas / Cancel Eviction toggle spec.evictionRequested.
+	// deletes. Evict Replicas / Cancel Eviction toggle spec.evictionRequested.
 	"Evict Replicas":  true,
 	"Cancel Eviction": true,
 
 	// Karpenter NodeClaim mutations. Disrupt removes the underlying
-	// node; Cordon / Uncordon / Drain Node operate on the node bound
+	// node. Cordon / Uncordon / Drain Node operate on the node bound
 	// to the NodeClaim.
 	"Disrupt":              true,
 	"Cordon/Uncordon Node": true,
@@ -120,7 +120,7 @@ func isUnionAllowedActionForKind(kind, label string) bool {
 //
 // Built-in action labels are checked against mutatingActions. Custom user
 // actions (ui.CustomAction) bypass this set because their labels are
-// arbitrary; isMutatingActionForKind handles them — call that variant
+// arbitrary. isMutatingActionForKind handles them — call that variant
 // when the resource kind is known so custom actions can be evaluated
 // against their ReadOnlySafe flag.
 func isMutatingAction(label string) bool {
@@ -171,7 +171,7 @@ func (m Model) readOnlyForContext(ctx string) bool {
 
 // bulkReadOnlyContext returns the first target context that would make a
 // mutating bulk action illegal. Bulk union actions are all-or-nothing at the
-// dispatcher; individual handlers should not partially mutate a mixed
+// dispatcher. Individual handlers should not partially mutate a mixed
 // read-only/read-write selection.
 func (m Model) bulkReadOnlyContext() (string, bool) {
 	if len(m.bulkItems) == 0 {
@@ -326,7 +326,7 @@ func (m *Model) recomputeHideSecurityBadges(ctx string) {
 //     that row updates immediately, and the new state is stored in
 //     contextROOverrides so it persists across re-navigations within the
 //     session and is honored on context entry. Per-context config and
-//     global config provide the *initial* state; the override wins until
+//     global config provide the *initial* state. The override wins until
 //     toggled again.
 //
 //   - Inside a context, the toggle flips the active tab's read-only
@@ -358,7 +358,7 @@ func (m Model) handleKeyReadOnlyToggle() (tea.Model, tea.Cmd) {
 		m.contextROOverrides[sel.Name] = newState
 		// Update m.middleItems by index rather than via the sel pointer.
 		// selectedMiddleItem may return a pointer into a transient filtered
-		// slice on its fallback path; writing through that pointer would
+		// slice on its fallback path. Writing through that pointer would
 		// not reach the cached middleItems below, leaving the [RO] marker
 		// stale until the next refresh.
 		for i := range m.middleItems {

--- a/internal/app/scheduler/config.go
+++ b/internal/app/scheduler/config.go
@@ -35,7 +35,7 @@ const (
 )
 
 // Package-level config globals populated from internal/ui/config_apply.go.
-// These are read at scheduler.New() time; later mutations have no effect
+// These are read at scheduler.New() time. Later mutations have no effect
 // on already-running schedulers (consistent with ConfigWatchInterval).
 var (
 	ConfigWorkersPerContext     = DefaultWorkersPerContext

--- a/internal/app/scheduler/config.go
+++ b/internal/app/scheduler/config.go
@@ -10,15 +10,15 @@ import (
 const (
 	MinWorkersPerContext = 1
 	MaxWorkersPerContext = 16
-	// DefaultWorkersPerContext is the per-context worker pool size. 8 (up from
-	// 4) gives a slow-responding cluster enough concurrent slots that the
-	// foreground resource lists, previews, and the background metrics/events
-	// fan-out are not all contending for the same handful of workers — the
-	// "Low tasks queued but never run" symptom on a slow API server.
+	// DefaultWorkersPerContext is the per-context worker pool size. 8 (up
+	// from 4) gives a slow cluster enough concurrent slots so foreground
+	// resource lists, previews, and background metrics/events don't
+	// contend for the same workers. That's the "Low tasks queued but
+	// never run" symptom on a slow API server.
 	DefaultWorkersPerContext = 8
 	DefaultCriticalReserved  = 1
-	// DefaultLowReserved is how many workers prefer Low (background) work so
-	// metrics, events, and dashboard scans always have a slot even while the
+	// DefaultLowReserved is how many workers prefer Low (background) work
+	// so metrics, events, and dashboard scans have a slot while the
 	// foreground floods the general pool. Mirrors CriticalReserved at the
 	// other end of the priority range. Clamped to leave >=1 general worker.
 	DefaultLowReserved    = 2
@@ -114,9 +114,9 @@ func ClampAgingThreshold(n int) int {
 }
 
 // ClampLowReserved enforces 0 <= reserved <= workers - critical - 1 so at
-// least one general worker always remains for High work (a low-reserved
-// worker prefers Low but falls back, so the floor is about guaranteeing High
-// is never left without a dedicated slot). Negative values clamp to 0.
+// least one general worker always remains for High work. A low-reserved
+// worker prefers Low but falls back, so the floor is about guaranteeing
+// High is never left without a dedicated slot. Negative values clamp to 0.
 func ClampLowReserved(reserved, workers, critical int) int {
 	if reserved < 0 {
 		return 0

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -89,14 +89,14 @@ func (k Kind) String() string {
 }
 
 // Task is a single tracked unit of work. While in flight FinishedAt is
-// the zero value; after Finish() is called the field is set and the
+// the zero value. After Finish() is called the field is set and the
 // task remains in the Running list for DefaultLingerDuration so users
 // can see what just ran.
 //
 // Silent marks routine work that should NOT activate the title-bar
 // spinner (watch-mode auto-refresh). Silent tasks still appear in
 // Snapshot/SnapshotCompleted so they show up in the :scheduler
-// overlay history; only the title-bar renderer filters them out.
+// overlay history. Only the title-bar renderer filters them out.
 type Task struct {
 	ID         uint64
 	Kind       Kind
@@ -104,7 +104,7 @@ type Task struct {
 	Name       string   // human label, e.g. "List Pods"
 	Target     string   // human context, e.g. "default / web-7d8c-abc"
 	StartedAt  time.Time
-	FinishedAt time.Time // zero while running; set on Finish()
+	FinishedAt time.Time // zero while running. Set on Finish()
 	Silent     bool      // suppress from title-bar indicator only
 	Current    int       // progress: items processed so far (0 = not started)
 	Total      int       // progress: total items (0 = unknown/not applicable)
@@ -162,7 +162,7 @@ type Registry struct {
 	nextID         atomic.Uint64
 	threshold      time.Duration
 	lingerDuration time.Duration   // how long finished tasks stay in the Running list
-	completed      []CompletedTask // newest-first; capped at completedCap
+	completed      []CompletedTask // newest-first. Capped at completedCap
 	completedCap   int
 
 	// Scheduling state — per-context priority queues.
@@ -292,7 +292,7 @@ func (r *Registry) startWithPriority(kind Kind, prio Priority, name, target stri
 }
 
 // StartUntracked is the no-op variant used by routine work that should not
-// surface in the indicator (watch-mode refreshes). Returns 0; Finish(0) is
+// surface in the indicator (watch-mode refreshes). Returns 0. Finish(0) is
 // also a no-op, so callers can use the same defer pattern as the tracked
 // path. Safe to call on a nil receiver.
 func (r *Registry) StartUntracked() uint64 {
@@ -316,7 +316,7 @@ func (r *Registry) StartCancellable(owner uint64, kind Kind, name, target string
 }
 
 // UpdateProgress sets the Current and Total counters on a tracked task.
-// Called from background goroutines during bulk operations; the values
+// Called from background goroutines during bulk operations. The values
 // are read on the next View() cycle via Snapshot(). No-op for unknown
 // IDs or nil receiver.
 func (r *Registry) UpdateProgress(id uint64, current, total int) {
@@ -451,7 +451,7 @@ func (r *Registry) Finish(id uint64) {
 
 // pruneExpiredLocked removes finished-lingering tasks whose linger
 // window has expired. Called by Snapshot under r.mu. Returns the new
-// order slice; expired tasks are deleted from r.tasks and r.cancels.
+// order slice. Expired tasks are deleted from r.tasks and r.cancels.
 func (r *Registry) pruneExpiredLocked(now time.Time) {
 	if r.lingerDuration <= 0 {
 		return
@@ -554,7 +554,7 @@ func (r *Registry) LenIndicator() int {
 
 // lenLocked counts visible tasks under r.mu. skipSilent drops silent
 // tasks (watch-mode refresh). skipFinished drops finished-lingering
-// tasks; pass true for title-bar indicator semantics, false for the
+// tasks. Pass true for title-bar indicator semantics, false for the
 // overlay-facing count that includes the linger window.
 func (r *Registry) lenLocked(skipSilent, skipFinished bool) int {
 	now := time.Now()
@@ -563,7 +563,7 @@ func (r *Registry) lenLocked(skipSilent, skipFinished bool) int {
 		if skipSilent && t.Silent {
 			continue
 		}
-		// Past-linger entries are skipped unconditionally; we do not GC
+		// Past-linger entries are skipped unconditionally. We do not GC
 		// here (kept read-only style), Snapshot's prune handles eviction.
 		// A non-positive lingerDuration means "do not linger" so finished
 		// tasks expire immediately for counting purposes.
@@ -632,7 +632,7 @@ func (r *Registry) InjectCompletedForTest(c CompletedTask) {
 
 // CancelContext drops every queued task for kctx (delivering
 // ErrContextSwitched to their Futures) and cancels every in-flight
-// task on that context. Worker goroutines for kctx exit; a subsequent
+// task on that context. Worker goroutines for kctx exit. A subsequent
 // Submit re-spawns them lazily.
 //
 // Called from app code when the user switches away from a cluster
@@ -689,11 +689,11 @@ func (r *Registry) CancelStaleByGen(kctx string, keepGen uint64) {
 	}
 
 	for _, rt := range running {
-		// Snapshot taken under r.mu above; we act outside the lock (mirrors
+		// Snapshot taken under r.mu above. We act outside the lock (mirrors
 		// CancelContext). The window is safe: rt.cancel() is idempotent, and
 		// the Future is only ever sent-to/closed by runTask — never here. If
 		// a concurrent CancelContext already set contextSwitched, this guard
-		// skips the task and runTask delivers ErrContextSwitched; otherwise
+		// skips the task and runTask delivers ErrContextSwitched. Otherwise
 		// runTask sees superseded and delivers ErrSuperseded. No double-send.
 		if rt.superseded.Load() || rt.preempted.Load() || rt.contextSwitched.Load() {
 			continue

--- a/internal/app/scheduler/registry.go
+++ b/internal/app/scheduler/registry.go
@@ -1,6 +1,6 @@
 // Package scheduler tracks the in-flight async operations lfk is currently
-// running (resource list fetches, YAML loads, metrics enrichment, etc.) so
-// the title bar can show an ambient indicator and the :tasks overlay can
+// running (resource list fetches, YAML loads, metrics enrichment, etc.).
+// That lets the title bar show an ambient indicator and the :tasks overlay
 // list them with elapsed time. Long-lived sessions like port forwards and
 // log streams are deliberately excluded — they have their own surfaces.
 package scheduler
@@ -152,10 +152,10 @@ type Registry struct {
 	cancels map[uint64]context.CancelFunc // cancel funcs for cancellable tasks
 	// disowned holds the UIDs of closed tabs. Work already queued when a
 	// tab closes registers later, so the owner is stripped at Start time
-	// too — otherwise it would come back owned by a tab that is gone.
-	// Entries are never evicted: a queued task can register at any later
-	// point, and there is no moment where that becomes impossible (it may
-	// sit behind arbitrarily long work). Growth is one 8-byte key per tab
+	// too. Otherwise it would come back owned by a tab that is gone.
+	// Entries are never evicted. A queued task can register at any later
+	// point, with no moment where that becomes impossible (it may sit
+	// behind arbitrarily long work). Growth is one 8-byte key per tab
 	// the user closes, so even an extreme session stays well under 100 KB.
 	disowned       map[uint64]struct{}
 	order          []uint64 // insertion order for stable Snapshot output
@@ -225,17 +225,17 @@ func (r *Registry) SetLingerDurationForTest(d time.Duration) {
 // completes, regardless of success/error/cancel.
 //
 // If the registry already contains a task with the same (Kind, Name,
-// Target) signature, that earlier entry is removed first so only the
-// most recent attempt is visible. The earlier task's goroutine keeps
-// running — its deferred Finish will become a no-op because the id is
-// no longer in the map. This dedupes the common case where the user
-// cursor-hovers across the sidebar, generating a fresh preview load
-// for each row while the previous one is still in flight.
+// Target) signature, that earlier entry is removed first. Only the most
+// recent attempt is visible. The earlier task's goroutine keeps running
+// — its deferred Finish becomes a no-op because the id is no longer in
+// the map. This dedupes the common case where the user cursor-hovers
+// across the sidebar. Each hover generates a fresh preview load for
+// each row while the previous one is still in flight.
 //
-// A nil receiver is treated as an untracked no-op and returns 0, so call
-// sites in loaders do not have to guard against a Model constructed
-// without a registry (e.g. minimal test fixtures). Finish(0) is already
-// a no-op, so the standard defer pattern still works.
+// A nil receiver is treated as an untracked no-op and returns 0. So
+// call sites in loaders do not have to guard against a Model
+// constructed without a registry (e.g. minimal test fixtures).
+// Finish(0) is already a no-op, so the standard defer pattern works.
 func (r *Registry) Start(kind Kind, name, target string) uint64 {
 	return r.StartOwned(0, kind, name, target)
 }
@@ -249,8 +249,8 @@ func (r *Registry) StartOwned(owner uint64, kind Kind, name, target string) uint
 
 // startWithPriority is the internal variant of Start that lets scheduler
 // workers override the priority lookup with the submission's explicit
-// choice and mark routine work as silent. External callers use Start
-// and get DefaultPriorityFor(kind), Silent=false.
+// choice. It also lets them mark routine work as silent. External
+// callers use Start and get DefaultPriorityFor(kind), Silent=false.
 func (r *Registry) startWithPriority(kind Kind, prio Priority, name, target string, silent bool, owner uint64) uint64 {
 	if r == nil {
 		return 0
@@ -398,8 +398,8 @@ func (r *Registry) CancelMutationsOwnedBy(owner uint64) {
 
 // HasActiveMutationsOwnedBy returns true if the given tab has in-flight
 // KindMutation tasks. Used by the key handler to decide whether Ctrl+C/Esc
-// should cancel bulk operations instead of closing the tab/quitting — work
-// started on another tab must not swallow the key.
+// should cancel bulk operations instead of closing the tab/quitting.
+// Work started on another tab must not swallow the key.
 func (r *Registry) HasActiveMutationsOwnedBy(owner uint64) bool {
 	if r == nil {
 		return false
@@ -418,9 +418,9 @@ func (r *Registry) HasActiveMutationsOwnedBy(owner uint64) bool {
 
 // Finish removes the task with the given ID and appends it to the
 // completed-history ring (newest-first, capped at completedCap).
-// Finishing 0 or an unknown ID is a no-op (idempotent — important
+// Finishing 0 or an unknown ID is a no-op (idempotent). That matters
 // because cancel + late Finish can race, and dedupe eviction also
-// leaves stale IDs behind). A nil receiver is also a no-op to mirror
+// leaves stale IDs behind. A nil receiver is also a no-op to mirror
 // Start's nil behavior.
 func (r *Registry) Finish(id uint64) {
 	if r == nil || id == 0 {
@@ -517,11 +517,11 @@ func (r *Registry) Snapshot() []Task {
 // finished-lingering entries.
 //
 // The result may differ from len(Snapshot()) by at most one task when a
-// task's age is crossing the threshold between the two calls, because
-// each method reads time.Now() independently. This is acceptable for the
-// render loop: a one-frame flicker is invisible, and callers that need
-// strict consistency should call Snapshot() once and cache the slice.
-// A nil receiver returns 0.
+// task's age is crossing the threshold between the two calls. Each
+// method reads time.Now() independently. That is acceptable for the
+// render loop, since a one-frame flicker is invisible. Callers that
+// need strict consistency should call Snapshot() once and cache the
+// slice. A nil receiver returns 0.
 func (r *Registry) Len() int {
 	if r == nil {
 		return 0
@@ -636,8 +636,8 @@ func (r *Registry) InjectCompletedForTest(c CompletedTask) {
 // Submit re-spawns them lazily.
 //
 // Called from app code when the user switches away from a cluster
-// context (cluster picker change, tab close on the last tab for that
-// context, etc.).
+// context. Examples: cluster picker change, tab close on the last
+// tab for that context, etc.
 func (r *Registry) CancelContext(kctx string) {
 	if r == nil {
 		return
@@ -663,18 +663,19 @@ func (r *Registry) CancelContext(kctx string) {
 }
 
 // CancelStaleByGen reclaims background work on kctx that a newer
-// requestGen has made irrelevant: it drops queued Low-priority tasks and
+// requestGen has made irrelevant. It drops queued Low-priority tasks and
 // cancels in-flight Low-priority tasks whose Gen predates keepGen,
 // delivering ErrSuperseded to their Futures.
 //
 // Scoped to Low priority on purpose. Cursor moves bump requestGen only to
-// invalidate the preview pane, so the user's current view (High-priority
+// invalidate the preview pane. So the user's current view (High-priority
 // resource list, YAML, containers) and foundational/mutation work
-// (Critical) must survive a gen bump — only the decorative Low lane
+// (Critical) must survive a gen bump. Only the decorative Low lane
 // (dashboard sections, metrics, preview events) is safe to reclaim and
-// cheap to re-issue. Called from navigation paths right after the bump so
-// superseded dashboard/preview fetches stop blocking fresh work in the
-// shared Low lane instead of running to completion only to be discarded.
+// cheap to re-issue. Called from navigation paths right after the bump.
+// So superseded dashboard/preview fetches stop blocking fresh work in
+// the shared Low lane instead of running to completion only to be
+// discarded.
 func (r *Registry) CancelStaleByGen(kctx string, keepGen uint64) {
 	if r == nil {
 		return

--- a/internal/app/scheduler/scheduler.go
+++ b/internal/app/scheduler/scheduler.go
@@ -58,7 +58,7 @@ var (
 
 	// ErrContextSwitched is delivered when CancelContext drops this
 	// task's context before it could run. Caller's tea.Cmd should return
-	// nil (no UI update needed; the cluster context is gone).
+	// nil (no UI update needed, the cluster context is gone).
 	ErrContextSwitched = errors.New("scheduler: context switched")
 
 	// ErrSuperseded is delivered when CancelStaleByGen drops or cancels a
@@ -78,7 +78,7 @@ type queuedTask struct {
 // a wake signal channel.
 //
 // skips and agingThreshold implement anti-starvation aging: skips[p] counts
-// how many times lane p has been passed over while non-empty; once it reaches
+// how many times lane p has been passed over while non-empty. Once it reaches
 // agingThreshold the lane is promoted ahead of higher-priority lanes for one
 // dequeue. Critical (lane 0) is never aged. agingThreshold == 0 disables aging
 // (strict priority). See dequeueByPriorityLocked.
@@ -202,7 +202,7 @@ func (q *ctxQueue) drain(err error) {
 // agingThreshold times preempts it for a single dequeue. Without this, sustained
 // High submissions on a slow cluster keep the High lane non-empty forever and
 // Low work (security scans, dashboard, metrics) never runs (priority
-// starvation); aging bounds that wait to ~agingThreshold higher-priority
+// starvation). Aging bounds that wait to ~agingThreshold higher-priority
 // dispatches. agingThreshold == 0 restores strict priority.
 func (q *ctxQueue) dequeueByPriorityLocked() (*queuedTask, bool) {
 	if lane := q.lanes[int(PriorityCritical)]; len(lane) > 0 {
@@ -269,7 +269,7 @@ func (q *ctxQueue) hasPendingWork() bool {
 // Registry is nil or has been closed, the Future immediately receives
 // Result{Err: ErrContextSwitched}.
 //
-// No workers are spawned by this commit; submitted tasks accumulate in
+// No workers are spawned by this commit. Submitted tasks accumulate in
 // their priority lane until a later commit adds the worker pool.
 func (r *Registry) Submit(req SubmitReq) Future {
 	fut := make(chan Result, 1)

--- a/internal/app/scheduler/scheduler.go
+++ b/internal/app/scheduler/scheduler.go
@@ -45,8 +45,8 @@ type Result struct {
 
 // Future is a buffered (size 1) channel the caller awaits inside its
 // tea.Cmd goroutine. The buffer guarantees the worker never blocks on
-// send even if the caller goroutine has already returned (defensive —
-// in practice the caller always reads exactly once).
+// send even if the caller goroutine has already returned. This is
+// defensive — in practice the caller always reads exactly once.
 type Future <-chan Result
 
 // Sentinel errors delivered via Result.Err.
@@ -196,14 +196,15 @@ func (q *ctxQueue) drain(err error) {
 // empty. Caller must hold q.mu.
 //
 // Critical is absolute: foundational gating work (API discovery, RBAC,
-// namespaces) and destructive mutations must never be delayed, so it is served
-// outright and is never aged. Among the non-Critical lanes the highest-priority
-// non-empty lane wins by default, but a lower lane passed over more than
-// agingThreshold times preempts it for a single dequeue. Without this, sustained
-// High submissions on a slow cluster keep the High lane non-empty forever and
-// Low work (security scans, dashboard, metrics) never runs (priority
-// starvation). Aging bounds that wait to ~agingThreshold higher-priority
-// dispatches. agingThreshold == 0 restores strict priority.
+// namespaces) and destructive mutations must never be delayed. So it is
+// served outright and is never aged. Among the non-Critical lanes the
+// highest-priority non-empty lane wins by default. But a lower lane
+// passed over more than agingThreshold times preempts it for a single
+// dequeue. Without this, sustained High submissions on a slow cluster
+// keep the High lane non-empty forever. Low work (security scans,
+// dashboard, metrics) never runs (priority starvation). Aging bounds
+// that wait to ~agingThreshold higher-priority dispatches.
+// agingThreshold == 0 restores strict priority.
 func (q *ctxQueue) dequeueByPriorityLocked() (*queuedTask, bool) {
 	if lane := q.lanes[int(PriorityCritical)]; len(lane) > 0 {
 		q.lanes[int(PriorityCritical)] = lane[1:]
@@ -247,13 +248,13 @@ func (q *ctxQueue) dequeueByPriorityLocked() (*queuedTask, bool) {
 
 // hasPendingWork reports whether any priority lane is non-empty. Used by
 // the worker loop to decide whether to re-signal q.wake after a failed
-// pickTask: if the queue is truly empty we must NOT re-signal, otherwise
-// a stale wake left over from a previous drain creates a hot loop in
-// which the same worker repeatedly receives and resends the signal
-// without parking (issue #206 — observed as 2.26M goroutine
-// block/unblock events per second). Caller does not need to hold q.mu;
-// the read is racy but only used as a hint and the worst case is one
-// extra empty wake which the workers tolerate by parking again.
+// pickTask. If the queue is truly empty we must NOT re-signal. Otherwise
+// a stale wake left over from a previous drain creates a hot loop. In
+// that loop the same worker repeatedly receives and resends the signal
+// without parking. This was issue #206 — observed as 2.26M goroutine
+// block/unblock events per second. Caller does not need to hold q.mu.
+// The read is racy but only used as a hint. The worst case is one
+// extra empty wake, which the workers tolerate by parking again.
 func (q *ctxQueue) hasPendingWork() bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -301,13 +302,13 @@ func (r *Registry) Submit(req SubmitReq) Future {
 
 	// Coalesce against work already IN FLIGHT, not just queued. Without this,
 	// a slow fetch (e.g. Pod metrics on a sluggish cluster) that is still
-	// running cannot absorb an identical resubmission — the duplicate queues
+	// running cannot absorb an identical resubmission. The duplicate queues
 	// behind it and runs a redundant API call when the worker frees up. The
 	// queue-only coalesce below never sees the running task because it lives
 	// in runningTasks, not q.lanes. Checked before enqueue so the caller's
-	// Future resolves immediately with ErrCoalesced (its tea.Cmd returns nil;
-	// the in-flight task's result is the one that matters). Mutations opt out
-	// via NeverCoalesce — a second write must always run.
+	// Future resolves immediately with ErrCoalesced (its tea.Cmd returns nil,
+	// because the in-flight task's result is the one that matters). Mutations
+	// opt out via NeverCoalesce — a second write must always run.
 	if !sig.NeverCoalesce() && r.coalescesWithRunning(req.KubeContext, sig) {
 		fut <- Result{Err: ErrCoalesced}
 		close(fut)
@@ -344,7 +345,7 @@ func (r *Registry) Submit(req SubmitReq) Future {
 
 // coalescesWithRunning reports whether an in-flight task on kctx has a Sig that
 // the incoming sig coalesces with. A task already being torn down (preempted,
-// superseded, or context-switched) is skipped: it is about to free its slot
+// superseded, or context-switched) is skipped. It is about to free its slot
 // and deliver a sentinel, so coalescing onto it would drop the fresh request.
 func (r *Registry) coalescesWithRunning(kctx string, sig Sig) bool {
 	r.mu.Lock()

--- a/internal/app/scheduler/scheduler_coalesce.go
+++ b/internal/app/scheduler/scheduler_coalesce.go
@@ -6,18 +6,18 @@ package scheduler
 // compared by value. All five fields contribute to identity.
 //
 // Name is included so two distinct loads with the same Kind/Target/Gen
-// do not collapse into each other — e.g. "List Deployments" (the main
-// resource list at LevelResources) and "List Deployment children" (the
-// owned-pod preview for the hovered Deployment) both run with
+// do not collapse into each other. For example, "List Deployments" (the
+// main resource list at LevelResources) and "List Deployment children"
+// (the owned-pod preview for the hovered Deployment). Both run with
 // Kind=ResourceList against the same context/namespace, but represent
 // different requests that must both complete. Without Name in the Sig,
 // each watch-tick refresh would drop whichever of the two was still
 // queued, leaving the right-pane children stuck empty.
 //
-// Gen is the caller's requestGen at submission time so navigation that
-// invalidates cached results also invalidates the coalesce signature
-// (a stale-cancelled fetch and a fresh fetch live in different
-// generations and therefore do not accidentally coalesce).
+// Gen is the caller's requestGen at submission time. So navigation
+// that invalidates cached results also invalidates the coalesce
+// signature. A stale-cancelled fetch and a fresh fetch live in
+// different generations and therefore do not accidentally coalesce.
 type Sig struct {
 	KubeContext string
 	Kind        Kind
@@ -28,9 +28,9 @@ type Sig struct {
 
 // NeverCoalesce returns true for Sigs whose Kind opts out of coalescing
 // regardless of signature equality. Used for Mutations: two delete-pod
-// calls with the same target must both run (defensive, since legitimate
-// duplicates are rare but the cost of accidentally dropping a write is
-// high).
+// calls with the same target must both run. This is defensive, since
+// legitimate duplicates are rare but the cost of accidentally dropping
+// a write is high.
 func (s Sig) NeverCoalesce() bool {
 	return s.Kind == KindMutation
 }
@@ -40,9 +40,9 @@ func (s Sig) NeverCoalesce() bool {
 // fixed per-context target (e.g. "c1#metrics") every refresh. Keeping Gen
 // in their coalesce identity let a watch-tick or cursor-move resubmission
 // stack a second full six-task batch behind the first instead of replacing
-// it, so stale batches accumulated in the Low lane. Other Kinds keep Gen in
-// their identity (see Sig's Gen doc) so a stale-cancelled fetch and a fresh
-// fetch never collapse into one.
+// it. So stale batches accumulated in the Low lane. Other Kinds keep Gen
+// in their identity (see Sig's Gen doc) so a stale-cancelled fetch and a
+// fresh fetch never collapse into one.
 func (k Kind) coalesceIgnoresGen() bool {
 	return k == KindDashboard
 }

--- a/internal/app/scheduler/scheduler_coalesce.go
+++ b/internal/app/scheduler/scheduler_coalesce.go
@@ -3,7 +3,7 @@ package scheduler
 // Sig identifies an in-flight or queued scheduler task for coalescing.
 // Two Submits with identical Sigs are treated as duplicates: the older
 // queued entry is replaced by the newer one (newer wins). Sigs are
-// compared by value; all five fields contribute to identity.
+// compared by value. All five fields contribute to identity.
 //
 // Name is included so two distinct loads with the same Kind/Target/Gen
 // do not collapse into each other — e.g. "List Deployments" (the main
@@ -37,7 +37,7 @@ func (s Sig) NeverCoalesce() bool {
 
 // coalesceIgnoresGen reports whether two submissions of this Kind should
 // coalesce even when their Gen differs. Dashboard sections re-fire on a
-// fixed per-context target (e.g. "c1#metrics") every refresh; keeping Gen
+// fixed per-context target (e.g. "c1#metrics") every refresh. Keeping Gen
 // in their coalesce identity let a watch-tick or cursor-move resubmission
 // stack a second full six-task batch behind the first instead of replacing
 // it, so stale batches accumulated in the Low lane. Other Kinds keep Gen in
@@ -48,7 +48,7 @@ func (k Kind) coalesceIgnoresGen() bool {
 }
 
 // CoalescesWith reports whether a queued task's Sig should be displaced by a
-// newer submission with Sig s. Identity is Kind+Context+Name+Target; Gen is
+// newer submission with Sig s. Identity is Kind+Context+Name+Target. Gen is
 // included only for Kinds that do not opt out via coalesceIgnoresGen.
 func (s Sig) CoalescesWith(other Sig) bool {
 	if s.Kind != other.Kind ||

--- a/internal/app/scheduler/scheduler_workers.go
+++ b/internal/app/scheduler/scheduler_workers.go
@@ -7,7 +7,7 @@ import (
 )
 
 // workerClass selects which priority lane a worker prefers when picking the
-// next task. General workers honor strict priority (with aging); the reserved
+// next task. General workers honor strict priority (with aging). The reserved
 // classes bias toward one end of the range but always fall back so a reserved
 // slot is never wasted when its preferred lane is empty.
 type workerClass int
@@ -25,7 +25,7 @@ const (
 // dequeue scenario.
 //
 // In production, StartWorkers is called once at app init right after New().
-// Tests that don't exercise dispatch can skip StartWorkers; only Submit's
+// Tests that don't exercise dispatch can skip StartWorkers. Only Submit's
 // queueing surface is needed.
 func (r *Registry) StartWorkers() {
 	if r == nil {
@@ -96,7 +96,7 @@ func (r *Registry) SetWorkersForTest(workers, criticalReserved int) {
 
 // SetLowReservedForTest overrides the low-reserved worker count before any
 // pool is spawned. Clamped against the current worker/critical totals.
-// Production code MUST NOT call this; use the ConfigLowReserved global.
+// Production code MUST NOT call this. Use the ConfigLowReserved global.
 func (r *Registry) SetLowReservedForTest(n int) {
 	if r == nil {
 		return
@@ -110,7 +110,7 @@ func (r *Registry) SetLowReservedForTest(n int) {
 // Registry before any per-context queue is created (queues capture it lazily on
 // first Submit). The value is used verbatim — including 0 to disable aging — so
 // tests can exercise both small thresholds and the strict-priority kill switch.
-// Production code MUST NOT call this; use the ConfigAgingThreshold global.
+// Production code MUST NOT call this. Use the ConfigAgingThreshold global.
 func (r *Registry) SetAgingThresholdForTest(n int) {
 	if r == nil {
 		return
@@ -153,7 +153,7 @@ func workerClassFor(i, criticalReserved, lowReserved int) workerClass {
 
 // workerLoop is one worker goroutine: pulls tasks from q honoring priority
 // and its worker class, runs Fn with timeout, delivers Result. The class
-// biases which lane it prefers (see pickTask); all classes fall back so no
+// biases which lane it prefers (see pickTask). All classes fall back so no
 // worker idles while work is queued.
 func (r *Registry) workerLoop(q *ctxQueue, class workerClass) {
 	defer r.workersWG.Done()
@@ -249,7 +249,7 @@ func shutdownPending(stopAll, stop chan struct{}) bool {
 
 // pickTask dequeues the next task for this worker, biased by its class.
 //
-// A Critical-class worker takes Critical first; a Low-class worker takes Low
+// A Critical-class worker takes Critical first. A Low-class worker takes Low
 // first. When the preferred lane is empty, BOTH fall through to
 // dequeueByPriorityLocked (priority + aging) rather than idling while other
 // work waits — the reservation guarantees a slot is biased toward that lane,
@@ -359,7 +359,7 @@ func (r *Registry) pokePreempt(kctx string, newPrio Priority) bool {
 // runTask executes a single queued task with timeout. Future is
 // delivered on completion (or error). If the task is preempted while
 // running, it is requeued at the head of its priority lane and runTask
-// returns; the same task will be picked up by a worker again later
+// returns. The same task will be picked up by a worker again later
 // when the higher-priority work has cleared.
 //
 // The visibility surface (Start/Finish) is populated for every
@@ -407,7 +407,7 @@ func (r *Registry) runTask(task *queuedTask) {
 			close(task.future)
 			return
 		}
-		// Finish the visibility entry from this attempt; the next
+		// Finish the visibility entry from this attempt. The next
 		// attempt (after re-dispatch) calls Start again.
 		r.Finish(visID)
 		q.mu.Lock()

--- a/internal/app/scheduler/scheduler_workers.go
+++ b/internal/app/scheduler/scheduler_workers.go
@@ -7,9 +7,9 @@ import (
 )
 
 // workerClass selects which priority lane a worker prefers when picking the
-// next task. General workers honor strict priority (with aging). The reserved
-// classes bias toward one end of the range but always fall back so a reserved
-// slot is never wasted when its preferred lane is empty.
+// next task. General workers honor strict priority (with aging). The
+// reserved classes bias toward one end of the range but always fall back.
+// A reserved slot is never wasted when its preferred lane is empty.
 type workerClass int
 
 const (
@@ -20,7 +20,7 @@ const (
 
 // StartWorkers enables worker dispatch. Idempotent. Workers are spawned
 // per cluster context on first Submit AND retroactively for any
-// queues that already exist when StartWorkers is called — this lets
+// queues that already exist when StartWorkers is called. This lets
 // tests Submit before starting workers to set up a deterministic
 // dequeue scenario.
 //
@@ -48,9 +48,9 @@ func (r *Registry) StartWorkers() {
 }
 
 // StopWorkers signals all workers to exit and waits for them. Idempotent.
-// In-flight Fns continue but their Futures receive nothing further;
-// Close (or CancelContext, in a later commit) is what drains pending
-// Futures with ErrContextSwitched.
+// In-flight Fns continue but their Futures receive nothing further.
+// Close (or CancelContext, in a later commit) drains pending Futures
+// with ErrContextSwitched.
 func (r *Registry) StopWorkers() {
 	if r == nil {
 		return
@@ -164,7 +164,7 @@ func (r *Registry) workerLoop(q *ctxQueue, class workerClass) {
 		case <-q.stop:
 			return
 		case <-q.wake:
-			// Re-check stop before picking — between the wake signal
+			// Re-check stop before picking. Between the wake signal
 			// and now, StopWorkers / CancelContext could have closed
 			// q.stop, and we must not start new work past that point.
 			if shutdownPending(r.stopAll, q.stop) {
@@ -172,13 +172,13 @@ func (r *Registry) workerLoop(q *ctxQueue, class workerClass) {
 			}
 			// Try to pick a task for this worker class. pickTask returns
 			// (nil, false) only when the queue is genuinely empty (a race
-			// between the wake signal and a concurrent pick) — a reserved
+			// between the wake signal and a concurrent pick). A reserved
 			// worker no longer idles on a non-empty queue since it falls
-			// back to non-Critical work. Re-signal so a sibling retries, but
-			// ONLY when work is actually pending: a stale wake left over from
-			// the inner drain loop below would otherwise feed itself (this
-			// worker re-signals, wins the receive race, fails pickTask again,
-			// re-signals, ad infinitum — issue #206).
+			// back to non-Critical work. Re-signal so a sibling retries,
+			// but ONLY when work is actually pending. A stale wake left
+			// over from the inner drain loop below would otherwise feed
+			// itself. This worker re-signals, wins the receive race,
+			// fails pickTask again, re-signals, ad infinitum (issue #206).
 			task, ok := r.pickTask(q, class)
 			if !ok {
 				if q.hasPendingWork() {
@@ -190,17 +190,18 @@ func (r *Registry) workerLoop(q *ctxQueue, class workerClass) {
 				continue
 			}
 			// Wake a sibling before running: runTask blocks for the whole
-			// duration of the (potentially slow) Fn, so without this a burst
-			// of submits whose wake signals collapsed into the size-1 buffer
-			// would be drained by THIS worker serially while siblings stay
-			// parked — the lost-wakeup jam (one task runs, the rest queue
-			// behind a single blocked worker). Re-signalling on every
-			// successful pick cascades the wake across the pool so queued
-			// work runs in parallel up to WorkersPerContext.
+			// duration of the (potentially slow) Fn. Without this, a burst
+			// of submits whose wake signals collapsed into the size-1
+			// buffer would be drained by THIS worker serially while
+			// siblings stay parked. This is the lost-wakeup jam: one task
+			// runs, the rest queue behind a single blocked worker.
+			// Re-signalling on every successful pick cascades the wake
+			// across the pool so queued work runs in parallel up to
+			// WorkersPerContext.
 			r.wakeSibling(q)
 			r.runTask(task)
 			// Drain remaining work for this worker class after running
-			// one — but bail at every iteration if shutdown has been
+			// one. But bail at every iteration if shutdown has been
 			// signalled, so an in-flight Stop doesn't have to wait for
 			// the queue to drain.
 			for {
@@ -220,10 +221,10 @@ func (r *Registry) workerLoop(q *ctxQueue, class workerClass) {
 
 // wakeSibling re-signals q.wake when work is still queued, so another parked
 // worker engages instead of leaving the current (about-to-block) worker to
-// drain the burst serially. Guarded by hasPendingWork so it never spins on an
-// empty queue (issue #206): the non-blocking send + size-1 buffer cap the
-// signal at one outstanding wake, and a spurious wake just parks the receiver
-// again after a failed pick.
+// drain the burst serially. Guarded by hasPendingWork so it never spins on
+// an empty queue (issue #206). The non-blocking send + size-1 buffer cap
+// the signal at one outstanding wake. A spurious wake just parks the
+// receiver again after a failed pick.
 func (r *Registry) wakeSibling(q *ctxQueue) {
 	if q.hasPendingWork() {
 		select {
@@ -252,9 +253,9 @@ func shutdownPending(stopAll, stop chan struct{}) bool {
 // A Critical-class worker takes Critical first. A Low-class worker takes Low
 // first. When the preferred lane is empty, BOTH fall through to
 // dequeueByPriorityLocked (priority + aging) rather than idling while other
-// work waits — the reservation guarantees a slot is biased toward that lane,
+// work waits. The reservation guarantees a slot is biased toward that lane,
 // not that the worker sits idle. This is what gives background (Low) work a
-// guaranteed floor: under a flood of High submissions the Low-class workers
+// guaranteed floor. Under a flood of High submissions the Low-class workers
 // still drain the Low lane, so metrics/events/dashboards keep running instead
 // of queueing behind the foreground backlog. A General worker always honors
 // strict priority (with aging). The Critical preempt poker still makes a
@@ -323,8 +324,8 @@ func (r *Registry) unregisterRunning(kctx string, rt *runningTask) {
 // preempted something.
 //
 // Critical can never be preempted because nothing has a strictly worse
-// priority below Critical except by the same logic, but Submit only
-// invokes pokePreempt for the new request's priority — and a Submit
+// priority below Critical except by the same logic. But Submit only
+// invokes pokePreempt for the new request's priority, and a Submit
 // of priority X only preempts tasks of priority > X.
 func (r *Registry) pokePreempt(kctx string, newPrio Priority) bool {
 	r.mu.Lock()
@@ -337,7 +338,7 @@ func (r *Registry) pokePreempt(kctx string, newPrio Priority) bool {
 	worstPrio := newPrio
 	for _, rt := range list {
 		// Skip tasks already being torn down (preempted, or superseded by
-		// CancelStaleByGen): preempting one wastes this submission's single
+		// CancelStaleByGen). Preempting one wastes this submission's single
 		// preemption on a worker slot that is already being reclaimed.
 		if rt.preempted.Load() || rt.superseded.Load() {
 			continue
@@ -387,7 +388,7 @@ func (r *Registry) runTask(task *queuedTask) {
 		return
 	}
 
-	// Superseded is checked before preempted: a stale-cancelled task must
+	// Superseded is checked before preempted. A stale-cancelled task must
 	// resolve as ErrSuperseded and NOT be requeued (the preempt path would
 	// re-run it), since a newer generation already owns the result.
 	if rt.superseded.Load() {

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -28,7 +28,7 @@ func (m *Model) sortMiddleItems() {
 	colName := m.sortColumnName
 	if colName == "" {
 		// Production always seeds sortColumnName with sortColDefault in
-		// NewModel; an empty value here means a test fixture that built
+		// NewModel. An empty value here means a test fixture that built
 		// a bare Model{} literal. Skip sorting in that case — otherwise
 		// the tiebreaker below would impose a deterministic order on
 		// items the caller may want to keep in their original sequence.
@@ -195,7 +195,7 @@ func metricValueMissing(colName string, item model.Item) bool {
 // preservation.
 //
 // Columns whose comparator needs the whole Item (top-level fields,
-// timestamps, status priority) are handled inline; extra columns go
+// timestamps, status priority) are handled inline. Extra columns go
 // through columnValueCmp, with auto-detection as the final fallback.
 func comparePrimaryColumn(a, b model.Item, colName string) int {
 	switch colName {
@@ -487,7 +487,7 @@ var ageDurationUnits = map[byte]time.Duration{
 // parseAgeDuration parses the single-unit duration strings emitted by
 // k8s.formatAge (e.g. "45s", "5d", "2y") — never a combined form like
 // "5d3h". time.ParseDuration only understands ns/us/ms/s/m/h, so it can't
-// parse formatAge's "d"/"y" suffixes; this is a dedicated parser instead
+// parse formatAge's "d"/"y" suffixes. This is a dedicated parser instead
 // of reusing compareDurationCmp.
 func parseAgeDuration(s string) (time.Duration, bool) {
 	s = strings.TrimSpace(s)
@@ -547,7 +547,7 @@ func compareREVCmp(a, b string) int {
 
 // compareIPCmp compares IP-address column values numerically, so
 // "10.0.0.9" sorts before "10.0.0.10". Values may be comma-joined lists
-// (e.g. External IPs); only the first address drives the comparison.
+// (e.g. External IPs). Only the first address drives the comparison.
 // Falls back to case-insensitive lexicographic comparison when either
 // value lacks a parseable leading address (e.g. "None", "<none>").
 func compareIPCmp(a, b string) int {

--- a/internal/app/update_column_toggle.go
+++ b/internal/app/update_column_toggle.go
@@ -42,7 +42,7 @@ type columnToggleState struct {
 	columnToggleSnapshot columnToggleSnapshot
 	sessionColumns       map[string][]string // kind -> ordered visible extra column keys (session-only)
 	hiddenBuiltinColumns map[string][]string // kind -> hidden built-in column keys (session-only)
-	columnOrder          map[string][]string // kind -> ordered column keys (built-ins + extras interleaved; Name is implicit)
+	columnOrder          map[string][]string // kind -> ordered column keys (built-ins + extras interleaved, Name is implicit)
 }
 
 // captureColumnToggleSnapshot deep-copies the current per-kind column
@@ -156,7 +156,7 @@ func mergeColumnToggleEntries(builtinEntries, extraEntries []columnToggleEntry, 
 
 	// Backward compatibility: saved orders that predate configurable Name omit
 	// the "Name" key. Pin Name first so reopening the overlay matches the
-	// renderer's pinned-first behaviour in orderedColumnKeys; without this,
+	// renderer's pinned-first behaviour in orderedColumnKeys. Without this,
 	// reopening a legacy order and pressing Enter would persist Name at a
 	// non-first position. An order that lists "Name" honours that position.
 	if e, ok := byKey["Name"]; ok && !slices.Contains(savedOrder, "Name") {
@@ -490,7 +490,7 @@ func (m Model) handleColumnToggleKeyK2() (tea.Model, tea.Cmd) {
 // sessionColumns / hiddenBuiltinColumns / columnOrder for the current
 // kind WITHOUT closing the overlay. Called after every Space/J/K/c so
 // the table behind the overlay reflects edits live. handleColumnToggleKeyEnter
-// is now just "apply + close"; Esc reverts via restoreColumnToggleSnapshot.
+// is now just "apply + close". Esc reverts via restoreColumnToggleSnapshot.
 //
 // Pointer receiver because we may need to assign newly-allocated maps
 // when the caller's map fields are nil — a value receiver would only
@@ -565,8 +565,8 @@ func (m Model) handleColumnToggleKeyEnter() (tea.Model, tea.Cmd) {
 	// the snapshot so a future Esc-after-reopen doesn't restore stale
 	// state.
 	m.applyColumnToggleState()
-	// Persist the committed layout (issue #353 follow-up). Live-apply during
-	// the overlay only touches in-memory maps; the on-disk layout is written
+	// Persist the committed layout. Live-apply during
+	// the overlay only touches in-memory maps. The on-disk layout is written
 	// here on commit so an Esc that reverts via the snapshot never leaks an
 	// uncommitted edit to disk.
 	m.persistColumnPrefs()

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -21,8 +21,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// chance to — mouse-toggle, tab-switch, and mode-specific handlers below
 	// all run ahead of handleExplorerKey's own copy of this guard (kept there
 	// too, for callers that invoke it directly), and previously left the leader
-	// armed indefinitely after, e.g., the mouse-capture toggle key
-	// (IMPORTANT-5, review round 1).
+	// armed indefinitely after, e.g., the mouse-capture toggle key.
 	mdl, consumed := m.whichKeyLeaderIntercept(msg)
 	m = mdl
 	if consumed {
@@ -184,7 +183,7 @@ func (m Model) handleTabSwitchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool
 // In modeExplorer at the resource-data levels (LevelResources, LevelOwned,
 // LevelContainers) it batches the right-pane preview load with a
 // background refresh of the middle column. The cached middleItems
-// restored by loadTab are shown immediately; the refresh result replaces
+// restored by loadTab are shown immediately. The refresh result replaces
 // them when the fetch returns. This is stale-while-revalidate — without
 // it, a mutation on tab A (e.g. deleting a pod whose restart count was
 // 10) leaves tab B's saved list stale until the next watch tick or
@@ -195,7 +194,7 @@ func (m Model) handleTabSwitchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool
 // is a live resource list for the hovered type — those items DO go stale
 // when another tab mutates the cluster. loadResources(forPreview=true)
 // has a fresh-cache shortcut for hover-cycles that returns cached items
-// synchronously; the per-tab itemCache means mutations on a sibling tab
+// synchronously. The per-tab itemCache means mutations on a sibling tab
 // never invalidate it. Drop the cache-freshness fingerprint for the
 // hovered resource type so the shortcut misses and a real fetch runs.
 // The itemCache entry itself is left in place so navigation-history
@@ -525,7 +524,7 @@ func (m Model) handleKeyOpenMarks() Model {
 	m.overlay = overlayBookmarks
 	m.overlayCursor = 0
 	m.bookmarkFilter.Clear()
-	// Every open starts with "load saved namespace" (the default); Tab
+	// Every open starts with "load saved namespace" (the default). Tab
 	// opts out to keep the current scope. A prior open's toggle must not leak in.
 	m.bookmarkLoadNamespace = true
 	return m

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -445,7 +445,7 @@ func (m Model) handleExplorerActionKeySaveResource() (tea.Model, tea.Cmd, bool) 
 
 func (m Model) handleExplorerActionKeyPreviewDown() (tea.Model, tea.Cmd, bool) {
 	if m.fullLogPreview {
-		// J: scroll toward newest (reduce fromBottom); 0 = auto-follow.
+		// J: scroll toward newest (reduce fromBottom). 0 = auto-follow.
 		if m.previewLog.fromBottom > 0 {
 			m.previewLog.fromBottom--
 		}
@@ -698,7 +698,7 @@ func (m Model) handleExplorerActionKeyFilterPresets() (tea.Model, tea.Cmd, bool)
 		return m, tea.Batch(scheduleStatusClear(), m.loadPreview()), true
 	}
 	// Open the filter preset overlay. Orphan presets require a context-wide
-	// scan and are omitted at the union sentinel; other quick filters remain
+	// scan and are omitted at the union sentinel. Other quick filters remain
 	// useful against the merged rows.
 	kind := m.nav.ResourceType.Kind
 	key := orphanCacheKey{kubeContext: m.nav.Context, namespace: m.orphanCacheNamespace()}
@@ -718,11 +718,9 @@ func (m Model) handleExplorerActionKeyFilterPresets() (tea.Model, tea.Cmd, bool)
 
 func (m Model) handleExplorerActionKeyDiff() (tea.Model, tea.Cmd, bool) {
 	if m.nav.Level < model.LevelResources {
-		// Diff requires two resources to compare; cluster picker and
+		// Diff requires two resources to compare. Cluster picker and
 		// resource-type levels have nothing to diff. Don't consume the
-		// key here — let it fall through to other handlers (the local-
-		// cluster manager's `d` handler used to live at LevelClusters,
-		// which is why this used to show an error). Silent no-op now.
+		// key here — let it fall through to other handlers instead.
 		return m, nil, false
 	}
 	selected := m.selectedItemsList()

--- a/internal/app/update_localcluster.go
+++ b/internal/app/update_localcluster.go
@@ -27,7 +27,7 @@ func (m Model) buildLocalClusterOverlayState() ui.LocalClusterOverlayState {
 	}
 	// Single source of truth: m.localClusterState.clusters carries
 	// every row, distinguished by .state (Real / InFlight / Failed).
-	// The renderer paints all three with the same column layout; the
+	// The renderer paints all three with the same column layout. The
 	// Mutating pill is what visually flags InFlight rows.
 	rows := make([]ui.LocalClusterRowView, 0, len(m.localClusterState.clusters))
 	for _, r := range m.localClusterState.clusters {
@@ -148,7 +148,7 @@ func (m Model) updateLocalClustersDetected(msg localClustersDetectedMsg) (Model,
 
 // refreshLocalClusterCache mirrors the manager's view into the on-Model
 // cache and persists it. Best-effort save: a write failure is logged
-// at the storage layer; the in-memory state stays authoritative.
+// at the storage layer. The in-memory state stays authoritative.
 //
 // IMPORTANT receiver semantics: this is a pointer receiver method
 // called from updateLocalClustersDetected, which has a value receiver.
@@ -214,7 +214,7 @@ func (m Model) updateLocalClusterCreated(msg localClusterCreatedMsg) (Model, tea
 				r.Mutating = ""
 				r.Status = "failed"
 			} else {
-				// Drop the InFlight row in place; Detect repopulates.
+				// Drop the InFlight row in place. Detect repopulates.
 				m.localClusterState.clusters = append(m.localClusterState.clusters[:i], m.localClusterState.clusters[i+1:]...)
 			}
 			break
@@ -263,8 +263,8 @@ func (m Model) updateLocalClusterKey(msg tea.KeyPressMsg) (Model, tea.Cmd, bool)
 	case localClusterScreenDeleteConfirm:
 		return m.updateDeleteConfirmKey(msg)
 	}
-	// Sub-screens added in later tasks consume keys without effect for now
-	// so half-typed wizard input doesn't leak through to the explorer.
+	// Unhandled sub-screens consume keys without effect so half-typed
+	// wizard input doesn't leak through to the explorer.
 	return m, nil, true
 }
 
@@ -409,7 +409,7 @@ func (m Model) handleListMutate(verb string) (Model, tea.Cmd, bool) {
 	}
 	// Type-assert to LifecycleProvider — kind doesn't satisfy it (no
 	// native start/stop), so the s/S keypress falls through silently
-	// for kind rows. The hint bar still advertises the keys; the cost
+	// for kind rows. The hint bar still advertises the keys. The cost
 	// of greying them per-row isn't worth the renderer complexity.
 	lp, ok := localcluster.ByName(row.Provider).(localcluster.LifecycleProvider)
 	if !ok {

--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -18,7 +18,7 @@ import (
 // a long multi-cluster session can't accumulate every resource ever hovered.
 // The secret cache holds decoded plaintext, so it gets the tighter cap (also a
 // security win — less plaintext resident). When a cache is full a fresh map is
-// started, dropping the cold set; the active hover repopulates instantly.
+// started, dropping the cold set. The active hover repopulates instantly.
 const (
 	secretPreviewCacheCap    = 64
 	serviceEndpointsCacheCap = 256
@@ -98,7 +98,7 @@ func (m Model) updatePreviewEventsLoaded(msg previewEventsLoadedMsg) Model {
 // map, so the assignment is a no-op for those.
 func (m Model) updatePreviewServiceEndpointsLoaded(msg previewServiceEndpointsLoadedMsg) Model {
 	if msg.gen != m.requestGen {
-		return m // stale response; the caller's m.previewLoading stays armed
+		return m // stale response. The caller's m.previewLoading stays armed
 	}
 	// The fetch is no longer in flight for the current gen. Clear the
 	// spinner regardless of outcome so the right pane stops saying
@@ -122,7 +122,7 @@ func (m Model) updatePreviewServiceEndpointsLoaded(msg previewServiceEndpointsLo
 		// only inject if it's still the cache's current value. A fresher
 		// fetch may have already updated the cache (extremely rare race
 		// where the fresh response beats the tea.Batch goroutine
-		// scheduling); in that case its handler already injected and
+		// scheduling). In that case its handler already injected and
 		// this stale emit must not clobber it. Don't write the cache
 		// either — it already holds msg.data when the guard passes.
 		if existing, ok := m.serviceEndpointsCache[key]; !ok || existing != msg.data {
@@ -179,7 +179,7 @@ func injectServiceEndpointColumns(item *model.Item, data *k8s.ServiceEndpoints) 
 
 func (m Model) updatePreviewSecretDataLoaded(msg previewSecretDataLoadedMsg) Model {
 	if msg.gen != m.requestGen {
-		return m // stale response; discard. A newer load is still in flight,
+		return m // stale response. Discard. A newer load is still in flight,
 		// so leave previewLoading armed for the next reply.
 	}
 	// The fetch is no longer in flight for the current gen. Clear the spinner
@@ -428,7 +428,7 @@ func ensureNodeMetricsColumnsPlaceholder(item *model.Item) {
 
 // updateRightsizingLoaded handles the rightsizingLoadedMsg. Stale
 // generation discarded (overlay closed + reopened with a different
-// workload before this fetch returned); otherwise stores the result
+// workload before this fetch returned). Otherwise stores the result
 // in m.rightsizing (or m.rightsizing.err) and caches it for re-opens.
 //
 // Errors are NOT cached — the next overlay open will retry instead
@@ -508,7 +508,7 @@ func (m Model) updateNodeMetricsEnriched(msg nodeMetricsEnrichedMsg) Model {
 		if !ok {
 			// Metrics-server didn't return data for this node (or not yet).
 			// Touch the item so CPU/CPU%/MEM/MEM% columns exist with "n/a"
-			// values; otherwise autoDetectColumns hides the columns
+			// values. Otherwise autoDetectColumns hides the columns
 			// entirely whenever metrics are unavailable, and they pop
 			// in/out as metrics-server churns.
 			ensureNodeMetricsColumnsPlaceholder(item)

--- a/internal/app/update_mouse.go
+++ b/internal/app/update_mouse.go
@@ -28,7 +28,7 @@ func (m Model) handleMouseToggleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bo
 
 // toggleMouseCapture suspends or resumes mouse reporting at runtime. When
 // suspended the terminal regains the mouse, so the user can select text,
-// copy, and use native scrollback; resuming re-enables cell-motion capture
+// copy, and use native scrollback. Resuming re-enables cell-motion capture
 // (the same mode main.go installs at startup). It is a no-op with an
 // explanatory message when mouse capture was never available.
 func (m Model) toggleMouseCapture() (tea.Model, tea.Cmd) {
@@ -97,7 +97,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Object Explorer wheel: route by the pointer column. Over the right
-	// (preview) pane the wheel scrolls the YAML preview; over the left and
+	// (preview) pane the wheel scrolls the YAML preview. Over the left and
 	// middle panes it moves the tree cursor — mirroring the main explorer's
 	// per-pane wheel routing (#379). Non-wheel mouse falls through so
 	// tab-bar clicks keep working.
@@ -126,7 +126,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 	// Handle tab bar clicks in any mode — but only when no centered
 	// overlay is open. A modal overlay covers the rest of the screen
-	// and owns mouse input; without this guard a click on row 1 would
+	// and owns mouse input. Without this guard a click on row 1 would
 	// switch tabs underneath the modal.
 	if m.overlay == overlayNone && len(m.tabs) > 1 && mouse.Button == tea.MouseLeft && isMousePress(msg) && mouse.Y == 1 {
 		if tab := m.tabAtX(mouse.X); tab >= 0 && tab != m.activeTab {
@@ -172,14 +172,14 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 // decelerating trackpad-momentum stream (its sparse tail can be 150-300ms
 // apart), so the whole tail of a voided gesture stays suppressed until the
 // momentum actually stops — not just its dense head. Too small and the tail
-// revives on the wrong list (the #524 "jumps by 3 after navigating" case); too
+// revives on the wrong list (the #524 "jumps by 3 after navigating" case). Too
 // large and a deliberate re-scroll right after navigating feels laggy.
 const wheelQuietGap = 350 * time.Millisecond
 
 // beginWheelTick advances the wheel-burst state machine for a wheel tick at
 // pointer column x and reports whether the tick should be dropped. After
 // wheelQuietGap of silence the tick starts a brand-new gesture and always
-// scrolls; otherwise it is dropped once the gesture has been marked dead (a
+// scrolls. Otherwise it is dropped once the gesture has been marked dead (a
 // boundary was reached or a navigation happened) or when the pointer has moved
 // to a different target than the one the gesture started on. Dropped ticks keep
 // the gesture alive (lastAt advances), so a continuous momentum tail stays
@@ -204,7 +204,7 @@ func (m Model) beginWheelTick(x int) (Model, bool) {
 
 // wheelTargetID names what a wheel tick at pointer column x would currently
 // scroll. Its only job is to detect when the pointer (or the screen) has moved
-// off the target a momentum burst started on; the exact strings are internal.
+// off the target a momentum burst started on. The exact strings are internal.
 // It mirrors the routing in handleMouse so a burst is bound to one scroll
 // target.
 func (m Model) wheelTargetID(x int) string {
@@ -240,7 +240,7 @@ func (m Model) wheelTargetID(x int) string {
 }
 
 // handleExplorerWheel routes a wheel tick to the pane under the pointer
-// at x. The right pane scrolls its preview content; the left and middle
+// at x. The right pane scrolls its preview content. The left and middle
 // panes move the row cursor — the whole-window behaviour the wheel had
 // before per-pane routing existed (issue #319 b). delta is the signed
 // line count (negative scrolls up, positive scrolls down).
@@ -320,14 +320,14 @@ func (m *Model) markWheelBurstDeadIfClamped(before, after int) {
 
 // handleObjectExplorerWheel routes a wheel tick in the Object Explorer to
 // the pane under the pointer at x. Over the right (preview) pane it scrolls
-// the YAML preview, mirroring the J/K keys; over the left and middle panes
+// the YAML preview, mirroring the J/K keys. Over the left and middle panes
 // it moves the tree cursor, mirroring j/k. dir is -1 (up) or +1 (down);
 // each tick moves wheelStep lines to match the other viewers' wheel feel.
 func (m Model) handleObjectExplorerWheel(x, dir int) (tea.Model, tea.Cmd) {
 	const wheelStep = 3
 	rt := &m.objectExplorerView
 	if x >= m.objectExplorerRightPaneStart() {
-		// Scroll-up is a plain decrement with a zero floor; scroll-down
+		// Scroll-up is a plain decrement with a zero floor. Scroll-down
 		// increments and clamps to the preview content height (which
 		// re-marshals the node YAML, so only do it when scrolling down).
 		before := rt.previewScroll
@@ -351,7 +351,7 @@ func (m Model) handleObjectExplorerWheel(x, dir int) (tea.Model, tea.Cmd) {
 
 // handleLogsMouse routes a mouse event in the log viewer. The wheel scrolls
 // the pane under the pointer: over the preview side panel it scrolls the
-// structured preview (mirroring the J/K keys); over the log stream it scrolls
+// structured preview (mirroring the J/K keys). Over the log stream it scrolls
 // the log — the same per-pane routing as the explorers (#379). Non-wheel
 // mouse is a no-op.
 func (m Model) handleLogsMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
@@ -426,7 +426,7 @@ func (m Model) columnBoundaries() (leftEnd, middleEnd int) {
 		// Fullscreen: only middle column exists.
 		return 0, m.width
 	}
-	// Single source of truth for widths; hideLeftPane returns leftW=0
+	// Single source of truth for widths. hideLeftPane returns leftW=0
 	// so the left band collapses and the middle band starts at x=0.
 	leftW, middleW, _ := m.explorerColumnWidths()
 	leftEnd = leftW + 2
@@ -671,7 +671,7 @@ func isViewerMode(mode viewMode) bool {
 
 // dispatchWheelKey synthesizes 3 presses of key (typically "j" or "k")
 // through handleKey so each viewer mode's existing scroll logic runs
-// unchanged. The model is threaded between iterations; the last cmd is
+// unchanged. The model is threaded between iterations. The last cmd is
 // returned (per-mode scroll handlers are pure state mutations and
 // typically return nil, so dropping intermediate cmds is safe).
 func (m Model) dispatchWheelKey(key string) (tea.Model, tea.Cmd) {

--- a/internal/app/update_mouse_overlay.go
+++ b/internal/app/update_mouse_overlay.go
@@ -120,7 +120,7 @@ func (m Model) dispatchOverlayWheel(button tea.MouseButton) (tea.Model, tea.Cmd)
 // update in one place.
 //
 // handled=false means the click was inside the box but not on a
-// clickable row; the caller should swallow it (no dismiss) so a stray
+// clickable row. The caller should swallow it (no dismiss) so a stray
 // click on the title or padding doesn't close the overlay.
 func (m Model) activateOverlayItemAt(innerY int) (tea.Model, tea.Cmd, bool) {
 	switch m.overlay {

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -115,7 +115,7 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 		m.restoreCursor()
 		m.restoreLevelFilter()
 		// The restored rows were captured on context entry and carry stale
-		// [RO] markers; an in-context Ctrl+R toggle since then updated the
+		// [RO] markers. An in-context Ctrl+R toggle since then updated the
 		// override but not this snapshot. Re-apply so the picker marker
 		// matches the context's current read-only state.
 		m.refreshContextReadOnlyMarkers()
@@ -237,7 +237,7 @@ func resolveOwnerResourceType(kind, apiVersion string, discovered []model.Resour
 }
 
 // navigateToOwner teleports to the owning resource. apiVersion may be empty
-// for callers that only know a built-in Kind ("Pod", "Node"); see
+// for callers that only know a built-in Kind ("Pod", "Node"). See
 // resolveOwnerResourceType.
 func (m Model) navigateToOwner(kind, name, apiVersion string) (tea.Model, tea.Cmd) {
 	crds := m.discoveredResources[m.discoveryContext()]
@@ -288,7 +288,7 @@ func (m Model) navigateChild() (tea.Model, tea.Cmd) {
 	ui.ActiveLeftScroll = 0
 
 	// Remember this level's filter, then clear all live filter/search state so
-	// the child level is a fresh start; navigating back (navigateParent)
+	// the child level is a fresh start. Navigating back (navigateParent)
 	// restores the list exactly as the user left it.
 	m.resetFilterForTypeSwitch()
 
@@ -364,7 +364,7 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	case m.discoveringContexts[sel.Name] && len(previewItems) > 0:
 		// Hover-discovery is in flight and the right pane already had
 		// something to show (seed fallback). Reuse those items so the
-		// user sees content immediately; apiResourceDiscoveryMsg will
+		// user sees content immediately. apiResourceDiscoveryMsg will
 		// replace them with the real list when discovery completes.
 		m.setMiddleItems(previewItems)
 		m.itemCache[m.navKey()] = m.middleItems
@@ -525,7 +525,7 @@ func (m Model) navigateChildResourceType(sel *model.Item) (tea.Model, tea.Cmd) {
 	m.saveCurrentSession()
 	// Show the cached list immediately while loadResources decides
 	// whether to serve from cache (fresh-cache shortcut) or issue a real
-	// fetch. The cache-then-refresh UX is unchanged; the refetch-suppression
+	// fetch. The cache-then-refresh UX is unchanged. The refetch-suppression
 	// now lives in loadResources, which compares the cache's freshness
 	// fingerprint against the current fetch parameters.
 	if cached, cacheHit := m.itemCache[m.navKey()]; cacheHit {
@@ -563,7 +563,7 @@ func (m Model) navigateChildResource(sel *model.Item) (tea.Model, tea.Cmd) {
 			m.setCursor(0)
 		}
 		// loadSecurityAffectedResources legitimately returns nil (manager
-		// torn down, no group key); arming the spinner without a command
+		// torn down, no group key). Arming the spinner without a command
 		// would strand it forever.
 		if cmd := m.loadSecurityAffectedResources(false); cmd != nil {
 			m.loading = true
@@ -755,7 +755,7 @@ func (m Model) enterFullView() (tea.Model, tea.Cmd) {
 	// (navigateChildResource handles __security_finding_group__,
 	// navigateChildOwned routes __security_affected_resource__ through
 	// jumpToFindingResource). Falling through to loadYAML here used to
-	// produce "Warning: unknown resource type"; an earlier fix returned
+	// produce "Warning: unknown resource type". An earlier fix returned
 	// nil here which silently no-op'd Enter and stranded users on the
 	// finding-groups list.
 	if onSecurityView(&m) {

--- a/internal/app/update_orphans.go
+++ b/internal/app/update_orphans.go
@@ -166,7 +166,7 @@ func (m Model) handleOrphansKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		return m, nil
 	case "s":
 		// Toggle strict ↔ lenient. Strict (default) hides items with
-		// no live consumer but a workload-template ref; lenient
+		// no live consumer but a workload-template ref. Lenient
 		// surfaces them so the user can audit "what's currently idle"
 		// in addition to "what's truly unused". Visible-list size
 		// changes, so re-clamp the cursor afterwards.
@@ -228,7 +228,7 @@ func (m Model) handleOrphansFilterInput(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 // last looking at — not at the top of the list. Only filterActive is
 // forced to false so the next keypress drives navigation rather than
 // being captured as filter input. Context-switch invalidation (via
-// invalidateOrphanCacheForContext) blows away the cache; a fresh
+// invalidateOrphanCacheForContext) blows away the cache. A fresh
 // cmdLoadOrphans then arrives and orphansClampCursor pulls the cursor
 // into the new list.
 func (m Model) openOrphansOverlay() (Model, tea.Cmd) {

--- a/internal/app/update_overlays_rightsizing.go
+++ b/internal/app/update_overlays_rightsizing.go
@@ -109,7 +109,7 @@ func (m Model) handleRightsizingOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.
 //  1. Cache hit for the (strategy, newHeadroom) pair → swap data
 //     pointer in place, no fetch.
 //  2. s.data populated → call k8s.RescaleRightsizing to multiply
-//     every recommendation by newH/oldH locally; cache the result
+//     every recommendation by newH/oldH locally. Cache the result
 //     under the new key for future revisits.
 //  3. Fallback (cache miss AND s.data == nil) → async load. This
 //     path is only hit on the first frame before
@@ -208,7 +208,7 @@ func indexOfHeadroom(h float64, headrooms []float64) int {
 // snapHeadroomInDirection picks the preset to land on when the
 // current headroom is not in the preset list. `direction == +1` →
 // smallest preset > current (or the first preset when current is
-// already past the top); `direction == -1` → largest preset < current
+// already past the top). `direction == -1` → largest preset < current
 // (or the last preset when current is below the bottom). Mirrors the
 // vim wrap behavior at the edges so a snapped press still cycles.
 func snapHeadroomInDirection(current float64, direction int, headrooms []float64) float64 {
@@ -239,7 +239,7 @@ func snapHeadroomInDirection(current float64, direction int, headrooms []float64
 // Two paths:
 //
 //  1. Cache hit on (newStrategy, headroom) → swap data pointer in
-//     place; no async fetch and no flash.
+//     place. No async fetch and no flash.
 //  2. Cache miss → kick the async load BUT keep the previous
 //     strategy's data in s.data so the renderer can keep showing it
 //     while the new fetch runs. The renderer combines `loading=true`

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -21,7 +21,7 @@ func (m Model) updateContextsLoaded(msg contextsLoadedMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 	if msg.err != nil {
-		// Without a context list there is nothing to restore into; show the
+		// Without a context list there is nothing to restore into. Show the
 		// error rather than a splash that never ends.
 		m.abandonSessionRestore()
 		m.err = msg.err
@@ -202,7 +202,7 @@ func (m Model) updateAPIResourceDiscovery(msg apiResourceDiscoveryMsg) (Model, t
 		}
 	}
 	// Replay a bookmark that was queued waiting on this context's discovery.
-	// IsContextAware switches the bookmark's effective context; for context-free
+	// IsContextAware switches the bookmark's effective context. For context-free
 	// bookmarks the effective context is the model's current context, which we
 	// match against msg.context so we only replay when the right discovery lands.
 	if m.bookmarkAwaitingDiscovery != nil {
@@ -500,7 +500,7 @@ func (m Model) updateResourcesLoadedMain(msg resourcesLoadedMsg) (tea.Model, tea
 	// Align previewLoading with whether a preview fetch is actually in
 	// flight. clearRight() / invalidatePreviewForCursorChange() armed the
 	// flag to true on navigation so the right pane keeps showing the
-	// spinner across the main-list arrival; if no preview cmd is
+	// spinner across the main-list arrival. If no preview cmd is
 	// dispatched (e.g., empty namespace, so selectedMiddleItem is nil and
 	// loadPreview returns nil), leaving the flag armed would render
 	// "Loading..." forever instead of letting the right pane fall through
@@ -552,7 +552,7 @@ func (m *Model) applyWarningEventsFilter() {
 
 // applyEventGrouping collapses duplicate Events sharing ClusterName/Type/
 // Reason/Message/Object into a single row with a summed Count. Runs only when
-// viewing the Event resource list with grouping enabled; other resource kinds
+// viewing the Event resource list with grouping enabled. Other resource kinds
 // pass through untouched.
 func (m *Model) applyEventGrouping() {
 	if !m.eventGrouping || m.nav.ResourceType.Kind != "Event" {
@@ -565,7 +565,7 @@ func (m *Model) applyEventGrouping() {
 // after an Events-view toggle (warnings-only, grouping). It re-applies the
 // full pipeline — warning filter, grouping, and the active filter preset —
 // so toggling any one of them never silently drops the others. A cache miss
-// leaves m.middleItems untouched; the next resource load will rebuild it.
+// leaves m.middleItems untouched. The next resource load will rebuild it.
 func (m *Model) rebuildEventsFromCache() {
 	cached, ok := m.itemCache[m.navKey()]
 	if !ok {
@@ -651,7 +651,7 @@ func (m Model) updateOwnedLoaded(msg ownedLoadedMsg) (tea.Model, tea.Cmd) {
 	// Align previewLoading with whether a preview fetch is actually in
 	// flight (see updateResourcesLoadedMain for rationale). At LevelOwned,
 	// kinds without further owned children (or empty Helm releases) make
-	// loadPreview return nil; without this the right pane spins forever.
+	// loadPreview return nil. Without this the right pane spins forever.
 	previewCmd := m.loadPreview()
 	m.previewLoading = previewCmd != nil
 	m.suppressBgtasks = savedSuppress
@@ -707,7 +707,7 @@ func (m Model) updateContainersLoaded(msg containersLoadedMsg) (tea.Model, tea.C
 		m.suppressBgtasks = true
 	}
 	// Align previewLoading with whether a preview fetch is actually in
-	// flight. clearRight() armed the flag to true on navigation; at
+	// flight. clearRight() armed the flag to true on navigation. At
 	// LevelContainers loadPreview returns nil, so leaving it armed would
 	// make the right pane render "Loading..." forever. Conversely, when a
 	// preview cmd is dispatched the flag must stay true so the spinner

--- a/internal/app/update_sync_wave.go
+++ b/internal/app/update_sync_wave.go
@@ -18,7 +18,7 @@ const syncWaveRefreshInterval = 3 * time.Second
 // syncWaveSpinnerInterval is the cadence of the loading-spinner glyph
 // rotation. 100ms is the standard cadence for terminal spinners — fast
 // enough to feel responsive, slow enough not to burn CPU. Tighter than
-// 100ms looks jittery on most terminals; slower looks laggy.
+// 100ms looks jittery on most terminals. Slower looks laggy.
 const syncWaveSpinnerInterval = 100 * time.Millisecond
 
 // scheduleSyncWaveSpinnerTick fires the next spinner-rotation message.
@@ -49,7 +49,7 @@ func (m Model) updateSyncWaveTimeline(msg syncWaveTimelineMsg) (tea.Model, tea.C
 		m.setStatusMessage("Sync wave timeline returned no data", true)
 		return m, withSyncWaveAutoRefresh(m, scheduleStatusClear())
 	}
-	// Keep the loading flag set while we still await the wave map; the
+	// Keep the loading flag set while we still await the wave map. The
 	// skeleton message paints the phase structure but waves are not yet
 	// known.
 	m.loading = msg.info.Loading
@@ -139,7 +139,7 @@ func withSyncWaveAutoRefresh(m Model, base tea.Cmd) tea.Cmd {
 
 // applySmartDefaults sets the default collapsed state on first open:
 // empty fail/delete phases collapse so they don't visually clutter the
-// sidebar; non-empty phases stay expanded.
+// sidebar. Non-empty phases stay expanded.
 func applySmartDefaults(s *syncWaveState) {
 	if s.data == nil {
 		return
@@ -249,7 +249,7 @@ func clampBodyScrollForPhase(s *syncWaveState, phase k8s.SyncWavePhase) {
 // session, that the overlay is still open, and that the phase is still
 // Running. On any miss, returns no cmd. On match, issues the next
 // loadSyncWaveTimeline.
-func (m Model) handleSyncWaveTick(msg syncWaveTickMsg) (tea.Model, tea.Cmd) { //nolint:unparam // consistent message handler signature; tea.Model return is consumed by the dispatch wired in Task 13.
+func (m Model) handleSyncWaveTick(msg syncWaveTickMsg) (tea.Model, tea.Cmd) { //nolint:unparam // consistent message handler signature; tea.Model return is consumed by the central message dispatch.
 	if msg.token != m.syncWave.token {
 		return m, nil
 	}

--- a/internal/app/update_whocan.go
+++ b/internal/app/update_whocan.go
@@ -13,7 +13,7 @@ import (
 // enterWhoCanMode flips the Can-I overlay into reverse-RBAC mode and
 // prepares the resource picker. The resource list is the deduped union
 // of all Can-I groups so the user sees the same canonical names as in
-// the forward view; the cursor lands on whatever resource was
+// the forward view. The cursor lands on whatever resource was
 // highlighted in Can-I (when reachable) so Tab feels like a
 // continuation rather than a fresh start.
 func (m Model) enterWhoCanMode() (tea.Model, tea.Cmd) {
@@ -48,7 +48,7 @@ func (m Model) enterWhoCanMode() (tea.Model, tea.Cmd) {
 	resource := whoCanCurrentResource(m.whoCan.resourceList, m.whoCan.resourceCursor)
 	if resource == "" {
 		// No resources in the picker (Can-I hadn't loaded any). Leave
-		// the subjects panel idle; the user will see the empty list.
+		// the subjects panel idle. The user will see the empty list.
 		m.whoCan.resource = ""
 		return m, nil
 	}
@@ -268,7 +268,7 @@ func (m Model) refreshWhoCanForCursor(visible []string) (tea.Model, tea.Cmd) {
 // handleWhoCanFilterKey processes typing into the resource filter.
 // As keystrokes land the visible list narrows and the cursor snaps to
 // the top of the new list (with a query fire so the right pane keeps
-// up). Enter accepts the filter and exits filter mode; Esc clears it.
+// up). Enter accepts the filter and exits filter mode. Esc clears it.
 func (m Model) handleWhoCanFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	action := handleFilterKey(&m.whoCan.resourceFilter, msg)
 	switch action {
@@ -322,7 +322,7 @@ func (m Model) handleWhoCanFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 // loadWhoCan dispatches the WhoCan fetch for the current verb +
-// resource + namespace. Fires asynchronously; the result lands as
+// resource + namespace. Fires asynchronously. The result lands as
 // whoCanLoadedMsg and is injected into m.whoCan.subjects by the
 // handler.
 //
@@ -333,7 +333,7 @@ func (m Model) handleWhoCanFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // in-flight fetch.
 func (m Model) loadWhoCan() tea.Cmd {
 	verb := ui.WhoCanVerbs[m.whoCan.verbCursor]
-	// "*" means "any verb"; passed through to verbMatches which treats
+	// "*" means "any verb". Passed through to verbMatches which treats
 	// it as "match any rule with at least one verb". An earlier version
 	// rewrote "*" to "get" — that silently dropped subjects whose roles
 	// granted list/watch/etc. but not get.
@@ -440,7 +440,7 @@ func (m Model) renderWhoCanOverlay(background string) string {
 // renderer paints the new subject list on the next frame.
 func (m Model) updateWhoCanLoaded(msg whoCanLoadedMsg) Model {
 	if msg.gen != m.requestGen {
-		return m // stale; user moved on
+		return m // stale. User moved on
 	}
 	m.whoCan.loading = false
 	if msg.err != nil {

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -59,7 +59,7 @@ func followFieldDocCursor(mdl tea.Model, cmd tea.Cmd, path func(Model) []string)
 // Match highlights update on every keystroke so the user sees results land
 // in real time instead of having to commit with Enter just to see whether
 // the query matches anything. Enter still ends search-input mode and
-// scrolls to the first match -- it's the "commit" action; typing only
+// scrolls to the first match -- it's the "commit" action. Typing only
 // drives the live highlight overlay.
 func (m Model) handleYAMLSearchInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	viewportLines := m.yamlViewportLines()
@@ -117,7 +117,7 @@ func (m Model) handleYAMLSearchInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 // handleYAMLNormalCopy copies the original YAML line under the cursor to the
 // clipboard. A digit prefix (e.g. `123y`) yanks that many visible lines
-// starting at the cursor; an empty buffer falls back to a single line.
+// starting at the cursor. An empty buffer falls back to a single line.
 // Counts operate on the visible-line mapping, so folded children are simply
 // not in scope — a count that reaches a folded section jumps over its hidden
 // children and continues with the lines that follow.
@@ -397,7 +397,7 @@ func (m Model) handleYAMLNormalG(totalVisible, maxScroll int) (tea.Model, tea.Cm
 // handleYAMLNormalHalfPageDown handles ctrl+d (half page down) in normal YAML mode.
 //
 // Vim semantics via vimScrollStep: a counted press sets the sticky 'scroll'
-// option to min(count, viewport); plain presses reuse the sticky value
+// option to min(count, viewport). Plain presses reuse the sticky value
 // (defaulting to viewport/2). The same option is shared with ctrl+u.
 func (m Model) handleYAMLNormalHalfPageDown(totalVisible int) (tea.Model, tea.Cmd) {
 	step := vimScrollStep(&m.yamlView.lineInput, &m.yamlView.scrollOption, m.yamlViewportLines())
@@ -529,7 +529,7 @@ func (m *Model) yamlNextIntraLineMatch(forward bool) bool {
 		if curBytePos > 0 {
 			prefix := line[:curBytePos]
 			// For backward search, find the last match in the prefix.
-			// FindColumnInLine returns the first match; iterate to find the last.
+			// FindColumnInLine returns the first match. Iterate to find the last.
 			lastCol := -1
 			remaining := prefix
 			offset := 0
@@ -624,7 +624,7 @@ func (m Model) handleYAMLKeyCtrlV() (tea.Model, tea.Cmd) {
 
 // handleYAMLKeyObjectExplorer switches from the YAML viewer to the Object Explorer
 // browser (O), positioning the tree on the node under the YAML cursor. When the
-// viewer was opened from the tree, it reuses the preserved tree; otherwise
+// viewer was opened from the tree, it reuses the preserved tree. Otherwise
 // (opened via Enter) it opens a fresh tree for the current resource. The tree
 // returns to the YAML viewer with P (open full YAML), keeping the cursor in
 // sync in both directions.

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -250,7 +250,7 @@ func (m Model) applySessionColumnsForKind(kind string) {
 	// CRD additionalPrinterColumns for the navigated resource type drive
 	// priority-aware, first-class printer-column rendering. Only applies when
 	// the rendered kind matches nav.ResourceType (the middle column at
-	// LevelResources); owned children/containers have their own kinds.
+	// LevelResources). Owned children/containers have their own kinds.
 	if rt := m.nav.ResourceType; len(rt.PrinterColumns) > 0 && rt.Kind != "" && strings.EqualFold(rt.Kind, kind) {
 		pcs := make(map[string]int, len(rt.PrinterColumns))
 		for _, pc := range rt.PrinterColumns {
@@ -272,7 +272,7 @@ func (m Model) applySessionColumnsForKind(kind string) {
 		ui.ActiveSessionColumns = nil
 	}
 	// Hidden built-in columns for this kind. Session toggles (from the
-	// column-toggle overlay) win over view-derived defaults; when neither is
+	// column-toggle overlay) win over view-derived defaults. When neither is
 	// set, fall back to the view's column list — any built-in not listed in
 	// views.<kind>.columns is hidden so the table doesn't render columns the
 	// user didn't ask for.
@@ -318,7 +318,7 @@ func (m Model) withSessionColumnsForKind(kind string, fn func() string) string {
 
 // rightColumnKind returns the lowercased kind that identifies the items
 // currently rendered in the right column (children pane). Derived from
-// the first rightItem when available; falls back to the empty string,
+// the first rightItem when available. Falls back to the empty string,
 // which applySessionColumnsForKind treats as "no overrides".
 func (m Model) rightColumnKind() string {
 	if len(m.rightItems) > 0 && m.rightItems[0].Kind != "" {
@@ -342,7 +342,7 @@ func (m Model) viewExplorer() string {
 	// Category bars only light up when the user opted into category
 	// matching via Tab — at LevelResourceTypes only, since that's
 	// where the bars actually render. Plain `/foo` or `f foo` thus
-	// stays a name-search both visually and behaviourally; Tab is
+	// stays a name-search both visually and behaviourally. Tab is
 	// the explicit "include groups" toggle in both senses.
 	ui.ActiveHighlightCategories = m.nav.Level == model.LevelResourceTypes &&
 		((m.searchInput.Value != "" && m.searchBroadMode) ||
@@ -649,7 +649,7 @@ func (m Model) leftColumnLoading() bool {
 // neither the left (parent context: resource-type categories,
 // kubeconfigs, …) nor the right (child preview) should light up just
 // because the user typed `/workload`. The middle was already rendered
-// upstream with ActiveHighlightQuery active; we clear it here before
+// upstream with ActiveHighlightQuery active. We clear it here before
 // touching either side column and restore at the end.
 func (m Model) viewExplorerThreeCol(middle string, leftW, leftInner, rightW, rightInner, contentHeight int) string {
 	savedHighlight := ui.ActiveHighlightQuery
@@ -675,7 +675,7 @@ func (m Model) viewExplorerThreeCol(middle string, leftW, leftInner, rightW, rig
 // viewExplorerTwoColMiddleRight renders the explorer with the left sidebar
 // hidden (the hide-sidebar phase of the kb.Fullscreen cycle). Same
 // right-column rendering as viewExplorerThreeCol
-// minus the left column; ActiveLeftScroll/HighlightQuery are still saved and
+// minus the left column. ActiveLeftScroll/HighlightQuery are still saved and
 // cleared so the right pane doesn't inherit middle-pane highlight state.
 func (m Model) viewExplorerTwoColMiddleRight(middle string, rightW, rightInner, contentHeight int) string {
 	savedHighlight := ui.ActiveHighlightQuery

--- a/internal/app/view_modes.go
+++ b/internal/app/view_modes.go
@@ -347,7 +347,7 @@ func (m *Model) clampLogScroll() {
 // ensureLogCursorVisible adjusts logScroll so the cursor is within the visible
 // content area. In wrap mode the math accounts for visual rows (each source
 // line may produce multiple wrapped sub-lines) so the cursor doesn't drift
-// off-screen when intermediate lines wrap heavily; outside wrap mode it's
+// off-screen when intermediate lines wrap heavily. Outside wrap mode it's
 // classic source-line scrolloff. logFollow always wins: it snaps to the
 // (maxScroll, topSkip) pair that pins the most recent sub-line to the bottom.
 func (m *Model) ensureLogCursorVisible() {
@@ -388,7 +388,7 @@ func (m *Model) ensureLogCursorVisible() {
 // adjustLogScrollForCursorWrap positions logScroll/logWrapTopSkip so that
 // the cursor's source line (and ideally all of its wrapped sub-lines) is
 // inside the visible viewport, in visual-row terms. Pins cursor's bottom
-// sub-line to the viewport's bottom row when scrolling down; cursor's first
+// sub-line to the viewport's bottom row when scrolling down. Cursor's first
 // sub-line to row 0 when scrolling up. Drops scrolloff for simplicity.
 func (m *Model) adjustLogScrollForCursorWrap(viewH int) {
 	availWidth := m.logWrapAvailWidth()
@@ -523,7 +523,7 @@ func wrappedLineCount(line string, width int) int {
 // via lipgloss Height, so we don't pad here.
 //
 // Lines are rendered in the default style. The hint bar's "scrolled N"
-// indicator is enough signal that the user is in history mode; dimming
+// indicator is enough signal that the user is in history mode. Dimming
 // the body just made it harder to read without adding new information.
 func renderScrollbackView(sb *scrollback, offset, viewH, viewW int) string {
 	lines := sb.Snapshot()
@@ -663,7 +663,7 @@ func (m Model) viewExecTerminal() string {
 		BorderForeground(lipgloss.Color(ui.ColorPrimary)).
 		Padding(0, 0).
 		Width(m.width)
-	// viewH counts content rows only; BoxHeight adds the top/bottom rules back,
+	// viewH counts content rows only. BoxHeight adds the top/bottom rules back,
 	// since lipgloss v2 counts the border inside Height(). Width needs no such
 	// adjustment here — this border has no left/right edges.
 	bordered := ui.BoxHeight(borderStyle, viewH).Render(termContent)

--- a/internal/app/view_overlay_lists.go
+++ b/internal/app/view_overlay_lists.go
@@ -43,7 +43,7 @@ func overlayListScroll(prev *int, cursor, total, maxVisible int) int {
 // overlayListChromeFilterable returns the number of non-item rows the
 // OverlayList block occupies for a filterable overlay (Filterable=true):
 // title (1) + title's bottom padding row (1) + filter prompt (1) +
-// blank separator below filter (1) = 4 rows. Lipgloss's 1+1 vertical
+// blank separator below filter (1) = 4 rows, and lipgloss's 1+1 vertical
 // padding around the block is handled by the caller subtracting 2 from
 // the outer overlay height before passing the result as cfg.Height —
 // so this helper returns the chrome INSIDE the block only.
@@ -657,7 +657,7 @@ func renderClusterColorOverlay(m Model, innerW, contentH int) string {
 }
 
 // padRight returns s padded with spaces to at least width visual cells.
-// Used to align the badge column across rows in OverlayList. Lipgloss
+// Used to align the badge column across rows in OverlayList, because lipgloss
 // handles overflow truncation for us, so this only adds — never trims.
 //
 //nolint:unparam // intentionally generic; current callers happen to share width=14 but each picks its own

--- a/internal/app/view_overlay_lists.go
+++ b/internal/app/view_overlay_lists.go
@@ -50,7 +50,7 @@ func overlayListScroll(prev *int, cursor, total, maxVisible int) int {
 func overlayListChromeFilterable() int { return 4 }
 
 // renderActionOverlay maps the action-menu items onto OverlayList. The
-// verb code (model.Item.Status) renders as the "[s]" status badge; the
+// verb code (model.Item.Status) renders as the "[s]" status badge. The
 // long-form description (Extra) renders dim after the action name.
 // Adaptive width replaces the old ActionOverlayWidth helper so long
 // Karpenter / Knative descriptions still grow the box without wrapping.
@@ -71,7 +71,7 @@ func renderActionOverlay(m Model) (string, int) {
 
 // renderPodSelectOverlay maps the pod picker (used by both the standard
 // log-pod selector and the embedded view's pod-switcher) onto OverlayList.
-// Pod status moves into the dim Description segment; the per-status color
+// Pod status moves into the dim Description segment. The per-status color
 // styling from the bespoke renderer is not preserved (acceptable for the
 // log viewer's "pick a pod" UX).
 func renderPodSelectOverlay(m Model) string {
@@ -124,7 +124,7 @@ func renderCanISubjectOverlay(m Model, innerW int) string {
 
 // renderBookmarkOverlay maps the bookmark picker onto OverlayList. Each row
 // shows the bookmark's saved namespace scope as a dim "ns: <scope>" suffix.
-// The jump replays that scope by default; Tab opts out, surfaced by the
+// The jump replays that scope by default. Tab opts out, surfaced by the
 // "[KEEP CURRENT NS]" title chip.
 func renderBookmarkOverlay(m Model) string {
 	const w = 90
@@ -218,7 +218,7 @@ func renderSessionsOverlay(m Model) string {
 
 // renderTemplateOverlay maps the resource-template picker onto OverlayList.
 // The "[Category] Name" composition collapses into Status (the category) +
-// Name; the bespoke "> " cursor indicator is replaced by OverlayList's
+// Name. The bespoke "> " cursor indicator is replaced by OverlayList's
 // uniform highlight background.
 func renderTemplateOverlay(m Model) (string, int) {
 	src := m.filteredTemplates()
@@ -305,7 +305,7 @@ func renderColumnToggleOverlay(m Model, entries []ui.ColumnToggleEntry, width, h
 
 // renderColorschemeOverlay maps the colorscheme picker (with its group-
 // divider headers between Dark / Light / etc. sections) onto OverlayList.
-// Headers render as "── Name ──" via OverlayList's Header item flag; the
+// Headers render as "── Name ──" via OverlayList's Header item flag. The
 // caller's `cursor` (selectable-index) is translated to the display index
 // inside the items slice so OverlayList can highlight the right row.
 //
@@ -400,10 +400,10 @@ func buildColorschemeItems(entries []ui.SchemeEntry, filter string, cursor int) 
 // renderAutoSyncOverlay maps the ArgoCD AutoSync configuration picker
 // onto OverlayList. Three rows (AutoSync, Self-Heal, Prune) each carry
 // a pre-styled " ON" / "OFF" / "  -" indicator in the Badge column.
-// Self-Heal and Prune are gated on AutoSync being on; when AutoSync is
+// Self-Heal and Prune are gated on AutoSync being on. When AutoSync is
 // off they render with Disabled=true (dim) and show the "  -" badge
 // instead of OFF. The cursor highlight is capped to the label column
-// (CursorHighlightWidth) so it never sits behind the ON/OFF switches; the
+// (CursorHighlightWidth) so it never sits behind the ON/OFF switches. The
 // space/enter/esc keys live in the app-wide hint bar at the bottom.
 func renderAutoSyncOverlay(m Model) string {
 	const (
@@ -460,7 +460,7 @@ func renderAutoSyncOverlay(m Model) string {
 // OverlayList. The renderer is fullscreen-style (returns a fully styled
 // overlay including OverlayStyle wrapping) so it slots into the
 // renderOverlayFullscreen path the same way the legacy renderer did.
-// Column header lives in cfg.Subtitle; row fields pack into Name with
+// Column header lives in cfg.Subtitle. Row fields pack into Name with
 // fixed widths so they align with the header.
 func renderHelmHistoryOverlay(m Model) string {
 	const (
@@ -657,7 +657,7 @@ func renderClusterColorOverlay(m Model, innerW, contentH int) string {
 }
 
 // padRight returns s padded with spaces to at least width visual cells.
-// Used to align the badge column across rows in OverlayList; lipgloss
+// Used to align the badge column across rows in OverlayList. Lipgloss
 // handles overflow truncation for us, so this only adds — never trims.
 //
 //nolint:unparam // intentionally generic; current callers happen to share width=14 but each picks its own

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -34,7 +34,7 @@ func (m Model) renderOverlay(background string) string {
 	// breadcrumb, and the bold weight on selection highlights all keep
 	// their tint — the explorer fades without going gray. Stacked
 	// overlays (CanISubject on top of CanI) re-enter this function via
-	// the layered recursion below; an extra faint wrap on an
+	// the layered recursion below. An extra faint wrap on an
 	// already-faint line is a visual no-op (the terminal just sees more
 	// SGR 2 markers), so the recursive call composes safely.
 	//
@@ -103,7 +103,7 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 	switch m.overlay {
 	case overlayNamespace:
 		// Pass the overlay box height to the helper so its visible-item
-		// cap matches what fits; otherwise on a list of 30+ namespaces
+		// cap matches what fits. Otherwise on a list of 30+ namespaces
 		// lipgloss grows the box on overflow and the user sees it
 		// "shrink" back to its declared size when a filter narrows the
 		// list.
@@ -139,7 +139,7 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 	case overlayShuttingDown:
 		// Mirror the Quit overlay: a single line centered on both axes in a
 		// fixed-size box. See the overlayQuitConfirm case for the height
-		// arithmetic (visible outer height is sh+2; the inner slice is
+		// arithmetic (visible outer height is sh+2, the inner slice is
 		// sh-2 rows so Align centers the title on the middle row).
 		sw := max(min(32, m.width-10), 10)
 		sh := max(min(3, m.height-6), 3)
@@ -635,7 +635,7 @@ func (m Model) renderOverlayColumnToggle() (string, int, int) {
 	// Pass the overlay box dimensions (not the full screen) so the
 	// renderer's maxVisible cap matches what fits inside the box.
 	// Otherwise on a tall terminal the renderer emits ~34 lines into a
-	// 20-tall box; the box visibly grew on overflow and "shrank" back
+	// 20-tall box. The box visibly grew on overflow and "shrank" back
 	// as the filter narrowed results — looked like the window was
 	// resizing.
 	overlayW := min(50, m.width-10)
@@ -700,7 +700,7 @@ func (m Model) renderCanIOverlay(background string) string {
 	innerW := overlayW - 4
 	innerH := overlayH - 2
 
-	// Search bar shown inside the overlay; normal hints moved to the main status bar.
+	// Search bar shown inside the overlay. Normal hints moved to the main status bar.
 	var hintBar string
 	if m.canISearchActive {
 		searchBar := ui.HelpKeyStyle.Render("/") + ui.BarNormalStyle.Render(m.canISearchInput.CursorLeft()) + ui.BarDimStyle.Render("█") + ui.BarNormalStyle.Render(m.canISearchInput.CursorRight())
@@ -734,7 +734,7 @@ func (m Model) renderCanIOverlay(background string) string {
 }
 
 // renderErrorLogOverlay renders the error log overlay on top of the given background.
-// In fullscreen mode it replaces the background entirely; in overlay mode it centers on top.
+// In fullscreen mode it replaces the background entirely. In overlay mode it centers on top.
 func (m Model) renderErrorLogOverlay(background string) string {
 	vp := ui.ErrorLogVisualParams{
 		VisualMode:     m.errorLogVisualMode,

--- a/internal/app/view_right.go
+++ b/internal/app/view_right.go
@@ -30,7 +30,7 @@ func (m *Model) clearRight() {
 }
 
 // clampPreviewScroll prevents scrolling past the preview content.
-// Only details+events scroll; pinned header (children) and footer (resource usage) are excluded.
+// Only details+events scroll. Pinned header (children) and footer (resource usage) are excluded.
 func (m *Model) clampPreviewScroll() {
 	// This runs in the Update path (preview wheel/keys) and renders right-pane
 	// content below (the split pinned header and the measurement render), all
@@ -150,7 +150,7 @@ type previewMeasureKey struct {
 // content once at a height tall enough to hold all of it (so a long list or YAML
 // document can scroll to the end — see the issue where the right pane froze
 // ~halfway down a few-hundred-item list because the height was capped). While
-// the user scrolls, the key is unchanged so this is O(1); it recomputes only
+// the user scrolls, the key is unchanged so this is O(1). It recomputes only
 // when the content or layout changes.
 func (m *Model) measureScrollableLines(innerW, scrollableH int) int {
 	yaml := m.previewYAML
@@ -217,7 +217,7 @@ func (m Model) previewSummaryBand(width int) string {
 	sel := m.selectedMiddleItem()
 	// Synthetic rows (dashboards, security sources, port-forwards, captures,
 	// collapsed groups) all carry a "__"-prefixed Kind and have no status
-	// rollup; real resource types carry their Kubernetes Kind.
+	// rollup. Real resource types carry their Kubernetes Kind.
 	if sel == nil || strings.HasPrefix(sel.Kind, "__") {
 		return ""
 	}
@@ -321,7 +321,7 @@ func (m Model) renderRightColumn(width, height int) string {
 	}
 
 	// Append events to scrollable content (events scroll with the details).
-	// Lists have no events; their scroll is already applied above.
+	// Lists have no events. Their scroll is already applied above.
 	if !listPreview && !m.fullYAMLPreview && m.previewEventsContent != "" {
 		result += "\n" + ui.DimStyle.Render(strings.Repeat("\u2500", width)) + "\n" + m.previewEventsContent
 	}
@@ -362,7 +362,7 @@ func (m Model) renderRightColumn(width, height int) string {
 // isRightListPreview reports whether the right pane's scrollable content is the
 // plain resource list shown while hovering a resource type (renderRightDefault's
 // RenderTable over rightItems). Only this path honours ActiveRightScroll, so the
-// windowed render in renderRightColumn is gated on it; every other case
+// windowed render in renderRightColumn is gated on it. Every other case
 // (dashboards, security sources, union members rendered with RenderColumn,
 // details/YAML/tree) falls back to the generic render-then-slice path.
 func (m Model) isRightListPreview() bool {
@@ -430,7 +430,7 @@ func (m Model) isSecurityGroupSplit() bool {
 // reserve one line for the header).
 func (m Model) renderDetailsOnly(width, height int) string {
 	sel := m.selectedMiddleItem()
-	// Security finding groups carry their own title line; no DETAILS header.
+	// Security finding groups carry their own title line. No DETAILS header.
 	if sel != nil && sel.Kind == "__security_finding_group__" {
 		return ui.RenderFindingGroupDetails(*sel, nil, width, height)
 	}
@@ -517,7 +517,7 @@ func (m Model) renderRightResourceTypes(width, height int) string {
 		return m.monitoringPreview
 	}
 	// Security sources: show a scanning spinner while the findings
-	// preview load is actually in flight; once it completes, an empty
+	// preview load is actually in flight. Once it completes, an empty
 	// rightItems means "this source returned zero findings" or "the
 	// fetch errored out", and the spinner would loop forever — so fall
 	// through to renderRightDefault (which says "No resources found")

--- a/internal/app/view_status.go
+++ b/internal/app/view_status.go
@@ -12,7 +12,7 @@ import (
 
 // broadModeSuffix names the extra match dimension Tab opens at the
 // current level. At LevelResourceTypes Tab adds category-bar matches
-// ("+groups"); everywhere else it scans column values ("+columns").
+// ("+groups"). Everywhere else it scans column values ("+columns").
 // Returned with parentheses so the caller can drop it next to the
 // "filter"/"search" label without ad-hoc spacing logic.
 func (m Model) broadModeSuffix() string {
@@ -154,7 +154,7 @@ func (m Model) explorerDrillPath() []string {
 			return []string{name}
 		}
 	case modeDiff:
-		// Diff compares two resources; name both.
+		// Diff compares two resources. Name both.
 		switch {
 		case m.diffView.leftName != "" && m.diffView.rightName != "":
 			return []string{m.diffView.leftName + " ↔ " + m.diffView.rightName}
@@ -198,7 +198,7 @@ func (m Model) explorerDrillPath() []string {
 // The namespace is dropped for cluster-scoped resources (empty namespace) and
 // the kind when it is unknown.
 func resourceTitleLabel(kind, namespace, name string) string {
-	// kind/namespace/name come from cluster-controlled resources; sanitize
+	// kind/namespace/name come from cluster-controlled resources. Sanitize
 	// once here rather than at each of the nine call sites.
 	kind = ui.SanitizeTerminalText(kind)
 	namespace = ui.SanitizeTerminalText(namespace)
@@ -407,7 +407,7 @@ func (m Model) statusBar() string {
 	}
 
 	// Layout: the informational chip group (sort, counter / selected
-	// count, filter preset, NYAN) anchors the FAR RIGHT; the keymap
+	// count, filter preset, NYAN) anchors the FAR RIGHT. The keymap
 	// hints fill the remaining space on the left. JoinStatusBar treats
 	// the right side as priority — on overflow the keymap is the part
 	// that yields. Overlay hint bars use a separate code path above and
@@ -509,7 +509,7 @@ func (m Model) whichKeyLeaderHintBar() string {
 // explorerStatusChips composes the right-anchored chip group for the
 // explorer status bar: sort indicator, cursor counter or selection
 // badge, active filter preset, and NYAN flag. Reading order is
-// left-to-right; the chip group as a whole is right-aligned by
+// left-to-right. The chip group as a whole is right-aligned by
 // JoinStatusBar in statusBar(). Returns the joined string ready to
 // pass as the `right` argument to JoinStatusBar.
 func (m Model) explorerStatusChips() string {
@@ -523,7 +523,7 @@ func (m Model) explorerStatusChips() string {
 		parts = append(parts, ui.BarDimStyle.Render("sort:"+m.sortModeName()))
 	}
 	// Counter ↔ selection swap. By default we surface the cursor position
-	// inside the visible item list ("[1/47]"); the moment the user marks
+	// inside the visible item list ("[1/47]"). The moment the user marks
 	// at least one item we replace that chip with the selection-count
 	// badge ("3 selected"). Showing both was redundant — the user knows
 	// they're in bulk mode the second they kick off a selection — and the
@@ -560,7 +560,7 @@ func (m Model) explorerStatusChips() string {
 // explorerHintEntries builds the bottom hint bar for explorer views (cluster
 // picker, resource-type browser, resource list). Extracted from statusBar to
 // keep that function under the gocyclo budget. Dashboard views use a reduced
-// set; standard explorer views use the full set with conditional hides for
+// set. Standard explorer views use the full set with conditional hides for
 // keys that are no-ops at the current level.
 func (m Model) explorerHintEntries() []ui.HintEntry {
 	kb := ui.ActiveKeybindings
@@ -614,7 +614,7 @@ func (m Model) explorerHintEntries() []ui.HintEntry {
 	}
 	// Advertise the read-only toggle on every level so users can
 	// discover it without reading docs. At the cluster picker it
-	// flips a row marker; inside a context it locks/unlocks the
+	// flips a row marker. Inside a context it locks/unlocks the
 	// active tab. Hidden inside a context when --read-only is set,
 	// since the gate rejects the toggle.
 	if m.nav.Level == model.LevelClusters || !m.cliReadOnly {
@@ -705,7 +705,7 @@ func renderInputWithCursor(value string, cursor int) string {
 // helpHintBar renders the status-bar hint line for the help screen,
 // switching shape based on which input/applied state is active.
 // Extracted from statusBar to keep that function under the gocyclo
-// budget; the help screen has five distinct prompt shapes.
+// budget. The help screen has five distinct prompt shapes.
 func (m Model) helpHintBar() string {
 	switch {
 	case m.helpSearchActive:

--- a/internal/app/whichkey_catalog.go
+++ b/internal/app/whichkey_catalog.go
@@ -123,7 +123,7 @@ type whichKeyCatalog interface {
 // needing it would otherwise pay for two.
 type wkCatalog[C any] struct {
 	resolve func(m *Model) C
-	// input reports a focused text input; nil means the mode has none that
+	// input reports a focused text input, nil means the mode has none that
 	// reaches the leader dispatch.
 	input   func(m *Model) bool
 	actions []wkAction[C]
@@ -164,10 +164,10 @@ func (c wkCatalog[C]) available(m *Model) []whichKeyEntry {
 // Explorer's literal "r" (objectexplorer.go:289), a k9s habit that costs
 // nothing to configure. One of the two rows is then a lie, and the panel cannot
 // tell which: the viewers interleave literal and kb.* cases in their switches
-// (update_describe.go dispatches kb.ToggleWrap BEFORE "y"; update_yaml.go
+// (update_describe.go dispatches kb.ToggleWrap BEFORE "y", update_yaml.go
 // dispatches "y" before kb.Refresh), so neither "the literal wins" nor "the
 // binding wins" holds. Advertising neither is the only answer that is never
-// false; the key still works, it just stops being advertised as two things.
+// false. The key still works, it just stops being advertised as two things.
 //
 // Under any keybinding set that does not create such an overlap this is a
 // no-op: the entries that deliberately share a key (y with three meanings, q
@@ -208,7 +208,7 @@ func (c wkCatalog[C]) inputFocused(m *Model) bool {
 }
 
 // whichKeyModeCatalog binds one viewMode to its catalog. name is the label the
-// guards report a failure under; the modes have no String() of their own.
+// guards report a failure under. The modes have no String() of their own.
 type whichKeyModeCatalog struct {
 	mode    viewMode
 	name    string

--- a/internal/app/whichkey_leader.go
+++ b/internal/app/whichkey_leader.go
@@ -20,7 +20,7 @@ type whichKeyState struct {
 	// grouping is the panel's entry order. The zero value follows
 	// ui.ConfigWhichKeyGrouped rather than copying it, so a zero-value Model
 	// reads the CONFIGURED default instead of a stale snapshot of it. NewModel
-	// seeds it from the state file (whichkey_prefs.go); the runtime toggle is
+	// seeds it from the state file (whichkey_prefs.go). The runtime toggle is
 	// persisted there, never written back to the user's config file.
 	grouping wkGrouping
 	// cells caches the visible panel's entries for the duration of ONE
@@ -75,10 +75,10 @@ type whichKeyLeaderTickMsg struct{ seq int }
 
 // armWhichKeyLeader is called on every leader keypress. The panel scrolls
 // rather than pages, so a repeat press while already armed has nothing to
-// advance to; USER DECISION: it toggles the entry order instead — grouped by
+// advance to. USER DECISION: it toggles the entry order instead — grouped by
 // category or pure key order — indefinitely, and leaves the panel open. esc
 // closes it (whichKeyLeaderIntercept), as does pressing any action key. With
-// the default zero delay the panel shows at once; which_key_leader_delay_ms
+// the default zero delay the panel shows at once. which_key_leader_delay_ms
 // instead schedules a reveal tick.
 func (m Model) armWhichKeyLeader() (Model, tea.Cmd) {
 	if !ui.ConfigWhichKeyEnabled {
@@ -124,7 +124,7 @@ func (m Model) disarmWhichKeyLeader() Model {
 // so each group lands as one contiguous run — the entries flow column-major
 // across the whole panel rather than restarting per section, and the group's
 // color (not a header) is what reads as the category cue. Ungrouped drops the
-// clustering; the colors and the legend stay, and carry the category on their
+// clustering. The colors and the legend stay, and carry the category on their
 // own.
 func (m Model) whichKeyLeaderCells() []whichKeyCell {
 	acts := m.availableWhichKeyActions()

--- a/internal/app/whichkey_registry.go
+++ b/internal/app/whichkey_registry.go
@@ -9,7 +9,7 @@ import (
 )
 
 // whichKeyGroup classifies a catalog entry. The panel renders one flat list
-// with no section headers, the way neovim's which-key does; the category cue
+// with no section headers, the way neovim's which-key does. The category cue
 // the headers used to be is the color each group tints its entries'
 // DESCRIPTIONS with (whichKeyGroupStyles - the keys keep one shared accent).
 // The group name reaches the screen only in the legend row at the foot of the
@@ -48,7 +48,7 @@ type whichKeyAction = wkAction[*wkCtx]
 
 // wkCtx carries the row state every predicate needs, resolved once per call.
 // Predicates used to each call selectedMiddleItem() -> visibleMiddleItems(),
-// which re-filters the whole list; at ~14 predicates that was 14 filter passes
+// which re-filters the whole list. At ~14 predicates that was 14 filter passes
 // per render. unionSentinel and readOnly are included because multiple
 // predicates (wkSingleCluster/wkUnionAllowed and wkWritable/wkWritableKindIn/
 // PasteApply, respectively) each derive the same value from m.
@@ -116,7 +116,7 @@ func wkLevelIn(pred func(c *wkCtx) bool, levels ...model.Level) func(c *wkCtx) b
 
 // wkOnRow reports whether a resource row is highlighted at a level a direct
 // kubectl-backed action (Describe/Edit/Logs/Force Delete/...) can act on.
-// Most handlers in that family don't level-check explicitly; they rely on
+// Most handlers in that family don't level-check explicitly. They rely on
 // selectedResourceKind() returning "" (blocked by isVirtualResourceKind or
 // an empty wkKindIn match) above LevelResources, so this stays a plain
 // comparison rather than a wkLevelIn call for cheapness. Delete is the
@@ -342,8 +342,8 @@ func wkAllNamespacesAvailable(c *wkCtx) bool {
 
 // wkReadOnlyToggleAvailable mirrors handleKeyReadOnlyToggle (readonly.go):
 // blocked outright when --read-only was set at startup (cliReadOnly, sticky
-// for the process); at LevelClusters it additionally needs a selected
-// context that isn't a union-set row (wkClusterRowSelected); every other
+// for the process). At LevelClusters it additionally needs a selected
+// context that isn't a union-set row (wkClusterRowSelected). Every other
 // level needs no row.
 func wkReadOnlyToggleAvailable(c *wkCtx) bool {
 	if c.m.cliReadOnly {
@@ -358,7 +358,7 @@ func wkReadOnlyToggleAvailable(c *wkCtx) bool {
 // wkTogglePreviewAvailable mirrors handleExplorerTogglePreview
 // (update_keys_explorer.go): blocked only when hovering the Overview or
 // Monitoring dashboard pseudo-item at LevelResourceTypes, a silent no-op in
-// the handler; every other row and level toggles the preview.
+// the handler. Every other row and level toggles the preview.
 func wkTogglePreviewAvailable(c *wkCtx) bool {
 	if c.level != model.LevelResourceTypes || c.sel == nil {
 		return true
@@ -375,7 +375,7 @@ func wkTogglePreviewAvailable(c *wkCtx) bool {
 // never reaches handleExplorerToggleLogPreview there, regardless of
 // fullLogPreview. Below LevelClusters: turning the preview OFF always
 // succeeds, so once it is already on the key stays available regardless of
-// kind; turning it ON only produces a real log stream for a Pod row, or a
+// kind. Turning it ON only produces a real log stream for a Pod row, or a
 // Container row with an owning pod name resolved (m.nav.OwnedName, set at
 // LevelContainers).
 func wkTogglePreviewLogsAvailable(c *wkCtx) bool {
@@ -389,10 +389,10 @@ func wkTogglePreviewLogsAvailable(c *wkCtx) bool {
 }
 
 // wkAPIExplorerAvailable mirrors openExplainBrowser's level switch
-// (update_explain.go): unavailable at LevelClusters; at LevelResourceTypes it
+// (update_explain.go): unavailable at LevelClusters. At LevelResourceTypes it
 // additionally needs a selected row that isn't a collapsed-group header or
 // one of the dashboard pseudo-items (kind or Extra "__overview__" /
-// "__monitoring__"); LevelResources/Owned/Containers work off the navigated
+// "__monitoring__"). LevelResources/Owned/Containers work off the navigated
 // resource type and need no row.
 func wkAPIExplorerAvailable(c *wkCtx) bool {
 	switch c.level {
@@ -459,7 +459,7 @@ func wkFullscreenAvailable(c *wkCtx) bool {
 // "select exactly 2" toast, so those counts are excluded the same way
 // Delete/Edit exclude union-blocked kinds. len(m.selectedItems) is used
 // instead of the handler's selectedItemsList() to avoid an extra
-// visibleMiddleItems filter pass per render; the two differ only when a
+// visibleMiddleItems filter pass per render. The two differ only when a
 // selected row has since scrolled out of the current filter, the same
 // accepted approximation wkActionMenuAvailable documents for hasSelection().
 func wkDiffAvailable(c *wkCtx) bool {
@@ -588,7 +588,7 @@ func whichKeyHelpKey(kb ui.Keybindings) string {
 
 // whichKeyExplorerActions returns a copy of the shared explorer catalog, so a
 // caller cannot reorder or overwrite the package slice through it. Only tests
-// call this; the render path reads whichKeyExplorerActionList directly, so the
+// call this. The render path reads whichKeyExplorerActionList directly, so the
 // clone costs nothing per frame.
 func whichKeyExplorerActions() []whichKeyAction {
 	return slices.Clone(whichKeyExplorerActionList)
@@ -616,7 +616,7 @@ func whichKeyExcludedBindings() map[string]string {
 		// the panel.
 		"WhichKeyLeader": "the leader key itself",
 		// SetMark ("m") arms m.pendingMark and waits for the bookmark-slot
-		// key (update_keys_explorer.go:26-33,330-332); unlike the g-prefix
+		// key (update_keys_explorer.go:26-33,330-332). Unlike the g-prefix
 		// (armWhichKey/renderWhichKey), nothing renders while pendingMark is
 		// true — there is no popup, just a silent wait for the next key.
 		"SetMark": "chord prefix, no rendered continuation",

--- a/internal/app/whichkey_render.go
+++ b/internal/app/whichkey_render.go
@@ -36,7 +36,7 @@ func (c whichKeyCell) keyText() string {
 
 // fillWhichKeyDisplay resolves each cell's drawn key once per build. The grid
 // measures the key twice (panel width, then per-column field) and the renderer
-// writes it a third time; parsing the chord at each of those points is three
+// writes it a third time. Parsing the chord at each of those points is three
 // passes per frame for the same answer.
 func fillWhichKeyDisplay(cells []whichKeyCell) {
 	for i := range cells {
@@ -75,7 +75,7 @@ const (
 	// equivalent knob - its long labels make one unnecessary - but lfk's
 	// short ones need it to stop the panel from going wide-and-flat instead
 	// of tall-and-narrow. 5 leaves whichKeyMinColW as the sole driver (never
-	// binding) up to a 227-column terminal; the cap first binds at 228
+	// binding) up to a 227-column terminal. The cap first binds at 228
 	// columns (container 198, which the width-driven formula would split into
 	// 6 columns), and the even redivision that follows leaves 39-wide columns
 	// - 36 of content once whichKeySpacing is subtracted - comfortably above
@@ -132,7 +132,7 @@ const (
 	// above) are guaranteed to match or beat the old flat-4 column count.
 	// The one place that trade-off surfaces is width 179-186, which lands
 	// one column narrower (4 instead of 5) than the old margin=4 would have
-	// given; it never drops below 4 columns, and every width outside that
+	// given. It never drops below 4 columns, and every width outside that
 	// eight-wide band matches or improves on the old baseline.
 	whichKeyOuterMargin           = 4  // tier 1, unchanged from before
 	whichKeyOuterMarginTier2      = 8  // starts at whichKeyOuterMarginTier2Width
@@ -176,10 +176,10 @@ const (
 type whichKeyGrid struct {
 	boxW  int // column width, spacing included
 	boxN  int // column count
-	rowN  int // grid rows; entries fill column-major
+	rowN  int // grid rows. Entries fill column-major
 	lead  int // spaces before each column, always whichKeySpacing
 	keyW  int // right-aligned key field, shared by every column
-	descW int // description field; 0 drops the description
+	descW int // description field. 0 drops the description
 }
 
 // whichKeyGridFor ports which-key.nvim's box arithmetic (view.lua:340-344):
@@ -225,7 +225,7 @@ func whichKeyGridFor(cells []whichKeyCell, container int) whichKeyGrid {
 	// which-key.nvim lays each box out at box_width - spacing (view.lua:346)
 	// and prepends that spacing before every box, including the first, once
 	// there is more than one column (view.lua:358) - so win.padding[2] alone
-	// (whichKeyPadH) is not neovim's real left margin; padding[2] + spacing
+	// (whichKeyPadH) is not neovim's real left margin. Padding[2] + spacing
 	// is (2+3=5 here). lfk applies that same lead unconditionally, even at a
 	// single column, which is where it deliberately parts from neovim: a
 	// which-key.nvim popup shrink-wraps to its content there, so the reserved
@@ -238,7 +238,7 @@ func whichKeyGridFor(cells []whichKeyCell, container int) whichKeyGrid {
 	}
 	g.rowN = (len(cells) + boxN - 1) / boxN
 	contentW := max(boxW-whichKeySpacing, 1)
-	// A key wider than the cell would starve the label; clamp it so at least
+	// A key wider than the cell would starve the label. Clamp it so at least
 	// one column of description survives, and let writeWhichKeyCell truncate.
 	// Reachable only on a terminal too narrow for box_width to honour maxRow.
 	if maxKey+whichKeyGap+1 > contentW {
@@ -289,7 +289,7 @@ func wkPad(n int) string {
 // registry group. Resolved once per render rather than per cell.
 type whichKeyCellStyles struct {
 	key   lipgloss.Style // uniform across every entry
-	desc  lipgloss.Style // ungrouped fallback; the whole goto popup uses it
+	desc  lipgloss.Style // ungrouped fallback. The whole goto popup uses it
 	group map[whichKeyGroup]lipgloss.Style
 }
 
@@ -391,7 +391,7 @@ type whichKeyPanelLayout struct {
 	container  int
 	bodyRows   int // rows the content needs
 	viewRows   int // rows the panel shows
-	maxScroll  int // largest row offset; 0 when everything fits
+	maxScroll  int // largest row offset. 0 when everything fits
 	legendRows int // 1 when the group-color legend renders below the entries, else 0
 }
 
@@ -519,7 +519,7 @@ func (m Model) renderWhichKey(background string) string {
 // panel spanning the full width, styled after neovim's which-key: one flat
 // list, no section headers, flowing column-major through a uniform grid. The
 // panel grows to fit its content up to whichKeyMaxRows and whatever the
-// terminal allows; anything past that scrolls (scroll is a row offset, clamped
+// terminal allows. Anything past that scrolls (scroll is a row offset, clamped
 // here). Returns background unchanged when there is nothing to show or the
 // terminal is too small.
 func (m Model) renderWhichKeyPanel(background string, cells []whichKeyCell, scroll int) string {

--- a/internal/app/whichkey_sort.go
+++ b/internal/app/whichkey_sort.go
@@ -24,7 +24,7 @@ const wkNaturalDigits = 9
 //  0. group    — declared catalog group (whichKeyGroupOrder), ungrouped last
 //  1. modTier  — no modifier, then ctrl, then alt, then ctrl+alt, then any
 //     other modifier combination (see wkModTier below)
-//  2. order    — explicit per-entry override (whichKeyAction.Order); entries
+//  2. order    — explicit per-entry override (whichKeyAction.Order). Entries
 //     that don't set one fall through unchanged
 //  3. shape    — single-character alphanumerics, then single-character
 //     punctuation, then multi-character named keys (see wkKeyShapeRank)
@@ -139,7 +139,7 @@ func wkGroupRank(ranks map[whichKeyGroup]int, g whichKeyGroup) int {
 //
 // The shape is read from the key UNDER the modifiers, so the rule holds inside
 // every tier — "ctrl+space" trails "ctrl+z" exactly as "space" trails "z".
-// ui.IsNamedKey is the same table ui.IsSingleKeypress consults; the panel must
+// ui.IsNamedKey is the same table ui.IsSingleKeypress consults. The panel must
 // not grow a second opinion on what a key name is.
 //
 // Rank 3 covers what is not a keypress shape at all: a binding

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -31,7 +31,7 @@ func NewCompletionCommand(rootCmd *cobra.Command) *cobra.Command {
 		Short: "Generate shell completion script",
 		Long: `Generate a shell completion script for lfk.
 
-		For zsh:
+For zsh:
   source <(lfk completion zsh)`,
 		Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		ValidArgs: []string{
@@ -62,7 +62,7 @@ func NewCompletionCommand(rootCmd *cobra.Command) *cobra.Command {
 func completeUnionContextFlag(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	kubeconfig, _ := cmd.Flags().GetString("kubeconfig")
 	kubeconfigDirs, _ := cmd.Flags().GetStringArray("kubeconfig-dir")
-	// Completion runs without the config file; resolve exclusivity from
+	// Completion runs without the config file. Resolve exclusivity from
 	// the flag and env only, defaulting to exclusive like the app.
 	exclusiveFlag, _ := cmd.Flags().GetBool("kubeconfig-exclusive")
 	kubeconfigExclusive := k8s.ResolveKubeconfigExclusive(

--- a/internal/democli/args.go
+++ b/internal/democli/args.go
@@ -75,8 +75,8 @@ func parseLogArgs(args []string) logArgs {
 	return a
 }
 
-// podName derives a stable, readable pod identity from the parsed target:
-// a literal pod name is used as-is, a "kind/name" resource ref contributes
+// podName derives a stable, readable pod identity from the parsed target.
+// A literal pod name is used as-is, a "kind/name" resource ref contributes
 // its name, and a label selector ("app=web,tier=x") contributes the first
 // label's value. Different targets deterministically produce different
 // identities, which is what seeds a different (but reproducible) log stream

--- a/internal/democli/democli.go
+++ b/internal/democli/democli.go
@@ -1,7 +1,7 @@
 // Package democli implements the hidden "__demo-kubectl" subcommand that
 // --demo mode re-enters instead of a real kubectl binary (see
 // k8s.KubectlPath). Every existing kubectl call site in the app keeps
-// running unmodified; only the resolved binary path changes, so this
+// running unmodified. Only the resolved binary path changes, so this
 // package must accept the same argument shapes the app already passes.
 package democli
 
@@ -13,9 +13,9 @@ import (
 
 // Run dispatches args (the kubectl-style argv, verb first) to the matching
 // verb handler. Verbs the app never needs to serve in demo mode (exec,
-// port-forward, drain, debug, apply, and anything else unimplemented) print
-// a single clear refusal line and return a non-nil error so the caller exits
-// non-zero — never falling through to a real binary.
+// port-forward, drain, debug, apply, and anything else unimplemented)
+// print a single clear refusal line. They return a non-nil error so the
+// caller exits non-zero — never falling through to a real binary.
 func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "__demo-kubectl: no kubectl verb given") //nolint:errcheck

--- a/internal/democli/describe.go
+++ b/internal/democli/describe.go
@@ -44,9 +44,9 @@ func runDescribe(args []string, stdout io.Writer) error {
 }
 
 // renderDescribe builds a plain-text kubectl-describe-shaped body for the
-// known demo pods, falling back to a minimal generic body for anything else
-// (namespace/context are still echoed so the caller sees the object it
-// asked about, rather than an error).
+// known demo pods, falling back to a minimal generic body for anything
+// else. Namespace/context are still echoed, so the caller sees the
+// object it asked about, rather than an error.
 func renderDescribe(kind, name, namespace, kctx string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Name:         %s\n", name)

--- a/internal/democli/get.go
+++ b/internal/democli/get.go
@@ -29,13 +29,13 @@ func runGet(args []string, stdout io.Writer) error {
 }
 
 // parseGetArgs collects every positional argument (in order) and the "-l"
-// selector value, if any, skipping the values of flags this stub never
+// selector value, if any. It skips the values of flags this stub never
 // inspects otherwise (-n, --context, -o).
 func parseGetArgs(args []string) (positional []string, selector string, hasSelector bool) {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "-n", "--context", "-o":
-			i++ // skip the flag's value; unused by this stub
+			i++ // skip the flag's value, unused by this stub
 		case "-l":
 			i++
 			if i < len(args) {

--- a/internal/democli/logs.go
+++ b/internal/democli/logs.go
@@ -69,7 +69,7 @@ func runLogs(ctx context.Context, args []string, stdout io.Writer) error {
 			return nil
 		case t := <-ticker.C:
 			if err := writeLogLine(w, rng, a, pod, t); err != nil {
-				return nil // consumer closed the read end; not an error to report
+				return nil // consumer closed the read end. Not an error to report
 			}
 			if err := w.Flush(); err != nil {
 				return nil

--- a/internal/democli/logs.go
+++ b/internal/democli/logs.go
@@ -31,9 +31,9 @@ var demoMethods = []string{"GET", "GET", "GET", "POST", "PUT", "DELETE"}
 
 // runLogs emulates `kubectl logs`. Non-follow requests emit `tail` (or
 // defaultTailLines) historical lines and return. Follow requests replay the
-// same backlog, then keep emitting new lines on demoLineInterval until ctx is
-// cancelled — mirroring a real `-f` stream that only ends when the caller
-// tears down the process.
+// same backlog, then keep emitting new lines on demoLineInterval until ctx
+// is cancelled. That mirrors a real `-f` stream that only ends when the
+// caller tears down the process.
 func runLogs(ctx context.Context, args []string, stdout io.Writer) error {
 	a := parseLogArgs(args)
 	pod := a.podName()
@@ -83,7 +83,7 @@ func runLogs(ctx context.Context, args []string, stdout io.Writer) error {
 //
 // pod is attacker-controllable: the demo apply path builds it from
 // metadata.name in arbitrary user-supplied YAML with no RFC1123 validation
-// (see Client.ApplyManifest), so it can carry terminal escape sequences.
+// (see Client.ApplyManifest). So it can carry terminal escape sequences.
 // Sanitized here (not just at the write side) as defense in depth, the same
 // way listsummary and yamlblame guard their own sinks against
 // cluster-controlled strings.

--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -39,7 +39,7 @@ type CaptureRequest struct {
 	Context   string
 	Namespace string
 	PodName   string
-	Container string // optional; passed as --target to kubectl debug
+	Container string // optional. Passed as --target to kubectl debug
 	Interface string // default "any"
 	SnapLen   int    // default 65535
 	BPFFilter string // optional
@@ -72,7 +72,7 @@ type CaptureManager struct {
 	onUpdate func()
 
 	// backendFactory builds backend implementations. Defaults to
-	// defaultBackendFactory; tests inject fakes via SetBackendFactory.
+	// defaultBackendFactory. Tests inject fakes via SetBackendFactory.
 	backendFactory func(CaptureBackend) (captureBackend, error)
 }
 
@@ -165,7 +165,7 @@ func defaultBackendFactory(b CaptureBackend) (captureBackend, error) {
 	}
 }
 
-// Start spawns a streaming capture; not used for kubeshark hand-off.
+// Start spawns a streaming capture. Not used for kubeshark hand-off.
 func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket func(PacketSummary)) (int, error) {
 	if req.Backend == BackendKubeshark {
 		return 0, fmt.Errorf("kubeshark hand-off does not use CaptureManager")
@@ -306,7 +306,7 @@ func classifyCaptureExit(backend CaptureBackend, runErr, waitErr error, stderrTx
 		return CaptureStopped, ""
 	}
 
-	// Translate stderr first; if a backend-specific message matches, prefer
+	// Translate stderr first. If a backend-specific message matches, prefer
 	// it over the raw exit-code text.
 	friendly := ""
 	if backend == BackendKubectlDebug && stderrTxt != "" {
@@ -371,7 +371,7 @@ func (m *CaptureManager) Stop(id int) error {
 	return fmt.Errorf("capture id %d not found", id)
 }
 
-// StopAll cancels every entry; used on lfk shutdown.
+// StopAll cancels every entry. Used on lfk shutdown.
 func (m *CaptureManager) StopAll() {
 	m.mu.Lock()
 	for _, e := range m.entries {

--- a/internal/k8s/capture_backend_kubectl_debug.go
+++ b/internal/k8s/capture_backend_kubectl_debug.go
@@ -18,7 +18,7 @@ import (
 
 // netshootImage is the pinned image used for the ephemeral debug container.
 //
-// Pinned by tag rather than digest to keep the build self-contained; for
+// Pinned by tag rather than digest to keep the build self-contained. For
 // hardened deployments swap to a digest pin (e.g.
 // "nicolaka/netshoot@sha256:...") so registry tampering is detected.
 // Bumping this image needs a security review — the container runs with
@@ -29,7 +29,7 @@ type kubectlDebugBackend struct{}
 
 // debugContainerCounter feeds the suffix on the per-capture debug-container
 // name (lfk-trafcap-<n>). Atomic so concurrent Start calls don't collide on
-// the same name within a single process lifetime; combined with the
+// the same name within a single process lifetime. Combined with the
 // nanosecond timestamp prefix, collisions across lfk runs are also bounded.
 var debugContainerCounter atomic.Uint64
 
@@ -156,7 +156,7 @@ func terminateRemoteCapture(req CaptureRequest, kubectlPath, debugContainer stri
 //
 // Notes:
 //   - `--attach=true` is REQUIRED. kubectl debug's `--attach` defaults to
-//     false unless `-i`/`--stdin` is set; without it, kubectl creates the
+//     false unless `-i`/`--stdin` is set. Without it, kubectl creates the
 //     ephemeral container and exits cleanly, leaving our pcap reader
 //     observing an immediate EOF on kubectl's stdout. We don't want `-i`
 //     because it keeps stdin open on the container — irrelevant for tcpdump
@@ -169,7 +169,7 @@ func terminateRemoteCapture(req CaptureRequest, kubectlPath, debugContainer stri
 //     from.
 //   - `--profile=netadmin` is required for tcpdump to open AF_PACKET. This
 //     was added to kubectl in 1.30. Older versions surface "unknown flag:
-//     --profile" via stderr; translateKubectlDebugErr maps that to a
+//     --profile" via stderr. TranslateKubectlDebugErr maps that to a
 //     friendly message.
 //   - tcpdump runs inside `sh -c "sleep 1; exec timeout 30m tcpdump ..."`.
 //     The leading sleep is REQUIRED to defeat kubectl-debug's attach race:
@@ -205,7 +205,7 @@ func kubectlDebugArgv(req CaptureRequest, debugContainer string) []string {
 
 // kubectlDebugAttachDelay is the inline `sleep` value (in seconds) that runs
 // in the ephemeral container before tcpdump starts. See the kubectlDebugArgv
-// notes for why this is required. 1 second is enough for local clusters; if
+// notes for why this is required. 1 second is enough for local clusters. If
 // users on slow remote clusters report missing-header failures, bumping this
 // is the dial.
 const kubectlDebugAttachDelay = 1
@@ -284,7 +284,7 @@ type pcapPreambleSkipper struct {
 	rc       io.ReadCloser
 	found    bool
 	overflow []byte // bytes already read past the magic, waiting to flush
-	window   []byte // accumulated bytes waiting for a magic match; persists across Read calls
+	window   []byte // accumulated bytes waiting for a magic match. Persists across Read calls
 	// dumpPath, if non-empty, receives the buffered window when the preamble
 	// overflows without a pcap magic. Lets the user hexdump kubectl's actual
 	// stdout (which the in-overlay error message necessarily truncates).
@@ -359,8 +359,7 @@ func findPcapMagic(buf []byte) int {
 }
 
 // summarizePreamble returns the first ~120 bytes of `buf` for use in error
-// messages, with non-printable characters escaped. encoding/binary import
-// kept for future structured magic detection.
+// messages, with non-printable characters escaped.
 func summarizePreamble(buf []byte) string {
 	const cap = 120
 	if len(buf) > cap {

--- a/internal/k8s/capture_backend_kubectl_debug.go
+++ b/internal/k8s/capture_backend_kubectl_debug.go
@@ -169,7 +169,7 @@ func terminateRemoteCapture(req CaptureRequest, kubectlPath, debugContainer stri
 //     from.
 //   - `--profile=netadmin` is required for tcpdump to open AF_PACKET. This
 //     was added to kubectl in 1.30. Older versions surface "unknown flag:
-//     --profile" via stderr. TranslateKubectlDebugErr maps that to a
+//     --profile" via stderr, and translateKubectlDebugErr maps that to a
 //     friendly message.
 //   - tcpdump runs inside `sh -c "sleep 1; exec timeout 30m tcpdump ..."`.
 //     The leading sleep is REQUIRED to defeat kubectl-debug's attach race:

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -40,7 +40,7 @@ const applyFieldManager = "lfk"
 // — issue #23.
 type contextInfo struct {
 	// display is the unique name shown in the lfk UI. Equal to original
-	// when no other file defines a context with the same name; otherwise of
+	// when no other file defines a context with the same name. Otherwise of
 	// the form "original (basename)".
 	display string
 	// original is the context name as written in the source kubeconfig
@@ -93,7 +93,7 @@ type Client struct {
 	injectedMetaClient any // metadata.Interface
 
 	// demo is true when this Client was built by NewDemoClient (--demo flag).
-	// It never talks to a real cluster; IsDemo lets the app layer surface a
+	// It never talks to a real cluster. IsDemo lets the app layer surface a
 	// badge instead of inspecting the injected fields directly.
 	demo bool
 
@@ -113,7 +113,7 @@ type Client struct {
 	// testHostByDisplay, when set, lets tests bypass kubeconfig host
 	// resolution in HostForContext. Most fake test clients are constructed
 	// without Cluster definitions (no server URL), so a real
-	// restConfigForContext call would fail; this map provides synthetic
+	// restConfigForContext call would fail. This map provides synthetic
 	// answers keyed by display name.
 	testHostByDisplay map[string]string
 
@@ -125,10 +125,10 @@ type Client struct {
 	// secretLazyLoading, when true, routes Secret listing through the
 	// metadata-only API so decoded values are lazy-fetched on hover instead
 	// of being pulled up-front. Configured via the secret_lazy_loading
-	// option; off by default so the list behaves like every other resource.
+	// option. Off by default so the list behaves like every other resource.
 	// Accessed concurrently from tea.Cmd goroutines (GetResources et al)
 	// while the startup setter (and any future runtime-reload path) writes
-	// it; an atomic load/store keeps the access race-free without a lock.
+	// it. An atomic load/store keeps the access race-free without a lock.
 	secretLazyLoading atomic.Bool
 
 	// kubesharkNamespaceOverride is the namespace probed for the kubeshark
@@ -139,7 +139,7 @@ type Client struct {
 	// concurrency rationale as secretLazyLoading above.
 	kubesharkNamespaceOverride atomic.Pointer[string]
 
-	// Guarded by discoveryMu; concurrent tea.Cmd goroutines may discover
+	// Guarded by discoveryMu. Concurrent tea.Cmd goroutines may discover
 	// across different contexts.
 	discoveryMu      sync.Mutex
 	discoveryClients map[string]*disk.CachedDiscoveryClient
@@ -164,23 +164,23 @@ type Client struct {
 	clientCache map[string]*ctxClients
 	// clientGroup coalesces concurrent builds for the same cache key+kind so a
 	// burst of cold-cache callers runs ONE construction, not N. clientCacheGen
-	// is bumped (under clientMu) on every cache invalidation; a build that
+	// is bumped (under clientMu) on every cache invalidation. A build that
 	// races an invalidate compares the generation it captured before building
 	// and skips caching its now-stale result, so an invalidated client is
 	// never served as a cache hit. (The old lock-across-build made invalidate
-	// and build mutually exclusive; building outside the lock reintroduces the
+	// and build mutually exclusive. Building outside the lock reintroduces the
 	// race that the generation guard closes.)
 	clientGroup    singleflight.Group
 	clientCacheGen uint64
 
 	// informerMu guards informerMode + informers. Writes happen at most
-	// once (SetInformerCacheMode at startup); reads happen on every
+	// once (SetInformerCacheMode at startup). Reads happen on every
 	// GetResources. RWMutex is overkill for the call rate but documents
 	// the intent — and a future runtime config-reload path can flip the
 	// mode safely without retrofitting synchronization across callers.
 	informerMu sync.RWMutex
 	// informerMode selects the routing strategy for GetResources. See
-	// InformerCacheMode for the three values; default (zero value "") is
+	// InformerCacheMode for the three values. Default (zero value "") is
 	// treated as InformerCacheAuto so users get the issue #86 win without
 	// any config change. Read via informerSnapshot.
 	informerMode InformerCacheMode
@@ -211,7 +211,7 @@ type Client struct {
 	ignoreChecker IgnoreChecker
 	// showIgnored, when true, includes ignored findings in the output
 	// (rendered with an "ignored" indicator) instead of hiding them. Off
-	// by default; toggled via the security ignore-list overlay. Read via
+	// by default. Toggled via the security ignore-list overlay. Read via
 	// securityIgnoreSnapshot.
 	showIgnored bool
 }
@@ -339,7 +339,7 @@ func (c *Client) Shutdown() {
 // creates or updates each object through the dynamic client — no kubectl
 // subprocess. Demo mode's fake dynamic client lives only in this process,
 // so a subprocess kubectl would write into a separate in-memory tracker the
-// UI never reads from; this is the apply path demo mode must use to
+// UI never reads from. This is the apply path demo mode must use to
 // actually change what the UI shows. defaultNamespace fills in any object
 // that leaves metadata.namespace unset, matching kubectl apply -n.
 func (c *Client) ApplyManifest(ctx context.Context, contextName, defaultNamespace, manifest string) error {
@@ -435,7 +435,7 @@ func (c *Client) ApplyManifest(ctx context.Context, contextName, defaultNamespac
 //     default), it is exclusive (kubectl/k9s semantics): step 2 and the
 //     default of step 3 are skipped.
 //  2. ~/.kube/config (skipped under an exclusive KUBECONFIG).
-//  3. All files in each kubeconfigDirs entry (recursively; symlinks to directories are followed).
+//  3. All files in each kubeconfigDirs entry (recursively, symlinks to directories are followed).
 //     Defaults to [~/.kube/config.d/] when the slice is empty and no exclusive KUBECONFIG applies.
 //
 // kubeconfigOverride (--kubeconfig) beats everything: when non-empty it is
@@ -616,7 +616,7 @@ func (c *Client) GetNamespaces(ctx context.Context, contextName string) ([]model
 
 // GetResourcesUnion fetches resources from multiple contexts in parallel and
 // merges the results. Each item is stamped with ClusterName for drill-down
-// routing; the UI renders that field as the first-class CONTEXT column.
+// routing. The UI renders that field as the first-class CONTEXT column.
 // Partial results are returned alongside an errors.Join of every per-context
 // failure, so the status bar can surface "2 of 8 contexts failed: …" instead
 // of silently truncating to the first error.

--- a/internal/k8s/client_cache.go
+++ b/internal/k8s/client_cache.go
@@ -103,7 +103,7 @@ func (c *Client) buildMetadata(contextName string, cfg *rest.Config) (metadata.I
 // for the same (key, kind) are coalesced by clientGroup so a cold-cache burst
 // runs one construction, not N.
 //
-// get/set read and write the kind-specific ctxClients field; build performs the
+// get/set read and write the kind-specific ctxClients field. Build performs the
 // actual construction. kind disambiguates the singleflight key so a clientset
 // and a dynamic build for the same cache key never collapse into each other.
 func buildCachedClient[T comparable](
@@ -128,7 +128,7 @@ func buildCachedClient[T comparable](
 	gen := c.clientCacheGen
 	c.clientMu.Unlock()
 
-	// The singleflight key includes BOTH kind and gen; clientCache itself stays
+	// The singleflight key includes BOTH kind and gen. clientCache itself stays
 	// keyed by key alone (one ctxClients per context, get/set select the field):
 	//   - kind: a clientset and a dynamic build for the same context must be
 	//     independent flights, or one caller gets the wrong type.
@@ -208,7 +208,7 @@ func (c *Client) cachedDynamic(contextName string, throttled bool, restConfig fu
 }
 
 // cachedMetadata returns the memoized metadata-only client for contextName
-// (foreground rate only; no throttled metadata variant is used).
+// (foreground rate only, no throttled metadata variant is used).
 func (c *Client) cachedMetadata(contextName string, restConfig func() (*rest.Config, error)) (metadata.Interface, error) {
 	return buildCachedClient(c, clientCacheKey(contextName, false), "metadata",
 		func(e *ctxClients) metadata.Interface { return e.metadata },

--- a/internal/k8s/client_kubeconfig.go
+++ b/internal/k8s/client_kubeconfig.go
@@ -93,7 +93,7 @@ func (c *Client) HostForContext(displayName string) string {
 // preserved by suffixing the display name with the source file's basename
 // (e.g. "dev (dev-envs)" / "dev (itg-k8s)"). This is essential for issue #23:
 // clientcmd merges duplicates into one entry, hiding every file but the
-// first; surfacing each as its own UI entry lets the user actually drill into
+// first. Surfacing each as its own UI entry lets the user actually drill into
 // the cluster they want.
 //
 // fallbackCurrent is the current-context that clientcmd's merged config
@@ -248,7 +248,7 @@ func buildKubeconfigPaths(kubeconfigDirs []string, exclusive bool) []string {
 	var paths []string
 
 	// KUBECONFIG env var (colon-separated on unix). Empty entries (a stray
-	// "KUBECONFIG=:" or a trailing colon) are dropped; when nothing
+	// "KUBECONFIG=:" or a trailing colon) are dropped. When nothing
 	// non-empty remains the variable counts as unset, so the default
 	// discovery still applies instead of silently loading zero clusters.
 	envPaths := trimNonEmpty(filepath.SplitList(os.Getenv("KUBECONFIG")))
@@ -363,9 +363,9 @@ func expandTilde(path, home string) string {
 // ResolveKubeconfigDirs picks the user's kubeconfig discovery directories by
 // applying the documented precedence: CLI flags > env var > config file.
 // Replacement semantics — the first layer that yields any non-empty entry
-// wins outright; lower-priority layers are NOT merged in.
+// wins outright. Lower-priority layers are NOT merged in.
 //
-// Each entry is trimmed of surrounding whitespace; whitespace-only entries
+// Each entry is trimmed of surrounding whitespace. Whitespace-only entries
 // are dropped so they do not silently shadow a lower-priority layer that
 // has real paths. The env var is split on the OS path-list separator
 // (":" on unix, ";" on Windows), matching how KUBECONFIG itself is parsed.
@@ -417,7 +417,7 @@ func ValidateKubeconfigDirs(paths []string) error {
 // a wrapped error otherwise. Empty path is treated as "no override" and
 // passes silently — the caller falls back to default discovery. Tilde
 // prefixes ("~", "~/...") are expanded against the user's home directory
-// before stat; an unresolvable home is itself a validation error so a typo
+// before stat. An unresolvable home is itself a validation error so a typo
 // like "~/.kuibe/config.d" doesn't silently degrade to "no directory
 // override applied".
 func ValidateKubeconfigDir(path string) error {
@@ -443,7 +443,7 @@ func ValidateKubeconfigDir(path string) error {
 }
 
 // resolveKubeconfigPaths returns the kubeconfig file list for NewClient:
-// an explicit --kubeconfig override wins outright; otherwise discovery
+// an explicit --kubeconfig override wins outright. Otherwise discovery
 // runs via buildKubeconfigPaths.
 func resolveKubeconfigPaths(override string, kubeconfigDirs []string, exclusive bool) []string {
 	if override != "" {

--- a/internal/k8s/client_operations.go
+++ b/internal/k8s/client_operations.go
@@ -91,7 +91,7 @@ func marshalResourceYAML(obj map[string]any) (string, error) {
 
 // GetPodYAML returns the YAML for a pod.
 func (c *Client) GetPodYAML(ctx context.Context, contextName, namespace, podName string) (string, error) {
-	// Pods are namespaced; without Namespaced: true, GetResourceYAML
+	// Pods are namespaced. Without Namespaced: true, GetResourceYAML
 	// falls through to the cluster-scoped branch (dynClient.Resource(gvr)
 	// with no .Namespace(...)), which hits /api/v1/pods/<name> — an
 	// endpoint that does not exist on the API server. The API replies
@@ -156,7 +156,7 @@ func (c *Client) DeleteResource(contextName, namespace string, rt model.Resource
 
 // ToggleNodeSchedulable flips a node's spec.unschedulable and returns the new
 // value: true when the node is now cordoned, false when it is uncordoned.
-// Equivalent to `kubectl cordon`/`uncordon` (which patch the same field); the
+// Equivalent to `kubectl cordon`/`uncordon` (which patch the same field). The
 // live object is read first so the toggle stays authoritative.
 func (c *Client) ToggleNodeSchedulable(ctx context.Context, contextName, nodeName string) (bool, error) {
 	cs, err := c.clientsetForContext(contextName)
@@ -435,7 +435,7 @@ func (c *Client) restConfigForContext(displayName string) (*rest.Config, error) 
 	// displayName is the lfk-side identifier (potentially disambiguated to
 	// "name (basename)"). The override below uses the *original* name from
 	// the source kubeconfig because that's what's recorded inside the file.
-	// Snapshot the kubeconfig-derived state under RLock; ReloadKubeconfig swaps
+	// Snapshot the kubeconfig-derived state under RLock. ReloadKubeconfig swaps
 	// c.contexts concurrently. Release before clientcmd I/O below — never hold
 	// configMu across the rest-config build.
 	c.configMu.RLock()

--- a/internal/k8s/client_populate_helpers.go
+++ b/internal/k8s/client_populate_helpers.go
@@ -97,7 +97,7 @@ func populateMetadataFields(ti *model.Item, obj map[string]any) {
 
 // appendAllConditions stores every well-formed condition on ti.Conditions for
 // the details pane's CONDITIONS section. It is the single source of that
-// section across all resource kinds; the column extractors below only produce
+// section across all resource kinds. The column extractors below only produce
 // the compact at-a-glance summary in ti.Columns.
 func appendAllConditions(ti *model.Item, conditions []any) {
 	for _, c := range conditions {
@@ -123,7 +123,7 @@ func appendAllConditions(ti *model.Item, conditions []any) {
 }
 
 // extractGenericConditions adds a compact, single-condition summary to
-// ti.Columns for generic CRD resources. It prefers the "Ready" condition; if
+// ti.Columns for generic CRD resources. It prefers the "Ready" condition. If
 // not found, it falls back to the last condition in the array. The full
 // per-condition detail is populated separately via appendAllConditions.
 func extractGenericConditions(ti *model.Item, conditions []any) {

--- a/internal/k8s/client_rbac.go
+++ b/internal/k8s/client_rbac.go
@@ -65,7 +65,7 @@ func (c *Client) GetSelfRules(ctx context.Context, contextName, namespace string
 }
 
 // GetSelfRulesAs returns all access rules for the specified user/ServiceAccount in the given namespace.
-// The asUser parameter should be in the format "system:serviceaccount:<namespace>:<name>" for ServiceAccounts.
+// The asUser parameter must be in the format "system:serviceaccount:<namespace>:<name>" for ServiceAccounts.
 // If asUser is empty, it checks the current user's permissions.
 func (c *Client) GetSelfRulesAs(ctx context.Context, contextName, namespace, asUser string) ([]AccessRule, error) {
 	cfg, err := c.restConfigForContext(contextName)
@@ -166,9 +166,9 @@ func (c *Client) GetSelfRulesMultiNS(ctx context.Context, contextName, asUser st
 		}
 	}
 
-	// Also check ClusterRoleBindings — if the SA is bound at cluster scope, the
-	// SelfSubjectRulesReview in any namespace will already reflect those permissions,
-	// but we note this for completeness. No extra namespaces to add here.
+	// ClusterRoleBindings are not walked: if the SA is bound at cluster scope,
+	// SelfSubjectRulesReview in any namespace already reflects those permissions,
+	// so no extra namespaces need to be added here.
 
 	// Build the sorted, capped namespace list.
 	namespaces := make([]string, 0, len(nsSet))
@@ -273,7 +273,7 @@ func (c *Client) ListRBACSubjects(ctx context.Context, contextName string) ([]RB
 	// Collect subjects from ClusterRoleBindings.
 	crbList, err := clientset.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		// Permission denied is non-fatal; continue with RoleBindings.
+		// Permission denied is non-fatal. Continue with RoleBindings.
 		crbList = &rbacv1.ClusterRoleBindingList{}
 	}
 	for _, crb := range crbList.Items {
@@ -309,7 +309,7 @@ func (c *Client) ListRBACSubjects(ctx context.Context, contextName string) ([]RB
 		subjects = append(subjects, RBACSubject(key))
 	}
 
-	// Sort: Users first, then Groups, then ServiceAccounts; within each kind by name.
+	// Sort: Users first, then Groups, then ServiceAccounts. Within each kind by name.
 	kindOrder := map[string]int{"User": 0, "Group": 1, "ServiceAccount": 2}
 	sort.Slice(subjects, func(i, j int) bool {
 		if kindOrder[subjects[i].Kind] != kindOrder[subjects[j].Kind] {

--- a/internal/k8s/client_resources.go
+++ b/internal/k8s/client_resources.go
@@ -19,7 +19,7 @@ import (
 var secretGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 
 // GetResources lists resources of a given type. For namespaced resources it
-// scopes to the given namespace; for cluster-scoped resources it lists globally.
+// scopes to the given namespace. For cluster-scoped resources it lists globally.
 // When namespace is empty and the resource is namespaced, it lists across all namespaces.
 //
 // Secrets are fetched via the metadata-only API (PartialObjectMetadataList) to
@@ -44,7 +44,7 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	// Secrets optionally use the metadata-only path to avoid transferring
 	// large base64 data payloads (especially Helm release secrets). Gated
 	// behind SetSecretLazyLoading so the default list behaviour stays
-	// consistent with every other resource type; decoded values are then
+	// consistent with every other resource type. Decoded values are then
 	// loaded on hover at LevelResources.
 	if c.secretLazyLoading.Load() && rt.APIGroup == "" && rt.Resource == "secrets" {
 		return c.listSecretsMetadata(ctx, contextName, namespace, rt)
@@ -57,7 +57,7 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	}
 
 	// Issue #86: route through the informer cache when it makes sense.
-	// "always" forces every list through the cache; "auto" promotes a
+	// "always" forces every list through the cache. "auto" promotes a
 	// (context, GVR) on the first large list and demotes it back to direct
 	// once cached size has stayed below the demote threshold for several
 	// calls. Cache miss (sync timeout) falls through to the direct path so
@@ -66,7 +66,7 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	// listItems memoizes per-item by namespace/name + the object's own
 	// resourceVersion: items unchanged since the last call are reused
 	// without re-running buildResourceItem or copying anything. On a
-	// busy cluster only the few churning pods rebuild; the rest hit the
+	// busy cluster only the few churning pods rebuild. The rest hit the
 	// memo. That's what removes the residual ~300ms per-call cost on a
 	// 6k-pod list when the cluster has background churn.
 	mode, infs := c.informerSnapshot()
@@ -125,7 +125,7 @@ func cacheEnabled(mode InformerCacheMode, infs *informerCache) bool {
 
 // shouldUseCache decides — for the current call — whether to take the
 // informer-backed path or fall through to a direct list. Always-mode
-// short-circuits to true; auto-mode consults the per-(context, GVR) state
+// short-circuits to true. Auto-mode consults the per-(context, GVR) state
 // machine maintained by observeDirectListSize / observeCachedListSize.
 func shouldUseCache(mode InformerCacheMode, infs *informerCache, contextName string, gvr schema.GroupVersionResource) bool {
 	if mode == InformerCacheAlways {
@@ -140,7 +140,7 @@ func shouldUseCache(mode InformerCacheMode, infs *informerCache, contextName str
 // sortResourceItems applies the canonical row order GetResources uses
 // regardless of whether the items came from a fresh apiserver LIST or from
 // the informer cache. Events sort by most recent observation (LastSeen, not
-// CreatedAt) so a recurring incident's latest report stays on top; everything
+// CreatedAt) so a recurring incident's latest report stays on top. Everything
 // else sorts alphabetically by Name.
 func sortResourceItems(items []model.Item, kind string) []model.Item {
 	if kind == "Event" {

--- a/internal/k8s/client_rightsizing.go
+++ b/internal/k8s/client_rightsizing.go
@@ -81,7 +81,7 @@ func hasPrometheusConfigured(contextName string) bool {
 // GetRightsizing builds a per-container recommendation payload for
 // the given workload using the requested strategy + headroom factor.
 // Empty strategy defaults to StrategySnapshot for backward
-// compatibility; headroom == 0 defaults to
+// compatibility. Headroom == 0 defaults to
 // model.DefaultRightsizingHeadroom so callers that haven't migrated
 // to the new signature still get a sane recommendation.
 //
@@ -282,7 +282,7 @@ func (c *Client) applySnapshotStrategy(ctx context.Context, contextName, namespa
 
 // podSpecContainers returns the container list from the workload's
 // pod spec template. CronJob is two levels deep (.spec.jobTemplate
-// .spec.template.spec.containers); Pod has it directly on .spec.
+// .spec.template.spec.containers). Pod has it directly on .spec.
 //
 // Init containers are intentionally excluded — their resource needs
 // are different from steady-state recommendations (out of v1 scope).
@@ -532,7 +532,7 @@ func scaleQuantityByHeadroom(q string, headroom float64) string {
 		return q
 	}
 	if isMemoryQuantity(q) {
-		// MilliValue() for memory returns bytes×1000; convert back to
+		// MilliValue() for memory returns bytes×1000. Convert back to
 		// bytes before scaling so SnapMemBytesToCanonical sees the right
 		// unit.
 		bytes := parsed.MilliValue() / 1000
@@ -544,7 +544,7 @@ func scaleQuantityByHeadroom(q string, headroom float64) string {
 // scaleLimitFromRatio returns the recommended limit that preserves
 // the spec's request:limit ratio. Empty string when any input is
 // empty/zero or unparseable — callers treat that as "don't recommend
-// a limit; user didn't have one."
+// a limit. User didn't have one."
 func scaleLimitFromRatio(currentRequest, currentLimit, recommendedRequest string) string {
 	if currentRequest == "" || currentLimit == "" || recommendedRequest == "" {
 		return ""
@@ -564,7 +564,7 @@ func scaleLimitFromRatio(currentRequest, currentLimit, recommendedRequest string
 	ratio := float64(cl.MilliValue()) / float64(cr.MilliValue())
 	scaled := int64(float64(rr.MilliValue()) * ratio)
 	if isMemoryQuantity(currentRequest) {
-		// MilliValue for memory returns bytes×1000; convert back to bytes for the snap.
+		// MilliValue for memory returns bytes×1000. Convert back to bytes for the snap.
 		return SnapMemBytesToCanonical(scaled / 1000)
 	}
 	return SnapCPUMilliToCanonical(scaled)
@@ -588,7 +588,7 @@ func isMemoryQuantity(s string) bool {
 // snapping logic from internal/ui/quantity_math.go. The k8s package
 // can't import internal/ui (would invert the architecture's data ->
 // presentation direction), so the helpers live in both places. Keep
-// in sync; they're only ~15 lines each.
+// in sync. They're only ~15 lines each.
 func SnapCPUMilliToCanonical(milli int64) string {
 	if milli <= 0 {
 		return "0"

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -41,7 +41,7 @@ func (c *Client) applyPrometheusStrategy(ctx context.Context, contextName, names
 
 	for i := range out.Containers {
 		cr := &out.Containers[i]
-		// CPU value is in cores; convert to millicores.
+		// CPU value is in cores. Convert to millicores.
 		if cores, ok := cpuResult[cr.Name]; ok && cores > 0 {
 			milli := int64(cores * 1000.0 * headroom)
 			rec := SnapCPUMilliToCanonical(milli)
@@ -76,7 +76,7 @@ func promStrategyWindow(s model.RightsizingStrategy) string {
 // pods named in `pods` (escaped into a regex alternation).
 //
 // CPU uses container_cpu_usage_seconds_total wrapped in rate(...) over
-// a 5-minute window so the inner sample is cores/sec; the outer
+// a 5-minute window so the inner sample is cores/sec. The outer
 // aggregation (max_over_time / avg_over_time / quantile_over_time)
 // folds those samples across the strategy's window.
 //
@@ -140,7 +140,7 @@ func podsRegex(pods []string) string {
 
 // queryPromContainerMetric runs an instant PromQL query and returns a
 // map of container name -> raw float value. Tests inject the request
-// pipeline via Client.testPromQuery; production builds the proxy URL
+// pipeline via Client.testPromQuery. Production builds the proxy URL
 // from the configured Prometheus endpoint and calls Service.ProxyGet.
 func (c *Client) queryPromContainerMetric(ctx context.Context, contextName, query string) (map[string]float64, error) {
 	body, err := c.runPrometheusQuery(ctx, contextName, query)
@@ -208,7 +208,7 @@ func (c *Client) runPrometheusQuery(ctx context.Context, contextName, query stri
 
 // parsePrometheusContainerResponse extracts the per-container value
 // vector from a PromQL instant query response. The "container" label
-// keys the result map; empty container labels are skipped (the cgroup
+// keys the result map. Empty container labels are skipped (the cgroup
 // "POD" pause container is filtered out by the query, but defensive
 // code here keeps a malformed metric from polluting the map).
 func parsePrometheusContainerResponse(data []byte) (map[string]float64, error) {

--- a/internal/k8s/client_rightsizing_rescale.go
+++ b/internal/k8s/client_rightsizing_rescale.go
@@ -17,7 +17,7 @@ import (
 // (</>) uses this so flipping headroom doesn't kick a re-fetch and
 // the table never flashes through "Computing right-sizing…".
 //
-// Backward compat: returns nil when data == nil; returns the input
+// Backward compat: returns nil when data == nil. Returns the input
 // pointer unchanged when data.Headroom == 0 (legacy / not set) —
 // better to do nothing than mis-scale by an unknown ratio. Mutation
 // safety: when scaling does happen, a NEW *model.Rightsizing is
@@ -101,7 +101,7 @@ func scaleQuantityByRatio(q string, ratio float64, isMemory bool) string {
 		return q
 	}
 	if isMemory {
-		// MilliValue() for memory returns bytes×1000; convert back to
+		// MilliValue() for memory returns bytes×1000. Convert back to
 		// bytes before scaling so SnapMemBytesToCanonical sees the right
 		// unit.
 		bytes := parsed.MilliValue() / 1000

--- a/internal/k8s/crash_investigator.go
+++ b/internal/k8s/crash_investigator.go
@@ -22,8 +22,8 @@ import (
 // events, and a (possibly trimmed) describe blob.
 type CrashInvestigation struct {
 	Pod            PodSummary
-	InitContainers []ContainerCrash // declaration order; init containers
-	AppContainers  []ContainerCrash // declaration order; app containers
+	InitContainers []ContainerCrash // declaration order. Init containers
+	AppContainers  []ContainerCrash // declaration order. App containers
 	Events         []corev1.Event   // sorted by LastTimestamp desc
 	Describe       string
 	DescribeError  string
@@ -88,7 +88,7 @@ const crashLogStreamConcurrency = 8
 // + log info, pod-scoped events, and a kubectl describe blob. Events are
 // scoped to the current pod incarnation by UID so a recreated pod with the
 // same name does not surface old-incarnation events. Per-stream log errors
-// and a describe-fetch error do NOT fail the whole call; only a Pod Get
+// and a describe-fetch error do NOT fail the whole call. Only a Pod Get
 // failure does.
 func (c *Client) GetCrashInvestigation(ctx context.Context, contextName, namespace, podName string) (*CrashInvestigation, error) {
 	clientset, err := c.clientsetForContext(contextName)
@@ -157,7 +157,7 @@ func buildPodSummary(pod *corev1.Pod) PodSummary {
 }
 
 // buildContainerCrashes returns init + app ContainerCrash slices in the
-// pod's declaration order. Statuses are matched by name; spec containers
+// pod's declaration order. Statuses are matched by name. Spec containers
 // without a matching status get a zero-value entry (e.g. pods scheduled
 // but the kubelet hasn't reported yet).
 func buildContainerCrashes(pod *corev1.Pod) (initCC, appCC []ContainerCrash) {
@@ -234,7 +234,7 @@ func buildContainerCrash(spec corev1.Container, status *corev1.ContainerStatus, 
 // missing events are less harmful than denying the user the rest of the
 // diagnostic snapshot.
 //
-// FieldSelector is a server-side optimization; we still re-filter on the
+// FieldSelector is a server-side optimization. We still re-filter on the
 // client because (a) the fake clientset ignores FieldSelector and would
 // otherwise return cross-pod events in tests, and (b) production servers
 // occasionally return extra rows when watch-cached.
@@ -275,7 +275,7 @@ func fetchPodEvents(ctx context.Context, clientset kubernetes.Interface, namespa
 
 // fetchContainerLogs streams the previous + current tails for every container
 // in containers, in parallel. Per-stream errors are stored on the matching
-// container as LogError; a stream that returns no content but no error
+// container as LogError. A stream that returns no content but no error
 // (e.g. previous logs not available because container has not been
 // terminated yet) leaves both LogError and the corresponding *Log empty.
 func fetchContainerLogs(ctx context.Context, clientset kubernetes.Interface, namespace, podName string, containers []ContainerCrash) []ContainerCrash {

--- a/internal/k8s/demo/convert.go
+++ b/internal/k8s/demo/convert.go
@@ -17,8 +17,8 @@ var demoEpoch = time.Now().UTC()
 
 // mustToUnstructured converts a typed API object into the unstructured form
 // the dynamic fake client serves. It panics on conversion failure, which can
-// only happen here if one of the static builders below is malformed — a
-// programming error the package's own tests catch immediately.
+// only happen here if one of the static builders below is malformed. That is
+// a programming error the package's own tests catch immediately.
 func mustToUnstructured(obj runtime.Object) *unstructured.Unstructured {
 	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {

--- a/internal/k8s/demo/discovery.go
+++ b/internal/k8s/demo/discovery.go
@@ -13,7 +13,7 @@ import (
 // can target, not only the ones seeded with data (see
 // TestListKinds_CoversEveryAdvertisedResource and
 // TestNewDemoClient_DiscoverAPIResources_NoPanic). metrics.k8s.io/v1 is
-// mapped alongside v1beta1 because internal/k8s.metricsGVR tries both; only
+// mapped alongside v1beta1 because internal/k8s.metricsGVR tries both. Only
 // v1beta1 carries seed data since GetPodMetrics/GetNodeMetrics stop at the
 // first route that returns.
 func ListKinds() map[schema.GroupVersionResource]string {

--- a/internal/k8s/demo/discovery.go
+++ b/internal/k8s/demo/discovery.go
@@ -6,10 +6,10 @@ import (
 )
 
 // ListKinds maps every GroupVersionResource any internal/k8s code path can
-// LIST against the dynamic client to its List kind — the shape
+// LIST against the dynamic client to its List kind. That is the shape
 // dynamicfake.NewSimpleDynamicClientWithCustomListKinds needs to serve List
 // calls. An unregistered GVR makes the fake panic on List instead of
-// returning an error, so this map must register every resource a List call
+// returning an error. So this map must register every resource a List call
 // can target, not only the ones seeded with data (see
 // TestListKinds_CoversEveryAdvertisedResource and
 // TestNewDemoClient_DiscoverAPIResources_NoPanic). metrics.k8s.io/v1 is
@@ -42,8 +42,8 @@ func ListKinds() map[schema.GroupVersionResource]string {
 		// apiextensions.k8s.io/v1 CustomResourceDefinitions: fetchCRDPrinterColumns
 		// (internal/k8s/discovery.go) lists this unconditionally as part of
 		// every DiscoverAPIResources call. Zero CRDs are seeded in demo mode,
-		// but the registration must exist regardless or the fake panics
-		// before it gets the chance to return an empty list.
+		// but the registration must exist regardless. Otherwise the fake
+		// panics before it gets the chance to return an empty list.
 		{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
 
 		// networking.k8s.io/v1 NetworkPolicies and their Cilium CRD
@@ -62,9 +62,9 @@ func ListKinds() map[schema.GroupVersionResource]string {
 }
 
 // APIResourceLists is the discovery output installed on the fake clientset's
-// FakeDiscovery.Resources, covering every kind ListKinds serves so
-// DiscoverAPIResources (internal/k8s/discovery.go) populates the sidebar
-// from the demo cluster the same way it would from a real one.
+// FakeDiscovery.Resources, covering every kind ListKinds serves. This lets
+// DiscoverAPIResources (internal/k8s/discovery.go) populate the sidebar from
+// the demo cluster the same way it would from a real one.
 func APIResourceLists() []*metav1.APIResourceList {
 	rw := metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
 	ro := metav1.Verbs{"get", "list"}

--- a/internal/k8s/demo/doc.go
+++ b/internal/k8s/demo/doc.go
@@ -1,11 +1,12 @@
 // Package demo provides seed data for an in-memory fake Kubernetes cluster,
 // used to run lfk against a realistic dataset without a live cluster. It
 // builds a small set of Pods, a Deployment, a ReplicaSet, a Job, a Service, a
-// ConfigMap, Nodes and Events spanning two namespaces, with ownerReferences,
-// managedFields and status fields shaped the way a real API server would
-// populate them.
+// ConfigMap, Nodes and Events spanning two namespaces. These objects carry
+// ownerReferences, managedFields and status fields shaped the way a real API
+// server would populate them.
 //
 // NewClientset and NewDynamicClient hand back fake clients already wired
-// with this data, RBAC reactors that grant every action, and the discovery
-// metadata internal/k8s reads through NewTestClient's injection points.
+// with this data and RBAC reactors that grant every action. They also carry
+// the discovery metadata internal/k8s reads through NewTestClient's
+// injection points.
 package demo

--- a/internal/k8s/demo/fake.go
+++ b/internal/k8s/demo/fake.go
@@ -11,9 +11,9 @@ import (
 )
 
 // NewClientset returns a fake kubernetes.Interface seeded with the demo
-// cluster's typed objects, RBAC reactors that grant every action (see
-// AddRBACReactors), and a discovery client reporting every kind the dynamic
-// client serves (see APIResourceLists).
+// cluster's typed objects and RBAC reactors that grant every action (see
+// AddRBACReactors). It also carries a discovery client reporting every kind
+// the dynamic client serves (see APIResourceLists).
 func NewClientset() *k8sfake.Clientset {
 	cs := k8sfake.NewClientset(typedObjects()...)
 	AddRBACReactors(cs)
@@ -34,10 +34,10 @@ func NewDynamicClient() *dynamicfake.FakeDynamicClient {
 }
 
 // seedMetrics adds the metrics.k8s.io readings directly against their real
-// GVR ({metrics.k8s.io, v1beta1, pods|nodes}). They can't go through the
-// constructor's objects... path: ObjectTracker.Add guesses the resource
-// name from the object's Kind via naive pluralization, and "PodMetrics" /
-// "NodeMetrics" guess to "podmetricses" / "nodemetricses" — not the "pods" /
+// GVR ({metrics.k8s.io, v1beta1, pods|nodes}). They cannot go through the
+// constructor's objects... path. ObjectTracker.Add guesses the resource
+// name from the object's Kind via naive pluralization. "PodMetrics" /
+// "NodeMetrics" guess to "podmetricses" / "nodemetricses", not the "pods" /
 // "nodes" resource name the real metrics API (and internal/k8s.metricsGVR)
 // actually uses. Tracker().Create takes the GVR explicitly, bypassing the guess.
 func seedMetrics(dyn *dynamicfake.FakeDynamicClient) {
@@ -56,7 +56,7 @@ func seedMetrics(dyn *dynamicfake.FakeDynamicClient) {
 	}
 }
 
-// typedObjects returns every seed object as its typed API type — what the
+// typedObjects returns every seed object as its typed API type: what the
 // fake clientset's tracker and Discovery() need.
 func typedObjects() []runtime.Object {
 	objs := make([]runtime.Object, 0, 20)

--- a/internal/k8s/demo/guard.go
+++ b/internal/k8s/demo/guard.go
@@ -13,14 +13,14 @@ import (
 // GuardListPanics wraps a dynamic.Interface so a List call against an
 // unregistered GVR degrades to an error instead of panicking. The fake
 // dynamic client (dynamicfake.NewSimpleDynamicClientWithCustomListKinds)
-// panics rather than errors when its ListKinds map is missing an entry —
-// see ListKinds for the registration this guards against ever missing
-// again. DiscoverAPIResources and similar calls run on a scheduler worker
-// goroutine with nothing upstream able to recover a panic, so a fixture
-// gap here would otherwise crash the whole app instead of degrading one
-// feature. This wrapper is demo-only: a real cluster's dynamic client talks
-// to an API server and never panics on List, so production code paths
-// never carry this guard.
+// panics rather than errors when its ListKinds map is missing an entry. See
+// ListKinds for the registration this guards against ever missing again.
+// DiscoverAPIResources and similar calls run on a scheduler worker goroutine
+// with nothing upstream able to recover a panic. A fixture gap here would
+// otherwise crash the whole app instead of degrading one feature. This
+// wrapper is demo-only: a real cluster's dynamic client talks to an API
+// server and never panics on List. So production code paths never carry
+// this guard.
 func GuardListPanics(dyn dynamic.Interface) dynamic.Interface {
 	return recoveringDynamicClient{Interface: dyn}
 }

--- a/internal/k8s/demo/metrics.go
+++ b/internal/k8s/demo/metrics.go
@@ -9,10 +9,10 @@ import (
 // buildPodMetrics and buildNodeMetrics seed the metrics.k8s.io/v1beta1
 // PodMetrics/NodeMetrics objects internal/k8s.getPodMetricsFromAPI and
 // getNodeMetricsFromAPI read. They are unstructured because no typed Go
-// package for metrics.k8s.io is vendored here — internal/k8s reads them as
+// package for metrics.k8s.io is vendored here. internal/k8s reads them as
 // unstructured too, so the shape only needs to match what parsePodMetrics
-// and getNodeMetricsFromAPI expect: a top-level "containers[].usage" map for
-// pods, a top-level "usage" map for nodes.
+// and getNodeMetricsFromAPI expect. The shape is a top-level
+// "containers[].usage" map for pods, a top-level "usage" map for nodes.
 
 func buildPodMetrics() []*unstructured.Unstructured {
 	ts := demoEpoch.Add(-30 * time.Second).Format(time.RFC3339)

--- a/internal/k8s/demo/namespaces.go
+++ b/internal/k8s/demo/namespaces.go
@@ -10,8 +10,9 @@ import (
 
 // buildNamespaces returns a Namespace object for every namespace the seed
 // data uses (NamespaceDemo, NamespaceJobs), plus the two namespaces every
-// real cluster has (default, kube-system), so the namespace picker and
-// GetNamespaces count reflect a coherent cluster instead of reporting zero.
+// real cluster has (default, kube-system). This way the namespace picker
+// and GetNamespaces count reflect a coherent cluster instead of reporting
+// zero.
 func buildNamespaces() []*corev1.Namespace {
 	return []*corev1.Namespace{
 		namespace(NamespaceDemo, uidNamespaceDemo, demoEpoch.Add(-30*24*time.Hour)),

--- a/internal/k8s/demo/reactors.go
+++ b/internal/k8s/demo/reactors.go
@@ -8,7 +8,7 @@ import (
 
 // reactingClientset is the subset of *k8sfake.Clientset (via its embedded
 // testing.Fake) AddRBACReactors needs. Declared here instead of importing
-// k8sfake so the reactor logic doesn't depend on the fake package's full
+// k8sfake so the reactor logic does not depend on the fake package's full
 // surface.
 type reactingClientset interface {
 	PrependReactor(verb, resource string, reaction clienttesting.ReactionFunc)
@@ -17,7 +17,7 @@ type reactingClientset interface {
 // AddRBACReactors wires SelfSubjectAccessReview and SelfSubjectRulesReview
 // reactors that report the demo user as fully authorized. Neither review
 // type is a tracked object, so the fake clientset has no built-in reactor
-// for them: Create falls through to a zero-value response (Allowed: false,
+// for them. Create falls through to a zero-value response (Allowed: false,
 // no resource rules), which hides every action in the UI. See
 // internal/k8s/client_rbac.go CheckRBAC and GetSelfRulesAs for the exact
 // request/response shape the app reads.

--- a/internal/k8s/demo/ticker.go
+++ b/internal/k8s/demo/ticker.go
@@ -50,7 +50,7 @@ var deploymentReadyReplicaCycle = []int64{6, 6, 5}
 // tick count, so driving a fresh Ticker N times always reaches the same
 // state — tests and screenshots stay stable.
 //
-// Ticker only touches the dynamic client passed to NewTicker; it is not
+// Ticker only touches the dynamic client passed to NewTicker. It is not
 // wired into any client lifecycle here.
 type Ticker struct {
 	dyn      dynamic.Interface
@@ -119,7 +119,7 @@ func (t *Ticker) run(ctx context.Context, done chan struct{}) {
 		close(done)
 	}()
 
-	// time.NewTicker panics for a non-positive duration; treat a
+	// time.NewTicker panics for a non-positive duration. Treat a
 	// misconfigured interval as a no-op run instead of crashing the
 	// process from a background goroutine.
 	if t.interval <= 0 {
@@ -143,7 +143,7 @@ func (t *Ticker) run(ctx context.Context, done chan struct{}) {
 }
 
 // Stop cancels the ticker's goroutine and blocks until it has exited.
-// Idempotent and safe to call even if Start was never called; concurrent
+// Idempotent and safe to call even if Start was never called. Concurrent
 // Stop calls all wait for the same goroutine to exit before any of them
 // return. Start and Stop are not safe to call concurrently with each
 // other — serialize lifecycle calls at the call site.
@@ -167,7 +167,7 @@ func (t *Ticker) Stop() {
 
 // Tick performs one deterministic mutation step against the tracked demo
 // objects. Exported so tests can drive the sequence precisely without
-// sleeping on real time; Start's internal loop calls it the same way. The
+// sleeping on real time. Start's internal loop calls it the same way. The
 // whole step runs under the Ticker's lock so a direct Tick call never races
 // against Start's background loop calling it concurrently.
 func (t *Ticker) Tick(ctx context.Context) error {

--- a/internal/k8s/demo/ticker.go
+++ b/internal/k8s/demo/ticker.go
@@ -18,8 +18,8 @@ import (
 const tickerFieldManager = "lfk-demo-ticker"
 
 // maxTickerEvents caps how many Warning Events the ticker keeps appending
-// for the crashlooping pod. A demo session left running ticks indefinitely;
-// without a cap the Event list would grow without bound.
+// for the crashlooping pod. A demo session left running ticks indefinitely.
+// Without a cap the Event list would grow without bound.
 const maxTickerEvents = 20
 
 // healthyPodFlipEvery is how many ticks pass between phase flips on
@@ -43,12 +43,12 @@ var waitingReasons = []string{"CrashLoopBackOff", "Error"}
 var deploymentReadyReplicaCycle = []int64{6, 6, 5}
 
 // Ticker mutates a demo cluster's fake dynamic client on a fixed interval so
-// its informer-backed watchers see live changes: the crashlooping pod
-// restarts and its waiting reason rotates, a matching Warning Event lands, a
-// healthy pod's phase flips occasionally, and the web Deployment's
+// its informer-backed watchers see live changes. The crashlooping pod
+// restarts and its waiting reason rotates, and a matching Warning Event
+// lands. A healthy pod's phase flips occasionally, and the web Deployment's
 // readyReplicas drifts. Every mutation is a deterministic function of the
 // tick count, so driving a fresh Ticker N times always reaches the same
-// state — tests and screenshots stay stable.
+// state. Tests and screenshots stay stable.
 //
 // Ticker only touches the dynamic client passed to NewTicker. It is not
 // wired into any client lifecycle here.
@@ -77,8 +77,8 @@ type actionClearer interface {
 // NewTicker returns a Ticker over dyn that, once started, mutates the demo
 // cluster every interval. It does not touch dyn until Start or Tick is
 // called. extraClearers are additional fake clients (e.g. the typed demo
-// clientset) whose action log gets cleared on the same cadence as dyn's,
-// even though the ticker itself never calls them — the app's own List/Get
+// clientset). Their action log gets cleared on the same cadence as dyn's,
+// even though the ticker itself never calls them. The app's own List/Get
 // calls share those fakes and grow their action log too.
 func NewTicker(dyn dynamic.Interface, interval time.Duration, extraClearers ...actionClearer) *Ticker {
 	return &Ticker{dyn: dyn, interval: interval, extraClearers: extraClearers}
@@ -105,9 +105,9 @@ func (t *Ticker) Start(ctx context.Context) {
 func (t *Ticker) run(ctx context.Context, done chan struct{}) {
 	defer func() {
 		// A goroutine that exits because ctx was cancelled by something
-		// other than Stop (Stop cancels this same runCtx too, so this path
-		// also fires there) must clear running itself — otherwise a later
-		// Start call sees running still true and silently no-ops even
+		// other than Stop must clear running itself. Stop cancels this same
+		// runCtx too, so this path also fires there. Otherwise a later
+		// Start call sees running still true and silently no-ops, even
 		// though nothing is left mutating the demo cluster. Guarded by
 		// t.done == done so a concurrent Stop that already reset running
 		// (and possibly started a fresh run) is never clobbered.
@@ -134,7 +134,7 @@ func (t *Ticker) run(ctx context.Context, done chan struct{}) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// Best-effort: a single failed mutation should not take down
+			// Best-effort: a single failed mutation must not take down
 			// the background loop. The caller wiring this in decides
 			// whether failures need surfacing.
 			_ = t.Tick(ctx)
@@ -146,7 +146,7 @@ func (t *Ticker) run(ctx context.Context, done chan struct{}) {
 // Idempotent and safe to call even if Start was never called. Concurrent
 // Stop calls all wait for the same goroutine to exit before any of them
 // return. Start and Stop are not safe to call concurrently with each
-// other — serialize lifecycle calls at the call site.
+// other. Serialize lifecycle calls at the call site.
 func (t *Ticker) Stop() {
 	t.mu.Lock()
 	if !t.running {
@@ -195,9 +195,9 @@ func (t *Ticker) Tick(ctx context.Context) error {
 
 // clearActionLogs drops the Actions() log accumulated on dyn and every
 // extra clearer since the last call. Runs at the end of every Tick
-// regardless of error, so a demo session left running overnight (about
-// 28,800 ticks a day at the 3s interval) never retains more than one tick's
-// worth of action history in memory.
+// regardless of error. A demo session left running overnight ticks about
+// 28,800 times a day at the 3s interval. So it never retains more than one
+// tick's worth of action history in memory.
 func (t *Ticker) clearActionLogs() {
 	if clearer, ok := t.dyn.(actionClearer); ok {
 		clearer.ClearActions()

--- a/internal/k8s/demo/workloads.go
+++ b/internal/k8s/demo/workloads.go
@@ -35,7 +35,7 @@ func webContainerSpec() corev1.Container {
 func buildDeployment() *appsv1.Deployment {
 	created := demoEpoch.Add(-7 * 24 * time.Hour)
 	labels := map[string]string{"app": "web"}
-	// 6 desired replicas: 5 healthy plus the one crashlooping pod, so the
+	// 6 desired replicas: 5 healthy plus the one crashlooping pod. So the
 	// crashloop stays the single obviously-unhealthy workload among a
 	// mostly-healthy deployment instead of dominating a tiny replica set.
 	replicas := int32(6)
@@ -121,8 +121,8 @@ func buildReplicaSet() *appsv1.ReplicaSet {
 
 // buildWebPods returns the "web" ReplicaSet's pods: 5 healthy pods (one of
 // which the Ticker flips between Running and Pending) and the single
-// crashlooping pod, so Running pods stay a majority throughout the ticker
-// cycle.
+// crashlooping pod. This keeps Running pods a majority throughout the
+// ticker cycle.
 func buildWebPods() []*corev1.Pod {
 	return []*corev1.Pod{
 		healthyWebPod(PodWebHealthy1, uidPodWebHealthy1, "10.0.2.11"),

--- a/internal/k8s/dependents_fetch.go
+++ b/internal/k8s/dependents_fetch.go
@@ -150,7 +150,7 @@ func dependentRefsFrom(
 	if namespace == "" {
 		// An empty namespace lists cluster-wide, which needs cluster-scoped
 		// RBAC a user holding one namespaced Role does not have. Both callers
-		// already filter these out; this keeps a future owner kind from
+		// already filter these out. This keeps a future owner kind from
 		// reintroducing the cluster-wide call by accident.
 		return nil, fmt.Errorf("the dependent walk needs a namespace")
 	}

--- a/internal/k8s/gitops_argo_wave.go
+++ b/internal/k8s/gitops_argo_wave.go
@@ -24,7 +24,7 @@ import (
 const unknownWave = math.MinInt
 
 // SyncWaveTimeline is the immutable result of one fetch against an ArgoCD
-// Application. The renderer reads it; nothing in the data layer mutates it
+// Application. The renderer reads it. Nothing in the data layer mutates it
 // after Build returns.
 type SyncWaveTimeline struct {
 	AppName       string
@@ -120,7 +120,7 @@ func pluralFor(kind string) string {
 }
 
 // waveResourceWithWave pairs a SyncWaveResource with the wave it belongs
-// to. Used internally by the builder before bucketization; never exported.
+// to. Used internally by the builder before bucketization. Never exported.
 type waveResourceWithWave struct {
 	wave int
 	res  SyncWaveResource
@@ -184,7 +184,7 @@ func resourceSortKey(r SyncWaveResource) string {
 // parseHookResources reads operationState.syncResult.resources[] and
 // returns hook entries grouped by syncPhase. Non-hook entries (no
 // hookType) are skipped. Wave is unknownWave for hooks since they aren't
-// wave-bucketed; the renderer ignores wave for hook rows.
+// wave-bucketed. The renderer ignores wave for hook rows.
 func parseHookResources(syncResult map[string]any) map[string][]waveResourceWithWave {
 	if syncResult == nil {
 		return nil
@@ -458,7 +458,7 @@ func buildSyncWaveTimelineFromApp(app *unstructured.Unstructured, appName, names
 // parse only. All managed resources land at unknownWave so the overlay
 // can render the phase pipeline immediately while the slow per-resource
 // annotation fan-out runs in the background. The returned timeline has
-// Loading set to true; the renderer surfaces this as "Loading wave map…"
+// Loading set to true. The renderer surfaces this as "Loading wave map…"
 // in the header.
 func (c *Client) GetSyncWaveTimelineSkeleton(ctx context.Context, contextName, namespace, appName string) (*SyncWaveTimeline, error) {
 	app, err := c.fetchSyncWaveApplication(ctx, contextName, namespace, appName)

--- a/internal/k8s/helm.go
+++ b/internal/k8s/helm.go
@@ -132,7 +132,7 @@ func (c *Client) GetHelmReleases(ctx context.Context, contextName, namespace str
 }
 
 // buildHelmReleaseColumns builds the detail columns for a helm release list item.
-// It tries to decode the gzipped release blob stored in the secret data; on
+// It tries to decode the gzipped release blob stored in the secret data. On
 // failure it logs a warning and returns an empty slice so the list still renders.
 func buildHelmReleaseColumns(data map[string][]byte, relName, displayStatus string) []model.KeyValue {
 	raw, ok := data["release"]
@@ -335,7 +335,7 @@ func findLatestHelmReleaseSecret(ctx context.Context, cs kubernetes.Interface, n
 }
 
 // latestHelmReleaseSecret returns the highest-revision release secret. The helm
-// `version` label is the authoritative revision; CreationTimestamp only breaks
+// `version` label is the authoritative revision. CreationTimestamp only breaks
 // ties (its 1s granularity collides on fast install/rollback and CI upgrades,
 // and the API's name-sort orders "v10" before "v2"). items must be non-empty.
 func latestHelmReleaseSecret(items []corev1.Secret) corev1.Secret {

--- a/internal/k8s/helm_manifest.go
+++ b/internal/k8s/helm_manifest.go
@@ -8,7 +8,7 @@ import (
 
 // ManifestResourceRef represents a single resource declared in a helm release
 // manifest. Fields are extracted from apiVersion, kind, metadata.name, and
-// metadata.namespace; cluster-scoped resources have an empty Namespace.
+// metadata.namespace. Cluster-scoped resources have an empty Namespace.
 type ManifestResourceRef struct {
 	APIVersion string
 	Kind       string
@@ -36,7 +36,7 @@ type manifestDoc struct {
 // cannot prevent the rest of a chart from rendering.
 //
 // The error return value is reserved for a future fatal-failure signal (such
-// as an input that exceeds a size cap); the current best-effort implementation
+// as an input that exceeds a size cap). The current best-effort implementation
 // never uses it, but keeping the signature lets callers add error handling
 // without breaking compatibility.
 //
@@ -131,7 +131,7 @@ func isYAMLDocSeparator(line string) bool {
 		return true
 	}
 	// The character immediately following "---" must be whitespace for the
-	// rest-of-line content to even be considered; otherwise "---foo" is just
+	// rest-of-line content to even be considered. Otherwise "---foo" is just
 	// a document body line that happens to start with dashes.
 	if rest[0] != ' ' && rest[0] != '\t' && rest[0] != '\r' {
 		return false

--- a/internal/k8s/informer_cache.go
+++ b/internal/k8s/informer_cache.go
@@ -104,8 +104,8 @@ type informerEntry struct {
 	synced   chan struct{} // closed when the informer's first LIST has completed
 
 	// memoMu guards memo. Keys are "<namespace>/<name>" (or "/<name>"
-	// for cluster-scoped resources). Entries grow over the cache's
-	// lifetime. Entries for deleted pods linger until Stop. At typical
+	// for cluster-scoped resources). Entries outside the current list's
+	// scope are pruned on each applyMemo call. At typical
 	// scales (a few thousand items, hours-long sessions) this is a
 	// negligible memory footprint relative to the indexer itself.
 	memoMu sync.Mutex

--- a/internal/k8s/informer_cache.go
+++ b/internal/k8s/informer_cache.go
@@ -43,7 +43,7 @@ type InformerCacheMode string
 // are also what the config file accepts.
 const (
 	// InformerCacheOff routes every list directly to the apiserver. Matches
-	// kubectl semantics; recommended when the apiserver dislikes extra
+	// kubectl semantics. Recommended when the apiserver dislikes extra
 	// watch traffic.
 	InformerCacheOff InformerCacheMode = "off"
 	// InformerCacheAuto starts in direct-list mode per (context, GVR) and
@@ -54,7 +54,7 @@ const (
 	InformerCacheAuto InformerCacheMode = "auto"
 	// InformerCacheAlways routes every list through the informer cache,
 	// starting watches eagerly on first use. Matches the always-on behaviour
-	// from issue #86's first cut; use when you know the cluster is large.
+	// from issue #86's first cut. Use when you know the cluster is large.
 	InformerCacheAlways InformerCacheMode = "always"
 )
 
@@ -105,7 +105,7 @@ type informerEntry struct {
 
 	// memoMu guards memo. Keys are "<namespace>/<name>" (or "/<name>"
 	// for cluster-scoped resources). Entries grow over the cache's
-	// lifetime; entries for deleted pods linger until Stop. At typical
+	// lifetime. Entries for deleted pods linger until Stop. At typical
 	// scales (a few thousand items, hours-long sessions) this is a
 	// negligible memory footprint relative to the indexer itself.
 	memoMu sync.Mutex
@@ -119,7 +119,7 @@ type informerEntry struct {
 //
 // Lifecycle: factories and informers persist for the lifetime of the parent
 // Client. Stop() closes every watch and blocks until all informer goroutines
-// have exited; it is called from Client.Shutdown().
+// have exited. It is called from Client.Shutdown().
 type informerCache struct {
 	clientFactory func(contextName string) (dynamic.Interface, error)
 
@@ -230,7 +230,7 @@ func (ic *informerCache) observeCachedListSize(contextName string, gvr schema.Gr
 
 // isPromoted reports whether the auto-mode router should send the next list
 // for (contextName, gvr) through the informer cache. False means take the
-// direct path; observeDirectListSize will decide whether to flip later.
+// direct path. observeDirectListSize will decide whether to flip later.
 func (ic *informerCache) isPromoted(contextName string, gvr schema.GroupVersionResource) bool {
 	state := ic.getAutoState(contextName, gvr)
 	state.mu.Lock()
@@ -275,7 +275,7 @@ func (ic *informerCache) stopOne(contextName string, gvr schema.GroupVersionReso
 // listItems walks the cached objects for (context, GVR) filtered by
 // namespace and returns them as []model.Item. Each object is keyed in
 // the per-item memo by namespace/name plus its own
-// metadata.resourceVersion; items whose RV matches the cached entry
+// metadata.resourceVersion. Items whose RV matches the cached entry
 // are reused as-is, only items whose RV differs (or whose key was
 // never seen) run through build.
 //
@@ -363,7 +363,7 @@ func (e *informerEntry) applyMemo(listNamespace string, objs []*unstructured.Uns
 
 	// Prune memo entries within the current list's scope that did not
 	// appear in objs. An all-namespaces list ("") is authoritative for
-	// every key; a namespaced list is only authoritative for keys with
+	// every key. A namespaced list is only authoritative for keys with
 	// that namespace prefix, so we leave other namespaces' entries
 	// untouched. Without this, deleted pods accumulate in the memo for
 	// the lifetime of the informer.
@@ -453,7 +453,7 @@ func (ic *informerCache) getOrStart(contextName string, gvr schema.GroupVersionR
 	}(informer, entry.stopCh)
 	go func(inf cache.SharedIndexInformer, stopCh, synced chan struct{}) {
 		defer ic.wg.Done()
-		// HasSynced flips true after the initial LIST completes; we close
+		// HasSynced flips true after the initial LIST completes. We close
 		// `synced` so the first list() call can return promptly without
 		// burning CPU in cache.WaitForCacheSync's polling loop. When
 		// stopCh closes before sync (Stop or auto-demote during warmup),
@@ -506,7 +506,7 @@ func waitForSync(ctx context.Context, entry *informerEntry, timeout time.Duratio
 
 // Stop closes every watch and blocks until all informer goroutines have
 // exited. Idempotent — safe to call from a defer in main.go even if the
-// cache was never used; concurrent Stop calls all wait on the same
+// cache was never used. Concurrent Stop calls all wait on the same
 // WaitGroup. After Stop, getOrStart returns an error rather than silently
 // spinning up a new informer that would leak.
 func (ic *informerCache) Stop() {

--- a/internal/k8s/localcluster/exec.go
+++ b/internal/k8s/localcluster/exec.go
@@ -15,7 +15,7 @@ import (
 
 // CmdRunner abstracts the two os/exec calls each Provider needs:
 // LookPath (for Installed()) and Run (for everything else). Production
-// uses realRunner; tests inject FakeRunner for hermetic unit tests.
+// uses realRunner. Tests inject FakeRunner for hermetic unit tests.
 type CmdRunner interface {
 	LookPath(name string) (string, error)
 	Run(ctx context.Context, name string, args ...string) (stdout, stderr string, exitCode int, err error)

--- a/internal/k8s/localcluster/k3d.go
+++ b/internal/k8s/localcluster/k3d.go
@@ -63,7 +63,7 @@ func (p *k3dProvider) List(ctx context.Context) ([]Cluster, error) {
 		}
 		// Nodes counts only servers + agents. k3d also adds a default
 		// load-balancer container per cluster, but that's implementation
-		// detail, not topology — the manager UI's "node count" should
+		// detail, not topology. The manager UI's "node count" should
 		// reflect what the user asked for, not container count.
 		out = append(out, Cluster{
 			Provider:    "k3d",

--- a/internal/k8s/localcluster/kind.go
+++ b/internal/k8s/localcluster/kind.go
@@ -20,7 +20,7 @@ const (
 //   - err == nil with non-zero exit code: emits a plain error (no %!w)
 //   - empty stderr: omits the double-colon ": :"
 //
-// Both are theoretically reachable through FakeRunner; the production
+// Both are theoretically reachable through FakeRunner. The production
 // realRunner always pairs a non-zero exit with a non-nil ExitError.
 func kindCLIError(op string, code int, stderr string, err error) error {
 	base := fmt.Sprintf("kind: %s failed (exit %d)", op, code)
@@ -135,7 +135,7 @@ func (p *kindProvider) Delete(ctx context.Context, name string) error {
 
 // kindContainerStatus asks Docker for the control-plane container's
 // state. Multi-node kind clusters have additional worker containers
-// whose state is NOT polled here; if a partial-stop leaves only
+// whose state is NOT polled here. If a partial-stop leaves only
 // workers down, this function still reports ClusterStatusRunning.
 // That's a deliberate simplification: the manager UI's "is this cluster
 // roughly up" probe doesn't justify N docker-inspect calls per cluster.

--- a/internal/k8s/localcluster/kind.go
+++ b/internal/k8s/localcluster/kind.go
@@ -130,7 +130,7 @@ func (p *kindProvider) Delete(ctx context.Context, name string) error {
 
 // kindProvider intentionally does NOT implement LifecycleProvider.
 // kind has no native verb for stopping or restarting an existing
-// cluster — handlers must type-assert prov.(LifecycleProvider) and
+// cluster. Handlers must type-assert prov.(LifecycleProvider) and
 // silently fall through when the provider doesn't satisfy it.
 
 // kindContainerStatus asks Docker for the control-plane container's
@@ -142,8 +142,8 @@ func (p *kindProvider) Delete(ctx context.Context, name string) error {
 //
 // `name` here is a string from kind's own stdout (`kind get clusters`),
 // not from wizard-validated user input. It reaches `docker inspect` as
-// a discrete argv element via exec.CommandContext (NOT via `sh -c`),
-// so shell metacharacters cannot escape — argv injection is contained
+// a discrete argv element via exec.CommandContext (NOT via `sh -c`).
+// So shell metacharacters cannot escape: argv injection is contained
 // at the os/exec layer regardless of what kind reports. If a future
 // refactor switches to a shell-interpreted path, this is the call site
 // that needs explicit validation.

--- a/internal/k8s/localcluster/localcluster.go
+++ b/internal/k8s/localcluster/localcluster.go
@@ -187,7 +187,7 @@ func ByName(name string) Provider {
 // --- providers ---
 //
 // Each provider type has a runner field for the os/exec seam. Real
-// lifecycle implementations live in kind.go, k3d.go, and minikube.go;
+// lifecycle implementations live in kind.go, k3d.go, and minikube.go.
 // k3d and minikube also satisfy LifecycleProvider via Start/Stop
 // methods declared in their respective files. The trivial Name and
 // Installed methods stay here (provider-uniform shape).

--- a/internal/k8s/localcluster/localcluster.go
+++ b/internal/k8s/localcluster/localcluster.go
@@ -67,14 +67,13 @@ const (
 
 // Provider is the minimum contract every local-cluster CLI wrapper
 // implements: identity, presence, listing, and creation/destruction.
-// Implementations are not required to be goroutine-safe; callers must
+// Implementations are not required to be goroutine-safe. Callers must
 // serialize access to a single Provider.
 //
 // kind cannot start or stop existing clusters in place (it has no
 // native verb for it), so kindProvider implements Provider but NOT
 // LifecycleProvider. Callers that need start/stop must type-assert
-// to LifecycleProvider — the type assertion replaces the runtime
-// SupportsStartStop() capability query that earlier revisions used.
+// to LifecycleProvider.
 type Provider interface {
 	Name() string
 	// Installed reports whether the underlying CLI is present on $PATH.
@@ -90,7 +89,7 @@ type Provider interface {
 
 // LifecycleProvider is the optional capability for providers whose
 // CLIs support stopping and restarting an existing cluster. k3d and
-// minikube implement this; kind does not (creating + deleting are the
+// minikube implement this. Kind does not (creating + deleting are the
 // only kind verbs that touch cluster lifecycle).
 //
 // Use a type assertion to test for it:
@@ -121,14 +120,14 @@ type LifecycleProvider interface {
 // ConfigFile is validated by Provider.Create at the boundary
 // (validateConfigFile): must be empty, or an absolute path to an
 // existing regular file with no traversal segments. The v1 wizard
-// always leaves it empty; the validation exists so a future
+// always leaves it empty. The validation exists so a future
 // programmatic caller can't smuggle ../etc/passwd or similar into
 // the underlying CLI's --config flag.
 type CreateSpec struct {
 	Name       string
 	K8sVersion string
 	Nodes      int    // ignored when ConfigFile is set
-	ConfigFile string // optional absolute path to existing regular file; see validateConfigFile
+	ConfigFile string // optional absolute path to existing regular file. See validateConfigFile
 }
 
 // Cluster is the manager's view of one local cluster. Best-effort: any

--- a/internal/k8s/localcluster/minikube.go
+++ b/internal/k8s/localcluster/minikube.go
@@ -34,7 +34,7 @@ func minikubeCLIError(op string, code int, stderr string, err error) error {
 
 // minikubeProfileListJSONShape mirrors the subset of `minikube profile
 // list -o json` we care about. minikube's JSON has more fields than
-// these; anything we omit is ignored on Unmarshal.
+// these. Anything we omit is ignored on Unmarshal.
 type minikubeProfileListJSONShape struct {
 	Valid []minikubeProfile `json:"valid"`
 }
@@ -126,7 +126,7 @@ func (p *minikubeProvider) Create(ctx context.Context, spec CreateSpec) error {
 		// — `--extra-config` is for component knobs like
 		// `kubelet.foo=bar`, not a YAML file path. Rather than smuggle
 		// the path into the wrong flag, fail loud. The wizard's
-		// config-file escape hatch is deferred to v1.1; v1 keeps
+		// config-file escape hatch is deferred to v1.1. v1 keeps
 		// CreateSpec.ConfigFile as always-empty.
 		return fmt.Errorf("minikube: config-file is not supported (deferred to v1.1)")
 	}

--- a/internal/k8s/localcluster/minikube.go
+++ b/internal/k8s/localcluster/minikube.go
@@ -79,13 +79,13 @@ func (p *minikubeProvider) List(ctx context.Context) ([]Cluster, error) {
 }
 
 // minikubeStatus maps minikube's profile-list Status string to the
-// closed ClusterStatus set. minikube emits at least Running / Stopped /
-// Paused / Stopping / Starting / Misconfigured / OK (recent versions
-// aggregate host+apiserver into "OK" when both are Running) — we
-// surface the two healthy states (running/ok → Running, stopped →
-// Stopped) and let transient/misconfigured states fall through to
-// Unknown. Casting the raw string into ClusterStatus directly would
-// smuggle arbitrary values past the type's "closed set" contract.
+// closed ClusterStatus set. minikube emits Running / Stopped / Paused /
+// Stopping / Starting / Misconfigured / OK (recent versions aggregate
+// host+apiserver into "OK" when both are Running). We surface the two
+// healthy states (running/ok → Running, stopped → Stopped) and let
+// transient/misconfigured states fall through to Unknown. Casting the
+// raw string into ClusterStatus directly would smuggle arbitrary
+// values past the type's "closed set" contract.
 //
 // Unknown raw values get logged so we can spot new minikube version
 // behaviours from user reports without having to reproduce locally.
@@ -109,7 +109,7 @@ func (p *minikubeProvider) Create(ctx context.Context, spec CreateSpec) error {
 	defer cancel()
 
 	// `--interactive=false` is critical: lfk attaches a TTY to the
-	// child process, so minikube's first-run driver picker / sudo
+	// child process. So minikube's first-run driver picker / sudo
 	// prompts would block forever, looking like a silent hang until
 	// the 10-minute timeout. Forcing non-interactive mode makes
 	// minikube error loud instead — the stderr surfaces in the

--- a/internal/k8s/netpol_matching.go
+++ b/internal/k8s/netpol_matching.go
@@ -187,7 +187,7 @@ func listNetpolsAndPods(ctx context.Context, dynClient dynamic.Interface, namesp
 
 // parseNetpolForMatch parses a NetworkPolicy object into a label selector and
 // a display info struct. The selector honors both matchLabels and
-// matchExpressions; an empty podSelector selects all pods in the namespace.
+// matchExpressions. An empty podSelector selects all pods in the namespace.
 // Returns a nil selector if the podSelector cannot be parsed.
 func parseNetpolForMatch(obj *unstructured.Unstructured) (labels.Selector, *NetworkPolicyInfo) {
 	info := &NetworkPolicyInfo{
@@ -275,7 +275,7 @@ func ciliumPodLabels(lbls map[string]string, namespace string, nsOwnLabels map[s
 
 // lazyNamespaceLabels returns a function that lists all namespaces once, on
 // first use, into a namespace-name -> labels map. Cilium namespace-derived
-// selectors need this to resolve which namespaces carry a given label; on list
+// selectors need this to resolve which namespaces carry a given label. On list
 // failure (e.g. no permission) it yields an empty map, disabling only the
 // namespace-derived matching.
 func lazyNamespaceLabels(ctx context.Context, dynClient dynamic.Interface) func() map[string]map[string]string {
@@ -297,7 +297,7 @@ func lazyNamespaceLabels(ctx context.Context, dynClient dynamic.Interface) func(
 
 // lazyClusterPods returns a function that lists pods across all namespaces
 // once, on first use. Clusterwide Cilium policies need the full list to
-// report affected pods accurately; on list failure it falls back to the
+// report affected pods accurately. On list failure it falls back to the
 // namespace-scoped pods.
 func lazyClusterPods(ctx context.Context, dynClient dynamic.Interface, fallback []unstructured.Unstructured) func() []unstructured.Unstructured {
 	var cached []unstructured.Unstructured

--- a/internal/k8s/orphan_detector.go
+++ b/internal/k8s/orphan_detector.go
@@ -48,7 +48,7 @@ type OrphanReport struct {
 //     right now, but a workload template (Deployment/Job/CronJob/...)
 //     still references it — typical CronJob between firings or a
 //     scaled-to-zero Deployment. Reason is "no live consumer". Hidden by
-//     default; the strict-mode toggle in the overlay flips them on so
+//     default. The strict-mode toggle in the overlay flips them on so
 //     users can audit "what's idle right now" instead of just "what's
 //     truly unused".
 //
@@ -96,7 +96,7 @@ type orphanLists struct {
 }
 
 // fetchOrphanLists pulls every input the detector needs in one place.
-// Per-list errors accumulate; the corresponding pointer stays nil and
+// Per-list errors accumulate. The corresponding pointer stays nil and
 // the safe*Items helpers turn that into an empty slice so the rest of
 // the pipeline runs unaffected.
 func fetchOrphanLists(ctx context.Context, cs kubernetes.Interface, namespace string) (orphanLists, []error) {
@@ -244,7 +244,7 @@ func computeOrphanDeps(l orphanLists) orphanDeps {
 		pdbs:    podsOK && workloadTemplatesOK,
 		netpols: podsOK && workloadTemplatesOK,
 		// RBAC is a mutual dependency web: Role/ClusterRole "bound"
-		// status is computed from the binding lists; RoleBinding/
+		// status is computed from the binding lists. RoleBinding/
 		// ClusterRoleBinding roleRef validity is computed from the
 		// Role/ClusterRole lists. See buildRBACIndex.
 		roles:               l.roleBindings != nil,

--- a/internal/k8s/orphan_kinds.go
+++ b/internal/k8s/orphan_kinds.go
@@ -20,7 +20,7 @@ import (
 // rbacIndex tracks which (Cluster)Roles are bound and which Roles
 // exist (so binding.roleRef validation can flag dangling references).
 // A RoleBinding's roleRef can target either a Role (in the binding's
-// own namespace) or a ClusterRole (cluster-wide); a ClusterRoleBinding
+// own namespace) or a ClusterRole (cluster-wide). A ClusterRoleBinding
 // only ever targets a ClusterRole.
 type rbacIndex struct {
 	// boundRoles tracks Role refs by (binding.namespace, role.Name).
@@ -185,7 +185,7 @@ func buildWorkloadIndex(in workloadInputs) workloadIndex {
 		idx.keys[workloadKey{"DaemonSet", ds.Namespace, ds.Name}] = struct{}{}
 	}
 	// ReplicaSets and Pods can theoretically also be scaleTargetRefs but
-	// it's rare; HPA targeting bare Pods isn't even valid. Skip those —
+	// it's rare. HPA targeting bare Pods isn't even valid. Skip those —
 	// users with custom-resource HPA targets will see false positives,
 	// which is acceptable until someone actually hits one.
 	return idx
@@ -365,7 +365,7 @@ func pvcOrphan(p corev1.PersistentVolumeClaim, lenient, strict refSet) (OrphanIt
 // different kind). Owner-managed HPAs (rare — usually a HelmRelease or
 // custom controller) are excluded since the owner manages the
 // reference. Custom-resource HPA targets aren't validated here — we'd
-// need to walk every CRD; until someone hits a real false positive
+// need to walk every CRD. Until someone hits a real false positive
 // from that, skip the lookup if the target kind isn't one of the
 // well-known workload kinds we list.
 func hpaOrphan(h autoscalingv2.HorizontalPodAutoscaler, idx workloadIndex) (OrphanItem, bool) {
@@ -397,7 +397,7 @@ func hpaOrphan(h autoscalingv2.HorizontalPodAutoscaler, idx workloadIndex) (Orph
 // the workload-template walker already fixed for Secrets/ConfigMaps.
 //
 // Empty selector matches all pods in the namespace per API contract,
-// so it's never an orphan. nil selector is invalid; treat as orphan
+// so it's never an orphan. nil selector is invalid. Treat as orphan
 // with a distinct reason so the user knows what's wrong.
 func pdbOrphan(b policyv1.PodDisruptionBudget, _ []corev1.Pod, allLabels templatePodLabels) (OrphanItem, bool) {
 	if len(b.OwnerReferences) > 0 {

--- a/internal/k8s/packet_decoder.go
+++ b/internal/k8s/packet_decoder.go
@@ -27,7 +27,7 @@ type PacketSummary struct {
 	DstPort  string
 	Length   int
 	Flags    string // for TCP: "PSH ACK"
-	Extra    string // for DNS: "Q kubernetes.default"; for ICMP: "echo request"
+	Extra    string // for DNS: "Q kubernetes.default", for ICMP: "echo request"
 }
 
 func decodePacket(data []byte, ci gopacket.CaptureInfo, linkLayer gopacket.LayerType) PacketSummary {
@@ -136,7 +136,7 @@ func (c *countingWriter) Write(p []byte) (int, error) {
 }
 
 // Run reads packets from src until EOF, context cancellation, or a read error.
-// Raw pcap bytes are teed to d.file via io.TeeReader; each decoded packet is
+// Raw pcap bytes are teed to d.file via io.TeeReader. Each decoded packet is
 // forwarded to d.onPacket. Atomic counters are updated per packet/byte.
 func (d *packetDecoder) Run(ctx context.Context, src io.Reader) error {
 	counting := &countingWriter{w: d.file, n: d.byteCount}
@@ -149,7 +149,7 @@ func (d *packetDecoder) Run(ctx context.Context, src io.Reader) error {
 	// returns it. Parsing here lets stripSLL2 actually fire.
 	//
 	// pcap is endian-tagged: a magic of 0xa1b2c3d4 / 0xa1b23c4d means the
-	// rest of the header is big-endian; 0xd4c3b2a1 / 0x4d3cb2a1 means
+	// rest of the header is big-endian. 0xd4c3b2a1 / 0x4d3cb2a1 means
 	// little-endian. tcpdump on Linux/macOS produces little-endian by
 	// default, but a pcap captured on a big-endian host (some MIPS / older
 	// SPARC) and shipped to lfk would silently parse the linktype wrong
@@ -249,7 +249,7 @@ func stripSLL2(data []byte) ([]byte, gopacket.LayerType) {
 
 // layerTypeForLinkType maps a pcap link-type to the gopacket layer type used
 // as the decoding entry point. gopacket v1.1.19 does not include LinuxSLL2
-// (DLT 276); SLL2 is handled by stripSLL2 in the decoder loop, so other
+// (DLT 276). SLL2 is handled by stripSLL2 in the decoder loop, so other
 // unknown link types fall back to Ethernet as best-effort.
 func layerTypeForLinkType(lt layers.LinkType) gopacket.LayerType {
 	switch lt {

--- a/internal/k8s/resources_pod_refs.go
+++ b/internal/k8s/resources_pod_refs.go
@@ -97,7 +97,7 @@ func appendPodRefs(podNode *model.ResourceNode, podObj map[string]any, namespace
 		add("ServiceAccount", saName, false)
 	}
 
-	// imagePullSecrets are required at pull time; treat as non-optional.
+	// imagePullSecrets are required at pull time. Treat as non-optional.
 	if pull, ok := spec["imagePullSecrets"].([]any); ok {
 		for _, p := range pull {
 			if m, ok := p.(map[string]any); ok {
@@ -190,7 +190,7 @@ func collectContainerRefs(c map[string]any, add func(kind, name string, optional
 }
 
 func collectVolumeRefs(v map[string]any, add func(kind, name string, optional bool)) {
-	// SecretVolumeSource uses secretName; SecretProjection uses name.
+	// SecretVolumeSource uses secretName. SecretProjection uses name.
 	if s, ok := v["secret"].(map[string]any); ok {
 		name, _ := s["secretName"].(string)
 		opt, _ := s["optional"].(bool)
@@ -235,11 +235,11 @@ func collectVolumeRefs(v map[string]any, add func(kind, name string, optional bo
 // a single tree build cost one GET. Errors other than IsNotFound are treated
 // as "exists" so transient RBAC/network failures don't false-flag refs.
 //
-// The provided ctx is reused for every kube GET the closure issues — it does
-// not impose its own timeout, so callers should pass a context with a
-// deadline or cancellation to avoid indefinite blocking on a slow apiserver.
+// The provided ctx is reused for every kube GET the closure issues. It does
+// not impose its own timeout: pass a context with a deadline or cancellation,
+// or a slow apiserver blocks indefinitely.
 //
-// The cache map is not safe for concurrent use; the closure assumes
+// The cache map is not safe for concurrent use. The closure assumes
 // sequential calls within a single tree build (which is how
 // build*Tree paths invoke it today).
 func newRefExistsFn(ctx context.Context, dynClient dynamic.Interface, namespace string) existsFn {

--- a/internal/k8s/security.go
+++ b/internal/k8s/security.go
@@ -49,7 +49,7 @@ func severityOrder(it model.Item) int {
 // column. When Kind or Name is missing the row renders as
 // "(unknown resource)" — the previous "(cluster-scoped)" placeholder was
 // misleading because real cluster-scoped objects (e.g., ClusterRole/admin)
-// carry a non-empty Kind and Name and render through the normal path; the
+// carry a non-empty Kind and Name and render through the normal path. The
 // empty-ref case only fires when the source could not extract the resource
 // (e.g., Falco events without InvolvedObject), and labelling those as
 // cluster-scoped suggested a real K8s cluster-level finding existed.
@@ -232,7 +232,7 @@ func (c *Client) GetSecurityAffectedResourcesCached(contextName, namespace strin
 // affectedResourcesFromResult builds the affected-resource items for one
 // finding group from a FetchResult: surfaces the source error, matches
 // findings by source+group, dedups + sorts resources, and applies the ignore
-// policy (hide when show-ignored is off; tag __ignored__ when on). Shared by
+// policy (hide when show-ignored is off, tag __ignored__ when on). Shared by
 // the scanning and cache-only paths.
 func (c *Client) affectedResourcesFromResult(res security.FetchResult, sourceName, groupKey string) ([]model.Item, error) {
 	// Surface the requested source's per-source error so a source-specific

--- a/internal/k8s/whocan.go
+++ b/internal/k8s/whocan.go
@@ -16,7 +16,7 @@ import (
 // that ultimately resolves to a (Cluster)Role with a matching rule.
 //
 // Multiple bindings can grant the same subject — each grant is emitted
-// as its own row so the user can audit every path; the renderer
+// as its own row so the user can audit every path. The renderer
 // shouldn't dedupe.
 type WhoCanSubject struct {
 	// Kind is "User" / "Group" / "ServiceAccount", straight from
@@ -40,7 +40,7 @@ type WhoCanSubject struct {
 // (group, resource) in the requested namespace scope.
 //
 // Scope rules (matching kubectl-who-can):
-//   - namespace == "" → all namespaces are in scope; every RoleBinding
+//   - namespace == "" → all namespaces are in scope. Every RoleBinding
 //     in the cluster plus every ClusterRoleBinding is examined.
 //   - namespace != "" → ClusterRoleBindings still count (cluster-wide
 //     grants always apply), but RoleBindings outside `namespace` are
@@ -76,7 +76,7 @@ func (c *Client) WhoCan(ctx context.Context, contextName, namespace, group, reso
 	for _, crb := range clusterRoleBindings.Items {
 		role, ok := lookupRoleForBinding(crb.RoleRef, "", clusterRoles, roles)
 		if !ok {
-			continue // dangling RoleRef; treat as no grant
+			continue // dangling RoleRef. Treat as no grant
 		}
 		if !ruleSetMatches(role.rules, verb, group, resource) {
 			continue
@@ -143,7 +143,7 @@ func loadClusterRoles(ctx context.Context, cs kubernetes.Interface) (map[string]
 }
 
 // loadRoles fetches Roles. When namespace is empty it walks every
-// namespace; otherwise it scopes to the one in question. Indexed by
+// namespace. Otherwise it scopes to the one in question. Indexed by
 // "<namespace>/<name>" because Role names aren't unique cluster-wide.
 func loadRoles(ctx context.Context, cs kubernetes.Interface, namespace string) (map[string]roleEntry, error) {
 	list, err := cs.RbacV1().Roles(namespace).List(ctx, metav1.ListOptions{})
@@ -169,7 +169,7 @@ func loadRoleBindings(ctx context.Context, cs kubernetes.Interface, namespace st
 
 // lookupRoleForBinding resolves a RoleRef into the underlying role's
 // rules. RoleBindings can reference either a Role (in their own
-// namespace) or a ClusterRole; ClusterRoleBindings always reference
+// namespace) or a ClusterRole. ClusterRoleBindings always reference
 // a ClusterRole. Returns false when the referenced role isn't loaded
 // (orphan ref, RBAC drift) so the caller skips silently — kubectl
 // does the same.
@@ -186,7 +186,7 @@ func lookupRoleForBinding(ref rbacv1.RoleRef, bindingNamespace string, clusterRo
 }
 
 // subjectFromBinding converts an rbacv1.Subject into our flat result
-// row. ServiceAccount kept its namespace (part of identity); other
+// row. ServiceAccount kept its namespace (part of identity). Other
 // kinds normalise namespace to empty so the table doesn't show
 // misleading values.
 func subjectFromBinding(s rbacv1.Subject, via string) WhoCanSubject {
@@ -200,7 +200,7 @@ func subjectFromBinding(s rbacv1.Subject, via string) WhoCanSubject {
 // ruleSetMatches returns true when at least one rule in the set grants
 // the (verb, group, resource) tuple. Skips:
 //   - nonResourceURLs rules (don't grant resource permissions)
-//   - resourceNames-scoped rules (restrict to named objects; the picker
+//   - resourceNames-scoped rules (restrict to named objects, the picker
 //     does not model object names, so reporting these as generic access
 //     would over-report permissions).
 func ruleSetMatches(rules []rbacv1.PolicyRule, verb, group, resource string) bool {
@@ -239,7 +239,7 @@ func verbMatches(ruleVerbs []string, verb string) bool {
 }
 
 // groupMatches: rule grants the group when rule.APIGroups contains
-// the group or "*". Empty group ("") is the core API group; the rule
+// the group or "*". Empty group ("") is the core API group. The rule
 // must list it explicitly (or "*") for a match — there is no "any"
 // fallback because authors who write "" mean the core group.
 func groupMatches(ruleGroups []string, group string) bool {

--- a/internal/logagg/aggregate.go
+++ b/internal/logagg/aggregate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // durBucketsMs are ascending millisecond upper-bounds for the latency
-// histogram. A value falls in the first bucket whose bound is >= it; values
+// histogram. A value falls in the first bucket whose bound is >= it. Values
 // above the last bound fall in the overflow bucket (index len(durBucketsMs)).
 var durBucketsMs = []float64{
 	1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987,
@@ -65,11 +65,11 @@ type Row struct {
 	Count     int
 	ErrCount  int
 	Dims      map[string]string // per-dimension display string: uniform value, or "*N", or "*50+"
-	P50       float64           // approximate p50 latency in ms; -1 when no duration data
-	P95       float64           // approximate p95 latency in ms; -1 when no duration data
-	P99       float64           // approximate p99 latency in ms; -1 when no duration data
-	Avg       float64           // mean latency in ms; -1 when no duration data
-	Max       float64           // max latency in ms; -1 when no duration data
+	P50       float64           // approximate p50 latency in ms. -1 when no duration data
+	P95       float64           // approximate p95 latency in ms. -1 when no duration data
+	P99       float64           // approximate p99 latency in ms. -1 when no duration data
+	Avg       float64           // mean latency in ms. -1 when no duration data
+	Max       float64           // max latency in ms. -1 when no duration data
 	Status4xx int               // count of HTTP 4xx responses
 	Status5xx int               // count of HTTP 5xx responses
 	id        string            // cached "\x00"-joined Values, for a stable allocation-free sort tiebreak

--- a/internal/logagg/detect.go
+++ b/internal/logagg/detect.go
@@ -26,8 +26,8 @@ func ParserFor(kind ProfileKind) Parser {
 }
 
 // structuredHTTPKinds are the strict HTTP access-log profiles. They are
-// structurally demanding (traefik-json requires DownstreamStatus/RequestMethod;
-// envoy/nginx/ingress require a specific line shape), so a non-HTTP app log
+// structurally demanding (traefik-json requires DownstreamStatus/RequestMethod,
+// and envoy/nginx/ingress require a specific line shape), so a non-HTTP app log
 // cannot accidentally match them. When one matches even a few sample lines it is
 // preferred over the loose logfmt/json matchers — see DetectKind.
 var structuredHTTPKinds = []ProfileKind{ProfileTraefikJSON, ProfileIngressNginx, ProfileEnvoy, ProfileNginx}
@@ -35,14 +35,14 @@ var structuredHTTPKinds = []ProfileKind{ProfileTraefikJSON, ProfileIngressNginx,
 // structuredDetectMinHits is how many sample lines a structured HTTP profile
 // must match to be preferred over a generic matcher that scores higher. It is a
 // small absolute count because the structured parsers are strict (no false
-// positives), so a handful of real access-log lines reliably identifies the
+// positives). So a handful of real access-log lines reliably identifies the
 // format even amid a flood of console/error lines.
 const structuredDetectMinHits = 3
 
 // DetectKind picks the log format for a sample. A structured HTTP access-log
 // profile (traefik-json / ingress-nginx / envoy / nginx) is preferred whenever
-// it matches at least structuredDetectMinHits lines, EVEN IF the generic
-// logfmt/json matchers match more lines. This handles mixed deployments (e.g.
+// it matches at least structuredDetectMinHits lines. This holds EVEN IF the
+// generic logfmt/json matchers match more lines. This handles mixed deployments (e.g.
 // Traefik emitting JSON access logs alongside ANSI console error lines that the
 // logfmt matcher loosely catches): the access logs are the data the Top view
 // exists for, so they win over the noise. When no structured profile is present,

--- a/internal/logagg/parse_logfmt.go
+++ b/internal/logagg/parse_logfmt.go
@@ -25,10 +25,8 @@ func (logfmtParser) Parse(line string) (Fields, bool) {
 		// m[3] is the content within quotes (empty if unquoted)
 		var val string
 		if m[2][0] == '"' {
-			// Quoted value: use the unquoted content from group 3
 			val = m[3]
 		} else {
-			// Unquoted value: use the raw value from group 2
 			val = m[2]
 		}
 		if norm, ok := jsonKeyAliases[key]; ok {

--- a/internal/logger/auth_stderr.go
+++ b/internal/logger/auth_stderr.go
@@ -5,8 +5,8 @@ import "strings"
 // execCredentialStderrMarkers are case-insensitive substrings that identify a
 // kubeconfig exec credential plugin (AWS SSO, gke-gcloud-auth-plugin, generic
 // AWS credential providers) reporting a credential failure on os.Stderr. These
-// lines carry no cluster context; the failing API call is attributed to its
-// context separately (see internal/k8s credTaggingRoundTripper), so the raw
+// lines carry no cluster context. The failing API call is attributed to its
+// context separately (see internal/k8s credTaggingRoundTripper). So the raw
 // line is demoted out of the in-app overlay to avoid a contextless duplicate.
 var execCredentialStderrMarkers = []string{
 	"sso session",
@@ -20,8 +20,8 @@ var execCredentialStderrMarkers = []string{
 
 // looksLikeExecCredentialStderr reports whether a captured stderr line is a
 // credential-plugin failure that should be demoted (logged at Debug, kept out
-// of the in-app overlay) in favor of the context-tagged log emitted at the
-// failing API call.
+// of the in-app overlay). Demoting favors the context-tagged log emitted at
+// the failing API call.
 func looksLikeExecCredentialStderr(line string) bool {
 	l := strings.ToLower(line)
 	for _, marker := range execCredentialStderrMarkers {

--- a/internal/logger/dedup.go
+++ b/internal/logger/dedup.go
@@ -71,7 +71,7 @@ func ShouldEmit(tag, contextKey string) (emit bool, suppressed int) {
 }
 
 // WarnOnce emits a WARN log at most once per dedup window. Identical
-// repeats during the window are silently counted; the next emission
+// repeats during the window are silently counted. The next emission
 // after the window includes "suppressed_during_window" so the rate is
 // not lost. The entry is also published to UIChan for the in-app log
 // overlay.

--- a/internal/logger/dedup.go
+++ b/internal/logger/dedup.go
@@ -21,9 +21,9 @@ var (
 
 // dedupPruneEvery is how often (in ShouldEmit calls) we sweep stale
 // entries. Tuned high enough that the O(N) scan cost is amortized to
-// near zero, low enough that a high-cardinality key space (varying
-// stderr lines, per-pod tags across many namespaces) can't accumulate
-// for long. Exposed via a var so tests can lower it.
+// near zero. Also tuned low enough that a high-cardinality key space
+// (varying stderr lines, per-pod tags across many namespaces) can't
+// accumulate for long. Exposed via a var so tests can lower it.
 var dedupPruneEvery = 1024
 
 type dedupEntry struct {
@@ -33,10 +33,10 @@ type dedupEntry struct {
 
 // ShouldEmit reports whether a deduplicated log event identified by
 // (tag, contextKey) should be emitted right now. If the window has
-// elapsed since the previous emission, it returns true plus the count
-// of events suppressed during that window (so callers can surface
-// "(suppressed 142x)" in the next line). If still inside the window,
-// it returns false and increments the suppressed counter.
+// elapsed since the previous emission, it returns true. It also returns
+// the count of events suppressed during that window, so callers can
+// surface "(suppressed 142x)" in the next line. If still inside the
+// window, it returns false and increments the suppressed counter.
 //
 // The (tag, contextKey) pair is the dedup key. Use a stable tag per
 // call site ("node-metrics-load", "stderr-aws-sso") and a contextKey
@@ -105,8 +105,8 @@ func ErrorOnce(tag, contextKey, msg string, args ...any) {
 // pruneDedupStateLocked evicts entries whose window has fully elapsed
 // AND have no suppressed events still owed an emission. The 2x window
 // margin keeps an entry around long enough that a flapping failure
-// (down, up, down) still emits once-per-window rather than re-emitting
-// the first occurrence as "new". Caller must hold dedupMu.
+// (down, up, down) still emits once-per-window. It doesn't re-emit the
+// first occurrence as "new". Caller must hold dedupMu.
 func pruneDedupStateLocked(now time.Time) {
 	cutoff := now.Add(-2 * dedupWindow)
 	for k, v := range dedupState {
@@ -117,7 +117,7 @@ func pruneDedupStateLocked(now time.Time) {
 }
 
 // ResetDedupForTest clears the dedup state AND restores every
-// Set*ForTest override to its production default, so tests can't leak
+// Set*ForTest override to its production default. So tests can't leak
 // state into each other via a forgotten window/clock/prune setting.
 // Test-only.
 func ResetDedupForTest() {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -158,9 +158,9 @@ func (sc *StderrCapture) readLoop() {
 			if msg != "" {
 				// Redact tokens/credentials before logging or surfacing to the
 				// TUI. Exec credential plugins (AWS SSO, gke-gcloud-auth-plugin,
-				// OIDC helpers) routinely emit short-lived tokens to stderr,
-				// and the TUI message also flows through setStatusMessage which
-				// re-logs it — so we must redact at the source.
+				// OIDC helpers) routinely emit short-lived tokens to stderr, and
+				// the TUI message also flows through setStatusMessage which
+				// re-logs it. So we must redact at the source.
 				redacted := Redact(msg)
 				// Dedup identical lines per rolling window. A wedged exec
 				// credential plugin (expired SSO, missing VPN) emits the
@@ -179,8 +179,8 @@ func (sc *StderrCapture) readLoop() {
 				// A kubeconfig exec credential plugin (AWS SSO, gke auth) writes
 				// its credential error here with no cluster context. The failing
 				// in-process API call is tagged with the context separately (see
-				// internal/k8s credTaggingRoundTripper), so demote this contextless
-				// duplicate to Debug and keep it out of the in-app overlay rather
+				// internal/k8s credTaggingRoundTripper). So demote this contextless
+				// duplicate to Debug and keep it out of the in-app overlay, rather
 				// than surfacing an unactionable "which cluster?" line.
 				if looksLikeExecCredentialStderr(redacted) {
 					Logger.Debug(redacted, args...)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -109,7 +109,7 @@ type StderrCapture struct {
 }
 
 // NewStderrCapture creates a pipe-based stderr capture. The write end can
-// replace os.Stderr; a background goroutine reads from the pipe and logs
+// replace os.Stderr. A background goroutine reads from the pipe and logs
 // each line via the application logger.
 func NewStderrCapture() *StderrCapture {
 	r, w, err := os.Pipe()
@@ -164,7 +164,7 @@ func (sc *StderrCapture) readLoop() {
 				redacted := Redact(msg)
 				// Dedup identical lines per rolling window. A wedged exec
 				// credential plugin (expired SSO, missing VPN) emits the
-				// same error 20+ times/sec; without this gate, both the
+				// same error 20+ times/sec. Without this gate, both the
 				// on-disk log and the in-app overlay drown in repeats.
 				// Key on the redacted text itself so any change in the
 				// error surfaces immediately.

--- a/internal/logger/redact.go
+++ b/internal/logger/redact.go
@@ -2,11 +2,12 @@ package logger
 
 import "regexp"
 
-// redactPatterns is a curated set of regexes for likely-sensitive content
-// that may end up in stderr from auth helpers, exec credential plugins,
-// kubectl invocations, or upstream library messages. The list is intentionally
-// conservative — false positives in stderr logs are worse than missing a
-// novel pattern, since users investigating issues need readable context.
+// redactPatterns is a curated set of regexes for likely-sensitive content.
+// It targets content that may end up in stderr from auth helpers, exec
+// credential plugins, kubectl invocations, or upstream library messages.
+// The list is intentionally conservative — false positives in stderr logs
+// are worse than missing a novel pattern, since users investigating issues
+// need readable context.
 var redactPatterns = []struct {
 	re   *regexp.Regexp
 	repl string

--- a/internal/logger/ui_channel.go
+++ b/internal/logger/ui_channel.go
@@ -23,10 +23,9 @@ func UIChan() <-chan UIEntry {
 	return uiChan
 }
 
-// publishUI sends to the UI channel without blocking. Drops on full;
-// the on-disk log already has the line, and dropping is preferable to
-// stalling the emit path (or growing the channel unbounded in the
-// presence of a wedged UI).
+// publishUI sends to the UI channel without blocking, and drops the entry
+// when the channel is full. The on-disk log already has the line. A wedged
+// UI must not stall the emit path or grow the channel unbounded.
 func publishUI(level, msg string, args []any) {
 	e := UIEntry{Time: time.Now(), Level: level, Message: msg, Args: args}
 	select {

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -72,7 +72,7 @@ const ActionLabelExportTemplate = "Export Template"
 // (internal/app/update_overlays.go) closes the overlay on that keypress
 // before any chip matcher runs — the chip would be unreachable (TASK-891).
 // "T" was freed by moving Log Top, Terminate Sync, and Terminate Workflow to
-// lowercase "t" (their menus had no lowercase "t" of their own); CronJob's
+// lowercase "t" (their menus had no lowercase "t" of their own). CronJob's
 // existing "t" Trigger moved to "r" to avoid colliding with the relocated
 // Log Top.
 func exportTemplateAction() ActionMenuItem {
@@ -546,7 +546,7 @@ func actionsForKarpenterKind(kind string) ([]ActionMenuItem, bool) {
 // kinds. Revision exposes Activate — patching the parent Service's
 // spec.traffic to send 100% of traffic to the selected revision, the
 // canonical Knative rollback / promotion gesture. Configuration and
-// Route stay on the standard surface; their CRD printer columns (URL,
+// Route stay on the standard surface. Their CRD printer columns (URL,
 // LatestReady, Ready) carry the operationally useful state and the
 // generic Describe/Edit/Delete/Events covers the rest.
 //
@@ -591,7 +591,7 @@ func actionsForKnativeKind(kind string) ([]ActionMenuItem, bool) {
 // kubectl node verbs that do not apply here): a longhorn.io node is managed
 // through its spec. Evict Replicas / Cancel Eviction toggle
 // spec.evictionRequested so Longhorn rebuilds replicas elsewhere before
-// removing them; Force Delete disables scheduling then deletes past the
+// removing them. Force Delete disables scheduling then deletes past the
 // validating webhook (which rejects deletion of a still-schedulable node).
 func ActionsForLonghornNode() []ActionMenuItem {
 	return []ActionMenuItem{
@@ -646,7 +646,7 @@ type ClusterPickerKeys struct {
 // the Local clusters action. Hardcoded because (a) action-menu
 // dispatch routes single keypresses, not chords, and (b) the global
 // LocalClusterManager binding (ctrl+n) opens the manager from
-// anywhere; the action-menu chip is a separate discoverability
+// anywhere. The action-menu chip is a separate discoverability
 // channel and need not echo it.
 const localClustersMenuChip = "n"
 

--- a/internal/model/delete_propagation.go
+++ b/internal/model/delete_propagation.go
@@ -6,12 +6,12 @@ import (
 )
 
 // DeletePropagation selects how a delete cascades to dependent objects.
-// Values match the lowercase config spelling; the k8s layer maps them to
+// Values match the lowercase config spelling. The k8s layer maps them to
 // metav1.DeletionPropagation.
 type DeletePropagation string
 
 const (
-	// DeletePropagationBackground deletes the object immediately; the garbage
+	// DeletePropagationBackground deletes the object immediately. The garbage
 	// collector removes dependents afterwards. This is kubectl's default.
 	DeletePropagationBackground DeletePropagation = "background"
 	// DeletePropagationForeground keeps the object visible until every
@@ -49,7 +49,7 @@ var deletePropagationCascading = []DeletePropagation{
 }
 
 // ParseDeletePropagation resolves a config string to a policy. The bool
-// reports whether the input was recognized; callers that want to warn on a
+// reports whether the input was recognized. Callers that want to warn on a
 // typo check it, everyone else can use the Background fallback directly.
 func ParseDeletePropagation(raw string) (DeletePropagation, bool) {
 	switch DeletePropagation(strings.ToLower(strings.TrimSpace(raw))) {

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -8,7 +8,7 @@ import "slices"
 var CoreCategories = []string{
 	"Dashboards",
 	"Security", // dynamically populated via model.SecuritySourcesFn
-	"Pinned",   // user-pinned resource types; section hidden when empty
+	"Pinned",   // user-pinned resource types. Section hidden when empty
 	"Cluster",
 	"Workloads",
 	"Config",
@@ -114,7 +114,7 @@ var GroupCategoryFallback = map[string]string{
 
 // GroupFallbackRank gives auto-categorized items a sort rank so they
 // slot into a predictable position within their category. All items
-// sharing a group use the same rank; ties fall back to alphabetical
+// sharing a group use the same rank. Ties fall back to alphabetical
 // by display name. Consulted by itemOrderRank when a key-level lookup
 // in BuiltInOrderRank misses.
 var GroupFallbackRank = map[string]int{
@@ -256,7 +256,7 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"longhorn.io/recurringjobs": {Category: "longhorn.io", DisplayName: "RecurringJobs", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"longhorn.io/settings":      {Category: "longhorn.io", DisplayName: "Settings", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// Istio — ecosystem CRDs; "⎈" is now Helm-specific.
+	// Istio — ecosystem CRDs. "⎈" is now Helm-specific.
 	"networking.istio.io/virtualservices":      {Category: "networking.istio.io", DisplayName: "VirtualServices", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"networking.istio.io/destinationrules":     {Category: "networking.istio.io", DisplayName: "DestinationRules", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"networking.istio.io/gateways":             {Category: "networking.istio.io", DisplayName: "Gateways", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
@@ -267,7 +267,7 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"security.istio.io/requestauthentications": {Category: "security.istio.io", DisplayName: "RequestAuthentications", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"telemetry.istio.io/telemetries":           {Category: "telemetry.istio.io", DisplayName: "Telemetries", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// Cloud provider — ecosystem CRDs; use the generic fallback.
+	// Cloud provider — ecosystem CRDs. Use the generic fallback.
 	"cloud.google.com/backendconfigs":                          {Category: "cloud.google.com", DisplayName: "BackendConfigs", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"networking.gke.io/managedcertificates":                    {Category: "networking.gke.io", DisplayName: "ManagedCertificates", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"vpcresources.k8s.aws/securitygrouppolicies":               {Category: "vpcresources.k8s.aws", DisplayName: "SecurityGroupPolicies", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
@@ -279,7 +279,7 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 
 	// Karpenter — kind-specific glyphs so node-provisioning CRDs read
 	// at a glance against the surrounding generic-CR rows. Core Node
-	// uses "⌹"; we deliberately stay distinct so a NodePool / NodeClaim
+	// uses "⌹". We deliberately stay distinct so a NodePool / NodeClaim
 	// row never gets confused with a real Node row.
 	"karpenter.sh/nodepools":           {Category: "karpenter.sh", DisplayName: "NodePools", Icon: Icon{Unicode: "⏣", Simple: "[NP]", Emoji: "🗄️", NerdFont: "\U000f048b"}},
 	"karpenter.sh/nodeclaims":          {Category: "karpenter.sh", DisplayName: "NodeClaims", Icon: Icon{Unicode: "⌬", Simple: "[NC]", Emoji: "📦", NerdFont: "\U000f048b"}},
@@ -293,23 +293,23 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"monitoring.coreos.com/prometheuses":    {Category: "monitoring.coreos.com", DisplayName: "Prometheuses", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"monitoring.coreos.com/thanosrulers":    {Category: "monitoring.coreos.com", DisplayName: "ThanosRulers", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// keda.sh — ecosystem CRDs; "⚡" is now /events.
+	// keda.sh — ecosystem CRDs. "⚡" is now /events.
 	"keda.sh/scaledobjects":                 {Category: "keda.sh", DisplayName: "ScaledObjects", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"keda.sh/scaledjobs":                    {Category: "keda.sh", DisplayName: "ScaledJobs", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"keda.sh/triggerauthentications":        {Category: "keda.sh", DisplayName: "TriggerAuthentications", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"keda.sh/clustertriggerauthentications": {Category: "keda.sh", DisplayName: "ClusterTriggerAuthentications", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// external-secrets.io — ecosystem CRDs; "⚿" is now RBAC roles.
+	// external-secrets.io — ecosystem CRDs. "⚿" is now RBAC roles.
 	"external-secrets.io/externalsecrets":        {Category: "external-secrets.io", DisplayName: "ExternalSecrets", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"external-secrets.io/clusterexternalsecrets": {Category: "external-secrets.io", DisplayName: "ClusterExternalSecrets", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"external-secrets.io/pushsecrets":            {Category: "external-secrets.io", DisplayName: "PushSecrets", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"external-secrets.io/secretstores":           {Category: "external-secrets.io", DisplayName: "SecretStores", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"external-secrets.io/clustersecretstores":    {Category: "external-secrets.io", DisplayName: "ClusterSecretStores", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// bitnami.com — ecosystem CRD; "⚿" is now RBAC roles.
+	// bitnami.com — ecosystem CRD. "⚿" is now RBAC roles.
 	"bitnami.com/sealedsecrets": {Category: "bitnami.com", DisplayName: "SealedSecrets", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 
-	// traefik.io — ecosystem CRDs; "⎈" is now Helm-specific.
+	// traefik.io — ecosystem CRDs. "⎈" is now Helm-specific.
 	"traefik.io/ingressroutes":    {Category: "traefik.io", DisplayName: "IngressRoutes", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"traefik.io/middlewares":      {Category: "traefik.io", DisplayName: "Middlewares", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},
 	"traefik.io/ingressroutetcps": {Category: "traefik.io", DisplayName: "IngressRouteTCPs", Icon: Icon{Unicode: "⧫", Simple: "[CR]", Emoji: "🔷", NerdFont: "\U000f0174"}},

--- a/internal/model/objecttree.go
+++ b/internal/model/objecttree.go
@@ -153,7 +153,7 @@ func ObjectValuePreview(v any) string {
 	}
 }
 
-// scalarString stringifies a scalar value; non-scalars and nil yield "".
+// scalarString stringifies a scalar value. Non-scalars and nil yield "".
 func scalarString(v any) string {
 	switch t := v.(type) {
 	case nil:
@@ -184,7 +184,7 @@ func scalarString(v any) string {
 }
 
 // ResolveObjectPath walks root along segs and returns the value at the end.
-// Plain segments index into a map; "[i]" segments index into an array. Returns
+// Plain segments index into a map. "[i]" segments index into an array. Returns
 // ok=false if any segment is missing or out of range.
 func ResolveObjectPath(root any, segs []string) (any, bool) {
 	cur := root

--- a/internal/model/resource_lookup.go
+++ b/internal/model/resource_lookup.go
@@ -46,7 +46,7 @@ func FindResourceTypeIn(ref string, discovered []ResourceTypeEntry) (ResourceTyp
 
 // FindResourceType is kept as a convenience wrapper that searches without
 // a discovered slice. It exists for callers that don't have access to the
-// discovered set yet; most callers should use FindResourceTypeIn directly.
+// discovered set yet. Most callers should use FindResourceTypeIn directly.
 func FindResourceType(ref string) (ResourceTypeEntry, bool) {
 	return FindResourceTypeIn(ref, nil)
 }

--- a/internal/model/sidebar.go
+++ b/internal/model/sidebar.go
@@ -33,7 +33,7 @@ func BuildSidebarItems(discovered []ResourceTypeEntry) []Item {
 
 // markHiddenItems applies the user's per-context HiddenTypes to the sidebar.
 // When the reveal toggle (ShowRareResources) is off, items whose version-
-// agnostic type key is hidden are dropped; when it is on they are kept but
+// agnostic type key is hidden are dropped. When it is on they are kept but
 // flagged Hidden so the renderer dims them, letting the user find a hidden
 // type and un-hide it. Items without a pinnable key (dashboards, collapsed
 // group placeholders) never match.
@@ -69,7 +69,7 @@ func markHiddenItems(items []Item) []Item {
 //
 // A SecuritySourceEntry with empty SourceName is treated as a loader
 // placeholder (shown while the availability probe is in flight on a
-// fresh cluster); the produced Item carries SecurityLoaderKind and no
+// fresh cluster). The produced Item carries SecurityLoaderKind and no
 // Extra so the navigation layer can no-op clicks on it.
 func injectSecuritySourceItems() []Item {
 	if SecuritySourcesFn == nil {

--- a/internal/model/taints.go
+++ b/internal/model/taints.go
@@ -82,7 +82,7 @@ type taintIdentity struct{ key, effect string }
 
 // ComputeFinalTaints returns existing minus removals plus additions,
 // matching by key+effect identity (never by position). Removals of
-// taints that no longer exist are no-ops; additions whose identity is
+// taints that no longer exist are no-ops. Additions whose identity is
 // already present are dropped (the server would reject them). Taints
 // present on the node but unknown to the caller — added concurrently —
 // survive untouched. Inputs are not mutated.

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -92,7 +92,7 @@ type PrinterColumn struct {
 	JSONPath string // e.g. ".status.phase", ".spec.source.repoURL"
 	// Priority mirrors the column's additionalPrinterColumns priority.
 	// kubectl shows priority 0 columns in standard output and hides
-	// priority > 0 columns unless `-o wide`; LFK applies the same default.
+	// priority > 0 columns unless `-o wide`. LFK applies the same default.
 	Priority int
 }
 
@@ -234,7 +234,7 @@ var ConfigDefaultRightsizingHeadroom float64
 // GroupedRef identifies a single resource within a grouped row (e.g., one
 // of the many Event objects collapsed into a single line by event grouping).
 // ClusterName is set in union mode so the bulk dispatcher can route each ref
-// to its source cluster; empty otherwise.
+// to its source cluster. Empty otherwise.
 type GroupedRef struct {
 	Name        string
 	Namespace   string
@@ -258,7 +258,7 @@ type Item struct {
 	LastSeen      time.Time        // Most recent observation (Events only — drives the "Last Seen" column)
 	Columns       []KeyValue       // Additional resource fields for summary preview
 	Conditions    []ConditionEntry // Status conditions for the details pane
-	ClusterName   string           // Source cluster in union mode; empty in normal mode
+	ClusterName   string           // Source cluster in union mode. Empty in normal mode
 	Selected      bool             // Whether this item is part of a multi-selection
 	Deprecated    bool             // Whether this resource uses a deprecated API version
 	Deleting      bool             // Whether this resource has a deletionTimestamp set
@@ -267,15 +267,15 @@ type Item struct {
 	// duplicate of Status, so the list summary can still roll up by phase
 	// rather than falling back to coarse Ready/NotReady conditions (issue #536).
 	StatusFromPhase bool
-	Hidden          bool // Resource-type row the user hid; rendered dimmed when revealed via ShowRareResources
-	Rare            bool // Rarely-used type surfaced only via ShowRareResources; rendered dimmed and not user-hideable
+	Hidden          bool // Resource-type row the user hid. Rendered dimmed when revealed via ShowRareResources
+	Rare            bool // Rarely-used type surfaced only via ShowRareResources. Rendered dimmed and not user-hideable
 
 	ReadOnly     bool   // Whether this item represents a context locked in read-only mode (renders as a [RO] suffix in the picker)
-	ClusterColor string // Optional named color (one of ui.ClusterColorNames) for context rows; empty = no swatch.
+	ClusterColor string // Optional named color (one of ui.ClusterColorNames) for context rows. Empty = no swatch.
 	// LocalClusterStatus is "running" / "stopped" / "" — populated only
 	// for cluster-picker rows whose context name is recognised in
 	// Model.localClusterCache. The renderer prepends a filled-circle
-	// glyph for "running" and a hollow-circle glyph for "stopped"; an
+	// glyph for "running" and a hollow-circle glyph for "stopped". An
 	// empty string means the row is not a local cluster and the
 	// renderer skips the icon entirely.
 	LocalClusterStatus string
@@ -298,7 +298,7 @@ type Item struct {
 // SelectionKey returns the stable map key identifying this item in a
 // multi-selection set. Union-mode rows carry a non-empty ClusterName, which
 // is prepended so the same name+namespace appearing in two clusters stays
-// distinct; non-union rows produce the legacy "namespace/name" (or bare
+// distinct. Non-union rows produce the legacy "namespace/name" (or bare
 // "name") form. This is the single source of truth for the key: both the
 // app's selection store and the ui renderer's selected-row check derive
 // their keys here so the two can never drift.
@@ -326,7 +326,7 @@ func (i Item) ColumnValue(key string) string {
 
 // MissingRefStatus is the Status string assigned to a ResourceNode whose
 // referenced object (Secret/ConfigMap/PVC/ServiceAccount) does not exist on
-// the cluster. The k8s package writes it; the ui package matches on it in
+// the cluster. The k8s package writes it. The ui package matches on it in
 // StatusStyle to render the node red. Keep these two callers in sync via
 // this single constant.
 const MissingRefStatus = "MissingRef"
@@ -401,7 +401,7 @@ type Bookmark struct {
 
 // IsContextAware reports whether this bookmark is anchored to a specific
 // kube context or named union set. Context-aware bookmarks switch to their
-// stored target on jump; context-free bookmarks use whatever target is
+// stored target on jump. Context-free bookmarks use whatever target is
 // currently active.
 func (b Bookmark) IsContextAware() bool {
 	return b.Context != "" || b.UnionSet != ""
@@ -498,14 +498,14 @@ func (s RightsizingStrategy) MethodologyHint() string {
 
 // Rightsizing is the per-workload right-sizing recommendation
 // payload. Source is the legacy human-readable label kept for
-// external readers; new code should branch on Strategy instead.
+// external readers. New code should branch on Strategy instead.
 type Rightsizing struct {
 	Source              string                // legacy human-readable label (set from Strategy.HumanLabel())
 	Strategy            RightsizingStrategy   // which algorithm produced these numbers
 	AvailableStrategies []RightsizingStrategy // subset of AllRightsizingStrategies usable on this workload + cluster
 	Headroom            float64               // headroom multiplier that produced these numbers (e.g. 1.25 = 25% padding above usage)
 	PodCount            int                   // pods aggregated (always 1 for Pod kind)
-	Window              string                // sampling window (e.g. "30s" for metrics-server, "1d"/"7d" for Prometheus); empty for VPA
+	Window              string                // sampling window (e.g. "30s" for metrics-server, "1d"/"7d" for Prometheus). Empty for VPA
 	Containers          []ContainerRec
 }
 

--- a/internal/profiling/memstats.go
+++ b/internal/profiling/memstats.go
@@ -48,7 +48,7 @@ func Sample() MemSample {
 }
 
 // LogFields renders a sample as structured key/value pairs for slog-style
-// logging. Byte counts are reported in MiB for readability; HeapObjects and
+// logging. Byte counts are reported in MiB for readability. HeapObjects and
 // goroutines are the leak-class discriminators and are reported raw.
 func LogFields(s MemSample) []any {
 	return []any{
@@ -63,7 +63,7 @@ func LogFields(s MemSample) []any {
 }
 
 // NormalizeInterval validates a requested sampling interval. A non-positive
-// interval disables sampling (ok=false); anything below MinInterval is clamped
+// interval disables sampling (ok=false). Anything below MinInterval is clamped
 // up to MinInterval.
 func NormalizeInterval(d time.Duration) (interval time.Duration, ok bool) {
 	if d <= 0 {

--- a/internal/security/advisor/advisor.go
+++ b/internal/security/advisor/advisor.go
@@ -82,10 +82,9 @@ type workload struct {
 	// updateStrategy: OnDelete. An empty type is NOT OnDelete — the API
 	// server defaults it to RollingUpdate.
 	onDeleteUpdate bool
-	// staticReplicasOwner is the field manager that owns .spec.replicas
-	// through a whole-object write per managedFields (scale-subresource
-	// writers like the HPA are excluded) — empty when no manifest pins
-	// the replica count.
+	// staticReplicasOwner is the field manager that owns .spec.replicas through
+	// a whole-object write per managedFields (scale-subresource writers like
+	// the HPA are excluded). It is empty when no manifest pins the replica count.
 	staticReplicasOwner string
 	// stsServiceName is the StatefulSet's spec.serviceName (governing
 	// headless Service). Empty for other kinds.
@@ -118,8 +117,8 @@ func templateSpreads(tmpl *corev1.PodTemplateSpec) bool {
 type clusterData struct {
 	workloads []workload
 	// workloadsOK is true only when every workload list (Deployments,
-	// StatefulSets, DaemonSets) succeeded — required by checks that reason
-	// about the absence of a matching workload (orphan_pdb).
+	// StatefulSets, DaemonSets) succeeded. It is required by checks that
+	// reason about the absence of a matching workload (orphan_pdb).
 	workloadsOK bool
 	pdbs        []policyv1.PodDisruptionBudget
 	pdbsOK      bool

--- a/internal/security/advisor/advisor.go
+++ b/internal/security/advisor/advisor.go
@@ -88,10 +88,10 @@ type workload struct {
 	// the replica count.
 	staticReplicasOwner string
 	// stsServiceName is the StatefulSet's spec.serviceName (governing
-	// headless Service); empty for other kinds.
+	// headless Service). Empty for other kinds.
 	stsServiceName string
 	// stsVCTClasses holds the storageClassName of each StatefulSet
-	// volumeClaimTemplate ("" = the cluster default class); nil for other
+	// volumeClaimTemplate ("" = the cluster default class), nil for other
 	// kinds.
 	stsVCTClasses []string
 }
@@ -113,7 +113,7 @@ func templateSpreads(tmpl *corev1.PodTemplateSpec) bool {
 }
 
 // clusterData holds everything Fetch could list. Each OK flag records whether
-// the corresponding list succeeded; checks that depend on a failed list are
+// the corresponding list succeeded. Checks that depend on a failed list are
 // skipped entirely (best-effort RBAC) instead of emitting false positives.
 type clusterData struct {
 	workloads []workload

--- a/internal/security/advisor/checks.go
+++ b/internal/security/advisor/checks.go
@@ -155,10 +155,11 @@ func (d *clusterData) workloadFindings() []security.Finding {
 }
 
 // badRolloutStrategy returns a non-empty reason when a multi-replica
-// Deployment's rollout takes every replica down: strategy Recreate, or a
+// Deployment's rollout takes down every replica: strategy Recreate, or a
 // RollingUpdate that allows 100% (or >= replicas) unavailable. An empty
-// strategy Type (possible only pre-API-defaulting, e.g. fakes) falls through
-// to the RollingUpdate branch, matching the API server's default.
+// strategy Type is possible only pre-API-defaulting, for example in fakes.
+// It falls through to the RollingUpdate branch, matching the API server's
+// default.
 func badRolloutStrategy(w *workload) string {
 	if w.strategy == nil || w.replicas < 2 {
 		return ""
@@ -194,7 +195,7 @@ func unboundedEmptyDirs(volumes []corev1.Volume) []string {
 }
 
 // containersWithIdenticalProbes returns names of containers whose liveness
-// and readiness probes are exactly equal — the readiness failure mode
+// and readiness probes are exactly equal. The readiness failure mode
 // (shed traffic) is replaced by the liveness one (restart).
 func containersWithIdenticalProbes(containers []corev1.Container) []string {
 	var names []string
@@ -292,7 +293,7 @@ func pdbBlocksDrain(p *policyv1.PodDisruptionBudget, workloads []workload) strin
 }
 
 // hpaFindings flags HPAs scaling on resource utilization while the target
-// workload's containers set no request for that resource — the HPA cannot
+// workload's containers set no request for that resource. The HPA cannot
 // compute utilization and never scales.
 func (d *clusterData) hpaFindings() []security.Finding {
 	if !d.hpasOK {

--- a/internal/security/advisor/checks_capacity.go
+++ b/internal/security/advisor/checks_capacity.go
@@ -29,7 +29,7 @@ func (d *clusterData) quotaFindings() []security.Finding {
 			continue
 		}
 		// Status.Hard mirrors Spec.Hard once the quota controller has
-		// reconciled; fall back to Spec.Hard for a brand-new quota. Used is
+		// reconciled. Fall back to Spec.Hard for a brand-new quota. Used is
 		// empty in that window too, so the fallback cannot create a finding.
 		hard := q.Status.Hard
 		if len(hard) == 0 {

--- a/internal/security/advisor/checks_jobs.go
+++ b/internal/security/advisor/checks_jobs.go
@@ -45,7 +45,7 @@ func (d *clusterData) batchFindings() []security.Finding {
 }
 
 // storageExpansionFindings flags StatefulSets whose volumeClaimTemplates use
-// a StorageClass with allowVolumeExpansion unset or false — the volumes
+// a StorageClass with allowVolumeExpansion unset or false. The volumes
 // cannot grow in place, and StatefulSet storage is painful to migrate.
 func (d *clusterData) storageExpansionFindings() []security.Finding {
 	if !d.scOK {
@@ -72,7 +72,7 @@ func (d *clusterData) storageExpansionFindings() []security.Finding {
 				class = defaultClass
 			}
 			if class == "" {
-				continue // no default class resolvable; different problem
+				continue // no default class resolvable, a separate problem
 			}
 			if canExpand, known := expandable[class]; known && !canExpand {
 				fixed = append(fixed, class)

--- a/internal/security/advisor/checks_scaling.go
+++ b/internal/security/advisor/checks_scaling.go
@@ -1,6 +1,6 @@
 // Scaling/disruption interaction checks: PDBs that deadlock against HPA
-// minimums, PDBs that strand crashlooping pods during drains, and manifests
-// that fight their autoscaler over the replica count.
+// minimums, and PDBs that strand crashlooping pods during drains. Also
+// covers manifests that fight their autoscaler over the replica count.
 
 package advisor
 
@@ -24,10 +24,9 @@ func (d *clusterData) scalingFindings() []security.Finding {
 	)
 }
 
-// pdbUnhealthyPolicyFindings flags PDBs without unhealthyPodEvictionPolicy.
-// The default (IfHealthyBudget) refuses to evict already-unhealthy pods when
-// the budget is not met, so a drain can hang on a crashlooping workload that
-// the eviction could not make any less available. AlwaysAllow (1.27+) fixes it.
+// pdbUnhealthyPolicyFindings flags PDBs without unhealthyPodEvictionPolicy. The default (IfHealthyBudget)
+// refuses to evict already-unhealthy pods when the budget is not met. A drain can hang on a crashlooping
+// workload that the eviction could not make any less available. AlwaysAllow (1.27+) fixes it.
 func (d *clusterData) pdbUnhealthyPolicyFindings() []security.Finding {
 	if !d.pdbsOK {
 		return nil
@@ -46,7 +45,7 @@ func (d *clusterData) pdbUnhealthyPolicyFindings() []security.Finding {
 }
 
 // pdbVsHPAFindings flags PDBs whose integer minAvailable exceeds the
-// minReplicas of an HPA scaling the same workload: when the HPA scales to
+// minReplicas of an HPA scaling the same workload. When the HPA scales to
 // its minimum, the PDB permits zero disruptions and drains deadlock.
 // minAvailable == minReplicas is deliberately not flagged (too common, and
 // pdb_blocks_drain covers the current-replica case). Percentage minAvailable
@@ -93,8 +92,8 @@ func (d *clusterData) pdbVsHPAFindings() []security.Finding {
 }
 
 // staticReplicasFindings flags HPA-scaled workloads whose .spec.replicas is
-// still owned by another field manager (helm, kubectl, a GitOps controller):
-// every re-apply of that manifest resets the replica count and fights the
+// still owned by another field manager (helm, kubectl, a GitOps controller).
+// Every re-apply of that manifest resets the replica count and fights the
 // autoscaler.
 func (d *clusterData) staticReplicasFindings() []security.Finding {
 	if !d.hpasOK {
@@ -119,14 +118,13 @@ func (d *clusterData) staticReplicasFindings() []security.Finding {
 	return out
 }
 
-// staticReplicasOwner returns the field manager that owns .spec.replicas
-// through a whole-object write — i.e. a manifest that re-applies. Writes
-// through the scale subresource (the HPA controller, kubectl scale) are
-// excluded by their Subresource field rather than by manager name, which
-// varies across Kubernetes versions (kube-controller-manager pre-1.24,
-// horizontal-pod-autoscaler later). Both names are excluded as a fallback
-// for entries recorded before subresource tracking. Empty when no manifest
-// pins the field. Malformed managedFields entries are skipped — they must
+// staticReplicasOwner returns the field manager that owns .spec.replicas through a
+// whole-object write — i.e. a manifest that re-applies. Writes through the scale
+// subresource (the HPA controller, kubectl scale) are excluded by their Subresource
+// field rather than by manager name. Manager names vary across Kubernetes versions
+// (kube-controller-manager pre-1.24, horizontal-pod-autoscaler later). Both names are
+// excluded as a fallback for entries recorded before subresource tracking. Empty when
+// no manifest pins the field. Malformed managedFields entries are skipped — they must
 // not invent findings.
 func staticReplicasOwner(entries []metav1.ManagedFieldsEntry) string {
 	for i := range entries {

--- a/internal/security/advisor/checks_scaling.go
+++ b/internal/security/advisor/checks_scaling.go
@@ -49,7 +49,7 @@ func (d *clusterData) pdbUnhealthyPolicyFindings() []security.Finding {
 // minReplicas of an HPA scaling the same workload: when the HPA scales to
 // its minimum, the PDB permits zero disruptions and drains deadlock.
 // minAvailable == minReplicas is deliberately not flagged (too common, and
-// pdb_blocks_drain covers the current-replica case); percentage minAvailable
+// pdb_blocks_drain covers the current-replica case). Percentage minAvailable
 // is skipped because its pod count depends on the live scale.
 func (d *clusterData) pdbVsHPAFindings() []security.Finding {
 	if !d.pdbsOK || !d.hpasOK {
@@ -124,7 +124,7 @@ func (d *clusterData) staticReplicasFindings() []security.Finding {
 // through the scale subresource (the HPA controller, kubectl scale) are
 // excluded by their Subresource field rather than by manager name, which
 // varies across Kubernetes versions (kube-controller-manager pre-1.24,
-// horizontal-pod-autoscaler later); both names are excluded as a fallback
+// horizontal-pod-autoscaler later). Both names are excluded as a fallback
 // for entries recorded before subresource tracking. Empty when no manifest
 // pins the field. Malformed managedFields entries are skipped — they must
 // not invent findings.

--- a/internal/security/advisor/checks_service.go
+++ b/internal/security/advisor/checks_service.go
@@ -37,7 +37,7 @@ func (d *clusterData) statefulSetServiceFindings() []security.Finding {
 			continue
 		}
 		if w.stsServiceName == "" {
-			// serviceName is required by validation; an empty value only
+			// serviceName is required by validation. An empty value only
 			// appears in pre-validation fakes. Nothing to check.
 			continue
 		}
@@ -56,11 +56,9 @@ func (d *clusterData) statefulSetServiceFindings() []security.Finding {
 	return out
 }
 
-// endpointFindings flags selector Services with zero ready endpoints
-// (selector matches nothing, or every backend is down) and Services with
-// exactly one ready endpoint (any restart is a full outage). Selector-less
-// and ExternalName Services manage their endpoints elsewhere and are
-// skipped.
+// endpointFindings flags selector Services with zero ready endpoints (selector matches nothing, or every
+// backend is down). It also flags Services with exactly one ready endpoint (any restart is a full outage).
+// Selector-less and ExternalName Services manage their endpoints elsewhere and are skipped.
 func (d *clusterData) endpointFindings() []security.Finding {
 	if !d.servicesOK || !d.epsOK {
 		return nil

--- a/internal/security/falco/falco.go
+++ b/internal/security/falco/falco.go
@@ -135,7 +135,6 @@ func (s *Source) fetchFromLogs(ctx context.Context, namespace string) []security
 
 	for i := range falcoPods {
 		pod := &falcoPods[i]
-		// Read logs from the falco container.
 		logOpts := &corev1.PodLogOptions{
 			TailLines: &tail,
 			Container: "falco",

--- a/internal/security/falco/falco.go
+++ b/internal/security/falco/falco.go
@@ -16,7 +16,7 @@ import (
 )
 
 // tailLines is the number of log lines to read from each Falco pod.
-// Falco outputs one JSON line per alert; 500 covers the recent history
+// Falco outputs one JSON line per alert. 500 covers the recent history
 // without pulling excessive data.
 const tailLines int64 = 500
 
@@ -156,7 +156,7 @@ func (s *Source) fetchFromLogs(ctx context.Context, namespace string) []security
 		func() {
 			defer func() { _ = stream.Close() }()
 			scanner := bufio.NewScanner(stream)
-			// Allow individual log lines up to maxScannerLineBytes; the
+			// Allow individual log lines up to maxScannerLineBytes. The
 			// default 64 KiB cap is small enough that a long JSON event
 			// (rule with deeply nested output_fields) can hit
 			// bufio.ErrTooLong and abort the scan silently.

--- a/internal/security/falco/parse.go
+++ b/internal/security/falco/parse.go
@@ -75,7 +75,7 @@ func parseLogLine(line []byte, namespace string) []security.Finding {
 }
 
 // formatFalcoOutput extracts a human-readable summary and structured details
-// from a Falco log entry. The summary is a one-liner; the details show
+// from a Falco log entry. The summary is a one-liner. The details show
 // key fields as labeled lines.
 func formatFalcoOutput(entry falcoLogEntry) (summary, details string) {
 	fields := entry.OutputFields

--- a/internal/security/gatekeeper/gatekeeper.go
+++ b/internal/security/gatekeeper/gatekeeper.go
@@ -28,7 +28,7 @@ import (
 const ConstraintsGroup = "constraints.gatekeeper.sh"
 
 // ConstraintsVersion is the API version Gatekeeper has shipped Constraints
-// under since v3.0. Newer versions (v1) are anticipated; for now we list
+// under since v3.0. Newer versions (v1) are anticipated. For now we list
 // only v1beta1 instances and accept that v1-only constraints would be
 // missed until this constant is updated.
 const ConstraintsVersion = "v1beta1"
@@ -37,7 +37,7 @@ const ConstraintsVersion = "v1beta1"
 // newest API version first. The probe avoids the Discovery API (which
 // client-go doesn't expose with a context, so a hung API server would
 // block the probe goroutine past the manager's 3s timeout). v1 has been
-// GA since Gatekeeper 3.10; clusters older than that serve
+// GA since Gatekeeper 3.10. Clusters older than that serve
 // ConstraintTemplate as v1beta1 only, so the probe falls back to it
 // before reporting Gatekeeper unavailable.
 var constraintTemplateGVRs = []schema.GroupVersionResource{
@@ -143,7 +143,7 @@ func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]securi
 // discoverConstraintKinds returns every API resource served under
 // constraints.gatekeeper.sh/v1beta1, bounded by ctx. client-go's
 // Discovery() ServerResourcesForGroupVersion has no Context-aware
-// variant, so we run it on a goroutine and select on ctx.Done(); the
+// variant, so we run it on a goroutine and select on ctx.Done(). The
 // goroutine may leak if the API server hangs forever, but the caller
 // returns promptly and the manager can move on.
 //
@@ -180,7 +180,7 @@ func discoverConstraintKinds(ctx context.Context, clientset kubernetes.Interface
 // parseConstraint walks a single Constraint object and converts every
 // status.violations entry into a security.Finding. constraintKind is
 // the Kubernetes Kind name of the parent constraint (e.g.,
-// "K8sRequiredLabels"); we surface it on the Finding so users can
+// "K8sRequiredLabels"). We surface it on the Finding so users can
 // distinguish "10 violations of K8sRequiredLabels" from "10 violations
 // of K8sBlockNodeport" in the group view.
 func parseConstraint(u *unstructured.Unstructured, constraintKind string) []security.Finding {

--- a/internal/security/gatekeeper/gatekeeper.go
+++ b/internal/security/gatekeeper/gatekeeper.go
@@ -2,9 +2,8 @@
 // the audit violations recorded on each Constraint's .status as
 // security.Findings.
 //
-// Constraints are dynamic: every ConstraintTemplate the cluster admin
-// installs creates a new CRD under constraints.gatekeeper.sh, so the
-// adapter has to discover the GroupVersionResources at fetch time
+// Constraints are dynamic. Every ConstraintTemplate the cluster admin installs creates a new CRD under
+// constraints.gatekeeper.sh. The adapter therefore has to discover the GroupVersionResources at fetch time
 // (via the Kubernetes Discovery API) before listing them.
 package gatekeeper
 
@@ -33,13 +32,11 @@ const ConstraintsGroup = "constraints.gatekeeper.sh"
 // missed until this constant is updated.
 const ConstraintsVersion = "v1beta1"
 
-// constraintTemplateGVRs are the parent-CRD availability probe targets,
-// newest API version first. The probe avoids the Discovery API (which
-// client-go doesn't expose with a context, so a hung API server would
-// block the probe goroutine past the manager's 3s timeout). v1 has been
-// GA since Gatekeeper 3.10. Clusters older than that serve
-// ConstraintTemplate as v1beta1 only, so the probe falls back to it
-// before reporting Gatekeeper unavailable.
+// constraintTemplateGVRs are the parent-CRD availability probe targets, newest API version
+// first. The probe avoids the Discovery API (which client-go doesn't expose with a context).
+// A hung API server would otherwise block the probe goroutine past the manager's 3s timeout.
+// v1 has been GA since Gatekeeper 3.10. Clusters older than that serve ConstraintTemplate as
+// v1beta1 only, so the probe falls back to it before reporting Gatekeeper unavailable.
 var constraintTemplateGVRs = []schema.GroupVersionResource{
 	{Group: "templates.gatekeeper.sh", Version: "v1", Resource: "constrainttemplates"},
 	{Group: "templates.gatekeeper.sh", Version: "v1beta1", Resource: "constrainttemplates"},
@@ -68,13 +65,11 @@ func (s *Source) Categories() []security.Category {
 	return []security.Category{security.CategoryPolicy, security.CategoryCompliance}
 }
 
-// IsAvailable returns true when the cluster serves the
-// templates.gatekeeper.sh API group (the parent ConstraintTemplate
-// CRD). Probing via the dynamic client honours the caller's context
-// timeout, unlike client-go's Discovery() ServerResourcesForGroupVersion
-// which has no Context-aware variant — a stalled API server there
-// would block the manager's 3s probe timeout indefinitely and starve
-// the rest of the security source probes.
+// IsAvailable returns true when the cluster serves the templates.gatekeeper.sh API group (the parent
+// ConstraintTemplate CRD). Probing via the dynamic client honours the caller's context timeout. By
+// contrast, client-go's Discovery() ServerResourcesForGroupVersion has no Context-aware variant. A
+// stalled API server there would therefore block the manager's 3s probe timeout indefinitely and
+// starve the rest of the security source probes.
 func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) {
 	if s.dynClient == nil {
 		return false, nil
@@ -84,8 +79,8 @@ func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) 
 		if err == nil {
 			return true, nil
 		}
-		// NotFound / no-such-resource → this API version isn't served;
-		// try the next. Other errors propagate so the manager's probe
+		// NotFound / no-such-resource → this API version is not served.
+		// Try the next one. Other errors propagate so the manager's probe
 		// preserves the previous-known availability rather than briefly
 		// hiding Gatekeeper on a transient failure.
 		if !apierrors.IsNotFound(err) {
@@ -99,14 +94,14 @@ func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) 
 // Fetch lists every Constraint instance the cluster currently knows
 // about and converts each .status.violations entry into a Finding.
 // Each kind's instance list is paginated (default 200 items per page)
-// to keep per-response payloads bounded — Constraints carry full
+// to keep per-response payloads bounded. Constraints carry full
 // status.violations[] arrays and can balloon on busy clusters. The
 // per-CRD listing failure mode is swallowed so a single broken kind
 // doesn't black out the whole feed.
 //
 // namespace is ignored: Gatekeeper Constraints are cluster-scoped, but
-// each violation carries its own (group, version, kind, namespace, name)
-// — the namespace surface comes from there, not from the parent CR.
+// each violation carries its own (group, version, kind, namespace, name).
+// The namespace surface comes from there, not from the parent CR.
 func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]security.Finding, error) {
 	if s.dynClient == nil || s.clientset == nil {
 		return nil, nil
@@ -149,7 +144,7 @@ func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]securi
 //
 // A NotFound discovery error is treated as "Gatekeeper webhook
 // installed but no ConstraintTemplates registered yet" rather than a
-// failure: returning the error here would surface as a per-fetch
+// failure. Returning the error here would surface as a per-fetch
 // "Application error" in the explorer and spam the log on every
 // FetchAll. An empty list is the correct semantic — there are zero
 // constraint kinds to query, so there are zero violations.
@@ -237,7 +232,7 @@ func defaultEnforcementAction(u *unstructured.Unstructured) string {
 
 // severityFromEnforcement maps Gatekeeper's enforcementAction values to
 // the explorer's coarse severity buckets so the SEC badge colour matches
-// users' expectations: a "deny" violation is louder than a "dryrun" one
+// users' expectations. A "deny" violation is louder than a "dryrun" one,
 // even though Gatekeeper itself doesn't grade severities.
 func severityFromEnforcement(action string) security.Severity {
 	switch strings.ToLower(action) {

--- a/internal/security/heuristic/checks.go
+++ b/internal/security/heuristic/checks.go
@@ -15,12 +15,11 @@ func baseRef(pod *corev1.Pod, container corev1.Container) security.ResourceRef {
 		Kind:      "Pod",
 		Name:      pod.Name,
 		Container: container.Name,
-		// Carry the pod's labels so declarative label-match ignore patterns can
-		// exclude infrastructure pods (CNI/CSI) by label. The Manager
-		// propagates these to same-resource findings from other sources.
-		// Aliasing pod.Labels (not cloning) is safe: pods come from a direct,
-		// ephemeral Pods().List() — never a shared informer cache — and the map
-		// is only read after the scan, so nothing mutates it.
+		// Carry the pod's labels so label-match ignore patterns can exclude
+		// infrastructure pods (CNI/CSI) by label. The Manager propagates these to
+		// same-resource findings from other sources. Aliasing pod.Labels (not
+		// cloning) is safe. Pods come from a direct, ephemeral Pods().List(),
+		// never a shared informer cache, and the map is only read after the scan.
 		Labels: pod.Labels,
 	}
 }

--- a/internal/security/heuristic/checks_configmap.go
+++ b/internal/security/heuristic/checks_configmap.go
@@ -19,7 +19,7 @@ import (
 // fetchConfigMapFindings lists ConfigMaps (best-effort) and flags those with
 // credential-looking data keys — plaintext secrets outside Secrets are not
 // covered by encryption-at-rest or Secret RBAC. Also returns the "ns/name"
-// set of existing ConfigMaps for the missing-reference check; ok=false means
+// set of existing ConfigMaps for the missing-reference check. ok=false means
 // the list failed and reference checks must be skipped.
 func (s *Source) fetchConfigMapFindings(ctx context.Context, namespace string) (findings []security.Finding, names map[string]bool, ok bool) {
 	cms, ok := security.Collect(func(o metav1.ListOptions) ([]corev1.ConfigMap, string, error) {
@@ -78,7 +78,7 @@ func credentialLookingKeys(cm *corev1.ConfigMap, include, exclude []string) []st
 		}
 		names = append(names, key)
 	}
-	// Map iteration order is random; sort for stable summaries.
+	// Map iteration order is random. Sort for stable summaries.
 	slices.Sort(names)
 	return names
 }

--- a/internal/security/heuristic/checks_extended.go
+++ b/internal/security/heuristic/checks_extended.go
@@ -16,7 +16,7 @@ func firstContainer(pod *corev1.Pod, c corev1.Container) bool {
 	return len(pod.Spec.Containers) > 0 && pod.Spec.Containers[0].Name == c.Name
 }
 
-// runtimeSocketPaths are container-runtime control sockets; mounting one is
+// runtimeSocketPaths are container-runtime control sockets. Mounting one is
 // equivalent to root on the node. /var/run is a symlink to /run on modern
 // distros, so both spellings are listed.
 var runtimeSocketPaths = map[string]bool{
@@ -60,7 +60,7 @@ func checkRuntimeSocket(pod *corev1.Pod, c corev1.Container) []security.Finding 
 
 // safeSysctls is the kubelet's allowed-by-default set (Pod Security Standards
 // baseline), mirroring upstream pkg/kubelet/sysctl/safe_sysctls.go. It tracks
-// the newest Kubernetes release; some entries are version-gated upstream, so
+// the newest Kubernetes release. Some entries are version-gated upstream, so
 // on older clusters a listed sysctl may still need the kubelet allowlist.
 var safeSysctls = map[string]bool{
 	"kernel.shm_rmid_forced":              true,
@@ -196,7 +196,7 @@ func checkSecretEnv(pod *corev1.Pod, c corev1.Container) []security.Finding {
 // whose value is a literal in the pod spec instead of a secretKeyRef. The
 // summary lists names only — never the values. Include/exclude are
 // case-insensitive name globs from config: include adds names to flag (and,
-// matched explicitly, overrides a built-in exemption); exclude is never
+// matched explicitly, overrides a built-in exemption). Exclude is never
 // flagged and wins over include.
 func checkSecretEnvWith(pod *corev1.Pod, c corev1.Container, include, exclude []string) []security.Finding {
 	var names []string

--- a/internal/security/heuristic/checks_extra.go
+++ b/internal/security/heuristic/checks_extra.go
@@ -9,10 +9,9 @@ import (
 	"github.com/janosmiko/lfk/internal/security"
 )
 
-// checkEnvFromSecret flags containers importing entire Secrets into their
-// environment via envFrom. Unlike secret_env (which inspects literal env
-// values by name and never sees envFrom), this exposes every key of the
-// Secret to the whole process environment, where it leaks via
+// checkEnvFromSecret flags containers importing entire Secrets via envFrom.
+// Unlike secret_env (name-based, doesn't see envFrom), this exposes every
+// Secret key to the whole process environment, leaking via
 // /proc/<pid>/environ, crash dumps, and child processes. The summary lists
 // Secret names only — never values.
 func checkEnvFromSecret(pod *corev1.Pod, c corev1.Container) []security.Finding {

--- a/internal/security/heuristic/checks_namespace.go
+++ b/internal/security/heuristic/checks_namespace.go
@@ -16,7 +16,7 @@ import (
 	"github.com/janosmiko/lfk/internal/security"
 )
 
-// systemNamespaces are skipped by the namespace-level checks: kube-system
+// systemNamespaces are skipped by the namespace-level checks. kube-system
 // requires privileged pods (no PSA enforce label fits) and securing it is
 // the distribution's job, not the user's.
 var systemNamespaces = map[string]bool{

--- a/internal/security/heuristic/checks_secret.go
+++ b/internal/security/heuristic/checks_secret.go
@@ -1,7 +1,7 @@
 // Secret-level heuristic checks: legacy long-lived ServiceAccount token
 // Secrets and expiring TLS certificates. Gated by
 // security.heuristic.scan_secrets (default on) because they require listing
-// Secret objects; the list is best-effort like the other non-pod scans.
+// Secret objects. The list is best-effort like the other non-pod scans.
 // Summaries never include Secret data.
 
 package heuristic
@@ -38,7 +38,7 @@ func makeSecretFinding(ns, name, check string, sev security.Severity, title, sum
 
 // fetchSecretFindings lists Secrets (best-effort) and runs the Secret-level
 // checks. Returns immediately when scan_secrets is disabled. Also returns
-// the "ns/name" set of existing Secrets for the missing-reference check;
+// the "ns/name" set of existing Secrets for the missing-reference check.
 // ok=false (disabled or list failed) means Secret references cannot be
 // verified and must be skipped.
 func (s *Source) fetchSecretFindings(ctx context.Context, namespace string) (findings []security.Finding, names map[string]bool, ok bool) {

--- a/internal/security/heuristic/checks_service.go
+++ b/internal/security/heuristic/checks_service.go
@@ -27,7 +27,7 @@ func makeServiceFinding(svc *corev1.Service, check string, sev security.Severity
 
 // checkServiceExternalIPs flags Services with spec.externalIPs set. Anyone
 // who can create or update such a Service can intercept traffic to that IP
-// from any node (CVE-2020-8554 MITM); most clusters never need the field.
+// from any node (CVE-2020-8554 MITM). Most clusters never need the field.
 func checkServiceExternalIPs(svc *corev1.Service) []security.Finding {
 	if len(svc.Spec.ExternalIPs) == 0 {
 		return nil

--- a/internal/security/heuristic/heuristic.go
+++ b/internal/security/heuristic/heuristic.go
@@ -19,7 +19,7 @@ type Source struct {
 	secretEnvInclude  []string
 	secretEnvExclude  []string
 	// scanSecrets gates the Secret-listing checks (legacy_sa_token_secret,
-	// tls_secret_expiry); from security.heuristic.scan_secrets.
+	// tls_secret_expiry). From security.heuristic.scan_secrets.
 	scanSecrets bool
 }
 
@@ -142,7 +142,7 @@ func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]securi
 // fetchServiceFindings lists Services (paginated) and runs the Service-level
 // checks. Best-effort: a list error (typically Forbidden for restricted
 // users) stops the Service scan without failing the source — the pod
-// findings must survive. Findings from pages that did load are kept; the
+// findings must survive. Findings from pages that did load are kept. The
 // checks are presence-based, so a partial list can under-report but never
 // invent findings.
 func (s *Source) fetchServiceFindings(ctx context.Context, namespace string) []security.Finding {

--- a/internal/security/heuristic/heuristic.go
+++ b/internal/security/heuristic/heuristic.go
@@ -74,8 +74,8 @@ func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) 
 }
 
 // Fetch lists pods in the given namespace (empty = all namespaces) and runs
-// every registered check against every container, then the best-effort
-// non-pod scans (Services, namespaces, ConfigMaps, Ingresses).
+// every registered check against every container. Then it runs the
+// best-effort non-pod scans (Services, namespaces, ConfigMaps, Ingresses).
 func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]security.Finding, error) {
 	if s.client == nil {
 		return nil, nil

--- a/internal/security/kubescape/kubescape.go
+++ b/internal/security/kubescape/kubescape.go
@@ -18,7 +18,7 @@ import (
 // WorkloadConfigurationScanGVR is the primary CRD the kubescape-operator
 // emits — one object per scanned workload, listing the result of every
 // control it ran. Other Kubescape CRDs (vulnerability manifests, summary
-// objects) are out of scope for this MVP; they can be wired in later
+// objects) are out of scope for this MVP. They can be wired in later
 // without changing the public Source API.
 var WorkloadConfigurationScanGVR = schema.GroupVersionResource{
 	Group:    "spdx.softwarecomposition.kubescape.io",

--- a/internal/security/kubescape/kubescape.go
+++ b/internal/security/kubescape/kubescape.go
@@ -50,7 +50,7 @@ func (s *Source) Categories() []security.Category {
 // IsAvailable checks that the WorkloadConfigurationScan CRD is served.
 // NotFound is returned as (false, nil) so the manager's probe treats
 // it as a definitive "kubescape-operator not installed" signal.
-// Transient errors propagate so a 3s timeout / RBAC blip / API server
+// Transient errors propagate. A 3s timeout / RBAC blip / API server
 // hiccup leaves the previous availability untouched rather than
 // briefly hiding Kubescape on shift+r.
 func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) {
@@ -67,12 +67,11 @@ func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) 
 	return true, nil
 }
 
-// Fetch lists WorkloadConfigurationScan CRDs and converts every failing
-// control into a security.Finding. Lists are paginated (default 200
-// items per page) so the per-page response stays bounded — Kubescape
-// scans embed the full control list per workload and can produce large
-// payloads on busy clusters. Per-object parse errors are swallowed so a
-// malformed report doesn't black out the whole feed.
+// Fetch lists WorkloadConfigurationScan CRDs and converts every failing control into a
+// security.Finding. Lists are paginated (default 200 items per page) so the per-page response
+// stays bounded. Kubescape scans embed the full control list per workload and can produce large
+// payloads on busy clusters. Per-object parse errors are swallowed so a malformed report doesn't
+// black out the whole feed.
 func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]security.Finding, error) {
 	if s.client == nil {
 		return nil, nil

--- a/internal/security/kubescape/parse.go
+++ b/internal/security/kubescape/parse.go
@@ -10,8 +10,8 @@ import (
 )
 
 // parseSeverity converts Kubescape's numeric severity (1-10 scale) into
-// our coarser bucketed Severity. Kubescape uses 1=info ... 10=critical;
-// we collapse to the four UI buckets the rest of the explorer renders.
+// our coarser bucketed Severity. Kubescape uses 1=info ... 10=critical.
+// We collapse that to the four UI buckets the rest of the explorer renders.
 func parseSeverity(score float64) security.Severity {
 	switch {
 	case score >= 9:
@@ -26,19 +26,18 @@ func parseSeverity(score float64) security.Severity {
 	return security.SeverityUnknown
 }
 
-// targetRefFromName parses the WorkloadConfigurationScan name into a
-// ResourceRef. Kubescape names scans as "<kind-lower>-<workload-name>"
-// (e.g., "deployment-api"); when the leading kind isn't recognised we
-// fall back to using the entire name as the resource Name and leave Kind
-// empty so shortResource renders "(unknown resource)" rather than
-// fabricating a wrong Kind. Namespace comes from the CR itself.
+// targetRefFromName parses the WorkloadConfigurationScan name into a ResourceRef. Kubescape names
+// scans as "<kind-lower>-<workload-name>" (e.g., "deployment-api"). When the leading kind is not
+// recognised, we fall back to using the entire name as the resource Name and leave Kind empty.
+// shortResource then renders "(unknown resource)" rather than fabricating a wrong Kind. Namespace
+// comes from the CR itself.
 func targetRefFromName(name, namespace string) security.ResourceRef {
 	parts := strings.SplitN(name, "-", 2)
 	if len(parts) != 2 {
 		return security.ResourceRef{Namespace: namespace, Name: name}
 	}
 	kind, rest := parts[0], parts[1]
-	// Kubescape lower-cases the kind in the scan name; restore the
+	// Kubescape lower-cases the kind in the scan name. Restore the
 	// canonical capitalisation for common workload kinds. Unknown kinds
 	// fall through with the lower-cased value preserved so the row still
 	// surfaces the real workload name.
@@ -121,7 +120,7 @@ func parseWorkloadConfigurationScan(u *unstructured.Unstructured) []security.Fin
 
 // isFailingStatus reports whether a control's status string indicates a
 // finding worth surfacing. Kubescape uses "passed" / "failed" / "skipped"
-// / "irrelevant"; only "failed" produces a Finding.
+// / "irrelevant". Only "failed" produces a Finding.
 func isFailingStatus(s string) bool {
 	return strings.EqualFold(s, "failed")
 }

--- a/internal/security/labels.go
+++ b/internal/security/labels.go
@@ -64,10 +64,10 @@ func (m *Manager) resolveWorkloadLabels(ctx context.Context, kubeCtx string, fin
 // ignore pattern reaches findings from sources that carry no labels (trivy,
 // kyverno) as long as another source (heuristic) observed the same resource.
 //
-// Runs in O(n) with one index map; the shared label maps are read-only so
+// Runs in O(n) with one index map. The shared label maps are read-only so
 // aliasing them across findings is safe.
 func propagateResourceLabels(findings []Finding) {
-	// First non-empty label map per resource wins; later ones are not merged.
+	// First non-empty label map per resource wins. Later ones are not merged.
 	// Today only the heuristic source stamps labels, so a key has at most one
 	// authority. A future multi-stamping source would need merge logic here.
 	labelsByKey := make(map[string]map[string]string)

--- a/internal/security/labels.go
+++ b/internal/security/labels.go
@@ -29,7 +29,7 @@ func (m *Manager) resolveWorkloadLabels(ctx context.Context, kubeCtx string, fin
 			continue
 		}
 		ref := findings[i].Resource
-		// Skip refs the resolver is guaranteed to reject — the mapped kinds are
+		// Skip refs the resolver is guaranteed to reject. The mapped kinds are
 		// all namespaced, so a namespace-less ref (e.g. a cluster-scoped RBAC
 		// finding) resolves to nil. Skipping here keeps such refs from burning
 		// the lookup budget and starving resolvable workloads later in the scan.
@@ -59,10 +59,10 @@ func (m *Manager) resolveWorkloadLabels(ctx context.Context, kubeCtx string, fin
 }
 
 // propagateResourceLabels fills in ResourceRef.Labels for findings whose source
-// did not expose them, copying from same-resource findings that did. Resources
-// are matched by ResourceRef.Key() (namespace/kind/name), so a label-match
-// ignore pattern reaches findings from sources that carry no labels (trivy,
-// kyverno) as long as another source (heuristic) observed the same resource.
+// did not expose them, copying from same-resource findings that did. Matched by
+// ResourceRef.Key() (namespace/kind/name), so a label-match ignore pattern
+// reaches labelless sources (trivy, kyverno) once another source (heuristic)
+// observed the same resource.
 //
 // Runs in O(n) with one index map. The shared label maps are read-only so
 // aliasing them across findings is safe.

--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -44,11 +44,10 @@ type Manager struct {
 	cachedIndex   *FindingIndex
 
 	// fetchGroup coalesces concurrent FetchAll calls for the same
-	// (kubeCtx, namespace). On navigation the middle list, the SEC-badge
-	// index, and the right-pane preview each call FetchAll near-
-	// simultaneously. Without this they ran the full multi-source scan
-	// independently — tripling API load and leaving the right pane
-	// spinning on its own slow fetch after the list had resolved.
+	// (kubeCtx, namespace): navigation, the SEC-badge index, and the
+	// right-pane preview all call FetchAll near-simultaneously. Without
+	// it, each ran the full scan independently, tripling API load and
+	// leaving the right pane spinning on its own slow fetch.
 	fetchGroup singleflight.Group
 
 	availCache map[string]availEntry // key = kubeCtx
@@ -59,15 +58,15 @@ type Manager struct {
 	// the hint directly. The probe inside FetchAll is the dominant
 	// non-Fetch API cost on slow / throttled clusters. The app-level
 	// loadSecurityAvailability already performed the same probe with a
-	// 3s budget per source, so re-doing it inside FetchAll doubles the
+	// 3s budget per source. So re-doing it inside FetchAll doubles the
 	// API load on every navigation. SetAvailability populates this map.
 	perSourceAvail map[string]map[string]bool
 
 	ignoredNamespaces map[string]bool // global namespace filter applied to all sources
 
 	// labelResolver resolves a finding resource's Kubernetes labels by
-	// (kubeCtx, namespace, kind, name) for findings whose source did not
-	// expose them (e.g. Trivy CVEs keyed by a workload). nil disables
+	// (kubeCtx, namespace, kind, name). It covers findings whose source did
+	// not expose them (e.g. Trivy CVEs keyed by a workload). nil disables
 	// resolution — the app only installs it when label-match ignore patterns
 	// exist, so the lookups are pure overhead otherwise. Returns nil on any
 	// failure so a finding simply stays visible.
@@ -86,7 +85,7 @@ type availEntry struct {
 //
 // errorTTL defaults to 30s — the shorter window applied when every
 // source errored. Without it, slow / throttled clusters fall into a
-// hammering loop: each navigation tick re-fires the same failing list
+// hammering loop. Each navigation tick re-fires the same failing list
 // requests, the API server applies more aggressive rate limits, and the
 // right pane stays in "Scanning..." indefinitely. 30s is short enough
 // that genuine recovery feels responsive but long enough to break the
@@ -206,7 +205,7 @@ func (m *Manager) Refresh(ctx context.Context, kubeCtx, namespace string) (Fetch
 // user pressed `r` to refresh).
 //
 // Clearing cachedIndex matters because Index() is consulted by the SEC
-// badge renderer on every explorer paint — without clearing it, badges
+// badge renderer on every explorer paint. Without clearing it, badges
 // keep showing pre-invalidate per-resource counts until the next
 // FetchAll lands.
 func (m *Manager) Invalidate() {
@@ -224,8 +223,8 @@ func (m *Manager) Register(s SecuritySource) {
 	m.sources = append(m.sources, s)
 }
 
-// SetAvailability records the per-source availability map for kubeCtx
-// so subsequent FetchAll calls can skip their IsAvailable probe and go
+// SetAvailability records the per-source availability map for kubeCtx.
+// So subsequent FetchAll calls can skip their IsAvailable probe and go
 // straight to Fetch (or skip the source altogether). Pass the result of
 // the app-level availability probe (loadSecurityAvailability) here.
 //
@@ -311,9 +310,9 @@ func (m *Manager) AnyAvailable(ctx context.Context, kubeCtx string) (bool, error
 
 // FetchAll runs Fetch concurrently across all available sources. Per-source
 // errors do not cancel other sources. They are collected in result.Errors.
-// Results are cached by (kubeCtx, namespace) for refreshTTL on success
-// and for errorTTL when every source erred (negative cache, breaks the
-// throttling spiral on slow clusters).
+// Results are cached by (kubeCtx, namespace) for refreshTTL on success.
+// They are cached for errorTTL when every source erred (negative cache,
+// breaks the throttling spiral on slow clusters).
 func (m *Manager) FetchAll(ctx context.Context, kubeCtx, namespace string) (FetchResult, error) {
 	cacheKey := kubeCtx + "|" + namespace
 
@@ -325,18 +324,18 @@ func (m *Manager) FetchAll(ctx context.Context, kubeCtx, namespace string) (Fetc
 	// is deliberate: callers run inside the app's per-context scheduler
 	// worker pool, which preempts and times out work via context
 	// cancellation. A worker blocked on the uncancellable Do would ignore
-	// its ctx and stay stuck for the whole scan, starving the pod/dashboard
+	// its ctx and stay stuck for the whole scan. That starves the pod/dashboard
 	// loads that share the pool. With DoChan each caller selects on its own
 	// ctx and returns promptly when cancelled.
 	//
-	// The scan itself runs on a detached, bounded context — not the caller's
-	// — so it completes and populates the cache even if the caller that
+	// The scan itself runs on a detached, bounded context — not the caller's.
+	// So it completes and populates the cache even if the caller that
 	// started it navigates away. Tying the scan to one caller's ctx would
 	// let a preempted caller abort the shared scan and hand every waiter a
 	// premature empty result.
-	// Capture scanTimeout under the lock before the closure: the DoChan
+	// Capture scanTimeout under the lock before the closure. The DoChan
 	// goroutine reads it on a separate goroutine, and SetScanTimeout writes it
-	// under m.mu — reading m.scanTimeout directly inside the closure would be
+	// under m.mu. Reading m.scanTimeout directly inside the closure would be
 	// an unsynchronized read racing that write.
 	scanTimeout := m.ScanTimeout()
 	ch := m.fetchGroup.DoChan(cacheKey, func() (any, error) {
@@ -395,9 +394,9 @@ func (m *Manager) fetchAllScan(ctx context.Context, kubeCtx, namespace, cacheKey
 	results := make(chan sourceResult, len(sources))
 
 	// Per-source errors flow into res.Errors via the results channel and
-	// goroutines never return an error worth cancelling siblings on, so
+	// goroutines never return an error worth cancelling siblings on. So
 	// errgroup's WithContext semantics added dead weight without any
-	// benefit. A buffered semaphore caps simultaneous Fetch calls — the
+	// benefit. A buffered semaphore caps simultaneous Fetch calls. The
 	// default cap of 2 keeps a 6-source cluster from issuing six large
 	// list responses in parallel and stressing etcd. The semaphore is
 	// taken AFTER the IsAvailable hint check so unavailable sources cost
@@ -452,7 +451,7 @@ func (m *Manager) fetchAllScan(ctx context.Context, kubeCtx, namespace, cacheKey
 		// with Available=false so the cache decision sees them as
 		// "no successful fetch happened". Without this they'd fall into
 		// the success branch below and be reported as Available:true
-		// with 0 findings — making anySourceSucceeded return true on a
+		// with 0 findings. That would make anySourceSucceeded return true on a
 		// cluster with zero installed security tools.
 		if r.unavailable {
 			res.Sources = append(res.Sources, SourceStatus{Name: r.name})
@@ -500,10 +499,10 @@ func (m *Manager) fetchAllScan(ctx context.Context, kubeCtx, namespace, cacheKey
 	m.resolveWorkloadLabels(ctx, kubeCtx, res.Findings)
 
 	m.mu.Lock()
-	// Cache the result regardless of success — a clean cluster with zero
+	// Cache the result regardless of success. A clean cluster with zero
 	// findings is a valid full-TTL outcome (anySourceSucceeded=true,
-	// just empty), and an all-errored cluster gets the shorter errorTTL
-	// negative cache so the next navigation tick doesn't re-fire the
+	// just empty). An all-errored cluster gets the shorter errorTTL
+	// negative cache, so the next navigation tick doesn't re-fire the
 	// same failing requests and dig the throttle hole even deeper.
 	// SetErrorTTL(0) disables negative caching for callers (tests) that
 	// need the old "always retry on error" behavior.
@@ -602,14 +601,14 @@ func (i *FindingIndex) CountBySource(name string) int {
 // BuildFindingIndex constructs an index from a slice of findings.
 // Per-resource severity counts deduplicate by (resource, Title) so the
 // SEC badge shows unique checks (e.g., "privileged", "run_as_root")
-// rather than raw per-container counts: a pod with 3 containers all
+// rather than raw per-container counts. A pod with 3 containers all
 // running privileged contributes 1 to its severity bucket, not 3.
 //
 // bySource counts every emission without deduplication so callers like
 // CountBySource see the true per-source contribution. Deduplicating
 // bySource by (resource, Title) silently undercounts when two sources
-// (e.g., Trivy + policy-report) overlap on the same misconfiguration —
-// the second source got skipped before its bySource increment.
+// (e.g., Trivy + policy-report) overlap on the same misconfiguration.
+// The second source got skipped before its bySource increment.
 func BuildFindingIndex(findings []Finding) *FindingIndex {
 	idx := &FindingIndex{
 		counts:   make(map[string]SeverityCounts),
@@ -617,7 +616,7 @@ func BuildFindingIndex(findings []Finding) *FindingIndex {
 	}
 	// Pick the highest severity per (resource, Title) pair before counting.
 	// Two-pass keeps the per-source totals accurate (every finding increments
-	// bySource in the first pass) while ensuring a later duplicate that
+	// bySource in the first pass). It also ensures a later duplicate that
 	// reports a higher severity isn't lost to first-write-wins iteration
 	// order, which would silently under-color the SEC badge.
 	maxSev := make(map[string]Severity)
@@ -669,7 +668,7 @@ func (m *Manager) Index() *FindingIndex {
 
 // SetIndex overrides the cached FindingIndex. Used by callers that produce
 // findings outside of FetchAll (e.g., async message paths in internal/app
-// that receive a FetchResult via a tea.Msg and bypass the cache).
+// that receive a FetchResult via a tea.Msg). Those paths bypass the cache.
 func (m *Manager) SetIndex(idx *FindingIndex) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -34,7 +34,7 @@ type Manager struct {
 	refreshTTL          time.Duration
 	errorTTL            time.Duration // shorter TTL applied when no source succeeded
 	availabilityTTL     time.Duration
-	maxFetchConcurrency int           // upper bound on simultaneous source Fetches; 0 = unbounded
+	maxFetchConcurrency int           // upper bound on simultaneous source Fetches. 0 = unbounded
 	scanTimeout         time.Duration // hard ceiling on a single coalesced FetchAll scan
 
 	cacheKey      string // lastCtx + "|" + lastNamespace
@@ -46,7 +46,7 @@ type Manager struct {
 	// fetchGroup coalesces concurrent FetchAll calls for the same
 	// (kubeCtx, namespace). On navigation the middle list, the SEC-badge
 	// index, and the right-pane preview each call FetchAll near-
-	// simultaneously; without this they ran the full multi-source scan
+	// simultaneously. Without this they ran the full multi-source scan
 	// independently — tripling API load and leaving the right pane
 	// spinning on its own slow fetch after the list had resolved.
 	fetchGroup singleflight.Group
@@ -57,7 +57,7 @@ type Manager struct {
 	// hint, keyed by kubeCtx → sourceName → available. When present,
 	// FetchAll skips its own IsAvailable probe for that source and uses
 	// the hint directly. The probe inside FetchAll is the dominant
-	// non-Fetch API cost on slow / throttled clusters; the app-level
+	// non-Fetch API cost on slow / throttled clusters. The app-level
 	// loadSecurityAvailability already performed the same probe with a
 	// 3s budget per source, so re-doing it inside FetchAll doubles the
 	// API load on every navigation. SetAvailability populates this map.
@@ -148,7 +148,7 @@ func (m *Manager) SetErrorTTL(d time.Duration) {
 // fan-out behaviour on busy clusters with many CRD-backed sources
 // installed (Trivy + Kyverno + Gatekeeper + Kubescape can each list
 // hundreds of objects per call). Pass 0 to disable the cap (run every
-// source concurrently); useful in unit tests where the goroutines do
+// source concurrently). Useful in unit tests where the goroutines do
 // not actually hit a real API server.
 func (m *Manager) SetMaxFetchConcurrency(n int) {
 	m.mu.Lock()
@@ -170,7 +170,7 @@ func (m *Manager) ScanTimeout() time.Duration {
 }
 
 // SetScanTimeout overrides the per-scan hard ceiling. Clamped to a positive
-// value; non-positive is ignored so a misconfig can't disable the timeout.
+// value. Non-positive is ignored so a misconfig can't disable the timeout.
 func (m *Manager) SetScanTimeout(d time.Duration) {
 	if d <= 0 {
 		return
@@ -310,7 +310,7 @@ func (m *Manager) AnyAvailable(ctx context.Context, kubeCtx string) (bool, error
 }
 
 // FetchAll runs Fetch concurrently across all available sources. Per-source
-// errors do not cancel other sources; they are collected in result.Errors.
+// errors do not cancel other sources. They are collected in result.Errors.
 // Results are cached by (kubeCtx, namespace) for refreshTTL on success
 // and for errorTTL when every source erred (negative cache, breaks the
 // throttling spiral on slow clusters).
@@ -355,7 +355,7 @@ func (m *Manager) FetchAll(ctx context.Context, kubeCtx, namespace string) (Fetc
 		return res.Val.(FetchResult), nil
 	case <-ctx.Done():
 		// Caller cancelled / preempted / timed out. The detached scan keeps
-		// running and caches its result for the next call; this caller
+		// running and caches its result for the next call. This caller
 		// returns immediately so a scheduler worker is never stuck waiting.
 		return FetchResult{}, ctx.Err()
 	}
@@ -390,7 +390,7 @@ func (m *Manager) fetchAllScan(ctx context.Context, kubeCtx, namespace, cacheKey
 		name        string
 		findings    []Finding
 		err         error
-		unavailable bool // source's IsAvailable returned false; skip status emission
+		unavailable bool // source's IsAvailable returned false. Skip status emission
 	}
 	results := make(chan sourceResult, len(sources))
 
@@ -471,7 +471,7 @@ func (m *Manager) fetchAllScan(ctx context.Context, kubeCtx, namespace, cacheKey
 
 	// Apply global namespace filter. Snapshot the map under RLock so a
 	// concurrent SetIgnoredNamespaces can't race with the read. Build the
-	// filtered slice into a fresh backing array; an in-place `Findings[:0]`
+	// filtered slice into a fresh backing array. An in-place `Findings[:0]`
 	// trick aliases the backing memory that future cache hits return to
 	// callers, which we'd then overwrite from the next FetchAll's append.
 	m.mu.RLock()
@@ -489,7 +489,7 @@ func (m *Manager) fetchAllScan(ctx context.Context, kubeCtx, namespace, cacheKey
 
 	// Propagate resource labels across same-resource findings so label-match
 	// ignore patterns reach every source. Sources that hold the live object
-	// (heuristic) stamp ResourceRef.Labels; this fills in findings on the same
+	// (heuristic) stamp ResourceRef.Labels. This fills in findings on the same
 	// resource from sources that don't (trivy, kyverno). In-memory only —
 	// labels are not persisted (ResourceRef.Labels is json:"-").
 	propagateResourceLabels(res.Findings)
@@ -606,7 +606,7 @@ func (i *FindingIndex) CountBySource(name string) int {
 // running privileged contributes 1 to its severity bucket, not 3.
 //
 // bySource counts every emission without deduplication so callers like
-// CountBySource see the true per-source contribution; deduplicating
+// CountBySource see the true per-source contribution. Deduplicating
 // bySource by (resource, Title) silently undercounts when two sources
 // (e.g., Trivy + policy-report) overlap on the same misconfiguration —
 // the second source got skipped before its bySource increment.

--- a/internal/security/pagination.go
+++ b/internal/security/pagination.go
@@ -44,7 +44,7 @@ type DynamicLister interface {
 // back. EachListItem hands us the page items one at a time and lets us
 // build the UnstructuredList directly.
 //
-// Cancellation: client-go's pager honours the supplied context; the
+// Cancellation: client-go's pager honours the supplied context. The
 // underlying dynamic-client List calls return promptly when ctx is
 // cancelled, and the loop exits without performing additional pages.
 //

--- a/internal/security/pagination.go
+++ b/internal/security/pagination.go
@@ -2,9 +2,9 @@
 // Paginated list helper for the dynamic-client list calls every CRD-based
 // security source makes. Wrapping client-go's tools/pager keeps the
 // per-page response size bounded (etcd doesn't have to materialise the
-// whole list in memory) and recovers from continue-token expiration on
+// whole list in memory). It also recovers from continue-token expiration on
 // long lists. Without pagination, a single FetchAll on a busy cluster
-// can produce 10s of MB of JSON per source — enough to stress small
+// can produce 10s of MB of JSON per source. That is enough to stress small
 // control planes (we've seen one freeze on a 746-PolicyReport list).
 package security
 
@@ -18,13 +18,11 @@ import (
 	"k8s.io/client-go/tools/pager"
 )
 
-// DefaultListPageSize is the per-page Limit used by ListPaginated. 200
-// is a compromise: kubectl defaults to 500 (optimised for fast machines
-// against fat API servers), but security-source list responses are
-// unusually large per object (Trivy's VulnerabilityReport.report
-// carries the full vuln list, Kyverno's PolicyReport carries
-// .results[]), so 200 keeps each page response under a few MB on
-// realistic clusters.
+// DefaultListPageSize is the per-page Limit used by ListPaginated. 200 is a
+// compromise. Kubectl defaults to 500 for fast machines against fat API
+// servers. Security-source responses are unusually large per object
+// (Trivy's VulnerabilityReport.report carries the full vuln list, Kyverno's
+// PolicyReport carries .results[]). So 200 keeps each page under a few MB.
 const DefaultListPageSize = 200
 
 // DynamicLister is the subset of k8s.io/client-go/dynamic/Resource
@@ -40,7 +38,7 @@ type DynamicLister interface {
 // single combined UnstructuredList of all items. We use pager's
 // EachListItem rather than its List because List wraps results in a
 // *metainternalversion.List (a runtime container that doesn't preserve
-// the concrete UnstructuredList type), which is awkward to convert
+// the concrete UnstructuredList type). That is awkward to convert
 // back. EachListItem hands us the page items one at a time and lets us
 // build the UnstructuredList directly.
 //

--- a/internal/security/policyreport/parse.go
+++ b/internal/security/policyreport/parse.go
@@ -93,9 +93,8 @@ func parsePolicyReport(u *unstructured.Unstructured) []security.Finding {
 		return nil
 	}
 
-	// Skip entire reports created by falcosidekick. Match only on explicit
-	// metadata labels — substring "falco" in the name is too broad and
-	// drops legitimate Kyverno reports whose policy or resource name
+	// Skip entire reports created by falcosidekick. Match only on explicit metadata labels. The substring
+	// "falco" in the name is too broad and drops legitimate Kyverno reports whose policy or resource name
 	// happens to contain that token.
 	labels := u.GetLabels()
 	if isFalcoSource(labels["app.kubernetes.io/managed-by"]) ||

--- a/internal/security/policyreport/parse.go
+++ b/internal/security/policyreport/parse.go
@@ -143,7 +143,7 @@ func parsePolicyReport(u *unstructured.Unstructured) []security.Finding {
 		id := fmt.Sprintf("policy-report/%s/%s/%s/%s/%s",
 			ref.Namespace, ref.Kind, ref.Name, policy, rule)
 
-		// Title is the rule name; falls back to policy name.
+		// Title is the rule name. Falls back to policy name.
 		title := rule
 		if title == "" {
 			title = policy

--- a/internal/security/policyreport/policyreport.go
+++ b/internal/security/policyreport/policyreport.go
@@ -66,12 +66,11 @@ func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) 
 	return true, nil
 }
 
-// Fetch lists PolicyReport and ClusterPolicyReport CRDs and returns
-// failing results as findings. Lists are paginated (default 200 items
-// per page) so large clusters don't blow up etcd / HTTP/2 streams on
-// the way back — a 700+ PolicyReport list with full .results[] is the
-// scenario that has frozen control planes in the wild. Passing results
-// are skipped.
+// Fetch lists PolicyReport and ClusterPolicyReport CRDs and returns failing
+// results as findings. Passing results are skipped. Lists are paginated
+// (default 200 items per page) so large clusters do not blow up etcd or
+// HTTP/2 streams on the way back. A 700+ PolicyReport list with full
+// .results[] is the scenario that has frozen control planes in the wild.
 func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]security.Finding, error) {
 	if s.client == nil {
 		return nil, nil
@@ -88,10 +87,10 @@ func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]securi
 	}
 
 	// ClusterPolicyReports (cluster-scoped, only when namespace is empty).
-	// Only NotFound (CRD not installed) is non-fatal — anything else
-	// (RBAC denial, API server timeout, transport error) must surface so
-	// the caller can mark this source as errored instead of silently
-	// returning the partial namespaced result.
+	// Only NotFound (CRD not installed) is non-fatal. Anything else
+	// (RBAC denial, API server timeout, transport error) must surface.
+	// That lets the caller mark this source as errored instead of
+	// silently returning the partial namespaced result.
 	if namespace == "" {
 		cprList, err := security.ListPaginated(ctx, s.client.Resource(ClusterPolicyReportGVR))
 		if err != nil {

--- a/internal/security/rbac/checks_bindings.go
+++ b/internal/security/rbac/checks_bindings.go
@@ -72,8 +72,8 @@ func auditBinding(meta *metav1.ObjectMeta, ns, kind string, ref rbacv1.RoleRef, 
 }
 
 // nonSystemSubject reports whether a subject is outside the system:
-// namespace of identities — ServiceAccounts always count; Users and Groups
-// count unless system:-prefixed.
+// namespace of identities. ServiceAccounts always count. Users and Groups
+// count unless the name has a system: prefix.
 func nonSystemSubject(s *rbacv1.Subject) bool {
 	if s.Kind == rbacv1.ServiceAccountKind {
 		return true

--- a/internal/security/rbac/checks_rules.go
+++ b/internal/security/rbac/checks_rules.go
@@ -194,11 +194,10 @@ func auditRules(ns, kind, name string, rules []rbacv1.PolicyRule) []security.Fin
 	return out
 }
 
-// boundClusterRoles returns the set of ClusterRole names referenced by at
-// least one ClusterRoleBinding (including built-in bindings — a custom role
-// bound by any binding is live). RoleBindings are deliberately not indexed:
-// a RoleBinding referencing a ClusterRole scopes its grant to one namespace,
-// which is not a cluster-wide exposure.
+// boundClusterRoles returns the set of ClusterRole names referenced by at least one ClusterRoleBinding
+// (including built-in bindings). A custom role bound by any binding is live. RoleBindings are deliberately
+// not indexed: a RoleBinding referencing a ClusterRole scopes its grant to one namespace, which is not a
+// cluster-wide exposure.
 func (d *rbacData) boundClusterRoles() map[string]bool {
 	bound := make(map[string]bool, len(d.clusterRoleBindings))
 	for i := range d.clusterRoleBindings {

--- a/internal/security/rbac/checks_rules.go
+++ b/internal/security/rbac/checks_rules.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ruleCheck describes one dangerous grant to look for. A rule matches when
-// its apiGroups, verbs, and resources all intersect the wanted sets; "*" in
+// its apiGroups, verbs, and resources all intersect the wanted sets. "*" in
 // the rule's apiGroups or verbs matches anything, but resources must match
 // explicitly — wildcard-resource roles are rbac_wildcard's territory.
 type ruleCheck struct {
@@ -90,7 +90,7 @@ var ruleChecks = []ruleCheck{
 }
 
 // ruleMatches reports whether one PolicyRule grants what the check looks
-// for. apiGroups and verbs honor a "*" in the rule; resources must be
+// for. apiGroups and verbs honor a "*" in the rule. Resources must be
 // explicit.
 func ruleMatches(r *rbacv1.PolicyRule, c *ruleCheck) bool {
 	return intersectsOrWildcard(r.APIGroups, c.apiGroups) &&
@@ -161,7 +161,7 @@ func (d *rbacData) ruleFindings() []security.Finding {
 			}
 			out = append(out, auditRules("", "ClusterRole", r.Name, r.Rules)...)
 			// Cluster-wide secret read is only an exposure once the role is
-			// actually bound; an inert ClusterRole is just a definition.
+			// actually bound. An inert ClusterRole is just a definition.
 			if d.crbsOK && boundNames[r.Name] && readsSecrets(r.Rules) {
 				out = append(out, makeFinding("", "ClusterRole", r.Name, "rbac_secrets_cluster_wide", security.SeverityHigh,
 					"cluster-wide secret read",

--- a/internal/security/rbac/rbac.go
+++ b/internal/security/rbac/rbac.go
@@ -1,8 +1,7 @@
-// Package rbac implements a zero-dependency security.SecuritySource that
-// audits Roles, ClusterRoles, and their bindings for privilege-escalation
-// paths and over-broad grants: wildcard rules, impersonation, bind/escalate,
-// exec/attach/port-forward, kubelet and webhook control, CSR approval,
-// cluster-wide secret reads, and bindings to anonymous users,
+// Package rbac implements a zero-dependency security.SecuritySource that audits Roles, ClusterRoles,
+// and their bindings for privilege-escalation paths and over-broad grants. Checks cover wildcard
+// rules, impersonation, bind/escalate, exec/attach/port-forward, kubelet and webhook control, and CSR
+// approval. They also cover cluster-wide secret reads, and bindings to anonymous users,
 // system:masters, cluster-admin, or the default ServiceAccount.
 //
 // Kubernetes bootstrap objects (label kubernetes.io/bootstrapping:
@@ -67,8 +66,8 @@ type rbacData struct {
 // built-in set: bootstrap-labeled (kubeadm defaults, aggregated admin/edit/
 // view) or system:-prefixed. Built-ins legitimately hold broad grants.
 //
-// Known tradeoff: the API server does not reserve the system: prefix, so a
-// principal who can already write RBAC objects could name one "system:..."
+// Known tradeoff: the API server does not reserve the system: prefix. A
+// principal who can already write RBAC objects can name one "system:..."
 // to evade this audit. The source is a misconfiguration finder, not an
 // intrusion detector — an attacker with RBAC write access is already past
 // what it can see. Documented in docs/security.md.

--- a/internal/security/rbac/rbac.go
+++ b/internal/security/rbac/rbac.go
@@ -50,7 +50,7 @@ func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) 
 }
 
 // rbacData holds the four RBAC lists. Each OK flag records whether the list
-// succeeded; checks that depend on a failed list are skipped entirely
+// succeeded. Checks that depend on a failed list are skipped entirely
 // (best-effort RBAC) instead of emitting false positives.
 type rbacData struct {
 	roles               []rbacv1.Role
@@ -81,7 +81,7 @@ func skipObject(meta *metav1.ObjectMeta) bool {
 
 // Fetch lists Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings
 // (best-effort per type) and runs the RBAC checks over them. Empty namespace
-// means all namespaces; cluster-scoped objects are always included because
+// means all namespaces. Cluster-scoped objects are always included because
 // their grants apply everywhere.
 func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]security.Finding, error) {
 	if s.client == nil {

--- a/internal/security/source.go
+++ b/internal/security/source.go
@@ -19,7 +19,7 @@ const (
 	CategoryReliability Category = "reliability"
 )
 
-// Severity is a 4-level scale; sources map their own scales onto these.
+// Severity is a 4-level scale. Sources map their own scales onto these.
 type Severity int
 
 const (
@@ -42,7 +42,7 @@ type ResourceRef struct {
 	// declarative label-match ignore patterns. Populated by sources that hold
 	// the live object (heuristic, advisor) and propagated across same-resource
 	// findings by the Manager. Excluded from JSON/YAML so the on-disk findings
-	// cache stays lean (see issue #387); re-stamped on every fresh scan.
+	// cache stays lean (see issue #387). Re-stamped on every fresh scan.
 	Labels map[string]string `json:"-" yaml:"-"`
 }
 

--- a/internal/security/trivyop/trivyop.go
+++ b/internal/security/trivyop/trivyop.go
@@ -45,13 +45,11 @@ func (s *Source) Categories() []security.Category {
 	return []security.Category{security.CategoryVuln, security.CategoryMisconfig}
 }
 
-// IsAvailable checks that the VulnerabilityReport CRD is served by the API.
-// A successful List call means the CRD is registered — even if empty.
-// NotFound is returned as (false, nil) so the manager's probe treats it
-// as a definitive "not installed" signal (and updates the availability
-// map). Other errors (timeouts, RBAC, transient API failures) are
-// returned as (false, err) so the probe leaves the previous-known
-// state untouched rather than briefly hiding the source on a flake.
+// IsAvailable checks that the VulnerabilityReport CRD is served by the API. A successful List call
+// means the CRD is registered — even if empty. NotFound is returned as (false, nil) so the manager's
+// probe treats it as a definitive "not installed" signal (and updates the availability map). Other
+// errors (timeouts, RBAC, transient API failures) are returned as (false, err). That lets the probe
+// leave the previous-known state untouched rather than briefly hiding the source on a flake.
 func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) {
 	if s.client == nil {
 		return false, nil
@@ -68,8 +66,8 @@ func (s *Source) IsAvailable(ctx context.Context, kubeCtx string) (bool, error) 
 
 // Fetch lists VulnerabilityReport and ConfigAuditReport CRDs and returns
 // them as findings. Lists are paginated (default 200 items per page) so
-// large clusters don't materialise the whole report set in one response
-// — Trivy reports embed full vuln details, and a busy cluster easily
+// large clusters don't materialise the whole report set in one response.
+// Trivy reports embed full vuln details, and a busy cluster easily
 // produces 10s of MB per source. Per-report parse errors are swallowed
 // (malformed items skipped).
 func (s *Source) Fetch(ctx context.Context, kubeCtx, namespace string) ([]security.Finding, error) {

--- a/internal/tainted/json.go
+++ b/internal/tainted/json.go
@@ -3,16 +3,15 @@ package tainted
 import "errors"
 
 // errMarshalJSON is returned by MarshalJSON. Without it, json.Marshal on a
-// struct holding a String silently produces {} for that field - the payload
-// is unexported and the type has no marshaller - so the field vanishes
-// instead of erroring. A quiet MarshalJSON that emitted Line() instead would
-// fix the vanishing act but reopen the problem the type exists to close: it
-// would let any caller serialize cluster text without choosing between Line
-// and Body, bypassing both unwraps the same way a bare String() method
-// would. Failing loudly keeps that choice mandatory.
+// struct holding a String silently produces {}. The payload is unexported
+// and the type has no marshaller, so the field vanishes instead of erroring.
+// A quiet MarshalJSON emitting Line() would fix that, but it would reopen
+// the problem the type exists to close. Callers could serialize cluster
+// text without choosing between Line and Body, the same bypass a bare
+// String() method allows. Failing loudly keeps that choice mandatory.
 var errMarshalJSON = errors.New("tainted.String cannot be marshalled directly; unwrap with Line or Body first")
 
-// MarshalJSON always fails; see errMarshalJSON.
+// MarshalJSON always fails. See errMarshalJSON for the reason.
 func (t String) MarshalJSON() ([]byte, error) {
 	return nil, errMarshalJSON
 }

--- a/internal/tainted/sanitize.go
+++ b/internal/tainted/sanitize.go
@@ -54,14 +54,14 @@ func isBidiOverride(r rune) bool {
 }
 
 // logTabWidth is the column step used when expanding tab characters in
-// log lines. 8 matches the default tab stop on virtually every terminal,
-// so the post-expansion text aligns the way a user pasting the same line
-// into their shell would expect.
+// log lines. 8 matches the default tab stop on virtually every terminal.
+// The post-expansion text then aligns the way a user pasting the same
+// line into their shell would expect.
 const logTabWidth = 8
 
 // SanitizeLogBody is the exported entry point to sanitizeLogLine for sinks
-// outside this file (describe content, command-bar output) that render a
-// BODY rather than a name or title: unlike SanitizeTerminalText, it keeps
+// outside this file (describe content, command-bar output). It renders a
+// BODY rather than a name or title. Unlike SanitizeTerminalText, it keeps
 // SGR colour sequences and expands tabs instead of dropping them. See
 // sanitizeLogLine for the full behaviour.
 func SanitizeLogBody(s string, renderAnsi bool) string {
@@ -70,12 +70,12 @@ func SanitizeLogBody(s string, renderAnsi bool) string {
 
 // sanitizeLogLine replaces non-printable control bytes (NUL, DEL, the C0
 // control range minus tab, and the C1 range U+0080-U+009F) with the
-// Unicode replacement character and expands tab characters to spaces
-// using a logTabWidth-column tab stop. Binary data from processes like
-// MySQL handshakes contains bytes that break terminal width calculations
-// and corrupt the viewer layout. C1 controls (raw or UTF-8-encoded, e.g.
-// U+009B "CSI") let a log line hijack the terminal on emulators that
-// honour 8-bit C1 (VTE, Linux console).
+// Unicode replacement character. It also expands tab characters to
+// spaces using a logTabWidth-column tab stop. Binary data from processes
+// like MySQL handshakes contains bytes that break terminal width
+// calculations and corrupt the viewer layout. C1 controls (raw or
+// UTF-8-encoded, e.g. U+009B "CSI") let a log line hijack the terminal
+// on emulators that honour 8-bit C1 (VTE, Linux console).
 //
 // Tab expansion is required because lipgloss.Width treats '\t' as
 // zero-width while the terminal renders it as a jump to the next tab
@@ -87,23 +87,24 @@ func SanitizeLogBody(s string, renderAnsi bool) string {
 // logs in particular - those use tabs to separate timestamp / level /
 // logger / message.
 //
-// When renderAnsi is true, valid CSI SGR sequences (ESC [ params m — the
-// ones that set colour, bold, underline, etc.) are preserved verbatim so
-// log producers that emit ANSI colours render as intended. Non-SGR CSI
-// sequences (cursor movement, screen erase) remain unsafe for an inline
-// viewer and are still replaced. A bare ESC with no valid CSI introducer
-// is replaced too. Leaving it would cause terminals to wait for a
-// follow-up byte and mis-interpret subsequent output.
+// When renderAnsi is true, valid CSI SGR sequences (ESC [ params m, the
+// ones that set colour, bold, underline, etc.) are preserved verbatim.
+// So log producers that emit ANSI colours render as intended. Non-SGR
+// CSI sequences (cursor movement, screen erase) remain unsafe for an
+// inline viewer and are still replaced. A bare ESC with no valid CSI
+// introducer is replaced too. Leaving it would cause terminals to wait
+// for a follow-up byte and mis-interpret subsequent output.
 //
-// C1 detection is decode-aware, not a raw byte-range check: a byte-level
+// C1 detection is decode-aware, not a raw byte-range check. A byte-level
 // test for 0x80-0x9F would also catch UTF-8 continuation bytes of
-// ordinary non-ASCII runes (many common accented Latin, CJK, emoji, and
-// box-drawing characters have a continuation byte in that range) and
-// mangle them. Every non-ASCII byte is instead decoded to its full rune;
-// only a rune that actually equals U+0080-U+009F is replaced, whether it
-// arrived as a raw invalid byte or a valid two-byte UTF-8 encoding (e.g.
-// 0xC2 0x9B for U+009B). Anything else - including genuinely invalid
-// UTF-8 outside the C1 range - copies through as before.
+// ordinary non-ASCII runes. Many common accented Latin, CJK, emoji, and
+// box-drawing characters have a continuation byte in that range, and the
+// test would mangle them. Every non-ASCII byte is instead decoded to its
+// full rune. Only a rune that actually equals U+0080-U+009F is replaced,
+// regardless of whether it arrived as a raw invalid byte or a valid
+// two-byte UTF-8 encoding. For example, 0xC2 0x9B stands for U+009B.
+// Anything else - including genuinely invalid UTF-8 outside the C1
+// range - copies through as before.
 func sanitizeLogLine(s string, renderAnsi bool) string {
 	// Fast path: no control bytes, tabs needing expansion, or non-ASCII
 	// bytes means no work to do. Any byte >= 0x80 must go through the
@@ -154,10 +155,10 @@ func sanitizeLogLine(s string, renderAnsi bool) string {
 			i++
 			continue
 		}
-		// Non-ASCII byte: decode the full rune so a C1 control encoded
+		// Non-ASCII byte: decode the full rune. A C1 control encoded
 		// as two valid UTF-8 bytes is judged by its decoded value, not
-		// by the raw continuation byte (see the C1 detection note
-		// above).
+		// by the raw continuation byte. See the C1 detection note
+		// above.
 		r, size := utf8.DecodeRuneInString(s[i:])
 		switch {
 		case r == utf8.RuneError && size <= 1:
@@ -194,7 +195,7 @@ func sanitizeLogLine(s string, renderAnsi bool) string {
 // starting at s[i], or i if no valid sequence is present. Only SGR
 // (Select Graphic Rendition) finals are accepted because they set
 // colour and text attributes without moving the cursor or clearing the
-// screen — preserving them is safe in an inline viewer, whereas other
+// screen. Preserving them is safe in an inline viewer, whereas other
 // CSI finals would corrupt the layout.
 func parseSGRSequence(s string, i int) int {
 	if i+1 >= len(s) || s[i] != 0x1b || s[i+1] != '[' {
@@ -203,16 +204,16 @@ func parseSGRSequence(s string, i int) int {
 	j := i + 2
 	// Parameter bytes: digits, ';' and ':' only (truecolour uses both
 	// separators). This deliberately excludes the private markers < = > ?
-	// and the CSI intermediate bytes 0x20-0x2F: `CSI > Ps ; Ps m` is
-	// XTMODKEYS, which reprograms xterm's keyboard-modifier reporting, so
-	// forwarding a private marker let a cluster-controlled line change
-	// terminal state after rendering (TASK-885).
+	// and the CSI intermediate bytes 0x20-0x2F. `CSI > Ps ; Ps m` is
+	// XTMODKEYS, which reprograms xterm's keyboard-modifier reporting.
+	// So forwarding a private marker let a cluster-controlled line
+	// change terminal state after rendering (TASK-885).
 	for j < len(s) && (s[j] == ';' || s[j] == ':' || (s[j] >= '0' && s[j] <= '9')) {
 		j++
 	}
-	// SGR final byte is lowercase 'm'. Anything else - including a private
-	// marker or intermediate byte that stopped the loop above - is a CSI
-	// we can't safely forward to an inline viewer.
+	// SGR final byte is lowercase 'm'. Anything else, including a private
+	// marker or intermediate byte that stopped the loop above, is a CSI.
+	// We can't safely forward it to an inline viewer.
 	if j < len(s) && s[j] == 'm' {
 		return j + 1
 	}

--- a/internal/tainted/sanitize.go
+++ b/internal/tainted/sanitize.go
@@ -203,7 +203,7 @@ func parseSGRSequence(s string, i int) int {
 	j := i + 2
 	// Parameter bytes: digits, ';' and ':' only (truecolour uses both
 	// separators). This deliberately excludes the private markers < = > ?
-	// and the CSI intermediate bytes 0x20-0x2F: CSI > Ps . Ps m is
+	// and the CSI intermediate bytes 0x20-0x2F: `CSI > Ps ; Ps m` is
 	// XTMODKEYS, which reprograms xterm's keyboard-modifier reporting, so
 	// forwarding a private marker let a cluster-controlled line change
 	// terminal state after rendering (TASK-885).

--- a/internal/tainted/sanitize.go
+++ b/internal/tainted/sanitize.go
@@ -73,14 +73,14 @@ func SanitizeLogBody(s string, renderAnsi bool) string {
 // Unicode replacement character and expands tab characters to spaces
 // using a logTabWidth-column tab stop. Binary data from processes like
 // MySQL handshakes contains bytes that break terminal width calculations
-// and corrupt the viewer layout; C1 controls (raw or UTF-8-encoded, e.g.
+// and corrupt the viewer layout. C1 controls (raw or UTF-8-encoded, e.g.
 // U+009B "CSI") let a log line hijack the terminal on emulators that
 // honour 8-bit C1 (VTE, Linux console).
 //
 // Tab expansion is required because lipgloss.Width treats '\t' as
 // zero-width while the terminal renders it as a jump to the next tab
 // stop. The viewer's contentWidth-overflow guard (in RenderLogViewer)
-// uses lipgloss.Width to decide when to truncate; without expansion,
+// uses lipgloss.Width to decide when to truncate. Without expansion,
 // tab-bearing lines slip through with an undercounted width, get
 // re-wrapped internally by lipgloss, and push the bottom border off the
 // visible area. Reported on dragonfly-operator (controller-runtime/zap)
@@ -92,7 +92,7 @@ func SanitizeLogBody(s string, renderAnsi bool) string {
 // log producers that emit ANSI colours render as intended. Non-SGR CSI
 // sequences (cursor movement, screen erase) remain unsafe for an inline
 // viewer and are still replaced. A bare ESC with no valid CSI introducer
-// is replaced too; leaving it would cause terminals to wait for a
+// is replaced too. Leaving it would cause terminals to wait for a
 // follow-up byte and mis-interpret subsequent output.
 //
 // C1 detection is decode-aware, not a raw byte-range check: a byte-level
@@ -128,7 +128,7 @@ func sanitizeLogLine(s string, renderAnsi bool) string {
 		c := s[i]
 		if renderAnsi && c == 0x1b {
 			if end := parseSGRSequence(s, i); end > i {
-				// SGR sequences are zero-width; do not advance col.
+				// SGR sequences are zero-width. Do not advance col.
 				b.WriteString(s[i:end])
 				i = end
 				continue
@@ -162,7 +162,7 @@ func sanitizeLogLine(s string, renderAnsi bool) string {
 		switch {
 		case r == utf8.RuneError && size <= 1:
 			// Invalid UTF-8. A lone byte in the C1 range is still a
-			// control character regardless of encoding; anything else
+			// control character regardless of encoding. Anything else
 			// invalid passes through unchanged, matching legacy
 			// behaviour for non-UTF-8 binary payloads. Column tracking
 			// mirrors the old approximation: only a would-be leading
@@ -203,7 +203,7 @@ func parseSGRSequence(s string, i int) int {
 	j := i + 2
 	// Parameter bytes: digits, ';' and ':' only (truecolour uses both
 	// separators). This deliberately excludes the private markers < = > ?
-	// and the CSI intermediate bytes 0x20-0x2F: CSI > Ps ; Ps m is
+	// and the CSI intermediate bytes 0x20-0x2F: CSI > Ps . Ps m is
 	// XTMODKEYS, which reprograms xterm's keyboard-modifier reporting, so
 	// forwarding a private marker let a cluster-controlled line change
 	// terminal state after rendering (TASK-885).

--- a/internal/tainted/tainted.go
+++ b/internal/tainted/tainted.go
@@ -11,7 +11,7 @@
 // The package is a leaf: it imports nothing from lfk, so internal/k8s,
 // internal/model and internal/ui can all use it without an import cycle.
 // The sanitizer implementations live here (see sanitize.go) rather than in
-// internal/ui for the same reason; internal/ui re-exports them.
+// internal/ui for the same reason. internal/ui re-exports them.
 package tainted
 
 import (
@@ -50,7 +50,7 @@ func WrapAll(ss []string) []String {
 }
 
 // Line unwraps for a single-line sink: a table cell, a title, a status
-// message. Drops C0/C1 controls and bidi overrides entirely; no ANSI or tab
+// message. Drops C0/C1 controls and bidi overrides entirely. No ANSI or tab
 // survives, because a short cell has no legitimate use for either.
 func (t String) Line() string {
 	return SanitizeTerminalText(t.raw)

--- a/internal/ui/caniview.go
+++ b/internal/ui/caniview.go
@@ -23,7 +23,7 @@ var canIVerbs = []struct {
 }
 
 // RenderCanIView renders the can-i browser with a two-column layout.
-// The left column (API groups) is interactive; the right column (resources) is display-only.
+// The left column (API groups) is interactive. The right column (resources) is display-only.
 func RenderCanIView(groups []string, resources []model.CanIResource, groupCursor, groupScroll int, subjectName string, namespaces []string, width, height int, hintBar string, resourceScroll int, nsNegated bool) string {
 	// Title at the left, scope label flushed to the far right with
 	// baseBg-painted gap fill. Matches the WhoCan header layout so the
@@ -89,7 +89,7 @@ func RenderCanIView(groups []string, resources []model.CanIResource, groupCursor
 // confusing than no label).
 func joinTitleAndRightLabel(title, rightLabel string, width int) string {
 	if lipgloss.Width(title)+1+lipgloss.Width(rightLabel) > width {
-		// No room for the right label; just return the title.
+		// No room for the right label. Just return the title.
 		return title
 	}
 	gap := max(width-lipgloss.Width(title)-lipgloss.Width(rightLabel), 1)

--- a/internal/ui/cluster_color.go
+++ b/internal/ui/cluster_color.go
@@ -50,7 +50,7 @@ func IsValidClusterColor(name string) bool {
 // ActiveTheme so a colorscheme switch propagates on the next render —
 // the package-level Color* slots are stuck on Tokyo Night defaults
 // (they only branch between "default" and "no-color blanked" inside
-// ApplyTheme; they never receive the active theme's actual values), so
+// ApplyTheme. They never receive the active theme's actual values), so
 // using them here would have left the cluster tints frozen on the
 // boot-time palette regardless of which theme the user picked.
 //
@@ -76,7 +76,7 @@ func clusterColorBg(name string) color.Color {
 
 // clusterColorFg picks a contrasting foreground for the named colour.
 // Theme-mapped names get ActiveTheme.SelectedFg (designed to contrast
-// with the theme's accent backgrounds); ANSI-mapped names get ANSI
+// with the theme's accent backgrounds). ANSI-mapped names get ANSI
 // black, which is universally legible on every bright ANSI background.
 func clusterColorFg(name string) color.Color {
 	switch name {
@@ -150,7 +150,7 @@ func ClusterColorTileBg(name string) string {
 
 // ClusterColorTileBgOver is ClusterColorTileBg for a row wrapped by an outer
 // style — specifically the cursor row's selection highlight. The colored
-// tile ends with an SGR reset; left alone, that reset cancels the outer
+// tile ends with an SGR reset. Left alone, that reset cancels the outer
 // style for every cell after the tile, so the cursor highlight vanishes for
 // the rest of the row. Re-emitting the outer style's open codes right after
 // the tile restores it. Mirrors the HighlightMatchStyledOver "restore"

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -96,7 +96,7 @@ const (
 )
 
 // ConfigWatchInterval is the resolved polling interval used when watch mode
-// is active. Set from config file; CLI flag override is applied later in
+// is active. Set from config file. CLI flag override is applied later in
 // app.NewModel.
 var ConfigWatchInterval = DefaultWatchInterval
 
@@ -106,7 +106,7 @@ var ConfigWatchInterval = DefaultWatchInterval
 const DefaultBackgroundWatchInterval = 10 * time.Second
 
 // ConfigBackgroundWatchInterval is the resolved background/idle polling interval.
-// Set from config file; CLI flag override is applied in app.NewModel. Clamped
+// Set from config file. CLI flag override is applied in app.NewModel. Clamped
 // to [MinWatchInterval, MaxWatchInterval] like the foreground interval.
 var ConfigBackgroundWatchInterval = DefaultBackgroundWatchInterval
 
@@ -127,7 +127,7 @@ const DefaultWatchThrottle = true
 // to fully disable it (watch_interval is then used unconditionally).
 var ConfigWatchThrottle = DefaultWatchThrottle
 
-// ClampForegroundIdleTimeout restricts d to [0, MaxWatchInterval]; 0 disables.
+// ClampForegroundIdleTimeout restricts d to [0, MaxWatchInterval]. 0 disables.
 func ClampForegroundIdleTimeout(d time.Duration) time.Duration {
 	if d < 0 {
 		return 0
@@ -169,13 +169,13 @@ func ClampWatchInterval(d time.Duration) time.Duration {
 var ConfigLogPath string
 
 // ConfigKubeconfigDirs holds the kubeconfig_dir value from the config file (if any).
-// The YAML value may be either a single string or a list of strings; both are
-// normalised into this slice. Empty (nil) means "no override; use the default".
+// The YAML value may be either a single string or a list of strings. Both are
+// normalised into this slice. Empty (nil) means "no override, use the default".
 var ConfigKubeconfigDirs []string
 
 // ConfigKubeconfigExclusive holds kubeconfig_exclusive from the config file:
 // whether a set KUBECONFIG suppresses the default kubeconfig discovery
-// (kubectl semantics). Defaults to true; CLI flag and env override it at
+// (kubectl semantics). Defaults to true. CLI flag and env override it at
 // client construction (see k8s.ResolveKubeconfigExclusive).
 var ConfigKubeconfigExclusive = true
 
@@ -294,7 +294,7 @@ var ConfigClusterResourceColumns map[string]map[string][]string
 // Fields are AND-ed together. When `Invert` is true the resulting boolean is
 // negated, so e.g. `status: Bound` + `invert: true` matches everything that is
 // NOT Bound. The pre-existing `ReadyNot` flag remains for fine-grained Ready
-// negation; rule-level `Invert` is the general escape hatch.
+// negation. Rule-level `Invert` is the general escape hatch.
 type ConfigFilterMatch struct {
 	Status      string `json:"status" yaml:"status"`
 	ReadyNot    bool   `json:"ready_not" yaml:"ready_not"`
@@ -317,7 +317,7 @@ var ConfigFilterPresets map[string][]ConfigFilterPreset
 // ColumnsForKind returns the configured column list for the given resource
 // and cluster context. Resolution order: per-cluster resource_columns,
 // per-cluster views (GVR then Kind), global resource_columns, global views
-// (GVR then Kind). Per-cluster wins over global; the legacy resource_columns
+// (GVR then Kind). Per-cluster wins over global. The legacy resource_columns
 // surface wins over views within a scope so users with both keys configured
 // see the explicit resource_columns override. GVR keys win over Kind keys
 // within the views surface, matching ResolveView.
@@ -441,7 +441,7 @@ const (
 
 // ConfigInformerCacheMode resolves to one of "off"/"auto"/"always" after
 // LoadConfig. Default "auto" so users on large clusters (issue #86) get the
-// namespace-switch perf win for free; small clusters pay nothing because
+// namespace-switch perf win for free. Small clusters pay nothing because
 // auto-mode only promotes a (context, GVR) to the cache once a list crosses
 // 1000 items, and demotes it again when the list shrinks.
 var ConfigInformerCacheMode = InformerCacheAuto
@@ -459,7 +459,7 @@ var ConfigInformerCacheMode = InformerCacheAuto
 //	0.3   approx. WCAG AAA threshold (7.0:1)
 //	1.0   maximum — forces fg toward pure black or white against any bg
 //
-// Values outside [0, 1] are clamped. Only HSL lightness is adjusted; hue and
+// Values outside [0, 1] are clamped. Only HSL lightness is adjusted. Hue and
 // saturation are preserved at moderate values.
 var ConfigMinContrastRatio float64
 
@@ -468,7 +468,7 @@ var ConfigMinContrastRatio float64
 // key.
 const (
 	// TerminalModePTY embeds the shell in lfk's TUI via an internal vt10x
-	// terminal. Output stays inside lfk; selection works via host-terminal
+	// terminal. Output stays inside lfk. Selection works via host-terminal
 	// shift+drag. Default.
 	TerminalModePTY = "pty"
 	// TerminalModeExec hands the host terminal to the shell via
@@ -499,7 +499,7 @@ func defaultTerminalMode() string {
 
 // defaultTerminalModeForOS is the testable inner form. Windows must
 // default to Exec because creack/pty's Windows StartWithSize returns
-// ErrUnsupported; every other platform gets the richer embedded PTY.
+// ErrUnsupported. Every other platform gets the richer embedded PTY.
 func defaultTerminalModeForOS(goos string) string {
 	if goos == "windows" {
 		return TerminalModeExec
@@ -512,7 +512,7 @@ func defaultTerminalModeForOS(goos string) string {
 //   - effectiveMode is always a valid mode the caller can assign to
 //     ConfigTerminalMode. When the input is empty or unrecognised the
 //     caller's currentMode is returned unchanged.
-//   - warning is non-empty when a fallback was applied; the caller is
+//   - warning is non-empty when a fallback was applied. The caller is
 //     expected to log it at Warn level so the user sees why their
 //     configured value didn't stick.
 //
@@ -536,7 +536,7 @@ func resolveTerminalMode(configValue, goos, currentMode string) (mode string, wa
 	default:
 		// The raw configValue is intentionally NOT embedded in the
 		// warning — log redaction policy. Users can check their config
-		// file to see what they typed; the "valid" list logged by the
+		// file to see what they typed. The "valid" list logged by the
 		// caller tells them what is accepted.
 		return currentMode, "unrecognised terminal mode; using " + currentMode
 	}
@@ -544,8 +544,8 @@ func resolveTerminalMode(configValue, goos, currentMode string) (mode string, wa
 
 // ScrollbackLines clamps for the embedded PTY scrollback ring. The
 // default of 5000 covers an extended interactive session without
-// running the parent process out of memory; the floor stops a typo in
-// the config from disabling scrollback entirely; the ceiling caps
+// running the parent process out of memory. The floor stops a typo in
+// the config from disabling scrollback entirely. The ceiling caps
 // memory at roughly 10MB even with very long lines.
 const (
 	ScrollbackLinesDefault = 5000
@@ -594,7 +594,7 @@ var ConfigPinnedSummariesSet bool
 
 // ConfigUnionSets holds named multi-cluster groups defined in config.
 // Resolved by --union-set into a list of contexts + optional namespace.
-// Empty by default; populated by applyConfigOptions when union_sets is
+// Empty by default. Populated by applyConfigOptions when union_sets is
 // present in the YAML config.
 var ConfigUnionSets []UnionSetConfig
 
@@ -667,7 +667,7 @@ var ConfigWhichKeyLeaderDelayMs = 0
 
 // ConfigWhichKeyGrouped is the STARTUP default for the leader panel's entry
 // order: true clusters entries by category, false sorts purely by key. The
-// leader key toggles it at runtime for the rest of the session; the runtime
+// leader key toggles it at runtime for the rest of the session. The runtime
 // state is never written back here.
 var ConfigWhichKeyGrouped = true
 
@@ -694,7 +694,7 @@ func ResolveReadOnly(context string, cliFlag bool) bool {
 }
 
 // ConfigK8sClientQPS / ConfigK8sClientBurst are the global foreground REST
-// client rate limits. Defaults mirror k8s.DefaultClientQPS/Burst; raising the
+// client rate limits. Defaults mirror k8s.DefaultClientQPS/Burst. Raising the
 // stock client-go 5/10 keeps foreground lists responsive while background
 // scans run. Per-cluster overrides take precedence.
 var (
@@ -712,14 +712,14 @@ var (
 
 // init wires the foreground rate resolver into the k8s package so every REST
 // client picks up the configured (or default) QPS/Burst. Set unconditionally
-// at package load; resolution is lazy, so config applied later is honored.
+// at package load. Resolution is lazy, so config applied later is honored.
 func init() {
 	k8s.RateLimitForContext = ResolveK8sClientRate
 }
 
 // ResolveK8sClientRate returns the effective foreground QPS/Burst for a
 // context. Precedence: per-cluster override > global > compiled default.
-// Returned as (float32, int) to match rest.Config fields; this is the resolver
+// Returned as (float32, int) to match rest.Config fields. This is the resolver
 // wired into k8s.RateLimitForContext.
 func ResolveK8sClientRate(context string) (qps float32, burst int) {
 	q, b := ConfigK8sClientQPS, ConfigK8sClientBurst

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -24,9 +24,9 @@ import (
 //
 //  2. Ghostty-style dual-mode – "dark:Rose Pine,light:Rose Pine Dawn"
 //     Parses each comma-separated segment for a "dark:" or "light:" prefix.
-//     Both, one, or neither segment may be present; order does not matter.
+//     Both, one, or neither segment may be present. Order does not matter.
 //     ConfigDarkColorscheme / ConfigLightColorscheme are set accordingly.
-//     No default scheme is applied immediately; the terminal's first CSI 997
+//     No default scheme is applied immediately. The terminal's first CSI 997
 //     notification will trigger the initial switch.
 func applyColorscheme(theme *Theme, cfg configFile) {
 	if cfg.Colorscheme == "" {
@@ -109,7 +109,7 @@ func applyConfigOptions(cfg configFile) {
 		if warning != "" {
 			// Raw cfg.Terminal is intentionally not logged — log
 			// redaction policy. The "valid" list tells the user what
-			// is accepted; their own config file is the source of
+			// is accepted. Their own config file is the source of
 			// truth for what they typed.
 			logger.Warn(warning,
 				"valid", []string{TerminalModePTY, TerminalModeExec, TerminalModeMux},
@@ -140,7 +140,7 @@ func applyConfigOptions(cfg configFile) {
 	if len(cfg.PinnedTypes) > 0 {
 		ConfigPinnedTypes = cfg.PinnedTypes
 	}
-	if cfg.PinnedSummaries != nil { // nil vs "[]" distinguishes defaults-on from defaults-off; see ConfigPinnedSummariesSet
+	if cfg.PinnedSummaries != nil { // nil vs "[]" distinguishes defaults-on from defaults-off. See ConfigPinnedSummariesSet
 		ConfigPinnedSummaries = cfg.PinnedSummaries
 		ConfigPinnedSummariesSet = true
 	}
@@ -216,7 +216,7 @@ func applyConfigOptions(cfg configFile) {
 	if os.Getenv("NO_COLOR") != "" {
 		// Per https://no-color.org, the presence of NO_COLOR (regardless of
 		// value) disables color. Env takes precedence over the config file
-		// field; CLI flag is applied later in main.go.
+		// field. CLI flag is applied later in main.go.
 		ConfigNoColor = true
 	}
 }
@@ -269,7 +269,7 @@ func applyClusterSecurityConfig(ctx string, sec *securityConfig) {
 		ConfigClusterSecuritySources[ctx] = sec.Sources
 	}
 	// ignore_patterns is honored only in the top-level security
-	// section; per-cluster scoping is expressed via each pattern's
+	// section. Per-cluster scoping is expressed via each pattern's
 	// `cluster` glob instead. Warn rather than silently drop.
 	if len(sec.IgnorePatterns) > 0 {
 		logger.Warn("clusters.<ctx>.security.ignore_patterns is ignored; "+
@@ -401,7 +401,7 @@ func applySessionDefaults(cfg configFile) {
 	}
 }
 
-// applyTailLines copies a positive tail-line override into dst; non-positive
+// applyTailLines copies a positive tail-line override into dst. Non-positive
 // values are ignored so a stray `0` keeps the compiled default.
 func applyTailLines(src *int, dst *int) {
 	if src != nil && *src > 0 {
@@ -605,7 +605,7 @@ func applyRightsizingDefaults(cfg *RightsizingDefaultsConfig) {
 // parseRightsizingStrategy resolves a config string against the known
 // strategy literals (strict match, no case folding — predictable for
 // users typing config files by hand). Returns the matched strategy
-// and true on success; ("", false) for unknown values.
+// and true on success. ("", false) for unknown values.
 func parseRightsizingStrategy(s string) (model.RightsizingStrategy, bool) {
 	candidate := model.RightsizingStrategy(s)
 	if slices.Contains(model.AllRightsizingStrategies, candidate) {
@@ -641,7 +641,7 @@ func rightsizingStrategyLiterals() []string {
 
 // applySchedulerConfig pushes the YAML scheduler section into the
 // scheduler package-globals consumed by FromGlobals at request time.
-// A nil section is a no-op; zero/negative values are ignored so
+// A nil section is a no-op. Zero/negative values are ignored so
 // omitted fields don't clobber the compiled defaults.
 // K8sClientQPS and K8sClientBurst set the global foreground REST client rate
 // (per-cluster overrides are applied from the clusters section). The k8s

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -157,7 +157,7 @@ type Keybindings struct {
 
 	// TogglePreviewLogs toggles the right-pane live-log preview for the
 	// selected pod. Bound to "L" (shift+l) at deeper levels (resources,
-	// containers); at Level=Clusters the same key opens ClusterColorPicker
+	// containers). At Level=Clusters the same key opens ClusterColorPicker
 	// and the dispatcher gates accordingly. The fullscreen log viewer
 	// (kb.Logs) uses "ctrl+l" so the plain "L" is free for this toggle.
 	TogglePreviewLogs string `json:"toggle_preview_logs" yaml:"toggle_preview_logs"`
@@ -234,7 +234,7 @@ func DefaultKeybindings() Keybindings {
 		// footnote has to work in the Object Explorer, which scrolls its
 		// preview pane with J/K.
 		FieldDoc: "ctrl+k",
-		// "T" is also the explorer-level ThemeSelector; TreeView only dispatches
+		// "T" is also the explorer-level ThemeSelector. TreeView only dispatches
 		// inside the Object/API Explorer modes, which have their own handlers.
 		TreeView:      "T",
 		ThemeSelector: "T", CommandBar: ":", WatchMode: "w",
@@ -281,7 +281,7 @@ func DefaultKeybindings() Keybindings {
 
 		// Mouse capture toggle. Ctrl+Option+Y (Ctrl+Alt+Y) avoids the Ctrl+X
 		// collision with the bookmark-overlay delete and is hard to hit by
-		// accident; rebindable like any other key. Bubble Tea prints modifiers
+		// accident. Rebindable like any other key. Bubble Tea prints modifiers
 		// in a fixed order (ctrl, alt, shift, ...), so the stored string is
 		// "ctrl+alt+y".
 		MouseToggle: "ctrl+alt+y",
@@ -309,7 +309,7 @@ func DefaultKeybindings() Keybindings {
 		LocalClusterManager: "ctrl+n",
 
 		// Live-log preview pane toggle. "L" (shift+l) at resource/container
-		// levels; at Level=Clusters the same key opens ClusterColorPicker
+		// levels. At Level=Clusters the same key opens ClusterColorPicker
 		// (gated in handleExplorerNavKey). The fullscreen log viewer
 		// (kb.Logs) is "ctrl+l".
 		TogglePreviewLogs: "L",
@@ -356,7 +356,7 @@ var modifierOrder = []string{"ctrl", "alt", "shift", "meta", "hyper", "super"}
 //     ("alt+ctrl+y") and are now always printed in modifierOrder ("ctrl+alt+y")
 //   - a shift chord reports the SHIFTED character, so "ctrl+shift+x" has to
 //     become "ctrl+shift+X" — the lowercase form never matches
-//   - shift on its own is not reported as a modifier at all; the terminal just
+//   - shift on its own is not reported as a modifier at all. The terminal just
 //     sends the shifted character, so "shift+x" becomes plain "X"
 //
 // A binding naming an unrecognised modifier is returned untouched rather than

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -25,7 +25,7 @@ type configFile struct {
 	// Custom theme overrides in the "theme" section are applied on top.
 	// Appearance groups the visual knobs (colorscheme, icons, no_color,
 	// transparent_background, min_contrast_ratio, dim_overlay). This is the
-	// canonical home; the flat keys of the same name are deprecated aliases
+	// canonical home. The flat keys of the same name are deprecated aliases
 	// kept for backward compatibility. When both are set, the appearance group
 	// wins (it is merged down onto the flat fields at load time).
 	Appearance    *AppearanceConfig `json:"appearance" yaml:"appearance"`
@@ -60,7 +60,7 @@ type configFile struct {
 	// supported multiplexer).
 	Terminal string `json:"terminal" yaml:"terminal"`
 	// ScrollbackLines is the per-tab capacity of the embedded PTY
-	// scrollback ring buffer. Default 5000; clamped to
+	// scrollback ring buffer. Default 5000. Clamped to
 	// [ScrollbackLinesMin, ScrollbackLinesMax]. Only meaningful in pty
 	// mode — exec and mux delegate scrollback to the host terminal.
 	ScrollbackLines int `json:"scrollback_lines" yaml:"scrollback_lines"`
@@ -83,14 +83,14 @@ type configFile struct {
 	Tips *bool `json:"tips" yaml:"tips"`
 	// LogViewer groups all log-viewer settings (tail sizes, ANSI rendering,
 	// and the startup-toggle defaults for preview / prefixes / timestamps).
-	// This is the canonical home for these knobs; the flat log_tail_lines,
+	// This is the canonical home for these knobs. The flat log_tail_lines,
 	// log_tail_lines_short, and log_render_ansi keys below are deprecated
 	// aliases kept for backward compatibility. When both are set, the
 	// log_viewer group wins. Note: log_path is the application's own log
 	// file and is intentionally NOT part of this group.
 	LogViewer *LogViewerConfig `json:"log_viewer" yaml:"log_viewer"`
 	// LogTailLines is the deprecated flat alias for log_viewer.tail_lines.
-	// Controls how many log lines are initially loaded via --tail; scrolling
+	// Controls how many log lines are initially loaded via --tail. Scrolling
 	// to the top fetches older history in the background. Defaults to 1000.
 	LogTailLines *int `json:"log_tail_lines" yaml:"log_tail_lines"`
 	// LogTailLinesShort is the deprecated flat alias for
@@ -99,7 +99,7 @@ type configFile struct {
 	LogTailLinesShort *int `json:"log_tail_lines_short" yaml:"log_tail_lines_short"`
 	// LogRenderAnsi is the deprecated flat alias for log_viewer.render_ansi.
 	// Controls whether ANSI SGR sequences (colour, bold, underline) emitted by
-	// log producers are rendered. Defaults to true; false strips all ANSI.
+	// log producers are rendered. Defaults to true. False strips all ANSI.
 	LogRenderAnsi *bool `json:"log_render_ansi" yaml:"log_render_ansi"`
 	// LogTopDefaultProfile is the default Log Top parser profile. Valid values:
 	// auto | traefik-json | nginx-combined | ingress-nginx | envoy | json | logfmt.
@@ -165,7 +165,7 @@ type configFile struct {
 	// invalid. Set equal to watch_interval to disable background throttling.
 	BackgroundWatchInterval string `json:"background_watch_interval" yaml:"background_watch_interval"`
 	// ForegroundIdleTimeout is the no-input window before a focused window
-	// throttles to background_watch_interval. Go duration; 0 disables. Default 120s.
+	// throttles to background_watch_interval. Go duration. 0 disables. Default 120s.
 	ForegroundIdleTimeout string `json:"foreground_idle_timeout" yaml:"foreground_idle_timeout"`
 	// WatchThrottle enables focus/idle watch throttling. Set false to fully
 	// disable it: the watch tick then always uses watch_interval. Default true.
@@ -206,12 +206,12 @@ type configFile struct {
 	MinContrastRatio *float64 `json:"min_contrast_ratio" yaml:"min_contrast_ratio"`
 	// ReadOnly disables all mutating actions (delete, edit, scale, restart,
 	// exec, port-forward, drain, cordon, etc.) for every context. Per-context
-	// overrides under clusters.<name>.read_only take precedence; the
+	// overrides under clusters.<name>.read_only take precedence. The
 	// --read-only CLI flag wins over both.
 	ReadOnly *bool `json:"read_only" yaml:"read_only"`
 	// FieldManager overrides the name lfk sends as the field manager on every
 	// write. The apiserver records it in metadata.managedFields, which the
-	// YAML blame view reads. Empty falls back to "lfk:<os-user>"; set a plain
+	// YAML blame view reads. Empty falls back to "lfk:<os-user>". Set a plain
 	// "lfk" to keep the username off the cluster.
 	FieldManager string `json:"field_manager" yaml:"field_manager"`
 	// ShowRareTypes, when true, surfaces the rarely-used resource types (CSI
@@ -219,7 +219,7 @@ type configFile struct {
 	// synthetic "Advanced" category of uncategorized core resources) in the
 	// sidebar from startup — as if the ToggleRare key (H) were already pressed
 	// — so the full resource-type list is always visible. The runtime H toggle
-	// still flips it for the session; it resets to this value on the next
+	// still flips it for the session. It resets to this value on the next
 	// launch. Default false.
 	ShowRareTypes *bool `json:"show_rare_types" yaml:"show_rare_types"`
 	// Security configures the built-in security-findings dashboard. When
@@ -231,7 +231,7 @@ type configFile struct {
 	// the right-sizing advisor uses on its first overlay open of the
 	// session. Once the user changes strategy or headroom in the overlay,
 	// those choices stick across subsequent overlay opens (within the
-	// session); restarting lfk falls back to these config values.
+	// session). Restarting lfk falls back to these config values.
 	//
 	//   strategy: "vpa" | "prom_max_1d" | "prom_avg_1d" | "prom_p95_7d" | "snapshot"
 	//   headroom: one of 1.0, 1.1, 1.25, 1.5, 1.75, 2.0
@@ -246,12 +246,12 @@ type configFile struct {
 	// future fields can land here without further config schema changes.
 	Kubeshark *KubesharkConfig `json:"kubeshark" yaml:"kubeshark"`
 	// Scheduler holds the runtime knobs for the priority task scheduler.
-	// All fields are optional; missing keys fall back to the scheduler
+	// All fields are optional. Missing keys fall back to the scheduler
 	// package's compiled defaults.
 	Scheduler *SchedulerConfig `json:"scheduler" yaml:"scheduler"`
 	// KubeconfigDir overrides the default kubeconfig directory path (~/.kube/config.d).
 	// Accepts either a single string ("/path/to/dir") or a list of strings
-	// (["/dir/one", "/dir/two"]); when a list is given, every directory is
+	// (["/dir/one", "/dir/two"]). When a list is given, every directory is
 	// merged into the discovery set. The --kubeconfig-dir CLI flag takes
 	// precedence (repeatable), then the KUBECONFIG_DIR env var (colon-separated),
 	// then this config value.
@@ -259,7 +259,7 @@ type configFile struct {
 
 	// KubeconfigExclusive controls whether a set KUBECONFIG env var
 	// suppresses the default discovery (~/.kube/config and the
-	// ~/.kube/config.d scan), matching kubectl. Defaults to true; set
+	// ~/.kube/config.d scan), matching kubectl. Defaults to true. Set
 	// false to restore the historical merge-everything behavior. The
 	// --kubeconfig-exclusive CLI flag, then LFK_KUBECONFIG_EXCLUSIVE,
 	// take precedence over this value.
@@ -268,12 +268,12 @@ type configFile struct {
 	// flag. Each set bundles a list of contexts and an optional default
 	// namespace so users don't have to retype long --union-context lists
 	// for the same recurring cluster groups (e.g. blue/green/canary).
-	// CLI --namespace overrides the per-set namespace; --union-context and
+	// CLI --namespace overrides the per-set namespace. --union-context and
 	// --context are mutually exclusive with --union-set.
 	UnionSets UnionSetsConfig `json:"union_sets" yaml:"union_sets"`
 	// GotoTargets maps full g-prefix chords (e.g. "gA") to user-defined
 	// goto targets. Chords must start with the jump_top key and be exactly
-	// 2 runes. Kind is required; Group and Name are optional.
+	// 2 runes. Kind is required. Group and Name are optional.
 	// User entries override built-ins on chord collision.
 	GotoTargets map[string]GotoTargetEntry `json:"goto_targets" yaml:"goto_targets"`
 	// WhichKeyEnabled controls whether the which-key popup appears while a
@@ -287,7 +287,7 @@ type configFile struct {
 	WhichKeyLeaderDelayMs *int `json:"which_key_leader_delay_ms" yaml:"which_key_leader_delay_ms"`
 	// WhichKeyGrouped is the startup order of the leader panel: grouped by
 	// category (true) or purely by key (false). The leader key toggles it for
-	// the session; the toggle is not persisted back to the file.
+	// the session. The toggle is not persisted back to the file.
 	WhichKeyGrouped *bool `json:"which_key_grouped" yaml:"which_key_grouped"`
 }
 
@@ -340,7 +340,7 @@ func (sets *UnionSetsConfig) UnmarshalJSON(data []byte) error {
 }
 
 // SchedulerConfig holds the runtime knobs for the priority task
-// scheduler. All fields are optional; missing keys fall back to the
+// scheduler. All fields are optional. Missing keys fall back to the
 // scheduler package's compiled defaults.
 type SchedulerConfig struct {
 	WorkersPerContext int               `json:"workers_per_context" yaml:"workers_per_context"`
@@ -496,7 +496,7 @@ type KubesharkConfig struct {
 // UnionSetConfig is the on-disk schema for one entry under union_sets.
 type UnionSetConfig struct {
 	// Name is the identifier used by --union-set to reference this entry.
-	// Must be unique across UnionSets; duplicates are dropped at apply
+	// Must be unique across UnionSets. Duplicates are dropped at apply
 	// time (last wins) with a startup warning.
 	Name string `json:"name" yaml:"name"`
 	// Contexts is the list of cluster entries to merge in this union view.
@@ -519,7 +519,7 @@ type UnionSetConfig struct {
 // canary is green in this set, the prod-blue marker stays blue) without
 // affecting the cluster picker's global per-context tints.
 //
-// The color name must be one of ui.ClusterColorNames; invalid values are
+// The color name must be one of ui.ClusterColorNames. Invalid values are
 // dropped at sanitize time with a warning, leaving the entry usable but
 // untinted (the row gets a blank reserved cell instead of a colored tile).
 type UnionSetContextConfig struct {
@@ -581,7 +581,7 @@ type securityConfig struct {
 	// (omitted = enabled).
 	Enabled *bool `json:"enabled" yaml:"enabled"`
 	// HideBadges sets the default for suppressing the per-resource SEC severity
-	// badge. The dashboard still scans; only the inline row badge is hidden.
+	// badge. The dashboard still scans. Only the inline row badge is hidden.
 	// Toggleable at runtime. Settable globally and per-cluster (a per-cluster
 	// value overrides the global default for that context).
 	HideBadges *bool `json:"hide_badges" yaml:"hide_badges"`
@@ -609,18 +609,18 @@ type heuristicConfig struct {
 	// SecretEnvInclude / SecretEnvExclude tune the secret_env check with
 	// case-insensitive env-var name globs (`*`, `?`). Include adds names to
 	// flag on top of the built-in credential keywords (an explicit match
-	// overrides a built-in exemption); Exclude adds names to never flag and
+	// overrides a built-in exemption). Exclude adds names to never flag and
 	// wins over Include.
 	SecretEnvInclude []string `json:"secret_env_include" yaml:"secret_env_include"`
 	SecretEnvExclude []string `json:"secret_env_exclude" yaml:"secret_env_exclude"`
 	// ScanSecrets gates the heuristic checks that list Secret objects
-	// (legacy_sa_token_secret, tls_secret_expiry). Defaults to true; set
+	// (legacy_sa_token_secret, tls_secret_expiry). Defaults to true. Set
 	// false to keep the source from ever listing Secrets.
 	ScanSecrets *bool `json:"scan_secrets" yaml:"scan_secrets"`
 }
 
 // SecurityIgnorePattern is a declarative ignore rule from the config file.
-// Each field is a glob (`*` and `?`); an empty field matches anything. A
+// Each field is a glob (`*` and `?`). An empty field matches anything. A
 // finding is ignored when every non-empty field matches it. A pattern with
 // every field empty is treated as a no-op (skipped) to avoid silently hiding
 // all findings.
@@ -634,7 +634,7 @@ type SecurityIgnorePattern struct {
 	// Empty = any group.
 	Group string `json:"group,omitempty" yaml:"group,omitempty"`
 	// Namespace globs the resource namespace. Empty (or `*`) = any namespace,
-	// which hides the whole group; a specific value scopes the ignore to that
+	// which hides the whole group. A specific value scopes the ignore to that
 	// namespace only. Cluster-scoped findings have an empty namespace.
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	// Labels match the target resource's Kubernetes labels: each entry is a
@@ -664,7 +664,7 @@ func (p SecurityIgnorePattern) IsEmpty() bool {
 //
 // Strategy values mirror model.AllRightsizingStrategies (string form).
 // Headroom values must match one of model.RightsizingHeadrooms within
-// 1e-9 epsilon; off-preset values are dropped at apply time so the
+// 1e-9 epsilon. Off-preset values are dropped at apply time so the
 // picker never displays an out-of-list multiplier on first open.
 type RightsizingDefaultsConfig struct {
 	Strategy string  `json:"strategy" yaml:"strategy"`

--- a/internal/ui/explorer.go
+++ b/internal/ui/explorer.go
@@ -15,7 +15,7 @@ var ActiveHighlightQuery string
 // ActiveHighlightCategories opts-in to highlighting matching text in
 // the category bars too. Only set when the user explicitly opted into
 // category-aware search/filter (Tab inside the input at
-// LevelResourceTypes); otherwise category bars stay un-highlighted
+// LevelResourceTypes). Otherwise category bars stay un-highlighted
 // even when ActiveHighlightQuery is non-empty, so plain `/foo` doesn't
 // flash a category that the user hasn't asked to navigate into.
 var ActiveHighlightCategories bool
@@ -55,7 +55,7 @@ var ActiveColumnOrder []string
 var ActiveMiddleColumnLayout []MiddleColumnRegion
 
 // ActiveCollapsedCategories is set by the app before rendering the resource types
-// column. Keys are category names; presence means the category is collapsed.
+// column. Keys are category names. Presence means the category is collapsed.
 var ActiveCollapsedCategories map[string]bool
 
 // ActiveMiddleScroll is the persistent scroll position for the middle column.
@@ -81,7 +81,7 @@ var ActiveLeftScroll int
 // visible rows instead of every row from the top down (which made each frame
 // O(scroll position)). Column widths are still computed over all items, so the
 // layout stays stable while scrolling. -1 (the default) means "no windowing".
-// It applies only to a cursor-less RenderTable (cursor < 0); the middle column
+// It applies only to a cursor-less RenderTable (cursor < 0). The middle column
 // always renders with a real cursor, so it is never affected and none of its
 // click/sort globals are touched.
 var ActiveRightScroll = -1
@@ -298,7 +298,7 @@ func RenderColumn(header string, items []model.Item, cursor int, width, height i
 	}
 
 	// Build display-line-to-item map for mouse click handling (active middle
-	// column only; a cursor-less render is never the real middle column).
+	// column only. A cursor-less render is never the real middle column).
 	if isActive && cursor >= 0 {
 		ActiveMiddleLineMap = ActiveMiddleLineMap[:0]
 		for ei := startEntry; ei < endEntry; ei++ {
@@ -586,7 +586,7 @@ func FormatItem(item model.Item, width int) string {
 			}
 			visualName = iconPrefix + rawName
 		} else if ActiveHighlightQuery != "" {
-			// Name fits without truncation; apply highlight to displayName portion.
+			// Name fits without truncation. Apply highlight to displayName portion.
 			iconPrefix := ""
 			if icon != "" {
 				iconPrefix = IconStyle.Render(icon) + " "
@@ -598,7 +598,7 @@ func FormatItem(item model.Item, width int) string {
 		return visualName + strings.Repeat(" ", padding) + rightSide
 	}
 
-	// No right side info; apply highlight before truncation for simple case.
+	// No right side info. Apply highlight before truncation for simple case.
 	if ActiveHighlightQuery != "" {
 		iconPrefix := ""
 		if icon != "" {
@@ -623,7 +623,7 @@ func FormatItemPlain(item model.Item, width int) string {
 
 	name := displayName
 
-	// Prepend icon if present (plain text, no IconStyle; resolved based on IconMode).
+	// Prepend icon if present (plain text, no IconStyle, resolved based on IconMode).
 	icon := iconCell(item.Icon)
 	if icon != "" {
 		name = icon + " " + name

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -12,8 +12,6 @@ import (
 	"github.com/janosmiko/lfk/internal/model"
 )
 
-// sortIndicatorForColumn returns a sort direction indicator (" ▲" or " ▼") if
-// the given column name matches the currently sorted column, or "" otherwise.
 // sortIndicatorForColumn returns "↑" or "↓" if the given column is sorted, or "".
 func sortIndicatorForColumn(colName string) string {
 	if ActiveSortColumnName == colName {
@@ -54,13 +52,13 @@ type headerSegment struct {
 
 // renderStyledHeader renders the header segments into a single line capped at
 // width. The segment whose colName matches the active sort column is rendered
-// with SortActiveHeaderStyle (accent) so the sorted column stands out; every
+// with SortActiveHeaderStyle (accent) so the sorted column stands out. Every
 // other segment is dim+bold, matching the previous flat header. Truncation
 // happens on each segment's plain text before styling, so no ANSI escape
 // sequence is ever cut and styled cells stay self-contained.
 func renderStyledHeader(segments []headerSegment, width int) string {
 	var b strings.Builder
-	dimStyle := DimStyle.Bold(true) // derive once; reused for every inactive cell
+	dimStyle := DimStyle.Bold(true) // derive once. Reused for every inactive cell
 	remaining := width
 	for _, seg := range segments {
 		if remaining <= 0 {
@@ -123,7 +121,7 @@ func styledExtraCell(ec extraColumn, item *model.Item) string {
 // statusAbbreviations maps long-form Pod-ish status strings to a compact
 // label used when the STATUS column has been shrunk under width pressure.
 // Entries here are status values that are otherwise too verbose for narrow
-// layouts; status values not in the map render as-is and rely on the
+// layouts. Status values not in the map render as-is and rely on the
 // width-aware Truncate fallback. AbbreviateStatusForWidth picks between
 // the full string and the abbreviation based on the column's width budget.
 var statusAbbreviations = map[string]string{
@@ -141,8 +139,8 @@ var statusAbbreviations = map[string]string{
 }
 
 // AbbreviateStatusForWidth returns a status label that fits within w
-// visible columns. Returns the full status when it already fits; otherwise
-// looks up a curated abbreviation; otherwise falls back to the original
+// visible columns. Returns the full status when it already fits. Otherwise
+// looks up a curated abbreviation. Otherwise falls back to the original
 // (the caller will then truncate it). Pure function so the layout pass
 // and the cell renderer can both use it.
 func AbbreviateStatusForWidth(status string, w int) string {
@@ -157,7 +155,7 @@ func AbbreviateStatusForWidth(status string, w int) string {
 
 // styledRestartsCell renders the restarts column with recent-restart arrow
 // styling. Rows whose LastRestartAt is within the past hour are tagged with
-// an up-arrow; when any row in the table has a recent restart, rows without
+// an up-arrow. When any row in the table has a recent restart, rows without
 // one get a space prefix so values remain column-aligned.
 func styledRestartsCell(item model.Item, restartsW int, anyRecentRestart bool) string {
 	restarts := SanitizeTerminalText(item.Restarts)
@@ -195,7 +193,7 @@ func plainRestartsCell(item model.Item, anyRecentRestart bool) string {
 }
 
 // formatTableRowOrdered builds a plain-text table row using the given column
-// order. "Name" is rendered at its position within order; an order without a
+// order. "Name" is rendered at its position within order. An order without a
 // "Name" entry renders no name cell (the column is hidden). The preprocessed
 // values (ns, ready, restarts, status, age) are passed through since they have
 // row-specific handling upstream (e.g. the cursor row preprocesses restarts for
@@ -228,7 +226,7 @@ func formatTableRowOrdered(name, ns, ready, restarts, status, age string,
 
 // formatTableRowStyledOrdered builds a styled table row using the given
 // column order. The Name cell (with icon + badge handling) is rendered at its
-// position within order via the styled name helper; an order without a "Name"
+// position within order via the styled name helper. An order without a "Name"
 // entry renders no name cell (the column is hidden).
 func formatTableRowStyledOrdered(item model.Item,
 	nameW, contextW, nsW, readyW, restartsW, statusW, ageW int,
@@ -282,7 +280,7 @@ func plainNameCellWithBadge(name string, item *model.Item, nameW int) string {
 
 // styledNameCell renders the Name column with optional icon and dimmed
 // styling for completed items. Pods in Succeeded or Completed status get
-// their name dimmed; otherwise NormalStyle is used. The active highlight
+// their name dimmed. Otherwise NormalStyle is used. The active highlight
 // query is applied to the resolved display name.
 //
 // When a security finding index is active and the item has matching findings,
@@ -406,7 +404,7 @@ func resourceColumnStyle(key, val string) lipgloss.Style {
 func extraColumnValueStyle(key, val string) lipgloss.Style {
 	if canonical, ok := canonicalBoolStatus(val); ok {
 		// ALLCAPS headers would tokenize letter-by-letter in the polarity
-		// heuristic; lowercase them so "ESTABLISHED" matches like "Established".
+		// heuristic. Lowercase them so "ESTABLISHED" matches like "Established".
 		if key == strings.ToUpper(key) {
 			key = strings.ToLower(key)
 		}
@@ -474,7 +472,7 @@ func pctStyle(val string) lipgloss.Style {
 }
 
 // ParseResourceValue parses a CPU (millicores) or memory (bytes) string back to
-// int64. Unparseable input (empty, "n/a", garbage) yields 0; callers that must
+// int64. Unparseable input (empty, "n/a", garbage) yields 0. Callers that must
 // distinguish "missing" from a genuine 0 should use ParseResourceValueOK.
 func ParseResourceValue(val string, isCPU bool) int64 {
 	v, _ := ParseResourceValueOK(val, isCPU)

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -41,9 +41,9 @@ var ActiveSessionColumns []string
 
 // ActivePrinterColumns maps CRD additionalPrinterColumns names to their
 // declared priority for the resource type currently rendered in the middle
-// column. Set by the app before rendering; nil for non-CRD resources or CRDs
+// column. Set by the app before rendering. Nil for non-CRD resources or CRDs
 // without printer columns. Priority 0 columns are treated as mandatory (always
-// shown, never dropped by the width budget); priority > 0 columns are hidden by
+// shown, never dropped by the width budget). Priority > 0 columns are hidden by
 // default, matching kubectl's standard vs. `-o wide` behaviour.
 var ActivePrinterColumns map[string]int
 
@@ -127,7 +127,7 @@ func stabilizeColumnOrder(order []string) {
 		if iPinned && jPinned {
 			return ri < rj
 		}
-		// A pinned key sorts before any unpinned one; two unpinned keys
+		// A pinned key sorts before any unpinned one. Two unpinned keys
 		// compare equal so the stable sort preserves their discovery order.
 		return iPinned && !jPinned
 	})
@@ -223,7 +223,7 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	}
 
 	// Mandatory CRD printer-column protection applies only on the default
-	// auto-detect path; an explicit session or configured (views.<kind>.columns)
+	// auto-detect path. An explicit session or configured (views.<kind>.columns)
 	// order is authoritative and left untouched. When active, move mandatory
 	// columns to the front so the width budget serves them before optional extras.
 	mandatoryActive := fromAutoDetect && ActivePrinterColumns != nil
@@ -241,7 +241,7 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 	//   1. Default: longestName + 1 spacing column.
 	//   2. If that fits in (totalWidth - usedWidth) — i.e. name + builtins
 	//      already fit even without any extras — keep the full reservation.
-	//      Whatever room is left flows to extras; if it's not enough for a
+	//      Whatever room is left flows to extras. If it's not enough for a
 	//      column, the loop below drops them and Name gets the slack via
 	//      the caller's nameW computation. This is the case the user hit:
 	//      a 52-char Node FQDN on a 97-char middle column was getting
@@ -298,7 +298,7 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 		// config that renders fully in the wide full screen list silently drops
 		// trailing columns (issue #354). Reserve only what the configured
 		// columns leave after their capped widths and let NAME compress to a
-		// small floor; NAME still reclaims any leftover via the caller's nameW,
+		// small floor. NAME still reclaims any leftover via the caller's nameW,
 		// so wide panes are unchanged.
 		configuredBudget := 0
 		for _, key := range candidates {
@@ -316,7 +316,7 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 			nameReserve = max(totalWidth-usedWidth-minExtrasBudget, nameFloor)
 		}
 		if mandatoryBudget > 0 {
-			// Never let the name reservation crowd out mandatory columns; NAME
+			// Never let the name reservation crowd out mandatory columns. NAME
 			// shrinks toward its floor and overflow is clipped by the caller.
 			nameReserve = min(nameReserve, max(totalWidth-usedWidth-mandatoryBudget, nameFloor))
 		}
@@ -338,7 +338,7 @@ func collectExtraColumns(items []model.Item, totalWidth, usedWidth int, kind str
 
 // fitExtraColumns selects columns from candidates that fit within available
 // width and computes their display widths. Columns are added in order until the
-// budget is exhausted (optional columns then stop); mandatory CRD printer
+// budget is exhausted (optional columns then stop). Mandatory CRD printer
 // columns are always emitted even past the budget, leaving the row to be
 // clipped. Leftover budget is redistributed round-robin to capped columns.
 //
@@ -353,7 +353,7 @@ func fitExtraColumns(candidates []string, seen map[string]*colInfo, available, m
 	for _, key := range candidates {
 		info := seen[key]
 		colW, natural := extraColWidth(info, key, maxColW)
-		// Mandatory printer columns are always emitted; remainingW may go
+		// Mandatory printer columns are always emitted. remainingW may go
 		// negative, which is fine — NAME floors and the row is clipped.
 		if colW > remainingW && (!mandatoryActive || !isMandatoryColumn(key)) {
 			break
@@ -392,7 +392,7 @@ func fitExtraColumns(candidates []string, seen map[string]*colInfo, available, m
 
 // selectColumnCandidates determines which extra columns to display based on
 // session overrides, per-kind config, or auto-detection. The second return
-// value reports whether the auto-detect path produced the result; only then
+// value reports whether the auto-detect path produced the result. Only then
 // may mandatory CRD printer-column protection reorder/force columns (an
 // explicit session or config order is authoritative and left untouched).
 //
@@ -413,7 +413,7 @@ func selectColumnCandidates(seen map[string]*colInfo, order []string, kind strin
 
 	// Build a ResourceRef so GVR-keyed view configs resolve. When the
 	// rendered kind matches ActiveResourceRef (set by the app for the
-	// middle column) carry through the full GVR; otherwise fall back to
+	// middle column) carry through the full GVR. Otherwise fall back to
 	// Kind-only — at LevelOwned/LevelContainers the rendered kind diverges
 	// from nav.ResourceType so GVR can't be trusted and Kind lookup applies.
 	rt := ResourceRef{Kind: kind}
@@ -515,7 +515,7 @@ func isHiddenColumnPrefix(key string) bool {
 // blockedColumnsForMode returns the set of columns blocked in the current display mode.
 // Description and References are always blocked because security findings put
 // multi-line content into them (Falco's Details has \n-separated key/value
-// pairs, References is a \n-joined URL list); they belong in the right-pane
+// pairs, References is a \n-joined URL list). They belong in the right-pane
 // detail renderer, not in the explorer table where newlines break the layout.
 func blockedColumnsForMode() map[string]bool {
 	if ActiveFullscreenMode {
@@ -561,10 +561,10 @@ func GetExtraColumnValue(item *model.Item, key string) string {
 
 // columnHeaderAliases shortens column header labels without renaming the
 // underlying Column key. Renaming the key would silently break user session
-// state, persisted column configs, and the column-visibility overlay; the
+// state, persisted column configs, and the column-visibility overlay. The
 // header alias is purely cosmetic. Names listed here either:
 //   - duplicate the resource type's name (Ingress -> "Ingress Class" =>
-//     "Class"; the user already knows it's an Ingress).
+//     "Class". The user already knows it's an Ingress).
 //   - are unnecessarily verbose given typical column-width budgets.
 var columnHeaderAliases = map[string]string{
 	"Ingress Class":       "Class",
@@ -577,7 +577,7 @@ var columnHeaderAliases = map[string]string{
 	"Last Transition":     "Transition",
 	"Service Account":     "SA",
 	// Security finding columns: the underlying camelCase keys are kept as-is
-	// for ColumnValue() lookups in the details renderer; the alias is the
+	// for ColumnValue() lookups in the details renderer. The alias is the
 	// human-readable form rendered in the table header.
 	"ResourceKind": "Resource Kind",
 	"FindingCount": "Findings",
@@ -592,6 +592,6 @@ func ColumnHeaderLabel(key string) string {
 		return strings.ToUpper(alias)
 	}
 	// key can be a CRD condition type or printer-column name (cluster-sourced)
-	// promoted into a table HEADER; sanitize before it reaches the screen.
+	// promoted into a table HEADER. Sanitize before it reaches the screen.
 	return strings.ToUpper(SanitizeTerminalText(key))
 }

--- a/internal/ui/explorer_highlight.go
+++ b/internal/ui/explorer_highlight.go
@@ -115,7 +115,7 @@ func VimScrollOff(scroll, cursor, numEntries, height, scrollOff int, displayLine
 // UnicodeCoreActive reports whether the terminal measures text by grapheme
 // cluster, which it announces by answering the mode 2027 query. Bubble Tea
 // sends that query at startup and switches its renderer to grapheme width only
-// when an answer comes back; until then the renderer measures with wcwidth.
+// when an answer comes back. Until then the renderer measures with wcwidth.
 // lfk's own layout goes through lipgloss, which always measures by grapheme
 // cluster, so the renderer and the layout agree only while this is set.
 var UnicodeCoreActive bool
@@ -147,7 +147,7 @@ func iconCell(icon model.Icon) string {
 
 // normalizeEmojiWidth drops the variation selector when the terminal does not
 // measure by grapheme cluster. lipgloss counts a base codepoint plus the
-// selector as two columns; a terminal measuring with wcwidth draws one, so the
+// selector as two columns. A terminal measuring with wcwidth draws one, so the
 // row ends a column short and the panel border lands early. Without the
 // selector both measures say one column, the glyph renders in text
 // presentation, and the row stays aligned (#604).
@@ -255,7 +255,7 @@ func ClusterPickerHeader(width int) string {
 		padRight("STATUS", clusterPickerStatusColW) +
 		padLeft("COLOR", clusterPickerColorColW)
 	if width < clusterPickerTrailingW+4 {
-		// Column too narrow for the full header; fall back to a
+		// Column too narrow for the full header. Fall back to a
 		// section label so we don't return a mangled string.
 		return Truncate("KUBECONFIG", width)
 	}

--- a/internal/ui/explorer_resource.go
+++ b/internal/ui/explorer_resource.go
@@ -134,7 +134,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 			}
 		}
 		// Message/Reason/Health Message are free-text and may carry embedded
-		// SGR colour worth keeping; everything else is a short structured
+		// SGR colour worth keeping. Everything else is a short structured
 		// field value, so the plain single-line sanitizer is enough.
 		if messageKeys[kv.Key] {
 			val = SanitizeLogBody(StripBidiOverrides(val), false)
@@ -242,7 +242,7 @@ func RenderResourceSummary(item *model.Item, yaml string, width, height int) str
 		lines = append(lines, "")
 		lines = append(lines, detailKeyStyle.Render(strings.ToUpper(kv.Key)))
 		// Endpoints emits one entry per line with `\n` as separator so
-		// the per-endpoint render stays readable; everything else uses
+		// the per-endpoint render stays readable. Everything else uses
 		// the legacy `, ` split so existing fields render unchanged.
 		sep := ", "
 		if kv.Key == "Endpoints" {
@@ -545,7 +545,7 @@ func RenderPreviewEvents(events []EventTimelineEntry, width int) string {
 		// Type indicator and styling.
 		var dot, reasonStr string
 		// padRight/Truncate measure visual columns, matching maxReasonW
-		// above; truncateStr and fmt's "%-*s" both count runes, which
+		// above. truncateStr and fmt's "%-*s" both count runes, which
 		// mismeasures a wide (e.g. CJK) or multibyte Reason.
 		if e.warning {
 			dot = errorStyle.Render("\u25cf")

--- a/internal/ui/explorer_resource_usage.go
+++ b/internal/ui/explorer_resource_usage.go
@@ -95,7 +95,7 @@ func renderUsageBar(used, req, lim int64, barWidth int, formatFn func(int64) str
 	suffix := usageSuffixText(used, req, lim, formatFn)
 
 	// Reserve the fixed suffix column so the bar length is independent of the
-	// value string width; bars rendered with the same suffixWidth match.
+	// value string width. Bars rendered with the same suffixWidth match.
 	bw := max(barWidth-suffixWidth-2, 5) // 2 for brackets
 
 	bar := NormalStyle.Render("[") + renderUsageBarFill(bw, used, req, lim) + NormalStyle.Render("]")
@@ -109,8 +109,8 @@ func renderUsageBar(used, req, lim int64, barWidth int, formatFn func(int64) str
 // request up to 90% of the limit, red at/above 90% of the limit. The red zone
 // wins regardless of the request, so a container whose request sits near its
 // limit still turns red as usage approaches the limit. The remainder is a dim
-// headroom track; when usage has not reached the request, a tick marks the
-// request position. With a limit the bar spans 0..limit; without one it spans
+// headroom track. When usage has not reached the request, a tick marks the
+// request position. With a limit the bar spans 0..limit. Without one it spans
 // 0..max(usage, request) (so an over-request burst is visible) and there is no
 // red zone \u2014 there is no hard cap to reach. Glyphs ramp \u2592 -> \u2593 -> \u2588 so the zones
 // stay legible without color (NO_COLOR terminals).

--- a/internal/ui/explorer_table.go
+++ b/internal/ui/explorer_table.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RenderTable renders items in a table format with column headers for resource views.
-// headerLabel is used as the first column header; defaults to "NAME" if empty.
+// headerLabel is used as the first column header. Defaults to "NAME" if empty.
 //
 // Column-config contract: RenderTable applies the Active* column globals
 // (ActiveSessionColumns, ActiveHiddenBuiltinColumns, ActiveColumnOrder,
@@ -319,7 +319,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 
 	// Row-status-tint plan for this render (issue #540). Whole-row tint is the
 	// background mode (always) and the foreground fallback when both Status and
-	// Name are hidden; name-only foreground tint applies when the Status column
+	// Name are hidden. Name-only foreground tint applies when the Status column
 	// is hidden but Name is shown — so a failed/pending row stays visible even
 	// without its Status cell, without shouting a full colored line while the
 	// Status cell is right there. Status visible in foreground mode -> no tint.
@@ -355,7 +355,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 
 	nameW := max(width-contextW-nsW-readyW-restartsW-ageW-statusW-markerColW-extraTotalW-tileW, 10)
 	if nameHidden {
-		// No name cell is emitted (Name is absent from order); zero the width
+		// No name cell is emitted (Name is absent from order). Zero the width
 		// so the unused value can't be mistaken for a real reservation.
 		nameW = 0
 	}
@@ -566,7 +566,7 @@ func RenderTable(headerLabel string, items []model.Item, cursor int, width, heig
 				// (do not swap in the selection background) and mark the cursor
 				// with bold, so the "failed" background never disappears on
 				// selection (issue #540 UAT). The checkmark stays reserved for
-				// actual multi-selection; a blank marker cell keeps the row's
+				// actual multi-selection. A blank marker cell keeps the row's
 				// background.
 				markerPrefix := ""
 				if wantMarker {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -27,7 +27,7 @@ type helpSection struct {
 	bindings []helpEntry
 }
 
-// helpSections lives in help_sections.go; key formatting in help_keys.go.
+// helpSections lives in help_sections.go. Key formatting in help_keys.go.
 
 // BuildHelpLines builds the searchable help lines, optionally filtering
 // by a query string. contextMode limits sections to those matching the
@@ -55,14 +55,14 @@ func BuildHelpLines(filter, contextMode string, screenWidth int) []string {
 }
 
 // Overlay box geometry. The percentages and the 50x20 floors are the
-// long-standing sizing; the clamps against the terminal are what stop that
+// long-standing sizing. The clamps against the terminal are what stop that
 // floor from producing an overlay LARGER than the screen it sits in.
 const (
 	helpBoxPctW   = 70 // percent of the terminal width
 	helpBoxPctH   = 80 // percent of the terminal height
 	helpBoxFloorW = 50 // smallest comfortable box, when the terminal allows it
 	helpBoxFloorH = 20
-	helpBoxFrame  = 2 // border; lipgloss counts it inside Width()/Height()
+	helpBoxFrame  = 2 // border, lipgloss counts it inside Width()/Height()
 	// helpBoxHardW / helpBoxHardH are the irreducible box: 22 columns is what
 	// the widest fixed string in the chrome ("  ↓ more below") needs before it
 	// wraps and starts adding rows, and 9 rows is the chrome plus a single
@@ -88,7 +88,7 @@ func helpBoxWidth(screenWidth int) int {
 	return max(min(w, screenWidth-helpBoxFrame), helpBoxHardW)
 }
 
-// helpBoxHeight is helpBoxWidth's vertical counterpart; its floor overflows
+// helpBoxHeight is helpBoxWidth's vertical counterpart. Its floor overflows
 // below ~22 rows.
 func helpBoxHeight(screenHeight int) int {
 	h := max(screenHeight*helpBoxPctH/100, helpBoxFloorH)
@@ -184,7 +184,7 @@ func buildHelpSpecs(filter, contextMode string, innerW int) []helpLineSpec {
 	keyWidth := helpKeyColumnWidth(groups, innerW)
 	// rowOverhead is the fixed prefix helpSpecPlain puts before a
 	// description: 4 leading spaces + keyWidth + 2 spaces between the
-	// columns. descBudget is the exact room left; flooring at 1 keeps the
+	// columns. descBudget is the exact room left. Flooring at 1 keeps the
 	// wrapped row inside innerW so the renderer's Truncate never lops a
 	// character with a "~". The only residual overflow is a key wider than
 	// the capped column, which no description width could fix.
@@ -266,7 +266,7 @@ func collectHelpGroups(filter, contextMode string) []helpGroup {
 
 // helpSectionInContext reports whether a section belongs to the view the
 // help screen was opened from. An empty (or explorer-level) context shows
-// only the explorer sections; any other context shows only its own.
+// only the explorer sections. Any other context shows only its own.
 func helpSectionInContext(section helpSection, contextMode string) bool {
 	if contextMode == "" || contextMode == "Navigation" || contextMode == "Bookmarks" {
 		return section.context == ""
@@ -279,7 +279,7 @@ func helpSectionInContext(section helpSection, contextMode string) bool {
 // stepping in and out per section.
 //
 // The cap stops one unusually long key from pushing every description off
-// a narrow screen; a key past the cap simply overflows its own cell.
+// a narrow screen. A key past the cap simply overflows its own cell.
 func helpKeyColumnWidth(groups []helpGroup, innerW int) int {
 	maxWidth := max(innerW/3, helpKeyColumnMinWidth)
 	width := helpKeyColumnMinWidth
@@ -296,7 +296,7 @@ func helpKeyColumnWidth(groups []helpGroup, innerW int) int {
 // wrapHelpText word-wraps desc to width on word boundaries. A space-free
 // token wider than width (e.g. a slash-joined "owner/port-forward/orphan/
 // finding/mark" enumeration) is broken after its "/" separators so it
-// wraps at readable boundaries rather than mid-word; a segment between
+// wraps at readable boundaries rather than mid-word. A segment between
 // slashes that is itself wider than width falls back to a hard character
 // break. The output never exceeds width, so RenderHelpScreen's final
 // Truncate never adds a "~".
@@ -309,7 +309,7 @@ func wrapHelpText(desc string, width int) []string {
 	}
 
 	// Tokenize into pieces no wider than width. spaceBefore marks pieces
-	// that follow a real space (a word boundary); slash continuations and
+	// that follow a real space (a word boundary). Slash continuations and
 	// hard-break fragments glue to the previous piece with no space.
 	type piece struct {
 		text        string
@@ -537,7 +537,7 @@ func RenderHelpScreen(screenWidth, screenHeight, scroll int, filter, search, con
 	// buildHelpSpecs already word-wrapped descriptions to innerW, so each
 	// spec is one rendered row. Truncate stays as a safety net for the
 	// rare row whose key column alone overruns innerW (extremely narrow
-	// terminals); it never trims wrapped descriptions in normal layouts.
+	// terminals). It never trims wrapped descriptions in normal layouts.
 	lines := make([]string, len(specs))
 	for i, s := range specs {
 		lines[i] = Truncate(helpSpecStyled(s, search, i == currentMatchLine), innerW)

--- a/internal/ui/help_keys.go
+++ b/internal/ui/help_keys.go
@@ -52,7 +52,7 @@ func mapChordTokens(key string, f func(string) string) string {
 
 // helpKeyDisplay formats a keybinding value as text for the help screen.
 // A modified chord gets its modifiers capitalized and its key uppercased
-// ("ctrl+shift+x" -> "Ctrl+Shift+X", "shift+tab" -> "Shift+Tab"); anything
+// ("ctrl+shift+x" -> "Ctrl+Shift+X", "shift+tab" -> "Shift+Tab"). Anything
 // that is not a chord displays verbatim.
 //
 // This is also the form the help screen's search index is built from, so a
@@ -66,7 +66,7 @@ func helpKeyDisplay(key string) string {
 
 // helpKeySeparator is the display-only form of "/" between alternative
 // bindings for one action ("h/Left" -> "h / Left"). Spaced on both sides
-// so it reads as a gap rather than competing with the keys; styled dimmer
+// so it reads as a gap rather than competing with the keys. Styled dimmer
 // than the keys at render time (see styleHelpKeyCell in help.go) so it
 // stops drawing the eye like a third keybinding.
 //

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -436,7 +436,7 @@ func viewerHelpSections(kb Keybindings) []helpSection {
 			},
 		},
 		{
-			// Grouping and warnings-only used to be listed here; they are keys of
+			// Grouping and warnings-only used to be listed here. They are keys of
 			// the explorer's Events list (handleKeyExpandCollapse,
 			// handleExplorerActionKeySaveResource), not of the timeline, and are
 			// documented in Navigation and Actions where they dispatch.

--- a/internal/ui/kv_editor.go
+++ b/internal/ui/kv_editor.go
@@ -518,7 +518,7 @@ func scrollWindowStart(cursor, windowH, total int) int {
 
 // kvSelColumnW is the visible width (without padding) of the leading
 // "selection marker" column shared by every K/V editor. Wide enough
-// for the "✓" glyph plus no trailing space. Lipgloss/table's per-cell
+// for the "✓" glyph plus no trailing space, and lipgloss/table's per-cell
 // padding (1,1) supplies the gap to the KEY column on either side.
 const kvSelColumnW = 1
 

--- a/internal/ui/kv_editor.go
+++ b/internal/ui/kv_editor.go
@@ -11,7 +11,7 @@ import (
 // kv_editor.go holds rendering primitives shared by the three K/V
 // editor overlays (secret, configmap, label). Each editor used to
 // hand-roll its own ASCII table with `|` / `-` separators and manual
-// padding; centralising the rendering on lipgloss/table here keeps
+// padding. Centralising the rendering on lipgloss/table here keeps
 // the three editors visually consistent and removes ~60 lines of
 // near-identical code per editor.
 
@@ -42,7 +42,7 @@ func RenderKVEditorEditPane(
 	)
 
 	// Field-box dimensions: two fields share the available height.
-	// Key gets one content row; Value gets the rest.
+	// Key gets one content row. Value gets the rest.
 	fieldOuterW := max(width, 12)
 	keyContentH := 1
 	valContentH := max(height-keyContentH-4, 1) // -4: 2 borders for each box's top+bottom = 4 rows total chrome
@@ -60,7 +60,7 @@ func RenderKVEditorEditPane(
 }
 
 // kvFieldBox wraps `content` in a labelled bordered box. Active
-// fields get an accent border color; idle fields use the standard
+// fields get an accent border color. Idle fields use the standard
 // border color. The box's bg matches the editor's baseBg so it
 // doesn't paint a different shade against the surrounding pane.
 func kvFieldBox(label, content string, active bool, outerW, contentH int) string {
@@ -69,7 +69,7 @@ func kvFieldBox(label, content string, active bool, outerW, contentH int) string
 		BorderBackground(BaseBg).
 		Background(BaseBg).
 		Padding(0, 1)
-	// -2 for the left/right borders; BoxWidth/BoxHeight add them back, since
+	// -2 for the left/right borders. BoxWidth/BoxHeight add them back, since
 	// lipgloss v2 counts the border inside Width/Height.
 	border = BoxHeight(BoxWidth(border, outerW-2), contentH)
 
@@ -132,7 +132,7 @@ func sanitizeMultilineBody(s string) string {
 // cursor - a byte offset into the raw, unsanitized s - to the matching
 // offset in the sanitized result. The edit buffer is seeded straight from
 // the cluster value (a Secret/ConfigMap/annotation key or value), so this is
-// the last point before the live cursor overlay reaches the screen; mapping
+// the last point before the live cursor overlay reaches the screen. Mapping
 // the offset keeps the cursor on the same character instead of drifting once
 // bytes ahead of it are dropped.
 func sanitizeCursorText(s string, cursor int) (string, int) {
@@ -186,7 +186,7 @@ func overlayCursor(s string, cursor int, active bool, maxW int) string {
 // `scroll` is the visible-line offset — the renderer is purely a
 // function of state, so the SCROLL is supplied externally rather than
 // computed here. The handler owns the scroll state and keeps it
-// sticky (cursor moves freely inside [scroll, scroll+maxH); only when
+// sticky (cursor moves freely inside [scroll, scroll+maxH). Only when
 // the cursor leaves the window does the handler nudge scroll). See
 // AdjustEditValueScroll for the handler's update rule.
 func overlayCursorMultiline(s string, cursor int, active bool, scroll, maxW, maxH int) string {
@@ -428,7 +428,7 @@ func SingleLineCell(s string, maxW int) string {
 	if s == "" || maxW <= 0 {
 		return Truncate(s, maxW)
 	}
-	// strings.NewReplacer is allocation-friendly here; the inputs are
+	// strings.NewReplacer is allocation-friendly here. The inputs are
 	// small and we hit this once per visible cell per render.
 	flat := strings.NewReplacer(
 		"\r\n", " ↵ ",
@@ -502,7 +502,7 @@ func computeKeyColumnWidth(keys []string, totalWidth, divisor int) int {
 
 // scrollWindowStart returns the first visible row index so `cursor`
 // stays in view inside a window of `windowH` rows. Vim-like contract:
-// if the cursor is already inside [0, windowH), no scroll; otherwise
+// if the cursor is already inside [0, windowH), no scroll. Otherwise
 // pull just enough so the cursor lands on the last visible row.
 func scrollWindowStart(cursor, windowH, total int) int {
 	if total <= windowH {
@@ -518,7 +518,7 @@ func scrollWindowStart(cursor, windowH, total int) int {
 
 // kvSelColumnW is the visible width (without padding) of the leading
 // "selection marker" column shared by every K/V editor. Wide enough
-// for the "✓" glyph plus no trailing space; lipgloss/table's per-cell
+// for the "✓" glyph plus no trailing space. Lipgloss/table's per-cell
 // padding (1,1) supplies the gap to the KEY column on either side.
 const kvSelColumnW = 1
 
@@ -532,14 +532,14 @@ const kvSelColumnW = 1
 // to shift every row's key text two columns to the right whether or
 // not the row was actually selected).
 //
-// cursorRow is the body-row index (0-based; lipgloss/table's HeaderRow
+// cursorRow is the body-row index (0-based, lipgloss/table's HeaderRow
 // is the constant -1) of the cursor. Pass -1 when no row is the cursor
 // (e.g. an empty table that's only showing headers + a placeholder).
 //
 // editing toggles off the SelectedBg highlight on the cursor row when
 // the user is actively editing an inline cell. The cursor character
 // itself renders as reverse-video at the byte offset (see
-// overlayCursor); its embedded \x1b[7m / \x1b[0m SGR pair breaks the
+// overlayCursor). Its embedded \x1b[7m / \x1b[0m SGR pair breaks the
 // continuity of any background the table wraps around the cell, so
 // the row's SelectedBg ends up visible BEFORE the cursor and missing
 // AFTER it — the user-reported "background is different before and
@@ -560,7 +560,7 @@ func newKVEditorTable(keyColW, valColW, cursorRow int, editing bool) *table.Tabl
 			Background(BaseBg)).
 		Headers("", "KEY", "VALUE").
 		StyleFunc(func(row, col int) lipgloss.Style {
-			// Padding eats text space; widen the cell by the padding
+			// Padding eats text space. Widen the cell by the padding
 			// budget (1 + 1 = 2) so the row-data Truncate's full
 			// content can land inside without wrapping into a second
 			// visual line.

--- a/internal/ui/kv_format.go
+++ b/internal/ui/kv_format.go
@@ -79,7 +79,7 @@ func FormatKVPairs(pairs []KVPair, format KVFormat) (string, string) {
 	case KVFormatDotenv:
 		// dotenv: always-quoted values so whitespace, =, and special
 		// chars survive `source` of the file. Conservative — over-
-		// quoting is safe; under-quoting silently breaks downstream.
+		// quoting is safe. Under-quoting silently breaks downstream.
 		var b strings.Builder
 		for _, p := range pairs {
 			fmt.Fprintf(&b, "%s=%q\n", p.Key, p.Value)
@@ -121,7 +121,7 @@ func FormatKVPairs(pairs []KVPair, format KVFormat) (string, string) {
 // — booleans, null, or a number — that would round-trip as a non-
 // string type if emitted unquoted. K/V editor values are always
 // strings (k8s configmap / secret / label data), so over-quoting is
-// safe; a missed case silently changes the user's clipboard from
+// safe. A missed case silently changes the user's clipboard from
 // `"true"` (string) to `true` (bool) when re-parsed.
 func needsYAMLQuote(v string) bool {
 	if v == "" {
@@ -164,7 +164,7 @@ func isYAMLNumber(v string) bool {
 // RenderKVFormatPicker paints the Shift+Y format chip row that sits
 // above the editor's table when formatActive is set. The cursor chip
 // uses OverlaySelectedStyle so the highlight is visible regardless
-// of theme; idle chips render flat on the editor's baseBg. Trailing
+// of theme. Idle chips render flat on the editor's baseBg. Trailing
 // hint reminds the user of the apply/cancel keys so they don't have
 // to leave the picker to look it up.
 func RenderKVFormatPicker(cursor int) string {

--- a/internal/ui/listsummary.go
+++ b/internal/ui/listsummary.go
@@ -45,7 +45,7 @@ type summaryDimension struct {
 
 // summaryDimensions returns the breakdown axes for a kind, in render order, or
 // nil when the kind has no meaningful status rollup. Curated kinds get a
-// hand-picked signal; any other kind falls back to a generic signal derived
+// hand-picked signal. Any other kind falls back to a generic signal derived
 // only from data the list already shows (issue #352 follow-up).
 //
 // The fallback never groups by raw Item.Status: that surfaces noise — e.g.
@@ -87,7 +87,7 @@ func summaryDimensions(kind string, items []model.Item) []summaryDimension {
 }
 
 // maxGenericPhaseValues caps the distinct phase strings a generic .status.phase
-// rollup may carry. Phase fields are inherently low-cardinality; a column with
+// rollup may carry. Phase fields are inherently low-cardinality. A column with
 // more distinct values is likely free-form text, not a status, so it is left
 // to a count-only band rather than rendering a noisy bar.
 const maxGenericPhaseValues = 8
@@ -389,7 +389,7 @@ func allocateCells(counts []int, total, cells int) []int {
 		used += out[i]
 	}
 
-	// The min-1 floor can overshoot; reclaim from the largest buckets (never
+	// The min-1 floor can overshoot. Reclaim from the largest buckets (never
 	// below 1) until we are back within budget.
 	for used > cells {
 		best := -1

--- a/internal/ui/localcluster_overlay.go
+++ b/internal/ui/localcluster_overlay.go
@@ -22,7 +22,7 @@ type LocalClusterOverlayState struct {
 	Clusters           []LocalClusterRowView
 	Cursor             int
 	Loading            bool
-	Info               string // transient banner ("Created kind/dev"); rendered above the table
+	Info               string // transient banner ("Created kind/dev"). Rendered above the table
 	GlobalErr          string
 	Width              int
 	Height             int
@@ -164,9 +164,9 @@ func renderLocalClusterList(s LocalClusterOverlayState) string {
 }
 
 // formatLocalClusterRow lays out one table row. nameW is the width of
-// the Name column (flex with overlay width); other columns are fixed
+// the Name column (flex with overlay width). Other columns are fixed
 // (provider 9, status 12, k8s 10, nodes 5, age 8). Values are
-// truncated to fit; provider/status/k8s/nodes are short by
+// truncated to fit. Provider/status/k8s/nodes are short by
 // construction so truncation only really matters for Name.
 func formatLocalClusterRow(nameW int, prov, name, status, ver, nodes, age string) string {
 	return fmt.Sprintf("%-9s  %-*s  %-12s  %-10s  %-5s  %-8s",

--- a/internal/ui/log_preview.go
+++ b/internal/ui/log_preview.go
@@ -6,7 +6,7 @@ import (
 )
 
 // previewLogTimeColWidth is the fixed visual width of the time column in the
-// log preview pane. Relative times are at most ~8 chars ("365d ago"); 10 gives
+// log preview pane. Relative times are at most ~8 chars ("365d ago"). 10 gives
 // a clean 2-char gap between the time and the message column.
 const previewLogTimeColWidth = 10
 
@@ -17,7 +17,7 @@ const previewLogTimeColWidth = 10
 // the caller handles that pipeline so all physical lines share the same path.
 //
 // This form (joined, no indent) is used by the existing tests that call it
-// directly; production rendering goes through previewPhysicalLines.
+// directly. Production rendering goes through previewPhysicalLines.
 func formatPreviewLogLine(raw string) string {
 	p := ParseLogLine(raw)
 	// p.Prefix is dropped entirely.
@@ -146,7 +146,7 @@ func RenderLogPreview(lines []string, errMsg string, width, height int, podLabel
 	} else {
 		// Build physical lines: format each raw line (strip prefix, relativise
 		// timestamp), sanitize, then hard-wrap to width with table-aligned columns.
-		// Physical lines are already width-fit; do NOT re-truncate or re-wrap here.
+		// Physical lines are already width-fit. Do NOT re-truncate or re-wrap here.
 		physical := previewPhysicalLines(lines, width)
 		total := len(physical)
 		// Window: bottom-anchored by fromBottom.

--- a/internal/ui/logpreview.go
+++ b/internal/ui/logpreview.go
@@ -190,7 +190,7 @@ var zapLevelName = map[string]string{
 //	LEVEL\t[LOGGER\t]MESSAGE[\t{JSON_FIELDS}]
 //
 // produced by controller-runtime after a leading RFC3339 timestamp.
-// LEVEL must be a known token (see zapLevelName); the trailing JSON
+// LEVEL must be a known token (see zapLevelName). The trailing JSON
 // object, when present and parseable, is unpacked so structured context
 // (controller, namespace, reconcileID, ...) appears flat in the preview.
 //
@@ -315,7 +315,7 @@ func parseEnvoyFields(s string) ([]LogPreviewField, bool) {
 
 // javaLevelName normalises the SLF4J / Logback / Spring Boot level
 // tokens (the only frameworks worth recognising here cover all of
-// these). DEBUG and INFO are common; FATAL is rare in pure Logback but
+// these). DEBUG and INFO are common. FATAL is rare in pure Logback but
 // emitted by some shims.
 var javaLevelName = map[string]string{
 	"TRACE":   "Trace",
@@ -352,13 +352,13 @@ var javaSpringBoot = regexp.MustCompile(`^\s*(TRACE|DEBUG|INFO|WARN|WARNING|ERRO
 //	10:30:00.123 [main] INFO com.example.MyService - Connecting to database
 //
 // The " - " separator before the message is part of the canonical
-// pattern; lines without it are rejected to avoid claiming free-form
+// pattern. Lines without it are rejected to avoid claiming free-form
 // text that happens to contain a level word.
 var javaLogback = regexp.MustCompile(`^(\d{2}:\d{2}:\d{2}[.,]\d{3,})\s+\[([^\]]+)\]\s+(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL)\s+([\w.$]+)\s+-\s+(.*)$`)
 
 // parseJavaFields tries the Spring Boot pattern first, then the plain
 // Logback pattern. Field order leads with the level, logger, and
-// message because those are what a developer scans for; thread, pid,
+// message because those are what a developer scans for. Thread, pid,
 // and time follow. For Spring Boot the leading RFC3339 timestamp is
 // extracted earlier by splitLeadingTimestamp and lives in p.Time, so
 // time does not appear in the returned Fields. For Logback the pattern
@@ -462,7 +462,7 @@ func parseKlogFields(s string) ([]LogPreviewField, bool) {
 
 // splitLeadingTimestamp returns the leading RFC3339Nano timestamp and the
 // remainder, or ("", s, false) when s does not start with a timestamp.
-// This is the canonical primitive; stripTimestampRaw delegates to it.
+// This is the canonical primitive. stripTimestampRaw delegates to it.
 // Minimum length: "2024-01-15T10:30:00Z " = 21 chars.
 //
 // The separator after the timestamp may be either a space (kubectl logs)
@@ -564,7 +564,7 @@ func parseLogfmtFields(s string) ([]LogPreviewField, bool) {
 // single log line. Output is exactly width columns wide and height+2 rows
 // tall (matching RenderLogViewer's title + body + footer layout) so it can
 // be JoinHorizontal'd next to the main log view. scroll is the number of
-// body rows to skip from the top; it is clamped to [0, max] internally so
+// body rows to skip from the top. It is clamped to [0, max] internally so
 // callers can pass an unclamped value and rely on LogPreviewMaxScroll for
 // the upper bound when they need it (e.g. to gate key handlers).
 //

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -269,7 +269,7 @@ func RenderLogFooter(width int, statusMsg string, statusIsErr, searchActive bool
 // curRow is the rendered-slice index of the cursor line (-1 if none).
 // curCol is the absolute visual column of the current match start on that row
 // (-1 when curRow is -1). The cursor row's match at curCol is styled with
-// SelectedSearchHighlightStyle; all other matches use LogSearchHighlightStyle.
+// SelectedSearchHighlightStyle. All other matches use LogSearchHighlightStyle.
 func highlightSearchMatches(lines []string, query string, curRow, curCol int) []string {
 	result := make([]string, len(lines))
 	for i, line := range lines {
@@ -309,7 +309,7 @@ func renderPlainLines(lines []string, scroll, height, width int, lineNumbers boo
 			// Use ansi.Truncate (visual-width aware) for the pre-trim instead
 			// of rune-slicing. On a kyverno-style log row each embedded SGR
 			// sequence costs 4-5 rune slots while contributing zero visual
-			// width; the rune-based cap chopped lines off mid-content (and
+			// width. The rune-based cap chopped lines off mid-content (and
 			// often mid-CSI), which downstream let "0m" / "[NNm" leak as
 			// literal text and the visible payload was replaced by trailing
 			// spaces from FillLinesBg's pad-to-width pass.
@@ -356,8 +356,8 @@ func renderPlainLines(lines []string, scroll, height, width int, lineNumbers boo
 				}
 				line = YamlCursorIndicatorStyle.Render("\u258e") + colorizePodPrefix(cursorLine)
 				// Record where in the result slice this cursor row lands and its
-				// search-match column. The gutter indicator is 1 visual cell; the
-				// optional line-number gutter follows; then content at visualCurCol.
+				// search-match column. The gutter indicator is 1 visual cell. The
+				// optional line-number gutter follows. Then content at visualCurCol.
 				cursorRow = len(result)
 				cursorCol = 1 + visualCurCol
 				if lineNumbers {
@@ -395,7 +395,7 @@ func renderWrappedLines(lines []string, scroll, height, width int, lineNumbers b
 
 	// We need to figure out which source lines and which wrapped sub-lines
 	// correspond to the scroll offset. For wrapping, scroll refers to source
-	// lines; topSkip drops sub-lines from the very top of lines[scroll].
+	// lines. topSkip drops sub-lines from the very top of lines[scroll].
 	var result []string
 	cursorRow := -1
 	cursorCol := -1

--- a/internal/ui/orphans_overlay.go
+++ b/internal/ui/orphans_overlay.go
@@ -26,7 +26,7 @@ type OrphanCounts struct {
 // OrphanScrollForCursor returns the new scroll offset that keeps
 // `cursor` visible inside a viewport of `bodyHeight` rows starting at
 // `scroll`. Vim semantics: do nothing if the cursor is already in
-// view; otherwise scroll just enough to put the cursor on the nearest
+// view. Otherwise scroll just enough to put the cursor on the nearest
 // visible edge. Mirrors WhoCanScrollForCursor — keep them in sync.
 func OrphanScrollForCursor(scroll, cursor, bodyHeight, total int) int {
 	if total <= bodyHeight {
@@ -77,7 +77,7 @@ func OrphanClampScroll(scroll, total, bodyHeight int) int {
 //	[N+4] ""                                  trailing empty from header's "\n"
 //
 // chipLines must equal the wrapped row count emitted by
-// renderOrphanChips for the same width and counts; callers compute it
+// renderOrphanChips for the same width and counts. Callers compute it
 // via OrphanChipLines so the renderer and the move handler always
 // agree on viewport size. With all 11 kinds always shown, the strip
 // wraps to 2 rows on a typical 100-col overlay and to 3+ rows on
@@ -142,7 +142,7 @@ func RenderOrphansOverlay(
 	b.WriteString(OverlayTitleStyle.Render(title))
 	b.WriteString("\n\n")
 
-	// width-4 = OverlayStyle.Padding(1, 2) horizontal cost; the chip row
+	// width-4 = OverlayStyle.Padding(1, 2) horizontal cost. The chip row
 	// must fit inside the inner content area.
 	chips := renderOrphanChips(counts, activeChip, max(width-4, 40))
 	chipLines := strings.Count(chips, "\n") + 1
@@ -249,7 +249,7 @@ func orphanChipDefs(counts OrphanCounts) []orphanChipDef {
 // orphanChipLayout returns the widest unpadded chip text and the
 // column count for the chip grid given counts and inner width.
 // Renderer and move handler share this so their wrap row counts always
-// match exactly; the renderer also reuses maxTextW so every cell pads
+// match exactly. The renderer also reuses maxTextW so every cell pads
 // to a uniform width.
 func orphanChipLayout(counts OrphanCounts, width int) (maxTextW, cols int) {
 	defs := orphanChipDefs(counts)
@@ -301,7 +301,7 @@ func renderOrphanChips(counts OrphanCounts, active, width int) string {
 		// Pad the inner text to maxTextW so every chip occupies the
 		// same visual width. Surround with single-space padding (matches
 		// renderCrashTabBar). The styled span covers all of it — for
-		// the active chip the bg fills the whole padded button; for
+		// the active chip the bg fills the whole padded button. For
 		// inactive chips the dim fg covers the padding too, and bg is
 		// the surrounding overlay surface.
 		inner := fmt.Sprintf(" %-*s ", maxTextW, fmt.Sprintf("%s %d", d.label, d.count))

--- a/internal/ui/overlay_background_tasks.go
+++ b/internal/ui/overlay_background_tasks.go
@@ -24,11 +24,6 @@ const (
 	ModeCompleted
 )
 
-// BackgroundTaskRow is the data shape consumed by the overlay renderer.
-// The internal/app package converts scheduler.Task and scheduler.CompletedTask
-// slices into this type so the renderer has zero dependencies on
-// internal/app.
-//
 // BackgroundTaskStatus distinguishes the three lifecycle states a row
 // can be in inside the active (ModeRunning) view.
 type BackgroundTaskStatus int
@@ -43,7 +38,7 @@ const (
 	TaskStatusQueued
 	// TaskStatusFinished is a task whose Fn has returned and which is in
 	// the post-completion linger window. The same task is also in the
-	// Completed history; it leaves the active view once the linger
+	// Completed history. It leaves the active view once the linger
 	// window expires.
 	TaskStatusFinished
 )
@@ -55,13 +50,13 @@ const (
 // single table with a STATUS column.
 //
 // Field semantics by Status:
-//   - TaskStatusRunning: StartedAt is set; Duration/FinishedAt/Position are zero.
+//   - TaskStatusRunning: StartedAt is set. Duration/FinishedAt/Position are zero.
 //     ELAPSED ticks from now-StartedAt.
-//   - TaskStatusQueued: StartedAt is zero; Position is the 1-based head-of-lane
+//   - TaskStatusQueued: StartedAt is zero. Position is the 1-based head-of-lane
 //     position. ELAPSED renders as a placeholder.
-//   - TaskStatusFinished: StartedAt and FinishedAt are set; Duration is the
+//   - TaskStatusFinished: StartedAt and FinishedAt are set. Duration is the
 //     completion duration. ELAPSED freezes at Duration.
-//   - ModeCompleted history rows: Duration is set; everything else is
+//   - ModeCompleted history rows: Duration is set. Everything else is
 //     informational. The renderer reads only Duration.
 type BackgroundTaskRow struct {
 	Status     BackgroundTaskStatus
@@ -70,13 +65,13 @@ type BackgroundTaskRow struct {
 	Name       string
 	Target     string
 	StartedAt  time.Time
-	FinishedAt time.Time     // zero while running; set when in linger window
+	FinishedAt time.Time     // zero while running. Set when in linger window
 	Duration   time.Duration // (FinishedAt - StartedAt) for finished rows
-	Position   int           // 1-based queue position; only for TaskStatusQueued
+	Position   int           // 1-based queue position. Only for TaskStatusQueued
 }
 
 // RenderBackgroundTasksOverlay renders the modal content for the :scheduler
-// overlay. width and height are the outer overlay dimensions; the caller
+// overlay. width and height are the outer overlay dimensions. The caller
 // wraps this string in ui.OverlayStyle (rounded border + padding), so
 // this function only emits the inner content: title, header row, data
 // rows, and footer summary. No border, no padding.
@@ -87,7 +82,7 @@ type BackgroundTaskRow struct {
 // will wrap onto a second line.
 //
 // mode picks between the Running view (live ELAPSED column, "Scheduler
-// — Running" title; rows show STATUS = Running / Queued #N / Finished)
+// — Running" title, rows show STATUS = Running / Queued #N / Finished)
 // and the Completed view (fixed DURATION column, "Scheduler — Completed"
 // title, "N completed" footer).
 //
@@ -263,7 +258,7 @@ func bgtFooter(rows []BackgroundTaskRow, mode BackgroundTaskOverlayMode, complet
 }
 
 // bgtStatusCell returns the STATUS column text and the style to render
-// it with. Queued shows the position; Finished gets a dim chip; Running
+// it with. Queued shows the position. Finished gets a dim chip. Running
 // keeps the primary colour so the eye lands on it first.
 func bgtStatusCell(r BackgroundTaskRow, statusW int, mode BackgroundTaskOverlayMode, dim lipgloss.Style) (string, lipgloss.Style) {
 	if mode == ModeCompleted {
@@ -325,7 +320,7 @@ const bgtOuterPadRows = 2
 // VisibleRowsBackgroundTasks returns the data-area height (max visible
 // rows) for the background-tasks overlay given the outer overlay
 // height. Exported so the keyboard handler can clamp scroll values
-// against the same viewport the renderer uses; otherwise scroll-down
+// against the same viewport the renderer uses. Otherwise scroll-down
 // past the end leaves a stale scroll value the user has to press
 // scroll-up many times to undo.
 func VisibleRowsBackgroundTasks(height int) int {
@@ -339,7 +334,7 @@ func bgtColumnWidthsUnified(rows []BackgroundTaskRow, innerW int) (int, int, int
 	const minStatus, minPrio, minKind, minName, minTarget = 8, 4, 6, 6, 6
 	const totalGaps = 10 // 5 gaps * 2
 
-	// "Queued #999" is 11 chars; cap at 11 to bound the column. Most
+	// "Queued #999" is 11 chars. Cap at 11 to bound the column. Most
 	// rows show "Running" (7) or "Finished" (8) or "Queued #N" (9-11).
 	statusW := minStatus
 	prioW := len("PRIORITY")

--- a/internal/ui/overlay_confirm.go
+++ b/internal/ui/overlay_confirm.go
@@ -89,7 +89,7 @@ type OverlayConfirmConfig struct {
 
 	// ChoiceLabel/ChoiceValue render a labeled, cycleable value row below the
 	// warning (e.g. "Cascade: Background"). An empty ChoiceValue omits the
-	// row; the hotkey that cycles it lives in the hint bar. ChoiceWarn styles
+	// row. The hotkey that cycles it lives in the hint bar. ChoiceWarn styles
 	// the value as a warning so a riskier selection is not visually
 	// interchangeable with a safe one.
 	ChoiceLabel string
@@ -102,13 +102,13 @@ type OverlayConfirmConfig struct {
 	Notes []ConfirmNote
 
 	// TypeToken triggers the type-to-confirm row. When non-empty, the
-	// overlay prompts the user to type the token verbatim; Input is the
+	// overlay prompts the user to type the token verbatim. Input is the
 	// current accumulator. An empty Input renders a dim placeholder.
 	TypeToken string
 	Input     string
 
 	// Centered mode renders Title alone, centered both axes inside a
-	// fixed-size box. Used by the Quit overlay; ignores Warning, Body,
+	// fixed-size box. Used by the Quit overlay. Ignores Warning, Body,
 	// and TypeToken when true.
 	Centered    bool
 	InnerWidth  int
@@ -223,7 +223,7 @@ func RenderOverlayConfirm(cfg OverlayConfirmConfig) string {
 		labelWidth := confirmNoteLabelWidth(cfg.Notes)
 		for i, note := range cfg.Notes {
 			b.WriteString(renderConfirmNote(note, labelWidth, cfg.WrapWidth))
-			// Rows of the same block sit together; only the block is
+			// Rows of the same block sit together. Only the block is
 			// separated from what follows.
 			if i < len(cfg.Notes)-1 {
 				b.WriteString("\n")

--- a/internal/ui/overlay_crash_investigator.go
+++ b/internal/ui/overlay_crash_investigator.go
@@ -141,7 +141,7 @@ var crashHeaderStyle = lipgloss.NewStyle().
 // The previous redesign nested a second rounded-border panel around the
 // body, mirroring the label/secret editor pattern. That doubled the
 // horizontal chrome and pushed the visible row beyond the terminal width
-// on tighter terminals; the terminal then soft-wrapped each row and the
+// on tighter terminals. The terminal then soft-wrapped each row and the
 // next row's `│` border appeared mid-line on the wrap continuation. The
 // single-divider layout removes that nested chrome while keeping the
 // visual hierarchy.
@@ -400,7 +400,7 @@ func renderCrashContainerTableLines(containers []CrashContainerEntry, active str
 
 // crashCell returns s padded (or truncated) to width using lipgloss.
 // Using lipgloss.Width handles Unicode rune width correctly and is
-// transparent to ANSI escapes; fmt.Sprintf("%-Ns", ...) miscounts both.
+// transparent to ANSI escapes. Fmt.Sprintf("%-Ns", ...) miscounts both.
 func crashCell(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }
@@ -412,7 +412,7 @@ func crashJoinRow(cells ...string) string {
 }
 
 // findCrashContainer locates a container by name in either the init or
-// app slice; returns nil if not found.
+// app slice. Returns nil if not found.
 func findCrashContainer(entry CrashInvestigatorEntry, name string) *CrashContainerEntry {
 	for i := range entry.InitContainers {
 		if entry.InitContainers[i].Name == name {
@@ -521,9 +521,9 @@ func formatTimeAgo(t time.Time) string {
 // renderCrashEventsTab renders the Events tab body. The header line
 // declares the count and is followed by a thin divider so the user has a
 // clear visual hierarchy above the column headers. Empty state shows a
-// friendly "no events" message; otherwise a TYPE/REASON/AGE/MESSAGE
+// friendly "no events" message. Otherwise a TYPE/REASON/AGE/MESSAGE
 // table with Warning rows colored. Rows past the viewport are clipped
-// using scroll; the renderer clamps so G (sentinel 999999) lands on
+// using scroll. The renderer clamps so G (sentinel 999999) lands on
 // the last page.
 func renderCrashEventsTab(entry CrashInvestigatorEntry, scroll, width, height int) string {
 	header := crashHeaderStyle.Render(fmt.Sprintf("EVENTS · %d", len(entry.Events)))
@@ -535,7 +535,7 @@ func renderCrashEventsTab(entry CrashInvestigatorEntry, scroll, width, height in
 	}
 
 	// Reserve column space for the leading 4-space indent + fixed
-	// columns + 2-space gutters; remainder is the message budget.
+	// columns + 2-space gutters. Remainder is the message budget.
 	const (
 		typeW   = 7
 		reasonW = 18
@@ -587,7 +587,7 @@ func renderCrashEventsTab(entry CrashInvestigatorEntry, scroll, width, height in
 // dim divider for visual hierarchy. The body is clipped to the viewport
 // — long logs scroll with j/k/g/G/Ctrl+D/Ctrl+U.
 //
-// The header + divider are reserved as the top sticky lines; scroll
+// The header + divider are reserved as the top sticky lines. Scroll
 // only moves the body. That way users keep the "previous|current"
 // context visible at all times.
 func renderCrashLogsTab(entry CrashInvestigatorEntry, scroll, width, height int) string {
@@ -606,7 +606,7 @@ func renderCrashLogsTab(entry CrashInvestigatorEntry, scroll, width, height int)
 	b.WriteString(divider)
 	b.WriteString("\n\n")
 
-	// Reserve 3 lines for header + divider + blank; body has the rest.
+	// Reserve 3 lines for header + divider + blank. Body has the rest.
 	bodyHeight := max(height-3, 1)
 
 	if active == nil {
@@ -704,7 +704,7 @@ func sanitizeCrashMessage(s string) string {
 }
 
 // fallbackCrashStr returns an em-dash placeholder when s is blank
-// (whitespace-only); otherwise returns s unchanged.
+// (whitespace-only). Otherwise returns s unchanged.
 func fallbackCrashStr(s string) string {
 	if strings.TrimSpace(s) == "" {
 		return "—"

--- a/internal/ui/overlay_crash_investigator.go
+++ b/internal/ui/overlay_crash_investigator.go
@@ -400,7 +400,7 @@ func renderCrashContainerTableLines(containers []CrashContainerEntry, active str
 
 // crashCell returns s padded (or truncated) to width using lipgloss.
 // Using lipgloss.Width handles Unicode rune width correctly and is
-// transparent to ANSI escapes. Fmt.Sprintf("%-Ns", ...) miscounts both.
+// transparent to ANSI escapes, and fmt.Sprintf("%-Ns", ...) miscounts both.
 func crashCell(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }

--- a/internal/ui/overlay_diff.go
+++ b/internal/ui/overlay_diff.go
@@ -107,7 +107,7 @@ type DiffVisualParams struct {
 // to surface status messages (copy feedback, errors) without resorting
 // to post-render line surgery.
 // currentMatchLine is the original diff line index of the current n/N match
-// (-1 means none); that line gets the distinct SelectedSearchHighlightStyle.
+// (-1 means none). That line gets the distinct SelectedSearchHighlightStyle.
 func RenderDiffView(left, right, leftName, rightName string, scroll, width, height int, lineNumbers, wrap bool, searchQuery string, foldRegions []DiffFoldRegion, foldState []bool, searchMode bool, searchInput string, cursor, currentMatchLine int, vp DiffVisualParams, footerOverride string) string { //nolint:gocyclo // rendering function with inherent layout complexity
 	rawDiffLines := computeDiff(left, right)
 	visLines := BuildVisibleDiffLines(rawDiffLines, foldRegions, foldState)
@@ -247,7 +247,7 @@ func RenderDiffView(left, right, leftName, rightName string, scroll, width, heig
 // with search highlighting and fold support. footerOverride behaves the
 // same as in RenderDiffView.
 // currentMatchLine is the original diff line index of the current n/N match
-// (-1 means none); that line gets the distinct SelectedSearchHighlightStyle.
+// (-1 means none). That line gets the distinct SelectedSearchHighlightStyle.
 func RenderUnifiedDiffView(left, right, leftName, rightName string, scroll, width, height int, lineNumbers, wrap bool, searchQuery string, foldRegions []DiffFoldRegion, foldState []bool, searchMode bool, searchInput string, cursor, currentMatchLine int, vp DiffVisualParams, footerOverride string) string { //nolint:gocyclo // rendering function with inherent layout complexity
 	rawDiffLines := computeDiff(left, right)
 	visLines := BuildVisibleDiffLines(rawDiffLines, foldRegions, foldState)

--- a/internal/ui/overlay_event_viewer.go
+++ b/internal/ui/overlay_event_viewer.go
@@ -44,7 +44,7 @@ type wrappedEventChunk struct {
 }
 
 // wrappedEventChunks splits a logical event line into physical sub-lines
-// with column tracking. The first sub-line uses the full contentW; later
+// with column tracking. The first sub-line uses the full contentW. Later
 // sub-lines are indented by hangingIndent so the wrapped message stays
 // under the original message column.
 //
@@ -82,7 +82,7 @@ func wrappedEventChunks(line string, contentW, hangingIndent int) []wrappedEvent
 
 // WrapEventLine wraps a single event timeline line into physical lines
 // that fit within contentW. The first physical line uses the full
-// width; continuation lines are indented by hangingIndent so wrapped
+// width. Continuation lines are indented by hangingIndent so wrapped
 // message text aligns under the original message column instead of
 // re-flowing flush to the left margin.
 func WrapEventLine(line string, contentW, hangingIndent int) []string {
@@ -96,7 +96,7 @@ func WrapEventLine(line string, contentW, hangingIndent int) []string {
 
 // WrappedEventRowOpts bundles inputs for RenderWrappedEventRow. The
 // caller computes which selection range applies (line-mode highlights
-// the whole row; char-mode pre-computes the absolute column range on
+// the whole row. Char-mode pre-computes the absolute column range on
 // the logical line). Cursor block rendering is opt-in via IsCursor.
 type WrappedEventRowOpts struct {
 	Line          string
@@ -130,7 +130,7 @@ type WrappedEventRowOpts struct {
 // long event to a short one — same behaviour YAML relies on.
 //
 // V-mode (line) selection still spans every sub-line because the user
-// explicitly asked for the whole wrapped block to be highlighted; v
+// explicitly asked for the whole wrapped block to be highlighted. V
 // and B modes stick to the simpler single-line model.
 func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
 	chunks := wrappedEventChunks(opts.Line, opts.ContentW, opts.HangingIndent)
@@ -187,7 +187,7 @@ func RenderWrappedEventRow(opts WrappedEventRowOpts) string {
 
 // applyCharSelectionToFirstSubLine highlights the [selStart, selEnd)
 // column range on the first physical sub-line of a wrapped event. The
-// range is clamped to the sub-line's bounds; the selection that
+// range is clamped to the sub-line's bounds. The selection that
 // extends past contentW is not shown on continuation lines (matches
 // the YAML viewer's behaviour, where v-mode selection only paints the
 // first sub-line).
@@ -215,7 +215,7 @@ func RenderEventViewer(p EventViewerParams) string {
 	// Title with mode indicators.
 	title := "Event Timeline"
 	if p.ResourceName != "" {
-		// ResourceName is a cluster object name; the body lines (p.Lines)
+		// ResourceName is a cluster object name. The body lines (p.Lines)
 		// are already sanitized upstream, but the title is built here from
 		// the raw value.
 		title += " - " + SanitizeTerminalText(p.ResourceName)
@@ -285,7 +285,7 @@ func RenderEventViewer(p EventViewerParams) string {
 
 	// Resolve the start index so the cursor entry is visible under physical-line
 	// pagination. The key handler tracks scroll in logical-entry units and is
-	// wrap-unaware; without this a wrapped entry above the cursor can push it
+	// wrap-unaware. Without this a wrapped entry above the cursor can push it
 	// (and the footer's line number) off the viewport.
 	cursor := max(min(p.Cursor, len(p.Lines)-1), 0)
 	scroll := eventStartForCursor(p, evLineCtx, max(p.Scroll, 0), cursor, maxVisible)
@@ -343,7 +343,7 @@ func RenderEventViewer(p EventViewerParams) string {
 // cursor entry's first sub-line within maxVisible physical lines. It reconciles
 // the wrap-unaware logical-entry scroll the key handler supplies with the
 // renderer's physical-line pagination, mirroring errorLogStartForCursor. The
-// incoming scroll is honoured when it already shows the cursor; otherwise it is
+// incoming scroll is honoured when it already shows the cursor. Otherwise it is
 // pulled down just far enough.
 func eventStartForCursor(p EventViewerParams, ctx eventLineContext, scroll, cursor, maxVisible int) int {
 	minStart := cursor
@@ -440,8 +440,8 @@ func renderEventViewerLine(p EventViewerParams, i int, ctx eventLineContext) str
 // charSelectionRangeForLine returns the [start, end) column range to
 // highlight on the given logical line under v-mode selection. Mirrors
 // renderCharSelection's per-line logic: anchor-only line highlights
-// from anchorCol to end-of-line; cursor-only line highlights from 0 to
-// cursorCol+1; middle lines highlight everything (caller can detect
+// from anchorCol to end-of-line. Cursor-only line highlights from 0 to
+// cursorCol+1. Middle lines highlight everything (caller can detect
 // "everything" via end == len(line)).
 func charSelectionRangeForLine(p EventViewerParams, ctx eventLineContext, i int) (start, end int) {
 	lineWidth := len([]rune(p.Lines[i]))

--- a/internal/ui/overlay_list.go
+++ b/internal/ui/overlay_list.go
@@ -23,10 +23,10 @@ const overlayListChrome = 4
 // fields render only when the matching feature flag in OverlayListConfig
 // is enabled — callers leave them zero-valued otherwise.
 type OverlayListItem struct {
-	Key          string // shortcut letter; rendered "[k]" when cfg.ShowKey
+	Key          string // shortcut letter. Rendered "[k]" when cfg.ShowKey
 	Name         string // primary text
-	Description  string // dim secondary suffix; rendered when cfg.ShowDescription
-	Status       string // status badge; rendered "[s]" when cfg.ShowStatus
+	Description  string // dim secondary suffix. Rendered when cfg.ShowDescription
+	Status       string // status badge. Rendered "[s]" when cfg.ShowStatus
 	Active       bool   // ✓ marker when cfg.ShowActiveMarker
 	ActiveMarker string // overrides the default ✓ glyph when Active and non-empty
 	Selected     bool   // checkbox state when cfg.MultiSelect
@@ -47,7 +47,7 @@ type OverlayListItem struct {
 }
 
 // OverlayListConfig is the rendering contract for OverlayList. Feature
-// flags are independent; set the ones that apply to your overlay shape.
+// flags are independent. Set the ones that apply to your overlay shape.
 // Items are expected to be pre-filtered by the caller — Filter/FilterActive
 // only drive the filter-line display.
 type OverlayListConfig struct {
@@ -213,7 +213,7 @@ func RenderOverlayList(items []OverlayListItem, cfg OverlayListConfig, innerW in
 			// Cursor row: plain text padded so the selection background spans
 			// the item area. The scrollbar + badge sit outside the highlight
 			// so they stay readable against the box. CursorHighlightWidth
-			// caps the highlight short of the item area; the remainder pads
+			// caps the highlight short of the item area. The remainder pads
 			// with the surface background so the badge column stays put.
 			// Text is truncated to the highlight width — anything longer
 			// would wrap inside the Width(hlW) block, pushing every row
@@ -270,11 +270,6 @@ func RenderOverlayList(items []OverlayListItem, cfg OverlayListConfig, innerW in
 	return out
 }
 
-// itemPlainLine returns the item rendered as plain text (no styling).
-// Used for the cursor row (where embedded styles would punch holes in
-// the highlight background) and for width measurement. `hasActive`
-// controls whether the active-marker column is reserved — see
-// anyActive for the collapse rule.
 // activeMarkerGlyph returns the single-cell marker drawn for an Active row,
 // defaulting to ✓ unless the item overrides it (e.g. "!" for excluded items).
 func activeMarkerGlyph(it OverlayListItem) string {
@@ -284,6 +279,11 @@ func activeMarkerGlyph(it OverlayListItem) string {
 	return "✓"
 }
 
+// itemPlainLine returns the item rendered as plain text (no styling).
+// Used for the cursor row (where embedded styles would punch holes in
+// the highlight background) and for width measurement. `hasActive`
+// controls whether the active-marker column is reserved — see
+// anyActive for the collapse rule.
 func itemPlainLine(it OverlayListItem, cfg OverlayListConfig, hasActive bool) string {
 	if it.Header {
 		return "── " + it.Name + " ──"
@@ -360,9 +360,9 @@ func itemStyledLine(it OverlayListItem, cfg OverlayListConfig, hasActive bool) s
 
 // renderScrollbar returns the single-cell scrollbar character to draw on
 // the right of the row at visualIdx (0-indexed within the visible window).
-// Thumb size is proportional to viewport coverage (visible/total); thumb
+// Thumb size is proportional to viewport coverage (visible/total). Thumb
 // position interpolates linearly from 0 to (visible - thumb) across the
-// scroll range. Track uses OverlayDimStyle; thumb uses OverlayFilterStyle
+// scroll range. Track uses OverlayDimStyle. Thumb uses OverlayFilterStyle
 // so it reads against the dim track without competing with the cursor
 // highlight or filter-row colour.
 func renderScrollbar(visualIdx, totalVisible, totalItems, startIdx int) string {

--- a/internal/ui/overlay_monitoring.go
+++ b/internal/ui/overlay_monitoring.go
@@ -176,7 +176,7 @@ func errorLogVisualWrap(plainText string, contentW int) (first string, cont []st
 
 // renderErrorLogSelectionContent builds the selection-highlighted content
 // sub-lines for an entry (no gutter). Line ('V') mode highlights every
-// sub-line; char ('v') mode applies the column-range highlight to the first
+// sub-line. Char ('v') mode applies the column-range highlight to the first
 // sub-line only and renders continuation sub-lines as plain wrapped text —
 // matching the event viewer convention (RenderWrappedEventRow), where char
 // selection does not span wrapped lines.
@@ -215,14 +215,14 @@ func errorLogEntryLines(entry ErrorLogEntry, contentW int, inSelection bool) int
 
 // errorLogStartForCursor returns the scroll (start entry index) that keeps the
 // cursor entry's first sub-line within maxVisible physical lines. The incoming
-// scroll is honoured when it already shows the cursor; otherwise it is clamped
+// scroll is honoured when it already shows the cursor. Otherwise it is clamped
 // into the visible range. This reconciles the key handler's logical-entry
 // scroll model with the renderer's physical-line pagination, so the cursor is
 // never drawn off-screen whether or not entries wrap.
 func errorLogStartForCursor(reversed []ErrorLogEntry, scroll, cursor, maxVisible, contentW int, vp ErrorLogVisualParams, selStart, selEnd int) int {
 	inSel := func(i int) bool { return vp.VisualMode != 0 && i >= selStart && i <= selEnd }
 	// Walk back from the cursor accumulating physical lines until the next
-	// entry above would no longer fit; minStart is the earliest start that
+	// entry above would no longer fit. minStart is the earliest start that
 	// still keeps the cursor's first sub-line on screen.
 	minStart := cursor
 	used := 1 // the cursor entry's first sub-line
@@ -240,7 +240,7 @@ func errorLogStartForCursor(reversed []ErrorLogEntry, scroll, cursor, maxVisible
 // log entries with level indicators. Long messages are wrapped to width so they
 // stay readable instead of being truncated. The scroll parameter (in logical
 // entry units, matching the key handler) is honoured when it keeps the cursor
-// visible; pagination is by physical line and the start index is adjusted so a
+// visible. Pagination is by physical line and the start index is adjusted so a
 // wrapped entry never pushes the cursor (or the footer) off the viewport. When
 // showDebug is false, DBG entries are filtered out.
 func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll, width, height int, showDebug bool, vp ErrorLogVisualParams) string {
@@ -278,7 +278,7 @@ func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll, width, height int, s
 	colEnd := max(vp.VisualStartCol, vp.CursorCol)
 
 	// Resolve the start index so the cursor entry is always visible. The key
-	// handler tracks scroll in logical-entry units and is wrap-unaware; here
+	// handler tracks scroll in logical-entry units and is wrap-unaware. Here
 	// we paginate by physical line, so a literal entry-based scroll could
 	// leave the cursor (and the footer) off-screen when entries wrap.
 	cursor := max(min(vp.CursorLine, len(reversed)-1), 0)
@@ -327,7 +327,7 @@ func RenderErrorLogOverlay(entries []ErrorLogEntry, scroll, width, height int, s
 // Every physical sub-line is prefixed with the gutter (line marker) so the
 // cursor line is flagged consistently in all modes — matching the event
 // viewer. The cursor line also carries a reverse-video block cursor on its
-// first sub-line when not selecting; during selection the highlight stands in
+// first sub-line when not selecting. During selection the highlight stands in
 // for it. contentW is the width available after the gutter.
 func renderErrorLogEntry(entry ErrorLogEntry, contentW int, vp ErrorLogVisualParams, i, selStart, selEnd, colStart, colEnd int) string {
 	isCursor := i == vp.CursorLine

--- a/internal/ui/overlay_network.go
+++ b/internal/ui/overlay_network.go
@@ -192,7 +192,7 @@ func renderNetpolDirectionRules(info NetworkPolicyEntry, targetLabel string, wid
 }
 
 // renderNetpolRuleLabel renders a rule's heading line: deny rules (Cilium)
-// are marked and styled as warnings; an L7 summary is appended when present.
+// are marked and styled as warnings. An L7 summary is appended when present.
 func renderNetpolRuleLabel(rule NetpolRuleEntry, idx int) string {
 	label := fmt.Sprintf("  Rule %d:", idx+1)
 	style := OverlayNormalStyle

--- a/internal/ui/overlay_traffic_capture.go
+++ b/internal/ui/overlay_traffic_capture.go
@@ -103,7 +103,7 @@ type PacketRow struct {
 // RenderTrafficCaptureOverlay renders the inner content of the traffic
 // capture overlay. The caller wraps the result with OverlayStyle, which
 // supplies the rounded border and Padding(1, 2). contentW is the usable
-// width inside that padding (caller computes it as overlayW - 4); contentH
+// width inside that padding (caller computes it as overlayW - 4). contentH
 // is the usable height (caller computes it as overlayH - 4).
 //
 // contentH bounds the live packet table — without it the rendered string
@@ -210,7 +210,7 @@ func buildCaptureConfig(e CaptureOverlayEntry, contentW int) string {
 	}
 	sb.WriteString("\n")
 	// Hint bar lives in the bottom-of-screen status bar (overlayHintBarMisc).
-	// Adding inline hints here would duplicate that surface; see overlay.go
+	// Adding inline hints here would duplicate that surface. See overlay.go
 	// for the project-wide convention.
 	return sb.String()
 }
@@ -310,7 +310,7 @@ func buildCaptureLive(e CaptureOverlayEntry, contentW, contentH int) string {
 		sb.WriteString("\n")
 		// Bound the visible table to the rows that fit in the remaining
 		// overlay height so the box doesn't grow with packet count. Window
-		// into the buffer using ScrollOffset; G (jump-to-bottom) sends a
+		// into the buffer using ScrollOffset. G (jump-to-bottom) sends a
 		// huge ScrollOffset which we clamp to the last page.
 		visibleRows := remainingRowsForPacketTable(sb.String(), contentH)
 		start, end := windowPackets(len(e.Packets), e.ScrollOffset, visibleRows)
@@ -339,8 +339,8 @@ func remainingRowsForPacketTable(rendered string, contentH int) int {
 // to render. scrollOffset is "rows back from the latest packet" — 0 means
 // "show the most recent visible window" (tail -f), positive values reveal
 // older history. This matches what users expect from a live packet table:
-// new arrivals push old ones up; you scroll k/up to see history; G returns
-// to live; g jumps to the oldest packet. Clamps so a huge scrollOffset
+// new arrivals push old ones up. You scroll k/up to see history. G returns
+// to live. g jumps to the oldest packet. Clamps so a huge scrollOffset
 // (g key) lands on the oldest page rather than running past the buffer.
 func windowPackets(n, scrollOffset, visible int) (int, int) {
 	if n == 0 || visible <= 0 {

--- a/internal/ui/rightsizing_layout.go
+++ b/internal/ui/rightsizing_layout.go
@@ -10,7 +10,7 @@ import (
 // overlay. `widths` and `aligns` are per sub-column (one entry per
 // physical cell). `subHdrs` is the bottom-row header text per
 // sub-column. `spans` is the top-row group header (REQUEST, LIMIT,
-// BOUNDS); singletons (CONTAINER, RES, USAGE) are NOT included in
+// BOUNDS). Singletons (CONTAINER, RES, USAGE) are NOT included in
 // `spans` — they render as blank cells in the group header row.
 type rsLayout struct {
 	widths  []int
@@ -63,7 +63,7 @@ const (
 // longest sub-header label AND the typical maximum data value so cells
 // never wrap (lipgloss `Width(n)` wraps overflow rather than truncating).
 // CONTAINER stays near header width because names are variable and get
-// ellipsised when over-long; value columns must accommodate "SUGGESTION"
+// ellipsised when over-long. Value columns must accommodate "SUGGESTION"
 // (10) so the bottom-row labels render whole. USAGE has to fit memory
 // values like "2162Mi" (6) and "10000Mi" (7) — bumped to 8 so we don't
 // wrap on real argo-cd / kafka workloads. Δ holds "-100%" (5 chars).
@@ -89,7 +89,7 @@ const (
 //	      = sum(widths[i]) + 3N - 1
 //
 // where N is the number of sub-columns. The +2 per cell is the cell
-// padding; the (N-1) accounts for inter-cell separators.
+// padding. The (N-1) accounts for inter-cell separators.
 func rsLayoutFor(hasBounds bool, panelW int) rsLayout {
 	subHdrs := []string{"CONTAINER", "RES", "USAGE", "CURRENT", "SUGGESTION", "Δ", "CURRENT", "SUGGESTION", "Δ"}
 	aligns := []lipgloss.Position{
@@ -199,7 +199,7 @@ func rsDistributeWidths(panelW int, mins []int) []int {
 }
 
 // renderRSGroupHeader renders the top header row. Singletons (the
-// columns NOT covered by any span) render as blank space; group spans
+// columns NOT covered by any span) render as blank space. Group spans
 // render their `name` centered within the span's display width with
 // `─` filler chars on both sides so the span's extent is visually
 // obvious. Separators between cells use box-drawing corners to bracket
@@ -218,7 +218,7 @@ func rsDistributeWidths(panelW int, mins []int) []int {
 // reserves the +1 char for this trailing slot.
 //
 // Corners + filler use `ColorBorder` to match the mid-rule + sub-header
-// separators; the group `name` itself uses `ColorPrimary` bold so it
+// separators. The group `name` itself uses `ColorPrimary` bold so it
 // reads as the dominant signal.
 func renderRSGroupHeader(layout rsLayout) string {
 	nameStyle := lipgloss.NewStyle().
@@ -329,7 +329,7 @@ func renderRSSeparator(layout rsLayout) string {
 
 // renderRSDataRow assembles a data row from pre-rendered cells. Cells
 // must be pre-styled and width-fitted (use `renderRSCell` /
-// `renderRSCellPrestyled`); this helper just inserts separators
+// `renderRSCellPrestyled`). This helper just inserts separators
 // between them and appends the trailing closing `│`. Layout is unused
 // here — kept on the signature so all row renderers share a uniform
 // shape (group/sub/sep/data).
@@ -384,7 +384,7 @@ func renderRSCellPrestyled(content string, width int, align lipgloss.Position, f
 // budget the last char becomes `…` so the truncation is visible. When
 // `width <= 0` returns the empty string. Plain runes only — assumes
 // content has no embedded ANSI sequences (data values are unstyled
-// strings; the styling lives on the surrounding `renderRSCell` style).
+// strings. The styling lives on the surrounding `renderRSCell` style).
 func rsTruncate(s string, width int) string {
 	if width <= 0 {
 		return ""

--- a/internal/ui/rightsizing_overlay.go
+++ b/internal/ui/rightsizing_overlay.go
@@ -110,7 +110,7 @@ func RenderRightsizingOverlay(data *model.Rightsizing, loading bool, err error, 
 //     duplicate the indicator here.
 func renderRightsizingHeader(data *model.Rightsizing, loading bool, err error) string {
 	if loading && data == nil {
-		// Cold load — the centered body owns the placeholder; header
+		// Cold load — the centered body owns the placeholder. Header
 		// stays minimal so the cold state reads as one focused message.
 		return BarDimStyle.Render("Loading…")
 	}
@@ -260,7 +260,7 @@ func headroomMethodologySuffix(s model.RightsizingStrategy, headroom float64) st
 // renderRightsizingTable draws the 2-row grouped-header recommendations
 // table sized to fill `width`. The top header row has REQUEST / LIMIT
 // (and BOUNDS for VPA) group spans whose cells render centered without
-// internal separators inside each span; the sub-header row breaks each
+// internal separators inside each span. The sub-header row breaks each
 // group into CURRENT / SUGGESTION / Δ sub-columns. The BOUNDS group is
 // dropped when source != VPA, since estimated recommendations carry no
 // lower/upper bounds.
@@ -286,7 +286,7 @@ func renderRightsizingTable(data *model.Rightsizing, scroll, width, height int) 
 }
 
 // buildRightsizingDataRows yields one pre-rendered data row per
-// (container, resource). `scroll` skips the first N rows; `maxRows`
+// (container, resource). `scroll` skips the first N rows. `maxRows`
 // clips the rest. Each row is a slice of styled cell strings (already
 // padded + width-fitted) ready to be joined by the row renderer.
 func buildRightsizingDataRows(

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -19,7 +19,7 @@ var (
 )
 
 // compileSearchRegex compiles "(?i)"+query, memoizing the most recently used
-// query. The search/filter hot paths call this per item per frame; only one
+// query. The search/filter hot paths call this per item per frame. Only one
 // query is active at a time, so a single-entry cache eliminates redundant
 // compiles — e.g. filtering a 5k-pod list or running n/N over a 50k-line log
 // buffer would otherwise recompile the pattern thousands of times per keypress.
@@ -276,7 +276,7 @@ func HighlightMatchInline(line, rawQuery string, hlStyle lipgloss.Style) string 
 	}
 	switch mode {
 	case SearchRegex, SearchFuzzy:
-		// Regex / fuzzy don't get the inline-aware treatment yet; fall
+		// Regex / fuzzy don't get the inline-aware treatment yet. Fall
 		// back to the plain substring path so they keep the existing
 		// behavior. The YAML preview's main caller uses substring.
 		return HighlightMatchStyled(line, rawQuery, hlStyle)
@@ -342,7 +342,7 @@ func HighlightMatchInline(line, rawQuery string, hlStyle lipgloss.Style) string 
 
 // highlightSpans applies style to a list of [start, end) plain-byte
 // spans inside a (possibly already-styled) line. Spans are positions
-// in ansi.Strip(line); they're mapped to visual columns and spliced
+// in ansi.Strip(line). They're mapped to visual columns and spliced
 // back into the styled line via ansi.Cut / ansi.TruncateLeft so the
 // surrounding ANSI between matches is preserved.
 //
@@ -360,7 +360,7 @@ func HighlightMatchInline(line, rawQuery string, hlStyle lipgloss.Style) string 
 // plain text (help.go path) or text whose inner styling is uniform
 // (search-bar paths), so this is a non-issue in practice. A future
 // caller passing a syntax-highlighted line (e.g. log content with
-// per-token colors) would lose styling on matched characters; in
+// per-token colors) would lose styling on matched characters. In
 // that case use HighlightMatchInline (search.go) which tracks
 // activeOpen across the highlighted segment.
 //
@@ -487,7 +487,7 @@ func highlightFuzzy(line, query string, style lipgloss.Style, restoreCodes strin
 
 	// Convert rune indices to plain byte offsets so highlightSpans can
 	// map them to visual columns. range over plain yields the byte
-	// offset of each rune; the trailing len(plain) closes the last
+	// offset of each rune. The trailing len(plain) closes the last
 	// run.
 	runeByteOff := make([]int, 0, len(plainRunes)+1)
 	for byteOff := range plain {
@@ -535,7 +535,7 @@ func SearchModeIndicator(rawQuery string) string {
 // HighlightMatchCurrentAtCol highlights every match of rawQuery in line with
 // normalStyle, except the occurrence whose start is at visual column currentCol,
 // which uses currentStyle. currentCol < 0 (or no match starting there) means all
-// matches use normalStyle. Substring and regex modes only; fuzzy falls back to
+// matches use normalStyle. Substring and regex modes only. Fuzzy falls back to
 // uniform normalStyle (a fuzzy "current occurrence" is ill-defined).
 func HighlightMatchCurrentAtCol(line, rawQuery string, normalStyle, currentStyle lipgloss.Style, currentCol int) string {
 	if rawQuery == "" {

--- a/internal/ui/secretview.go
+++ b/internal/ui/secretview.go
@@ -24,7 +24,7 @@ var secretInnerPanelStyle = lipgloss.NewStyle().
 //   - searchQuery / searchActive: the / filter.
 //   - editKeyCursor / editValueCursor: byte offsets inside editKey /
 //     editValue where the "█" cursor block lands.
-//   - selected: keys marked with `s` for batch copy; rendered with a
+//   - selected: keys marked with `s` for batch copy. Rendered with a
 //     "✓" prefix in the key column. May be nil.
 //   - formatActive / formatCursor: drive the Shift+Y format-picker
 //     chip row, rendered above the inner panel when formatActive.
@@ -106,7 +106,7 @@ func RenderSecretEditorOverlay(
 	//   - value contains '\n'  → focused bordered pane (handles newlines
 	//     + scroll without breaking the table layout)
 	//   - value is single line  → inline table-cell edit (the cursor
-	//     row's value cell shows the cursor; surrounding rows stay
+	//     row's value cell shows the cursor. Surrounding rows stay
 	//     visible for context — the bordered pane is overkill for a
 	//     one-line password/token).
 	var dataContent string
@@ -184,7 +184,7 @@ func renderSecretEditorTable(
 	editValue string,
 	editValueCursor int,
 	editColumn int,
-	selectedKeys map[string]bool, // keys marked with `s` for batch copy; nil = none
+	selectedKeys map[string]bool, // keys marked with `s` for batch copy, nil = none
 	width, height int,
 ) string {
 	keyColW := computeKeyColumnWidth(secret.Keys, width, 3)
@@ -224,14 +224,14 @@ func renderSecretEditorTable(
 	rendered := t.Render()
 	if len(secret.Keys) == 0 {
 		// Headers always rendered (above) so the user sees the column
-		// labels; placeholder hint sits below them on its own line.
+		// labels. Placeholder hint sits below them on its own line.
 		return rendered + "\n" + BarDimStyle.Render("  (empty - press 'a' to add a key)")
 	}
 	return rendered
 }
 
 // secretValueDisplay returns the display string for a secret value.
-// Hidden values render as the fixed mask; revealed values flow through
+// Hidden values render as the fixed mask. Revealed values flow through
 // SingleLineCell so embedded newlines (multi-line secret payloads like
 // kubeconfig values) don't expand the table cell vertically.
 func secretValueDisplay(val string, revealed bool, maxW int) string {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Tokyonight Storm color palette default values. These back the mutable
-// Color* variables below; no-color mode blanks the variables so inline
+// Color* variables below. No-color mode blanks the variables so inline
 // lipgloss.Color(ColorX) calls scattered across the codebase yield
 // NoColor{} without touching any call site.
 const (
@@ -48,7 +48,7 @@ func ThemeColor(spec string) color.Color {
 
 // Theme color slots used by inline lipgloss.Color(ColorX) calls throughout
 // the codebase. ApplyTheme rewrites them from the active theme so inline
-// call sites track theme changes; applyNoColorTheme blanks them so inline
+// call sites track theme changes. applyNoColorTheme blanks them so inline
 // foreground calls resolve to NoColor{}. They stay as package variables
 // so code that already references them keeps compiling unchanged.
 //
@@ -122,7 +122,7 @@ var (
 	StatusWarning     = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorWarning))
 
 	// Whole-row status tint (issue #540). Colors mirror the Status cell (StatusFailed = error, StatusProgressing = primary) so
-	// the row tint and the cell never disagree. Fg variants recolor the row text; Bg variants lay a muted severity background.
+	// the row tint and the cell never disagree. Fg variants recolor the row text. Bg variants lay a muted severity background.
 	RowTintFailedFg      = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError))
 	RowTintProgressingFg = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary))
 	RowTintFailedBg      = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile)).
@@ -258,14 +258,14 @@ var (
 			Bold(true)
 
 	// Schema side pane (ctrl+k): the header names the field and carries
-	// the accent; the description is prose to read, so it stays plain.
+	// the accent. The description is prose to read, so it stays plain.
 	FieldDocHeaderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Bold(true)
 	FieldDocTextStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile))
 	FieldDocErrorStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError))
 
 	// Which-key panel. The panel draws one flat list with no section
 	// headers, so the description's color is the only thing left that says
-	// which family an entry belongs to; the key keeps one accent throughout.
+	// which family an entry belongs to. The key keeps one accent throughout.
 	// Red is deliberately unused: it is the app's failure/destructive signal,
 	// and a red description reads as an error message rather than as a
 	// category — a risk the panel's most destructive entries (Delete, Force
@@ -279,7 +279,7 @@ var (
 	// nor the key's, or the two halves of a row collapse into one
 	// (TestWhichKeyGroupStyles_NeverMatchThePlainDescriptionOrTheKey). The key
 	// keeps Secondary because HelpKeyStyle draws every hint-bar hotkey in that
-	// same green bold; Actions is what moved, having held Secondary since the
+	// same green bold. Actions is what moved, having held Secondary since the
 	// accent sat on the KEY rather than on the description.
 	WhichKeyKeyStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Bold(true)
 	WhichKeyDescStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile))
@@ -555,8 +555,8 @@ var phraseSeverityWords = map[string]statusSev{
 
 // phraseSeverity classifies an unknown status string by scanning its words
 // against phraseSeverityWords. The worst-severity word wins ("Healthy but
-// degraded" is failed); a positive word preceded by "not" reads as
-// progressing-amber, mirroring the exact-match "NotReady"; no recognized word
+// degraded" is failed). A positive word preceded by "not" reads as
+// progressing-amber, mirroring the exact-match "NotReady". No recognized word
 // yields sevUnknown (gray).
 func phraseSeverity(status string) statusSev {
 	sev := sevUnknown
@@ -667,7 +667,7 @@ const (
 // the heuristic where the type name alone would misclassify (e.g. cert-manager
 // "Issuing", whose False state is normal, not a failure). Keys are lowercase.
 var conditionPolarities = map[string]condPolarity{
-	// ArgoCD Application (status-less; the type's presence is the signal).
+	// ArgoCD Application (status-less, the type's presence is the signal).
 	"comparisonerror":         condError,
 	"invalidspecerror":        condError,
 	"unknownerror":            condError,
@@ -679,7 +679,7 @@ var conditionPolarities = map[string]condPolarity{
 	"orphanedresourcewarning": condWarning,
 	// cert-manager.
 	"ready":   condReady,
-	"issuing": condInfo, // actively issuing; False is the normal idle state
+	"issuing": condInfo, // actively issuing. False is the normal idle state
 	// external-secrets.
 	"secretsynced": condReady,
 	// FluxCD.
@@ -785,7 +785,7 @@ func ConditionStyle(condType, status string) lipgloss.Style {
 
 // BoxWidth sets style's width so its rendered CONTENT is w columns wide.
 //
-// lipgloss v2 counts the border inside Width(); v1 counted it outside. Every
+// lipgloss v2 counts the border inside Width(). v1 counted it outside. Every
 // caller computes a content width and budgets the border columns separately,
 // so the border has to be added back or each box renders two columns narrow —
 // and nested boxes compound the loss.

--- a/internal/ui/syncwaveview.go
+++ b/internal/ui/syncwaveview.go
@@ -11,7 +11,7 @@ import (
 
 // SyncWavePane mirrors the app-side syncWavePane enum. Determines
 // highlight tier in the renderer: active pane's cursor row gets the
-// bright Selected style; inactive pane's cursor row gets ParentHighlightStyle.
+// bright Selected style. Inactive pane's cursor row gets ParentHighlightStyle.
 type SyncWavePane int
 
 const (
@@ -35,14 +35,14 @@ type SyncWaveBodyCursor struct {
 //
 // BodyScroll is the body pane's first-visible row offset (in flattened-
 // row units) — applied to the right-pane content only. The sidebar is
-// fixed-position; only the body scrolls. SidebarCursor / BodyCursor /
+// fixed-position. Only the body scrolls. SidebarCursor / BodyCursor /
 // ActivePane drive cursor highlight (active pane's cursor gets the
-// bright SelectedFg + Primary style; inactive pane's cursor gets
+// bright SelectedFg + Primary style. Inactive pane's cursor gets
 // ParentHighlightStyle, matching the main browser's parent-pane
 // convention).
 //
 // SinglePane collapses the sidebar so narrow viewports (< 50 cols) get
-// a body-only fallback; the renderer falls through to a single-pane
+// a body-only fallback. The renderer falls through to a single-pane
 // path when this is true.
 //
 // Collapsed mirrors the app-side `collapsed` map keyed by phase name
@@ -66,14 +66,12 @@ type SyncWaveTimelineEntry struct {
 	Loading      bool
 	LoadingFrame int
 
-	// New for two-pane layout. Wired into the renderer in Task 5;
-	// populated from app state in Task 6.
 	SidebarCursor int
 	BodyCursor    SyncWaveBodyCursor
 	BodyScroll    int
 	ActivePane    SyncWavePane
 	SinglePane    bool            // when true, sidebar is hidden
-	Collapsed     map[string]bool // mirror of app-side collapsed; both phase and wave keys
+	Collapsed     map[string]bool // mirror of app-side collapsed. Both phase and wave keys
 }
 
 // SyncWaveLastOperation summarizes the previous (or current) operation
@@ -187,7 +185,7 @@ func formatRelative(t time.Time) string {
 func RenderSyncWaveTimeline(entry SyncWaveTimelineEntry, width, height int) string {
 	headerLines := buildSyncWaveHeader(entry, width)
 	if height <= 0 {
-		// Unbounded: emit header + body joined as today; useful for
+		// Unbounded: emit header + body joined as today. Useful for
 		// tests that pass height=0 to skip clipping.
 		body := buildBody(entry, width, 1000)
 		return strings.Join(append(headerLines, body...), "\n")
@@ -310,7 +308,7 @@ const (
 )
 
 // bodyRow is one logical row in the flattened body view. The renderer
-// uses it to apply cursor highlighting; the key handler uses it to walk
+// uses it to apply cursor highlighting. The key handler uses it to walk
 // the cursor through the visible rows skipping collapsed waves' resources.
 type bodyRow struct {
 	kind        bodyRowKind
@@ -433,7 +431,7 @@ func padOrTruncate(s string, width int) string {
 // tier is determined by entry.ActivePane and entry.BodyCursor.
 //
 // Body rows come from flattenBodyRows applied to the selected phase, then
-// rendered in order. BodyScroll slices off rows above the viewport; rows
+// rendered in order. BodyScroll slices off rows above the viewport. Rows
 // below the viewport are dropped. Empty padding rows fill any remainder.
 func buildBody(entry SyncWaveTimelineEntry, bodyWidth, viewportRows int) []string {
 	if len(entry.Phases) == 0 || entry.SidebarCursor < 0 || entry.SidebarCursor >= len(entry.Phases) {

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -17,7 +17,7 @@ var ActiveTheme = DefaultTheme()
 // them on the very next frame instead of waiting for an unrelated field
 // (data tick, age bucket roll, resize) to change. Atomic because the
 // other Active* / Config* globals are bound by an undocumented
-// "UI-thread only" contract; making this one self-enforcing eliminates
+// "UI-thread only" contract. Making this one self-enforcing eliminates
 // a torn-read class of bug if a future caller invokes ApplyTheme from
 // an informer callback or other background goroutine.
 var ThemeRev atomic.Uint64
@@ -41,7 +41,7 @@ type Theme struct {
 
 // BaseBg, BarBg, and SurfaceBg are exported TerminalColor values that inline
 // styles can use to set their background, respecting the transparency setting.
-// When ConfigTransparentBg is true they are NoColor{}; otherwise they hold
+// When ConfigTransparentBg is true they are NoColor{}. Otherwise they hold
 // the theme's Base, BarBg, and Surface colors respectively.
 var (
 	BaseBg    color.Color = lipgloss.NoColor{}
@@ -70,7 +70,7 @@ func DefaultTheme() Theme {
 
 // ApplyTheme updates all style variables with the given theme colors.
 // When ConfigNoColor is true, style globals are rebuilt without foreground
-// or background colors; emphasis is preserved via bold/underline/reverse.
+// or background colors. Emphasis is preserved via bold/underline/reverse.
 func ApplyTheme(t Theme) {
 	// Apply minimum contrast enforcement before storing the active theme.
 	// t is passed by value so mutations here are local to this function and
@@ -355,7 +355,7 @@ func ApplyTheme(t Theme) {
 	// Which-key group accents, which tint the DESCRIPTION (the key keeps one
 	// accent throughout — t.Secondary, the same hotkey green every hint bar
 	// draws its keys in, which is why no group may claim it). Three track the
-	// theme; Cyan, Orange and Magenta have no Theme field (the same
+	// theme. Cyan, Orange and Magenta have no Theme field (the same
 	// special-purpose constants the age and usage columns use), so they are the
 	// ones that can sit badly on an unusually light Base — run them through the
 	// same contrast floor the theme colors got above when the user asked for
@@ -437,7 +437,7 @@ func ApplyTheme(t Theme) {
 
 	// Crash investigator inner panel + section/header styles. Reassigned
 	// here so the surface background and border foreground track the
-	// active theme; init-time values capture SurfaceBg=NoColor{} before
+	// active theme. Init-time values capture SurfaceBg=NoColor{} before
 	// any theme is applied, so without this refresh borders / underlines
 	// would render fg-only and "punch through" to the terminal's default
 	// background.

--- a/internal/ui/theme_contrast.go
+++ b/internal/ui/theme_contrast.go
@@ -231,14 +231,14 @@ func derivedParentHighlightBg(t Theme) string {
 // minimum WCAG contrast ratio against the bg hex color. The value parameter is
 // the user-facing normalized knob in [0, 1]:
 //
-//   - 0.0  = off (no-op; returns fg unchanged)
+//   - 0.0  = off (no-op, returns fg unchanged)
 //   - 0.175 approx = WCAG AA threshold (4.5:1) for normal text
 //   - 0.3   approx = WCAG AAA threshold (7.0:1)
 //   - 1.0   = maximum (targets 21:1, forces fg toward pure black or white)
 //
 // The mapping is: wcagTarget = 1.0 + clamp(value, 0, 1) * 20.0
 //
-// Only the HSL lightness channel is adjusted; hue and saturation are
+// Only the HSL lightness channel is adjusted. Hue and saturation are
 // preserved, so chromatic colors keep their identity at moderate values.
 // At value=1.0 the extremes (L=0 or L=1) are achromatic by definition —
 // hue collapse at max value is an acceptable and documented trade-off.

--- a/internal/ui/visual.go
+++ b/internal/ui/visual.go
@@ -14,7 +14,7 @@ var CursorBlockStyle = lipgloss.NewStyle().Reverse(true)
 // of truth for both visual width and the rendered body — it carries the
 // already-applied YAML syntax highlighting / diff coloring / log producer
 // ANSI codes that we need to preserve around the cursor. plainLine is kept
-// as a parameter for legacy call sites; the function no longer reads it
+// as a parameter for legacy call sites. The function no longer reads it
 // because slicing plainLine destroyed any styling around the cursor row
 // (matched lines lost their YAML colors the moment the cursor sat on them).
 // When the cursor is at a negative column the styled line is returned as-is.
@@ -68,7 +68,7 @@ func RenderVisualSelection(line string, visualType rune, lineIdx, selStart, selE
 }
 
 // renderCharSelection highlights a character-level selection range. Columns
-// are visual columns; embedded ANSI escape sequences in line are treated as
+// are visual columns. Embedded ANSI escape sequences in line are treated as
 // zero-width so cursor and selection address the same positions.
 //
 // On the anchor line, highlight from anchorCol to end of line (downward) or
@@ -113,7 +113,7 @@ func renderBlockSelection(line string, lineWidth, colStart, colEnd int) string {
 }
 
 // highlightColumnRange highlights visible characters from colStart (inclusive)
-// to colEnd (exclusive). The line may carry producer SGR sequences; the
+// to colEnd (exclusive). The line may carry producer SGR sequences. The
 // before/after segments keep their original styling (ansi.Truncate /
 // TruncateLeft preserve embedded ANSI), while the selected slice is rendered
 // through SelectedStyle on stripped text so the selection's fg/bg pair
@@ -126,7 +126,7 @@ func highlightColumnRange(line string, lineWidth, colStart, colEnd int) string {
 		colEnd = lineWidth
 	}
 	if colStart >= lineWidth {
-		// Selection is beyond the line; render the line with a padded
+		// Selection is beyond the line. Render the line with a padded
 		// selection cell so the user sees where their cursor parked.
 		return line + SelectedStyle.Render(" ")
 	}

--- a/internal/ui/whocanview.go
+++ b/internal/ui/whocanview.go
@@ -14,7 +14,7 @@ import (
 type WhoCanRow struct {
 	Kind      string // "User" / "Group" / "ServiceAccount"
 	Name      string
-	Namespace string // ServiceAccount namespace; empty for User/Group
+	Namespace string // ServiceAccount namespace. Empty for User/Group
 	Via       string // "ClusterRoleBinding/foo → ClusterRole/bar"
 }
 
@@ -125,7 +125,7 @@ func currentResource(resources []string, cursor int) string {
 }
 
 // renderWhoCanVerbs builds the verb-chip row. Each chip is a label
-// padded with a space; the cursor chip uses OverlaySelectedStyle so
+// padded with a space. The cursor chip uses OverlaySelectedStyle so
 // the highlight covers it cleanly across themes.
 func renderWhoCanVerbs(cursor int) string {
 	var b strings.Builder
@@ -157,7 +157,7 @@ func renderWhoCanVerbs(cursor int) string {
 // Scroll is taken as input (not derived from cursor) so vim-like
 // behavior holds: the viewport stays put when the cursor moves inside
 // it, and only scrolls when the cursor leaves an edge. The handlers
-// maintain the scroll offset; this function only clamps to a valid
+// maintain the scroll offset. This function only clamps to a valid
 // range and renders.
 func renderWhoCanResourcePicker(resources []string, cursor, scroll, width, height int) string {
 	header := renderWhoCanResourceHeader(len(resources), width)
@@ -214,7 +214,7 @@ func whoCanClampScroll(scroll, total, bodyHeight int) int {
 // WhoCanScrollForCursor returns the new scroll offset that keeps
 // `cursor` visible inside a viewport of `bodyHeight` rows starting at
 // `scroll`. Vim semantics: do nothing if the cursor is already in
-// view; otherwise scroll just enough to put the cursor on the nearest
+// view. Otherwise scroll just enough to put the cursor on the nearest
 // visible edge. Used by handlers that move the cursor.
 func WhoCanScrollForCursor(scroll, cursor, bodyHeight, total int) int {
 	if total <= bodyHeight {
@@ -254,7 +254,7 @@ func renderWhoCanSubjects(rows []WhoCanRow, scroll int, loading bool, resource s
 	}
 
 	// Column widths shrink with `width` so the row fits inside narrow
-	// overlays. Kind/Namespace are short; SUBJECT and VIA both can be
+	// overlays. Kind/Namespace are short. SUBJECT and VIA both can be
 	// long (full SA paths, full RBAC chains) so the leftover width is
 	// split evenly between them — no upper cap on SUBJECT, otherwise
 	// long ServiceAccount paths get truncated unnecessarily even when

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,12 +19,12 @@ var (
 	BuildDate = "unknown"
 )
 
-// Full returns a human-readable multi-line version string.
+// Full returns a human-readable version string.
 func Full() string {
 	return fmt.Sprintf("lfk %s (commit: %s, built: %s)", Version, GitCommit, BuildDate)
 }
 
-// Short returns just the version tag (e.g., "dev" or "v1.2.3").
+// Short returns the version tag (e.g., "dev" or "v1.2.3").
 func Short() string {
 	return Version
 }

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ File locations:
   Override dirs for portable installs: LFK_CONFIG_DIR, LFK_STATE_DIR, LFK_DATA_DIR`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliOpts.KubeconfigExclusiveSet = cmd.Flags().Changed("kubeconfig-exclusive")
-			// LFK_SESSION is the env equivalent of --session; the explicit
+			// LFK_SESSION is the env equivalent of --session. The explicit
 			// flag wins when both are set.
 			if !cmd.Flags().Changed("session") {
 				if s := os.Getenv("LFK_SESSION"); s != "" {
@@ -165,7 +165,7 @@ func resolveStartupClient(opts app.StartupOptions) (*k8s.Client, error) {
 func runTUI(opts app.StartupOptions) error {
 	// Silence klog (Kubernetes client library) to prevent it from writing
 	// error messages to stderr which corrupts the TUI output.
-	// Initially discard; after logger init, redirect to our log file.
+	// Initially discard. After logger init, redirect to our log file.
 	klog.InitFlags(nil)
 	_ = flag.Set("logtostderr", "false")
 	_ = flag.Set("stderrthreshold", "FATAL")
@@ -225,7 +225,7 @@ func runTUI(opts app.StartupOptions) error {
 	)
 
 	// Optional pprof endpoint for debugging hot CPU paths (issue #206).
-	// Off by default; set LFK_PPROF_ADDR=127.0.0.1:6060 to enable. The
+	// Off by default. Set LFK_PPROF_ADDR=127.0.0.1:6060 to enable. The
 	// address MUST resolve to a loopback host — anything else exposes
 	// process internals (heap, goroutines, credentials in symbols) on
 	// the network and we refuse to start.
@@ -245,7 +245,7 @@ func runTUI(opts app.StartupOptions) error {
 	}
 
 	// Optional periodic memory diagnostics for chasing leaks (issue #387).
-	// Off by default; set LFK_MEMSTATS_INTERVAL=30s to log heap and goroutine
+	// Off by default. Set LFK_MEMSTATS_INTERVAL=30s to log heap and goroutine
 	// counts to the app log on each tick. A slow leak shows up as rising
 	// heap_objects (cache/buffer leak) or rising goroutines (watch/stream
 	// leak). Use alongside LFK_PPROF_ADDR for a full heap profile.
@@ -289,7 +289,7 @@ func runTUI(opts app.StartupOptions) error {
 	// has not let the process exit within the grace period, kill the
 	// program — which restores the terminal — and exit, so a drain wedged
 	// on an unreachable cluster cannot leave the user stuck on a frozen
-	// alt-screen. p is assigned just below; the closure captures the
+	// alt-screen. p is assigned just below. The closure captures the
 	// variable, so it is set by the time the notifier ever runs.
 	var p *tea.Program
 	m.SetShutdownNotifier(armForceQuit(app.ForceQuitGracePeriod,
@@ -298,7 +298,7 @@ func runTUI(opts app.StartupOptions) error {
 	))
 	p = tea.NewProgram(m)
 
-	// ErrProgramKilled is expected when the watchdog force-quits; treat it
+	// ErrProgramKilled is expected when the watchdog force-quits. Treat it
 	// as a clean exit rather than surfacing it as a startup failure.
 	if _, err := p.Run(); err != nil && !errors.Is(err, tea.ErrProgramKilled) {
 		os.Stderr = origStderr
@@ -379,7 +379,7 @@ func unionSetLookup(sets []ui.UnionSetConfig, client *k8s.Client) app.UnionSetLo
 				// ResolveUnionSet, so surface the malformed-set message via
 				// the kubeconfig context name so it reads naturally in the
 				// downstream "context not found" error path. Tests cover the
-				// happy path; production users with this bug will see the
+				// happy path. Production users with this bug will see the
 				// validation error at startup with the offending set name.
 				logger.Error("union set is malformed", "error", err)
 				return nil, "", nil, false


### PR DESCRIPTION
## Summary

Two rounds of `/doc-audit` over the 179 comment-densest Go files plus every doc file, with the findings applied. Then the README and the guides were reshaped for scanning: install and run first, one line per feature with a link to the doc that carries the detail, numbered steps for procedures.

## Type of change

- [x] docs: documentation only

## Related issue

TASK-898, TASK-899 (backlog)

## Changes

- Go comments: 3 stale or misplaced godoc blocks fixed (`explorer_format.go`, `capture_backend_kubectl_debug.go`, `overlay_background_tasks.go`, `overlay_list.go`), restating one-line docstrings deleted in `cursor.go` and `commandbar_execute.go`, task-tracker and review references dropped, two hard contracts changed from should to must, ~840 semicolons in comment prose replaced with a full stop or comma (line counts unchanged, gofmt clean).
- Docs: 51 oversized table cells moved into prose under their tables, `docs/security.md` Sources table split into per-source subsections, README title emoji removed, sponsor blurb trimmed, table formatting fixed in `commands.md` and `keybindings.md`.
- README: Install and Usage lead, Features cut to one-line bullets, screenshots/keybindings/tips grouped under subheadings, Configuration as 3 numbered steps. New `docs/features.md` holds facts that had no other home. Two errors corrected: layout cycle is `F` (not `Shift+F`), three built-in scanners (not two).
- Guides (`usage.md`, `installation.md`, `union-context.md`, `CONTRIBUTING.md`, `security.md`, `commands.md`, `views-and-overlays.md`, `release-process.md`, `SECURITY.md`): procedures numbered, preambles cut, semicolons fixed. Anchors linked from other files unchanged.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (no behavior change, comments and docs only)
- [x] Table-cell size script reports 0 outliers across `*.md`
- [x] Every relative doc link and `#anchor` in README, `docs/`, `CONTRIBUTING.md` resolves

## Checklist

- [x] Commits follow conventional commit style
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (no keybinding change)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots