### PR TITLE
feat(nav): make the 0/1/2 level keys walk back down

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Inside the namespace selector:
 
 | Key | Action |
 |---|---|
-| `0` / `1` / `2` | Clusters / resource types / resources level |
+| `0` / `1` / `2` | Clusters / resource types / resources level, both ways |
 | `o` | Owner or controller of the selected resource |
 | `Backspace` | Back through teleport history |
 | `g` + key | Goto resource type (`g` opens the which-key popup) |
@@ -442,7 +442,7 @@ All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A mu
 ### Navigating
 
 - Press `o` on a resource to jump to its owner (Pod -> Deployment), then `Backspace` to jump back
-- Teleport between levels with `0` / `1` / `2` (clusters / resource types / resources)
+- Teleport between levels with `0` / `1` / `2` (clusters / resource types / resources). `1` and `2` bring you back to the view you left, per cluster
 - Jump straight to a resource type from anywhere: type `:pod`, `:dep`, `:pvc`
 - Set a bookmark with `m<letter>`, jump back with `'<letter>`, the saved namespace and filter come with it
 - Pin your daily-driver resource types with `p` and hide noisy ones via `x`, both remembered per cluster

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -17,7 +17,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `Ctrl+F` / `Ctrl+B` / `PgDn` / `PgUp` | Page down / up (full page) |
 | `z` | Toggle expand / collapse all resource groups |
 | `x` | At resource types level: pin, hide, or show the selected type (action menu) |
-| `0` / `1` / `2` | Jump to clusters / types / resources level |
+| `0` / `1` / `2` | Jump to clusters / types / resources level, per cluster and both ways |
 | `J` / `K` | Scroll preview pane down / up |
 | `o` / `O` | Jump to owner/controller / open Object Explorer |
 | `Backspace` | Jump back through teleport history |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -135,7 +135,6 @@ type Model struct {
 
 	err error // error to display
 
-	// Loading indicator.
 	loading bool
 
 	// previewLoading is set true when a preview load is in flight for the
@@ -145,8 +144,7 @@ type Model struct {
 	// completing. Without this the right pane briefly renders
 	// "No resources found" between the two transitions.
 	previewLoading bool
-	// Spinner for loading animation.
-	spinner spinner.Model
+	spinner        spinner.Model
 	// spinnerTicking guards the tick loop. armSpinner never stacks a second loop.
 	spinnerTicking bool
 
@@ -744,6 +742,8 @@ type Model struct {
 
 	// Jump history: back stack for "teleport" jumps. jump_back pops it. Capped at jumpHistoryCap.
 	jumpBackStack []navSnapshot
+	// Level memory: the view each cluster was left at, so the 1 and 2 keys walk back down (level_memory.go).
+	levelMem levelMemory
 
 	// Stack of LevelOwned parents for nested drill-downs (popped by navigateParent).
 	ownedParentStack []ownedParentState

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -464,7 +464,10 @@ type TabState struct {
 	// its own jumps independently. navSnapshots are never mutated after
 	// captureNavSnapshot deep-copies their slices, so copying the outer
 	// slice on save/restore is enough.
-	jumpBackStack      []navSnapshot
+	jumpBackStack []navSnapshot
+	// levelMem holds the views this tab left each cluster at, so the level
+	// keys walk back down inside the tab that recorded them.
+	levelMem           levelMemory
 	cursors            [5]int
 	middleScroll       int // persistent scroll position for middle column (vim-style scrolloff)
 	leftScroll         int // persistent scroll position for left column (vim-style scrolloff)

--- a/internal/app/level_memory.go
+++ b/internal/app/level_memory.go
@@ -34,13 +34,19 @@ func (l *levelMemory) remember(key levelMemoryKey, snap navSnapshot) {
 	if l.views == nil {
 		l.views = make(map[levelMemoryKey]navSnapshot)
 	}
-	if _, exists := l.views[key]; !exists {
-		for len(l.order) >= levelMemoryCap {
-			delete(l.views, l.order[0])
-			l.order = l.order[1:]
+	// A rewrite moves the key back to the newest end, so the entry the user
+	// just refreshed is not the next one evicted.
+	for i, existing := range l.order {
+		if existing == key {
+			l.order = append(l.order[:i], l.order[i+1:]...)
+			break
 		}
-		l.order = append(l.order, key)
 	}
+	for len(l.order) >= levelMemoryCap {
+		delete(l.views, l.order[0])
+		l.order = l.order[1:]
+	}
+	l.order = append(l.order, key)
 	l.views[key] = snap
 	l.lastContext = key.context
 }

--- a/internal/app/level_memory.go
+++ b/internal/app/level_memory.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// levelMemoryCap bounds how many views one tab remembers. Each entry carries a
+// full item snapshot, so an uncapped map would hold every list the tab ever
+// left. The oldest entry goes when a write would exceed the cap.
+const levelMemoryCap = 24
+
+// levelMemoryKey identifies one remembered view: the cluster the user was in
+// and the level they left it at. Keying by cluster keeps one cluster's
+// resource type out of another's.
+type levelMemoryKey struct {
+	context string
+	level   model.Level
+}
+
+// levelMemory holds the view a tab left each cluster and level at, so the 1
+// and 2 keys walk back down to them.
+type levelMemory struct {
+	views map[levelMemoryKey]navSnapshot
+	order []levelMemoryKey // write order, oldest first, for the cap
+	// lastContext is the cluster the user left last. The cluster picker has
+	// no context of its own, so a restore from there needs this.
+	lastContext string
+}
+
+// remember records the given view under its cluster and level.
+func (l *levelMemory) remember(key levelMemoryKey, snap navSnapshot) {
+	if l.views == nil {
+		l.views = make(map[levelMemoryKey]navSnapshot)
+	}
+	if _, exists := l.views[key]; !exists {
+		for len(l.order) >= levelMemoryCap {
+			delete(l.views, l.order[0])
+			l.order = l.order[1:]
+		}
+		l.order = append(l.order, key)
+	}
+	l.views[key] = snap
+	l.lastContext = key.context
+}
+
+// clone deep-copies the memory so a tab save or restore shares no state with
+// the live Model.
+func (l levelMemory) clone() levelMemory {
+	out := levelMemory{lastContext: l.lastContext}
+	if l.views != nil {
+		out.views = make(map[levelMemoryKey]navSnapshot, len(l.views))
+		for k, v := range l.views {
+			out.views[k] = v.clone()
+		}
+	}
+	out.order = append([]levelMemoryKey(nil), l.order...)
+	return out
+}
+
+// rememberLevel records the current view so the level keys can walk back down
+// to it. navigateParent calls it for every level it leaves, which keeps the
+// memory in step with plain back-navigation too.
+func (m *Model) rememberLevel() {
+	// Union mode holds the sentinel in nav.Context. restoreNavSnapshot checks
+	// a snapshot's context against the kubeconfig, which the sentinel never
+	// matches, so a union snapshot would only ever restore as an error.
+	if m.nav.Context == "" || m.unionMode {
+		return
+	}
+	m.levelMem.remember(levelMemoryKey{context: m.nav.Context, level: m.nav.Level}, m.captureNavSnapshot())
+}
+
+// restoreLevel replays the view remembered for the given level, and reports
+// whether it had one. At the cluster picker the lookup uses the cluster the
+// user last left, because nav.Context is empty there.
+func (m *Model) restoreLevel(level model.Level) (tea.Cmd, bool) {
+	ctx := m.nav.Context
+	if m.nav.Level == model.LevelClusters {
+		ctx = m.levelMem.lastContext
+	}
+	if ctx == "" {
+		return nil, false
+	}
+	snap, ok := m.levelMem.views[levelMemoryKey{context: ctx, level: level}]
+	if !ok {
+		return nil, false
+	}
+	return m.restoreNavSnapshot(snap), true
+}

--- a/internal/app/level_memory_test.go
+++ b/internal/app/level_memory_test.go
@@ -124,6 +124,25 @@ func TestLevelMemoryStaysUnderItsCap(t *testing.T) {
 	assert.False(t, oldest, "the first cluster recorded must be gone")
 }
 
+func TestLevelMemoryEvictsTheLeastRecentlyWritten(t *testing.T) {
+	m := levelMemoryModel(t)
+	remember := func(i int) {
+		m.nav.Level = model.LevelResources
+		m.nav.Context = fmt.Sprintf("ctx-%d", i)
+		m.rememberLevel()
+	}
+	for i := range levelMemoryCap {
+		remember(i)
+	}
+	remember(0)              // refresh the oldest entry
+	remember(levelMemoryCap) // force one eviction
+
+	_, refreshed := m.levelMem.views[levelMemoryKey{context: "ctx-0", level: model.LevelResources}]
+	assert.True(t, refreshed, "a refreshed entry must not be the one evicted")
+	_, next := m.levelMem.views[levelMemoryKey{context: "ctx-1", level: model.LevelResources}]
+	assert.False(t, next, "the next-oldest entry must be evicted instead")
+}
+
 func TestNewTabStartsWithoutTheLevelMemoryOfItsSource(t *testing.T) {
 	m := levelMemoryModel(t)
 	up, _, _ := m.handleExplorerActionKeyLevelCluster()

--- a/internal/app/level_memory_test.go
+++ b/internal/app/level_memory_test.go
@@ -1,0 +1,154 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// levelMemoryModel returns a model sitting on a pod list in "test-ctx" with
+// the parent columns filled in, so navigateParent can walk up to the cluster
+// picker the way the real app does.
+func levelMemoryModel(t *testing.T) Model {
+	t.Helper()
+	m := basePush80Model()
+	m.nav.Namespace = "default"
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}
+	m.leftItems = []model.Item{{Name: "Pods", Kind: "Pod"}}
+	m.leftItemsHistory = [][]model.Item{{{Name: "test-ctx"}}}
+	return m
+}
+
+func TestLevelKeyClusterThenResourcesReturnsToTheSameList(t *testing.T) {
+	m := levelMemoryModel(t)
+
+	up, _, handled := m.handleExplorerActionKeyLevelCluster()
+	require.True(t, handled)
+	atClusters := up.(Model)
+	require.Equal(t, model.LevelClusters, atClusters.nav.Level)
+
+	back, _, handled := atClusters.handleExplorerActionKeyLevelResources()
+	require.True(t, handled)
+	bm := back.(Model)
+
+	assert.Equal(t, model.LevelResources, bm.nav.Level, "2 must return to the resource list")
+	assert.Equal(t, "test-ctx", bm.nav.Context)
+	assert.Equal(t, "Pod", bm.nav.ResourceType.Kind, "the resource type must be restored")
+}
+
+func TestLevelKeyClusterThenTypesReturnsToTheClusterLeft(t *testing.T) {
+	m := levelMemoryModel(t)
+
+	up, _, _ := m.handleExplorerActionKeyLevelCluster()
+	back, _, handled := up.(Model).handleExplorerActionKeyLevelTypes()
+	require.True(t, handled)
+	bm := back.(Model)
+
+	assert.Equal(t, model.LevelResourceTypes, bm.nav.Level, "1 must return to the type list")
+	assert.Equal(t, "test-ctx", bm.nav.Context, "the cluster the user left must be restored")
+}
+
+func TestLevelMemoryIsPerCluster(t *testing.T) {
+	m := levelMemoryModel(t)
+
+	up, _, _ := m.handleExplorerActionKeyLevelCluster()
+	other := up.(Model)
+	// The user enters a different cluster by hand. Its own memory is empty,
+	// so 2 must not replay the pod list of the cluster they left.
+	other.nav.Level = model.LevelResourceTypes
+	other.nav.Context = "other-ctx"
+
+	back, _, handled := other.handleExplorerActionKeyLevelResources()
+	require.True(t, handled)
+	bm := back.(Model)
+
+	assert.Equal(t, model.LevelResourceTypes, bm.nav.Level, "another cluster's memory must not apply")
+	assert.Equal(t, "other-ctx", bm.nav.Context)
+}
+
+func TestLevelKeysWithoutMemoryKeepCurrentBehaviour(t *testing.T) {
+	m := basePush80Model()
+	m.nav = model.NavigationState{Level: model.LevelClusters}
+
+	for _, tc := range []struct {
+		name string
+		key  func(Model) (any, any, bool)
+	}{
+		{"types", func(mm Model) (any, any, bool) {
+			r, c, h := mm.handleExplorerActionKeyLevelTypes()
+			return r, c, h
+		}},
+		{"resources", func(mm Model) (any, any, bool) {
+			r, c, h := mm.handleExplorerActionKeyLevelResources()
+			return r, c, h
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ret, _, handled := tc.key(m)
+			require.True(t, handled)
+			rm := ret.(Model)
+			assert.Equal(t, model.LevelClusters, rm.nav.Level, "level must not change")
+			assert.Empty(t, rm.statusMessage, "an empty memory must not raise an error")
+		})
+	}
+}
+
+func TestLevelMemorySkipsUnionMode(t *testing.T) {
+	m := levelMemoryModel(t)
+	m.unionMode = true
+	m.nav.Context = UnionContextSentinel
+
+	up, _, _ := m.handleExplorerActionKeyLevelCluster()
+
+	assert.Empty(t, up.(Model).levelMem.views,
+		"a union snapshot carries the sentinel context and could only restore as an error")
+}
+
+func TestLevelMemoryStaysUnderItsCap(t *testing.T) {
+	m := levelMemoryModel(t)
+	for i := range levelMemoryCap * 2 {
+		m.nav.Level = model.LevelResources
+		m.nav.Context = fmt.Sprintf("ctx-%d", i)
+		m.rememberLevel()
+	}
+
+	assert.Len(t, m.levelMem.views, levelMemoryCap, "the oldest entries must be evicted")
+	assert.Len(t, m.levelMem.order, levelMemoryCap)
+	_, oldest := m.levelMem.views[levelMemoryKey{context: "ctx-0", level: model.LevelResources}]
+	assert.False(t, oldest, "the first cluster recorded must be gone")
+}
+
+func TestNewTabStartsWithoutTheLevelMemoryOfItsSource(t *testing.T) {
+	m := levelMemoryModel(t)
+	up, _, _ := m.handleExplorerActionKeyLevelCluster()
+	source := up.(Model)
+	require.NotEmpty(t, source.levelMem.views, "precondition: the source tab remembers a view")
+
+	ret, _, handled := source.handleExplorerActionKeyNewTab()
+	require.True(t, handled)
+	fresh := ret.(Model)
+
+	assert.Empty(t, fresh.levelMem.views, "a new tab must not inherit where another tab has been")
+	assert.Empty(t, fresh.jumpBackStack, "the same holds for the teleport history")
+}
+
+func TestLevelMemoryFollowsItsTab(t *testing.T) {
+	m := levelMemoryModel(t)
+	up, _, _ := m.handleExplorerActionKeyLevelCluster()
+	saved := up.(Model)
+	require.NotEmpty(t, saved.levelMem.views, "precondition: the jump recorded a memory")
+
+	saved.saveCurrentTab()
+	saved.levelMem.views = nil
+	saved.levelMem.lastContext = ""
+	saved.loadTab(0)
+
+	assert.Equal(t, "test-ctx", saved.levelMem.lastContext, "the tab must carry the cluster back")
+	assert.NotEmpty(t, saved.levelMem.views, "the tab must carry the remembered levels back")
+}

--- a/internal/app/tab_state.go
+++ b/internal/app/tab_state.go
@@ -73,6 +73,7 @@ func (m *Model) saveCurrentTab() {
 		t.leftItemsHistory[i] = append([]model.Item(nil), hist...)
 	}
 	t.jumpBackStack = cloneNavSnapshots(m.jumpBackStack)
+	t.levelMem = m.levelMem.clone()
 	t.cursors = m.cursors
 	t.middleScroll = ui.ActiveMiddleScroll
 	t.leftScroll = ui.ActiveLeftScroll
@@ -214,6 +215,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 		m.leftItemsHistory[i] = append([]model.Item(nil), hist...)
 	}
 	m.jumpBackStack = cloneNavSnapshots(t.jumpBackStack)
+	m.levelMem = t.levelMem.clone()
 	m.cursors = t.cursors
 	ui.ActiveMiddleScroll = t.middleScroll
 	ui.ActiveLeftScroll = t.leftScroll

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -393,7 +393,10 @@ func (m Model) handleExplorerActionKeyLevelCluster() (tea.Model, tea.Cmd, bool) 
 
 func (m Model) handleExplorerActionKeyLevelTypes() (tea.Model, tea.Cmd, bool) {
 	if m.nav.Level < model.LevelResourceTypes {
-		return m, nil, true // can't jump forward
+		if cmd, ok := m.restoreLevel(model.LevelResourceTypes); ok {
+			return m, cmd, true
+		}
+		return m, nil, true // nothing remembered for this level
 	}
 	for m.nav.Level > model.LevelResourceTypes {
 		before := m.nav.Level
@@ -408,7 +411,10 @@ func (m Model) handleExplorerActionKeyLevelTypes() (tea.Model, tea.Cmd, bool) {
 
 func (m Model) handleExplorerActionKeyLevelResources() (tea.Model, tea.Cmd, bool) {
 	if m.nav.Level < model.LevelResources {
-		return m, nil, true
+		if cmd, ok := m.restoreLevel(model.LevelResources); ok {
+			return m, cmd, true
+		}
+		return m, nil, true // nothing remembered for this level
 	}
 	for m.nav.Level > model.LevelResources {
 		before := m.nav.Level

--- a/internal/app/update_keys_actions_tabs.go
+++ b/internal/app/update_keys_actions_tabs.go
@@ -23,8 +23,12 @@ func (m Model) handleExplorerActionKeyNewTab() (tea.Model, tea.Cmd, bool) {
 	newTab := m.cloneCurrentTab()
 	m.tabs = append(m.tabs[:insertAt], append([]TabState{newTab}, m.tabs[insertAt:]...)...)
 	m.activeTab = insertAt
+	// cloneCurrentTab leaves the new tab's navigation history empty on
+	// purpose. Those live on the Model, so without a load the new tab keeps
+	// using — and then saves back — the history of the tab it was cloned from.
+	loadCmd := m.loadTab(m.activeTab)
 	m.setStatusMessage(fmt.Sprintf("Tab %d created", m.activeTab+1), false)
-	return m, scheduleStatusClear(), true
+	return m, tea.Batch(loadCmd, scheduleStatusClear()), true
 }
 
 func (m Model) handleExplorerActionKeyNextTab() (tea.Model, tea.Cmd, bool) {

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -107,6 +107,7 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 			return m, nil // no cluster selection level in CLI-started union mode
 		}
 		m.saveCursor()
+		m.rememberLevel()
 		m.nav.Level = model.LevelClusters
 		m.nav.Context = ""
 		m.setMiddleItems(m.leftItems)
@@ -123,6 +124,7 @@ func (m Model) navigateParent() (tea.Model, tea.Cmd) {
 
 	case model.LevelResources:
 		m.saveCursor()
+		m.rememberLevel()
 		m.nav.Level = model.LevelResourceTypes
 		m.nav.ResourceType = model.ResourceTypeEntry{}
 		// When session restore puts us at LevelResources before API


### PR DESCRIPTION
## What

The level hotkeys only navigated up. From a pod list, `0` returned to the cluster picker, but `1` and `2` could not go back, because the app kept no record of the cluster and the resource type the user had left.

`navigateParent` now snapshots each view it leaves, keyed by cluster and level. The `1` and `2` keys replay that snapshot when the user sits above the level:

- `0` then `2` returns to the same resource list.
- `0` then `1` returns to the type list of the cluster the user left.
- The memory is per cluster, so switching clusters does not carry a resource type across.
- A level with nothing remembered keeps the old behaviour and shows no error.
- The memory follows its tab.

Two fixes came out of the code review:

- Union mode records nothing. Its snapshots carry the union sentinel as their context, which no kubeconfig entry matches, so a restore could only ever report an error.
- The new-tab action key now loads the tab it clones. `cloneCurrentTab` clears the navigation history on purpose, but that history lives on the `Model`, so without a load the new tab kept using the source tab's history and then saved it back. This also fixes the same leak for the teleport back stack.

The memory caps at 24 views per tab, oldest first, because each entry holds a full item list.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `golangci-lint run` - 0 issues
- [x] `go test ./...`
- [x] `go test -race ./internal/app/... ./internal/ui/...`
- [x] 8 new tests in `internal/app/level_memory_test.go`: the round trip for both keys, per-cluster isolation, the empty-memory fallback, the union skip, the cap, the new-tab isolation, and the tab round trip
- [ ] Manual: drill into a pod list, press `0`, then `2` and `1`; repeat with two tabs and two clusters