### PR TITLE
chore: update vendorHash in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-wmM3qWzNnb4zis5JhZNd2iXV6gzy1dMagADYh/hzKuc=";
+            vendorHash = "sha256-6ggE3voXdV8Yfv9fzdXFTI2zVPMfdPy6D8bWASRMc1g=";
 
             subPackages = [ "." ];
 


### PR DESCRIPTION
Recent Go module bumps changed the vendor tree. This updates `vendorHash` so the Nix build works again.

## Test plan
- [ ] CI build passes