### PR TITLE
fix: sort the Changed and Uptime columns by their real timestamps

### DIFF
--- a/internal/app/changed_column_test.go
+++ b/internal/app/changed_column_test.go
@@ -285,3 +285,23 @@ func TestChangedJoinsTheSortCycle(t *testing.T) {
 		t.Fatalf("the Changed key must be reachable in the cycle, got idx=%d ok=%v", idx, ok)
 	}
 }
+
+func TestChangedSortUsesTheRealTimeNotTheRenderedCell(t *testing.T) {
+	now := time.Now()
+	// Both rows render "1m". Only the timestamp separates them.
+	items := []model.Item{
+		podWithConditions("aaa-older", now.Add(-61*time.Second)),
+		podWithConditions("zzz-newer", now.Add(-60*time.Second)),
+	}
+
+	applyChangedColumn(items, now)
+	if a, b := items[0].ColumnValue(ChangedColumnKey), items[1].ColumnValue(ChangedColumnKey); a != b {
+		t.Fatalf("this test needs two equal cells, got %q and %q", a, b)
+	}
+
+	sortItemsByColumn(items, ChangedColumnKey, true, "Pod")
+
+	if items[0].Name != "zzz-newer" {
+		t.Fatalf("the newer change must sort first, got %q", items[0].Name)
+	}
+}

--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -137,6 +137,7 @@ func (m *Model) carryOverMetricsColumns(newItems []model.Item) {
 // preview fetches return unenriched items, so without the carry-over the
 // preview's column set flips against the drilled list on every refetch).
 func carryOverMetricsColumnsFrom(oldItems, newItems []model.Item) {
+	carryOverBootedAt(oldItems, newItems)
 	metricsKeys := map[string]bool{
 		"CPU": true, "CPU/R": true, "CPU/L": true,
 		"MEM": true, "MEM/R": true, "MEM/L": true,

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -150,23 +150,21 @@ type valueCmpFunc func(a, b string) int
 // percent/resource columns silently fell through to lexicographic sort
 // (e.g. "100%" < "9%").
 var columnValueCmp = map[string]valueCmpFunc{
-	"CPU":            func(a, b string) int { return compareResourceValuesCmp(a, b, "CPU") },
-	"MEM":            func(a, b string) int { return compareResourceValuesCmp(a, b, "MEM") },
-	"CPU%":           comparePercentCmp,
-	"MEM%":           comparePercentCmp,
-	"CPU/R":          comparePercentCmp,
-	"CPU/L":          comparePercentCmp,
-	"MEM/R":          comparePercentCmp,
-	"MEM/L":          comparePercentCmp,
-	"Ports":          comparePortsCmp,
-	"Progress":       compareReadyCmp, // "N/M" fraction, same shape as Ready ratio
-	"Duration":       compareDurationCmp,
-	"REV":            compareREVCmp,
-	"Cluster IP":     compareIPCmp,
-	"Pod IP":         compareIPCmp,
-	"External IPs":   compareIPCmp,
-	"Uptime":         compareUptimeCmp,
-	ChangedColumnKey: compareUptimeCmp,
+	"CPU":          func(a, b string) int { return compareResourceValuesCmp(a, b, "CPU") },
+	"MEM":          func(a, b string) int { return compareResourceValuesCmp(a, b, "MEM") },
+	"CPU%":         comparePercentCmp,
+	"MEM%":         comparePercentCmp,
+	"CPU/R":        comparePercentCmp,
+	"CPU/L":        comparePercentCmp,
+	"MEM/R":        comparePercentCmp,
+	"MEM/L":        comparePercentCmp,
+	"Ports":        comparePortsCmp,
+	"Progress":     compareReadyCmp, // "N/M" fraction, same shape as Ready ratio
+	"Duration":     compareDurationCmp,
+	"REV":          compareREVCmp,
+	"Cluster IP":   compareIPCmp,
+	"Pod IP":       compareIPCmp,
+	"External IPs": compareIPCmp,
 }
 
 // metricsMissingLastColumns are columns whose cells can render as an "n/a"
@@ -238,6 +236,10 @@ func comparePrimaryColumn(a, b model.Item, colName string) int {
 		return cmpInt(severityRank(getColumnValue(a, "Severity")), severityRank(getColumnValue(b, "Severity")))
 	case sortColEventLastSeen:
 		return compareLastSeenCmp(a, b)
+	case ChangedColumnKey:
+		return compareChangedCmp(a, b)
+	case "Uptime":
+		return compareUptimeItemCmp(a, b)
 	}
 	va, vb := getColumnValue(a, colName), getColumnValue(b, colName)
 	if cmp, ok := columnValueCmp[colName]; ok {
@@ -397,6 +399,35 @@ func compareAgeCmp(a, b model.Item) int {
 	case a.CreatedAt.After(b.CreatedAt):
 		return -1
 	case a.CreatedAt.Before(b.CreatedAt):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// compareChangedCmp compares by the real change timestamp instead of the
+// rendered cell. formatAge buckets a range of ages into one string, so a row
+// changed 60s ago and a row changed 61s ago both read "1m" and a string
+// comparison ranks them by name. Rows with no change source return 0 so the
+// shared tiebreaker chain orders them, and the empty cell already sends them
+// to the bottom through metricsMissingLastColumns.
+func compareChangedCmp(a, b model.Item) int {
+	ta, okA := changeAt(a)
+	tb, okB := changeAt(b)
+	switch {
+	case okA && okB:
+		// Newer sorts first in ascending view, matching Age.
+		switch {
+		case ta.After(tb):
+			return -1
+		case ta.Before(tb):
+			return 1
+		default:
+			return 0
+		}
+	case okA:
+		return -1
+	case okB:
 		return 1
 	default:
 		return 0

--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -650,6 +650,7 @@ func (m Model) updateNodeUptimeEnriched(msg nodeUptimeEnrichedMsg) Model {
 		var value string
 		if d, ok := lookupNodeUptime(*item, msg.uptimes); ok {
 			value = k8s.FormatAge(d)
+			item.BootedAt = time.Now().Add(-d)
 		} else {
 			value = "n/a"
 		}

--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -639,6 +639,10 @@ func (m Model) updateNodeUptimeEnriched(msg nodeUptimeEnrichedMsg) Model {
 		return m
 	}
 	m.middleItemsRev++
+	// One clock read for the whole message: a per-item read separates two
+	// nodes with equal uptime by the loop delay, and the sort then ranks
+	// that noise ahead of the name tiebreaker.
+	now := time.Now()
 	for i := range m.middleItems {
 		item := &m.middleItems[i]
 		if empty {
@@ -650,7 +654,7 @@ func (m Model) updateNodeUptimeEnriched(msg nodeUptimeEnrichedMsg) Model {
 		var value string
 		if d, ok := lookupNodeUptime(*item, msg.uptimes); ok {
 			value = k8s.FormatAge(d)
-			item.BootedAt = time.Now().Add(-d)
+			item.BootedAt = now.Add(-d)
 		} else {
 			value = "n/a"
 		}

--- a/internal/app/uptime_sort.go
+++ b/internal/app/uptime_sort.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"time"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// compareUptimeItemCmp orders the Uptime column by the node boot time rather
+// than by the rendered cell. FormatAge buckets a whole range of durations
+// into one string ("5d" covers a full day), so two nodes inside one bucket
+// fell through to name order and swapped position the moment one crossed the
+// boundary. Rows with no boot time keep the string comparison: a CRD
+// additionalPrinterColumn may also be named Uptime, and Prometheus does not
+// match every node.
+func compareUptimeItemCmp(a, b model.Item) int {
+	if a.BootedAt.IsZero() || b.BootedAt.IsZero() {
+		return compareUptimeCmp(getColumnValue(a, "Uptime"), getColumnValue(b, "Uptime"))
+	}
+	// A later boot is a shorter uptime, which sorts first ascending — the
+	// same direction the string comparator gives.
+	switch {
+	case a.BootedAt.After(b.BootedAt):
+		return -1
+	case a.BootedAt.Before(b.BootedAt):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// carryOverBootedAt copies the node boot time onto freshly loaded items, keyed
+// exactly as carryOverMetricsColumnsFrom keys the Uptime cell it carries. A
+// watch tick replaces every Item, and without this the sort drops back to the
+// bucketed cell until the next Prometheus fetch lands.
+func carryOverBootedAt(oldItems, newItems []model.Item) {
+	type itemKey struct{ cluster, ns, name string }
+	booted := make(map[itemKey]time.Time, len(oldItems))
+	for _, item := range oldItems {
+		if !item.BootedAt.IsZero() {
+			booted[itemKey{item.ClusterName, item.Namespace, item.Name}] = item.BootedAt
+		}
+	}
+	if len(booted) == 0 {
+		return
+	}
+	for i := range newItems {
+		if !newItems[i].BootedAt.IsZero() {
+			continue
+		}
+		key := itemKey{newItems[i].ClusterName, newItems[i].Namespace, newItems[i].Name}
+		if at, ok := booted[key]; ok {
+			newItems[i].BootedAt = at
+		}
+	}
+}

--- a/internal/app/uptime_sort_test.go
+++ b/internal/app/uptime_sort_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func nodeWithUptime(name string, up time.Duration, now time.Time) model.Item {
+	return model.Item{
+		Name:     name,
+		Kind:     "Node",
+		BootedAt: now.Add(-up),
+		Columns:  []model.KeyValue{{Key: "Uptime", Value: k8s.FormatAge(up)}},
+	}
+}
+
+func TestUptimeSortUsesTheBootTimeNotTheRenderedCell(t *testing.T) {
+	now := time.Now()
+	// Both rows render "5d". Only the boot time separates them.
+	items := []model.Item{
+		nodeWithUptime("aaa-older", 5*24*time.Hour+3*time.Hour, now),
+		nodeWithUptime("zzz-younger", 5*24*time.Hour, now),
+	}
+	if a, b := items[0].ColumnValue("Uptime"), items[1].ColumnValue("Uptime"); a != b {
+		t.Fatalf("this test needs two equal cells, got %q and %q", a, b)
+	}
+
+	sortItemsByColumn(items, "Uptime", true, "Node")
+
+	if items[0].Name != "zzz-younger" {
+		t.Fatalf("the shorter uptime must sort first, got %q", items[0].Name)
+	}
+}
+
+func TestUptimeSortFallsBackToTheCellWithoutABootTime(t *testing.T) {
+	items := []model.Item{
+		{Name: "aaa", Kind: "Widget", Columns: []model.KeyValue{{Key: "Uptime", Value: "10d"}}},
+		{Name: "zzz", Kind: "Widget", Columns: []model.KeyValue{{Key: "Uptime", Value: "9h"}}},
+	}
+
+	sortItemsByColumn(items, "Uptime", true, "Widget")
+
+	if items[0].Name != "zzz" {
+		t.Fatalf("a CRD Uptime column must still sort by duration, got %q", items[0].Name)
+	}
+}
+
+func TestUptimeEnrichmentStampsTheBootTime(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{Name: "node-a"}}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{"node-a": 3 * time.Hour}},
+		gen:     0,
+	})
+	got := result.(Model).middleItems[0].BootedAt
+
+	if got.IsZero() {
+		t.Fatal("a matched node must carry a boot time")
+	}
+	if d := time.Since(got); d < 3*time.Hour-time.Minute || d > 3*time.Hour+time.Minute {
+		t.Fatalf("want a boot time about 3h back, got %v", d)
+	}
+}
+
+func TestUptimeCarryOverKeepsTheBootTime(t *testing.T) {
+	now := time.Now()
+	old := []model.Item{nodeWithUptime("node-a", 5*24*time.Hour, now)}
+	fresh := []model.Item{{Name: "node-a", Kind: "Node"}}
+
+	carryOverMetricsColumnsFrom(old, fresh)
+
+	if !fresh[0].BootedAt.Equal(old[0].BootedAt) {
+		t.Fatalf("a watch tick must keep the boot time, got %v", fresh[0].BootedAt)
+	}
+}

--- a/internal/app/uptime_sort_test.go
+++ b/internal/app/uptime_sort_test.go
@@ -77,3 +77,27 @@ func TestUptimeCarryOverKeepsTheBootTime(t *testing.T) {
 		t.Fatalf("a watch tick must keep the boot time, got %v", fresh[0].BootedAt)
 	}
 }
+
+func TestUptimeEnrichmentStampsOneReferenceTime(t *testing.T) {
+	m := baseModel()
+	m.middleItems = []model.Item{{Name: "aaa-node"}, {Name: "zzz-node"}}
+
+	result, _ := m.Update(nodeUptimeEnrichedMsg{
+		uptimes: k8s.NodeUptimes{ByName: map[string]time.Duration{
+			"aaa-node": 3 * time.Hour,
+			"zzz-node": 3 * time.Hour,
+		}},
+		gen: 0,
+	})
+	items := result.(Model).middleItems
+
+	// Equal uptimes must stay equal. A per-item clock read would separate
+	// them by the loop delay and rank them ahead of the name tiebreaker.
+	if !items[0].BootedAt.Equal(items[1].BootedAt) {
+		t.Fatalf("equal uptimes must share a boot time, got %v and %v", items[0].BootedAt, items[1].BootedAt)
+	}
+	sortItemsByColumn(items, "Uptime", true, "Node")
+	if items[0].Name != "aaa-node" {
+		t.Fatalf("equal uptimes must fall through to name order, got %q", items[0].Name)
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -244,24 +244,28 @@ type GroupedRef struct {
 // Item represents a single navigable entry in any column.
 type Item struct {
 	Name          string
-	Namespace     string           // Namespace of the resource (populated in all-namespaces mode)
-	Status        string           // Used for pod/resource status coloring
-	Kind          string           // The Kubernetes resource kind
-	Extra         string           // Extra metadata (e.g., resource ref "group/version/resource")
-	Category      string           // Display category grouping (e.g., "Workloads", "Networking")
-	Icon          Icon             // Icon variants for display (see icon.go)
-	Age           string           // Human-readable age (e.g., "5m", "2h", "3d")
-	Ready         string           // Ready count (e.g., "2/3" for pods or deployments)
-	Restarts      string           // Restart count (for pods)
-	LastRestartAt time.Time        // Most recent container restart time
-	CreatedAt     time.Time        // Creation timestamp for sorting (Events: first observed timestamp in the series)
-	LastSeen      time.Time        // Most recent observation (Events only — drives the "Last Seen" column)
-	Columns       []KeyValue       // Additional resource fields for summary preview
-	Conditions    []ConditionEntry // Status conditions for the details pane
-	ClusterName   string           // Source cluster in union mode. Empty in normal mode
-	Selected      bool             // Whether this item is part of a multi-selection
-	Deprecated    bool             // Whether this resource uses a deprecated API version
-	Deleting      bool             // Whether this resource has a deletionTimestamp set
+	Namespace     string    // Namespace of the resource (populated in all-namespaces mode)
+	Status        string    // Used for pod/resource status coloring
+	Kind          string    // The Kubernetes resource kind
+	Extra         string    // Extra metadata (e.g., resource ref "group/version/resource")
+	Category      string    // Display category grouping (e.g., "Workloads", "Networking")
+	Icon          Icon      // Icon variants for display (see icon.go)
+	Age           string    // Human-readable age (e.g., "5m", "2h", "3d")
+	Ready         string    // Ready count (e.g., "2/3" for pods or deployments)
+	Restarts      string    // Restart count (for pods)
+	LastRestartAt time.Time // Most recent container restart time
+	CreatedAt     time.Time // Creation timestamp for sorting (Events: first observed timestamp in the series)
+	LastSeen      time.Time // Most recent observation (Events only — drives the "Last Seen" column)
+	// BootedAt is when a node last booted (Nodes only, from Prometheus
+	// node_boot_time_seconds). The Uptime cell it feeds is a bucketed
+	// string, so the sort reads this instead — see compareUptimeItemCmp.
+	BootedAt    time.Time
+	Columns     []KeyValue       // Additional resource fields for summary preview
+	Conditions  []ConditionEntry // Status conditions for the details pane
+	ClusterName string           // Source cluster in union mode. Empty in normal mode
+	Selected    bool             // Whether this item is part of a multi-selection
+	Deprecated  bool             // Whether this resource uses a deprecated API version
+	Deleting    bool             // Whether this resource has a deletionTimestamp set
 	// StatusFromPhase records that Status was derived from .status.phase.
 	// Set for generic CRDs whose Phase printer column is suppressed as a
 	// duplicate of Status, so the list summary can still roll up by phase


### PR DESCRIPTION
## Summary

- The `Changed` column sorted on its rendered cell. `FormatAge` buckets a range of ages into one string, so a pod changed 60s ago and a pod changed 61s ago both read `1m` and the order flipped to name order. `comparePrimaryColumn` now compares the `changeAt()` timestamp.
- The `Uptime` column had the same defect one bucket wider: `5d` covers a full day. `model.Item` now carries `BootedAt`, stamped by the Prometheus enrichment and carried across watch ticks, and the comparator reads it.
- Rows with no timestamp keep the string comparison, so a CRD `additionalPrinterColumns` field named `Uptime` is unaffected. `n/a` rows still sort last in both directions.

`Age` and the events `Last Seen` column already compared item timestamps. `Duration` keeps second precision, so it has no bucket collision.

## Test plan

- [x] `TestChangedSortUsesTheRealTimeNotTheRenderedCell` - two pods at 60s and 61s, both cells `1m`
- [x] `TestUptimeSortUsesTheBootTimeNotTheRenderedCell` - two nodes inside the `5d` bucket
- [x] `TestUptimeSortFallsBackToTheCellWithoutABootTime` - CRD column regression guard
- [x] `TestUptimeEnrichmentStampsTheBootTime`, `TestUptimeCarryOverKeepsTheBootTime`
- [x] `go build ./...`, `go test ./...`, `golangci-lint run ./internal/...` all clean