### PR TITLE
fix: sort relative-time columns by duration

### DIFF
--- a/internal/app/relative_time_sort_test.go
+++ b/internal/app/relative_time_sort_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
@@ -72,5 +73,69 @@ func TestLastTransitionKeepsUnparseableCellsLast(t *testing.T) {
 				t.Fatalf("cell %q asc=%v: an unreadable cell must sort last, got %q", cell, asc, items[len(items)-1].Name)
 			}
 		}
+	}
+}
+
+func itemWithColumn(name, key, value string) model.Item {
+	return model.Item{Name: name, Kind: "Widget", Columns: []model.KeyValue{{Key: key, Value: value}}}
+}
+
+// The cells hold formatAge output, where "10d" is older than "9h" but sorts
+// before it as text.
+func TestAgeShapedColumnsSortByDuration(t *testing.T) {
+	for _, col := range []string{"Last Scale Time", "Next", "Last Deployed", "Last Seen"} {
+		items := []model.Item{
+			itemWithColumn("aaa-older", col, "10d"),
+			itemWithColumn("zzz-newer", col, "9h"),
+		}
+		sortItemsByColumn(items, col, true, "Widget")
+
+		if items[0].Name != "zzz-newer" {
+			t.Fatalf("%s: the shorter duration must sort first, got %q", col, items[0].Name)
+		}
+	}
+}
+
+func TestAgeShapedColumnsKeepUnreadableCellsLast(t *testing.T) {
+	for _, col := range []string{"Last Scale Time", "Next", "Last Deployed"} {
+		for _, asc := range []bool{true, false} {
+			items := []model.Item{
+				itemWithColumn("aaa-empty", col, ""),
+				itemWithColumn("zzz-real", col, "9h"),
+			}
+			sortItemsByColumn(items, col, asc, "Widget")
+
+			if items[len(items)-1].Name != "aaa-empty" {
+				t.Fatalf("%s asc=%v: an empty cell must sort last, got %q", col, asc, items[len(items)-1].Name)
+			}
+		}
+	}
+}
+
+func TestLastSeenColumnPrefersTheEventTimestamp(t *testing.T) {
+	now := time.Now()
+	older := itemWithColumn("aaa-older", "Last Seen", "1m")
+	older.LastSeen = now.Add(-61 * time.Second)
+	newer := itemWithColumn("zzz-newer", "Last Seen", "1m")
+	newer.LastSeen = now.Add(-60 * time.Second)
+
+	items := []model.Item{older, newer}
+	sortItemsByColumn(items, "Last Seen", true, "Event")
+
+	if items[0].Name != "zzz-newer" {
+		t.Fatalf("the real timestamp must break the tie, got %q", items[0].Name)
+	}
+}
+
+func TestIntervalSortsByDuration(t *testing.T) {
+	items := []model.Item{
+		itemWithColumn("aaa-long", "Interval", "10m0s"),
+		itemWithColumn("zzz-short", "Interval", "5m0s"),
+	}
+
+	sortItemsByColumn(items, "Interval", true, "GitRepository")
+
+	if items[0].Name != "zzz-short" {
+		t.Fatalf("the shorter interval must sort first, got %q", items[0].Name)
 	}
 }

--- a/internal/app/relative_time_sort_test.go
+++ b/internal/app/relative_time_sort_test.go
@@ -58,24 +58,6 @@ func TestSyncedAtSortsThroughItsStatusPrefix(t *testing.T) {
 	}
 }
 
-func TestLastTransitionKeepsUnparseableCellsLast(t *testing.T) {
-	// A CRD printer column may also be named Last Transition and hold
-	// anything, so an unreadable cell must behave like an empty one.
-	for _, cell := range []string{"", "unknown", "n/a"} {
-		for _, asc := range []bool{true, false} {
-			items := []model.Item{
-				crdWithTransition("aaa-empty", cell),
-				crdWithTransition("zzz-real", "14d ago"),
-			}
-			sortItemsByColumn(items, "Last Transition", asc, "CustomResourceDefinition")
-
-			if items[len(items)-1].Name != "aaa-empty" {
-				t.Fatalf("cell %q asc=%v: an unreadable cell must sort last, got %q", cell, asc, items[len(items)-1].Name)
-			}
-		}
-	}
-}
-
 func itemWithColumn(name, key, value string) model.Item {
 	return model.Item{Name: name, Kind: "Widget", Columns: []model.KeyValue{{Key: key, Value: value}}}
 }
@@ -96,17 +78,30 @@ func TestAgeShapedColumnsSortByDuration(t *testing.T) {
 	}
 }
 
-func TestAgeShapedColumnsKeepUnreadableCellsLast(t *testing.T) {
-	for _, col := range []string{"Last Scale Time", "Next", "Last Deployed"} {
-		for _, asc := range []bool{true, false} {
-			items := []model.Item{
-				itemWithColumn("aaa-empty", col, ""),
-				itemWithColumn("zzz-real", col, "9h"),
-			}
-			sortItemsByColumn(items, col, asc, "Widget")
+func TestTimeShapedColumnsKeepUnreadableCellsLast(t *testing.T) {
+	cases := []struct{ col, good string }{
+		{"Last Transition", "14d ago"},
+		{"Synced At", "14d ago"},
+		{"Last Scale Time", "9h"},
+		{"Next", "9h"},
+		{"Last Deployed", "9h"},
+		{"Last Seen", "9h"},
+		{"Interval", "5m0s"},
+	}
+	// A CRD printer column may reuse any of these names and hold any text.
+	for _, c := range cases {
+		for _, bad := range []string{"", "n/a", "unknown"} {
+			for _, asc := range []bool{true, false} {
+				items := []model.Item{
+					itemWithColumn("aaa-bad", c.col, bad),
+					itemWithColumn("zzz-real", c.col, c.good),
+				}
+				sortItemsByColumn(items, c.col, asc, "Widget")
 
-			if items[len(items)-1].Name != "aaa-empty" {
-				t.Fatalf("%s asc=%v: an empty cell must sort last, got %q", col, asc, items[len(items)-1].Name)
+				if items[len(items)-1].Name != "aaa-bad" {
+					t.Fatalf("%s cell %q asc=%v: an unreadable cell must sort last, got %q",
+						c.col, bad, asc, items[len(items)-1].Name)
+				}
 			}
 		}
 	}

--- a/internal/app/relative_time_sort_test.go
+++ b/internal/app/relative_time_sort_test.go
@@ -58,15 +58,19 @@ func TestSyncedAtSortsThroughItsStatusPrefix(t *testing.T) {
 }
 
 func TestLastTransitionKeepsUnparseableCellsLast(t *testing.T) {
-	for _, asc := range []bool{true, false} {
-		items := []model.Item{
-			crdWithTransition("aaa-empty", ""),
-			crdWithTransition("zzz-real", "14d ago"),
-		}
-		sortItemsByColumn(items, "Last Transition", asc, "CustomResourceDefinition")
+	// A CRD printer column may also be named Last Transition and hold
+	// anything, so an unreadable cell must behave like an empty one.
+	for _, cell := range []string{"", "unknown", "n/a"} {
+		for _, asc := range []bool{true, false} {
+			items := []model.Item{
+				crdWithTransition("aaa-empty", cell),
+				crdWithTransition("zzz-real", "14d ago"),
+			}
+			sortItemsByColumn(items, "Last Transition", asc, "CustomResourceDefinition")
 
-		if items[len(items)-1].Name != "aaa-empty" {
-			t.Fatalf("asc=%v: an empty cell must sort last, got %q", asc, items[len(items)-1].Name)
+			if items[len(items)-1].Name != "aaa-empty" {
+				t.Fatalf("cell %q asc=%v: an unreadable cell must sort last, got %q", cell, asc, items[len(items)-1].Name)
+			}
 		}
 	}
 }

--- a/internal/app/relative_time_sort_test.go
+++ b/internal/app/relative_time_sort_test.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func crdWithTransition(name, cell string) model.Item {
+	return model.Item{
+		Name:    name,
+		Kind:    "CustomResourceDefinition",
+		Columns: []model.KeyValue{{Key: "Last Transition", Value: cell}},
+	}
+}
+
+func TestLastTransitionSortsByDurationNotLexically(t *testing.T) {
+	items := []model.Item{
+		crdWithTransition("aaa-ancient", "1138d ago"),
+		crdWithTransition("zzz-recent", "14d ago"),
+	}
+
+	sortItemsByColumn(items, "Last Transition", true, "CustomResourceDefinition")
+
+	if items[0].Name != "zzz-recent" {
+		t.Fatalf("the most recent transition must sort first, got %q", items[0].Name)
+	}
+}
+
+func TestLastTransitionOrdersEveryUnit(t *testing.T) {
+	items := []model.Item{
+		crdWithTransition("d", "3d ago"),
+		crdWithTransition("s", "45s ago"),
+		crdWithTransition("h", "2h ago"),
+		crdWithTransition("m", "30m ago"),
+	}
+
+	sortItemsByColumn(items, "Last Transition", true, "CustomResourceDefinition")
+
+	for i, want := range []string{"s", "m", "h", "d"} {
+		if items[i].Name != want {
+			t.Fatalf("row %d: want %q, got %q", i, want, items[i].Name)
+		}
+	}
+}
+
+func TestSyncedAtSortsThroughItsStatusPrefix(t *testing.T) {
+	items := []model.Item{
+		{Name: "aaa", Kind: "Application", Columns: []model.KeyValue{{Key: "Synced At", Value: "1138d ago"}}},
+		{Name: "zzz", Kind: "Application", Columns: []model.KeyValue{{Key: "Synced At", Value: "syncing 14d ago"}}},
+	}
+
+	sortItemsByColumn(items, "Synced At", true, "Application")
+
+	if items[0].Name != "zzz" {
+		t.Fatalf("the prefix must not defeat the duration, got %q", items[0].Name)
+	}
+}
+
+func TestLastTransitionKeepsUnparseableCellsLast(t *testing.T) {
+	for _, asc := range []bool{true, false} {
+		items := []model.Item{
+			crdWithTransition("aaa-empty", ""),
+			crdWithTransition("zzz-real", "14d ago"),
+		}
+		sortItemsByColumn(items, "Last Transition", asc, "CustomResourceDefinition")
+
+		if items[len(items)-1].Name != "aaa-empty" {
+			t.Fatalf("asc=%v: an empty cell must sort last, got %q", asc, items[len(items)-1].Name)
+		}
+	}
+}

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -183,6 +183,14 @@ var metricsMissingLastColumns = map[string]bool{
 	"Synced At":       true,
 }
 
+// relativeAgoColumns hold formatRelativeTime output ("1138d ago"). A CRD
+// printer column may carry the same name and any text at all, so the sort
+// treats a cell it cannot read as missing data rather than ranking it.
+var relativeAgoColumns = map[string]bool{
+	"Last Transition": true,
+	"Synced At":       true,
+}
+
 // metricValueMissing reports whether item's value for colName is an "n/a"
 // placeholder that should always sort last. Returns false for columns not
 // in metricsMissingLastColumns.
@@ -191,7 +199,14 @@ func metricValueMissing(colName string, item model.Item) bool {
 		return false
 	}
 	v := strings.TrimSpace(getColumnValue(item, colName))
-	return v == "" || v == "n/a"
+	if v == "" || v == "n/a" {
+		return true
+	}
+	if relativeAgoColumns[colName] {
+		_, ok := parseRelativeAgo(v)
+		return !ok
+	}
+	return false
 }
 
 // comparePrimaryColumn returns -1, 0, or +1 for a < b, a == b, a > b

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -191,14 +191,39 @@ var metricsMissingLastColumns = map[string]bool{
 	"Next":               true,
 	"Last Deployed":      true,
 	k8s.EventColLastSeen: true,
+	"Interval":           true,
 }
 
-// relativeAgoColumns hold formatRelativeTime output ("1138d ago"). A CRD
-// printer column may carry the same name and any text at all, so the sort
-// treats a cell it cannot read as missing data rather than ranking it.
-var relativeAgoColumns = map[string]bool{
-	"Last Transition": true,
-	"Synced At":       true,
+// readableTimeValue maps a time-shaped column to the parser that decides
+// whether its cell holds a real value. A CRD printer column may reuse any of
+// these names and hold arbitrary text, so a cell no parser can read sorts last
+// instead of ranking among real durations.
+var readableTimeValue = map[string]func(string) bool{
+	"Last Transition":    readableRelativeAgo,
+	"Synced At":          readableRelativeAgo,
+	"Last Scale Time":    readableAge,
+	"Next":               readableAge,
+	"Last Deployed":      readableAge,
+	k8s.EventColLastSeen: readableAge,
+	"Interval":           readableGoDuration,
+}
+
+// readableRelativeAgo reports whether v is formatRelativeTime output.
+func readableRelativeAgo(v string) bool {
+	_, ok := parseRelativeAgo(v)
+	return ok
+}
+
+// readableAge reports whether v is formatAge output.
+func readableAge(v string) bool {
+	_, ok := parseAgeDuration(v)
+	return ok
+}
+
+// readableGoDuration reports whether v is a Go duration string.
+func readableGoDuration(v string) bool {
+	_, err := time.ParseDuration(strings.TrimSpace(v))
+	return err == nil
 }
 
 // metricValueMissing reports whether item's value for colName is an "n/a"
@@ -212,9 +237,8 @@ func metricValueMissing(colName string, item model.Item) bool {
 	if v == "" || v == "n/a" {
 		return true
 	}
-	if relativeAgoColumns[colName] {
-		_, ok := parseRelativeAgo(v)
-		return !ok
+	if readable, ok := readableTimeValue[colName]; ok {
+		return !readable(v)
 	}
 	return false
 }

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
@@ -165,6 +166,11 @@ var columnValueCmp = map[string]valueCmpFunc{
 	"Cluster IP":      compareIPCmp,
 	"Last Transition": compareRelativeAgoCmp,
 	"Synced At":       compareRelativeAgoCmp,
+	// formatAge output ("10d", "9h"), which sorts before "9h" as text.
+	"Last Scale Time": compareUptimeCmp,
+	"Next":            compareUptimeCmp,
+	"Last Deployed":   compareUptimeCmp,
+	"Interval":        compareDurationCmp,
 	"Pod IP":          compareIPCmp,
 	"External IPs":    compareIPCmp,
 }
@@ -177,10 +183,14 @@ var metricsMissingLastColumns = map[string]bool{
 	"CPU": true, "MEM": true,
 	"CPU%": true, "MEM%": true,
 	"CPU/R": true, "CPU/L": true, "MEM/R": true, "MEM/L": true,
-	"Uptime":          true,
-	ChangedColumnKey:  true,
-	"Last Transition": true,
-	"Synced At":       true,
+	"Uptime":             true,
+	ChangedColumnKey:     true,
+	"Last Transition":    true,
+	"Synced At":          true,
+	"Last Scale Time":    true,
+	"Next":               true,
+	"Last Deployed":      true,
+	k8s.EventColLastSeen: true,
 }
 
 // relativeAgoColumns hold formatRelativeTime output ("1138d ago"). A CRD
@@ -259,6 +269,14 @@ func comparePrimaryColumn(a, b model.Item, colName string) int {
 		return compareChangedCmp(a, b)
 	case "Uptime":
 		return compareUptimeItemCmp(a, b)
+	case k8s.EventColLastSeen:
+		// The cell is formatAge output, so two events one second apart can
+		// share it. Events carry the observation time, so compare that;
+		// anything else with a column of this name keeps the cell.
+		if a.LastSeen.IsZero() && b.LastSeen.IsZero() {
+			return compareUptimeCmp(getColumnValue(a, k8s.EventColLastSeen), getColumnValue(b, k8s.EventColLastSeen))
+		}
+		return compareLastSeenCmp(a, b)
 	}
 	va, vb := getColumnValue(a, colName), getColumnValue(b, colName)
 	if cmp, ok := columnValueCmp[colName]; ok {

--- a/internal/app/tabs_compare.go
+++ b/internal/app/tabs_compare.go
@@ -150,33 +150,37 @@ type valueCmpFunc func(a, b string) int
 // percent/resource columns silently fell through to lexicographic sort
 // (e.g. "100%" < "9%").
 var columnValueCmp = map[string]valueCmpFunc{
-	"CPU":          func(a, b string) int { return compareResourceValuesCmp(a, b, "CPU") },
-	"MEM":          func(a, b string) int { return compareResourceValuesCmp(a, b, "MEM") },
-	"CPU%":         comparePercentCmp,
-	"MEM%":         comparePercentCmp,
-	"CPU/R":        comparePercentCmp,
-	"CPU/L":        comparePercentCmp,
-	"MEM/R":        comparePercentCmp,
-	"MEM/L":        comparePercentCmp,
-	"Ports":        comparePortsCmp,
-	"Progress":     compareReadyCmp, // "N/M" fraction, same shape as Ready ratio
-	"Duration":     compareDurationCmp,
-	"REV":          compareREVCmp,
-	"Cluster IP":   compareIPCmp,
-	"Pod IP":       compareIPCmp,
-	"External IPs": compareIPCmp,
+	"CPU":             func(a, b string) int { return compareResourceValuesCmp(a, b, "CPU") },
+	"MEM":             func(a, b string) int { return compareResourceValuesCmp(a, b, "MEM") },
+	"CPU%":            comparePercentCmp,
+	"MEM%":            comparePercentCmp,
+	"CPU/R":           comparePercentCmp,
+	"CPU/L":           comparePercentCmp,
+	"MEM/R":           comparePercentCmp,
+	"MEM/L":           comparePercentCmp,
+	"Ports":           comparePortsCmp,
+	"Progress":        compareReadyCmp, // "N/M" fraction, same shape as Ready ratio
+	"Duration":        compareDurationCmp,
+	"REV":             compareREVCmp,
+	"Cluster IP":      compareIPCmp,
+	"Last Transition": compareRelativeAgoCmp,
+	"Synced At":       compareRelativeAgoCmp,
+	"Pod IP":          compareIPCmp,
+	"External IPs":    compareIPCmp,
 }
 
-// metricsMissingLastColumns are columns whose cells can render as an "n/a"
-// placeholder — metrics-server data missing (CPU/MEM family) or unknown
-// Uptime. Rows with such a value must sort to the bottom regardless of
-// sort direction (see sortMiddleItems).
+// metricsMissingLastColumns are columns whose cells can render empty or as an
+// "n/a" placeholder — metrics-server data missing (CPU/MEM family), unknown
+// Uptime, a resource with no condition timestamp. Rows with such a value must
+// sort to the bottom regardless of sort direction (see sortMiddleItems).
 var metricsMissingLastColumns = map[string]bool{
 	"CPU": true, "MEM": true,
 	"CPU%": true, "MEM%": true,
 	"CPU/R": true, "CPU/L": true, "MEM/R": true, "MEM/L": true,
-	"Uptime":         true,
-	ChangedColumnKey: true,
+	"Uptime":          true,
+	ChangedColumnKey:  true,
+	"Last Transition": true,
+	"Synced At":       true,
 }
 
 // metricValueMissing reports whether item's value for colName is an "n/a"
@@ -565,6 +569,35 @@ func compareUptimeCmp(a, b string) int {
 	default:
 		return strings.Compare(strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b)))
 	}
+}
+
+// compareRelativeAgoCmp compares formatRelativeTime output ("1138d ago") by
+// real duration. Without it the values sorted lexicographically and "1138d
+// ago" landed above "14d ago". A cell may carry a status word in front
+// ("syncing 5m ago"), so the last field before "ago" is the duration.
+// Unparseable values sort after real ones, mirroring compareUptimeCmp.
+func compareRelativeAgoCmp(a, b string) int {
+	da, okA := parseRelativeAgo(a)
+	db, okB := parseRelativeAgo(b)
+	switch {
+	case okA && okB:
+		return cmpInt64(int64(da), int64(db))
+	case okA:
+		return -1
+	case okB:
+		return 1
+	default:
+		return strings.Compare(strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b)))
+	}
+}
+
+// parseRelativeAgo extracts the duration from a "<n><unit> ago" cell.
+func parseRelativeAgo(v string) (time.Duration, bool) {
+	fields := strings.Fields(strings.TrimSpace(v))
+	if len(fields) < 2 || fields[len(fields)-1] != "ago" {
+		return 0, false
+	}
+	return parseAgeDuration(fields[len(fields)-2])
 }
 
 // compareREVCmp compares REV column values numerically (decimal). Falls back


### PR DESCRIPTION
## Summary

Sorting by `Last Transition` put `1138d ago` above `14d ago`. The cells carry `formatRelativeTime` output, no comparator matched that shape, and the fallback compared the strings, where `"11..." < "14..."`. An audit of every column found four more with the same defect.

- `compareRelativeAgoCmp` parses the duration out of a `"1138d ago"` cell. Registered for `Last Transition` (generic CRDs and Flux) and `Synced At` (Argo, whose cell can read `syncing 5m ago`).
- `Last Scale Time` (HPA), `Next` (CronJob) and `Last Deployed` (Helm) hold `formatAge` output and now use `compareUptimeCmp`, so `9h` sorts before `10d`.
- `Interval` (Flux) holds a Go duration string and now uses `compareDurationCmp`.
- `Last Seen` compares the event timestamp. Only the default Event sort reached that comparator before; picking the column by hand fell through to the rounded cell.
- A cell the sort cannot read now lands at the bottom in both directions, through the same path the `n/a` metrics rows use.

Ruled out and left alone: `Expires`, `Renewal` and `Last Schedule` hold raw RFC3339 with a `Z` offset, and that text sorts chronologically.

## Test plan

- [x] `TestLastTransitionSortsByDurationNotLexically` - the reported case, `1138d` against `14d`
- [x] `TestAgeShapedColumnsSortByDuration` - `10d` against `9h` across the four `formatAge` columns
- [x] `TestLastSeenColumnPrefersTheEventTimestamp` - two events one second apart sharing a `1m` cell
- [x] `TestIntervalSortsByDuration`, `TestSyncedAtSortsThroughItsStatusPrefix`, `TestLastTransitionOrdersEveryUnit`
- [x] Unreadable cells sort last in both directions: `TestLastTransitionKeepsUnparseableCellsLast`, `TestAgeShapedColumnsKeepUnreadableCellsLast`
- [x] `go build ./...`, `go test ./internal/...`, `golangci-lint run ./internal/...` clean

## Known limit

Past 24h a `formatAge` cell is day-grained, so two resources that changed on the same day still fall through to the name tiebreaker. Fixing that needs the raw timestamp on the Item, which is a larger change.