### PR TITLE
docs: restore the Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,3 +506,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, development setup, bui
 ## License
 
 Apache License 2.0, see [LICENSE](LICENSE).
+
+## Star History
+
+<a href="https://star-history.dera.page/#janosmiko/lfk&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=janosmiko/lfk&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=janosmiko/lfk&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=janosmiko/lfk&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
The Star History chart was removed from the README in commit 92a4d83 ("docs: doc-audit fixes and README reshape", PR #630). This restores it in the same place and points it at a working endpoint, since the previous chart is currently broken because of GitHub stargazer API restrictions. The fix is necessary so the project's stargazer history stays visible in the README.