### PR TITLE
fix: redact subprocess output before it reaches logs and the status bar

### DIFF
--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -152,8 +152,8 @@ func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
 		logExecCmd("Running kubectl command", cmd)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			logger.Error("kubectl apply failed", "cmd", cmd.String(), "error", err, "output", string(output))
-			return actionResultMsg{err: fmt.Errorf("kubectl apply: %s", strings.TrimSpace(string(output)))}
+			logger.Error("kubectl apply failed", "cmd", cmd.String(), "error", err, "output", logger.Redact(string(output)))
+			return actionResultMsg{err: fmt.Errorf("kubectl apply: %w", logger.RedactErr(err, output))}
 		}
 		// Templates are rare and may create a Namespace (either directly
 		// via the "Namespace" template or an edited YAML that adds one),

--- a/internal/app/commands_exec.go
+++ b/internal/app/commands_exec.go
@@ -35,10 +35,10 @@ func runInteractiveShellExec(cmd *exec.Cmd, title, sessionLabel string, clearBef
 			logExecCmd("Opening "+sessionLabel+" in "+mxName, wrapped)
 			output, err := wrapped.CombinedOutput()
 			if err != nil {
-				logger.Error(sessionLabel+" multiplexer spawn failed", "error", err, "output", string(output))
+				logger.Error(sessionLabel+" multiplexer spawn failed", "error", err, "output", logger.Redact(string(output)))
 				return actionResultMsg{
-					err: fmt.Errorf("opening %s in new %s %s: %w: %s",
-						sessionLabel, mxName, paneNoun, err, strings.TrimSpace(string(output))),
+					err: fmt.Errorf("opening %s in new %s %s: %w",
+						sessionLabel, mxName, paneNoun, logger.RedactErr(err, output)),
 				}
 			}
 			return actionResultMsg{
@@ -115,10 +115,10 @@ func (m Model) execKubectlDescribe() tea.Cmd {
 		logExecCmd("Running kubectl command", cmd)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			logger.Error("kubectl describe failed", "cmd", cmd.String(), "error", err, "output", string(output))
+			logger.Error("kubectl describe failed", "cmd", cmd.String(), "error", err, "output", logger.Redact(string(output)))
 			return describeLoadedMsg{
 				title: title,
-				err:   fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output))),
+				err:   logger.RedactErr(err, output),
 			}
 		}
 		return describeLoadedMsg{

--- a/internal/app/commands_exec_helm.go
+++ b/internal/app/commands_exec_helm.go
@@ -36,10 +36,9 @@ func runHelmCmdResult(cmd *exec.Cmd, successMsg, failPrefix string) tea.Msg {
 	logExecCmd("Running helm command", cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		// Do not log raw helm output — it can echo Secret values on error. The
-		// captured output still reaches the user via the (ephemeral) status bar.
+		// Do not log raw helm output — it can echo Secret values on error.
 		logger.Error("helm command failed", "cmd", cmd.String(), "error", err)
-		return actionResultMsg{err: fmt.Errorf("%s: %w: %s", failPrefix, err, strings.TrimSpace(string(out)))}
+		return actionResultMsg{err: fmt.Errorf("%s: %w", failPrefix, logger.RedactErr(err, out))}
 	}
 	return actionResultMsg{message: successMsg}
 }
@@ -215,7 +214,7 @@ func (m Model) helmDiff() tea.Cmd {
 			allCmd.Env = env
 			allOut, allErr := allCmd.CombinedOutput()
 			if allErr != nil {
-				return diffLoadedMsg{err: fmt.Errorf("getting all values: %w: %s", allErr, strings.TrimSpace(string(allOut)))}
+				return diffLoadedMsg{err: fmt.Errorf("getting all values: %w", logger.RedactErr(allErr, allOut))}
 			}
 			defaultOut = string(allOut)
 			leftLabel = "All Values (defaults + overrides)"
@@ -227,7 +226,7 @@ func (m Model) helmDiff() tea.Cmd {
 		logExecCmd("Running helm command", userCmd)
 		userOut, userErr := userCmd.CombinedOutput()
 		if userErr != nil {
-			return diffLoadedMsg{err: fmt.Errorf("getting user values: %w: %s", userErr, strings.TrimSpace(string(userOut)))}
+			return diffLoadedMsg{err: fmt.Errorf("getting user values: %w", logger.RedactErr(userErr, userOut))}
 		}
 
 		return diffLoadedMsg{
@@ -354,10 +353,9 @@ func (m Model) rollbackHelmRelease(revision int) tea.Cmd {
 		logExecCmd("Running helm command", cmd)
 		output, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
-			// Don't log raw helm output (may echo Secret values); the user still
-			// sees it via the returned error in the status bar.
+			// Don't log raw helm output (may echo Secret values).
 			logger.Error("helm rollback failed", "cmd", cmd.String(), "error", cmdErr)
-			return helmRollbackDoneMsg{err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output)))}
+			return helmRollbackDoneMsg{err: logger.RedactErr(cmdErr, output)}
 		}
 		return helmRollbackDoneMsg{}
 	})

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -59,7 +59,7 @@ func (m Model) forceDeleteResource() tea.Cmd {
 		logExecCmd("Running kubectl command", cmd)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			logger.Error("kubectl force delete failed", "resource", rt.Resource, "name", name, "namespace", ns, "context", ctx, "error", err)
-			return actionResultMsg{err: fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))}
+			return actionResultMsg{err: logger.RedactErr(err, output)}
 		}
 		return actionResultMsg{message: fmt.Sprintf("Force deleted %s/%s", rt.Resource, name)}
 	})
@@ -93,7 +93,7 @@ func (m Model) removeFinalizers() tea.Cmd {
 		logExecCmd("Running kubectl command", cmd)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			logger.Error("kubectl patch failed", "resource", rt.Resource, "name", name, "namespace", ns, "context", ctx, "error", err)
-			return actionResultMsg{err: fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))}
+			return actionResultMsg{err: logger.RedactErr(err, output)}
 		}
 		return actionResultMsg{message: fmt.Sprintf("Finalizers removed from %s/%s", rt.Resource, name)}
 	})

--- a/internal/app/commands_exec_pod.go
+++ b/internal/app/commands_exec_pod.go
@@ -466,7 +466,7 @@ func (m Model) execKubectlExplain(resource, apiVersion, fieldPath string) tea.Cm
 			logExplainFailure(target, apiVersion, cmdErr)
 			return explainLoadedMsg{
 				gen: gen,
-				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
+				err: logger.RedactErr(cmdErr, output),
 			}
 		}
 
@@ -509,7 +509,7 @@ func (m Model) execKubectlExplainRecursive(resource, apiVersion, query string) t
 			logExplainFailure(resource, apiVersion, cmdErr)
 			return explainRecursiveMsg{
 				gen: gen,
-				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
+				err: logger.RedactErr(cmdErr, output),
 			}
 		}
 
@@ -554,7 +554,7 @@ func (m Model) execKubectlExplainTree(resource, apiVersion, fieldPath string) te
 			logExplainFailure(target, apiVersion, cmdErr)
 			return explainTreeLoadedMsg{
 				gen: gen,
-				err: fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
+				err: logger.RedactErr(cmdErr, output),
 			}
 		}
 
@@ -610,7 +610,7 @@ func (m Model) execKubectlExplainTreeDesc(resource, apiVersion, parentPath strin
 		msg := ident
 		if cmdErr != nil {
 			logExplainFailure(target, apiVersion, cmdErr)
-			msg.err = fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output)))
+			msg.err = logger.RedactErr(cmdErr, output)
 			return msg
 		}
 		_, msg.fields = parseExplainOutput(string(output), parentPath)

--- a/internal/app/commands_load_helm_history.go
+++ b/internal/app/commands_load_helm_history.go
@@ -64,7 +64,7 @@ func fetchHelmHistory(helmPath, name, ns, kubeCtx, kubeconfigPaths string) ([]ui
 		if len(bytes.TrimSpace(detail)) == 0 {
 			detail = output
 		}
-		truncated := truncateHelmOutput(detail)
+		truncated := truncateHelmOutput([]byte(logger.Redact(string(detail))))
 		logger.Error("helm history failed", "cmd", cmd.String(), "error", cmdErr, "output", truncated)
 		return nil, fmt.Errorf("%w: %s", cmdErr, truncated)
 	}

--- a/internal/app/commands_load_preview.go
+++ b/internal/app/commands_load_preview.go
@@ -485,7 +485,7 @@ func (m Model) loadHelmValues(allValues bool) tea.Cmd {
 			logger.Error("helm get values failed", "cmd", cmd.String(), "error", cmdErr, "output", logger.Redact(string(output)))
 			return helmValuesLoadedMsg{
 				title: title,
-				err:   fmt.Errorf("%w: %s", cmdErr, strings.TrimSpace(string(output))),
+				err:   logger.RedactErr(cmdErr, output),
 			}
 		}
 		content := strings.TrimSpace(string(output))

--- a/internal/app/commands_load_test.go
+++ b/internal/app/commands_load_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
@@ -109,6 +111,28 @@ func TestCov80FetchHelmHistoryExecError(t *testing.T) {
 	revs, err := fetchHelmHistory("/bin/false", "my-release", "default", "test-ctx", "")
 	assert.Error(t, err)
 	assert.Nil(t, revs)
+}
+
+// A failing `helm history` can echo a credential (kubeconfig exec plugin,
+// registry auth) on stderr. That text reaches both the log and the caller's
+// error, which setErrorFromErr writes to lfk.log and the status bar.
+func TestCov80FetchHelmHistoryRedactsOutput(t *testing.T) {
+	dir := t.TempDir()
+	helmPath := filepath.Join(dir, "helm")
+	script := "#!/bin/sh\n" +
+		"echo 'Error: could not get Kubernetes client set: token=hunter2-HELMHISTORYMARKER' >&2\n" +
+		"exit 1\n"
+	require.NoError(t, os.WriteFile(helmPath, []byte(script), 0o755))
+
+	buf := captureLogger(t)
+	revs, err := fetchHelmHistory(helmPath, "my-release", "default", "test-ctx", "")
+
+	assert.Nil(t, revs)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "hunter2-HELMHISTORYMARKER", "error must not leak the secret")
+	assert.Contains(t, err.Error(), "[REDACTED]", "error must contain a redaction placeholder")
+	assert.Contains(t, err.Error(), "could not get Kubernetes client set", "error must preserve the non-secret reason")
+	assert.NotContains(t, buf.String(), "hunter2-HELMHISTORYMARKER", "log must not leak the secret")
 }
 
 func TestCov80LoadYAMLNilSel(t *testing.T) {

--- a/internal/app/fielddoc.go
+++ b/internal/app/fielddoc.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"github.com/janosmiko/lfk/internal/logger"
 )
 
 // fieldDocMaxEntries bounds the description cache. One entry is a short string,
@@ -138,6 +140,7 @@ func fieldDocPath(objPath []string) string {
 // exits non-zero, so the raw output plus the exit status fills the pane with
 // noise around a single "error:" line.
 func parseExplainError(output string, cmdErr error) error {
+	output = logger.Redact(output)
 	for line := range strings.SplitSeq(output, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if msg, ok := strings.CutPrefix(trimmed, "error:"); ok {

--- a/internal/app/fielddoc_error_test.go
+++ b/internal/app/fielddoc_error_test.go
@@ -54,6 +54,12 @@ func TestParseExplainError(t *testing.T) {
 			cmdErr: errors.New("exit status 1"),
 			want:   "KIND:       Pod\nVERSION:    v1",
 		},
+		{
+			name:   "error line carrying a credential is redacted",
+			output: `error: could not reach server: token=hunter2-EXPLAINMARKER` + "\n",
+			cmdErr: errors.New("exit status 1"),
+			want:   "could not reach server: token=[REDACTED]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,4 +80,17 @@ func TestParseExplainErrorDropsExitStatus(t *testing.T) {
 
 	assert.NotContains(t, got.Error(), "exit status")
 	assert.NotContains(t, got.Error(), "KIND:")
+}
+
+// An exec credential plugin can print its secret straight into the "error:"
+// line kubectl explain fails with. That line still reaches the pane.
+func TestParseExplainErrorRedactsCredentials(t *testing.T) {
+	got := parseExplainError(
+		"KIND:       Pod\n\nerror: auth failed: token=hunter2-EXPLAINMARKER\n",
+		errors.New("exit status 1"),
+	)
+
+	assert.NotContains(t, got.Error(), "hunter2-EXPLAINMARKER", "must not leak the credential")
+	assert.Contains(t, got.Error(), "[REDACTED]", "must contain a redaction placeholder")
+	assert.Contains(t, got.Error(), "auth failed", "must preserve the non-secret reason")
 }

--- a/internal/k8s/describe_pod.go
+++ b/internal/k8s/describe_pod.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
+
+	"github.com/janosmiko/lfk/internal/logger"
 )
 
 // DescribePod runs `kubectl describe pod <podName> -n <namespace> --context
@@ -28,7 +29,7 @@ func (c *Client) DescribePod(ctx context.Context, contextName, namespace, podNam
 	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+		return "", logger.RedactErr(err, output)
 	}
 	return string(output), nil
 }

--- a/internal/logger/redact.go
+++ b/internal/logger/redact.go
@@ -1,6 +1,10 @@
 package logger
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
 
 // redactPatterns is a curated set of regexes for likely-sensitive content.
 // It targets content that may end up in stderr from auth helpers, exec
@@ -41,4 +45,10 @@ func Redact(s string) string {
 		s = p.re.ReplaceAllString(s, p.repl)
 	}
 	return s
+}
+
+// RedactErr wraps err with output, redacted - subprocess output (e.g. helm
+// values) can carry secrets and this error reaches the log file and status bar.
+func RedactErr(err error, output []byte) error {
+	return fmt.Errorf("%w: %s", err, Redact(strings.TrimSpace(string(output))))
 }

--- a/internal/logger/redact.go
+++ b/internal/logger/redact.go
@@ -25,12 +25,14 @@ var redactPatterns = []struct {
 	// GitHub tokens (PAT, OAuth, server, user).
 	{regexp.MustCompile(`gh[opsu]_[A-Za-z0-9]{36,}`), "[REDACTED-GH-TOKEN]"},
 	// URLs with embedded credentials: keep scheme/host but redact the user:pass.
-	{regexp.MustCompile(`((?:https?|git|ssh)://)[^:@\s/]+:[^@\s/]+@`), "${1}[REDACTED-CREDS]@"},
+	// Any URI scheme (postgres, mysql, mongodb, redis, amqp, ...), not just
+	// the well-known ones - connection strings carry these just as often.
+	{regexp.MustCompile(`([A-Za-z][A-Za-z0-9+.-]*://)[^:@\s/]+:[^@\s/]+@`), "${1}[REDACTED-CREDS]@"},
 	// Bearer tokens in Authorization headers.
 	{regexp.MustCompile(`(?i)(Bearer\s+)[A-Za-z0-9._-]{20,}`), "${1}[REDACTED-BEARER]"},
 	// Generic key=value pairs for password/token/secret/api_key/etc.
 	// Keep the key visible (useful for diagnosis), redact only the value.
-	{regexp.MustCompile(`(?i)((?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret)\s*[=:]\s*)[^\s&"',;]+`), "${1}[REDACTED]"},
+	{regexp.MustCompile(`(?i)((?:password|passwd|pwd|db[_-]?pass(?:word)?|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|dsn|database[_-]?url|connection[_-]?string)\s*[=:]\s*)[^\s&"',;]+`), "${1}[REDACTED]"},
 	// kubectl --from-literal=KEY=VALUE — keep KEY, redact VALUE.
 	{regexp.MustCompile(`(--from-literal=[^=\s]+=)[^\s"']+`), "${1}[REDACTED]"},
 }

--- a/internal/logger/redact.go
+++ b/internal/logger/redact.go
@@ -30,12 +30,10 @@ var redactPatterns = []struct {
 	{regexp.MustCompile(`([A-Za-z][A-Za-z0-9+.-]*://)[^:@\s/]*:[^@\s/]+@`), "${1}[REDACTED-CREDS]@"},
 	// Bearer tokens in Authorization headers.
 	{regexp.MustCompile(`(?i)(Bearer\s+)[A-Za-z0-9._-]{20,}`), "${1}[REDACTED-BEARER]"},
-	// Generic key=value pairs for password/token/secret/api_key/etc.
-	// Keep the key visible (useful for diagnosis), redact only the value.
-	// Go's regexp (RE2) has no lookbehind, so the char before the keyword is
-	// captured and replayed rather than asserted away. Excluding "/" as well
-	// as \w keeps path segments like /etc/passwd from reading as a key.
-	{regexp.MustCompile(`(?i)(^|[^\w/])((?:password|passwd|pwd|db[_-]?pass(?:word)?|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|dsn|database[_-]?url|connection[_-]?string)\s*[=:]\s*)[^\s&"',;]+`), "${1}${2}[REDACTED]"},
+	// Matches env-style identifiers ending in the keyword too (MYSQL_PASSWORD).
+	// RE2 has no lookbehind, so the boundary char is captured and replayed.
+	// Excluding "/" there keeps /etc/passwd from reading as a key.
+	{regexp.MustCompile(`(?i)(^|[^\w/])([A-Za-z0-9_-]*(?:password|passwd|pwd|db[_-]?pass(?:word)?|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|dsn|database[_-]?url|connection[_-]?string)\s*[=:]\s*)[^\s&"',;]+`), "${1}${2}[REDACTED]"},
 	// kubectl --from-literal=KEY=VALUE — keep KEY, redact VALUE.
 	{regexp.MustCompile(`(--from-literal=[^=\s]+=)[^\s"']+`), "${1}[REDACTED]"},
 }

--- a/internal/logger/redact.go
+++ b/internal/logger/redact.go
@@ -27,12 +27,15 @@ var redactPatterns = []struct {
 	// URLs with embedded credentials: keep scheme/host but redact the user:pass.
 	// Any URI scheme (postgres, mysql, mongodb, redis, amqp, ...), not just
 	// the well-known ones - connection strings carry these just as often.
-	{regexp.MustCompile(`([A-Za-z][A-Za-z0-9+.-]*://)[^:@\s/]+:[^@\s/]+@`), "${1}[REDACTED-CREDS]@"},
+	{regexp.MustCompile(`([A-Za-z][A-Za-z0-9+.-]*://)[^:@\s/]*:[^@\s/]+@`), "${1}[REDACTED-CREDS]@"},
 	// Bearer tokens in Authorization headers.
 	{regexp.MustCompile(`(?i)(Bearer\s+)[A-Za-z0-9._-]{20,}`), "${1}[REDACTED-BEARER]"},
 	// Generic key=value pairs for password/token/secret/api_key/etc.
 	// Keep the key visible (useful for diagnosis), redact only the value.
-	{regexp.MustCompile(`(?i)((?:password|passwd|pwd|db[_-]?pass(?:word)?|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|dsn|database[_-]?url|connection[_-]?string)\s*[=:]\s*)[^\s&"',;]+`), "${1}[REDACTED]"},
+	// Go's regexp (RE2) has no lookbehind, so the char before the keyword is
+	// captured and replayed rather than asserted away. Excluding "/" as well
+	// as \w keeps path segments like /etc/passwd from reading as a key.
+	{regexp.MustCompile(`(?i)(^|[^\w/])((?:password|passwd|pwd|db[_-]?pass(?:word)?|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|dsn|database[_-]?url|connection[_-]?string)\s*[=:]\s*)[^\s&"',;]+`), "${1}${2}[REDACTED]"},
 	// kubectl --from-literal=KEY=VALUE — keep KEY, redact VALUE.
 	{regexp.MustCompile(`(--from-literal=[^=\s]+=)[^\s"']+`), "${1}[REDACTED]"},
 }

--- a/internal/logger/redact_test.go
+++ b/internal/logger/redact_test.go
@@ -1,9 +1,11 @@
 package logger
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRedact(t *testing.T) {
@@ -110,6 +112,20 @@ func TestRedact(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRedactErr(t *testing.T) {
+	baseErr := errors.New("exit status 1")
+	output := []byte("Error: UPGRADE FAILED: could not connect, password: hunter2-MARKER host=db.example.com")
+
+	got := RedactErr(baseErr, output)
+
+	require.Error(t, got)
+	assert.NotContains(t, got.Error(), "hunter2-MARKER", "redacted error must NOT leak the secret")
+	assert.Contains(t, got.Error(), "[REDACTED]", "redacted error must contain a redaction placeholder")
+	assert.Contains(t, got.Error(), "exit status 1", "redacted error must preserve the underlying error reason")
+	assert.Contains(t, got.Error(), "could not connect", "redacted error must preserve the non-secret output")
+	assert.ErrorIs(t, got, baseErr, "redacted error must still wrap the original error for errors.Is")
 }
 
 func TestRedactIsIdempotent(t *testing.T) {

--- a/internal/logger/redact_test.go
+++ b/internal/logger/redact_test.go
@@ -82,6 +82,42 @@ func TestRedact(t *testing.T) {
 			wantNotContains: []string{"topsecretvalue", "alsosecret"},
 		},
 		{
+			name:            "postgres URL with embedded credentials",
+			input:           "dial tcp: could not connect to postgres://dbuser:hunter2-PGMARKER@db.internal:5432/app: connection refused",
+			wantContains:    []string{"postgres://[REDACTED-CREDS]@db.internal:5432/app", "connection refused"},
+			wantNotContains: []string{"dbuser:hunter2-PGMARKER", "hunter2-PGMARKER@"},
+		},
+		{
+			name:            "mongodb URL with embedded credentials",
+			input:           "mongodb://root:s3cret-MONGOMARKER@cluster0.example.net/admin timed out",
+			wantContains:    []string{"mongodb://[REDACTED-CREDS]@cluster0.example.net/admin", "timed out"},
+			wantNotContains: []string{"root:s3cret-MONGOMARKER"},
+		},
+		{
+			name:            "DB_PASS kv inline",
+			input:           "connect: DB_PASS=hunter2-DBPASSMARKER host=db.example.com",
+			wantContains:    []string{"DB_PASS=[REDACTED]", "host=db.example.com"},
+			wantNotContains: []string{"hunter2-DBPASSMARKER"},
+		},
+		{
+			name:            "DATABASE_URL kv inline",
+			input:           "config error: DATABASE_URL=postgres://u:hunter2-DATABASEURLMARKER@db/app is invalid",
+			wantContains:    []string{"DATABASE_URL=[REDACTED]", "is invalid"},
+			wantNotContains: []string{"hunter2-DATABASEURLMARKER"},
+		},
+		{
+			name:            "connectionString kv inline",
+			input:           "startup failed: connectionString=hunter2-CONNSTRMARKER retrying",
+			wantContains:    []string{"connectionString=[REDACTED]", "retrying"},
+			wantNotContains: []string{"hunter2-CONNSTRMARKER"},
+		},
+		{
+			name:            "dsn kv inline",
+			input:           "sqlx: dsn=hunter2-DSNMARKER open failed",
+			wantContains:    []string{"dsn=[REDACTED]", "open failed"},
+			wantNotContains: []string{"hunter2-DSNMARKER"},
+		},
+		{
 			name:            "no secrets passes through unchanged",
 			input:           "kubectl get pods -n default --context prod",
 			wantContains:    []string{"kubectl get pods -n default --context prod"},

--- a/internal/logger/redact_test.go
+++ b/internal/logger/redact_test.go
@@ -118,6 +118,42 @@ func TestRedact(t *testing.T) {
 			wantNotContains: []string{"hunter2-DSNMARKER"},
 		},
 		{
+			name:            "MYSQL_PASSWORD env-style key",
+			input:           "startup: MYSQL_PASSWORD=hunter2marker refused",
+			wantContains:    []string{"MYSQL_PASSWORD=[REDACTED]", "refused"},
+			wantNotContains: []string{"hunter2marker"},
+		},
+		{
+			name:            "POSTGRES_PASSWORD env-style key with colon",
+			input:           "config: POSTGRES_PASSWORD: hunter2marker invalid",
+			wantContains:    []string{"POSTGRES_PASSWORD: [REDACTED]", "invalid"},
+			wantNotContains: []string{"hunter2marker"},
+		},
+		{
+			name:            "ADMIN_TOKEN env-style key",
+			input:           "auth: ADMIN_TOKEN=hunter2marker expired",
+			wantContains:    []string{"ADMIN_TOKEN=[REDACTED]", "expired"},
+			wantNotContains: []string{"hunter2marker"},
+		},
+		{
+			name:            "AWS_SECRET_ACCESS_KEY env-style key",
+			input:           "creds: AWS_SECRET_ACCESS_KEY=hunter2marker denied",
+			wantContains:    []string{"AWS_SECRET_ACCESS_KEY=[REDACTED]", "denied"},
+			wantNotContains: []string{"hunter2marker"},
+		},
+		{
+			name:            "MY_API_KEY env-style key",
+			input:           "request: MY_API_KEY=hunter2marker rejected",
+			wantContains:    []string{"MY_API_KEY=[REDACTED]", "rejected"},
+			wantNotContains: []string{"hunter2marker"},
+		},
+		{
+			name:            "user_password lowercase env-style key",
+			input:           "login: user_password=hunter2marker failed",
+			wantContains:    []string{"user_password=[REDACTED]", "failed"},
+			wantNotContains: []string{"hunter2marker"},
+		},
+		{
 			name:            "password as a path component is not mangled",
 			input:           "cat /etc/passwd: permission denied",
 			wantContains:    []string{"cat /etc/passwd: permission denied"},

--- a/internal/logger/redact_test.go
+++ b/internal/logger/redact_test.go
@@ -118,6 +118,24 @@ func TestRedact(t *testing.T) {
 			wantNotContains: []string{"hunter2-DSNMARKER"},
 		},
 		{
+			name:            "password as a path component is not mangled",
+			input:           "cat /etc/passwd: permission denied",
+			wantContains:    []string{"cat /etc/passwd: permission denied"},
+			wantNotContains: []string{"[REDACTED"},
+		},
+		{
+			name:            "redis URL with password only (no username)",
+			input:           "redis://:hunter2SECRET@host:6379/0 connection refused",
+			wantContains:    []string{"redis://[REDACTED-CREDS]@host:6379/0", "connection refused"},
+			wantNotContains: []string{"hunter2SECRET"},
+		},
+		{
+			name:            "redis URL with no credentials passes through unchanged",
+			input:           "connecting to redis://host:6379/0",
+			wantContains:    []string{"connecting to redis://host:6379/0"},
+			wantNotContains: []string{"[REDACTED"},
+		},
+		{
 			name:            "no secrets passes through unchanged",
 			input:           "kubectl get pods -n default --context prod",
 			wantContains:    []string{"kubectl get pods -n default --context prod"},


### PR DESCRIPTION
## Summary

- A failing `helm get values` or `helm diff` returned the raw command output inside the error, so chart secrets landed in plaintext in the log file and the status bar. The code already redacted the sibling `logger.Error` call, the error path slipped past it.
- Adds `logger.RedactErr` and routes every subprocess-output site through it: helm values/diff/rollback/history, kubectl apply/exec/describe/explain, and the multiplexer spawn path.
- Broadens the redaction patterns: credential URLs of any scheme including password-only forms (`redis://:pass@host`), and key names like `DB_PASS`, `dsn`, `DATABASE_URL`, `connectionString`. A word-boundary anchor keeps ordinary text such as `cat /etc/passwd: permission denied` unmangled.

## Test plan

- [x] New unit tests, each proven red before the fix: secret marker gone, `[REDACTED]` present, non-secret error reason survives, `errors.Is` chain intact
- [x] Negative cases: `/etc/passwd` path text and credential-free URLs pass through unchanged
- [x] `go build`, `go vet`, `golangci-lint run`, full `go test ./...` (26 packages) green
- [ ] Manual: trigger a failing helm values view against a release with secret-bearing values, check the TUI error, status bar, and log file