### PR TITLE
fix: bound local-cluster detection and make template apply cancellable

### DIFF
--- a/internal/app/commands_apply.go
+++ b/internal/app/commands_apply.go
@@ -140,6 +140,11 @@ func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
 		}
 	}
 
+	applyCtx := m.reqCtx
+	if applyCtx == nil {
+		applyCtx = context.Background()
+	}
+
 	return func() tea.Msg {
 		defer func() { _ = os.Remove(tmpFile) }()
 
@@ -147,7 +152,7 @@ func (m Model) applyTemplateFile(tmpFile, ctx, ns string) tea.Cmd {
 		if ns != "" {
 			args = append(args, "-n", ns)
 		}
-		cmd := exec.Command(kubectlPath, k8s.DemoKubectlArgs(args)...)
+		cmd := exec.CommandContext(applyCtx, kubectlPath, k8s.DemoKubectlArgs(args)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+m.client.KubeconfigPathForContext(ctx))
 		logExecCmd("Running kubectl command", cmd)
 		output, err := cmd.CombinedOutput()

--- a/internal/app/commands_localcluster.go
+++ b/internal/app/commands_localcluster.go
@@ -11,12 +11,17 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/k8s/localcluster"
 )
+
+// localClusterListTimeout bounds each provider's List call so a wedged
+// CLI can't hold up wg.Wait() forever.
+const localClusterListTimeout = 20 * time.Second
 
 // createLocalClusterCmd is the bare cmd factory: dispatches Provider.Create
 // and emits localClusterCreatedMsg with the result. ctx must be the
@@ -69,6 +74,13 @@ func deleteLocalClusterCmd(ctx context.Context, gen uint64, p localcluster.Provi
 // is echoed back on the message so the handler can drop stale results
 // from a previous open / refresh.
 func detectLocalClustersCmd(gen uint64, provs []localcluster.Provider) tea.Cmd {
+	return detectLocalClustersCmdWithTimeout(gen, provs, localClusterListTimeout)
+}
+
+// detectLocalClustersCmdWithTimeout is detectLocalClustersCmd with the
+// per-provider List timeout as a parameter, so tests can shrink it instead
+// of waiting out the production bound.
+func detectLocalClustersCmdWithTimeout(gen uint64, provs []localcluster.Provider, timeout time.Duration) tea.Cmd {
 	return func() tea.Msg {
 		var (
 			mu       sync.Mutex
@@ -83,7 +95,9 @@ func detectLocalClustersCmd(gen uint64, provs []localcluster.Provider) tea.Cmd {
 			wg.Add(1)
 			go func(p localcluster.Provider) {
 				defer wg.Done()
-				cs, err := p.List(context.Background())
+				cctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+				cs, err := p.List(cctx)
 				mu.Lock()
 				defer mu.Unlock()
 				if err != nil {

--- a/internal/app/commands_localcluster_test.go
+++ b/internal/app/commands_localcluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -58,6 +59,35 @@ func TestDetectLocalClustersCmd_AggregatesProviders(t *testing.T) {
 	}
 	if msg.providerErrors["k3d"] == "" {
 		t.Fatalf("expected k3d error captured, got %v", msg.providerErrors)
+	}
+}
+
+// A stuck docker daemon must not block wg.Wait() forever. The done-channel
+// select keeps a red run fast instead of wedging the suite.
+func TestDetectLocalClustersCmd_BoundedByPerProviderTimeout(t *testing.T) {
+	stuck := fakeProvider{
+		name: "stuck", installed: true,
+		listFn: func(ctx context.Context) ([]localcluster.Cluster, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	cmd := detectLocalClustersCmdWithTimeout(1, []localcluster.Provider{stuck}, 50*time.Millisecond)
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+
+	select {
+	case msg := <-done:
+		got, ok := msg.(localClustersDetectedMsg)
+		if !ok {
+			t.Fatalf("expected localClustersDetectedMsg, got %T", msg)
+		}
+		if got.providerErrors["stuck"] == "" {
+			t.Fatalf("expected stuck provider's timeout error recorded, got %v", got.providerErrors)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("detectLocalClustersCmd did not return within the per-provider timeout: List(context.Background()) blocks forever")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Local-cluster detection called every provider's List with a bare background context, so one hung docker daemon blocked the overlay forever. Each call now gets a 20s timeout, matching the cancellable pattern its sibling dispatch already used.
- Applying an exported template built exec.Command without a context while the demo path threaded the request context. The real path now uses exec.CommandContext, so the app's cancel works mid-apply.

## Test plan

- [x] New test: a provider whose List blocks forever no longer wedges detection (proven red before the fix)
- [x] Full suite, vet, lint green
- [ ] Manual: open the local-cluster manager with docker hung, expect the overlay to finish within ~20s; cancel a template apply mid-run, expect a clean stop