### PR TITLE
fix: cancel superseded update listeners in the port-forward and capture managers

### DIFF
--- a/internal/app/commands_capture.go
+++ b/internal/app/commands_capture.go
@@ -85,23 +85,19 @@ type kubesharkLaunchedMsg struct {
 // pattern.
 type captureUpdateMsg struct{}
 
-// waitForCaptureUpdate registers a manager-level update callback and returns a
-// tea.Cmd that blocks until the next state change. The handler is responsible
-// for re-arming via another waitForCaptureUpdate() — same pattern as
+// waitForCaptureUpdate blocks until the next capture state change. The handler
+// must re-arm it with another waitForCaptureUpdate(), same as
 // waitForPortForwardUpdate.
 func (m Model) waitForCaptureUpdate() tea.Cmd {
 	if m.captureMgr == nil {
 		return nil
 	}
 	ch := make(chan struct{}, 1)
-	m.captureMgr.SetUpdateCallback(func() {
-		select {
-		case ch <- struct{}{}:
-		default:
-		}
-	})
+	superseded := m.captureMgr.SetUpdateListener(ch)
 	return func() tea.Msg {
-		<-ch
+		if !waitForUpdateSignal(ch, nil, superseded) {
+			return nil
+		}
 		return captureUpdateMsg{}
 	}
 }

--- a/internal/app/commands_capture_test.go
+++ b/internal/app/commands_capture_test.go
@@ -68,7 +68,7 @@ func TestLaunchKubeshark_ReturnsTeaCmd(t *testing.T) {
 	// Don't call cmd() — would try to actually port-forward + open browser.
 }
 
-func TestWaitForCaptureUpdate_DispatchesMsgWhenCallbackFires(t *testing.T) {
+func TestWaitForCaptureUpdate_StaysBlockedWithoutAStateChange(t *testing.T) {
 	m := baseFinalModel()
 	m.captureMgr = k8s.NewCaptureManager()
 
@@ -80,34 +80,50 @@ func TestWaitForCaptureUpdate_DispatchesMsgWhenCallbackFires(t *testing.T) {
 	got := make(chan tea.Msg, 1)
 	go func() { got <- cmd() }()
 
-	// Drain any installed callback by triggering a state transition. Since the
-	// callback is wired into the manager, calling it directly via the
-	// manager's own callback hook is the cleanest path: re-register a
-	// shim that forwards into the wait channel and then invoke the
-	// registered callback by triggering Stop on a non-existent ID — no.
-	// The manager's onUpdate is fired only on real lifecycle events.
-	//
-	// Instead exercise the wiring by re-installing a callback that writes
-	// to a separate channel, confirming SetUpdateCallback overwrites work.
-	fired := make(chan struct{}, 1)
-	m.captureMgr.SetUpdateCallback(func() { fired <- struct{}{} })
-
-	// Manually fire the latest callback through a real state mutation.
-	// StopAll fires onUpdate when at least one entry transitions. The
-	// manager has no entries here, so we assert no spurious fire instead.
+	// StopAll has no entry to transition, so nothing should be reported.
 	m.captureMgr.StopAll()
 
 	select {
-	case <-fired:
-		t.Error("StopAll fired update callback on empty manager")
+	case msg := <-got:
+		t.Errorf("waitForCaptureUpdate returned spurious msg: %T", msg)
 	case <-time.After(20 * time.Millisecond):
 	}
 
-	// The original cmd is still blocked on the prior callback channel; it
-	// must not have fired spuriously either.
+	// Release the waiter so it does not outlive the test.
+	m.captureMgr.SetUpdateListener(make(chan struct{}, 1))
 	select {
 	case msg := <-got:
-		t.Errorf("waitForCaptureUpdate returned spurious msg: %T", msg)
-	case <-time.After(10 * time.Millisecond):
+		if msg != nil {
+			t.Errorf("superseded waiter reported an update it never received: %T", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("superseded waitForCaptureUpdate listener did not exit")
+	}
+}
+
+// SetUpdateListener keeps only one slot, so an older listener must be
+// released rather than blocking forever once a newer one is armed.
+func TestWaitForCaptureUpdate_SupersededListenerExits(t *testing.T) {
+	m := baseFinalModel()
+	m.captureMgr = k8s.NewCaptureManager()
+
+	firstCmd := m.waitForCaptureUpdate()
+	if firstCmd == nil {
+		t.Fatal("waitForCaptureUpdate returned nil cmd")
+	}
+	firstDone := make(chan tea.Msg, 1)
+	go func() { firstDone <- firstCmd() }()
+
+	// Give the first goroutine time to reach its select before it is superseded.
+	time.Sleep(20 * time.Millisecond)
+
+	if second := m.waitForCaptureUpdate(); second == nil {
+		t.Fatal("waitForCaptureUpdate returned nil cmd on re-arm")
+	}
+
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("superseded waitForCaptureUpdate listener did not exit when a new listener was armed")
 	}
 }

--- a/internal/app/commands_portforward.go
+++ b/internal/app/commands_portforward.go
@@ -115,10 +115,10 @@ func (m Model) waitForPortForwardUpdate() tea.Cmd {
 	superseded := mgr.SetUpdateListener(ch)
 	return func() tea.Msg {
 		var deadlineC <-chan time.Time
-		if d, ok := mgr.ArmEvictionRefresh(); ok {
+		if d, arm, ok := mgr.ArmEvictionRefresh(); ok {
 			timer := time.NewTimer(d)
 			defer timer.Stop()
-			defer mgr.DisarmEvictionRefresh()
+			defer mgr.DisarmEvictionRefresh(arm)
 			deadlineC = timer.C
 		}
 		return waitForPortForwardSignal(ch, deadlineC, superseded)

--- a/internal/app/commands_portforward.go
+++ b/internal/app/commands_portforward.go
@@ -128,17 +128,8 @@ func (m Model) waitForPortForwardUpdate() tea.Cmd {
 // waitForPortForwardSignal blocks until an update, the eviction deadline, or
 // supersession, whichever is first.
 func waitForPortForwardSignal(ch chan struct{}, deadlineC <-chan time.Time, superseded <-chan struct{}) tea.Msg {
-	select {
-	case <-ch:
-	case <-deadlineC:
-	case <-superseded:
-		// select can pick superseded over a racing write to ch. Drain once
-		// more so that pending update is not dropped.
-		select {
-		case <-ch:
-		default:
-			return nil
-		}
+	if !waitForUpdateSignal(ch, deadlineC, superseded) {
+		return nil
 	}
 	return portForwardUpdateMsg{}
 }

--- a/internal/app/commands_portforward.go
+++ b/internal/app/commands_portforward.go
@@ -112,12 +112,7 @@ func (m Model) restartPortForward(id int) tea.Cmd {
 func (m Model) waitForPortForwardUpdate() tea.Cmd {
 	ch := make(chan struct{}, 1)
 	mgr := m.portForwardMgr
-	superseded := mgr.SetUpdateCallback(func() {
-		select {
-		case ch <- struct{}{}:
-		default:
-		}
-	})
+	superseded := mgr.SetUpdateListener(ch)
 	return func() tea.Msg {
 		var deadlineC <-chan time.Time
 		if d, ok := mgr.ArmEvictionRefresh(); ok {

--- a/internal/app/commands_portforward.go
+++ b/internal/app/commands_portforward.go
@@ -126,12 +126,24 @@ func (m Model) waitForPortForwardUpdate() tea.Cmd {
 			defer mgr.DisarmEvictionRefresh()
 			deadlineC = timer.C
 		}
+		return waitForPortForwardSignal(ch, deadlineC, superseded)
+	}
+}
+
+// waitForPortForwardSignal blocks until an update, the eviction deadline, or
+// supersession, whichever is first.
+func waitForPortForwardSignal(ch chan struct{}, deadlineC <-chan time.Time, superseded <-chan struct{}) tea.Msg {
+	select {
+	case <-ch:
+	case <-deadlineC:
+	case <-superseded:
+		// select can pick superseded over a racing write to ch. Drain once
+		// more so that pending update is not dropped.
 		select {
 		case <-ch:
-		case <-deadlineC:
-		case <-superseded:
+		default:
 			return nil
 		}
-		return portForwardUpdateMsg{}
 	}
+	return portForwardUpdateMsg{}
 }

--- a/internal/app/commands_portforward.go
+++ b/internal/app/commands_portforward.go
@@ -112,7 +112,7 @@ func (m Model) restartPortForward(id int) tea.Cmd {
 func (m Model) waitForPortForwardUpdate() tea.Cmd {
 	ch := make(chan struct{}, 1)
 	mgr := m.portForwardMgr
-	mgr.SetUpdateCallback(func() {
+	superseded := mgr.SetUpdateCallback(func() {
 		select {
 		case ch <- struct{}{}:
 		default:
@@ -129,6 +129,8 @@ func (m Model) waitForPortForwardUpdate() tea.Cmd {
 		select {
 		case <-ch:
 		case <-deadlineC:
+		case <-superseded:
+			return nil
 		}
 		return portForwardUpdateMsg{}
 	}

--- a/internal/app/commands_portforward_test.go
+++ b/internal/app/commands_portforward_test.go
@@ -73,8 +73,8 @@ func TestRestartLocalPort(t *testing.T) {
 }
 
 // A terminal port-forward, once shown, must be evicted after its grace
-// period even if the manager never fires another update callback.
-func TestWaitForPortForwardUpdate_FiresOnEvictionDeadlineWithoutCallback(t *testing.T) {
+// period even if the manager never reports another update.
+func TestWaitForPortForwardUpdate_FiresOnEvictionDeadlineWithoutAnUpdate(t *testing.T) {
 	m := basePush80Model()
 	current := time.Now()
 	mgr := k8s.NewPortForwardManagerWithClock(func() time.Time { return current })
@@ -91,7 +91,7 @@ func TestWaitForPortForwardUpdate_FiresOnEvictionDeadlineWithoutCallback(t *test
 	case msg := <-done:
 		assert.IsType(t, portForwardUpdateMsg{}, msg)
 	case <-time.After(2 * time.Second):
-		t.Fatal("waitForPortForwardUpdate did not fire on the eviction deadline without a manager callback")
+		t.Fatal("waitForPortForwardUpdate did not fire on the eviction deadline without a manager update")
 	}
 }
 

--- a/internal/app/commands_portforward_test.go
+++ b/internal/app/commands_portforward_test.go
@@ -95,6 +95,24 @@ func TestWaitForPortForwardUpdate_FiresOnEvictionDeadlineWithoutCallback(t *test
 	}
 }
 
+// select picks pseudo-randomly among ready cases, so with ch and superseded
+// both ready every call, a version that returns nil on superseded drops the
+// pending update about half the time. 4000 iterations makes that certain.
+func TestWaitForPortForwardSignal_SupersededDoesNotDropPendingUpdate(t *testing.T) {
+	superseded := make(chan struct{})
+	close(superseded)
+
+	for i := range 4000 {
+		ch := make(chan struct{}, 1)
+		ch <- struct{}{}
+
+		msg := waitForPortForwardSignal(ch, nil, superseded)
+
+		require.NotNilf(t, msg, "iteration %d: pending update on ch was lost when superseded also fired", i)
+		assert.IsType(t, portForwardUpdateMsg{}, msg)
+	}
+}
+
 // SetUpdateCallback keeps only one slot, so an older listener must be
 // released rather than blocking forever once a newer one is armed.
 func TestWaitForPortForwardUpdate_SupersededListenerExits(t *testing.T) {

--- a/internal/app/commands_portforward_test.go
+++ b/internal/app/commands_portforward_test.go
@@ -94,3 +94,28 @@ func TestWaitForPortForwardUpdate_FiresOnEvictionDeadlineWithoutCallback(t *test
 		t.Fatal("waitForPortForwardUpdate did not fire on the eviction deadline without a manager callback")
 	}
 }
+
+// SetUpdateCallback keeps only one slot, so an older listener must be
+// released rather than blocking forever once a newer one is armed.
+func TestWaitForPortForwardUpdate_SupersededListenerExits(t *testing.T) {
+	m := basePush80Model()
+	m.portForwardMgr = k8s.NewPortForwardManager()
+
+	firstCmd := m.waitForPortForwardUpdate()
+	require.NotNil(t, firstCmd)
+
+	firstDone := make(chan tea.Msg, 1)
+	go func() { firstDone <- firstCmd() }()
+
+	// Give the first goroutine time to reach its select before it is superseded.
+	time.Sleep(20 * time.Millisecond)
+
+	secondCmd := m.waitForPortForwardUpdate()
+	require.NotNil(t, secondCmd)
+
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("superseded waitForPortForwardUpdate listener did not exit when a new listener was armed")
+	}
+}

--- a/internal/app/commands_portforward_test.go
+++ b/internal/app/commands_portforward_test.go
@@ -113,7 +113,7 @@ func TestWaitForPortForwardSignal_SupersededDoesNotDropPendingUpdate(t *testing.
 	}
 }
 
-// SetUpdateCallback keeps only one slot, so an older listener must be
+// SetUpdateListener keeps only one slot, so an older listener must be
 // released rather than blocking forever once a newer one is armed.
 func TestWaitForPortForwardUpdate_SupersededListenerExits(t *testing.T) {
 	m := basePush80Model()

--- a/internal/app/commands_portforward_test.go
+++ b/internal/app/commands_portforward_test.go
@@ -113,6 +113,43 @@ func TestWaitForPortForwardSignal_SupersededDoesNotDropPendingUpdate(t *testing.
 	}
 }
 
+// A superseded waiter tears down after its replacement took over, so its
+// teardown must leave the replacement's eviction deadline alone. Otherwise
+// the terminal entry never gets the render that evicts it.
+func TestWaitForPortForwardUpdate_SupersededTeardownKeepsTheEvictionDeadline(t *testing.T) {
+	m := basePush80Model()
+	current := time.Now()
+	mgr := k8s.NewPortForwardManagerWithClock(func() time.Time { return current })
+	mgr.SeedTerminalEntryForTest(1, current.Add(-2750*time.Millisecond))
+	m.portForwardMgr = mgr
+
+	older := m.waitForPortForwardUpdate()
+	require.NotNil(t, older)
+	olderDone := make(chan tea.Msg, 1)
+	go func() { olderDone <- older() }()
+
+	// Give the older waiter time to arm the deadline before it is superseded.
+	time.Sleep(30 * time.Millisecond)
+
+	newer := m.waitForPortForwardUpdate()
+	require.NotNil(t, newer)
+	newerDone := make(chan tea.Msg, 1)
+	go func() { newerDone <- newer() }()
+
+	select {
+	case <-olderDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the superseded waitForPortForwardUpdate waiter did not exit")
+	}
+
+	select {
+	case msg := <-newerDone:
+		assert.IsType(t, portForwardUpdateMsg{}, msg)
+	case <-time.After(3 * time.Second):
+		t.Fatal("the newer waiter never fired: the superseded waiter's teardown took the eviction deadline with it")
+	}
+}
+
 // SetUpdateListener keeps only one slot, so an older listener must be
 // released rather than blocking forever once a newer one is armed.
 func TestWaitForPortForwardUpdate_SupersededListenerExits(t *testing.T) {

--- a/internal/app/commands_update_wait.go
+++ b/internal/app/commands_update_wait.go
@@ -1,0 +1,22 @@
+package app
+
+import "time"
+
+// waitForUpdateSignal blocks until the manager reports a change on ch, the
+// optional deadline fires, or a newer listener supersedes this one. It reports
+// false only when the caller was superseded with no update pending.
+func waitForUpdateSignal(ch <-chan struct{}, deadlineC <-chan time.Time, superseded <-chan struct{}) bool {
+	select {
+	case <-ch:
+	case <-deadlineC:
+	case <-superseded:
+		// select can pick superseded over a racing write to ch. Drain once
+		// more so that pending update is not dropped.
+		select {
+		case <-ch:
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/paths"
 )
 
@@ -348,7 +349,9 @@ func classifyCaptureExit(backend CaptureBackend, runErr, waitErr error, stderrTx
 		// to limit incidental leakage of kubeconfig paths or API server URLs
 		// that kubectl errors sometimes embed. The user can re-run with
 		// kubectl directly to see the full message.
-		txt := stderrTxt
+		// Redact before the trim: trimming a secret first leaves a tail no
+		// pattern matches any more.
+		txt := logger.Redact(stderrTxt)
 		if len(txt) > captureLastErrorMaxLen {
 			txt = "…" + txt[len(txt)-captureLastErrorMaxLen:]
 		}

--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -58,18 +58,20 @@ type CaptureEntry struct {
 	OutputPath  string
 	LastError   string
 
-	cmd      *exec.Cmd
-	cancel   context.CancelFunc
-	decoder  *packetDecoder
-	onUpdate func()
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+	decoder *packetDecoder
 }
 
 // CaptureManager tracks running captures across the lfk session.
 type CaptureManager struct {
-	mu       sync.Mutex
-	entries  []*CaptureEntry
-	nextID   int
-	onUpdate func()
+	mu      sync.Mutex
+	entries []*CaptureEntry
+	nextID  int
+	// listener carries one token per change. The manager sends while holding
+	// m.mu, so no SetUpdateListener can retire the listener between the choice
+	// of it and the delivery to it.
+	listener updateListener
 
 	// backendFactory builds backend implementations. Defaults to
 	// defaultBackendFactory. Tests inject fakes via SetBackendFactory.
@@ -89,16 +91,23 @@ func (m *CaptureManager) SetBackendFactory(f func(CaptureBackend) (captureBacken
 	m.backendFactory = f
 }
 
-// SetUpdateCallback registers a no-arg notifier fired when entry state changes.
-func (m *CaptureManager) SetUpdateCallback(fn func()) {
+// SetUpdateListener registers ch as the single listener for entry changes. The
+// returned channel closes when a later call replaces this listener, so the
+// superseded one stops waiting instead of leaking.
+func (m *CaptureManager) SetUpdateListener(ch chan<- struct{}) <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.onUpdate = fn
+	return m.listener.setLocked(ch)
 }
 
-// Entries returns a snapshot of all entries (running and stopped). Only
-// the public fields are populated — the internal control handles (cmd,
-// cancel, decoder, onUpdate) stay zero-valued in the snapshot so callers
+// notifyLocked delivers one update to the current listener. Callers must hold
+// m.mu.
+func (m *CaptureManager) notifyLocked() {
+	m.listener.notifyLocked()
+}
+
+// Entries returns a snapshot of all entries (running and stopped). The
+// internal control handles (cmd, cancel, decoder) stay zero-valued so callers
 // can't accidentally drive lifecycle from a stale copy.
 //
 // PacketCount and ByteCount are read via atomic.LoadInt64 because the decoder
@@ -226,7 +235,6 @@ func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket
 		OutputPath: outPath,
 		cmd:        cmd,
 		cancel:     cancel,
-		onUpdate:   m.onUpdate,
 	}
 	d := &packetDecoder{
 		file:        f,
@@ -236,11 +244,8 @@ func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket
 	}
 	entry.decoder = d
 	m.entries = append(m.entries, entry)
-	cb := m.onUpdate
+	m.notifyLocked()
 	m.mu.Unlock()
-	if cb != nil {
-		cb()
-	}
 
 	// Decoder goroutine: tees pcap to file + decodes. After the stream
 	// closes, reap the child process and surface any non-zero exit + stderr
@@ -266,11 +271,8 @@ func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket
 		m.mu.Lock()
 		entry.Status, entry.LastError = classifyCaptureExit(req.Backend, runErr, waitErr, stderrTxt, ctx.Err())
 		entry.StoppedAt = &now
-		cb := m.onUpdate
+		m.notifyLocked()
 		m.mu.Unlock()
-		if cb != nil {
-			cb()
-		}
 	}()
 
 	// Flip Starting -> Running once the decoder has had a chance to consume the pcap header.
@@ -281,11 +283,8 @@ func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket
 			if entry.Status == CaptureStarting {
 				entry.Status = CaptureRunning
 			}
-			cb := m.onUpdate
+			m.notifyLocked()
 			m.mu.Unlock()
-			if cb != nil {
-				cb()
-			}
 		case <-ctx.Done():
 		}
 	}()

--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -288,17 +288,25 @@ func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket
 	go func() {
 		select {
 		case <-time.After(time.Duration(captureRunningFlipDelay.Load())):
-			m.mu.Lock()
-			if entry.Status == CaptureStarting {
-				entry.Status = CaptureRunning
-			}
-			m.notifyLocked()
-			m.mu.Unlock()
+			m.markCaptureRunning(entry)
 		case <-ctx.Done():
 		}
 	}()
 
 	return id, nil
+}
+
+// markCaptureRunning flips a still-starting capture to Running. A capture the
+// watchdog already finished stays as it is, and reports nothing: that terminal
+// transition announced itself.
+func (m *CaptureManager) markCaptureRunning(entry *CaptureEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if entry.Status != CaptureStarting {
+		return
+	}
+	entry.Status = CaptureRunning
+	m.notifyLocked()
 }
 
 // classifyCaptureExit folds the multiple error sources the watchdog sees

--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -174,6 +174,15 @@ func defaultBackendFactory(b CaptureBackend) (captureBackend, error) {
 	}
 }
 
+// captureRunningFlipDelay is the wait before a Starting entry flips to
+// Running. atomic.Int64 (nanoseconds) so tests can shrink it without racing
+// the concurrent flip-goroutine readers.
+var captureRunningFlipDelay atomic.Int64
+
+func init() {
+	captureRunningFlipDelay.Store(int64(100 * time.Millisecond))
+}
+
 // Start spawns a streaming capture. Not used for kubeshark hand-off.
 func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket func(PacketSummary)) (int, error) {
 	if req.Backend == BackendKubeshark {
@@ -278,7 +287,7 @@ func (m *CaptureManager) Start(ctx context.Context, req CaptureRequest, onPacket
 	// Flip Starting -> Running once the decoder has had a chance to consume the pcap header.
 	go func() {
 		select {
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(time.Duration(captureRunningFlipDelay.Load())):
 			m.mu.Lock()
 			if entry.Status == CaptureStarting {
 				entry.Status = CaptureRunning

--- a/internal/k8s/capture_supersede_test.go
+++ b/internal/k8s/capture_supersede_test.go
@@ -1,0 +1,80 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// checkWindow is how many further supersessions happen before a retired channel
+// is inspected. A late delivery lands microseconds after the supersession, so
+// this only has to outlast that, and it bounds the memory the sweep holds.
+const checkWindow = 256
+
+// A notify that picks its listener under the lock and sends after releasing it
+// hands the update to a channel nobody reads any more. The churn loop keeps a
+// SetUpdateListener call queued on the manager lock so it observes that gap.
+func TestCaptureManager_SupersededListenerNeverLosesAnUpdate(t *testing.T) {
+	const captures = 50
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	mgr := NewCaptureManager()
+	mgr.SetBackendFactory(func(CaptureBackend) (captureBackend, error) {
+		return &fakeBackend{stream: bytes.NewReader(emptyPcapHeader())}, nil
+	})
+	req := CaptureRequest{
+		Backend:   BackendKubectlDebug,
+		Context:   "ctx",
+		Namespace: "ns",
+		PodName:   "pod",
+		OutputDir: t.TempDir(),
+	}
+
+	started := make(chan error, 1)
+	go func() {
+		for range captures {
+			if _, err := mgr.Start(ctx, req, func(PacketSummary) {}); err != nil {
+				started <- err
+				return
+			}
+		}
+		started <- nil
+	}()
+
+	// A retired channel that is still empty checkWindow supersessions later
+	// was never handed a late update.
+	ring := make([]chan struct{}, checkWindow)
+	cur := make(chan struct{}, 1)
+	mgr.SetUpdateListener(cur)
+	churns := 0
+	for {
+		select {
+		case err := <-started:
+			require.NoError(t, err)
+			mgr.StopAll()
+			for i, ch := range ring {
+				require.Emptyf(t, ch, "retired listener %d was handed an update after its supersession, so nobody read it", i)
+			}
+			t.Logf("%d supersessions raced %d captures", churns, captures)
+			return
+		default:
+		}
+
+		next := make(chan struct{}, 1)
+		mgr.SetUpdateListener(next)
+		// Whatever arrived before the supersession is the waiter's to collect.
+		select {
+		case <-cur:
+		default:
+		}
+		slot := churns % checkWindow
+		require.Emptyf(t, ring[slot], "a retired listener was handed an update after its supersession, so nobody read it")
+		ring[slot] = cur
+		cur = next
+		churns++
+	}
+}

--- a/internal/k8s/capture_supersede_test.go
+++ b/internal/k8s/capture_supersede_test.go
@@ -3,8 +3,11 @@ package k8s
 import (
 	"bytes"
 	"context"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,6 +21,13 @@ const checkWindow = 256
 // SetUpdateListener call queued on the manager lock so it observes that gap.
 func TestCaptureManager_SupersededListenerNeverLosesAnUpdate(t *testing.T) {
 	const captures = 50
+
+	// Shrunk so the Starting->Running flip notify lands inside the churn
+	// window below (which closes in low-single-digit milliseconds), instead
+	// of firing 100ms later once the churn loop has long since stopped.
+	origFlipDelay := captureRunningFlipDelay.Load()
+	captureRunningFlipDelay.Store(int64(time.Microsecond))
+	defer captureRunningFlipDelay.Store(origFlipDelay)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -45,36 +55,56 @@ func TestCaptureManager_SupersededListenerNeverLosesAnUpdate(t *testing.T) {
 		started <- nil
 	}()
 
-	// A retired channel that is still empty checkWindow supersessions later
-	// was never handed a late update.
-	ring := make([]chan struct{}, checkWindow)
-	cur := make(chan struct{}, 1)
-	mgr.SetUpdateListener(cur)
-	churns := 0
-	for {
-		select {
-		case err := <-started:
-			require.NoError(t, err)
-			mgr.StopAll()
-			for i, ch := range ring {
-				require.Emptyf(t, ch, "retired listener %d was handed an update after its supersession, so nobody read it", i)
-			}
-			t.Logf("%d supersessions raced %d captures", churns, captures)
-			return
-		default:
-		}
+	// Several concurrent churners, not one, give a nanosecond-wide race
+	// window a realistic chance of being hit. assert (not require) is the
+	// only failure call safe to make off the test's own goroutine.
+	const churners = 16
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	churnCounts := make([]int, churners)
+	for g := range churners {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ring := make([]chan struct{}, checkWindow)
+			cur := make(chan struct{}, 1)
+			mgr.SetUpdateListener(cur)
+			churns := 0
+			for {
+				select {
+				case <-done:
+					for i, ch := range ring {
+						assert.Emptyf(t, ch, "retired listener %d (churner %d) was handed an update after its supersession, so nobody read it", i, idx)
+					}
+					churnCounts[idx] = churns
+					return
+				default:
+				}
 
-		next := make(chan struct{}, 1)
-		mgr.SetUpdateListener(next)
-		// Whatever arrived before the supersession is the waiter's to collect.
-		select {
-		case <-cur:
-		default:
-		}
-		slot := churns % checkWindow
-		require.Emptyf(t, ring[slot], "a retired listener was handed an update after its supersession, so nobody read it")
-		ring[slot] = cur
-		cur = next
-		churns++
+				next := make(chan struct{}, 1)
+				mgr.SetUpdateListener(next)
+				// Whatever arrived before the supersession is the waiter's to collect.
+				select {
+				case <-cur:
+				default:
+				}
+				slot := churns % checkWindow
+				assert.Emptyf(t, ring[slot], "a retired listener (churner %d) was handed an update after its supersession, so nobody read it", idx)
+				ring[slot] = cur
+				cur = next
+				churns++
+			}
+		}(g)
 	}
+
+	require.NoError(t, <-started)
+	mgr.StopAll()
+	close(done)
+	wg.Wait()
+
+	total := 0
+	for _, c := range churnCounts {
+		total += c
+	}
+	t.Logf("%d supersessions (across %d churners) raced %d captures", total, churners, captures)
 }

--- a/internal/k8s/capture_test.go
+++ b/internal/k8s/capture_test.go
@@ -245,21 +245,18 @@ func TestStderrBuffer_SingleOversizedWriteKeepsTail(t *testing.T) {
 // TestCaptureManager_Entries_StripsInternalControlHandles guards the
 // encapsulation contract: callers of Entries() get a public-only snapshot,
 // not a back-door to the lifecycle handles. A regression that re-copies
-// cmd / cancel / decoder / onUpdate would let a stale snapshot drive
-// state changes (or hold references after Stop), which is the kind of
-// subtle bug CodeRabbit flagged on review.
+// cmd / cancel / decoder would let a stale snapshot drive state changes,
+// or hold references after Stop.
 func TestCaptureManager_Entries_StripsInternalControlHandles(t *testing.T) {
 	m := NewCaptureManager()
 	cancelCalls := 0
-	updateCalls := 0
 	m.mu.Lock()
 	m.entries = append(m.entries, &CaptureEntry{
-		ID:       1,
-		Status:   CaptureRunning,
-		cmd:      &exec.Cmd{},
-		cancel:   func() { cancelCalls++ },
-		decoder:  &packetDecoder{},
-		onUpdate: func() { updateCalls++ },
+		ID:      1,
+		Status:  CaptureRunning,
+		cmd:     &exec.Cmd{},
+		cancel:  func() { cancelCalls++ },
+		decoder: &packetDecoder{},
 	})
 	m.mu.Unlock()
 
@@ -276,11 +273,8 @@ func TestCaptureManager_Entries_StripsInternalControlHandles(t *testing.T) {
 	if es[0].decoder != nil {
 		t.Errorf("snapshot.decoder should be nil; got %+v", es[0].decoder)
 	}
-	if es[0].onUpdate != nil {
-		t.Errorf("snapshot.onUpdate should be nil; got non-nil func")
-	}
-	if cancelCalls != 0 || updateCalls != 0 {
-		t.Errorf("Entries() must not invoke control handles; cancel=%d update=%d", cancelCalls, updateCalls)
+	if cancelCalls != 0 {
+		t.Errorf("Entries() must not invoke control handles; cancel=%d", cancelCalls)
 	}
 }
 

--- a/internal/k8s/notify_change_test.go
+++ b/internal/k8s/notify_change_test.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The delayed Starting->Running flip can find an entry the watchdog already
+// moved to a terminal state. That transition notified on its own, so a second
+// token here wakes the UI with nothing to redraw.
+func TestCaptureManager_RunningFlipNotifiesOnlyOnAStatusChange(t *testing.T) {
+	mgr := NewCaptureManager()
+	ch := make(chan struct{}, 1)
+	mgr.SetUpdateListener(ch)
+
+	done := &CaptureEntry{Status: CaptureStopped}
+	mgr.markCaptureRunning(done)
+	assert.Equal(t, CaptureStopped, done.Status, "a terminal capture must not flip back to Running")
+	assert.Empty(t, ch, "a flip that changed nothing must not wake the UI")
+
+	starting := &CaptureEntry{Status: CaptureStarting}
+	mgr.markCaptureRunning(starting)
+	assert.Equal(t, CaptureRunning, starting.Status)
+	require.Len(t, ch, 1, "the Starting->Running flip must reach the UI")
+}
+
+// Stop and StopAll set the terminal status themselves and announce it. The
+// monitor then sees the process exit and must stay quiet about a state it did
+// not change.
+func TestPortForwardManager_MonitorExitNotifiesOnlyOnAStateChange(t *testing.T) {
+	mgr := NewPortForwardManager()
+	ch := make(chan struct{}, 1)
+	mgr.SetUpdateListener(ch)
+
+	stopped := &PortForwardEntry{Status: PortForwardStopped}
+	mgr.recordProcessExit(stopped, errors.New("signal: killed"), "")
+	assert.Equal(t, PortForwardStopped, stopped.Status, "an already-stopped forward must not turn into a failure")
+	assert.Empty(t, stopped.Error)
+	assert.Empty(t, ch, "an exit that changed nothing must not wake the UI")
+
+	crashed := &PortForwardEntry{Status: PortForwardRunning}
+	mgr.recordProcessExit(crashed, errors.New("exit status 1"), "bind: address already in use")
+	assert.Equal(t, PortForwardFailed, crashed.Status)
+	assert.Equal(t, "bind: address already in use", crashed.Error)
+	require.Len(t, ch, 1, "a live forward that failed must reach the UI")
+}

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -306,26 +306,34 @@ func (m *PortForwardManager) Start(kubectlPath, kubeconfigPaths, resourceKind, r
 
 		// Wait for process to finish.
 		err := cmd.Wait()
-		m.mu.Lock()
-		if entry.Status == PortForwardRunning || entry.Status == PortForwardStarting {
-			if err != nil {
-				entry.Status = PortForwardFailed
-				errMsg := strings.TrimSpace(stderrBuf.String())
-				if errMsg != "" {
-					entry.Error = errMsg
-				} else {
-					entry.Error = err.Error()
-				}
-				logger.Error("port-forward failed", "id", id, "error", entry.Error)
-			} else {
-				entry.Status = PortForwardStopped
-			}
-		}
-		m.notifyLocked()
-		m.mu.Unlock()
+		m.recordProcessExit(entry, err, strings.TrimSpace(stderrBuf.String()))
 	}()
 
 	return id, nil
+}
+
+// recordProcessExit moves a still-live forward to its terminal state after the
+// kubectl process exits. A forward Stop or StopAll already retired stays as it
+// is, and reports nothing: those callers announced the change themselves.
+func (m *PortForwardManager) recordProcessExit(entry *PortForwardEntry, err error, stderrText string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry.Status != PortForwardRunning && entry.Status != PortForwardStarting {
+		return
+	}
+	if err != nil {
+		entry.Status = PortForwardFailed
+		if stderrText != "" {
+			entry.Error = stderrText
+		} else {
+			entry.Error = err.Error()
+		}
+		logger.Error("port-forward failed", "id", entry.ID, "error", entry.Error)
+	} else {
+		entry.Status = PortForwardStopped
+	}
+	m.notifyLocked()
 }
 
 // Stop stops a port forward by its ID.

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -397,11 +397,16 @@ func (m *PortForwardManager) StopAll() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	stopped := false
 	for _, e := range m.entries {
 		if e.Status == PortForwardRunning || e.Status == PortForwardStarting {
 			e.cancel()
 			e.Status = PortForwardStopped
+			stopped = true
 		}
+	}
+	if stopped {
+		m.notifyLocked()
 	}
 }
 

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -53,19 +53,15 @@ type PortForwardManager struct {
 	mu      sync.Mutex
 	entries []*PortForwardEntry
 	nextID  int
-	// updates carries one token per change. The manager sends on it while
-	// holding m.mu, so no SetUpdateListener can close superseded between the
-	// choice of listener and the delivery to it.
-	updates chan<- struct{}
-	now     func() time.Time
+	// listener carries one token per change. The manager sends while holding
+	// m.mu, so no SetUpdateListener can retire the listener between the choice
+	// of it and the delivery to it.
+	listener updateListener
+	now      func() time.Time
 	// evictionArmedAt is the deadline an in-flight waitForPortForwardUpdate
 	// tick is already waiting on, so repeated arm attempts between renders
 	// don't stack duplicate timers. Zero means nothing armed.
 	evictionArmedAt time.Time
-	// superseded is closed by the next SetUpdateListener call, so a
-	// listener goroutine waiting on the channel it registered exits
-	// instead of leaking once a newer listener takes the single slot.
-	superseded chan struct{}
 }
 
 // NewPortForwardManager creates a new port forward manager.
@@ -88,25 +84,13 @@ func NewPortForwardManagerWithClock(now func() time.Time) *PortForwardManager {
 func (m *PortForwardManager) SetUpdateListener(ch chan<- struct{}) <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.superseded != nil {
-		close(m.superseded)
-	}
-	m.updates = ch
-	m.superseded = make(chan struct{})
-	return m.superseded
+	return m.listener.setLocked(ch)
 }
 
 // notifyLocked delivers one update to the current listener. Callers must hold
-// m.mu. The send is non-blocking: a listener that already returned must never
-// stall the manager.
+// m.mu.
 func (m *PortForwardManager) notifyLocked() {
-	if m.updates == nil {
-		return
-	}
-	select {
-	case m.updates <- struct{}{}:
-	default:
-	}
+	m.listener.notifyLocked()
 }
 
 // Entries returns a copy of all port forward entries.

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -59,6 +59,10 @@ type PortForwardManager struct {
 	// tick is already waiting on, so repeated arm attempts between renders
 	// don't stack duplicate timers. Zero means nothing armed.
 	evictionArmedAt time.Time
+	// superseded is closed by the next SetUpdateCallback call, so a
+	// listener goroutine blocked on the callback it registered exits
+	// instead of leaking once a newer listener takes the single callback slot.
+	superseded chan struct{}
 }
 
 // NewPortForwardManager creates a new port forward manager.
@@ -75,11 +79,18 @@ func NewPortForwardManagerWithClock(now func() time.Time) *PortForwardManager {
 	}
 }
 
-// SetUpdateCallback sets a callback that is invoked when entries change.
-func (m *PortForwardManager) SetUpdateCallback(fn func()) {
+// SetUpdateCallback sets a callback that is invoked when entries change. The
+// returned channel closes when a later call replaces this callback, letting
+// a superseded listener stop waiting instead of leaking.
+func (m *PortForwardManager) SetUpdateCallback(fn func()) <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.superseded != nil {
+		close(m.superseded)
+	}
 	m.onUpdate = fn
+	m.superseded = make(chan struct{})
+	return m.superseded
 }
 
 // Entries returns a copy of all port forward entries.

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -337,10 +337,13 @@ func (m *PortForwardManager) recordProcessExit(entry *PortForwardEntry, err erro
 	}
 	if err != nil {
 		entry.Status = PortForwardFailed
+		// An exec credential plugin (AWS SSO, gke auth) writes its token to
+		// kubectl's stderr on failure. Redact here, not at the log call:
+		// entry.Error also reaches the port-forward overlay.
 		if stderrText != "" {
-			entry.Error = stderrText
+			entry.Error = logger.Redact(stderrText)
 		} else {
-			entry.Error = err.Error()
+			entry.Error = logger.Redact(err.Error())
 		}
 		logger.Error("port-forward failed", "id", entry.ID, "error", entry.Error)
 	} else {

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -50,18 +50,21 @@ const portForwardEvictionGrace = 3 * time.Second
 
 // PortForwardManager manages active port forwards.
 type PortForwardManager struct {
-	mu       sync.Mutex
-	entries  []*PortForwardEntry
-	nextID   int
-	onUpdate func() // callback when entries change
-	now      func() time.Time
+	mu      sync.Mutex
+	entries []*PortForwardEntry
+	nextID  int
+	// updates carries one token per change. The manager sends on it while
+	// holding m.mu, so no SetUpdateListener can close superseded between the
+	// choice of listener and the delivery to it.
+	updates chan<- struct{}
+	now     func() time.Time
 	// evictionArmedAt is the deadline an in-flight waitForPortForwardUpdate
 	// tick is already waiting on, so repeated arm attempts between renders
 	// don't stack duplicate timers. Zero means nothing armed.
 	evictionArmedAt time.Time
-	// superseded is closed by the next SetUpdateCallback call, so a
-	// listener goroutine blocked on the callback it registered exits
-	// instead of leaking once a newer listener takes the single callback slot.
+	// superseded is closed by the next SetUpdateListener call, so a
+	// listener goroutine waiting on the channel it registered exits
+	// instead of leaking once a newer listener takes the single slot.
 	superseded chan struct{}
 }
 
@@ -79,18 +82,31 @@ func NewPortForwardManagerWithClock(now func() time.Time) *PortForwardManager {
 	}
 }
 
-// SetUpdateCallback sets a callback that is invoked when entries change. The
-// returned channel closes when a later call replaces this callback, letting
-// a superseded listener stop waiting instead of leaking.
-func (m *PortForwardManager) SetUpdateCallback(fn func()) <-chan struct{} {
+// SetUpdateListener registers ch as the single listener for entry changes. The
+// returned channel closes when a later call replaces this listener, so the
+// superseded one stops waiting instead of leaking.
+func (m *PortForwardManager) SetUpdateListener(ch chan<- struct{}) <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.superseded != nil {
 		close(m.superseded)
 	}
-	m.onUpdate = fn
+	m.updates = ch
 	m.superseded = make(chan struct{})
 	return m.superseded
+}
+
+// notifyLocked delivers one update to the current listener. Callers must hold
+// m.mu. The send is non-blocking: a listener that already returned must never
+// stall the manager.
+func (m *PortForwardManager) notifyLocked() {
+	if m.updates == nil {
+		return
+	}
+	select {
+	case m.updates <- struct{}{}:
+	default:
+	}
 }
 
 // Entries returns a copy of all port forward entries.
@@ -269,12 +285,8 @@ func (m *PortForwardManager) Start(kubectlPath, kubeconfigPaths, resourceKind, r
 
 	m.mu.Lock()
 	m.entries = append(m.entries, entry)
-	onUpdate := m.onUpdate
+	m.notifyLocked()
 	m.mu.Unlock()
-
-	if onUpdate != nil {
-		onUpdate()
-	}
 
 	// Monitor stdout for readiness confirmation and process lifecycle.
 	go func() {
@@ -303,11 +315,8 @@ func (m *PortForwardManager) Start(kubectlPath, kubeconfigPaths, resourceKind, r
 				if entry.Status == PortForwardStarting {
 					entry.Status = PortForwardRunning
 				}
-				onUpdate := m.onUpdate
+				m.notifyLocked()
 				m.mu.Unlock()
-				if onUpdate != nil {
-					onUpdate()
-				}
 			}
 		}
 
@@ -328,11 +337,8 @@ func (m *PortForwardManager) Start(kubectlPath, kubeconfigPaths, resourceKind, r
 				entry.Status = PortForwardStopped
 			}
 		}
-		onUpdate := m.onUpdate
+		m.notifyLocked()
 		m.mu.Unlock()
-		if onUpdate != nil {
-			onUpdate()
-		}
 	}()
 
 	return id, nil
@@ -357,9 +363,7 @@ func (m *PortForwardManager) Stop(id int) error {
 				"context", e.Context,
 				"localPort", e.LocalPort,
 				"remotePort", e.RemotePort)
-			if m.onUpdate != nil {
-				m.onUpdate()
-			}
+			m.notifyLocked()
 			return nil
 		}
 	}
@@ -385,9 +389,7 @@ func (m *PortForwardManager) Remove(id int) {
 				"namespace", e.Namespace,
 				"context", e.Context,
 				"wasRunning", wasRunning)
-			if m.onUpdate != nil {
-				m.onUpdate()
-			}
+			m.notifyLocked()
 			return
 		}
 	}

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -62,6 +62,10 @@ type PortForwardManager struct {
 	// tick is already waiting on, so repeated arm attempts between renders
 	// don't stack duplicate timers. Zero means nothing armed.
 	evictionArmedAt time.Time
+	// evictionArm names the waiter holding evictionArmedAt. A superseded
+	// waiter tears down after its replacement armed, so it must be told apart
+	// from the current owner or it clears a deadline nobody re-arms.
+	evictionArm uint64
 }
 
 // NewPortForwardManager creates a new port forward manager.
@@ -84,6 +88,9 @@ func NewPortForwardManagerWithClock(now func() time.Time) *PortForwardManager {
 func (m *PortForwardManager) SetUpdateListener(ch chan<- struct{}) <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// The retired waiter drops its eviction timer, so release the deadline
+	// for the incoming one to arm.
+	m.evictionArmedAt = time.Time{}
 	return m.listener.setLocked(ch)
 }
 
@@ -142,29 +149,35 @@ func isTerminalPortForwardStatus(s PortForwardStatus) bool {
 
 // ArmEvictionRefresh returns the delay until the earliest terminal,
 // already-shown entry is evictable, arming that deadline so concurrent
-// callers dedupe onto one pending timer until DisarmEvictionRefresh runs.
-func (m *PortForwardManager) ArmEvictionRefresh() (time.Duration, bool) {
+// callers dedupe onto one timer. The arm id passed back to DisarmEvictionRefresh
+// releases it.
+func (m *PortForwardManager) ArmEvictionRefresh() (time.Duration, uint64, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	deadline, found := m.earliestEvictionDeadlineLocked()
 	if !found {
-		return 0, false
+		return 0, 0, false
 	}
 	if !m.evictionArmedAt.IsZero() && !deadline.Before(m.evictionArmedAt) {
-		return 0, false
+		return 0, 0, false
 	}
 	m.evictionArmedAt = deadline
+	m.evictionArm++
 
 	d := max(deadline.Sub(m.now()), 0)
-	return d, true
+	return d, m.evictionArm, true
 }
 
 // DisarmEvictionRefresh clears the armed deadline, allowing the next
-// ArmEvictionRefresh call to schedule again.
-func (m *PortForwardManager) DisarmEvictionRefresh() {
+// ArmEvictionRefresh call to schedule again. A stale arm is ignored, so a
+// waiter tearing down late cannot release its successor's deadline.
+func (m *PortForwardManager) DisarmEvictionRefresh(arm uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if arm != m.evictionArm {
+		return
+	}
 	m.evictionArmedAt = time.Time{}
 }
 

--- a/internal/k8s/portforward_eviction_test.go
+++ b/internal/k8s/portforward_eviction_test.go
@@ -108,7 +108,7 @@ func TestArmEvictionRefresh_NothingPendingForActiveOrUnshownEntries(t *testing.T
 	}
 	mgr.mu.Unlock()
 
-	_, ok := mgr.ArmEvictionRefresh()
+	_, _, ok := mgr.ArmEvictionRefresh()
 	assert.False(t, ok, "a running or never-shown entry must not arm an eviction tick")
 }
 
@@ -119,7 +119,7 @@ func TestArmEvictionRefresh_SchedulesAtTheEntrysDeadline(t *testing.T) {
 	mgr.entries = []*PortForwardEntry{{ID: 1, Status: PortForwardStopped, shownAt: current.Add(-time.Second)}}
 	mgr.mu.Unlock()
 
-	d, ok := mgr.ArmEvictionRefresh()
+	d, _, ok := mgr.ArmEvictionRefresh()
 	require.True(t, ok)
 	assert.Equal(t, portForwardEvictionGrace-time.Second, d)
 }
@@ -131,14 +131,14 @@ func TestArmEvictionRefresh_DedupesUntilDisarmed(t *testing.T) {
 	mgr.entries = []*PortForwardEntry{{ID: 1, Status: PortForwardStopped, shownAt: current}}
 	mgr.mu.Unlock()
 
-	_, ok := mgr.ArmEvictionRefresh()
+	_, arm, ok := mgr.ArmEvictionRefresh()
 	require.True(t, ok, "first call must arm")
 
-	_, ok = mgr.ArmEvictionRefresh()
+	_, _, ok = mgr.ArmEvictionRefresh()
 	assert.False(t, ok, "a repeat call before the armed deadline fires must not stack another timer")
 
-	mgr.DisarmEvictionRefresh()
-	_, ok = mgr.ArmEvictionRefresh()
+	mgr.DisarmEvictionRefresh(arm)
+	_, _, ok = mgr.ArmEvictionRefresh()
 	assert.True(t, ok, "disarming must allow re-arming for the still-pending entry")
 }
 
@@ -148,16 +148,44 @@ func TestArmEvictionRefresh_ReArmsForAnEarlierDeadline(t *testing.T) {
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{{ID: 1, Status: PortForwardStopped, shownAt: current}}
 	mgr.mu.Unlock()
-	_, ok := mgr.ArmEvictionRefresh()
+	_, _, ok := mgr.ArmEvictionRefresh()
 	require.True(t, ok)
 
 	mgr.mu.Lock()
 	mgr.entries = append(mgr.entries, &PortForwardEntry{ID: 2, Status: PortForwardFailed, shownAt: current.Add(-2 * time.Second)})
 	mgr.mu.Unlock()
 
-	d, ok := mgr.ArmEvictionRefresh()
+	d, _, ok := mgr.ArmEvictionRefresh()
 	require.True(t, ok, "an earlier deadline must supersede the already-armed one")
 	assert.Equal(t, portForwardEvictionGrace-2*time.Second, d)
+}
+
+// The waiter holding the listener slot owns the armed deadline. Its
+// predecessor tears down afterwards and must not release it, or the entry
+// waits for a tick nobody scheduled.
+func TestArmEvictionRefresh_SupersededWaiterKeepsItsHandsOffTheNewArm(t *testing.T) {
+	current := time.Now()
+	mgr := NewPortForwardManagerWithClock(func() time.Time { return current })
+	mgr.mu.Lock()
+	mgr.entries = []*PortForwardEntry{{ID: 1, Status: PortForwardStopped, shownAt: current}}
+	mgr.mu.Unlock()
+
+	mgr.SetUpdateListener(make(chan struct{}, 1))
+	_, older, ok := mgr.ArmEvictionRefresh()
+	require.True(t, ok)
+
+	mgr.SetUpdateListener(make(chan struct{}, 1))
+	d, newer, ok := mgr.ArmEvictionRefresh()
+	require.True(t, ok, "the waiter taking over the listener slot must get a deadline of its own")
+	assert.Equal(t, portForwardEvictionGrace, d)
+
+	mgr.DisarmEvictionRefresh(older)
+	_, _, ok = mgr.ArmEvictionRefresh()
+	assert.False(t, ok, "a superseded waiter must not release the deadline its successor armed")
+
+	mgr.DisarmEvictionRefresh(newer)
+	_, _, ok = mgr.ArmEvictionRefresh()
+	assert.True(t, ok, "the owner must still be able to release its own deadline")
 }
 
 // EntriesForDisplay only evicts on the next call. ArmEvictionRefresh is the
@@ -171,7 +199,7 @@ func TestPortForward_StaysVisibleWithoutArming(t *testing.T) {
 
 	current = current.Add(portForwardEvictionGrace + time.Second)
 
-	d, ok := mgr.ArmEvictionRefresh()
+	d, _, ok := mgr.ArmEvictionRefresh()
 	require.True(t, ok, "a shown, expired terminal entry must arm a refresh")
 	assert.Equal(t, time.Duration(0), d, "a deadline already in the past must fire immediately, not be missed")
 }

--- a/internal/k8s/portforward_extra_test.go
+++ b/internal/k8s/portforward_extra_test.go
@@ -329,6 +329,9 @@ func TestPortForwardManagerStopAll_MixedStatuses(t *testing.T) {
 	_, cancel2 := context.WithCancel(t.Context())
 	_, cancel3 := context.WithCancel(t.Context())
 
+	updates := make(chan struct{}, 4)
+	mgr.SetUpdateListener(updates)
+
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
 		{ID: 1, Status: PortForwardRunning, cancel: cancel1},
@@ -344,6 +347,7 @@ func TestPortForwardManagerStopAll_MixedStatuses(t *testing.T) {
 		assert.Equal(t, PortForwardStopped, e.Status,
 			"entry %d should be stopped after StopAll", e.ID)
 	}
+	assert.Len(t, updates, 1, "the listener should be notified on StopAll")
 }
 
 func TestPortForwardManagerStopAll_AllRunning(t *testing.T) {

--- a/internal/k8s/portforward_extra_test.go
+++ b/internal/k8s/portforward_extra_test.go
@@ -95,10 +95,8 @@ func TestPortForwardManagerStop_RunningEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
 	_, cancel := context.WithCancel(t.Context())
 
-	callbackCalled := false
-	mgr.SetUpdateCallback(func() {
-		callbackCalled = true
-	})
+	updates := make(chan struct{}, 4)
+	mgr.SetUpdateListener(updates)
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -115,7 +113,7 @@ func TestPortForwardManagerStop_RunningEntry(t *testing.T) {
 
 	entry := mgr.Entries()
 	assert.Equal(t, PortForwardStopped, entry[0].Status)
-	assert.True(t, callbackCalled, "update callback should be called on Stop")
+	assert.Len(t, updates, 1, "the listener should be notified on Stop")
 }
 
 func TestPortForwardManagerStop_StartingEntry(t *testing.T) {
@@ -203,10 +201,8 @@ func TestPortForwardManagerRemove_StoppedEntry(t *testing.T) {
 	mgr := NewPortForwardManager()
 	_, cancel := context.WithCancel(t.Context())
 
-	callbackCalled := false
-	mgr.SetUpdateCallback(func() {
-		callbackCalled = true
-	})
+	updates := make(chan struct{}, 4)
+	mgr.SetUpdateListener(updates)
 
 	mgr.mu.Lock()
 	mgr.entries = []*PortForwardEntry{
@@ -218,7 +214,7 @@ func TestPortForwardManagerRemove_StoppedEntry(t *testing.T) {
 	mgr.Remove(1)
 	assert.Len(t, mgr.Entries(), 1)
 	assert.Equal(t, 2, mgr.Entries()[0].ID)
-	assert.True(t, callbackCalled)
+	assert.Len(t, updates, 1)
 }
 
 func TestPortForwardManagerRemove_RunningEntry(t *testing.T) {

--- a/internal/k8s/portforward_stderr_race_test.go
+++ b/internal/k8s/portforward_stderr_race_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,11 +30,10 @@ func TestPortForwardStderrCaptureNoRace(t *testing.T) {
 	require.NoError(t, os.WriteFile(fake, []byte(script), 0o700))
 
 	mgr := NewPortForwardManager()
-	// The callback runs on the monitor goroutine. Counting it keeps that
-	// concurrent write under the race detector without letting a slow reader
-	// block the monitor, which a channel would.
-	var updates atomic.Int64
-	mgr.SetUpdateCallback(func() { updates.Add(1) })
+	// Buffered past the two expected reports: the manager's send is
+	// non-blocking, so a full channel would silently drop one.
+	updates := make(chan struct{}, 8)
+	mgr.SetUpdateListener(updates)
 
 	_, err := mgr.Start(fake, "/dev/null", "Pod", "p", "ns", "ctx", "ctx", "8080", "80")
 	require.NoError(t, err, "Start should launch the fake binary")
@@ -57,10 +55,8 @@ func TestPortForwardStderrCaptureNoRace(t *testing.T) {
 	assert.Contains(t, entries[0].Error, "unable to listen on port",
 		"captured stderr must surface in entry.Error")
 	// Start reports once before it returns, the monitor once more after
-	// cmd.Wait. Reading the count here would be a race the other way: the
-	// monitor calls back after it releases the lock, so the status can be
-	// visible before the report is.
-	require.Eventually(t, func() bool { return updates.Load() >= 2 },
-		portForwardSettleTimeout, 10*time.Millisecond,
+	// cmd.Wait. Both reports land in the same critical section as the status
+	// they announce, so an observed Failed means both have already arrived.
+	require.GreaterOrEqual(t, len(updates), 2,
 		"the manager must report the move to Failed, not only the start")
 }

--- a/internal/k8s/portforward_supersede_test.go
+++ b/internal/k8s/portforward_supersede_test.go
@@ -1,0 +1,69 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A racing SetUpdateListener must not close the old superseded channel between
+// the choice of listener and the send, which would strand the update on a
+// channel its listener has stopped reading.
+func TestPortForwardManager_NotifyBeatsRacingSupersession(t *testing.T) {
+	mgr := NewPortForwardManager()
+	first := make(chan struct{}, 1)
+	superseded := mgr.SetUpdateListener(first)
+
+	mgr.mu.Lock()
+
+	superseding := make(chan struct{})
+	go func() {
+		mgr.SetUpdateListener(make(chan struct{}, 1))
+		close(superseding)
+	}()
+	require.Never(t, func() bool { return isClosed(superseding) },
+		50*time.Millisecond, 5*time.Millisecond,
+		"SetUpdateListener must wait for the lock a notify site holds")
+
+	mgr.notifyLocked()
+
+	require.False(t, isClosed(superseded),
+		"the old listener was retired before its update was delivered")
+	require.Len(t, first, 1, "the update must reach the listener chosen under the lock")
+
+	mgr.mu.Unlock()
+
+	require.Eventually(t, func() bool { return isClosed(superseding) },
+		time.Second, 5*time.Millisecond)
+	require.True(t, isClosed(superseded))
+	require.Len(t, first, 1, "the delivered update must survive the supersession")
+}
+
+// A listener that returned leaves its channel unread forever, so the manager
+// must never wait on it.
+func TestPortForwardManager_NotifyDoesNotBlockOnAbandonedListener(t *testing.T) {
+	mgr := NewPortForwardManager()
+	mgr.SetUpdateListener(make(chan struct{})) // unbuffered, nobody receiving
+
+	done := make(chan struct{})
+	go func() {
+		mgr.mu.Lock()
+		mgr.notifyLocked()
+		mgr.notifyLocked()
+		mgr.mu.Unlock()
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool { return isClosed(done) },
+		time.Second, 5*time.Millisecond, "notifyLocked blocked on an abandoned listener")
+}
+
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/k8s/portforward_supersede_test.go
+++ b/internal/k8s/portforward_supersede_test.go
@@ -59,6 +59,75 @@ func TestPortForwardManager_NotifyDoesNotBlockOnAbandonedListener(t *testing.T) 
 		time.Second, 5*time.Millisecond, "notifyLocked blocked on an abandoned listener")
 }
 
+// A notify that picks its listener under the lock and sends after releasing it
+// hands the update to a channel nobody reads any more. Only the public API can
+// catch that: notifyLocked under a held lock excludes the race by construction.
+func TestPortForwardManager_SupersededListenerNeverLosesAnUpdate(t *testing.T) {
+	const rounds = 2000
+
+	mgr := NewPortForwardManager()
+	var retired []chan struct{}
+
+	for i := range rounds {
+		id := i + 1
+		mgr.mu.Lock()
+		mgr.entries = []*PortForwardEntry{{ID: id, Status: PortForwardRunning, cancel: func() {}}}
+		mgr.mu.Unlock()
+
+		ch := make(chan struct{}, 1)
+		superseded := mgr.SetUpdateListener(ch)
+
+		// One gate for both goroutines so the change and the supersession
+		// reach the manager together instead of in a fixed order.
+		start := make(chan struct{})
+		changed := make(chan struct{})
+		go func() {
+			<-start
+			if id%2 == 0 {
+				mgr.Remove(id)
+			} else {
+				_ = mgr.Stop(id)
+			}
+			close(changed)
+		}()
+		swapped := make(chan struct{})
+		go func() {
+			<-start
+			mgr.SetUpdateListener(make(chan struct{}, 1))
+			close(swapped)
+		}()
+		close(start)
+
+		delivered := awaitUpdate(ch, superseded)
+		<-changed
+		<-swapped
+		if !delivered {
+			retired = append(retired, ch)
+		}
+	}
+
+	for i, ch := range retired {
+		require.Emptyf(t, ch, "retired listener %d was handed an update after its supersession, so nobody read it", i)
+	}
+}
+
+// awaitUpdate mirrors the app-side waiter. It reports false only when the
+// listener was retired with nothing pending, so a token found in its channel
+// afterwards is one the manager delivered too late for anyone to read.
+func awaitUpdate(ch <-chan struct{}, superseded <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	case <-superseded:
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}
+}
+
 func isClosed(ch <-chan struct{}) bool {
 	select {
 	case <-ch:

--- a/internal/k8s/portforward_test.go
+++ b/internal/k8s/portforward_test.go
@@ -36,13 +36,11 @@ func TestPortForwardManagerStopNonexistent(t *testing.T) {
 
 func TestPortForwardManagerUpdateCallback(t *testing.T) {
 	mgr := NewPortForwardManager()
-	called := false
-	mgr.SetUpdateCallback(func() {
-		called = true
-	})
-	// Remove triggers callback path but does nothing since entry doesn't exist.
+	updates := make(chan struct{}, 4)
+	mgr.SetUpdateListener(updates)
+	// Remove triggers the notify path but does nothing since entry doesn't exist.
 	mgr.Remove(1)
-	// StopAll triggers callback path.
+	// StopAll triggers the notify path.
 	mgr.StopAll()
-	assert.False(t, called) // No actual entries to trigger on.
+	assert.Empty(t, updates) // No actual entries to trigger on.
 }

--- a/internal/k8s/subprocess_stderr_redaction_test.go
+++ b/internal/k8s/subprocess_stderr_redaction_test.go
@@ -1,0 +1,87 @@
+package k8s
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gcpTokenStderr is the shape an exec credential plugin (gke-gcloud-auth-plugin)
+// leaves on kubectl's stderr when it fails after minting a token.
+const gcpTokenStderr = "ya29.a1b2c3d4e5f6g7h8i9j0ZZTOPSECRETTAILMARKER"
+
+// A kubectl port-forward that dies hands its raw stderr to recordProcessExit,
+// which stores it in entry.Error and logs it. That text is untrusted external
+// output and must not reach the log file or the overlay unredacted.
+func TestPortForwardManager_RedactsProcessExitStderr(t *testing.T) {
+	buf := &bytes.Buffer{}
+	orig := logger.Logger
+	logger.Logger = slog.New(slog.NewTextHandler(buf, nil))
+	defer func() { logger.Logger = orig }()
+
+	mgr := NewPortForwardManager()
+	entry := &PortForwardEntry{ID: 7, Status: PortForwardRunning}
+	stderr := "unable to connect: " + gcpTokenStderr + "\npassword: hunter2"
+	mgr.recordProcessExit(entry, errors.New("exit status 1"), stderr)
+
+	require.Equal(t, PortForwardFailed, entry.Status)
+	assert.NotContains(t, entry.Error, gcpTokenStderr, "the raw token must not survive in entry.Error")
+	assert.NotContains(t, entry.Error, "hunter2", "the raw password must not survive in entry.Error")
+	assert.Contains(t, entry.Error, "[REDACTED-GCP-TOKEN]")
+	assert.Contains(t, entry.Error, "unable to connect", "the non-secret diagnostic text must be kept")
+
+	logged := buf.String()
+	assert.NotContains(t, logged, gcpTokenStderr, "the raw token must not reach the log")
+	assert.NotContains(t, logged, "hunter2", "the raw password must not reach the log")
+}
+
+// The stderr-less branch falls back to the process error, which is redacted on
+// the same path.
+func TestPortForwardManager_RedactsProcessExitError(t *testing.T) {
+	mgr := NewPortForwardManager()
+	entry := &PortForwardEntry{ID: 8, Status: PortForwardRunning}
+	mgr.recordProcessExit(entry, errors.New("dial postgres://admin:hunter2@db:5432 failed"), "")
+
+	require.Equal(t, PortForwardFailed, entry.Status)
+	assert.NotContains(t, entry.Error, "hunter2")
+	assert.Contains(t, entry.Error, "[REDACTED-CREDS]")
+}
+
+// classifyCaptureExit folds backend stderr into CaptureEntry.LastError, which
+// the traffic-capture overlay renders. Same untrusted source, same rule.
+func TestClassifyCaptureExit_RedactsStderr(t *testing.T) {
+	status, msg := classifyCaptureExit(
+		BackendKubeshark, nil, errors.New("exit status 1"),
+		"auth failed: "+gcpTokenStderr, nil)
+
+	require.Equal(t, CaptureFailed, status)
+	assert.NotContains(t, msg, gcpTokenStderr, "the raw token must not survive in LastError")
+	assert.Contains(t, msg, "[REDACTED-GCP-TOKEN]")
+	assert.Contains(t, msg, "auth failed", "the non-secret diagnostic text must be kept")
+}
+
+// LastError keeps only the tail of a long stderr. Redaction has to run before
+// that trim: trimming first can cut a token's prefix off, leaving a tail that
+// no pattern matches and that then gets stored raw.
+func TestClassifyCaptureExit_RedactsBeforeTrimmingLongStderr(t *testing.T) {
+	// Size the parts so the tail-keeping cut lands 10 bytes into the token,
+	// past the "ya29." prefix the pattern needs to recognize it.
+	const pad = 100
+	const cutInto = 10
+	suffix := strings.Repeat("z", pad+cutInto+captureLastErrorMaxLen-pad-len(gcpTokenStderr)-1)
+	stderr := strings.Repeat("x", pad) + gcpTokenStderr + " " + suffix
+	require.Equal(t, pad+cutInto, len(stderr)-captureLastErrorMaxLen, "the cut must land inside the token")
+
+	status, msg := classifyCaptureExit(BackendKubeshark, nil, errors.New("exit status 1"), stderr, nil)
+
+	require.Equal(t, CaptureFailed, status)
+	tail := gcpTokenStderr[10:]
+	assert.NotContains(t, msg, tail, "a trim-first order would leave this raw token fragment behind")
+	assert.Contains(t, msg, "[REDACTED-GCP-TOKEN]")
+}

--- a/internal/k8s/update_listener.go
+++ b/internal/k8s/update_listener.go
@@ -1,0 +1,33 @@
+package k8s
+
+// updateListener is the single-slot registry the managers use to push state
+// changes at the UI. It holds no lock of its own: the owner calls every method
+// under the mutex guarding the state being announced.
+type updateListener struct {
+	ch         chan<- struct{}
+	superseded chan struct{}
+}
+
+// setLocked installs ch as the only listener. The returned channel closes when
+// a later call retires it, so the waiter on the old channel stops waiting
+// instead of leaking.
+func (l *updateListener) setLocked(ch chan<- struct{}) <-chan struct{} {
+	if l.superseded != nil {
+		close(l.superseded)
+	}
+	l.ch = ch
+	l.superseded = make(chan struct{})
+	return l.superseded
+}
+
+// notifyLocked delivers one update. The send is non-blocking: a listener that
+// already returned must never stall the manager.
+func (l *updateListener) notifyLocked() {
+	if l.ch == nil {
+		return
+	}
+	select {
+	case l.ch <- struct{}{}:
+	default:
+	}
+}


### PR DESCRIPTION
`restorePortForwards` armed one `waitForPortForwardUpdate` listener per restore batch. Every `portForwardUpdateMsg` re-armed a new listener with a new channel while `SetUpdateCallback` held only one slot, so each superseded listener blocked forever on a channel nothing would ever write to. One goroutine leaked per restored port-forward.

`CaptureManager` had the same pair of bugs, so this fixes the cause once rather than patching one surface.

## What changed

The manager now owns the listener channel instead of calling a callback. `SetUpdateListener(ch chan<- struct{})` returns a `superseded` channel that closes when a newer listener replaces the old one, and `notifyLocked` does a non-blocking send while the manager holds its own mutex.

That ordering is the fix. Previously the manager captured the callback under the lock and invoked it after unlocking, so a supersession could slip into the gap and the listener would exit while the update was still in flight. Now every send completes inside the same critical section that guards the state being announced, so a listener that observes the close is guaranteed the drain finds its update.

Two shared pieces came out of it: `internal/k8s/update_listener.go` for the handshake, embedded by both managers, and `internal/app/commands_update_wait.go` for the drain-on-superseded waiter both commands use. `waitForPortForwardSignal` is now a two-line wrapper, so the existing port-forward tests still exercise the real path.

The helper deliberately carries no mutex of its own. Correctness depends on the owner calling `setLocked` and `notifyLocked` under the mutex guarding the state being announced. That contract is documented on the type and both methods, and the `-Locked` suffix follows the usual Go convention. A review checked all 11 call sites across both managers, not a sample.

Also here: `StopAll` now notifies when an entry actually changed state, and `CaptureEntry.onUpdate` is gone, having been assigned and never read.

## On the regression test

The first version of the stress test only proved that a mutex excludes. A review reproduced the pre-fix shape at each capture notify site and found the test shipped green for one of the three. The test now shrinks the Starting-to-Running flip delay through an injectable `captureRunningFlipDelay` and churns 16 concurrent listeners, which brings that site from 0 of 30 runs caught to 23 of 30.

Measured over 30 `-race` runs per site with the pre-fix shape restored:

| Notify site | Caught |
|---|---|
| append, Starting | 15 / 30 |
| decoder done | 25 / 30 |
| flip to Running | 23 / 30 |
| correct code | 0 / 30, no false positive |

This is a real scheduling race, so none of the three is deterministic, and the rates vary by machine. With `-count=5` in CI the weakest site misses roughly 3% of the time, against 100% before.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -race ./...` — 23 packages ok. One unrelated pre-existing flake, `TestExplainFetchesStopWhenTheViewCloses`, passed 5 of 5 in isolation
- [x] `go test -race -count=3 ./internal/k8s/... ./internal/app/...` — no leaked goroutine, no timeout
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual pass against a live cluster: start three port-forwards, quit and relaunch so the session restores them, stop one and confirm the others keep updating; start a capture, stop it, restart it
