### PR TITLE
fix: keep the discovery-error fallback from clobbering a deeper level

### DIFF
--- a/internal/app/discovery_failure_level_test.go
+++ b/internal/app/discovery_failure_level_test.go
@@ -14,8 +14,10 @@ import (
 // type before the apiserver answers. A failure arriving then must not paint the
 // seed resource types over the resource list, nor cache them as "test-ctx/pods".
 func TestDiscoveryFailureAtResourceLevelLeavesMiddleColumnAlone(t *testing.T) {
-	t.Parallel()
-	m := baseModelCov()
+	// Not t.Parallel(): View() writes ui.ActiveCollapsedCategories, a
+	// package-level render global, so two Model.View() calls racing across
+	// goroutines trip -race.
+	m := basePush80Model()
 	m.nav.Level = model.LevelResources
 	m.nav.Context = "test-ctx"
 	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods"}
@@ -46,13 +48,21 @@ func TestDiscoveryFailureAtResourceLevelLeavesMiddleColumnAlone(t *testing.T) {
 	assert.False(t, cached,
 		"the fallback must not write resource-type items into the item "+
 			"cache under the resource-level navKey (test-ctx/pods)")
+
+	view := stripANSI(updated.View().Content)
+	assert.Contains(t, view, "api-0")
+	assert.Contains(t, view, "api-1")
+	assert.Contains(t, view, "api-2")
+	assert.NotContains(t, view, "Deployments",
+		"a discovery failure at LevelResources must not paint the resource-type "+
+			"sidebar into the middle column")
 }
 
 // The fallback belongs to LevelResourceTypes: there it must still paint the
 // seed list and cache it under the context key.
 func TestDiscoveryFailureAtResourceTypesLevelSeedsAndCachesUnderContext(t *testing.T) {
-	t.Parallel()
-	m := baseModelCov()
+	// Not t.Parallel(): see the sibling test above.
+	m := basePush80Model()
 	m.nav.Level = model.LevelResourceTypes
 	m.nav.Context = "test-ctx"
 	m.allGroupsExpanded = true
@@ -70,4 +80,8 @@ func TestDiscoveryFailureAtResourceTypesLevelSeedsAndCachesUnderContext(t *testi
 	assert.Equal(t, updated.middleItems, updated.itemCache["test-ctx"],
 		"the seed list must be cached under the resource-types key")
 	assert.False(t, updated.loading)
+
+	view := stripANSI(updated.View().Content)
+	assert.Contains(t, view, "Deployments")
+	assert.Contains(t, view, "ConfigMaps")
 }

--- a/internal/app/discovery_failure_level_test.go
+++ b/internal/app/discovery_failure_level_test.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// Entering a context fires discovery, and the user can drill into a resource
+// type before the apiserver answers. A failure arriving then must not paint the
+// seed resource types over the resource list, nor cache them as "test-ctx/pods".
+func TestDiscoveryFailureAtResourceLevelLeavesMiddleColumnAlone(t *testing.T) {
+	t.Parallel()
+	m := baseModelCov()
+	m.nav.Level = model.LevelResources
+	m.nav.Context = "test-ctx"
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", Resource: "pods"}
+	m.allGroupsExpanded = true
+
+	pods := []model.Item{
+		{Name: "api-0", Kind: "Pod"},
+		{Name: "api-1", Kind: "Pod"},
+		{Name: "api-2", Kind: "Pod"},
+	}
+	m.setMiddleItems(pods)
+	m.setCursor(2)
+	// The pod list is still being fetched, so the loader is up.
+	m.loading = true
+
+	updated, _ := m.updateAPIResourceDiscovery(apiResourceDiscoveryMsg{
+		context: "test-ctx",
+		err:     errors.New("the server is currently unable to handle the request"),
+	})
+
+	assert.Equal(t, pods, updated.middleItems,
+		"a discovery failure while the user is at LevelResources must not "+
+			"replace the resource list with the resource-type seed list")
+	assert.Equal(t, 2, updated.cursor(),
+		"the cursor belongs to the resource list and must survive an "+
+			"unrelated discovery failure")
+	_, cached := updated.itemCache[updated.navKey()]
+	assert.False(t, cached,
+		"the fallback must not write resource-type items into the item "+
+			"cache under the resource-level navKey (test-ctx/pods)")
+}
+
+// The fallback belongs to LevelResourceTypes: there it must still paint the
+// seed list and cache it under the context key.
+func TestDiscoveryFailureAtResourceTypesLevelSeedsAndCachesUnderContext(t *testing.T) {
+	t.Parallel()
+	m := baseModelCov()
+	m.nav.Level = model.LevelResourceTypes
+	m.nav.Context = "test-ctx"
+	m.allGroupsExpanded = true
+	m.setMiddleItems(nil)
+	m.loading = true
+
+	updated, _ := m.updateAPIResourceDiscovery(apiResourceDiscoveryMsg{
+		context: "test-ctx",
+		err:     errors.New("connection refused"),
+	})
+
+	require.NotEmpty(t, updated.middleItems,
+		"the seed list must render so the user can navigate a cluster whose "+
+			"discovery is broken")
+	assert.Equal(t, updated.middleItems, updated.itemCache["test-ctx"],
+		"the seed list must be cached under the resource-types key")
+	assert.False(t, updated.loading)
+}

--- a/internal/app/update_resources_discovery.go
+++ b/internal/app/update_resources_discovery.go
@@ -185,7 +185,10 @@ func (m Model) handleAPIResourceDiscoveryError(msg apiResourceDiscoveryMsg, isCu
 		m.dropDeferredSessionRestore()
 	}
 	m.finishSessionRestoreForContext(isCurrentContext)
-	if isCurrentContext && m.loading {
+	// The level guard mirrors the success branch: a request fired on context
+	// entry can land after the user drilled in, and m.loading is true there
+	// for the resource list, so without it the seed types overwrite that list.
+	if isCurrentContext && m.nav.Level == model.LevelResourceTypes && m.loading {
 		// Mirror the success branch's wasInitial guard. m.loading alone
 		// is unreliable as an "is this the initial discovery" signal
 		// because invalidatePreviewForCursorChange flips it true on
@@ -196,7 +199,7 @@ func (m Model) handleAPIResourceDiscoveryError(msg apiResourceDiscoveryMsg, isCu
 		wasInitial := len(m.middleItems) == 0
 		m.loading = false
 		m.setMiddleItems(model.BuildSidebarItems(model.SeedResources()))
-		m.itemCache[m.navKey()] = m.middleItems
+		m.itemCache[m.nav.Context] = m.middleItems
 		if wasInitial {
 			m.restoreCursor()
 		} else {


### PR DESCRIPTION
## The bug

Enter a context, then drill into a resource type before the apiserver answers the discovery request. If discovery then fails, `handleAPIResourceDiscoveryError` replaced your pod list with the seed resource-type sidebar and wrote those resource types into `itemCache["<ctx>/pods"]`, so going back and re-entering served the poisoned entry.

The fallback guarded only on `m.loading` and keyed the cache with `m.navKey()`, neither of which says anything about which level the user is on.

Entering a context fires `discoverAPIResources` (`update_navigation.go:409`), so the window is real: the user drills in while that request is still outstanding.

## The fix

The fallback now guards `isCurrentContext && m.nav.Level == model.LevelResourceTypes && m.loading`, mirroring the success branch, and keys the cache with `m.nav.Context`.

The key change is a no-op in every state the new guard can reach, since `nav.ResourceType`, `ResourceName` and `OwnedName` are all cleared at that level. It is there to make the intent explicit rather than to fix a second bug.

One asymmetry against the success branch is deliberate. The success path caches unconditionally when the context matches, even at deeper levels, because it has real discovered data. The error path caches only inside the level guard, because on failure it has nothing but a seed list, and writing that while the user is deeper is the bug.

## Where CodeRabbit had it

CodeRabbit flagged this on #663 and named `LevelResourceTypes` as the vulnerable level. That level is actually safe: back-navigation clears `nav.ResourceType`, so `navKey()` already equals `nav.Context`, and `syncExpandedGroup` clamps the cursor. The reachable case is one level deeper, at `LevelResources`. The finding was worth chasing, but not where it pointed.

## Test plan

- [x] `TestDiscoveryFailureAtResourceLevelLeavesMiddleColumnAlone` — fails against the pre-fix file, passes now. Verified by running it against a copy of the parent's `update_resources_discovery.go`
- [x] `TestDiscoveryFailureAtResourceTypesLevelSeedsAndCachesUnderContext` — pins the intentional fallback so a future change cannot quietly remove it
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -race ./...` — 26 packages ok. `TestExplainFetchesStopWhenTheViewCloses` is a known unrelated flake and passes in isolation
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual pass: point a context at an unroutable server, drill into a resource type before discovery answers, confirm the list is not replaced when it fails

Every site that sets `m.loading` before firing discovery sets the level to `LevelResourceTypes` first, so the tighter guard drops no legitimate case and cannot leave a spinner stuck.

Supersedes #665, which GitHub closed when its base branch was deleted on merge. The CodeRabbit review there raised one finding about copying `itemCache`, declined with the mechanism in that thread: `copyItemCache` deep-copies at all three tab seams, so an in-place write cannot leak across tabs.
