### PR TITLE
fix: rank fuzzy results by the field that actually matched

### DIFF
--- a/internal/app/cursor_filter.go
+++ b/internal/app/cursor_filter.go
@@ -89,21 +89,21 @@ func (m *Model) applyTextFilter(items []model.Item) []model.Item {
 	// When in fuzzy mode, sort results by fuzzy score (best matches first).
 	mode, query := ui.DetectSearchMode(rawQuery)
 	if mode == ui.SearchFuzzy && query != "" {
-		items = sortItemsByFuzzyScore(items, query)
+		items = sortItemsByFuzzyScore(items, query, expandByCategory, matchedCategories, m.filterBroadMode)
 	}
 
 	return items
 }
 
 // sortItemsByFuzzyScore is the fuzzy re-sort inside applyTextFilter.
-func sortItemsByFuzzyScore(items []model.Item, query string) []model.Item {
+func sortItemsByFuzzyScore(items []model.Item, query string, expandByCategory bool, matchedCategories map[string]bool, broadMode bool) []model.Item {
 	type scoredItem struct {
 		item  model.Item
 		score int
 	}
 	scored := make([]scoredItem, 0, len(items))
 	for _, item := range items {
-		s := ui.FuzzyScore(item.Name, query)
+		s := fuzzyFieldScore(item, query, expandByCategory, matchedCategories, broadMode)
 		scored = append(scored, scoredItem{item: item, score: s})
 	}
 	sort.SliceStable(scored, func(i, j int) bool {
@@ -114,6 +114,31 @@ func sortItemsByFuzzyScore(items []model.Item, query string) []model.Item {
 		sortedItems[i] = si.item
 	}
 	return sortedItems
+}
+
+// fuzzyFieldScore mirrors the matching pass above: Category alone for a
+// category-expanded item, otherwise the best of namespace/name and (broad
+// mode) column values.
+func fuzzyFieldScore(item model.Item, query string, expandByCategory bool, matchedCategories map[string]bool, broadMode bool) int {
+	if expandByCategory && item.Category != "" && matchedCategories[item.Category] {
+		return ui.FuzzyScore(item.Category, query)
+	}
+	searchText := item.Name
+	if item.Namespace != "" {
+		searchText = item.Namespace + "/" + searchText
+	}
+	best := ui.FuzzyScore(searchText, query)
+	if broadMode {
+		for _, kv := range item.Columns {
+			if isInternalColumnKey(kv.Key) {
+				continue
+			}
+			if s := ui.FuzzyScore(kv.Value, query); s > best {
+				best = s
+			}
+		}
+	}
+	return best
 }
 
 // applyGroupCollapse is the accordion collapse pass of computeVisibleMiddleItems.

--- a/internal/app/cursor_filter_test.go
+++ b/internal/app/cursor_filter_test.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// TestApplyTextFilter_FuzzySort_ScoresAcceptedField reproduces the bug where
+// an item pulled in by a strong Category match gets ranked by its (weak or
+// absent) Name match instead, because the sort only ever scored Name.
+func TestApplyTextFilter_FuzzySort_ScoresAcceptedField(t *testing.T) {
+	m := newTestModel()
+	m.filterBroadMode = true
+	m.nav.Level = model.LevelResourceTypes
+	m.filterText = "~net"
+
+	items := []model.Item{
+		{Name: "node-exporter-tool", Category: "Storage"},
+		{Name: "foobar-service", Category: "Networking"},
+	}
+
+	got := m.applyTextFilter(items)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 items, got %d: %+v", len(got), got)
+	}
+	if got[0].Category != "Networking" {
+		t.Fatalf("expected the strong Category match to rank first, got order: %q then %q",
+			got[0].Name, got[1].Name)
+	}
+}


### PR DESCRIPTION
## The problem

`applyTextFilter` accepts a fuzzy match on four things: the name, `namespace/name`, the `Category` (in broad mode at the resource-types level), and column values (in broad mode, excluding internal keys). `sortItemsByFuzzyScore` then ranked every surviving item by how well its **name** matched.

So an item that earned its place because its Category or its Pod IP matched got ranked by a name score that had nothing to do with why it was there. The order looked arbitrary.

## The fix

Score each item by the best fuzzy score across the fields the filter actually accepted for that item, and sort on that.

The scoring set cannot drift from the filtering set, because `expandByCategory`, `matchedCategories` and `broadMode` are computed once in `applyTextFilter` and passed into the scorer rather than recomputed. The internal-column exclusion reuses the same `isInternalColumnKey` helper. `sort.SliceStable` keeps equal scores in their existing order.

Items accepted through the Category early-accept path are scored on Category alone, matching the filter's own short-circuit, since those items need not match on anything else.

## Allocations

This runs on the render path, so the change was measured rather than assumed. Benchmarking `computeVisibleMiddleItems` directly, bypassing the memo, on this commit and on its parent:

| Items | Before | After |
|---|---|---|
| 1000 | 1014 allocs/op, 532 KB/op | identical |
| 5000 | 5019 allocs/op, 5.46 MB/op | identical |

Scoring four fields instead of one adds no heap allocation. The new `namespace + "/" + name` concat does not escape, confirmed with `-gcflags="-m -m"`, because `ui.FuzzyScore` only reads it.

Worth noting for anyone who reaches for it later: `BenchmarkVisibleMiddleItemsUnchanged` says nothing about this change. Its filter text has no `~`, so it stays in substring mode and never reaches the fuzzy path.

`visibleMiddleItemsKey` already covers every field the scorer newly reads, so the memo cannot go stale.

## Test plan

- [x] `TestApplyTextFilter_FuzzySort_ScoresAcceptedField` — red before the fix, confirmed by reverting it
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -race ./...` — all 26 packages ok
- [x] `golangci-lint run ./...` — 0 issues
- [x] Allocation comparison above
- [ ] Manual pass in `--demo`: filter `~os` with broad mode on and confirm ReplicaSets and StatefulSets hold their place instead of sinking, then filter `~2.15` in the pod list and confirm the match comes through the Pod IP

Found by CodeRabbit on #663 and confirmed pre-existing, so it is not a regression from that refactor.

Supersedes #666, which GitHub closed when its base branch was deleted on merge. The CodeRabbit review there raised one trivial nitpick about test construction, declined in that thread because six sibling test files use the same form and `newTestModel()` takes no parameters.
