### PR TITLE
refactor: make a torn capture counter impossible to write by accident

### DIFF
--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -49,19 +49,38 @@ type CaptureRequest struct {
 
 // CaptureEntry is one running or completed capture.
 type CaptureEntry struct {
+	ID         int
+	Request    CaptureRequest
+	Status     CaptureStatus
+	StartedAt  time.Time
+	StoppedAt  *time.Time
+	OutputPath string
+	LastError  string
+
+	// The decoder goroutine writes these outside m.mu, so a plain copy of the
+	// entry would tear a counter. atomic.Int64 embeds noCopy, which makes
+	// `copy := *entry` a go vet copylocks failure instead of a silent tear.
+	// CaptureSnapshot is the shape callers read.
+	PacketCount atomic.Int64
+	ByteCount   atomic.Int64
+
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+	decoder *packetDecoder
+}
+
+// CaptureSnapshot is one entry as callers outside the manager see it: the
+// counters resolved to plain values and the lifecycle handles left behind.
+type CaptureSnapshot struct {
 	ID          int
 	Request     CaptureRequest
 	Status      CaptureStatus
 	StartedAt   time.Time
 	StoppedAt   *time.Time
-	PacketCount int64 // atomic
-	ByteCount   int64 // atomic
+	PacketCount int64
+	ByteCount   int64
 	OutputPath  string
 	LastError   string
-
-	cmd     *exec.Cmd
-	cancel  context.CancelFunc
-	decoder *packetDecoder
 }
 
 // CaptureManager tracks running captures across the lfk session.
@@ -108,25 +127,21 @@ func (m *CaptureManager) notifyLocked() {
 }
 
 // Entries returns a snapshot of all entries (running and stopped). The
-// internal control handles (cmd, cancel, decoder) stay zero-valued so callers
+// internal control handles (cmd, cancel, decoder) are left behind so callers
 // can't accidentally drive lifecycle from a stale copy.
-//
-// PacketCount and ByteCount are read via atomic.LoadInt64 because the decoder
-// goroutine writes them via atomic.AddInt64 outside m.mu — a plain struct copy
-// would race the decoder's writes.
-func (m *CaptureManager) Entries() []CaptureEntry {
+func (m *CaptureManager) Entries() []CaptureSnapshot {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]CaptureEntry, len(m.entries))
+	out := make([]CaptureSnapshot, len(m.entries))
 	for i, e := range m.entries {
-		out[i] = CaptureEntry{
+		out[i] = CaptureSnapshot{
 			ID:          e.ID,
 			Request:     e.Request,
 			Status:      e.Status,
 			StartedAt:   e.StartedAt,
 			StoppedAt:   e.StoppedAt,
-			PacketCount: atomic.LoadInt64(&e.PacketCount),
-			ByteCount:   atomic.LoadInt64(&e.ByteCount),
+			PacketCount: e.PacketCount.Load(),
+			ByteCount:   e.ByteCount.Load(),
 			OutputPath:  e.OutputPath,
 			LastError:   e.LastError,
 		}

--- a/internal/k8s/capture.go
+++ b/internal/k8s/capture.go
@@ -69,6 +69,16 @@ type CaptureEntry struct {
 	decoder *packetDecoder
 }
 
+// cloneTime copies the pointed-to timestamp so a caller mutating
+// snapshot.StoppedAt cannot reach back into the manager's entry.
+func cloneTime(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	c := *t
+	return &c
+}
+
 // CaptureSnapshot is one entry as callers outside the manager see it: the
 // counters resolved to plain values and the lifecycle handles left behind.
 type CaptureSnapshot struct {
@@ -139,7 +149,7 @@ func (m *CaptureManager) Entries() []CaptureSnapshot {
 			Request:     e.Request,
 			Status:      e.Status,
 			StartedAt:   e.StartedAt,
-			StoppedAt:   e.StoppedAt,
+			StoppedAt:   cloneTime(e.StoppedAt),
 			PacketCount: e.PacketCount.Load(),
 			ByteCount:   e.ByteCount.Load(),
 			OutputPath:  e.OutputPath,

--- a/internal/k8s/capture_test.go
+++ b/internal/k8s/capture_test.go
@@ -476,3 +476,28 @@ func emptyPcapHeader() []byte {
 		0x01, 0x00, 0x00, 0x00, // linktype Ethernet
 	}
 }
+
+// A snapshot that shared the manager's *time.Time would let a caller rewrite
+// the entry's stop time and change every later snapshot.
+func TestCaptureManagerEntriesCopiesStoppedAt(t *testing.T) {
+	m := NewCaptureManager()
+	stopped := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	m.mu.Lock()
+	m.entries = append(m.entries, &CaptureEntry{ID: 1, Status: CaptureStopped, StoppedAt: &stopped})
+	m.mu.Unlock()
+
+	// want is read before the mutation: an aliased snapshot rewrites `stopped`
+	// too, so comparing against it would compare the mutation with itself.
+	want := stopped
+
+	first := m.Entries()
+	if len(first) != 1 || first[0].StoppedAt == nil {
+		t.Fatalf("first snapshot = %+v, want one entry with a stop time", first)
+	}
+	*first[0].StoppedAt = want.Add(time.Hour)
+
+	second := m.Entries()
+	if second[0].StoppedAt == nil || !second[0].StoppedAt.Equal(want) {
+		t.Errorf("stop time after mutating the snapshot = %v, want %v", second[0].StoppedAt, want)
+	}
+}

--- a/internal/k8s/capture_test.go
+++ b/internal/k8s/capture_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -260,18 +259,12 @@ func TestCaptureManager_Entries_StripsInternalControlHandles(t *testing.T) {
 	})
 	m.mu.Unlock()
 
+	// CaptureSnapshot has no cmd/cancel/decoder fields at all, so the compiler
+	// now carries the half of this guarantee the assertions used to. What is
+	// left to check is that building the snapshot touches none of them.
 	es := m.Entries()
 	if len(es) != 1 {
 		t.Fatalf("entries len = %d, want 1", len(es))
-	}
-	if es[0].cmd != nil {
-		t.Errorf("snapshot.cmd should be nil; got %+v", es[0].cmd)
-	}
-	if es[0].cancel != nil {
-		t.Errorf("snapshot.cancel should be nil; got non-nil func")
-	}
-	if es[0].decoder != nil {
-		t.Errorf("snapshot.decoder should be nil; got %+v", es[0].decoder)
 	}
 	if cancelCalls != 0 {
 		t.Errorf("Entries() must not invoke control handles; cancel=%d", cancelCalls)
@@ -279,8 +272,8 @@ func TestCaptureManager_Entries_StripsInternalControlHandles(t *testing.T) {
 }
 
 // TestCaptureManager_Entries_AtomicCountersRace exercises Entries() against
-// concurrent atomic.AddInt64 writes on PacketCount/ByteCount. Without atomic
-// reads in the snapshot, `go test -race` flags this as a data race.
+// concurrent counter writes. Without atomic reads in the snapshot, `go test
+// -race` flags this as a data race.
 func TestCaptureManager_Entries_AtomicCountersRace(t *testing.T) {
 	m := NewCaptureManager()
 	m.mu.Lock()
@@ -298,8 +291,8 @@ func TestCaptureManager_Entries_AtomicCountersRace(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				atomic.AddInt64(&entry.PacketCount, 1)
-				atomic.AddInt64(&entry.ByteCount, 64)
+				entry.PacketCount.Add(1)
+				entry.ByteCount.Add(64)
 			}
 		}
 	}()

--- a/internal/k8s/packet_decoder.go
+++ b/internal/k8s/packet_decoder.go
@@ -116,21 +116,21 @@ func dnsSummary(d *layers.DNS) string {
 // into an on-disk file for export, and decodes each packet for the live UI table.
 type packetDecoder struct {
 	file        io.WriteCloser
-	packetCount *int64 // atomic counter shared with CaptureEntry
-	byteCount   *int64 // atomic counter shared with CaptureEntry
+	packetCount *atomic.Int64 // shared with CaptureEntry
+	byteCount   *atomic.Int64 // shared with CaptureEntry
 	onPacket    func(PacketSummary)
 }
 
 // countingWriter wraps an io.Writer and atomically accumulates written byte totals.
 type countingWriter struct {
 	w io.Writer
-	n *int64
+	n *atomic.Int64
 }
 
 func (c *countingWriter) Write(p []byte) (int, error) {
 	n, err := c.w.Write(p)
 	if c.n != nil {
-		atomic.AddInt64(c.n, int64(n))
+		c.n.Add(int64(n))
 	}
 	return n, err
 }
@@ -191,7 +191,7 @@ func (d *packetDecoder) Run(ctx context.Context, src io.Reader) error {
 		// nil-guard mirrors countingWriter.Write so callers can pass a
 		// decoder without a counter without crashing the read loop.
 		if d.packetCount != nil {
-			atomic.AddInt64(d.packetCount, 1)
+			d.packetCount.Add(1)
 		}
 		// SLL2 (linktype 276) is what tcpdump uses for `-i any` on libpcap
 		// >= 1.10. gopacket v1.1.19 has no SLL2 decoder, so without this

--- a/internal/k8s/packet_decoder_test.go
+++ b/internal/k8s/packet_decoder_test.go
@@ -131,7 +131,7 @@ func TestPacketDecoder_Run_CountsPacketsAndBytes(t *testing.T) {
 	}
 
 	var fileSink bytes.Buffer
-	var pkt, byt int64
+	var pkt, byt atomic.Int64
 	var got []PacketSummary
 	d := &packetDecoder{
 		file:        nopCloser{&fileSink},
@@ -143,10 +143,10 @@ func TestPacketDecoder_Run_CountsPacketsAndBytes(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if n := atomic.LoadInt64(&pkt); n != 2 {
+	if n := pkt.Load(); n != 2 {
 		t.Errorf("packetCount = %d, want 2", n)
 	}
-	if atomic.LoadInt64(&byt) == 0 {
+	if byt.Load() == 0 {
 		t.Errorf("byteCount = 0, want > 0 (TeeReader should have piped to fileSink)")
 	}
 	if fileSink.Len() == 0 {
@@ -214,7 +214,7 @@ func TestPacketDecoder_LinuxSLL_LinkTypeDispatch(t *testing.T) {
 	}
 
 	var fileSink bytes.Buffer
-	var pkt, byt int64
+	var pkt, byt atomic.Int64
 	var got []PacketSummary
 	d := &packetDecoder{
 		file:        nopCloser{&fileSink},
@@ -298,7 +298,7 @@ func TestPacketDecoder_LinuxSLL2_DecodesIPv4(t *testing.T) {
 	pcapBuf.Write(pktBytes)
 
 	var fileSink bytes.Buffer
-	var pkt, byt int64
+	var pkt, byt atomic.Int64
 	var got []PacketSummary
 	d := &packetDecoder{
 		file:        nopCloser{&fileSink},
@@ -369,7 +369,7 @@ func TestPacketDecoder_LinuxSLL2_BigEndianMagic(t *testing.T) {
 	pcapBuf.Write(pktBytes)
 
 	var fileSink bytes.Buffer
-	var pkt, byt int64
+	var pkt, byt atomic.Int64
 	var got []PacketSummary
 	d := &packetDecoder{
 		file:        nopCloser{&fileSink},


### PR DESCRIPTION
`CaptureEntry.PacketCount` and `ByteCount` were plain `int64` fields with an `// atomic` comment next to them. `Entries()` read both through `atomic.LoadInt64`, so it was correct, but nothing stopped the next caller from writing `copy := *entry` and tearing a counter against the decoder goroutine.

Both are `atomic.Int64` now. That type embeds `noCopy`, so a plain copy is a `go vet` copylocks failure:

```
return copies lock value: k8s.CaptureEntry contains sync/atomic.Int64 contains sync/atomic.noCopy
```

`Entries()` returns a new `CaptureSnapshot`: counters resolved to plain values, lifecycle handles left behind. Three assertions in `TestCaptureManager_Entries_StripsInternalControlHandles` checked that the snapshot's `cmd`, `cancel`, and `decoder` were nil. The snapshot type has no such fields, so the compiler carries that half now and the test keeps the half it still owns: building a snapshot must not invoke the handles.

Follow-up to a CodeRabbit review on #664, where the wider immutability finding was declined.

## Test plan

- [x] `go vet` flags a plain copy (verified with a throwaway `return *e`, then removed)
- [x] `go test -race ./internal/k8s/... ./internal/app/... ./internal/ui/...`
- [x] `golangci-lint run ./internal/...` reports 0 issues
- [x] `TestCaptureManager_Entries_AtomicCountersRace` still passes under `-race`