### PR TITLE
fix: let two tests render under t.Parallel without racing

### DIFF
--- a/internal/app/discovery_failure_level_test.go
+++ b/internal/app/discovery_failure_level_test.go
@@ -14,9 +14,8 @@ import (
 // type before the apiserver answers. A failure arriving then must not paint the
 // seed resource types over the resource list, nor cache them as "test-ctx/pods".
 func TestDiscoveryFailureAtResourceLevelLeavesMiddleColumnAlone(t *testing.T) {
-	// Not t.Parallel(): View() writes ui.ActiveCollapsedCategories, a
-	// package-level render global, so two Model.View() calls racing across
-	// goroutines trip -race.
+	t.Parallel()
+
 	m := basePush80Model()
 	m.nav.Level = model.LevelResources
 	m.nav.Context = "test-ctx"
@@ -61,7 +60,8 @@ func TestDiscoveryFailureAtResourceLevelLeavesMiddleColumnAlone(t *testing.T) {
 // The fallback belongs to LevelResourceTypes: there it must still paint the
 // seed list and cache it under the context key.
 func TestDiscoveryFailureAtResourceTypesLevelSeedsAndCachesUnderContext(t *testing.T) {
-	// Not t.Parallel(): see the sibling test above.
+	t.Parallel()
+
 	m := basePush80Model()
 	m.nav.Level = model.LevelResourceTypes
 	m.nav.Context = "test-ctx"

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -83,6 +83,11 @@ func (m Model) renderView() string {
 		return "Loading..."
 	}
 
+	// The assignments below and every renderer they feed share ui's per-frame
+	// globals, so the whole pass has to be exclusive. See ui.RenderMu.
+	ui.RenderMu.Lock()
+	defer ui.RenderMu.Unlock()
+
 	// Sync nyan mode state to UI globals for rendering.
 	ui.NyanMode = m.nyanMode
 	ui.NyanTick = m.nyanTick

--- a/internal/ui/render_state.go
+++ b/internal/ui/render_state.go
@@ -1,0 +1,8 @@
+package ui
+
+import "sync"
+
+// RenderMu serialises a whole render pass: a frame needs every package-level
+// Active* and Nyan* variable to come from the same Model. Bubble Tea renders on
+// one goroutine, so only tests contend, and without this none can use t.Parallel().
+var RenderMu sync.Mutex


### PR DESCRIPTION
`Model.View()` sets the package-level `ui.Active*` and `ui.Nyan*` variables that the renderers read a moment later. Two renders on different goroutines therefore race them, and worse than racing, one can read another Model's values.

Bubble Tea renders on a single goroutine, so this is latent in production. It shows up in tests: any second test that renders under `t.Parallel()` trips `-race`. Two tests in `discovery_failure_level_test.go` carried a comment saying they could not be parallel because of it.

## Why a lock rather than parameters

The original plan was to turn `ActiveCollapsedCategories` and `ActiveCategoryCounts` into parameters. The race detector showed the problem is wider than those two: the first report lands on `view.go:87`, which is `ui.NyanMode`, and the same block sets the security-badge state right after. `RenderColumn` already takes nine parameters, and threading a dozen values through it would be a large change to a hot path for a latent bug.

Guarding each variable individually would not fix the real defect either. A frame needs all of them to come from the same Model, so a per-variable lock would still let one render read another Model's values and paint a wrong frame. `ui.RenderMu` takes the whole pass, which is the unit the assignments and the renderers actually share. An uncontended mutex costs about 20ns against a multi-millisecond render.

## Test plan

- [x] Both `TestDiscoveryFailureAt*` tests now call `t.Parallel()` and pass under `-race`
- [x] Verified red first: with `t.Parallel()` added and no lock, all three parallel tests report `race detected`
- [x] `go test -race ./internal/app/...` (3 consecutive runs)
- [x] `golangci-lint run ./internal/...` reports 0 issues

`TestWatchTickAgeAdvancesOnMemoizedItems` already had `t.Parallel()` and was racing silently until another parallel test joined it.