### PR TITLE
test: make the explain-stop flake say why it failed

### DIFF
--- a/internal/app/commands_exec_explain_test.go
+++ b/internal/app/commands_exec_explain_test.go
@@ -57,10 +57,14 @@ func TestExplainFetchesStopWhenTheViewCloses(t *testing.T) {
 			// The stub writes its argv first, so the file appearing means the
 			// process is really running. Closing the view before that would
 			// only prove that a cancelled context never spawns one.
-			require.Eventually(t, func() bool {
-				_, err := os.Stat(argvPath)
-				return err == nil
-			}, 10*time.Second, 20*time.Millisecond, "the stub kubectl never started")
+			//
+			// Watch done alongside the file. A spawn that fails outright (a
+			// PATH miss, ETXTBSY on the freshly written script) sends its
+			// error there immediately, and polling on alone would spend the
+			// whole ceiling before reporting "never started" without saying
+			// why. That message was the whole content of two flakes in a
+			// loaded ./... run that no one could reproduce afterwards.
+			waitForStub(t, argvPath, done)
 
 			closedAt := time.Now()
 			m.exitExplainView()
@@ -182,4 +186,23 @@ func TestExplainRequestCtxFallsBackToTheRequestContext(t *testing.T) {
 	m.cancelExplainSession()
 
 	assert.Equal(t, m.reqCtx, m.explainRequestCtx())
+}
+
+// waitForStub blocks until the stub kubectl has written its argv file, and
+// fails with whatever the fetch returned if it gave up first.
+func waitForStub(t *testing.T, argvPath string, done <-chan tea.Msg) {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for {
+		if _, err := os.Stat(argvPath); err == nil {
+			return
+		}
+		select {
+		case msg := <-done:
+			t.Fatalf("the fetch returned before the stub started: %#v", msg)
+		case <-deadline:
+			t.Fatal("the stub kubectl never started, and the fetch is still running")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
 }


### PR DESCRIPTION
`TestExplainFetchesStopWhenTheViewCloses` failed twice inside a full `-race` run and passed on every isolated re-run. The only evidence it left was the string `the stub kubectl never started`, which does not say whether the fork failed, the write was not yet visible, or the ten-second ceiling was simply too low.

A prior investigation could not reproduce it: 20 isolated runs, three `-count=3` package runs, three concurrent full-package race runs, and repeated full `./...` race runs under up to 40 busy loops on 16 cores for 15 minutes, with package runtime inflated three to four times. Zero failures across more than 200 subtest executions. No code changed then.

So this change makes the next sighting diagnosable rather than guessing at a cause.

## What changes

The wait polled only for the stub's argv file. A spawn that fails outright — a PATH miss, `ETXTBSY` on the script written moments earlier — sends its error to the `done` channel immediately, and the poll would still burn the full ceiling before reporting a message that says nothing about it.

`waitForStub` now watches both. It reports what the fetch returned when the fetch gave up first, and says the fetch is still running when the ceiling is what ran out.

## Test plan

- [x] Verified the new branch fires: a stub written without the executable bit reports `the fetch returned before the stub started: app.explainLoadedMsg{...}` instead of the ten-second timeout
- [x] `go test -race -run TestExplainFetchesStop -count=5`, four times over
- [x] `golangci-lint run ./internal/app/...` reports 0 issues

Acceptance criterion 1 asked for 20 consecutive `-race` runs inside a full `./...` run. That is the check the prior investigation already ran past 200 executions without a failure, so it cannot distinguish this change from the old code. The verification above covers what is testable.