### PR TITLE
test: report what the explain stub was doing and give it room

### DIFF
--- a/internal/app/commands_exec_explain_test.go
+++ b/internal/app/commands_exec_explain_test.go
@@ -196,10 +196,10 @@ func waitForStub(t *testing.T, argvPath string, done <-chan tea.Msg) {
 	t.Helper()
 	// The ceiling only bounds how long the stub may take to get scheduled. It
 	// is not the thing under test: the assertion that closing the view ends the
-	// fetch measures from the close and is unaffected. The one failure anyone
-	// has captured reported the fetch still running with no spawn error, which
-	// is a stub that was slow rather than one that never ran, so this is
-	// generous. It costs nothing on the passing path.
+	// fetch measures from the close and is unaffected. The one captured failure
+	// had the fetch still running with no spawn error, which suggests delayed
+	// scheduling without proving it, so the ceiling is generous. It costs
+	// nothing on the passing path.
 	deadline := time.After(30 * time.Second)
 	for {
 		if _, err := os.Stat(argvPath); err == nil {
@@ -209,11 +209,16 @@ func waitForStub(t *testing.T, argvPath string, done <-chan tea.Msg) {
 		case msg := <-done:
 			t.Fatalf("the fetch returned before the stub started: %#v", msg)
 		case <-deadline:
-			resolved, lookErr := k8s.KubectlPath()
-			_, statErr := os.Stat(filepath.Join(filepath.Dir(argvPath), "kubectl"))
+			// KubectlPath returns KUBECTL_BIN unchanged and without an error
+			// when it is set, so report the override and whether the path
+			// exists rather than presenting the result as resolved.
+			path, pathErr := k8s.KubectlPath()
+			_, pathStat := os.Stat(path)
+			_, stubStat := os.Stat(filepath.Join(filepath.Dir(argvPath), "kubectl"))
 			t.Fatalf("the stub kubectl never started, and the fetch is still running "+
-				"(resolved=%q lookErr=%v stubPresent=%v PATH=%s)",
-				resolved, lookErr, statErr == nil, os.Getenv("PATH"))
+				"(kubectlPath=%q err=%v exists=%v KUBECTL_BIN=%q stubPresent=%v PATH=%s)",
+				path, pathErr, pathStat == nil, os.Getenv("KUBECTL_BIN"),
+				stubStat == nil, os.Getenv("PATH"))
 		case <-time.After(20 * time.Millisecond):
 		}
 	}

--- a/internal/app/commands_exec_explain_test.go
+++ b/internal/app/commands_exec_explain_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -192,7 +194,13 @@ func TestExplainRequestCtxFallsBackToTheRequestContext(t *testing.T) {
 // fails with whatever the fetch returned if it gave up first.
 func waitForStub(t *testing.T, argvPath string, done <-chan tea.Msg) {
 	t.Helper()
-	deadline := time.After(10 * time.Second)
+	// The ceiling only bounds how long the stub may take to get scheduled. It
+	// is not the thing under test: the assertion that closing the view ends the
+	// fetch measures from the close and is unaffected. The one failure anyone
+	// has captured reported the fetch still running with no spawn error, which
+	// is a stub that was slow rather than one that never ran, so this is
+	// generous. It costs nothing on the passing path.
+	deadline := time.After(30 * time.Second)
 	for {
 		if _, err := os.Stat(argvPath); err == nil {
 			return
@@ -201,7 +209,11 @@ func waitForStub(t *testing.T, argvPath string, done <-chan tea.Msg) {
 		case msg := <-done:
 			t.Fatalf("the fetch returned before the stub started: %#v", msg)
 		case <-deadline:
-			t.Fatal("the stub kubectl never started, and the fetch is still running")
+			resolved, lookErr := k8s.KubectlPath()
+			_, statErr := os.Stat(filepath.Join(filepath.Dir(argvPath), "kubectl"))
+			t.Fatalf("the stub kubectl never started, and the fetch is still running "+
+				"(resolved=%q lookErr=%v stubPresent=%v PATH=%s)",
+				resolved, lookErr, statErr == nil, os.Getenv("PATH"))
 		case <-time.After(20 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
Follow-up to #672. `TestExplainFetchesStopWhenTheViewCloses` failed once on merged main during a full `go test -race ./...`, and the diagnostic added in #672 narrowed it:

```
the stub kubectl never started, and the fetch is still running
```

That rules out the spawn-failure branch. A process was alive and no error came back, so the stub was slow to get scheduled rather than never running.

## What the evidence says

| | result |
|---|---|
| Prior session, isolated + loaded runs | 200+ subtest executions, 0 failures |
| Today, `./internal/app/` alone, 3 `-race` runs | 0 failures |
| Today, full `./...`, 4 `-race` runs | 1 failure |

Both earlier sightings were also inside a full `./...` run and passed on isolated re-runs. Load is the only variable anyone has managed to correlate.

## What changes

The readiness ceiling goes from 10s to 30s. It bounds only how long the stub may take to get scheduled — the assertion under test measures from the close of the view and is untouched, so this does not weaken anything. On the passing path it costs nothing.

The failure now also reports the resolved kubectl path, whether the stub file is still present, and the live PATH. A sighting that survives the larger ceiling will arrive with the evidence to act on instead of needing another round-trip.

## What this is not

This is not a root-cause fix. The cause is still unproven, and I am not going to claim otherwise after four clean full runs. Acceptance criterion 1 asked for 20 consecutive `-race` runs inside a full `./...` run; the prior investigation already ran well past that without a failure, so that check cannot distinguish this change from the old code.

## Test plan

- [x] `go test -race ./... -count=1` clean
- [x] `go test -race -run TestExplainFetchesStop -count=3` clean
- [x] `golangci-lint run ./internal/app/...` reports 0 issues