### PR TITLE
test: wait on signals only the target view emits in the CronJob log e2e

### DIFF
--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -54,7 +54,11 @@ func TestClusterModeCronJobLogs(t *testing.T) {
 	// way here draws it, so this separates "ctrl+l did not land" from "the logs
 	// never arrived". The failure that prompted this reported a missing marker
 	// while the app was still in the explorer.
-	at = waitForAfter2(t, out, at, "half page", clusterStartupTimeout)
+	//
+	// Both waits run from the offset ctrl+l was sent at. The viewer paints its
+	// body and its footer in one frame, so advancing past the footer would step
+	// over the log line this is looking for.
+	waitForAfter(t, out, at, "half page", clusterStartupTimeout)
 	waitForAfter(t, out, at, marker, clusterStartupTimeout)
 
 	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -26,6 +26,10 @@ func TestClusterModeCronJobLogs(t *testing.T) {
 	if marker == "" {
 		t.Fatal("LFK_E2E_LOG_MARKER must be set alongside LFK_E2E_REAL_CLUSTER")
 	}
+	cronJob := os.Getenv("LFK_CRONJOB")
+	if cronJob == "" {
+		cronJob = "nightly-backup"
+	}
 
 	binPath := buildBinary(t)
 
@@ -39,10 +43,18 @@ func TestClusterModeCronJobLogs(t *testing.T) {
 	// discovery lists populate too slowly for a fixed sleep to outlast.
 	at := waitForThenSend(t, out, "kind-lfk-e2e", ptmx, "\r", clusterStartupTimeout)
 	at = waitForNewThenSend(t, out, at, "CronJobs", ptmx, "/CronJobs\r", clusterStartupTimeout)
-	at = waitForNewThenSend(t, out, at, "nightly-backup", ptmx, "\r", clusterStartupTimeout)
-	// ctrl+l opens the fullscreen log viewer.
-	at = waitForNewThenSend(t, out, at, "nightly-backup", ptmx, "\x0c", clusterStartupTimeout)
+	at = waitForNewThenSend(t, out, at, cronJob, ptmx, "\r", clusterStartupTimeout)
+	// Wait for the Job row rather than the CronJob's own name. The CronJob name
+	// prefixes the Job's, so the shorter string is already on screen in the
+	// details pane and a repaint would satisfy the wait before the drilled-in
+	// list exists, sending ctrl+l at a selection that resolves to no pod.
+	at = waitForNewThenSend(t, out, at, cronJob+"-run", ptmx, "\x0c", clusterStartupTimeout)
 
+	// "half page" belongs to the fullscreen viewer's footer and nothing on the
+	// way here draws it, so this separates "ctrl+l did not land" from "the logs
+	// never arrived". The failure that prompted this reported a missing marker
+	// while the app was still in the explorer.
+	at = waitForAfter2(t, out, at, "half page", clusterStartupTimeout)
 	waitForAfter(t, out, at, marker, clusterStartupTimeout)
 
 	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -251,7 +251,10 @@ func TestDemoModeCronJobLogs(t *testing.T) {
 	// list exists. Same reasoning as the cluster test.
 	at = waitForNewThenSend(t, out, at, demo.JobNightlyBackupRun, ptmx, "\x0c", startupTimeout)
 
-	at = waitForAfter2(t, out, at, "half page", startupTimeout)
+	// Both waits run from the offset ctrl+l was sent at: the viewer paints its
+	// body and its footer in one frame, so advancing past the footer would step
+	// over the content this is looking for.
+	waitForAfter(t, out, at, "half page", startupTimeout)
 	waitForAfter(t, out, at, demo.JobNightlyBackupRun, startupTimeout)
 
 	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {

--- a/e2e/demo_test.go
+++ b/e2e/demo_test.go
@@ -246,9 +246,12 @@ func TestDemoModeCronJobLogs(t *testing.T) {
 	sendKeys(t, ptmx, "\r")
 	at := waitForThenSend(t, out, "CronJobs", ptmx, "/CronJobs\r", startupTimeout)
 	at = waitForNewThenSend(t, out, at, demo.CronJobNightlyBackup, ptmx, "\r", startupTimeout)
-	// ctrl+l opens the fullscreen log viewer.
-	at = waitForNewThenSend(t, out, at, demo.CronJobNightlyBackup, ptmx, "\x0c", startupTimeout)
+	// The Job row, not the CronJob name: the latter prefixes the former, so a
+	// details-pane repaint would satisfy the shorter wait before the drilled-in
+	// list exists. Same reasoning as the cluster test.
+	at = waitForNewThenSend(t, out, at, demo.JobNightlyBackupRun, ptmx, "\x0c", startupTimeout)
 
+	at = waitForAfter2(t, out, at, "half page", startupTimeout)
 	waitForAfter(t, out, at, demo.JobNightlyBackupRun, startupTimeout)
 
 	if strings.Contains(out.String(), "panic:") || strings.Contains(stderr.String(), "panic:") {


### PR DESCRIPTION
Closes the flake tracked in the e2e CronJob log test. `TestClusterModeCronJobLogs` timed out waiting for the log marker while `kubectl logs` showed the pod had printed it.

## What was ambiguous

The CronJob is `nightly-backup` and its Job is `nightly-backup-run`, so the CronJob's name is a prefix of the Job's. The step before `ctrl+l` waited for the CronJob name a second time — a string the details pane was already drawing. A repaint satisfied it before the drilled-in Job list existed, and `ctrl+l` went to a selection that resolved to no pod.

Two changes:

- Wait for the Job row (`<cronjob>-run`) rather than the CronJob name, so the wait can only be met once the drill-in has happened.
- After `ctrl+l`, wait for the footer's `half page` hint before waiting on log content. Nothing on the way to the log viewer draws it.

## Why `half page`

It separates two failures that used to look identical. The captured run contains **zero** occurrences of `half page` and zero of `timestamps` across 21KB of PTY output, which is how we know the app was still in the explorer rather than sitting in an open viewer waiting for logs. Without that gate the only symptom was a missing marker.

It is the fourth hint in the footer, so a 200-column PTY cannot truncate it away.

## Test plan

- [x] `go test -tags e2e ./e2e/ -run TestDemoModeCronJobLogs -count=3` passes, exercising the new `half page` gate
- [x] Confirmed the gate is not vacuous: `half page` does not appear anywhere in the failing CI run's output
- [x] `golangci-lint run ./e2e/...` reports 0 issues
- [ ] The cluster variant needs the CI kind job; it cannot run locally

The demo sibling carries the same prefix ambiguity and gets the same treatment.