### PR TITLE
fix: cluster-scoped views ignore the namespace selection

### DIFF
--- a/internal/app/negative_namespace_test.go
+++ b/internal/app/negative_namespace_test.go
@@ -514,3 +514,41 @@ func newNamespaceOverlayModel() Model {
 		height:        40,
 	}
 }
+
+// TestUpdateOwnedLoadedUsesSharedNamespaceFilter guards the owned-resources
+// list against the two defects a hand-rolled copy of the namespace filter
+// carried: it dropped cluster-scoped items (issue #676), and under EXCLUDE
+// mode it kept exactly the namespaces the user had excluded.
+func TestUpdateOwnedLoadedUsesSharedNamespaceFilter(t *testing.T) {
+	items := []model.Item{
+		{Name: "pod-a", Namespace: "default"},
+		{Name: "pod-b", Namespace: "kube-system"},
+		{Name: "pod-c", Namespace: "monitoring"},
+		{Name: "node-1", Namespace: ""},
+	}
+
+	t.Run("include mode keeps cluster-scoped items", func(t *testing.T) {
+		m := Model{
+			selectedNamespaces: map[string]bool{"default": true, "monitoring": true},
+		}
+		updated, _ := m.updateOwnedLoaded(ownedLoadedMsg{items: items, forPreview: true})
+		names := negNsItemNames(updated.(Model).rightItems)
+		assert.Contains(t, names, "pod-a")
+		assert.NotContains(t, names, "pod-b")
+		assert.Contains(t, names, "pod-c")
+		assert.Contains(t, names, "node-1")
+	})
+
+	t.Run("exclude mode drops the excluded namespaces", func(t *testing.T) {
+		m := Model{
+			selectedNamespaces: map[string]bool{"default": true, "monitoring": true},
+			nsSelectionNegated: true,
+		}
+		updated, _ := m.updateOwnedLoaded(ownedLoadedMsg{items: items, forPreview: true})
+		names := negNsItemNames(updated.(Model).rightItems)
+		assert.NotContains(t, names, "pod-a")
+		assert.Contains(t, names, "pod-b")
+		assert.NotContains(t, names, "pod-c")
+		assert.Contains(t, names, "node-1")
+	})
+}

--- a/internal/app/update_resources_loaded.go
+++ b/internal/app/update_resources_loaded.go
@@ -375,16 +375,7 @@ func (m Model) updateOwnedLoaded(msg ownedLoadedMsg) (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 	m.err = nil
-	// Filter by selected namespaces when multi-select is active.
-	if len(m.selectedNamespaces) > 1 {
-		filtered := make([]model.Item, 0, len(msg.items))
-		for _, item := range msg.items {
-			if m.selectedNamespaces[item.Namespace] {
-				filtered = append(filtered, item)
-			}
-		}
-		msg.items = filtered
-	}
+	msg.items = m.filterLoadedItemsBySelectedNamespaces(msg.items)
 	if msg.forPreview {
 		m.previewLoading = false
 		m.rightItems = msg.items

--- a/internal/k8s/client_resources.go
+++ b/internal/k8s/client_resources.go
@@ -50,6 +50,14 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 		return c.listSecretsMetadata(ctx, contextName, namespace, rt)
 	}
 
+	// Issue #676: a cluster-scoped kind has no .metadata.namespace, so the
+	// informer cache's ListAllByNamespace matches nothing and the user sees
+	// an empty Nodes view for every namespace but "All Namespaces". Drop the
+	// namespace here so the cache path and the direct list below agree.
+	if !rt.Namespaced {
+		namespace = ""
+	}
+
 	gvr := schema.GroupVersionResource{
 		Group:    rt.APIGroup,
 		Version:  rt.APIVersion,

--- a/internal/k8s/informer_cache_test.go
+++ b/internal/k8s/informer_cache_test.go
@@ -702,3 +702,60 @@ func TestApplyMemo_PerNamespaceListDoesNotPruneOtherNamespaces(t *testing.T) {
 	assert.Contains(t, entry.memo, "team-b/worker-1",
 		"per-namespace list must not prune entries from other namespaces")
 }
+
+// nodeRT is the cluster-scoped counterpart of podRT. Nodes carry no
+// .metadata.namespace, so a namespace-keyed cache read finds nothing.
+var nodeRT = model.ResourceTypeEntry{
+	APIGroup:   "",
+	APIVersion: "v1",
+	Resource:   "nodes",
+	Kind:       "Node",
+	Namespaced: false,
+}
+
+// nodeObj builds a minimal cluster-scoped Node object.
+func nodeObj(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Node",
+			"metadata": map[string]any{
+				"name":              name,
+				"creationTimestamp": "2026-04-01T00:00:00Z",
+			},
+		},
+	}
+}
+
+// TestGetResources_ClusterScopedIgnoresNamespace is the regression guard for
+// issue #676. The direct-list path drops the namespace for a cluster-scoped
+// kind, but the informer-cache path passed it through to
+// ListAllByNamespace, which matched nothing because a Node has no
+// namespace. The user saw an empty Nodes view for every namespace except
+// "All Namespaces".
+func TestGetResources_ClusterScopedIgnoresNamespace(t *testing.T) {
+	dc := newFakeDynClientWith(
+		map[schema.GroupVersionResource]string{
+			{Group: "", Version: "v1", Resource: "nodes"}: "NodeList",
+		},
+		nodeObj("worker-1"),
+		nodeObj("worker-2"),
+	)
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+
+	// Warm the cache with an all-namespaces list, the state the user reaches
+	// before they pick a namespace.
+	warm, err := c.GetResources(t.Context(), "", "", nodeRT)
+	require.NoError(t, err)
+	require.Len(t, warm, 2)
+
+	// Pick a namespace. A cluster-scoped kind must ignore it.
+	scoped, err := c.GetResources(t.Context(), "", "team-a", nodeRT)
+	require.NoError(t, err)
+	require.Len(t, scoped, 2,
+		"cluster-scoped resources must ignore the selected namespace (issue #676)")
+	assert.Equal(t, []string{"worker-1", "worker-2"},
+		[]string{scoped[0].Name, scoped[1].Name})
+}

--- a/internal/k8s/informer_cache_test.go
+++ b/internal/k8s/informer_cache_test.go
@@ -703,22 +703,12 @@ func TestApplyMemo_PerNamespaceListDoesNotPruneOtherNamespaces(t *testing.T) {
 		"per-namespace list must not prune entries from other namespaces")
 }
 
-// nodeRT is the cluster-scoped counterpart of podRT. Nodes carry no
-// .metadata.namespace, so a namespace-keyed cache read finds nothing.
-var nodeRT = model.ResourceTypeEntry{
-	APIGroup:   "",
-	APIVersion: "v1",
-	Resource:   "nodes",
-	Kind:       "Node",
-	Namespaced: false,
-}
-
-// nodeObj builds a minimal cluster-scoped Node object.
-func nodeObj(name string) *unstructured.Unstructured {
+// clusterScopedObj builds a minimal cluster-scoped object of any kind.
+func clusterScopedObj(apiVersion, kind, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Node",
+			"apiVersion": apiVersion,
+			"kind":       kind,
 			"metadata": map[string]any{
 				"name":              name,
 				"creationTimestamp": "2026-04-01T00:00:00Z",
@@ -730,32 +720,90 @@ func nodeObj(name string) *unstructured.Unstructured {
 // TestGetResources_ClusterScopedIgnoresNamespace is the regression guard for
 // issue #676. The direct-list path drops the namespace for a cluster-scoped
 // kind, but the informer-cache path passed it through to
-// ListAllByNamespace, which matched nothing because a Node has no
-// namespace. The user saw an empty Nodes view for every namespace except
-// "All Namespaces".
+// ListAllByNamespace, which matched nothing because these objects carry no
+// .metadata.namespace. The user saw an empty Nodes view for every namespace
+// but "All Namespaces".
+//
+// The table covers a core kind, storage, RBAC, apiextensions, and a
+// cluster-scoped CRD, because the fix keys on rt.Namespaced rather than on
+// any kind name. A per-kind special case would pass the Node row alone.
 func TestGetResources_ClusterScopedIgnoresNamespace(t *testing.T) {
-	dc := newFakeDynClientWith(
-		map[schema.GroupVersionResource]string{
-			{Group: "", Version: "v1", Resource: "nodes"}: "NodeList",
+	tests := []struct {
+		name       string
+		group      string
+		version    string
+		resource   string
+		listKind   string
+		kind       string
+		apiVersion string
+	}{
+		{"Node", "", "v1", "nodes", "NodeList", "Node", "v1"},
+		{"PersistentVolume", "", "v1", "persistentvolumes", "PersistentVolumeList", "PersistentVolume", "v1"},
+		{"StorageClass", "storage.k8s.io", "v1", "storageclasses", "StorageClassList", "StorageClass", "storage.k8s.io/v1"},
+		{"ClusterRole", "rbac.authorization.k8s.io", "v1", "clusterroles", "ClusterRoleList", "ClusterRole", "rbac.authorization.k8s.io/v1"},
+		{
+			"CustomResourceDefinition", "apiextensions.k8s.io", "v1", "customresourcedefinitions",
+			"CustomResourceDefinitionList", "CustomResourceDefinition", "apiextensions.k8s.io/v1",
 		},
-		nodeObj("worker-1"),
-		nodeObj("worker-2"),
+		{"NodePool", "karpenter.sh", "v1", "nodepools", "NodePoolList", "NodePool", "karpenter.sh/v1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gvr := schema.GroupVersionResource{Group: tc.group, Version: tc.version, Resource: tc.resource}
+			dc := newFakeDynClientWith(
+				map[schema.GroupVersionResource]string{gvr: tc.listKind},
+				clusterScopedObj(tc.apiVersion, tc.kind, "obj-1"),
+				clusterScopedObj(tc.apiVersion, tc.kind, "obj-2"),
+			)
+			c := NewTestClient(nil, dc)
+			c.SetInformerCacheMode(InformerCacheAlways)
+			t.Cleanup(c.Shutdown)
+
+			rt := model.ResourceTypeEntry{
+				APIGroup:   tc.group,
+				APIVersion: tc.version,
+				Resource:   tc.resource,
+				Kind:       tc.kind,
+				Namespaced: false,
+			}
+
+			// Warm the cache with an all-namespaces list, the state the user
+			// reaches before they pick a namespace.
+			warm, err := c.GetResources(t.Context(), "", "", rt)
+			require.NoError(t, err)
+			require.Len(t, warm, 2)
+
+			// Pick a namespace. A cluster-scoped kind must ignore it.
+			scoped, err := c.GetResources(t.Context(), "", "team-a", rt)
+			require.NoError(t, err)
+			require.Len(t, scoped, 2,
+				"cluster-scoped resources must ignore the selected namespace (issue #676)")
+			assert.Equal(t, []string{"obj-1", "obj-2"},
+				[]string{scoped[0].Name, scoped[1].Name})
+		})
+	}
+}
+
+// TestGetResources_NamespacedStillFiltersByNamespace is the counterweight to
+// the test above: clearing the namespace must apply to cluster-scoped kinds
+// only. A blanket clear would turn every namespaced list into an
+// all-namespaces list.
+func TestGetResources_NamespacedStillFiltersByNamespace(t *testing.T) {
+	dc := newFakeDynClient(
+		pod("api-1", "team-a"),
+		pod("worker-1", "team-b"),
 	)
 	c := NewTestClient(nil, dc)
 	c.SetInformerCacheMode(InformerCacheAlways)
 	t.Cleanup(c.Shutdown)
 
-	// Warm the cache with an all-namespaces list, the state the user reaches
-	// before they pick a namespace.
-	warm, err := c.GetResources(t.Context(), "", "", nodeRT)
+	all, err := c.GetResources(t.Context(), "", "", podRT)
 	require.NoError(t, err)
-	require.Len(t, warm, 2)
+	require.Len(t, all, 2)
 
-	// Pick a namespace. A cluster-scoped kind must ignore it.
-	scoped, err := c.GetResources(t.Context(), "", "team-a", nodeRT)
+	scoped, err := c.GetResources(t.Context(), "", "team-a", podRT)
 	require.NoError(t, err)
-	require.Len(t, scoped, 2,
-		"cluster-scoped resources must ignore the selected namespace (issue #676)")
-	assert.Equal(t, []string{"worker-1", "worker-2"},
-		[]string{scoped[0].Name, scoped[1].Name})
+	require.Len(t, scoped, 1)
+	assert.Equal(t, "api-1", scoped[0].Name)
 }


### PR DESCRIPTION
Closes #676

## What broke

`GetResources` has two list paths. The direct list already dropped the namespace for a cluster-scoped kind. The informer-cache path passed it straight to `ListAllByNamespace`. A Node carries no `.metadata.namespace`, so the cache matched nothing and the Nodes view was empty for every namespace except "All Namespaces".

The cache takes over from the second list of a GVR onward, so the view failed on every refresh, not now and then.

## Changes

- `internal/k8s/client_resources.go` - clear the namespace when `rt.Namespaced` is false, before both list paths. This covers Nodes, PersistentVolumes, StorageClasses, ClusterRoles, CRDs, IngressClasses, PriorityClasses, and cluster-scoped CRDs such as Karpenter NodePools.
- `internal/app/update_resources_loaded.go` - `updateOwnedLoaded` held a hand-rolled copy of the namespace filter with the same defect, plus an inverted EXCLUDE mode because the copy never read `nsSelectionNegated`. It now calls the shared `filterLoadedItemsBySelectedNamespaces` helper, which the main list and the preview path already use.

## Test plan

- [x] `TestGetResources_ClusterScopedIgnoresNamespace` - fails on `main` with 0 items, passes with 2.
- [x] `TestUpdateOwnedLoadedUsesSharedNamespaceFilter` - both subtests fail on `main`, one for the dropped cluster-scoped item, one for the inverted EXCLUDE mode.
- [x] `go build ./...`, `go test ./... -count=1`, `golangci-lint run ./...` all clean.
- [ ] Manual check: select a single namespace, open the Nodes view, confirm the nodes list.