### PR TITLE
fix: respect the kubeconfig context namespace at startup

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -234,10 +234,9 @@ log_path: /tmp/lfk.log
 #   tree: false  # open in the ASCII-art tree view (toggle: T)
 
 # ─── Session Defaults ────────────────────────────────────────────────────────
-# Startup state for the main view. split_preview toggles the preview pane;
-# watch_mode toggles live polling; all_namespaces sets the namespace scope
-# (false starts scoped to the context's default namespace). The --namespace CLI
-# flag and per-bookmark/session scope override all_namespaces.
+# Startup state for the main view. split_preview toggles the preview pane,
+# watch_mode toggles live polling, all_namespaces sets the namespace scope
+# (unset, a pinned kubeconfig namespace wins). CLI/session scope overrides it.
 # split_preview: true
 # watch_mode: true
 # all_namespaces: true

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -56,7 +56,7 @@ Prefer a local copy? Point `$schema` at a relative or absolute path instead of t
 | `foreground_idle_timeout` | string | `120s` | No-input window before a focused window throttles to `background_watch_interval`. Go duration; `0` disables focused-idle throttling (background throttling still applies). Clamped to [0, 10m]. |
 | `metrics_interval` | string | `15s` | Minimum gap between two list-wide CPU/MEM fetches on a watch-tick refresh. Go duration, clamped to [2s, 10m]; `0` fetches on every tick. Manual refresh always fetches. |
 | `watch_throttle` | bool | `true` | Master switch for focus/idle watch throttling. Set `false` to disable it entirely; the watch tick then always uses `watch_interval`. |
-| `all_namespaces` | bool | `true` | Startup namespace scope: `true` shows all namespaces, `false` scopes to the context's default namespace. The `--namespace` CLI flag and per-bookmark/session scope override this. |
+| `all_namespaces` | bool | `true` | Startup namespace scope: `true` shows all namespaces, `false` scopes to the context's default namespace. Unset, a kubeconfig context that pins a namespace scopes to it instead. The `--namespace` CLI flag and per-bookmark/session scope override this. |
 | `events` | object | *(see Events section)* | Events view startup-toggle defaults. See [Events](#events). |
 | `log_tail_lines` | int | `100` | **Deprecated** — use `log_viewer.tail_lines`. Number of log lines to load initially via `--tail`. |
 | `log_tail_lines_short` | int | `10` | **Deprecated** — use `log_viewer.tail_lines_short`. Number of log lines loaded by the action menu "Tail Logs" entry. Non-positive values are ignored. |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -222,7 +222,7 @@
     },
     "all_namespaces": {
       "type": "boolean",
-      "description": "Startup namespace scope: true shows all namespaces, false scopes to the context's default namespace. The --namespace CLI flag and per-bookmark/session scope override this.",
+      "description": "Startup namespace scope: true shows all namespaces, false scopes to the context's default namespace. Unset, a kubeconfig context that pins a namespace scopes to it instead. The --namespace CLI flag and per-bookmark/session scope override this.",
       "default": true
     },
     "events": {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,8 +9,9 @@ CLI flags, environment variables, and runtime tuning options for `lfk`.
 lfk
 
 # Start in a specific context. Without -n, lfk opens in the namespace that the
-# context pins in the kubeconfig. Switching context inside the app re-scopes the
-# same way. Set all_namespaces in the config file to override both.
+# context pins in the kubeconfig. A restored session keeps its own scope, and
+# all_namespaces in the config file overrides the pinned namespace either way.
+# Switching context inside the app re-scopes the same way.
 lfk --context my-cluster
 
 # Start in a specific namespace (disables all-namespaces mode)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,9 @@ CLI flags, environment variables, and runtime tuning options for `lfk`.
 # Use default kubeconfig (~/.kube/config + ~/.kube/config.d/*)
 lfk
 
-# Start in a specific context
+# Start in a specific context. Without -n, lfk opens in the namespace that the
+# context pins in the kubeconfig. Switching context inside the app re-scopes the
+# same way. Set all_namespaces in the config file to override both.
 lfk --context my-cluster
 
 # Start in a specific namespace (disables all-namespaces mode)

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -16,6 +16,22 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
+// resolveStartupAllNamespaces reports whether the app opens in all-namespaces
+// mode. An explicit all_namespaces in config wins. Otherwise a kubeconfig
+// context that pins a namespace scopes the view to it, matching kubectl.
+func resolveStartupAllNamespaces(client *k8s.Client, contextName string) bool {
+	if ui.ConfigAllNamespacesSet {
+		return ui.ConfigAllNamespaces
+	}
+	if client == nil {
+		return ui.ConfigAllNamespaces
+	}
+	if _, pinned := client.ContextNamespace(contextName); pinned {
+		return false
+	}
+	return ui.ConfigAllNamespaces
+}
+
 // NewModel creates the initial model.
 func NewModel(client *k8s.Client, opts StartupOptions) Model {
 	s := spinner.New()
@@ -27,6 +43,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		contextName = opts.Context
 	}
 	defaultNS := client.DefaultNamespace(contextName)
+	startupAllNamespaces := resolveStartupAllNamespaces(client, contextName)
 
 	// Watch interval precedence: CLI flag > config > default.
 	watchInterval := ui.ConfigWatchInterval
@@ -90,7 +107,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		foregroundIdleTimeout:      resolveForegroundIdle(opts),
 		fullLogPreview:             ui.ConfigLogPreviewLive,
 		splitPreview:               ui.ConfigSplitPreview,
-		allNamespaces:              ui.ConfigAllNamespaces,
+		allNamespaces:              startupAllNamespaces,
 		watchMode:                  ui.ConfigWatchMode,
 		objectExplorerLive:         ui.ConfigObjectExplorerLive,
 		objectExplorerTree:         ui.ConfigObjectExplorerTree,
@@ -147,7 +164,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 			nav:                        model.NavigationState{Level: model.LevelClusters},
 			namespace:                  defaultNS,
 			splitPreview:               ui.ConfigSplitPreview,
-			allNamespaces:              ui.ConfigAllNamespaces,
+			allNamespaces:              startupAllNamespaces,
 			watchMode:                  ui.ConfigWatchMode,
 			objectExplorerLive:         ui.ConfigObjectExplorerLive,
 			objectExplorerTree:         ui.ConfigObjectExplorerTree,
@@ -205,7 +222,10 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 			tab.Namespace = opts.Namespaces[0]
 			tab.SelectedNamespaces = opts.Namespaces
 		} else {
-			tab.AllNamespaces = true
+			tab.AllNamespaces = startupAllNamespaces
+			if !startupAllNamespaces {
+				tab.Namespace = defaultNS
+			}
 		}
 		m.pendingSession = &SessionState{
 			Context: contextName,

--- a/internal/app/commandbar_execute.go
+++ b/internal/app/commandbar_execute.go
@@ -330,6 +330,7 @@ func (m Model) executeContextCommand(arg string) (tea.Model, tea.Cmd) {
 	m.nav.Context = arg
 	m.invalidateOrphanCacheForContext(oldCtx)
 	m.recomputeReadOnly(arg)
+	m.rescopeNamespaceForContext(arg)
 	m.setStatusMessage(fmt.Sprintf("Context set to %s", arg), false)
 	cmds := []tea.Cmd{m.loadResourceTypes(), scheduleStatusClear()}
 	if cmd := m.ensureNamespaceCacheFresh(); cmd != nil {

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -641,6 +641,30 @@ func (m Model) defaultNamespaceForContext() string {
 	return "default"
 }
 
+// rescopeNamespaceForContext re-applies the namespace scope after a plain
+// context switch, so each cluster opens in the namespace its kubeconfig
+// context pins. An explicit all_namespaces in config still wins.
+func (m *Model) rescopeNamespaceForContext(ctxName string) {
+	if m.client == nil || m.unionMode {
+		return
+	}
+	// Every namespace selection here belongs to the cluster we just left. Those
+	// names rarely exist in the new one, so a later A-toggle or previous-namespace
+	// jump would scope this cluster to a namespace the user never picked.
+	m.selectedNamespaces = nil
+	m.nsSelectionNegated = false
+	m.savedSelectedNamespaces = nil
+	m.savedNsSelectionNegated = false
+	m.nsSelectionModified = false
+	m.previousNsScope = nil
+	if resolveStartupAllNamespaces(m.client, ctxName) {
+		m.allNamespaces = true
+		return
+	}
+	m.allNamespaces = false
+	m.namespace = m.client.DefaultNamespace(ctxName)
+}
+
 // loadRevisions fetches the revision history for a deployment.
 func (m Model) loadRevisions() tea.Cmd {
 	sel := m.selectedMiddleItem()

--- a/internal/app/commands_load.go
+++ b/internal/app/commands_load.go
@@ -659,6 +659,10 @@ func (m *Model) rescopeNamespaceForContext(ctxName string) {
 	m.previousNsScope = nil
 	if resolveStartupAllNamespaces(m.client, ctxName) {
 		m.allNamespaces = true
+		// The A-toggle only resolves the new context's default namespace when
+		// this is empty, so a leftover value scopes the new cluster to the old
+		// cluster's namespace.
+		m.namespace = ""
 		return
 	}
 	m.allNamespaces = false

--- a/internal/app/namespace_context_scope_test.go
+++ b/internal/app/namespace_context_scope_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -162,7 +163,7 @@ func TestRescopeNamespaceForContext_DropsAllNamespacesStash(t *testing.T) {
 		wantNamespace string
 	}{
 		{name: "context pins a namespace", pinnedNs: "team-a", wantAllNs: false, wantNamespace: "team-a"},
-		{name: "context pins nothing", pinnedNs: "", wantAllNs: true, wantNamespace: "stale"},
+		{name: "context pins nothing", pinnedNs: "", wantAllNs: true, wantNamespace: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := baseModelWithFakeClient()
@@ -185,4 +186,34 @@ func TestRescopeNamespaceForContext_DropsAllNamespacesStash(t *testing.T) {
 			assert.Nil(t, m.previousNsScope, "a previous-namespace jump would land in the old cluster's namespace")
 		})
 	}
+}
+
+// A context switch into all-namespaces mode must clear m.namespace too. The
+// A-toggle only falls back to the new context's default when m.namespace is
+// empty (update_keys_actions.go), so a leftover value silently scopes the new
+// cluster to a namespace from the old one.
+func TestRescopeNamespaceForContext_AllNamespacesClearsStaleNamespace(t *testing.T) {
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = false
+
+	m := baseModelWithFakeClient()
+	m.client.AddTestContextWithNamespace("staging", "https://staging.example.local:6443", "")
+	m.nav.Level = model.LevelResourceTypes
+	m.namespace = "old-cluster-ns"
+	m.allNamespaces = false
+
+	m.nav.Context = "staging"
+	m.rescopeNamespaceForContext("staging")
+	require.True(t, m.allNamespaces)
+	require.Empty(t, m.namespace, "the old cluster's namespace must not survive the switch")
+
+	// Toggle all-namespaces off in the new cluster.
+	toggled, _, _ := m.handleExplorerActionKeyAllNamespaces()
+	after, ok := toggled.(Model)
+	require.True(t, ok)
+
+	assert.False(t, after.allNamespaces)
+	assert.Equal(t, "default", after.namespace, "the toggle must resolve the new context's default namespace")
 }

--- a/internal/app/namespace_context_scope_test.go
+++ b/internal/app/namespace_context_scope_test.go
@@ -1,0 +1,188 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// --- resolveStartupAllNamespaces precedence ---
+
+func TestResolveStartupAllNamespaces_ContextPinsNamespace_ScopesToIt(t *testing.T) {
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = false
+
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContextWithNamespace("prod", "https://prod.example.local:6443", "billing")
+
+	got := resolveStartupAllNamespaces(client, "prod")
+	assert.False(t, got, "a pinned context namespace must scope the startup view when all_namespaces is unset")
+}
+
+func TestResolveStartupAllNamespaces_ContextPinsNoNamespace_AllNamespaces(t *testing.T) {
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = false
+
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContextWithNamespace("dev", "https://dev.example.local:6443", "")
+
+	got := resolveStartupAllNamespaces(client, "dev")
+	assert.True(t, got, "a context with no pinned namespace must fall back to all-namespaces")
+}
+
+func TestResolveStartupAllNamespaces_ConfigTrueWinsOverPinnedNamespace(t *testing.T) {
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = true
+
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContextWithNamespace("prod", "https://prod.example.local:6443", "billing")
+
+	got := resolveStartupAllNamespaces(client, "prod")
+	assert.True(t, got, "an explicit all_namespaces: true must win over a pinned context namespace")
+}
+
+func TestResolveStartupAllNamespaces_ConfigFalseScopesToContextNamespace(t *testing.T) {
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = false
+	ui.ConfigAllNamespacesSet = true
+
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContextWithNamespace("dev", "https://dev.example.local:6443", "")
+
+	got := resolveStartupAllNamespaces(client, "dev")
+	assert.False(t, got, "an explicit all_namespaces: false must scope even without a pinned namespace")
+}
+
+// --- NewModel / CLI flag precedence ---
+
+func TestNewModel_CLINamespaceOverridesConfigAndKubeconfig(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = false
+
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContextWithNamespace("prod", "https://prod.example.local:6443", "billing")
+
+	m := NewModel(client, StartupOptions{Context: "prod", Namespaces: []string{"checkout"}})
+
+	require.NotNil(t, m.pendingSession)
+	require.Len(t, m.pendingSession.Tabs, 1)
+	tab := m.pendingSession.Tabs[0]
+	assert.False(t, tab.AllNamespaces)
+	assert.Equal(t, "checkout", tab.Namespace, "--namespace must win over both config and the kubeconfig-pinned namespace")
+}
+
+// TestNewModel_CLIContextOnlyHonoursConfigAndKubeconfigNamespace is the
+// regression test for the --context (no --namespace) startup path: it must
+// not force all-namespaces and drop the kubeconfig-pinned scope.
+func TestNewModel_CLIContextOnlyHonoursConfigAndKubeconfigNamespace(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = false
+
+	client := k8s.NewTestClient(nil, nil)
+	client.AddTestContextWithNamespace("prod", "https://prod.example.local:6443", "billing")
+
+	m := NewModel(client, StartupOptions{Context: "prod"})
+
+	require.NotNil(t, m.pendingSession)
+	require.Len(t, m.pendingSession.Tabs, 1)
+	tab := m.pendingSession.Tabs[0]
+	assert.False(t, tab.AllNamespaces, "--context alone must not force all-namespaces over a pinned kubeconfig namespace")
+	assert.Equal(t, "billing", tab.Namespace)
+}
+
+// --- rescopeNamespaceForContext ---
+
+func TestRescopeNamespaceForContext_ScopesToPinnedNamespaceAndClearsSelection(t *testing.T) {
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = false
+
+	m := baseModelWithFakeClient()
+	m.client.AddTestContextWithNamespace("staging", "https://staging.example.local:6443", "team-a")
+	m.allNamespaces = true
+	m.selectedNamespaces = map[string]bool{"old-ns": true}
+	m.nsSelectionNegated = true
+
+	m.rescopeNamespaceForContext("staging")
+
+	assert.False(t, m.allNamespaces)
+	assert.Equal(t, "team-a", m.namespace)
+	assert.Nil(t, m.selectedNamespaces, "switching clusters must drop the prior cluster's multi-namespace selection")
+	assert.False(t, m.nsSelectionNegated)
+}
+
+func TestRescopeNamespaceForContext_NoOpInUnionMode(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.client.AddTestContextWithNamespace("staging", "https://staging.example.local:6443", "team-a")
+	m.unionMode = true
+	m.allNamespaces = true
+	m.namespace = "kept"
+	m.selectedNamespaces = map[string]bool{"kept-ns": true}
+
+	m.rescopeNamespaceForContext("staging")
+
+	assert.True(t, m.allNamespaces)
+	assert.Equal(t, "kept", m.namespace)
+	assert.Equal(t, map[string]bool{"kept-ns": true}, m.selectedNamespaces)
+}
+
+// The all-namespaces stash (savedSelectedNamespaces) survives an A-toggle so a
+// second press can restore the prior selection. It must not survive a context
+// switch: restoring it in the new cluster scopes to a namespace that belongs to
+// the old one. namespace_history.go drops the same pair on a previous-namespace
+// jump for the same reason.
+func TestRescopeNamespaceForContext_DropsAllNamespacesStash(t *testing.T) {
+	orig, origSet := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet
+	defer func() { ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet = orig, origSet }()
+	ui.ConfigAllNamespaces = true
+	ui.ConfigAllNamespacesSet = false
+
+	for _, tc := range []struct {
+		name          string
+		pinnedNs      string
+		wantAllNs     bool
+		wantNamespace string
+	}{
+		{name: "context pins a namespace", pinnedNs: "team-a", wantAllNs: false, wantNamespace: "team-a"},
+		{name: "context pins nothing", pinnedNs: "", wantAllNs: true, wantNamespace: "stale"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := baseModelWithFakeClient()
+			m.client.AddTestContextWithNamespace("staging", "https://staging.example.local:6443", tc.pinnedNs)
+			m.namespace = "stale"
+			m.allNamespaces = true
+			// State the A-toggle leaves behind in the cluster we are leaving.
+			m.savedSelectedNamespaces = map[string]bool{"team-a-ns": true}
+			m.savedNsSelectionNegated = true
+			m.nsSelectionModified = true
+			m.previousNsScope = &nsScope{namespace: "old-ns"}
+
+			m.rescopeNamespaceForContext("staging")
+
+			assert.Equal(t, tc.wantAllNs, m.allNamespaces)
+			assert.Equal(t, tc.wantNamespace, m.namespace)
+			assert.Nil(t, m.savedSelectedNamespaces, "a later A-toggle would restore the old cluster's selection")
+			assert.False(t, m.savedNsSelectionNegated)
+			assert.False(t, m.nsSelectionModified)
+			assert.Nil(t, m.previousNsScope, "a previous-namespace jump would land in the old cluster's namespace")
+		})
+	}
+}

--- a/internal/app/options_test.go
+++ b/internal/app/options_test.go
@@ -78,6 +78,8 @@ func newTestClientForOptions(t *testing.T) *k8s.Client {
 	return k8s.NewTestClient(nil, nil)
 }
 
+// test-ctx pins namespace "default" (see NewTestClient), so the pinned
+// namespace must win over the all-namespaces startup default (issue #686).
 func TestNewModel_CLIOverrideContextOnly(t *testing.T) {
 	client := newTestClientForOptions(t)
 
@@ -87,8 +89,9 @@ func TestNewModel_CLIOverrideContextOnly(t *testing.T) {
 	require.NotNil(t, m.pendingSession, "pendingSession should be set when Context CLI override is provided")
 	assert.Equal(t, "test-ctx", m.pendingSession.Context)
 	require.Len(t, m.pendingSession.Tabs, 1)
-	assert.True(t, m.pendingSession.Tabs[0].AllNamespaces,
-		"AllNamespaces should be true when no namespaces are provided")
+	assert.False(t, m.pendingSession.Tabs[0].AllNamespaces,
+		"AllNamespaces should be false when the context pins a namespace and no override applies")
+	assert.Equal(t, "default", m.pendingSession.Tabs[0].Namespace)
 	assert.Equal(t, "test-ctx", m.pendingSession.Tabs[0].Context)
 }
 
@@ -367,12 +370,16 @@ func TestNewModel_WatchIntervalPrecedence(t *testing.T) {
 func TestNewModel_BasicFieldsInitialized(t *testing.T) {
 	// allNamespaces / splitPreview are seeded from config globals; pin them to
 	// their defaults so a sibling test mutating the globals can't leak in.
-	origNs, origSplit := ui.ConfigAllNamespaces, ui.ConfigSplitPreview
+	origNs, origNsSet, origSplit := ui.ConfigAllNamespaces, ui.ConfigAllNamespacesSet, ui.ConfigSplitPreview
 	t.Cleanup(func() {
 		ui.ConfigAllNamespaces = origNs
+		ui.ConfigAllNamespacesSet = origNsSet
 		ui.ConfigSplitPreview = origSplit
 	})
 	ui.ConfigAllNamespaces = true
+	// Explicitly set so the seeded default wins over test-ctx's pinned
+	// "default" namespace (see resolveStartupAllNamespaces).
+	ui.ConfigAllNamespacesSet = true
 	ui.ConfigSplitPreview = true
 
 	client := newTestClientForOptions(t)

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -330,6 +330,7 @@ func (m Model) navigateChildCluster(sel *model.Item) (tea.Model, tea.Cmd) {
 	m.nav.Context = sel.Name
 	m.invalidateOrphanCacheForContext(oldCtx)
 	m.recomputeReadOnly(sel.Name)
+	m.rescopeNamespaceForContext(sel.Name)
 	m.dashboardPreview = ""
 	m.dashboardEventsPreview = ""
 	m.monitoringPreview = ""

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -396,6 +396,7 @@ func applySessionDefaults(cfg configFile) {
 	applyBoolPtr(cfg.WatchMode, &ConfigWatchMode)
 	applyBoolPtr(cfg.WatchThrottle, &ConfigWatchThrottle)
 	applyBoolPtr(cfg.AllNamespaces, &ConfigAllNamespaces)
+	ConfigAllNamespacesSet = cfg.AllNamespaces != nil
 	if ev := cfg.Events; ev != nil {
 		applyBoolPtr(ev.WarningsOnly, &ConfigEventsWarningsOnly)
 		applyBoolPtr(ev.Grouping, &ConfigEventsGrouping)

--- a/internal/ui/config_session.go
+++ b/internal/ui/config_session.go
@@ -17,6 +17,10 @@ var ConfigWatchMode = true
 // Default true.
 var ConfigAllNamespaces = true
 
+// ConfigAllNamespacesSet reports whether the config file set all_namespaces
+// at all. Absent, a kubeconfig context that pins a namespace wins instead.
+var ConfigAllNamespacesSet bool
+
 // ConfigEventsWarningsOnly is the startup default for the events view's
 // warning-only filter. Default true.
 var ConfigEventsWarningsOnly = true

--- a/internal/ui/config_session_test.go
+++ b/internal/ui/config_session_test.go
@@ -12,18 +12,21 @@ func snapshotSessionDefaultGlobals(t *testing.T) {
 	prevSplit := ConfigSplitPreview
 	prevWatch := ConfigWatchMode
 	prevAllNs := ConfigAllNamespaces
+	prevAllNsSet := ConfigAllNamespacesSet
 	prevWarn := ConfigEventsWarningsOnly
 	prevGroup := ConfigEventsGrouping
 	t.Cleanup(func() {
 		ConfigSplitPreview = prevSplit
 		ConfigWatchMode = prevWatch
 		ConfigAllNamespaces = prevAllNs
+		ConfigAllNamespacesSet = prevAllNsSet
 		ConfigEventsWarningsOnly = prevWarn
 		ConfigEventsGrouping = prevGroup
 	})
 	ConfigSplitPreview = true
 	ConfigWatchMode = true
 	ConfigAllNamespaces = true
+	ConfigAllNamespacesSet = false
 	ConfigEventsWarningsOnly = true
 	ConfigEventsGrouping = true
 }
@@ -45,6 +48,7 @@ events:
 	assert.False(t, ConfigSplitPreview, "split_preview")
 	assert.False(t, ConfigWatchMode, "watch_mode")
 	assert.False(t, ConfigAllNamespaces, "all_namespaces")
+	assert.True(t, ConfigAllNamespacesSet, "all_namespaces (set flag)")
 	assert.False(t, ConfigEventsWarningsOnly, "events.warnings_only")
 	assert.False(t, ConfigEventsGrouping, "events.grouping")
 }
@@ -63,6 +67,7 @@ events:
 	assert.False(t, ConfigWatchMode, "watch_mode applied")
 	assert.True(t, ConfigSplitPreview, "split_preview default preserved")
 	assert.True(t, ConfigAllNamespaces, "all_namespaces default preserved")
+	assert.False(t, ConfigAllNamespacesSet, "all_namespaces (set flag) stays unset when the key is absent")
 	assert.False(t, ConfigEventsGrouping, "events.grouping applied")
 	assert.True(t, ConfigEventsWarningsOnly, "events.warnings_only default preserved")
 }

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -236,6 +236,7 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	assert.False(t, ConfigWatchMode, "watch_mode")
 	assert.False(t, ConfigWatchThrottle, "watch_throttle")
 	assert.False(t, ConfigAllNamespaces, "all_namespaces")
+	assert.True(t, ConfigAllNamespacesSet, "all_namespaces (set flag)")
 	assert.False(t, ConfigEventsWarningsOnly, "events.warnings_only")
 	assert.False(t, ConfigEventsGrouping, "events.grouping")
 	assert.Equal(t, 9, ConfigScrollOff, "scrolloff")
@@ -363,6 +364,40 @@ func TestLoadConfig_PinnedSummariesAbsentKeyLeavesFlagUnset(t *testing.T) {
 	assert.Empty(t, ConfigPinnedSummaries)
 }
 
+// TestLoadConfig_AllNamespacesAbsentKeyLeavesFlagUnset verifies the key
+// being absent from the config file leaves ConfigAllNamespacesSet false, so
+// resolveStartupAllNamespaces falls through to a kubeconfig-pinned namespace.
+func TestLoadConfig_AllNamespacesAbsentKeyLeavesFlagUnset(t *testing.T) {
+	restore := snapshotAllConfigGlobals(t)
+	defer restore()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("dashboard: true\n"), 0o600))
+
+	LoadConfig(path)
+
+	assert.False(t, ConfigAllNamespacesSet, "an absent key must not set the flag")
+	assert.True(t, ConfigAllNamespaces, "an absent key must keep the compiled default")
+}
+
+// TestLoadConfig_AllNamespacesExplicitFalseSetsFlag verifies an explicit
+// `all_namespaces: false` sets ConfigAllNamespacesSet, distinguishing it from
+// the key being absent.
+func TestLoadConfig_AllNamespacesExplicitFalseSetsFlag(t *testing.T) {
+	restore := snapshotAllConfigGlobals(t)
+	defer restore()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("all_namespaces: false\n"), 0o600))
+
+	LoadConfig(path)
+
+	assert.True(t, ConfigAllNamespacesSet, "an explicit false must set the flag")
+	assert.False(t, ConfigAllNamespaces)
+}
+
 // wiringCoveredFields records, for every configFile json field, where its
 // YAML->runtime wiring is asserted. TestConfigFile_EveryFieldHasWiringCoverage
 // fails if a field is added (or removed) without updating this map, forcing new
@@ -400,7 +435,7 @@ var wiringCoveredFields = map[string]string{
 	"split_preview":             "TestLoadConfig_AllSettingsWired",
 	"watch_mode":                "TestLoadConfig_AllSettingsWired",
 	"watch_throttle":            "TestLoadConfig_AllSettingsWired",
-	"all_namespaces":            "TestLoadConfig_AllSettingsWired",
+	"all_namespaces":            "TestLoadConfig_AllSettingsWired + TestLoadConfig_AllNamespacesExplicitFalseSetsFlag + TestLoadConfig_AllNamespacesAbsentKeyLeavesFlagUnset",
 	"events":                    "TestLoadConfig_AllSettingsWired",
 	"scrolloff":                 "TestLoadConfig_AllSettingsWired",
 	"confirm_on_exit":           "TestLoadConfig_AllSettingsWired",
@@ -499,6 +534,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 	origWatchMode := ConfigWatchMode
 	origWatchThrottle := ConfigWatchThrottle
 	origAllNamespaces := ConfigAllNamespaces
+	origAllNamespacesSet := ConfigAllNamespacesSet
 	origEventsWarn := ConfigEventsWarningsOnly
 	origEventsGroup := ConfigEventsGrouping
 	origScrollOff := ConfigScrollOff
@@ -593,6 +629,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 		ConfigWatchMode = origWatchMode
 		ConfigWatchThrottle = origWatchThrottle
 		ConfigAllNamespaces = origAllNamespaces
+		ConfigAllNamespacesSet = origAllNamespacesSet
 		ConfigEventsWarningsOnly = origEventsWarn
 		ConfigEventsGrouping = origEventsGroup
 		ConfigScrollOff = origScrollOff


### PR DESCRIPTION
Closes #686

`lfk` already read `contexts[*].namespace` from the kubeconfig into the model, but the `all_namespaces` startup default of `true` masked it. A context that pinned a namespace still opened on every namespace, so the setting looked ignored.

## Precedence

Highest first:

1. `--namespace` flag
2. restored session tab namespace
3. `all_namespaces` set explicitly in the config file (true = all, false = context namespace)
4. kubeconfig `contexts[*].namespace`, when the context pins one
5. all-namespaces default

No new config key. The kubeconfig is the per-context source of truth, which is what a multi-cluster tool needs.

## Changes

- `resolveStartupAllNamespaces` decides the startup scope. An explicit `all_namespaces` wins. Otherwise a pinned context namespace scopes the view.
- `rescopeNamespaceForContext` re-applies the same rule on a plain context switch, so each cluster opens where its own kubeconfig says. Wired at two sites only: entering a cluster from the clusters list, and `:ctx <name>`. Bookmarks, sessions, and union sets carry their own namespace and stay untouched.
- The re-scope drops the namespace selection state that belongs to the cluster you left, including the all-namespaces stash. Without that, a later `A`-toggle or previous-namespace jump restored a namespace name from the previous cluster. `namespace_history.go` already drops the same pair for the same reason.
- `lfk --context foo` with no `-n` no longer forces all-namespaces mode. It honoured neither the config setting nor the pinned namespace before.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/app/... ./internal/ui/... ./internal/k8s/...`
- [x] `golangci-lint run` (0 issues)
- [x] 9 new tests in `internal/app/namespace_context_scope_test.go`, one per precedence rule plus the stash-leak guard
- [x] Mutation-checked the stash-leak guard: it fails when the clearing lines are removed, passes when restored
- [ ] Manual check against a kubeconfig whose context pins a namespace
