### PR TITLE
feat: remember viewer display toggles across restarts

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -231,7 +231,7 @@ api_explorer:
 | `object_explorer.tree` | bool | `false` | `tree_view` (`T`) | Open the Object Explorer in the ASCII-art tree view. |
 | `api_explorer.tree` | bool | `false` | `tree_view` (`T`) | Open the API Explorer in the ASCII-art tree view (sticky across navigation). |
 
-A toggle changed at runtime sticks for the session and resets to the configured default the next time the viewer opens.
+A toggle changed at runtime sticks for the rest of the session and persists across restarts, recorded in `viewer_prefs.yaml` in the state directory. It outranks the value set here, so the fields above seed a viewer you never toggled. To go back to the configured defaults, delete that file.
 
 ## Events
 
@@ -1193,6 +1193,7 @@ The application follows the [XDG Base Directory Specification](https://specifica
 | `$XDG_STATE_HOME/lfk/pinned.yaml` | Per-context and per-union-set pinned CRD groups, managed via `p` key (default: `~/.local/state/lfk/pinned.yaml`) |
 | `$XDG_STATE_HOME/lfk/hidden_types.yaml` | Per-context and per-union-set hidden resource types, managed via the action menu (`x`) at the resource types level (default: `~/.local/state/lfk/hidden_types.yaml`) |
 | `$XDG_STATE_HOME/lfk/pinned_summaries.yaml` | Per-context and per-union-set resource-type summaries pinned to the cluster dashboard, managed via the action menu (default: `~/.local/state/lfk/pinned_summaries.yaml`) |
+| `$XDG_STATE_HOME/lfk/viewer_prefs.yaml` | Log, YAML, diff, describe, and explorer display toggles from their runtime keys, auto-managed; outranks the `log_viewer` and viewer-default config groups (default: `~/.local/state/lfk/viewer_prefs.yaml`) |
 | `$XDG_STATE_HOME/lfk/whichkey_prefs.yaml` | Which-key panel entry order from the leader-key toggle, auto-managed; outranks `which_key_grouped` (default: `~/.local/state/lfk/whichkey_prefs.yaml`) |
 | `~/.local/share/lfk/lfk.log` (default) | Application log file (configurable via `log_path`) |
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -575,6 +575,8 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 | `F1` | Full help |
 | `q` / `Esc` | Close log viewer |
 
+The display toggles (`>` wrap, `s` timestamps, `p` prefixes, `P` preview panel, and their counterparts in the YAML, diff, describe, and explorer views) are remembered across restarts in `~/.local/state/lfk/viewer_prefs.yaml`, so a layout you set once survives the next open and the next launch. They outrank the `log_viewer` and viewer-default config groups. Delete that file to go back to the configured defaults.
+
 `i` / `o` cycle the minimum severity through `off`, `INFO+`, `WARN+`, and `ERROR+`. All source levels merge into these three tiers. Structured logs use the parsed level. Plain-text logs are classified by keyword (error/warn/debug), defaulting to INFO. `INFO+` hides debug/trace lines, `WARN+` shows only warn and error lines, and `ERROR+` shows only error and failure lines.
 
 The log viewer's `/` keeps its own persistent history at `$XDG_STATE_HOME/lfk/log-search-history` (default `~/.local/state/lfk/log-search-history`), separate from the explorer's `query-history`. Log search matches raw log lines (substring/regex over arbitrary text) rather than resource names, so pooling the two would surface irrelevant entries on Up/Down in either context.

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-dwKDeKERX3grVdxIYGjTxk6NQLevMjv2+YiDifM1B/o=";
+            vendorHash = "sha256-UBm+debRps5XRCJBXjik1akjUgoY5prQ+2v0Hzy9jfQ=";
 
             subPackages = [ "." ];
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/creack/pty v1.1.24
+	github.com/gofrs/flock v0.13.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/go-openapi/testify/enable/yaml/v2 v2.5.1 h1:q9NtHwK4qHF7yZziBPvZyv7zW
 github.com/go-openapi/testify/enable/yaml/v2 v2.5.1/go.mod h1:JW0MXIotCYps/XsgJnG3a8Q7rE5xAiBwoOD5OfaIQBk=
 github.com/go-openapi/testify/v2 v2.5.1 h1:TMdhCaw8fUNraVSf3Omoob1dO/AzBfhtFAPW0an6sBo=
 github.com/go-openapi/testify/v2 v2.5.1/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -233,12 +233,12 @@ type Model struct {
 	watchTickGen uint64
 
 	// objectExplorerLive controls whether the Object Explorer re-syncs its
-	// browsed object on list refreshes (issue #391). Defaults from
-	// ui.ConfigObjectExplorerLive. Runtime toggle is w inside the explorer.
+	// browsed object on list refreshes (issue #391). Runtime toggle is w.
 	// objectExplorerForceSync forces a single re-sync on the next list refresh
 	// even when live is off, so manual refresh (R) updates the view once.
 	objectExplorerLive, objectExplorerForceSync bool
-	objectExplorerTree                          bool // session tree-view pref (T). Seeded from ui.ConfigObjectExplorerTree
+	objectExplorerTree                          bool             // session tree-view pref (T)
+	viewerPrefs                                 viewerPrefValues // live viewer toggles; see viewer_prefs.go
 
 	// Read-only mode: blocks all mutating actions for the active tab. Mirrors
 	// the active TabState.readOnly. Re-evaluated on context switch and tab

--- a/internal/app/app_init.go
+++ b/internal/app/app_init.go
@@ -34,6 +34,7 @@ func resolveStartupAllNamespaces(client *k8s.Client, contextName string) bool {
 
 // NewModel creates the initial model.
 func NewModel(client *k8s.Client, opts StartupOptions) Model {
+	vp := newViewerPrefValues()
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(ui.ThemeColor("62"))
@@ -88,10 +89,10 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		queryHistory:        loadInputHistory(historyFileQuery),
 		logView: logViewState{
 			searchHistory:  loadInputHistory(historyFileLogSearch),
-			previewVisible: ui.ConfigLogShowPreview,
-			hidePrefixes:   !ui.ConfigLogShowPrefixes,
-			timestamps:     ui.ConfigLogShowTimestamps,
-			wrap:           ui.ConfigLogWrap,
+			previewVisible: vp[prefLogShowPreview],
+			hidePrefixes:   !vp[prefLogShowPrefixes],
+			timestamps:     vp[prefLogShowTimestamps],
+			wrap:           vp[prefLogWrap],
 		},
 		pinnedState:                pinnedSt,
 		pinnedSummariesState:       pinnedSummariesSt,
@@ -105,13 +106,14 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		backgroundWatchInterval:    resolveBackgroundInterval(opts),
 		watchThrottle:              ui.ConfigWatchThrottle,
 		foregroundIdleTimeout:      resolveForegroundIdle(opts),
-		fullLogPreview:             ui.ConfigLogPreviewLive,
+		viewerPrefs:                vp,
+		fullLogPreview:             vp[prefLogPreviewLive],
 		splitPreview:               ui.ConfigSplitPreview,
 		allNamespaces:              startupAllNamespaces,
 		watchMode:                  ui.ConfigWatchMode,
-		objectExplorerLive:         ui.ConfigObjectExplorerLive,
-		objectExplorerTree:         ui.ConfigObjectExplorerTree,
-		explainTreeWanted:          ui.ConfigAPIExplorerTree,
+		objectExplorerLive:         vp[prefObjectExplorerLive],
+		objectExplorerTree:         vp[prefObjectExplorerTree],
+		explainTreeWanted:          vp[prefAPIExplorerTree],
 		readOnly:                   ui.ResolveReadOnly(contextName, opts.ReadOnly),
 		cliReadOnly:                opts.ReadOnly,
 		showRareResources:          ui.ConfigShowRareTypes,
@@ -135,8 +137,8 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		perms:                      newPermissionState(),
 		selectedItems:              make(map[string]bool),
 		selectionAnchor:            -1,
-		yamlView:                   yamlViewState{collapsed: make(map[string]bool), wrap: ui.ConfigYAMLViewerWrap},
-		describeView:               describeViewState{wrap: ui.ConfigDescribeViewerWrap},
+		yamlView:                   yamlViewState{collapsed: make(map[string]bool), wrap: vp[prefYAMLViewerWrap]},
+		describeView:               describeViewState{wrap: vp[prefDescribeViewerWrap]},
 		dashboardAcc:               make(map[string]*dashboardAccumulator),
 		discoveredResources:        make(map[string][]model.ResourceTypeEntry),
 		discoveringContexts:        make(map[string]bool),
@@ -152,7 +154,7 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 		warningEventsOnly:          ui.ConfigEventsWarningsOnly,
 		eventGrouping:              ui.ConfigEventsGrouping,
 		scheduler:                  scheduler.New(scheduler.DefaultThreshold),
-		diffView:                   diffViewState{wrap: ui.ConfigDiffViewerWrap, lineNumbers: ui.ConfigDiffViewerLineNumbers, unified: ui.ConfigDiffViewerUnified, diffCache: &ui.DiffCache{}},
+		diffView:                   diffViewState{wrap: vp[prefDiffViewerWrap], lineNumbers: vp[prefDiffViewerLineNumbers], unified: vp[prefDiffViewerUnified], diffCache: &ui.DiffCache{}},
 		fieldDoc:                   fieldDocState{cache: newFieldDocCache()},
 		execTickGen:                &atomic.Uint64{},
 		logReaderInFlight:          make(map[chan string]bool),
@@ -166,8 +168,8 @@ func NewModel(client *k8s.Client, opts StartupOptions) Model {
 			splitPreview:               ui.ConfigSplitPreview,
 			allNamespaces:              startupAllNamespaces,
 			watchMode:                  ui.ConfigWatchMode,
-			objectExplorerLive:         ui.ConfigObjectExplorerLive,
-			objectExplorerTree:         ui.ConfigObjectExplorerTree,
+			objectExplorerLive:         vp[prefObjectExplorerLive],
+			objectExplorerTree:         vp[prefObjectExplorerTree],
 			readOnly:                   ui.ResolveReadOnly(contextName, opts.ReadOnly),
 			sortColumnName:             sortColDefault,
 			sortAscending:              true,

--- a/internal/app/commands_logs_multi.go
+++ b/internal/app/commands_logs_multi.go
@@ -32,11 +32,11 @@ func (m *Model) startMultiLogStream(items []model.Item) (tea.Model, tea.Cmd) {
 	m.resetLogBuffer()
 	m.logView.scroll = 0
 	m.logView.follow = true
-	m.logView.wrap = ui.ConfigLogWrap
+	m.logView.wrap = m.viewerPrefs[prefLogWrap]
 	m.logView.lineNumbers = true
-	m.logView.timestamps = ui.ConfigLogShowTimestamps
-	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
-	m.logView.previewVisible = ui.ConfigLogShowPreview
+	m.logView.timestamps = m.viewerPrefs[prefLogShowTimestamps]
+	m.logView.hidePrefixes = !m.viewerPrefs[prefLogShowPrefixes]
+	m.logView.previewVisible = m.viewerPrefs[prefLogShowPreview]
 	m.logView.previous = false
 	m.logView.isMulti = true
 	m.logView.multiItems = items

--- a/internal/app/explain_tree.go
+++ b/internal/app/explain_tree.go
@@ -64,6 +64,7 @@ type explainTreeState struct {
 func (m Model) toggleExplainTree() (tea.Model, tea.Cmd) {
 	if m.explainTree {
 		m.explainTreeWanted = false
+		m.setViewerPref(prefAPIExplorerTree, false)
 		m.restoreExplainFlatLevel()
 		return m, nil
 	}
@@ -72,9 +73,11 @@ func (m Model) toggleExplainTree() (tea.Model, tea.Cmd) {
 		// a second press cancels instead of firing a duplicate fetch. The
 		// in-flight result is dropped by the wanted guard on arrival.
 		m.explainTreeWanted = false
+		m.setViewerPref(prefAPIExplorerTree, false)
 		return m, nil
 	}
 	m.explainTreeWanted = true
+	m.setViewerPref(prefAPIExplorerTree, true)
 	m.loading = true
 	m.setStatusMessage("Loading field tree...", false)
 	return m, m.execKubectlExplainTree(m.explainResource, m.explainAPIVersion, m.explainPath)

--- a/internal/app/objectexplorer.go
+++ b/internal/app/objectexplorer.go
@@ -216,6 +216,7 @@ func (m *Model) syncObjectExplorerLive() {
 // current state instead of waiting for the next watch tick.
 func (m Model) toggleObjectExplorerLive() (tea.Model, tea.Cmd) {
 	m.objectExplorerLive = !m.objectExplorerLive
+	m.setViewerPref(prefObjectExplorerLive, m.objectExplorerLive)
 	if m.objectExplorerLive {
 		m.setStatusMessage("Object Explorer live refresh: on", false)
 		m.objectExplorerForceSync = true

--- a/internal/app/objectexplorer_treemode.go
+++ b/internal/app/objectexplorer_treemode.go
@@ -20,7 +20,8 @@ func (m Model) toggleObjectExplorerTree() (tea.Model, tea.Cmd) {
 		if rows := rt.visibleTreeRows(); rt.cursor >= 0 && rt.cursor < len(rows) {
 			topKey = rows[rt.cursor].Segs[0]
 		}
-		m.objectExplorerTree = false // session preference for the next open
+		m.setViewerPref(prefObjectExplorerTree, false)
+		m.objectExplorerTree = false // this tab keeps it; the pref above seeds new ones
 		rt.tree = false
 		rt.treeRows = nil
 		rt.treeCollapsed = nil
@@ -43,7 +44,8 @@ func (m Model) toggleObjectExplorerTree() (tea.Model, tea.Cmd) {
 	if f, ok := rt.selected(); ok {
 		flatKey = f.Key
 	}
-	m.objectExplorerTree = true // session preference for the next open
+	m.setViewerPref(prefObjectExplorerTree, true)
+	m.objectExplorerTree = true // this tab keeps it; the pref above seeds new ones
 	rt.tree = true
 	rt.rebuildTreeRows()
 	rt.cursor = 0

--- a/internal/app/previewlog.go
+++ b/internal/app/previewlog.go
@@ -347,6 +347,7 @@ func (m Model) updatePreviewLogRestart(msg previewLogRestartMsg) (tea.Model, tea
 // and cancels the stream on disable.
 func (m Model) handleExplorerToggleLogPreview() (tea.Model, tea.Cmd) {
 	m.fullLogPreview = !m.fullLogPreview
+	m.setViewerPref(prefLogPreviewLive, m.fullLogPreview)
 	// Log preview is mutually exclusive with YAML preview and resource map.
 	m.fullYAMLPreview = false
 	m.mapView = false

--- a/internal/app/state_lock.go
+++ b/internal/app/state_lock.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// stateLockBudget caps how long a load-modify-save waits for the lock. The
+// critical section is a few milliseconds, so this is only reached under real
+// contention, and it runs on the Bubble Tea Update goroutine where a longer
+// wait would stall the frame.
+const stateLockBudget = 250 * time.Millisecond
+
+// stateLockRetry is how often the waiter re-tries while inside the budget.
+const stateLockRetry = 5 * time.Millisecond
+
+// withStateFileLock runs fn while holding an exclusive interprocess lock for
+// one state file, so a read-modify-write cannot lose a concurrent lfk
+// instance's change. It reports whether fn ran: on a timeout the caller skips
+// the write rather than clobbering the other process.
+//
+// The lock lives on a sibling ".lock" file, never on the state file itself.
+// writeFileDurable renames a temp file over the target, which replaces the
+// inode a lock on the target would be attached to.
+func withStateFileLock(path string, fn func()) bool {
+	dir := filepath.Dir(path)
+	// The lock file needs the state directory to exist. The writer inside fn
+	// creates it too, but that runs after the lock is already taken.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		logger.Warn("Could not create the state directory; skipping this write",
+			"error", err, "path", dir)
+		return false
+	}
+	lockPath := filepath.Join(dir, "."+filepath.Base(path)+".lock")
+	lock := flock.New(lockPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), stateLockBudget)
+	defer cancel()
+
+	locked, err := lock.TryLockContext(ctx, stateLockRetry)
+	if err != nil || !locked {
+		logger.Warn("Could not lock state file; skipping this write",
+			"error", err, "path", path)
+		return false
+	}
+	defer func() {
+		if err := lock.Unlock(); err != nil {
+			logger.Warn("Failed to release state file lock", "error", err, "path", lockPath)
+		}
+	}()
+
+	fn()
+	return true
+}

--- a/internal/app/state_lock_test.go
+++ b/internal/app/state_lock_test.go
@@ -1,7 +1,13 @@
 package app
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -66,5 +72,96 @@ func TestPersistViewerPref_ConcurrentTogglesAllSurvive(t *testing.T) {
 		if !*v {
 			t.Errorf("pref %d is false, want true", i)
 		}
+	}
+}
+
+// lockHelperEnv carries the lock-file path to the child half of
+// TestWithStateFileLock_ContendsAcrossProcesses.
+const lockHelperEnv = "LFK_TEST_HOLD_LOCK_PATH"
+
+// TestHoldStateLockHelper is the child process, not a test of its own. The
+// parent re-execs the test binary with lockHelperEnv set. It takes the lock,
+// announces it on stdout, and holds it until the parent closes stdin.
+func TestHoldStateLockHelper(t *testing.T) {
+	path := os.Getenv(lockHelperEnv)
+	if path == "" {
+		t.Skip("child-process helper, driven by TestWithStateFileLock_ContendsAcrossProcesses")
+	}
+	lock := flock.New(path)
+	if err := lock.Lock(); err != nil {
+		t.Fatalf("child could not take the lock: %v", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	fmt.Println("LOCKED")
+	// Blocks until the parent closes our stdin.
+	_, _ = io.Copy(io.Discard, os.Stdin)
+}
+
+// TestWithStateFileLock_ContendsAcrossProcesses proves the property the lock
+// exists for. The same-process tests contend on two file descriptors, which is
+// what flock(2) and LockFileEx key on, but only a second process shows that two
+// lfk instances actually exclude each other.
+func TestWithStateFileLock_ContendsAcrossProcesses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thing.yaml")
+	lockPath := filepath.Join(dir, ".thing.yaml.lock")
+
+	child := exec.Command(os.Args[0], "-test.run=^TestHoldStateLockHelper$", "-test.timeout=60s")
+	child.Env = append(os.Environ(), lockHelperEnv+"="+lockPath)
+	stdin, err := child.StdinPipe()
+	if err != nil {
+		t.Fatalf("test setup: %v", err)
+	}
+	stdout, err := child.StdoutPipe()
+	if err != nil {
+		t.Fatalf("test setup: %v", err)
+	}
+	if err := child.Start(); err != nil {
+		t.Fatalf("test setup: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = child.Wait()
+	})
+
+	if !awaitLine(t, stdout, "LOCKED") {
+		t.Fatal("the child never reported that it holds the lock")
+	}
+
+	if withStateFileLock(path, func() {}) {
+		t.Error("the lock was granted while another process holds it")
+	}
+
+	// Releasing the child's stdin ends the child, which drops the lock.
+	_ = stdin.Close()
+	if err := child.Wait(); err != nil {
+		t.Fatalf("child exited badly: %v", err)
+	}
+
+	if !withStateFileLock(path, func() {}) {
+		t.Error("the lock was refused after the holding process exited")
+	}
+}
+
+// awaitLine reports whether want shows up on r before the test deadline.
+func awaitLine(t *testing.T, r io.Reader, want string) bool {
+	t.Helper()
+	found := make(chan bool, 1)
+	go func() {
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			if strings.TrimSpace(sc.Text()) == want {
+				found <- true
+				return
+			}
+		}
+		found <- false
+	}()
+	select {
+	case ok := <-found:
+		return ok
+	case <-time.After(30 * time.Second):
+		return false
 	}
 }

--- a/internal/app/state_lock_test.go
+++ b/internal/app/state_lock_test.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+func TestWithStateFileLock_RunsAndReleases(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "thing.yaml")
+
+	ran := 0
+	for range 3 {
+		if !withStateFileLock(path, func() { ran++ }) {
+			t.Fatal("a lock nobody else holds must be granted")
+		}
+	}
+	if ran != 3 {
+		t.Errorf("fn ran %d times, want 3: the lock is not being released", ran)
+	}
+}
+
+func TestWithStateFileLock_GivesUpWhenHeld(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thing.yaml")
+	held := flock.New(filepath.Join(dir, ".thing.yaml.lock"))
+	if err := held.Lock(); err != nil {
+		t.Fatalf("test setup: %v", err)
+	}
+	defer func() { _ = held.Unlock() }()
+
+	start := time.Now()
+	ran := false
+	got := withStateFileLock(path, func() { ran = true })
+
+	if got || ran {
+		t.Error("a lock another holder owns must not be granted, and fn must not run")
+	}
+	if elapsed := time.Since(start); elapsed > 2*stateLockBudget {
+		t.Errorf("waited %v, want the caller released near the %v budget", elapsed, stateLockBudget)
+	}
+}
+
+// TestPersistViewerPref_ConcurrentTogglesAllSurvive is the case the lock exists
+// for. Each writer opens the lock file separately, the way two lfk processes
+// would. Without the lock the last writer wins and the others' toggles vanish.
+func TestPersistViewerPref_ConcurrentTogglesAllSurvive(t *testing.T) {
+	isolateViewerPrefs(t)
+
+	var wg sync.WaitGroup
+	for i := range int(numViewerPrefs) {
+		wg.Go(func() { persistViewerPref(viewerPref(i), true) })
+	}
+	wg.Wait()
+
+	s := loadViewerPrefsState()
+	for i, b := range viewerPrefBindings {
+		v := *b.field(&s)
+		if v == nil {
+			t.Errorf("pref %d was dropped: a concurrent writer overwrote it", i)
+			continue
+		}
+		if !*v {
+			t.Errorf("pref %d is false, want true", i)
+		}
+	}
+}

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -28,6 +28,7 @@ func baseFinalModel() Model {
 	dyn := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
 
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -67,6 +68,7 @@ func baseFinalModelWithDynamic() Model {
 	dyn := newFinalDynClient()
 
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -102,6 +104,7 @@ func baseFinalModelWithDynamic() Model {
 
 func baseModelActions() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -130,6 +133,7 @@ func baseModelBoost2() Model {
 	dyn := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
 
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -175,6 +179,7 @@ func colKey(kind string) string {
 // baseModelCov returns a minimal Model for coverage tests.
 func baseModelCov() Model {
 	return Model{
+		viewerPrefs:                newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                        model.NavigationState{Level: model.LevelResources},
 		tabs:                       []TabState{{}},
 		selectedItems:              make(map[string]bool),
@@ -205,6 +210,7 @@ func baseModelWithFakeClientAndScheduler(t *testing.T, objs ...runtime.Object) M
 
 func baseModelDescribe() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -223,6 +229,7 @@ func baseModelDescribe() Model {
 
 func baseModelExplain() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -249,6 +256,7 @@ func baseModelExplain() Model {
 
 func baseModelFinalizer() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -272,6 +280,7 @@ func baseModelFinalizer() Model {
 
 func baseModelHandlers2() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -288,6 +297,7 @@ func baseModelHandlers2() Model {
 
 func baseModelNav() Model {
 	m := Model{
+		viewerPrefs: newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav: model.NavigationState{
 			Level:   model.LevelResources,
 			Context: "test-ctx",
@@ -318,6 +328,7 @@ func baseModelNav() Model {
 
 func baseModelOverlay() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -334,6 +345,7 @@ func baseModelOverlay() Model {
 
 func baseModelSearch() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -354,6 +366,7 @@ func baseModelUpdate() Model {
 	dyn := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
 
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -412,6 +425,7 @@ func baseModelWithFakeDynamic(
 
 func basePush4Model() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -442,6 +456,7 @@ func basePush4Model() Model {
 // basePush80Model returns a model with a fake k8s client for coverage tests.
 func basePush80Model() Model {
 	m := Model{
+		viewerPrefs: newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav: model.NavigationState{
 			Level:   model.LevelResources,
 			Context: "test-ctx",
@@ -483,6 +498,7 @@ func basePush80Model() Model {
 
 func basePush80v2Model() Model {
 	m := Model{
+		viewerPrefs: newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav: model.NavigationState{
 			Level:   model.LevelResources,
 			Context: "test-ctx",
@@ -521,6 +537,7 @@ func basePush80v2Model() Model {
 
 func basePush80v3Model() Model {
 	m := Model{
+		viewerPrefs: newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav: model.NavigationState{
 			Level:   model.LevelResources,
 			Context: "test-ctx",
@@ -561,6 +578,7 @@ func baseRichModel() Model {
 	dyn := newRichDynClient()
 
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -596,6 +614,7 @@ func baseRichModel() Model {
 
 func bp4() Model {
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),
@@ -847,6 +866,7 @@ func testModelExec() Model {
 	dyn := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
 
 	m := Model{
+		viewerPrefs:         newViewerPrefValues(), // production toggle defaults, as NewModel seeds them
 		nav:                 model.NavigationState{Level: model.LevelResources, Context: "test-ctx"},
 		tabs:                []TabState{{}},
 		selectedItems:       make(map[string]bool),

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -80,11 +80,11 @@ func (m Model) executeActionLogsWithTail(pendingLabel string, tailLines int) (te
 	m.resetLogBuffer()
 	m.logView.scroll = 0
 	m.logView.follow = true
-	m.logView.wrap = ui.ConfigLogWrap
+	m.logView.wrap = m.viewerPrefs[prefLogWrap]
 	m.logView.lineNumbers = true
-	m.logView.timestamps = ui.ConfigLogShowTimestamps
-	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
-	m.logView.previewVisible = ui.ConfigLogShowPreview
+	m.logView.timestamps = m.viewerPrefs[prefLogShowTimestamps]
+	m.logView.hidePrefixes = !m.viewerPrefs[prefLogShowPrefixes]
+	m.logView.previewVisible = m.viewerPrefs[prefLogShowPreview]
 	m.logView.previous = false
 	m.logView.isMulti = false
 	m.logView.multiItems = nil

--- a/internal/app/update_actions_logtop.go
+++ b/internal/app/update_actions_logtop.go
@@ -24,9 +24,9 @@ func (m Model) executeActionLogTop() (tea.Model, tea.Cmd) {
 	m.resetLogBuffer()
 	m.logView.scroll = 0
 	m.logView.follow = true
-	m.logView.wrap = ui.ConfigLogWrap
+	m.logView.wrap = m.viewerPrefs[prefLogWrap]
 	m.logView.timestamps = true // Log Top needs timestamps for REQ/s calculation
-	m.logView.hidePrefixes = !ui.ConfigLogShowPrefixes
+	m.logView.hidePrefixes = !m.viewerPrefs[prefLogShowPrefixes]
 	m.logView.previous = false
 	m.logView.isMulti = false
 	m.logView.multiItems = nil

--- a/internal/app/update_describe.go
+++ b/internal/app/update_describe.go
@@ -44,6 +44,7 @@ func (m Model) handleDescribeNormalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 	case kb.ToggleWrap:
 		m.describeView.lineInput = ""
 		m.describeView.wrap = !m.describeView.wrap
+		m.setViewerPref(prefDescribeViewerWrap, m.describeView.wrap)
 		return m, nil
 	case "q", "esc":
 		return m.handleDescribeQuit()
@@ -174,7 +175,7 @@ func (m Model) handleDescribeQuit() (tea.Model, tea.Cmd) {
 	m.describeView.scroll = 0
 	m.describeView.cursor = 0
 	m.describeView.cursorCol = 0
-	m.describeView.wrap = ui.ConfigDescribeViewerWrap
+	m.describeView.wrap = m.viewerPrefs[prefDescribeViewerWrap]
 	m.describeView.autoRefresh = false
 	m.describeView.refreshFunc = nil
 	m.describeView.visualMode = 0

--- a/internal/app/update_describe_msgs.go
+++ b/internal/app/update_describe_msgs.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	tea "charm.land/bubbletea/v2"
-
-	"github.com/janosmiko/lfk/internal/ui"
 )
 
 func (m Model) updateDescribeLoaded(msg describeLoadedMsg) (tea.Model, tea.Cmd) {
@@ -61,7 +59,7 @@ func (m Model) updateDiffLoaded(msg diffLoadedMsg) (tea.Model, tea.Cmd) {
 	m.diffView.leftName = msg.leftName
 	m.diffView.rightName = msg.rightName
 	m.diffView.scroll = 0
-	m.diffView.unified = ui.ConfigDiffViewerUnified
+	m.diffView.unified = m.viewerPrefs[prefDiffViewerUnified]
 	return m, nil
 }
 

--- a/internal/app/update_diff.go
+++ b/internal/app/update_diff.go
@@ -116,6 +116,7 @@ func (m Model) handleDiffNormalKey(msg tea.KeyPressMsg, foldRegions []ui.DiffFol
 		return m, nil
 	case kb.ToggleWrap:
 		m.diffView.wrap = !m.diffView.wrap
+		m.setViewerPref(prefDiffViewerWrap, m.diffView.wrap)
 		return m, nil
 	case "q", "esc":
 		return m.handleDiffQuit()
@@ -189,11 +190,13 @@ func (m Model) handleDiffNormalKey(msg tea.KeyPressMsg, foldRegions []ui.DiffFol
 	case kb.ToggleUnified:
 		m.diffView.lineInput = ""
 		m.diffView.unified = !m.diffView.unified
+		m.setViewerPref(prefDiffViewerUnified, m.diffView.unified)
 		m.diffView.scroll = 0
 		return m, nil
 	case kb.ToggleLineNumbers:
 		m.diffView.lineInput = ""
 		m.diffView.lineNumbers = !m.diffView.lineNumbers
+		m.setViewerPref(prefDiffViewerLineNumbers, m.diffView.lineNumbers)
 		return m, nil
 	case kb.Search:
 		m.diffView.lineInput = ""
@@ -237,7 +240,7 @@ func (m Model) handleDiffQuit() (tea.Model, tea.Cmd) {
 	m.diffView.cursor = 0
 	m.diffView.cursorSide = 0
 	m.diffView.lineInput = ""
-	m.diffView.wrap = ui.ConfigDiffViewerWrap
+	m.diffView.wrap = m.viewerPrefs[prefDiffViewerWrap]
 	m.diffView.searchQuery = ""
 	m.diffView.searchText.Clear()
 	m.diffView.matchLines = nil

--- a/internal/app/update_logs_normal.go
+++ b/internal/app/update_logs_normal.go
@@ -249,6 +249,7 @@ func (m Model) handleLogKeyF() Model {
 func (m Model) handleLogKeyTab() Model {
 	m.logView.lineInput = ""
 	m.logView.wrap = !m.logView.wrap
+	m.setViewerPref(prefLogWrap, m.logView.wrap)
 	// Re-pin to the bottom on toggle: maxScroll and topSkip both depend on
 	// wrap mode, so the previous values are stale. ensureLogCursorVisible
 	// snaps to the follow position when m.logView.follow is true and otherwise
@@ -384,12 +385,14 @@ func (m Model) handleLogKeyN2() Model {
 func (m Model) handleLogKeyP() Model {
 	m.logView.lineInput = ""
 	m.logView.hidePrefixes = !m.logView.hidePrefixes
+	m.setViewerPref(prefLogShowPrefixes, !m.logView.hidePrefixes)
 	return m
 }
 
 func (m Model) handleLogKeyP2() Model {
 	m.logView.lineInput = ""
 	m.logView.previewVisible = !m.logView.previewVisible
+	m.setViewerPref(prefLogShowPreview, m.logView.previewVisible)
 	m.logView.previewScroll = 0
 	// Effective viewer width changes when the panel toggles, so wrap-aware
 	// scroll/skip values need recomputing for the new geometry.
@@ -439,6 +442,7 @@ func (m Model) handleLogKeyHash() Model {
 func (m Model) handleLogKeyS() Model {
 	m.logView.lineInput = ""
 	m.logView.timestamps = !m.logView.timestamps
+	m.setViewerPref(prefLogShowTimestamps, m.logView.timestamps)
 	return m
 }
 

--- a/internal/app/update_yaml.go
+++ b/internal/app/update_yaml.go
@@ -236,6 +236,7 @@ func (m Model) handleYAMLNormalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleYAMLRefresh()
 	case kb.ToggleWrap:
 		m.yamlView.wrap = !m.yamlView.wrap
+		m.setViewerPref(prefYAMLViewerWrap, m.yamlView.wrap)
 		return m, nil
 	case kb.ToggleFold:
 		return m.handleYAMLKeyFoldToggle()
@@ -638,7 +639,7 @@ func (m Model) handleYAMLKeyObjectExplorer() (tea.Model, tea.Cmd) {
 		}
 		m.yamlView.scroll = 0
 		m.yamlView.cursor = 0
-		m.yamlView.wrap = ui.ConfigYAMLViewerWrap
+		m.yamlView.wrap = m.viewerPrefs[prefYAMLViewerWrap]
 		return m, nil
 	}
 	mdl, cmd := m.openObjectExplorer()
@@ -692,7 +693,7 @@ func (m Model) handleYAMLKeyQ() (tea.Model, tea.Cmd) {
 	m.yamlReturnMode = modeExplorer
 	m.yamlView.scroll = 0
 	m.yamlView.cursor = 0
-	m.yamlView.wrap = ui.ConfigYAMLViewerWrap
+	m.yamlView.wrap = m.viewerPrefs[prefYAMLViewerWrap]
 	return m, nil
 }
 
@@ -701,7 +702,7 @@ func (m Model) handleYAMLKeyCtrlC() (tea.Model, tea.Cmd) {
 	m.yamlReturnMode = modeExplorer
 	m.yamlView.scroll = 0
 	m.yamlView.cursor = 0
-	m.yamlView.wrap = ui.ConfigYAMLViewerWrap
+	m.yamlView.wrap = m.viewerPrefs[prefYAMLViewerWrap]
 	m.yamlView.searchText.Clear()
 	m.yamlView.matchLines = nil
 	return m, nil

--- a/internal/app/viewer_prefs.go
+++ b/internal/app/viewer_prefs.go
@@ -174,8 +174,18 @@ func (m *Model) setViewerPref(p viewerPref, v bool) {
 // never drops another. It deliberately leaves the ui global alone: the global
 // is the startup seed, and rewriting it here would make one viewer's keypress
 // change what an unrelated viewer opens with later in the same session.
+//
+// The load and the save sit inside one interprocess lock. Two lfk instances
+// share a state directory, so an unlocked merge lets the later writer drop a
+// toggle the other instance recorded between its read and its write.
 func persistViewerPref(p viewerPref, v bool) {
-	s := loadViewerPrefsState()
-	*viewerPrefBindings[p].field(&s) = &v
-	saveViewerPrefs(s)
+	path := viewerPrefsFilePath()
+	if path == "" {
+		return
+	}
+	withStateFileLock(path, func() {
+		s := loadViewerPrefsState()
+		*viewerPrefBindings[p].field(&s) = &v
+		saveViewerPrefs(s)
+	})
 }

--- a/internal/app/viewer_prefs.go
+++ b/internal/app/viewer_prefs.go
@@ -1,0 +1,181 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/paths"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// ViewerPrefsState records the fullscreen-viewer toggles the user last pressed.
+// It lives in the state directory, not config.yaml: config.yaml is user-authored
+// and seeds each default, this file is the app remembering a keypress. A nil
+// field means the user never toggled that setting, so config.yaml still wins for
+// it — that is why every field is a pointer and not a plain bool.
+type ViewerPrefsState struct {
+	LogShowPreview        *bool `json:"log_show_preview,omitempty" yaml:"log_show_preview,omitempty"`
+	LogShowPrefixes       *bool `json:"log_show_prefixes,omitempty" yaml:"log_show_prefixes,omitempty"`
+	LogShowTimestamps     *bool `json:"log_show_timestamps,omitempty" yaml:"log_show_timestamps,omitempty"`
+	LogPreviewLive        *bool `json:"log_preview_live,omitempty" yaml:"log_preview_live,omitempty"`
+	LogWrap               *bool `json:"log_wrap,omitempty" yaml:"log_wrap,omitempty"`
+	YAMLViewerWrap        *bool `json:"yaml_viewer_wrap,omitempty" yaml:"yaml_viewer_wrap,omitempty"`
+	DiffViewerWrap        *bool `json:"diff_viewer_wrap,omitempty" yaml:"diff_viewer_wrap,omitempty"`
+	DiffViewerLineNumbers *bool `json:"diff_viewer_line_numbers,omitempty" yaml:"diff_viewer_line_numbers,omitempty"`
+	DiffViewerUnified     *bool `json:"diff_viewer_unified,omitempty" yaml:"diff_viewer_unified,omitempty"`
+	DescribeViewerWrap    *bool `json:"describe_viewer_wrap,omitempty" yaml:"describe_viewer_wrap,omitempty"`
+	ObjectExplorerLive    *bool `json:"object_explorer_live,omitempty" yaml:"object_explorer_live,omitempty"`
+	ObjectExplorerTree    *bool `json:"object_explorer_tree,omitempty" yaml:"object_explorer_tree,omitempty"`
+	APIExplorerTree       *bool `json:"api_explorer_tree,omitempty" yaml:"api_explorer_tree,omitempty"`
+}
+
+// viewerPref names one persisted toggle. It indexes both viewerPrefBindings and
+// viewerPrefValues, so a caller cannot name a toggle the table does not know.
+type viewerPref int
+
+const (
+	prefLogShowPreview viewerPref = iota
+	prefLogShowPrefixes
+	prefLogShowTimestamps
+	prefLogPreviewLive
+	prefLogWrap
+	prefYAMLViewerWrap
+	prefDiffViewerWrap
+	prefDiffViewerLineNumbers
+	prefDiffViewerUnified
+	prefDescribeViewerWrap
+	prefObjectExplorerLive
+	prefObjectExplorerTree
+	prefAPIExplorerTree
+
+	// numViewerPrefs sizes viewerPrefValues. Keep it last.
+	numViewerPrefs
+)
+
+// viewerPrefBinding ties one persisted field to the ui global it seeds.
+type viewerPrefBinding struct {
+	global *bool
+	field  func(*ViewerPrefsState) **bool
+}
+
+// viewerPrefBindings is indexed by viewerPref. ApplyViewerPrefs is the only
+// writer of these globals, and it runs once at startup, so the viewer seed
+// sites that read them stay race-free and stay honest for tests that pin one.
+var viewerPrefBindings = []viewerPrefBinding{
+	{&ui.ConfigLogShowPreview, func(s *ViewerPrefsState) **bool { return &s.LogShowPreview }},
+	{&ui.ConfigLogShowPrefixes, func(s *ViewerPrefsState) **bool { return &s.LogShowPrefixes }},
+	{&ui.ConfigLogShowTimestamps, func(s *ViewerPrefsState) **bool { return &s.LogShowTimestamps }},
+	{&ui.ConfigLogPreviewLive, func(s *ViewerPrefsState) **bool { return &s.LogPreviewLive }},
+	{&ui.ConfigLogWrap, func(s *ViewerPrefsState) **bool { return &s.LogWrap }},
+	{&ui.ConfigYAMLViewerWrap, func(s *ViewerPrefsState) **bool { return &s.YAMLViewerWrap }},
+	{&ui.ConfigDiffViewerWrap, func(s *ViewerPrefsState) **bool { return &s.DiffViewerWrap }},
+	{&ui.ConfigDiffViewerLineNumbers, func(s *ViewerPrefsState) **bool { return &s.DiffViewerLineNumbers }},
+	{&ui.ConfigDiffViewerUnified, func(s *ViewerPrefsState) **bool { return &s.DiffViewerUnified }},
+	{&ui.ConfigDescribeViewerWrap, func(s *ViewerPrefsState) **bool { return &s.DescribeViewerWrap }},
+	{&ui.ConfigObjectExplorerLive, func(s *ViewerPrefsState) **bool { return &s.ObjectExplorerLive }},
+	{&ui.ConfigObjectExplorerTree, func(s *ViewerPrefsState) **bool { return &s.ObjectExplorerTree }},
+	{&ui.ConfigAPIExplorerTree, func(s *ViewerPrefsState) **bool { return &s.APIExplorerTree }},
+}
+
+// viewerPrefValues is the live set of fullscreen-viewer toggles for one
+// session, indexed by viewerPref. It lives on the Model rather than in the
+// ui.Config* globals so a keypress in one viewer cannot reach across into an
+// unrelated one, and so the test suite stays order-independent.
+type viewerPrefValues [numViewerPrefs]bool
+
+// newViewerPrefValues snapshots the startup seeds. ApplyViewerPrefs has already
+// folded the persisted file into them by the time NewModel calls this.
+func newViewerPrefValues() viewerPrefValues {
+	var v viewerPrefValues
+	for i, b := range viewerPrefBindings {
+		v[i] = *b.global
+	}
+	return v
+}
+
+func viewerPrefsFilePath() string {
+	dir, err := paths.StateDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "viewer_prefs.yaml")
+}
+
+// loadViewerPrefsState reads the file, returning an all-nil state when it is
+// missing or corrupt. Nothing here is fatal: a hand-edited state file must never
+// stop the app from starting, and an all-nil state means "use config.yaml".
+func loadViewerPrefsState() ViewerPrefsState {
+	var s ViewerPrefsState
+	path := viewerPrefsFilePath()
+	if path == "" {
+		return s
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Warn("Failed to read viewer prefs", "error", err, "path", path)
+		}
+		return s
+	}
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		logger.Warn("Viewer prefs file is corrupt; ignoring", "error", err, "path", path)
+		return ViewerPrefsState{}
+	}
+	return s
+}
+
+// ApplyViewerPrefs overlays the persisted toggles on the config defaults.
+// Call it once at startup, right after ui.LoadConfig and before the model seeds
+// a viewer from a ui.Config* global. It stays out of NewModel on purpose: a test
+// that pins a global must be able to trust that pin.
+func ApplyViewerPrefs() {
+	s := loadViewerPrefsState()
+	for _, b := range viewerPrefBindings {
+		if v := *b.field(&s); v != nil {
+			*b.global = *v
+		}
+	}
+}
+
+// saveViewerPrefs writes the state file. Best effort: losing a UI preference is
+// never worth failing a keypress over.
+func saveViewerPrefs(s ViewerPrefsState) {
+	path := viewerPrefsFilePath()
+	if path == "" {
+		return
+	}
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		logger.Error("Failed to encode viewer prefs", "error", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		logger.Error("Failed to create viewer prefs directory", "error", err, "path", path)
+		return
+	}
+	if err := writeFileDurable(path, data); err != nil {
+		logger.Error("Failed to persist viewer prefs", "error", err, "path", path)
+	}
+}
+
+// setViewerPref records a toggle for the rest of the session and for the next
+// start. Every viewer toggle handler goes through it, so the two halves cannot
+// drift apart.
+func (m *Model) setViewerPref(p viewerPref, v bool) {
+	m.viewerPrefs[p] = v
+	persistViewerPref(p, v)
+}
+
+// persistViewerPref records one runtime toggle so the next start reopens the
+// viewer with it. It merges into the file on disk, so recording one toggle
+// never drops another. It deliberately leaves the ui global alone: the global
+// is the startup seed, and rewriting it here would make one viewer's keypress
+// change what an unrelated viewer opens with later in the same session.
+func persistViewerPref(p viewerPref, v bool) {
+	s := loadViewerPrefsState()
+	*viewerPrefBindings[p].field(&s) = &v
+	saveViewerPrefs(s)
+}

--- a/internal/app/viewer_prefs_test.go
+++ b/internal/app/viewer_prefs_test.go
@@ -1,0 +1,161 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// isolateViewerPrefs points the state directory at a fresh temp dir and restores
+// every viewer global afterwards, so one case cannot leak into the next.
+// It returns the path the prefs file resolves to.
+func isolateViewerPrefs(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	saved := make([]bool, len(viewerPrefBindings))
+	for i, b := range viewerPrefBindings {
+		saved[i] = *b.global
+	}
+	t.Cleanup(func() {
+		for i, b := range viewerPrefBindings {
+			*b.global = saved[i]
+		}
+	})
+	return filepath.Join(dir, "lfk", "viewer_prefs.yaml")
+}
+
+// TestViewerPrefBindings_CoverEveryPref catches the way this file goes wrong:
+// a new toggle added to the viewerPref list but not to the binding table would
+// otherwise index past the table and panic at the first keypress.
+func TestViewerPrefBindings_CoverEveryPref(t *testing.T) {
+	if len(viewerPrefBindings) != int(numViewerPrefs) {
+		t.Fatalf("viewerPrefBindings has %d entries, viewerPref has %d",
+			len(viewerPrefBindings), numViewerPrefs)
+	}
+}
+
+func TestApplyViewerPrefs_MissingFileKeepsConfigDefaults(t *testing.T) {
+	isolateViewerPrefs(t)
+
+	ui.ConfigLogWrap = true
+	ui.ConfigLogShowTimestamps = true
+	ui.ConfigObjectExplorerLive = false
+
+	ApplyViewerPrefs()
+
+	if !ui.ConfigLogWrap || !ui.ConfigLogShowTimestamps || ui.ConfigObjectExplorerLive {
+		t.Fatalf("missing prefs file must not touch config defaults: wrap=%v ts=%v live=%v",
+			ui.ConfigLogWrap, ui.ConfigLogShowTimestamps, ui.ConfigObjectExplorerLive)
+	}
+}
+
+func TestApplyViewerPrefs_CorruptFileKeepsConfigDefaults(t *testing.T) {
+	path := isolateViewerPrefs(t)
+	writeViewerPrefsFile(t, path, "log_wrap: [not, a, bool")
+
+	ui.ConfigLogWrap = true
+	ApplyViewerPrefs()
+
+	if !ui.ConfigLogWrap {
+		t.Fatal("corrupt prefs file must fall back to the config default")
+	}
+}
+
+func TestApplyViewerPrefs_AbsentFieldKeepsConfigDefault(t *testing.T) {
+	path := isolateViewerPrefs(t)
+	// Only log_wrap was ever toggled; describe_viewer_wrap keeps its default.
+	writeViewerPrefsFile(t, path, "log_wrap: true\n")
+
+	ui.ConfigLogWrap = false
+	ui.ConfigDescribeViewerWrap = true
+
+	ApplyViewerPrefs()
+
+	if !ui.ConfigLogWrap {
+		t.Error("log_wrap: true in the prefs file must override the config default")
+	}
+	if !ui.ConfigDescribeViewerWrap {
+		t.Error("an absent field must leave the config default alone")
+	}
+}
+
+// TestPersistViewerPref_WritesTheFileNotTheGlobal pins the split that keeps the
+// rest of the suite order-independent: a keypress touches disk only, and
+// ApplyViewerPrefs is the one writer of the startup seed.
+func TestPersistViewerPref_WritesTheFileNotTheGlobal(t *testing.T) {
+	path := isolateViewerPrefs(t)
+
+	ui.ConfigLogWrap = false
+	persistViewerPref(prefLogWrap, true)
+
+	if ui.ConfigLogWrap {
+		t.Error("a keypress must not rewrite the startup seed")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("persistViewerPref must write the state file: %v", err)
+	}
+
+	ApplyViewerPrefs()
+	if !ui.ConfigLogWrap {
+		t.Error("the persisted value must survive a reload")
+	}
+}
+
+// TestPersistViewerPref_EveryToggleRoundTrips guards the binding table: a field
+// wired to the wrong global, or a global with no field, fails here.
+func TestPersistViewerPref_EveryToggleRoundTrips(t *testing.T) {
+	isolateViewerPrefs(t)
+
+	// Alternate the values so a table entry pointing at its neighbour's field
+	// produces a mismatch instead of an accidental pass.
+	want := make([]bool, len(viewerPrefBindings))
+	for i := range viewerPrefBindings {
+		want[i] = i%2 == 0
+		persistViewerPref(viewerPref(i), want[i])
+	}
+
+	for _, b := range viewerPrefBindings {
+		*b.global = false
+	}
+	ApplyViewerPrefs()
+
+	for i, b := range viewerPrefBindings {
+		if *b.global != want[i] {
+			t.Errorf("binding %d: got %v, want %v after round trip", i, *b.global, want[i])
+		}
+	}
+}
+
+// TestPersistViewerPref_MergesWithExistingFile proves one toggle never drops
+// another already on disk.
+func TestPersistViewerPref_MergesWithExistingFile(t *testing.T) {
+	isolateViewerPrefs(t)
+
+	persistViewerPref(prefLogWrap, true)
+	persistViewerPref(prefDiffViewerUnified, true)
+
+	ui.ConfigLogWrap = false
+	ui.ConfigDiffViewerUnified = false
+	ApplyViewerPrefs()
+
+	if !ui.ConfigLogWrap {
+		t.Error("the second toggle dropped the first from the state file")
+	}
+	if !ui.ConfigDiffViewerUnified {
+		t.Error("the second toggle was not persisted")
+	}
+}
+
+func writeViewerPrefsFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/app/viewer_prefs_test.go
+++ b/internal/app/viewer_prefs_test.go
@@ -15,6 +15,10 @@ func isolateViewerPrefs(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", dir)
+	// LFK_STATE_DIR outranks XDG_STATE_HOME in paths.resolve. TestMain unsets it
+	// for the package, but pinning it here keeps a stray value from sending a
+	// persistViewerPref write to the developer's real state directory.
+	t.Setenv("LFK_STATE_DIR", filepath.Join(dir, "lfk"))
 
 	saved := make([]bool, len(viewerPrefBindings))
 	for i, b := range viewerPrefBindings {

--- a/internal/ui/config_viewers.go
+++ b/internal/ui/config_viewers.go
@@ -2,9 +2,10 @@ package ui
 
 // Runtime globals for fullscreen-viewer startup-toggle defaults. These are set
 // from the log_viewer / yaml_viewer / diff_viewer / describe_viewer config
-// groups (see config_apply.go) and read by the app package when it constructs
-// or re-opens each viewer. Kept in their own file to keep config.go under the
-// 800-line limit.
+// groups (see config_apply.go), then overlaid with the toggles the user last
+// pressed (app.ApplyViewerPrefs, which outranks the config file). NewModel
+// snapshots them once; a runtime toggle updates its own model, never these.
+// Kept in their own file to keep config.go under the 800-line limit.
 
 // ConfigLogShowPreview is the startup default for the log viewer's structured
 // preview side panel (runtime toggle: P). Default true (panel shown).

--- a/main.go
+++ b/main.go
@@ -178,6 +178,8 @@ func runTUI(opts app.StartupOptions) error {
 		}
 	}
 	ui.LoadConfig(opts.Config)
+	// Viewer toggles the user pressed last session outrank the config file.
+	app.ApplyViewerPrefs()
 
 	if opts.Kubeconfig != "" {
 		if _, err := os.Stat(opts.Kubeconfig); err != nil {


### PR DESCRIPTION
Closes #689.

## What

Viewer display toggles now survive a restart, the way column visibility and sort already do.

Covers 13 toggles across five surfaces:

| Surface | Toggles |
|---|---|
| Log viewer | wrap (`>`), pod prefixes (`p`), timestamps (`s`), preview panel (`P`), live preview (`L`) |
| YAML viewer | wrap (`>`) |
| Diff viewer | wrap (`>`), unified (`u`), line numbers (`#`) |
| Describe viewer | wrap (`>`) |
| Explorers | Object Explorer live (`w`) and tree (`T`), API Explorer tree (`T`) |

They land in `viewer_prefs.yaml` in the state directory, next to `column_prefs.yaml` and `sort_memory.yaml`.

Precedence: `viewer_prefs.yaml` > `config.yaml` > built-in default. A toggle the user never pressed stays absent from the file, so `config.yaml` still seeds it. Delete the file to go back to the configured defaults.

No new config key. The `log_viewer` and viewer-default groups already existed; this adds the missing half.

## Design note

The live values moved onto the `Model` as `viewerPrefs` instead of staying in the `ui.Config*` globals.

The obvious shortcut is to have a keypress rewrite its global. That breaks two ways: the write outlives the test that made it, so 46 tests in `internal/app` become order-dependent, and one viewer's keypress changes what an unrelated viewer opens with later in the session. `ApplyViewerPrefs` (called once from `main.go`) is now the only writer of those globals, and `NewModel` snapshots them once.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `internal/app` green under `-shuffle=on` (3 runs)
- [x] New tests: missing file, corrupt file, absent field, per-toggle round trip, merge across two toggles, keypress writes the file but not the global, binding table covers every key
- [ ] Manual: toggle wrap in a pod log, quit, relaunch, confirm wrap is still on

## Out of scope

`internal/ui` fails under `-shuffle=on` on unmodified `origin/main` (theme and color globals leaking between tests), as does `TestSilentRefreshDoesNotArmPreviewLoading` in `internal/app`. Both reproduce on a clean baseline worktree. Not touched here.