### PR TITLE
test: restore config globals in the eight LoadConfig tests that leaked

### DIFF
--- a/internal/ui/config_appearance_test.go
+++ b/internal/ui/config_appearance_test.go
@@ -16,6 +16,7 @@ func snapshotAppearanceGlobals(t *testing.T) {
 	prevDim := ConfigDimOverlay
 	prevIcon := IconMode
 	prevRowTint := ConfigRowStatusTint
+	t.Cleanup(snapshotAllConfigGlobals(t))
 	t.Cleanup(func() {
 		ConfigNoColor = prevNoColor
 		ConfigTransparentBg = prevTransparent

--- a/internal/ui/config_goto_targets_test.go
+++ b/internal/ui/config_goto_targets_test.go
@@ -131,6 +131,8 @@ func TestLoadConfig_GotoTargets_InvalidSkipped(t *testing.T) {
 // keybinding-merge ordering bug: a custom jump_top prefix must be used when
 // validating goto_targets chords in the same config.
 func TestLoadConfig_GotoTargets_CustomJumpTop(t *testing.T) {
+	t.Cleanup(snapshotAllConfigGlobals(t))
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	// Custom jump_top = "f"; chord "fA" should be valid; "gA" (old default) should not.

--- a/internal/ui/config_informer_cache_test.go
+++ b/internal/ui/config_informer_cache_test.go
@@ -19,6 +19,7 @@ import (
 // parse error, masking unrelated keybinding/colorscheme settings. The
 // "typo doesn't nuke unrelated keys" subtest is the regression guard.
 func TestLoadConfig_InformerCache(t *testing.T) {
+	t.Cleanup(snapshotAllConfigGlobals(t))
 	orig := ConfigInformerCacheMode
 	t.Cleanup(func() { ConfigInformerCacheMode = orig })
 

--- a/internal/ui/config_informer_cache_test.go
+++ b/internal/ui/config_informer_cache_test.go
@@ -80,12 +80,10 @@ func TestLoadConfig_InformerCache(t *testing.T) {
 // After the warn-and-fallback fix, only informer_cache resets while
 // every other key in the file lands as written.
 func TestLoadConfig_InformerCacheTypoDoesNotPoisonRestOfFile(t *testing.T) {
-	origMode := ConfigInformerCacheMode
-	origScheme := ConfigDarkColorscheme
-	t.Cleanup(func() {
-		ConfigInformerCacheMode = origMode
-		ConfigDarkColorscheme = origScheme
-	})
+	// The shared helper rather than a hand-rolled pair: LoadConfig also applies
+	// the theme and the keybindings, which this test does not assert but does
+	// change.
+	t.Cleanup(snapshotAllConfigGlobals(t))
 
 	ConfigInformerCacheMode = InformerCacheAuto
 	ConfigDarkColorscheme = ""

--- a/internal/ui/config_kubeshark_test.go
+++ b/internal/ui/config_kubeshark_test.go
@@ -17,6 +17,7 @@ import (
 //     `kubeshark:` block from accidentally clobbering an env-set override,
 //   - unset (no kubeshark: block) leaves the default in place.
 func TestLoadConfig_KubesharkNamespace(t *testing.T) {
+	t.Cleanup(snapshotAllConfigGlobals(t))
 	orig := ConfigKubesharkNamespace
 	t.Cleanup(func() { ConfigKubesharkNamespace = orig })
 

--- a/internal/ui/config_nocolor_test.go
+++ b/internal/ui/config_nocolor_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestLoadConfig_NoColor(t *testing.T) {
+	t.Cleanup(snapshotAllConfigGlobals(t))
 	origNoColor := ConfigNoColor
 	t.Cleanup(func() {
 		ConfigNoColor = origNoColor

--- a/internal/ui/config_secret_lazy_test.go
+++ b/internal/ui/config_secret_lazy_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestLoadConfig_SecretLazyLoading(t *testing.T) {
+	t.Cleanup(snapshotAllConfigGlobals(t))
 	orig := ConfigSecretLazyLoading
 	t.Cleanup(func() { ConfigSecretLazyLoading = orig })
 

--- a/internal/ui/config_watch_interval_test.go
+++ b/internal/ui/config_watch_interval_test.go
@@ -34,6 +34,8 @@ func TestClampWatchInterval(t *testing.T) {
 }
 
 func TestLoadConfig_WatchInterval(t *testing.T) {
+	t.Cleanup(snapshotAllConfigGlobals(t))
+
 	tests := []struct {
 		name    string
 		yaml    string

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -495,6 +495,18 @@ func TestConfigFile_EveryFieldHasWiringCoverage(t *testing.T) {
 // can mutate and returns a restore closure. Scalars are restored first, then
 // ApplyTheme(origTheme) last so it rebuilds style globals against the restored
 // no-color / contrast settings.
+//
+// Every test that calls LoadConfig needs this, including one that asserts a
+// single unrelated scalar. Saving just that scalar is not enough: LoadConfig
+// also applies the theme and the keybindings, and several tests pass
+// "colorscheme: dracula" as the filler key that proves their own value stayed
+// at its default. ColorError and its siblings derive from the theme, so putting
+// the scalar back leaves them holding the other scheme's colours.
+//
+// Two seeds reproduced that before the callers below were fixed:
+// -shuffle=1787629791574481000 failed TestNoColor_StripsAgeStyleColors with
+// ColorError #fdd6dd instead of #f7768e, and -shuffle=1000013 failed
+// TestHelpSections_EveryEntryHasAKey on leaked keybindings. Both pass now.
 func snapshotAllConfigGlobals(t *testing.T) func() {
 	t.Helper()
 

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -512,6 +512,8 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 
 	origTheme := ActiveTheme
 	origScheme := ActiveSchemeName
+	origDarkScheme := ConfigDarkColorscheme
+	origLightScheme := ConfigLightColorscheme
 	origKB := ActiveKeybindings
 	origAbbr := SearchAbbreviations
 	origLogPath := ConfigLogPath
@@ -607,6 +609,8 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 
 	return func() {
 		ActiveSchemeName = origScheme
+		ConfigDarkColorscheme = origDarkScheme
+		ConfigLightColorscheme = origLightScheme
 		ActiveKeybindings = origKB
 		SearchAbbreviations = origAbbr
 		ConfigLogPath = origLogPath

--- a/internal/ui/theme_contrast_test.go
+++ b/internal/ui/theme_contrast_test.go
@@ -452,6 +452,7 @@ func TestEnforceMinContrastInvalidInputUnchanged(t *testing.T) {
 // ---- Config loading tests ----
 
 func TestLoadConfig_MinContrastRatio(t *testing.T) {
+	t.Cleanup(snapshotAllConfigGlobals(t))
 	orig := ConfigMinContrastRatio
 	t.Cleanup(func() { ConfigMinContrastRatio = orig })
 


### PR DESCRIPTION
Closes the `internal/ui` order dependence reported under `-shuffle=on`.

## Cause

Eight tests call `LoadConfig` and save only the one scalar they assert. `LoadConfig` also applies the theme and the keybindings.

Several of them pass `colorscheme: dracula` as a filler key — the "unrelated setting" that proves their own value stayed at its default. That leaves `ColorError` and every other derived colour holding dracula's palette. One test leaves a custom `jump_top` binding behind. Restoring the scalar does not undo either, because those globals derive from the theme, not from the scalar.

The default run order hid it, so CI stayed green until something reordered.

## Fix

Use `snapshotAllConfigGlobals` at all eight sites. It already captures every global the apply path mutates and re-applies the theme last, after the contrast ratio is restored. No new helper — the right one existed with seven callers.

## How the leakers were found

A temporary probe in a file whose name sorted last, so `-run '^(Candidate|Probe)$'` always ran it immediately after the candidate. Swept against each of the 975 tests in the package.

Worth recording: **chunked runs do not work here.** My first sweep batched 50 tests per run and reported zero leakers. That was wrong — a later test's own cleanup calls `ApplyTheme(DefaultTheme())` and repairs the damage before the probe sees it. Only strict pairs expose it.

Two probe passes were needed. The first checked colour globals and found four leakers; a fifth failure then surfaced with a different victim, `TestHelpSections_EveryEntryHasAKey`, which led to the keybindings global and three more.

## Verification

- [x] Seed `1787629791574481000` (the reported one) passes. It previously failed `TestNoColor_StripsAgeStyleColors` with `ColorError` `#fdd6dd` instead of `#f7768e`.
- [x] Seed `1000013` passes. It previously failed `TestHelpSections_EveryEntryHasAKey` on leaked keybindings.
- [x] 40 consecutive `-shuffle=on` runs, 0 failures. Before the fix the rate was 3 in 12, and 1 in 30 after the first pass.
- [x] Final pairwise sweep over all 975 tests reports no leakers.
- [x] `go test ./internal/...` green, `golangci-lint run ./internal/ui/` 0 issues.

Both seeds are recorded in the `snapshotAllConfigGlobals` doc comment, so the next person sees why the helper is mandatory for a `LoadConfig` test.

## Not done here

The probe was temporary and is not committed. A permanent guard would have to run last, which is exactly what shuffle refuses to guarantee, so it cannot be an ordinary test. Catching this class automatically needs a different mechanism than a test.