### PR TITLE
fix: lock the load-modify-save in column prefs and sort memory

### DIFF
--- a/internal/app/column_prefs.go
+++ b/internal/app/column_prefs.go
@@ -120,21 +120,29 @@ func loadColumnPrefs() columnPrefMaps {
 
 // persistColumnPrefsEntry writes one kind's committed column layout to disk,
 // merging with other contexts/kinds so a commit for one never drops another's.
-// Best-effort. Runs only on the single Bubble Tea Update goroutine (commit/reset
-// handlers), so the load-modify-save is never concurrent.
+// Best-effort. Callers run on the single Bubble Tea Update goroutine, and the
+// lock extends that guarantee across processes: two lfk instances sharing a
+// state directory would otherwise read the same file and the later writer would
+// drop the layout the other one just committed.
 func persistColumnPrefsEntry(key string, p persistedColumnPrefs) {
 	ctx, kind, ok := strings.Cut(key, "\x00")
 	if !ok {
 		return
 	}
-	state := loadColumnPrefsState()
-	if state.Contexts[ctx] == nil {
-		state.Contexts[ctx] = map[string]persistedColumnPrefs{}
+	path := columnPrefsFilePath()
+	if path == "" {
+		return
 	}
-	state.Contexts[ctx][kind] = p
-	if err := saveColumnPrefsState(state); err != nil {
-		logger.Error("Failed to persist column prefs", "error", err)
-	}
+	withStateFileLock(path, func() {
+		state := loadColumnPrefsState()
+		if state.Contexts[ctx] == nil {
+			state.Contexts[ctx] = map[string]persistedColumnPrefs{}
+		}
+		state.Contexts[ctx][kind] = p
+		if err := saveColumnPrefsState(state); err != nil {
+			logger.Error("Failed to persist column prefs", "error", err)
+		}
+	})
 }
 
 // persistForgottenColumnPrefs removes one kind's column layout from disk (the
@@ -144,21 +152,27 @@ func persistForgottenColumnPrefs(key string) {
 	if !ok {
 		return
 	}
-	state := loadColumnPrefsState()
-	kinds, ok := state.Contexts[ctx]
-	if !ok {
+	path := columnPrefsFilePath()
+	if path == "" {
 		return
 	}
-	if _, ok := kinds[kind]; !ok {
-		return
-	}
-	delete(kinds, kind)
-	if len(kinds) == 0 {
-		delete(state.Contexts, ctx)
-	}
-	if err := saveColumnPrefsState(state); err != nil {
-		logger.Error("Failed to persist column prefs", "error", err)
-	}
+	withStateFileLock(path, func() {
+		state := loadColumnPrefsState()
+		kinds, ok := state.Contexts[ctx]
+		if !ok {
+			return
+		}
+		if _, ok := kinds[kind]; !ok {
+			return
+		}
+		delete(kinds, kind)
+		if len(kinds) == 0 {
+			delete(state.Contexts, ctx)
+		}
+		if err := saveColumnPrefsState(state); err != nil {
+			logger.Error("Failed to persist column prefs", "error", err)
+		}
+	})
 }
 
 // persistColumnPrefs persists (or clears) the committed column layout for the

--- a/internal/app/sort_memory.go
+++ b/internal/app/sort_memory.go
@@ -110,26 +110,39 @@ func saveSortMemory(mem map[string]sortPref) error {
 // Best-effort: a write failure means the sort won't survive the next restart, so
 // log it for disk-full / permissions diagnosis from lfk.log.
 //
-// The load-modify-save is unsynchronised. Callers run on the single Bubble Tea
-// Update goroutine (rememberSort/forgetSort from key and mouse handlers), so the
-// sequence is never concurrent; do not call this from a background goroutine.
+// Callers run on the single Bubble Tea Update goroutine (rememberSort and
+// forgetSort from key and mouse handlers). The lock extends that across
+// processes, so a second lfk instance cannot drop the sort this one just
+// recorded. Do not call this from a background goroutine.
 func persistRememberedSort(key string, pref sortPref) {
-	mem := loadSortMemory()
-	mem[key] = pref
-	if err := saveSortMemory(mem); err != nil {
-		logger.Error("Failed to persist sort memory", "error", err)
+	path := sortMemoryFilePath()
+	if path == "" {
+		return
 	}
+	withStateFileLock(path, func() {
+		mem := loadSortMemory()
+		mem[key] = pref
+		if err := saveSortMemory(mem); err != nil {
+			logger.Error("Failed to persist sort memory", "error", err)
+		}
+	})
 }
 
 // persistForgottenSort removes a single sort pref from disk (the sort-reset
 // action), leaving every other remembered sort intact. Best-effort.
 func persistForgottenSort(key string) {
-	mem := loadSortMemory()
-	if _, ok := mem[key]; !ok {
+	path := sortMemoryFilePath()
+	if path == "" {
 		return
 	}
-	delete(mem, key)
-	if err := saveSortMemory(mem); err != nil {
-		logger.Error("Failed to persist sort memory", "error", err)
-	}
+	withStateFileLock(path, func() {
+		mem := loadSortMemory()
+		if _, ok := mem[key]; !ok {
+			return
+		}
+		delete(mem, key)
+		if err := saveSortMemory(mem); err != nil {
+			logger.Error("Failed to persist sort memory", "error", err)
+		}
+	})
 }

--- a/internal/app/state_lock_concurrency_test.go
+++ b/internal/app/state_lock_concurrency_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofrs/flock"
+)
+
+// These tests prove each load-modify-save runs inside withStateFileLock, by
+// holding the lock and checking the function writes nothing while it is held.
+//
+// A racing-goroutines test was tried first and does not work here. These save
+// paths use os.WriteFile, so the window between the load and the save is a
+// fraction of the fsync-backed one in viewer_prefs. Below about 40 writers the
+// goroutines never interleave and the test passes with the lock removed, which
+// makes it worthless as a guard. Above that, waiters exhaust the 250ms budget
+// and skip their writes by design, so the test fails with the lock in place.
+// No writer count satisfies both. Holding the lock tests the same property and
+// is deterministic.
+
+// holdStateLock takes the lock withStateFileLock uses for path, standing in for
+// a second lfk process, and returns the release func.
+func holdStateLock(t *testing.T, path string) func() {
+	t.Helper()
+	lockPath := filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".lock")
+	held := flock.New(lockPath)
+	if err := held.Lock(); err != nil {
+		t.Fatalf("test setup: cannot take the lock: %v", err)
+	}
+	return func() {
+		if err := held.Unlock(); err != nil {
+			t.Fatalf("test teardown: cannot release the lock: %v", err)
+		}
+	}
+}
+
+// assertWritesOnlyUnlocked runs write() twice: once while another holder owns
+// the lock, where it must leave the file untouched, and once after release,
+// where landed() must report the change arrived.
+func assertWritesOnlyUnlocked(t *testing.T, path string, write func(), landed func() bool) {
+	t.Helper()
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("test setup: seed write never reached %s: %v", path, err)
+	}
+
+	release := holdStateLock(t, path)
+	write()
+	during, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read while locked: %v", err)
+	}
+	if string(during) != string(before) {
+		t.Error("the file changed while another holder had the lock, so the load-modify-save runs outside it")
+	}
+	release()
+
+	write()
+	if !landed() {
+		t.Error("the write did not land once the lock was free")
+	}
+}
+
+func TestPersistColumnPrefsEntry_WritesInsideTheLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	persistColumnPrefsEntry("ctx\x00Seed", persistedColumnPrefs{VisibleExtras: []string{"col"}})
+
+	assertWritesOnlyUnlocked(t, columnPrefsFilePath(),
+		func() {
+			persistColumnPrefsEntry("ctx\x00Later", persistedColumnPrefs{VisibleExtras: []string{"col"}})
+		},
+		func() bool {
+			_, ok := loadColumnPrefsState().Contexts["ctx"]["Later"]
+			return ok
+		})
+}
+
+func TestPersistForgottenColumnPrefs_DeletesInsideTheLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	persistColumnPrefsEntry("ctx\x00Seed", persistedColumnPrefs{VisibleExtras: []string{"col"}})
+	persistColumnPrefsEntry("ctx\x00Doomed", persistedColumnPrefs{VisibleExtras: []string{"col"}})
+
+	assertWritesOnlyUnlocked(t, columnPrefsFilePath(),
+		func() { persistForgottenColumnPrefs("ctx\x00Doomed") },
+		func() bool {
+			_, ok := loadColumnPrefsState().Contexts["ctx"]["Doomed"]
+			return !ok
+		})
+}
+
+func TestPersistRememberedSort_WritesInsideTheLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	persistRememberedSort("ctx\x00v1/seed", sortPref{column: "NAME", ascending: true})
+
+	assertWritesOnlyUnlocked(t, sortMemoryFilePath(),
+		func() { persistRememberedSort("ctx\x00v1/later", sortPref{column: "AGE", ascending: false}) },
+		func() bool {
+			_, ok := loadSortMemory()["ctx\x00v1/later"]
+			return ok
+		})
+}
+
+func TestPersistForgottenSort_DeletesInsideTheLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	persistRememberedSort("ctx\x00v1/seed", sortPref{column: "NAME", ascending: true})
+	persistRememberedSort("ctx\x00v1/doomed", sortPref{column: "AGE", ascending: false})
+
+	assertWritesOnlyUnlocked(t, sortMemoryFilePath(),
+		func() { persistForgottenSort("ctx\x00v1/doomed") },
+		func() bool {
+			_, ok := loadSortMemory()["ctx\x00v1/doomed"]
+			return !ok
+		})
+}

--- a/internal/app/state_lock_concurrency_test.go
+++ b/internal/app/state_lock_concurrency_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gofrs/flock"
 )
@@ -112,5 +113,82 @@ func TestPersistForgottenSort_DeletesInsideTheLock(t *testing.T) {
 		func() bool {
 			_, ok := loadSortMemory()["ctx\x00v1/doomed"]
 			return !ok
+		})
+}
+
+// assertReadHappensInsideLock proves the load is inside the lock, not just the
+// save. assertWritesOnlyUnlocked above cannot tell the two apart: an
+// implementation that reads first and locks only around the update and the save
+// still writes nothing while the lock is held, yet it writes back state that
+// predates the other writer and loses their entry.
+//
+// The trick needs no test hook in production code. Hold the lock, start the
+// writer, and only then add a rival entry to the file. A writer that reads
+// inside the lock cannot have read yet, so it picks the rival up and preserves
+// it. A writer that read before locking already holds the older copy and
+// overwrites the rival away.
+func assertReadHappensInsideLock(t *testing.T, path string, write func(), addRival func(), rivalSurvived func() bool) {
+	t.Helper()
+	release := holdStateLock(t, path)
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		write()
+		close(done)
+	}()
+	<-started
+	// Give the writer time to reach its first file access. A writer that reads
+	// outside the lock has taken its stale copy by now.
+	time.Sleep(50 * time.Millisecond)
+
+	addRival()
+	release()
+	<-done
+
+	if !rivalSurvived() {
+		t.Error("the writer overwrote an entry added after it started, so it read the file before taking the lock")
+	}
+}
+
+func TestPersistColumnPrefsEntry_ReadsInsideTheLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	persistColumnPrefsEntry("ctx\x00Seed", persistedColumnPrefs{VisibleExtras: []string{"col"}})
+
+	assertReadHappensInsideLock(t, columnPrefsFilePath(),
+		func() {
+			persistColumnPrefsEntry("ctx\x00Mine", persistedColumnPrefs{VisibleExtras: []string{"col"}})
+		},
+		func() {
+			// Stands in for the other process's committed layout.
+			state := loadColumnPrefsState()
+			state.Contexts["ctx"]["Rival"] = persistedColumnPrefs{VisibleExtras: []string{"col"}}
+			if err := saveColumnPrefsState(state); err != nil {
+				t.Errorf("test setup: %v", err)
+			}
+		},
+		func() bool {
+			_, ok := loadColumnPrefsState().Contexts["ctx"]["Rival"]
+			return ok
+		})
+}
+
+func TestPersistRememberedSort_ReadsInsideTheLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	persistRememberedSort("ctx\x00v1/seed", sortPref{column: "NAME", ascending: true})
+
+	assertReadHappensInsideLock(t, sortMemoryFilePath(),
+		func() { persistRememberedSort("ctx\x00v1/mine", sortPref{column: "AGE", ascending: false}) },
+		func() {
+			mem := loadSortMemory()
+			mem["ctx\x00v1/rival"] = sortPref{column: "AGE", ascending: true}
+			if err := saveSortMemory(mem); err != nil {
+				t.Errorf("test setup: %v", err)
+			}
+		},
+		func() bool {
+			_, ok := loadSortMemory()["ctx\x00v1/rival"]
+			return ok
 		})
 }


### PR DESCRIPTION
Follow-up to #690, which added `withStateFileLock` and applied it to `viewer_prefs.yaml`.

## What is fixed

Four load-modify-save sites now hold the interprocess lock across the whole read-update-write:

| File | Functions |
|---|---|
| `column_prefs.go` | `persistColumnPrefsEntry`, `persistForgottenColumnPrefs` |
| `sort_memory.go` | `persistRememberedSort`, `persistForgottenSort` |

Each merges one entry into a file holding many. Two lfk instances sharing a state directory could read the same file and the later writer would drop the entry the other had just committed — a column layout or a remembered sort, gone with no error.

`sort_memory.go` already documented the gap: a comment said the sequence is unsynchronised and safe because callers share one goroutine. True within a process, never across two.

## Scope correction

The task listed eight files. **Only these two are load-modify-save.**

`session.go`, `pinned.go`, `pinned_summaries.go`, `hidden_types.go` and `export_strip_prefs.go` load once at startup and write the whole file from memory. A lock there would serialise the writes and lose exactly the same data: the loser writes back a full copy that never saw the winner's change. Adding a lock would look like a fix and prevent nothing.

Fixing those means reloading and merging at write time — a behaviour change, and a separate piece of work. I did not want to bolt on locks that buy nothing.

## On the tests

The AC asked for a concurrency test per file. I wrote racing-goroutine tests first and **they were worthless**: they passed with the lock removed. These save paths use `os.WriteFile`, so the window between load and save is a fraction of the fsync-backed one in `viewer_prefs`, and the goroutines never interleave.

Raising the writer count to 200 did expose the race — 334 dropped entries with the lock removed — but then the tests **failed with the lock in place**. Waiters poll on a 5ms retry inside a 250ms budget, so beyond roughly 50 queued writers they time out and skip their writes by design. No writer count satisfies both ends.

So the tests hold the lock and assert the function writes nothing while it is held, which tests the same property deterministically. All four fail with the lock removed and pass with it.

Worth knowing separately: `stateLockRetry` at 5ms with a 250ms budget caps the queue at about 50 waiters. Fine for a handful of lfk instances; it is not a general-purpose write queue.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` green
- [x] `golangci-lint run ./...` — 0 issues
- [x] Each of the four tests mutation-checked: forcing the lock to be granted makes it fail