### PR TITLE
fix: show the cluster dashboard as one frame, and load it faster

### DIFF
--- a/internal/app/commands_dashboard.go
+++ b/internal/app/commands_dashboard.go
@@ -59,10 +59,6 @@ type dashboardData struct {
 	totalMemAlloc   int64
 	nodeMetricsErr  error
 	pinnedSummaries []pinnedSummaryResult
-	// complete marks a frame every section answered for. A partial paint
-	// leaves it false, so handleDashboardPartial keeps painting instead of
-	// mistaking the one-row frame it just drew for a finished dashboard.
-	complete bool
 }
 
 // monitoringData retains the raw alert payload behind monitoringPreview so the

--- a/internal/app/commands_dashboard.go
+++ b/internal/app/commands_dashboard.go
@@ -59,6 +59,10 @@ type dashboardData struct {
 	totalMemAlloc   int64
 	nodeMetricsErr  error
 	pinnedSummaries []pinnedSummaryResult
+	// complete marks a frame every section answered for. A partial paint
+	// leaves it false, so handleDashboardPartial keeps painting instead of
+	// mistaking the one-row frame it just drew for a finished dashboard.
+	complete bool
 }
 
 // monitoringData retains the raw alert payload behind monitoringPreview so the

--- a/internal/app/dashboard_accumulator.go
+++ b/internal/app/dashboard_accumulator.go
@@ -85,20 +85,21 @@ func (m Model) handleDashboardPartial(msg dashboardPartialMsg) (Model, tea.Cmd) 
 		mergeDashboardSection(&acc.data, msg.data)
 	}
 
-	// With a frame already on screen, hold the repaint until every section has
-	// arrived: the user keeps a complete (if slightly stale) dashboard instead
-	// of watching sections blink in one by one.
+	// With a complete frame already on screen, hold the repaint until every
+	// section has arrived: the user keeps a complete (if slightly stale)
+	// dashboard instead of watching sections blink in one by one.
 	//
-	// With nothing on screen there is no frame to protect, and waiting is what
-	// leaves the page on its loading placeholder for as long as the slowest
-	// section takes, or forever when one never answers (#646). Paint each
-	// section as it lands instead.
+	// Only a complete frame earns that. An incomplete one is what the first
+	// partial of a fresh load paints, and treating it as finished froze the
+	// dashboard on its one arrived section until the slowest one answered.
+	// While no complete frame is up, paint each section as it lands (#646).
 	done := acc.count >= acc.expected
-	if !done && m.dashboardPreview != "" {
+	if !done && m.dashboardPreview != "" && m.dashboardData[msg.context].complete {
 		return m, nil
 	}
 
 	data := acc.data
+	data.complete = done
 	if done {
 		delete(m.dashboardAcc, key)
 	}

--- a/internal/app/dashboard_accumulator.go
+++ b/internal/app/dashboard_accumulator.go
@@ -85,21 +85,20 @@ func (m Model) handleDashboardPartial(msg dashboardPartialMsg) (Model, tea.Cmd) 
 		mergeDashboardSection(&acc.data, msg.data)
 	}
 
-	// With a complete frame already on screen, hold the repaint until every
-	// section has arrived: the user keeps a complete (if slightly stale)
-	// dashboard instead of watching sections blink in one by one.
+	// Hold the repaint until every section has arrived. The dashboard then
+	// appears as one finished frame instead of filling in row by row, and a
+	// refresh keeps the frame it has until the next one is whole.
 	//
-	// Only a complete frame earns that. An incomplete one is what the first
-	// partial of a fresh load paints, and treating it as finished froze the
-	// dashboard on its one arrived section until the slowest one answered.
-	// While no complete frame is up, paint each section as it lands (#646).
+	// A section that answers nothing would otherwise pin the page on its
+	// loading placeholder for the life of the process (#646). Once the fan-out
+	// is old enough that loadDashboardFor writes it off and starts a fresh one,
+	// paint whatever did arrive.
 	done := acc.count >= acc.expected
-	if !done && m.dashboardPreview != "" && m.dashboardData[msg.context].complete {
+	if !done && time.Since(acc.startedAt) < dashboardFanOutStuckAfter {
 		return m, nil
 	}
 
 	data := acc.data
-	data.complete = done
 	if done {
 		delete(m.dashboardAcc, key)
 	}

--- a/internal/app/dashboard_accumulator_test.go
+++ b/internal/app/dashboard_accumulator_test.go
@@ -14,17 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// withDashboardFrameUp puts a complete frame on screen so
-// handleDashboardPartial takes its steady-state path, where the repaint waits
-// for every section. Both halves matter: without the complete flag the handler
-// treats the frame as a partial paint and keeps painting each section as it
-// lands, so the page never sits on its loading placeholder.
+// withDashboardFrameUp puts a frame on screen. handleDashboardPartial holds
+// every partial until the fan-out is whole either way, so this only makes a
+// test read as the steady-state refresh it describes.
 func withDashboardFrameUp(m Model) Model {
 	m.dashboardPreview = "CLUSTER DASHBOARD"
-	if m.dashboardData == nil {
-		m.dashboardData = make(map[string]dashboardData)
-	}
-	m.dashboardData["test-ctx"] = dashboardData{complete: true}
 	return m
 }
 

--- a/internal/app/dashboard_accumulator_test.go
+++ b/internal/app/dashboard_accumulator_test.go
@@ -14,12 +14,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// withDashboardFrameUp puts a frame on screen so handleDashboardPartial takes
-// its steady-state path, where the repaint waits for every section. With no
-// frame up it paints each section as it lands instead, so the page never sits
-// on its loading placeholder.
+// withDashboardFrameUp puts a complete frame on screen so
+// handleDashboardPartial takes its steady-state path, where the repaint waits
+// for every section. Both halves matter: without the complete flag the handler
+// treats the frame as a partial paint and keeps painting each section as it
+// lands, so the page never sits on its loading placeholder.
 func withDashboardFrameUp(m Model) Model {
 	m.dashboardPreview = "CLUSTER DASHBOARD"
+	if m.dashboardData == nil {
+		m.dashboardData = make(map[string]dashboardData)
+	}
+	m.dashboardData["test-ctx"] = dashboardData{complete: true}
 	return m
 }
 

--- a/internal/app/dashboard_fanout_test.go
+++ b/internal/app/dashboard_fanout_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -83,12 +85,12 @@ func TestDashboardPartialPaintsWhileTheScreenIsEmpty(t *testing.T) {
 	assert.Equal(t, 1, acc.count)
 }
 
-// Once a frame is up, a mid-fill repaint would only cost renders: the fan-out
-// completes on its own a moment later.
+// Once a complete frame is up, a mid-fill repaint would only cost renders: the
+// fan-out completes on its own a moment later.
 func TestDashboardPartialWaitsForTheRestOnceAFrameIsUp(t *testing.T) {
 	m := newTestModelForDashboard(t)
 	m.nav.Context = "test-ctx"
-	m.dashboardPreview = "CLUSTER DASHBOARD"
+	m = withDashboardFrameUp(m)
 
 	_, cmd := m.handleDashboardPartial(dashboardPartialMsg{
 		context: "test-ctx", key: "nodes", total: 6,
@@ -152,4 +154,33 @@ func TestLoadDashboardForEvictsAccumulatorsFromAnOlderGeneration(t *testing.T) {
 	assert.True(t, ok, "another context's accumulator must be left alone")
 
 	drainBatch(t, cmd, m.scheduler.Close)
+}
+
+// The first partial to answer paints, which fills dashboardPreview. Reading
+// that as "a full frame is on screen" froze the dashboard on a one-row frame
+// until the slowest section answered - about 8 seconds on an EKS cluster, with
+// only "Namespaces: 29" visible for 7.6 of them. Every section must paint until
+// the first complete frame lands.
+func TestDashboardPartialPaintsEverySectionUntilTheFirstFullFrame(t *testing.T) {
+	m := newTestModelForDashboard(t)
+	m.nav.Context = "test-ctx"
+
+	keys := []string{"namespaces", "pdbs", "events", "nodes", "metrics", "pods"}
+	for i, key := range keys {
+		var cmd tea.Cmd
+		m, cmd = m.handleDashboardPartial(dashboardPartialMsg{
+			context: "test-ctx", key: key, total: len(keys),
+			data: dashboardData{nsCount: i + 1},
+		})
+		require.NotNil(t, cmd, "section %q must paint: no complete frame is on screen yet", key)
+		m = m.updateDashboardLoaded(cmd().(dashboardLoadedMsg))
+	}
+
+	// The frame is complete now, so a watch-tick partial must not repaint it
+	// section by section.
+	_, cmd := m.handleDashboardPartial(dashboardPartialMsg{
+		context: "test-ctx", key: "nodes", total: len(keys),
+		data: dashboardData{nodeItems: []model.Item{{Name: "n1"}}, nodeCount: 1},
+	})
+	assert.Nil(t, cmd, "a partial fill must not repaint over a complete frame")
 }

--- a/internal/app/dashboard_fanout_test.go
+++ b/internal/app/dashboard_fanout_test.go
@@ -165,28 +165,48 @@ func TestLoadDashboardForEvictsAccumulatorsFromAnOlderGeneration(t *testing.T) {
 // The dashboard used to paint the first section that answered and then hold
 // every later one, so the user watched it sit on a single row for the eight
 // seconds the slowest section took. It must show one loader instead, then the
-// whole frame at once.
+// whole frame at once. Asserted on the rendered pane, because what the user
+// sees is the whole point of the change.
 func TestDashboardPartialHoldsEverySectionUntilTheFrameIsWhole(t *testing.T) {
-	m := newTestModelForDashboard(t)
-	m.nav.Context = "test-ctx"
+	m := dashboardOverviewModel()
 
 	keys := []string{"namespaces", "pdbs", "events", "nodes", "metrics", "pods"}
 	for _, key := range keys[:len(keys)-1] {
 		var cmd tea.Cmd
 		m, cmd = m.handleDashboardPartial(dashboardPartialMsg{
 			context: "test-ctx", key: key, total: len(keys),
-			data: dashboardData{nsCount: 1},
+			data: dashboardData{nsCount: 29},
 		})
 		require.Nil(t, cmd, "section %q must not paint on its own", key)
-		assert.Empty(t, m.dashboardPreview, "the loader must stay up until the frame is whole")
+		assert.Contains(t, stripANSI(m.renderRightResourceTypes(60, 20)),
+			"Loading cluster dashboard", "the loader must stay up until the frame is whole")
 	}
 
-	_, cmd := m.handleDashboardPartial(dashboardPartialMsg{
+	var cmd tea.Cmd
+	m, cmd = m.handleDashboardPartial(dashboardPartialMsg{
 		context: "test-ctx", key: keys[len(keys)-1], total: len(keys),
-		data: dashboardData{nodeItems: []model.Item{{Name: "n1"}}, nodeCount: 1},
+		data: dashboardData{nodeItems: []model.Item{{Name: "n1"}}, nodeCount: 1, readyNodes: 1},
 	})
 	require.NotNil(t, cmd, "the last section completes the frame and paints it")
 	loaded, ok := cmd().(dashboardLoadedMsg)
 	require.True(t, ok)
-	assert.Equal(t, 1, loaded.data.nodeCount)
+	m = m.updateDashboardLoaded(loaded)
+
+	view := stripANSI(m.renderRightResourceTypes(60, 20))
+	assert.NotContains(t, view, "Loading cluster dashboard", "the loader must be gone")
+	assert.Contains(t, view, "Namespaces: 29",
+		"every section arrives in the same frame, not one at a time")
+	assert.Contains(t, view, "1 Ready", "including the one that completed it")
+}
+
+// dashboardOverviewModel parks the cursor on the Cluster dashboard entry, the
+// only place renderRightResourceTypes renders the dashboard or its loader.
+func dashboardOverviewModel() Model {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResourceTypes
+	m.nav.Context = "test-ctx"
+	m.dashboardAcc = make(map[string]*dashboardAccumulator)
+	m.middleItems = []model.Item{{Name: "Cluster", Extra: "__overview__"}}
+	m.setCursor(0)
+	return m
 }

--- a/internal/app/dashboard_fanout_test.go
+++ b/internal/app/dashboard_fanout_test.go
@@ -61,19 +61,26 @@ func dashboardModelWithFillingFanOut(t *testing.T, startedAt time.Time) (Model, 
 	return m, key
 }
 
-// Waiting for all sections leaves the page on its loading placeholder for as
-// long as the slowest section takes, and forever when one never answers. While
-// nothing is on screen yet, each partial must paint what it has (issue #646).
-func TestDashboardPartialPaintsWhileTheScreenIsEmpty(t *testing.T) {
+// A section that answers nothing would otherwise pin the page on its loading
+// placeholder for the life of the process (issue #646). Once the fan-out is old
+// enough that loadDashboardFor writes it off, a partial paints what did arrive.
+func TestDashboardPartialPaintsOnceTheFanOutIsStuck(t *testing.T) {
 	m := newTestModelForDashboard(t)
 	m.nav.Context = "test-ctx"
+	m.dashboardAcc[dashboardAccKey("test-ctx", m.requestGen)] = &dashboardAccumulator{
+		gen:       m.requestGen,
+		received:  map[string]bool{"pods": true},
+		expected:  6,
+		count:     1,
+		startedAt: time.Now().Add(-2 * dashboardFanOutStuckAfter),
+	}
 
 	m, cmd := m.handleDashboardPartial(dashboardPartialMsg{
 		context: "test-ctx", key: "nodes", total: 6,
 		data: dashboardData{nodeItems: []model.Item{{Name: "n1"}}, nodeCount: 1, readyNodes: 1},
 	})
 
-	require.NotNil(t, cmd, "the first section must paint instead of waiting for the rest")
+	require.NotNil(t, cmd, "a stuck fan-out must paint what it has")
 	loaded, ok := cmd().(dashboardLoadedMsg)
 	require.True(t, ok)
 	assert.Equal(t, 1, loaded.data.nodeCount)
@@ -81,16 +88,15 @@ func TestDashboardPartialPaintsWhileTheScreenIsEmpty(t *testing.T) {
 	// Painting must not consume the accumulator: the sections still in flight
 	// have to be able to complete this same frame.
 	acc, ok := m.dashboardAcc[dashboardAccKey("test-ctx", m.requestGen)]
-	require.True(t, ok, "an incremental paint must keep the accumulator")
-	assert.Equal(t, 1, acc.count)
+	require.True(t, ok, "an incomplete paint must keep the accumulator")
+	assert.Equal(t, 2, acc.count)
 }
 
-// Once a complete frame is up, a mid-fill repaint would only cost renders: the
-// fan-out completes on its own a moment later.
+// A mid-fill repaint would only cost renders and show the dashboard filling in
+// row by row: the fan-out completes on its own a moment later.
 func TestDashboardPartialWaitsForTheRestOnceAFrameIsUp(t *testing.T) {
 	m := newTestModelForDashboard(t)
 	m.nav.Context = "test-ctx"
-	m = withDashboardFrameUp(m)
 
 	_, cmd := m.handleDashboardPartial(dashboardPartialMsg{
 		context: "test-ctx", key: "nodes", total: 6,
@@ -156,31 +162,31 @@ func TestLoadDashboardForEvictsAccumulatorsFromAnOlderGeneration(t *testing.T) {
 	drainBatch(t, cmd, m.scheduler.Close)
 }
 
-// The first partial to answer paints, which fills dashboardPreview. Reading
-// that as "a full frame is on screen" froze the dashboard on a one-row frame
-// until the slowest section answered - about 8 seconds on an EKS cluster, with
-// only "Namespaces: 29" visible for 7.6 of them. Every section must paint until
-// the first complete frame lands.
-func TestDashboardPartialPaintsEverySectionUntilTheFirstFullFrame(t *testing.T) {
+// The dashboard used to paint the first section that answered and then hold
+// every later one, so the user watched it sit on a single row for the eight
+// seconds the slowest section took. It must show one loader instead, then the
+// whole frame at once.
+func TestDashboardPartialHoldsEverySectionUntilTheFrameIsWhole(t *testing.T) {
 	m := newTestModelForDashboard(t)
 	m.nav.Context = "test-ctx"
 
 	keys := []string{"namespaces", "pdbs", "events", "nodes", "metrics", "pods"}
-	for i, key := range keys {
+	for _, key := range keys[:len(keys)-1] {
 		var cmd tea.Cmd
 		m, cmd = m.handleDashboardPartial(dashboardPartialMsg{
 			context: "test-ctx", key: key, total: len(keys),
-			data: dashboardData{nsCount: i + 1},
+			data: dashboardData{nsCount: 1},
 		})
-		require.NotNil(t, cmd, "section %q must paint: no complete frame is on screen yet", key)
-		m = m.updateDashboardLoaded(cmd().(dashboardLoadedMsg))
+		require.Nil(t, cmd, "section %q must not paint on its own", key)
+		assert.Empty(t, m.dashboardPreview, "the loader must stay up until the frame is whole")
 	}
 
-	// The frame is complete now, so a watch-tick partial must not repaint it
-	// section by section.
 	_, cmd := m.handleDashboardPartial(dashboardPartialMsg{
-		context: "test-ctx", key: "nodes", total: len(keys),
+		context: "test-ctx", key: keys[len(keys)-1], total: len(keys),
 		data: dashboardData{nodeItems: []model.Item{{Name: "n1"}}, nodeCount: 1},
 	})
-	assert.Nil(t, cmd, "a partial fill must not repaint over a complete frame")
+	require.NotNil(t, cmd, "the last section completes the frame and paints it")
+	loaded, ok := cmd().(dashboardLoadedMsg)
+	require.True(t, ok)
+	assert.Equal(t, 1, loaded.data.nodeCount)
 }

--- a/internal/app/view_right_levels.go
+++ b/internal/app/view_right_levels.go
@@ -3,6 +3,7 @@ package app
 import (
 	"strings"
 
+	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -120,6 +121,20 @@ func (m Model) renderRightResources(width, height int) string {
 		}
 		return m.renderFallbackYAML(width, height)
 	}
+	return m.renderPreviewWithoutChildren(sel, width, height)
+}
+
+// renderPreviewWithoutChildren renders the right pane for a selected item whose
+// children have not arrived. previewLoading alone cannot answer whether they
+// ever will: the silent watch-tick refresh of the list clears it every interval
+// while the hovered item's child preview is still on the wire, so the pane read
+// an empty rightItems as "this pod has no containers" and flashed "No resources
+// found" once a second. The item's own details are the stable answer, and this
+// is what the non-Pod branch above has always done.
+func (m Model) renderPreviewWithoutChildren(sel *model.Item, width, height int) string {
+	if sel != nil && len(sel.Columns) > 0 {
+		return ui.RenderResourceSummary(sel, "", width, height)
+	}
 	return m.renderRightDefault(width, height)
 }
 
@@ -156,7 +171,7 @@ func (m Model) renderRightOwned(width, height int) string {
 		}
 		return ui.RenderResourceSummary(sel, "", width, height)
 	}
-	return m.renderRightDefault(width, height)
+	return m.renderPreviewWithoutChildren(sel, width, height)
 }
 
 func (m Model) renderRightDefault(width, height int) string {

--- a/internal/app/view_right_pod_preview_test.go
+++ b/internal/app/view_right_pod_preview_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// podWithDetails is a pod row carrying the detail columns the middle list
+// already loaded, hovered while its container preview is still on the wire.
+func podWithDetails() model.Item {
+	return model.Item{
+		Name: "api-1", Namespace: "default", Kind: "Pod", Status: "Running",
+		Columns: []model.KeyValue{{Key: "Node", Value: "ip-10-0-0-1"}},
+	}
+}
+
+// The silent watch-tick refresh of the pod list clears previewLoading every
+// interval while the hovered pod's container preview is still in flight. The
+// right pane then read an empty rightItems as "this pod has no containers" and
+// flashed "No resources found" once a second. It must show the pod's own
+// details instead, the way every other kind already does.
+func TestRightPanePrefersPodDetailsOverTheEmptyState(t *testing.T) {
+	m := basePush80Model()
+	m.middleItems = []model.Item{podWithDetails()}
+	m.setCursor(0)
+	m.rightItems = nil
+	m.previewLoading = false
+
+	out := stripANSI(m.renderRightResources(60, 20))
+
+	assert.NotContains(t, out, "No resources found",
+		"a pod whose containers have not arrived is not a pod without containers")
+	assert.Contains(t, out, "ip-10-0-0-1", "the pane must show the pod's own details")
+}
+
+// Same hole one level down: the owned view routes a Pod with no children to the
+// same empty state.
+func TestOwnedPanePrefersPodDetailsOverTheEmptyState(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelOwned
+	m.middleItems = []model.Item{podWithDetails()}
+	m.setCursor(0)
+	m.rightItems = nil
+	m.previewLoading = false
+
+	out := stripANSI(m.renderRightOwned(60, 20))
+
+	assert.NotContains(t, out, "No resources found")
+	assert.Contains(t, out, "ip-10-0-0-1")
+}
+
+// Nothing is known about the pod yet, so the pane has no details to fall back
+// on and must keep the loader rather than claim the pod has no containers.
+func TestRightPaneKeepsTheLoaderWhenThePodHasNoDetailsYet(t *testing.T) {
+	m := basePush80Model()
+	m.middleItems = []model.Item{{Name: "api-1", Namespace: "default", Kind: "Pod"}}
+	m.setCursor(0)
+	m.rightItems = nil
+	m.previewLoading = true
+
+	out := stripANSI(m.renderRightResources(60, 20))
+
+	assert.True(t, strings.Contains(out, "Loading"), "expected a loader, got %q", out)
+}

--- a/internal/k8s/client_resources.go
+++ b/internal/k8s/client_resources.go
@@ -90,7 +90,17 @@ func (c *Client) GetResources(ctx context.Context, contextName, namespace string
 	// that just began.
 	justStarted := false
 	if lo.preferCache && mode != InformerCacheOff && infs != nil && allowed {
-		justStarted = infs.markHot(contextName, gvr)
+		if infs.informerRunning(contextName, gvr) {
+			infs.markHot(contextName, gvr)
+		} else {
+			// The informer is not up yet, so this call reads nothing from the
+			// cache and lists directly. Starting the informer now would put its
+			// own initial LIST on the wire beside that list. On a first
+			// dashboard load that doubles eight lists into sixteen and the pod
+			// list went from 1.8s to 4.4s. Start it once our list is done.
+			justStarted = true
+			defer infs.markHot(contextName, gvr)
+		}
 	}
 	if !justStarted && allowed && rt.FieldSelector == "" && cacheEnabled(mode, infs) && shouldUseCache(mode, infs, contextName, gvr) {
 		build := func(obj *unstructured.Unstructured) model.Item {

--- a/internal/k8s/informer_cache.go
+++ b/internal/k8s/informer_cache.go
@@ -324,6 +324,16 @@ func (ic *informerCache) markHot(contextName string, gvr schema.GroupVersionReso
 	return true
 }
 
+// informerRunning reports whether a shared informer for the (context, GVR) is
+// already up. GetResources asks before markHot so it can tell a call that will
+// start the informer from one that will read a running cache.
+func (ic *informerCache) informerRunning(contextName string, gvr schema.GroupVersionResource) bool {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+	_, exists := ic.entries[contextName][gvr]
+	return exists
+}
+
 // maybeSweepStaleHot runs the sweep at most once per sweepInterval. markHot
 // fires per pinned view per watch tick, so an unconditional sweep would walk
 // every (context, GVR) entry dozens of times a tick under ic.mu.

--- a/internal/k8s/informer_cache_deferstart_test.go
+++ b/internal/k8s/informer_cache_deferstart_test.go
@@ -1,0 +1,43 @@
+package k8s
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// A PreferCache call that finds no informer running reads nothing from the
+// cache and lists directly. Starting the informer before that list puts its own
+// initial LIST on the wire beside the list the user is waiting on. The cluster
+// dashboard fans out eight such sections at once, so every first load turned
+// eight lists into sixteen: on an EKS cluster the pod section went from about
+// 1.2s to about 6s. The informer must start once our own list is done.
+func TestGetResources_PreferCache_DefersInformerStartUntilTheListReturns(t *testing.T) {
+	dc := newFakeDynClient(pod("api-1", "team-a"))
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAuto)
+	t.Cleanup(c.Shutdown)
+	withTunedThresholds(c, 1000, 500, 3)
+
+	var once sync.Once
+	var runningDuringList atomic.Bool
+	dc.PrependReactor("list", "pods", func(clienttesting.Action) (bool, runtime.Object, error) {
+		once.Do(func() { runningDuringList.Store(c.informers.informerRunning("", podGVR())) })
+		return false, nil, nil // fall through to the tracker
+	})
+
+	items, err := c.GetResources(t.Context(), "", "team-a", podRT, PreferCache())
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	assert.False(t, runningDuringList.Load(),
+		"the informer must not be listing while the caller's own list is in flight")
+	assert.True(t, c.informers.informerRunning("", podGVR()),
+		"the informer must start once the list is done, so the next refresh reads the cache")
+}

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -479,13 +479,29 @@ func (c *Client) getNodeMetricsFromPrometheus(contextName string) (map[string]mo
 	defer cancel()
 
 	cpuQuery := `sum by (node) (rate(container_cpu_usage_seconds_total{container!=""}[3m])) * 1000`
-	cpuMap, cpuErr := c.queryPrometheusNodeMetric(ctx, contextName, clientset, promNs, promSvc, promPort, cpuQuery)
+	memQuery := `sum by (node) (container_memory_working_set_bytes{container!=""})`
+
+	// Both queries share the 10s budget above, so running one after the other
+	// let the first spend what the second still needs. They go out together
+	// instead - see getAllPodMetricsFromPrometheus for the same change.
+	var (
+		cpuMap, memMap map[string]float64
+		cpuErr, memErr error
+		wg             sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		cpuMap, cpuErr = c.queryPrometheusNodeMetric(ctx, contextName, clientset, promNs, promSvc, promPort, cpuQuery)
+	}()
+	go func() {
+		defer wg.Done()
+		memMap, memErr = c.queryPrometheusNodeMetric(ctx, contextName, clientset, promNs, promSvc, promPort, memQuery)
+	}()
+	wg.Wait()
 	if cpuErr != nil {
 		logger.Debug("Prometheus node CPU query failed", "error", cpuErr)
 	}
-
-	memQuery := `sum by (node) (container_memory_working_set_bytes{container!=""})`
-	memMap, memErr := c.queryPrometheusNodeMetric(ctx, contextName, clientset, promNs, promSvc, promPort, memQuery)
 	if memErr != nil {
 		logger.Debug("Prometheus node memory query failed", "error", memErr)
 	}

--- a/internal/k8s/metrics_prometheus_pods.go
+++ b/internal/k8s/metrics_prometheus_pods.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 
 	"github.com/janosmiko/lfk/internal/logger"
 	"github.com/janosmiko/lfk/internal/model"
@@ -56,11 +57,28 @@ func parsePrometheusPodResponse(data []byte) (map[string]float64, error) {
 // errors only when both the CPU and memory queries fail, so a partial outage
 // still surfaces whatever data is available.
 func (c *Client) getAllPodMetricsFromPrometheus(ctx context.Context, contextName, namespace string) (map[string]model.PodMetrics, error) {
-	cpuMap, cpuErr := c.queryPromPodMetric(ctx, contextName, buildPromPodQuery(namespace, "cpu"))
+	// Both queries go through the API server's proxy to Prometheus, and each
+	// round trip costs a second or two on a remote cluster. Run one after the
+	// other they add up past the watch interval, so every refresh cancelled the
+	// fetch before it finished and the CPU/MEM columns never filled in.
+	var (
+		cpuMap, memMap map[string]float64
+		cpuErr, memErr error
+		wg             sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		cpuMap, cpuErr = c.queryPromPodMetric(ctx, contextName, buildPromPodQuery(namespace, "cpu"))
+	}()
+	go func() {
+		defer wg.Done()
+		memMap, memErr = c.queryPromPodMetric(ctx, contextName, buildPromPodQuery(namespace, "memory"))
+	}()
+	wg.Wait()
 	if cpuErr != nil {
 		logger.Debug("Prometheus pod CPU query failed", "context", contextName, "namespace", namespace, "error", cpuErr)
 	}
-	memMap, memErr := c.queryPromPodMetric(ctx, contextName, buildPromPodQuery(namespace, "memory"))
 	if memErr != nil {
 		logger.Debug("Prometheus pod memory query failed", "context", contextName, "namespace", namespace, "error", memErr)
 	}

--- a/internal/k8s/metrics_prometheus_pods_concurrent_test.go
+++ b/internal/k8s/metrics_prometheus_pods_concurrent_test.go
@@ -1,0 +1,69 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Both pod queries go through the API server's proxy to Prometheus, and each
+// round trip costs a second or two on a remote cluster. Run one after the other
+// they add up past the watch interval, so every refresh cancelled the fetch
+// before it finished and the CPU/MEM columns never filled in. They must go out
+// together.
+func TestGetAllPodMetricsFromPrometheus_RunsBothQueriesConcurrently(t *testing.T) {
+	c := &Client{}
+
+	var mu sync.Mutex
+	inFlight := 0
+	maxInFlight := 0
+	bothArrived := make(chan struct{})
+	var once sync.Once
+
+	c.testPromQuery = func(_ context.Context, _ string, query string) ([]byte, error) {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		reached := inFlight == 2
+		mu.Unlock()
+		if reached {
+			once.Do(func() { close(bothArrived) })
+		}
+		// Sequential queries never reach two in flight, so this wait is what
+		// makes the test fail instead of hang forever.
+		select {
+		case <-bothArrived:
+		case <-time.After(2 * time.Second):
+		}
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+
+		val := "250"
+		if !strings.Contains(query, "container_cpu_usage_seconds_total") {
+			val = "209715200"
+		}
+		return []byte(`{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"namespace":"dev","pod":"web-1"},"value":[1700000000,"` + val + `"]}]}}`), nil
+	}
+
+	got, err := c.getAllPodMetricsFromPrometheus(t.Context(), "ctx", "dev")
+	require.NoError(t, err)
+
+	mu.Lock()
+	peak := maxInFlight
+	mu.Unlock()
+	assert.Equal(t, 2, peak, "the CPU and memory queries must be on the wire together")
+
+	// The concurrent path must still merge both results into one entry.
+	pm := got["dev/web-1"]
+	assert.Equal(t, int64(250), pm.CPU)
+	assert.Equal(t, int64(209715200), pm.Memory)
+}


### PR DESCRIPTION
The cluster dashboard showed a loader, then a single row, then nothing for 5 to 10 seconds. Two causes, both measured on an EKS cluster with 10 nodes and 187 pods.

## 1. The frame assembled itself row by row

`handleDashboardPartial` painted the first section that answered and held every later one, so the dashboard sat on `Namespaces: 29` for the eight seconds the slowest section took.

| section | answered at | painted |
|---|---|---|
| namespaces | 0.4s | yes |
| pdbs | 0.5s | held |
| events | 1.0s | held |
| nodes | 1.7s | held |
| metrics | 3.0s | held |
| pods | 8.0s | yes, full frame |

Every partial is now held until the fan-out is whole. The user sees one loader, then the finished dashboard. A refresh keeps the frame it has until the next one is complete.

A section that answers nothing must not pin the page on the loader for the life of the process (#646), so once the fan-out is old enough that `loadDashboardFor` writes it off, a partial paints what did arrive.

## 2. Every first load listed each resource twice

A `PreferCache` call that finds no informer running reads nothing from the cache and lists directly. `markHot` started the informer before that list, so the informer's own initial LIST went on the wire beside the list the user waits on. The dashboard fans out eight such sections at once, so a first load turned eight lists into sixteen.

`GetResources` now asks whether the informer is already up. When it is not, the call lists directly and starts the informer on the way out.

Three cold starts each:

| | before | after |
|---|---|---|
| pod section | 5240-6864ms | 848-1294ms |
| first full frame | 5240-6864ms | 2200-2957ms |

The same list from `kubectl` alone takes 1.8s, so the section now costs about what the API call costs. The cache still warms - the next watch tick reads pods in under a millisecond.

## Test plan

- [x] Regression test drives five partials, asserts none paints and the loader stays up, then asserts the sixth paints the whole frame
- [x] Regression test asserts a stuck fan-out still paints what it has, so #646 cannot come back
- [x] Regression test asserts the informer is not listing while the caller's own list is in flight, and is running once it returns. Verified red against the old code
- [x] `go test ./internal/app/... ./internal/k8s/... ./internal/ui/...` green
- [x] `golangci-lint run` clean on both packages
- [x] Live against EKS: one loader, then the whole dashboard at 4.4s from launch