### PR TITLE
fix: scope multi-select keys by kind

### DIFF
--- a/internal/app/commands_test.go
+++ b/internal/app/commands_test.go
@@ -338,10 +338,9 @@ func TestCov80OpenBulkActionDirectNoSelection(t *testing.T) {
 
 func TestCov80OpenBulkActionDirectWithSelection(t *testing.T) {
 	m := basePush80Model()
-	// Selection keys use "namespace/name" format (see selectionKey()).
 	m.selectedItems = map[string]bool{
-		"default/pod-1": true,
-		"ns-2/pod-2":    true,
+		selectionKey(m.middleItems[0]): true,
+		selectionKey(m.middleItems[1]): true,
 	}
 	result, _ := m.openBulkActionDirect("Delete")
 	rm := result.(Model)
@@ -351,7 +350,7 @@ func TestCov80OpenBulkActionDirectWithSelection(t *testing.T) {
 func TestCov80OpenBulkActionDirectLogs(t *testing.T) {
 	m := basePush80Model()
 	m.selectedItems = map[string]bool{
-		"default/pod-1": true,
+		selectionKey(m.middleItems[0]): true,
 	}
 	result, _ := m.openBulkActionDirect("Logs")
 	// executeBulkAction("Logs") may return *Model.

--- a/internal/app/union_test.go
+++ b/internal/app/union_test.go
@@ -671,7 +671,7 @@ func TestToggleSelect_AllowedAtUnionSentinel(t *testing.T) {
 	assert.Len(t, result.selectedItems, 1, "the green row should be selected")
 	// selectionKey must include ClusterName so the green selection does not
 	// collide with the blue one when they share name+namespace.
-	assert.True(t, result.selectedItems["green:cloud-cd/my-pod"],
+	assert.True(t, result.selectedItems["green:cloud-cd/my-pod|Pod"],
 		"selection key must encode ClusterName; got: %v", result.selectedItems)
 }
 
@@ -1797,4 +1797,34 @@ func TestUnionDashboardMemberOpensContextAndBackReturnsToUnionView(t *testing.T)
 	assert.Empty(t, um.nav.ResourceType.Resource)
 	require.Len(t, um.middleItems, 2)
 	assert.Equal(t, "Monitoring", um.middleItems[1].Name)
+}
+
+// TestSelectionKey_MixedKindListKeepsRowsDistinct reproduces the ArgoCD
+// components bug: an application's resource list holds a Role and a
+// RoleBinding that share a namespace and a name. Before the kind entered
+// the key, both rows mapped to "ns/name", so the status bar counted one
+// selection for two marked rows and untoggling either row cleared both.
+func TestSelectionKey_MixedKindListKeepsRowsDistinct(t *testing.T) {
+	items := []model.Item{
+		{Name: "app", Kind: "Role", Namespace: "cloud-cd"},
+		{Name: "app", Kind: "RoleBinding", Namespace: "cloud-cd"},
+	}
+	m := Model{
+		nav:             model.NavigationState{Level: model.LevelResources},
+		middleItems:     items,
+		cursors:         [5]int{},
+		selectedItems:   make(map[string]bool),
+		selectionAnchor: -1,
+	}
+
+	m.toggleSelection(items[0])
+	m.toggleSelection(items[1])
+	assert.Len(t, m.selectedItems, 2, "each kind must own its own key")
+	assert.True(t, m.isSelected(items[0]))
+	assert.True(t, m.isSelected(items[1]))
+
+	m.toggleSelection(items[1])
+	assert.True(t, m.isSelected(items[0]), "untoggling the RoleBinding must not clear the Role")
+	assert.False(t, m.isSelected(items[1]))
+	assert.Len(t, m.selectedItems, 1)
 }

--- a/internal/app/update_actions_test.go
+++ b/internal/app/update_actions_test.go
@@ -381,8 +381,8 @@ func TestCov80DirectActionRefresh(t *testing.T) {
 func TestCov80OpenActionMenuBulkMode(t *testing.T) {
 	m := basePush80Model()
 	m.selectedItems = map[string]bool{
-		"default/pod-1": true,
-		"ns-2/pod-2":    true,
+		selectionKey(m.middleItems[0]): true,
+		selectionKey(m.middleItems[1]): true,
 	}
 	rm := m.openActionMenu()
 	assert.True(t, rm.bulkMode)
@@ -585,7 +585,7 @@ func TestCovOpenActionMenuNoSelection(t *testing.T) {
 
 func TestCovOpenActionMenuBulk(t *testing.T) {
 	m := baseModelActions()
-	m.selectedItems["default/pod-1"] = true
+	m.selectedItems[selectionKey(m.middleItems[0])] = true
 	rm := m.openActionMenu()
 	assert.True(t, rm.bulkMode)
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -303,17 +303,23 @@ type Item struct {
 // SelectionKey returns the stable map key identifying this item in a
 // multi-selection set. Union-mode rows carry a non-empty ClusterName, which
 // is prepended so the same name+namespace appearing in two clusters stays
-// distinct. Non-union rows produce the legacy "namespace/name" (or bare
-// "name") form. This is the single source of truth for the key: both the
-// app's selection store and the ui renderer's selected-row check derive
-// their keys here so the two can never drift.
+// distinct. Kind is appended when set, because a mixed-kind list (an ArgoCD
+// application's components, for one) can hold a Role and a RoleBinding that
+// share a namespace and a name. Without the kind those two rows collapse
+// onto one key, so the count under-reports and toggling either row clears
+// both. This is the single source of truth for the key: both the app's
+// selection store and the ui renderer's selected-row check derive their keys
+// here so the two can never drift.
 func (i Item) SelectionKey() string {
 	base := i.Name
 	if i.Namespace != "" {
 		base = i.Namespace + "/" + i.Name
 	}
 	if i.ClusterName != "" {
-		return i.ClusterName + ":" + base
+		base = i.ClusterName + ":" + base
+	}
+	if i.Kind != "" {
+		base += "|" + i.Kind
 	}
 	return base
 }

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -480,6 +480,16 @@ func TestItemSelectionKey(t *testing.T) {
 			item: Item{Name: "node-1", ClusterName: "prod"},
 			want: "prod:node-1",
 		},
+		{
+			name: "kinded row appends the kind",
+			item: Item{Name: "app", Namespace: "default", Kind: "Role"},
+			want: "default/app|Role",
+		},
+		{
+			name: "same name and namespace with a different kind is a different key",
+			item: Item{Name: "app", Namespace: "default", Kind: "RoleBinding"},
+			want: "default/app|RoleBinding",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- A mixed-kind list, such as an ArgoCD application's components, can hold a `Role` and a `RoleBinding` that share a namespace and a name. `Item.SelectionKey` built the key from cluster, namespace and name only, so both rows mapped onto one entry in `selectedItems`.
- Result: the status bar counted one selection for two marked rows, and untoggling either row cleared both.
- `SelectionKey` now appends `|<Kind>` when Kind is set. Kind-less rows keep the legacy `namespace/name` format, so union keys and every existing caller stay intact.

## Test plan

- [x] `TestItemSelectionKey` covers the kinded and the mixed-kind cases (`internal/model`)
- [x] `TestSelectionKey_MixedKindListKeepsRowsDistinct` covers toggle and untoggle on two same-named rows (`internal/app`)
- [x] `go test ./internal/...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] Manual: open an ArgoCD application, select a Role and a RoleBinding that share a name, confirm the count reads 2