### PR TITLE
fix: survive a proxy that resets long-lived watch connections

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -725,6 +725,12 @@ confirm_on_exit: true
 # Default: auto
 # informer_cache: auto
 
+# ─── Disable HTTP/2 ───────────────────────────────────────────────────────────
+# Talk HTTP/1.1 to the API server, for a proxy or VPN that resets long-lived
+# watch connections. The DISABLE_HTTP2 env var overrides this field.
+# Default: false
+# disable_http2: true
+
 # ─── Scrolloff ────────────────────────────────────────────────────────────────
 # Lines to keep visible above/below the cursor when scrolling. Used by all
 # views with cursor-based navigation.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -85,7 +85,8 @@ Prefer a local copy? Point `$schema` at a relative or absolute path instead of t
 | `security.heuristic.scan_secrets` | bool | `true` | Allow the heuristic source to list Secret objects, enabling the `legacy_sa_token_secret` and `tls_secret_expiry` checks and Secret-reference verification. `false` means the source never reads Secrets. Top-level `security` section only. |
 | `clusters.<name>.security` | object | _(unset)_ | Per-context security override (`enabled`, `hide_badges`, and/or `sources`). Wins over the global `security` settings for that context. |
 | `secret_lazy_loading` | bool | `false` | When `true`, Secret listing fetches metadata only and decoded values load on hover. See [Secret lazy loading](#secret-lazy-loading) for trade-offs. |
-| `informer_cache` | bool or string | `auto` | Selects the list strategy. Accepts `off` (round-trip every list — matches kubectl), `auto` (default; promote a resource type to a shared informer once a list crosses 1000 items, demote when sustained below 500), and `always` (open a watch eagerly on first use). Legacy bool form is still accepted: `true` → `always`, `false` → `off`. See [Informer cache](#informer-cache) for trade-offs. |
+| `disable_http2` | bool | `false` | When `true`, lfk talks HTTP/1.1 to the API server. Use behind a proxy or VPN that resets long-lived watch connections. The `DISABLE_HTTP2` env var overrides this field. |
+| `informer_cache` | bool or string | `auto` | Selects the list strategy. Accepts `off` (round-trip every list — matches kubectl), `auto` (default; promote a resource type to a shared informer once a list crosses 1000 items or a repeated refresh keeps it hot, demote when sustained below 500), and `always` (open a watch eagerly on first use). Legacy bool form is still accepted: `true` → `always`, `false` → `off`. See [Informer cache](#informer-cache) for trade-offs. |
 | `min_contrast_ratio` | float | `0.0` | **Deprecated** — use `appearance.min_contrast_ratio`. Normalized readability knob in `[0.0, 1.0]`. When above zero, foreground colors are nudged in HSL lightness space to meet a minimum WCAG contrast ratio against their paired background. See [Minimum Contrast Ratio](#minimum-contrast-ratio). |
 
 ### Auto dark/light mode
@@ -994,7 +995,7 @@ the next render even though we never re-issue a `LIST`.
 | | `off` | `auto` (default) | `always` |
 |---|---|---|---|
 | Namespace switch on 7k-pod list | 1–2 s API round trip | In-process walk (after first list) | In-process walk (after first list) |
-| API server load (small clusters) | One LIST per nav | One LIST per nav (never promoted) | One LIST + one watch per opened type |
+| API server load (small clusters) | One LIST per nav | One LIST per nav, plus a watch per refreshed type | One LIST + one watch per opened type |
 | API server load (large clusters) | One LIST per nav | One initial LIST then one watch per promoted type | Same as `auto` |
 | Memory in lfk | View only | Cached objects for promoted types | Cached objects for every opened type |
 | One-off large list strands a watch | n/a | No (auto-demote closes it) | Yes (until shutdown) |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -331,6 +331,11 @@
       "description": "When true, Secret listing fetches metadata only and decoded values load on hover. Faster in clusters with many large Secrets.",
       "default": false
     },
+    "disable_http2": {
+      "type": "boolean",
+      "description": "When true, lfk talks HTTP/1.1 to the API server instead of HTTP/2. Use behind a proxy or VPN that resets long-lived watch connections.",
+      "default": false
+    },
     "informer_cache": {
       "description": "List strategy: \"off\" round-trips every list, \"auto\" promotes a resource type to a shared informer above 1000 items, \"always\" opens a watch eagerly. Legacy bool form: true -> always, false -> off.",
       "oneOf": [

--- a/internal/k8s/client_resources.go
+++ b/internal/k8s/client_resources.go
@@ -160,10 +160,10 @@ func cacheEnabled(mode InformerCacheMode, infs *informerCache) bool {
 // short-circuits to true. Auto-mode consults the per-(context, GVR) state
 // machine maintained by observeDirectListSize / observeCachedListSize.
 func shouldUseCache(mode InformerCacheMode, infs *informerCache, contextName string, gvr schema.GroupVersionResource) bool {
-	// denyGVR stops the watch for the session. Routing a denied GVR back
-	// through the cache branch restarts the informer on every list and makes
-	// the caller pay the sync wait again (#646).
-	if infs != nil && infs.isDenied(contextName, gvr) {
+	// A given-up watch stays given up. Routing it back through the cache
+	// branch restarts the informer on every list and makes the caller pay
+	// the sync wait again (#646).
+	if infs != nil && infs.cacheBlocked(contextName, gvr) {
 		return false
 	}
 	if mode == InformerCacheAlways {

--- a/internal/k8s/informer_cache.go
+++ b/internal/k8s/informer_cache.go
@@ -99,6 +99,11 @@ type gvrAutoState struct {
 	// MethodNotSupported, or NotFound -- RBAC or API surface that will
 	// not change mid-session. Permanent for the life of the Client.
 	denied bool
+	// watchFailures counts consecutive non-status watch errors, cleared by
+	// a successful sync. cooldownUntil blocks the cache once the count
+	// trips maxWatchFailures. See noteWatchFailure.
+	watchFailures int
+	cooldownUntil time.Time
 }
 
 // itemMemoEntry caches one converted model.Item alongside the
@@ -177,6 +182,12 @@ type informerCache struct {
 	// multi-minute sleep.
 	hotTTL time.Duration
 
+	// maxWatchFailures / watchFailureCooldown bound how long a broken watch
+	// is retried. Stored on the struct so tests need neither three real
+	// reflector retries nor the production cooldown.
+	maxWatchFailures     int
+	watchFailureCooldown time.Duration
+
 	// sweepInterval rate-limits sweepStaleHot off the watch-tick path.
 	// lastSweep is guarded by ic.mu. Tests set sweepInterval to zero to
 	// force a sweep on the next markHot.
@@ -207,6 +218,9 @@ func newInformerCache(clientFactory func(string) (dynamic.Interface, error)) *in
 		hotTTL:             defaultHotTTL,
 		sweepInterval:      defaultSweepInterval,
 		lastSweep:          time.Now(),
+
+		maxWatchFailures:     defaultMaxWatchFailures,
+		watchFailureCooldown: defaultWatchFailureCooldown,
 	}
 }
 
@@ -283,19 +297,18 @@ func (ic *informerCache) isPromoted(contextName string, gvr schema.GroupVersionR
 	state := ic.getAutoState(contextName, gvr)
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	if state.denied {
+	if state.denied || state.blockedLocked() {
 		return false
 	}
 	return state.hot || state.promoted
 }
 
-// isDenied reports whether (contextName, gvr) has been permanently denied
-// informer routing for the session -- see denyGVR.
-func (ic *informerCache) isDenied(contextName string, gvr schema.GroupVersionResource) bool {
-	state := ic.getAutoState(contextName, gvr)
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	return state.denied
+// isDenied separates denyGVR's permanent verdict from noteWatchFailure's
+// expiring one, which cacheBlocked folds together.
+func (s *gvrAutoState) isDenied() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.denied
 }
 
 // markHot marks (contextName, gvr) hot and starts its informer if needed.
@@ -304,7 +317,7 @@ func (ic *informerCache) isDenied(contextName string, gvr schema.GroupVersionRes
 func (ic *informerCache) markHot(contextName string, gvr schema.GroupVersionResource) bool {
 	state := ic.getAutoState(contextName, gvr)
 	state.mu.Lock()
-	if state.denied {
+	if state.denied || state.blockedLocked() {
 		state.mu.Unlock()
 		return false
 	}
@@ -611,7 +624,9 @@ func (ic *informerCache) getOrStart(contextName string, gvr schema.GroupVersionR
 	_ = informer.SetWatchErrorHandlerWithContext(func(_ context.Context, _ *cache.Reflector, err error) {
 		if apierrors.IsForbidden(err) || apierrors.IsMethodNotSupported(err) || apierrors.IsNotFound(err) {
 			ic.denyGVR(contextName, gvr)
+			return
 		}
+		ic.noteWatchFailure(contextName, gvr, err)
 	})
 	// managedFields is never read by buildResourceItem. Drop it before
 	// objects enter the store to keep the cache's footprint down.
@@ -649,6 +664,7 @@ func (ic *informerCache) getOrStart(contextName string, gvr schema.GroupVersionR
 		// list() caller still inside waitForSync will pick up the stopCh
 		// signal instead.
 		if cache.WaitForCacheSync(stopCh, inf.HasSynced) {
+			ic.noteWatchSuccess(contextName, gvr)
 			close(synced)
 		}
 	}(informer, entry.stopCh, entry.synced)

--- a/internal/k8s/informer_cache.go
+++ b/internal/k8s/informer_cache.go
@@ -99,11 +99,11 @@ type gvrAutoState struct {
 	// MethodNotSupported, or NotFound -- RBAC or API surface that will
 	// not change mid-session. Permanent for the life of the Client.
 	denied bool
-	// watchFailures counts consecutive non-status watch errors, cleared by
-	// a successful sync. cooldownUntil blocks the cache once the count
-	// trips maxWatchFailures. See noteWatchFailure.
-	watchFailures int
-	cooldownUntil time.Time
+	// watchFailures counts consecutive non-status watch errors. A sync or a
+	// gap wider than watchFailureWindow clears it. See noteWatchFailure.
+	watchFailures    int
+	lastWatchFailure time.Time
+	cooldownUntil    time.Time
 }
 
 // itemMemoEntry caches one converted model.Item alongside the
@@ -187,6 +187,7 @@ type informerCache struct {
 	// reflector retries nor the production cooldown.
 	maxWatchFailures     int
 	watchFailureCooldown time.Duration
+	watchFailureWindow   time.Duration
 
 	// sweepInterval rate-limits sweepStaleHot off the watch-tick path.
 	// lastSweep is guarded by ic.mu. Tests set sweepInterval to zero to
@@ -221,6 +222,7 @@ func newInformerCache(clientFactory func(string) (dynamic.Interface, error)) *in
 
 		maxWatchFailures:     defaultMaxWatchFailures,
 		watchFailureCooldown: defaultWatchFailureCooldown,
+		watchFailureWindow:   defaultWatchFailureWindow,
 	}
 }
 

--- a/internal/k8s/informer_cache_preferhot_test.go
+++ b/internal/k8s/informer_cache_preferhot_test.go
@@ -112,13 +112,13 @@ func TestInformerCache_WatchForbiddenFallsBackPermanentlyAndLogsOnce(t *testing.
 	for time.Now().Before(deadline) {
 		items, err = c.GetResources(t.Context(), "", "team-a", podRT)
 		require.NoError(t, err)
-		if c.informers.isDenied("", gvr) {
+		if c.informers.getAutoState("", gvr).isDenied() {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	require.True(t, c.informers.isDenied("", gvr), "watch forbidden must permanently deny the GVR")
+	require.True(t, c.informers.getAutoState("", gvr).isDenied(), "watch forbidden must permanently deny the GVR")
 	require.False(t, c.informers.isPromoted("", gvr))
 	require.Len(t, items, 1, "denied GVR must still return items via direct list")
 	assert.Equal(t, "api-1", items[0].Name)

--- a/internal/k8s/informer_cache_sweep_test.go
+++ b/internal/k8s/informer_cache_sweep_test.go
@@ -68,5 +68,5 @@ func TestSweepStaleHot_PrunesColdAutoState(t *testing.T) {
 
 	assert.Len(t, ic.auto[""], 2, "cold auto-state entries must not survive a sweep")
 	assert.True(t, ic.isPromoted("", promoted))
-	assert.True(t, ic.isDenied("", denied))
+	assert.True(t, ic.getAutoState("", denied).isDenied())
 }

--- a/internal/k8s/informer_cache_test.go
+++ b/internal/k8s/informer_cache_test.go
@@ -325,6 +325,13 @@ func withTunedThresholds(c *Client, promoteAt, demoteBelow, demoteAfterN int) {
 	c.informers.demoteAfterN = demoteAfterN
 }
 
+// withWatchFailureTuning dials the watch give-up down so a test need not
+// wait out three reflector retries or a 10-minute cooldown.
+func withWatchFailureTuning(c *Client, maxFailures int, cooldown time.Duration) {
+	c.informers.maxWatchFailures = maxFailures
+	c.informers.watchFailureCooldown = cooldown
+}
+
 // TestGetResources_InformerCache_AutoPromote drives the auto-promote arc
 // of the state machine: a direct list returning ≥ promoteAt items must
 // flip the (context, GVR) into informer mode, so the next call goes to

--- a/internal/k8s/informer_cache_watchfail_test.go
+++ b/internal/k8s/informer_cache_watchfail_test.go
@@ -102,6 +102,31 @@ func TestInformerCache_WatchSuccessResetsFailureCount(t *testing.T) {
 	assert.True(t, c.informers.cacheBlocked("", gvr))
 }
 
+// client-go retries ListAndWatch itself and calls nothing back when a retry
+// works, so noteWatchSuccess never sees a recovery after the initial sync.
+// Age is the only signal left that the watch ran fine in between.
+func TestInformerCache_WatchFailuresExpireBetweenOutages(t *testing.T) {
+	c := NewTestClient(nil, newFakeDynClient(pod("api-1", "team-a")))
+	c.SetInformerCacheMode(InformerCacheAuto)
+	t.Cleanup(c.Shutdown)
+	withWatchFailureTuning(c, 3, time.Hour)
+	c.informers.watchFailureWindow = 20 * time.Millisecond
+	gvr := podGVR()
+
+	c.informers.noteWatchFailure("", gvr, errReset)
+	c.informers.noteWatchFailure("", gvr, errReset)
+	time.Sleep(40 * time.Millisecond)
+
+	c.informers.noteWatchFailure("", gvr, errReset)
+	assert.False(t, c.informers.cacheBlocked("", gvr),
+		"a failure after the window starts a new run instead of finishing the old one")
+
+	c.informers.noteWatchFailure("", gvr, errReset)
+	c.informers.noteWatchFailure("", gvr, errReset)
+	assert.True(t, c.informers.cacheBlocked("", gvr),
+		"three failures inside the window must still trip the give-up")
+}
+
 // TestInformerCache_WatchFailureLogsOnce keeps the reflector's retry storm
 // out of the user's log. The give-up is worth one line, not one per retry.
 func TestInformerCache_WatchFailureLogsOnce(t *testing.T) {

--- a/internal/k8s/informer_cache_watchfail_test.go
+++ b/internal/k8s/informer_cache_watchfail_test.go
@@ -1,0 +1,133 @@
+package k8s
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/watch"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// A transport error, not an API status error, so denyGVR's status checks
+// never match it (issue #694).
+var errReset = errors.New("read tcp 10.0.0.1:52000->10.0.0.2:443: read: connection reset by peer")
+
+// Issue #694: every request to one apiserver shares a single HTTP/2
+// connection, so a watch retried forever takes the plain lists down with it.
+func TestInformerCache_WatchNetworkErrorsDemote(t *testing.T) {
+	logger.ResetDedupForTest()
+	drainUIChan()
+
+	dc := newFakeDynClient(pod("api-1", "team-a"))
+	dc.PrependWatchReactor("pods", func(clienttesting.Action) (bool, watch.Interface, error) {
+		return true, nil, errReset
+	})
+	c := NewTestClient(nil, dc)
+	c.SetInformerCacheMode(InformerCacheAlways)
+	t.Cleanup(c.Shutdown)
+	// One failure, because the reflector backs off to roughly 0.22 QPS and
+	// three real retries would park the suite for ~15s. The threshold
+	// itself is covered by TestInformerCache_WatchSuccessResetsFailureCount.
+	withWatchFailureTuning(c, 1, time.Hour)
+	gvr := podGVR()
+
+	deadline := time.Now().Add(10 * time.Second)
+	var items []model.Item
+	var err error
+	for time.Now().Before(deadline) {
+		items, err = c.GetResources(t.Context(), "", "team-a", podRT)
+		require.NoError(t, err)
+		if c.informers.cacheBlocked("", gvr) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	require.True(t, c.informers.cacheBlocked("", gvr),
+		"a watch failing repeatedly on the network must stop being retried")
+	assert.False(t, c.informers.isPromoted("", gvr))
+	assert.False(t, c.informers.getAutoState("", gvr).isDenied(),
+		"a network error is transient, so it must not deny the GVR for the whole session")
+	assert.False(t, c.informers.hasEntry("", gvr), "the informer must be torn down")
+
+	require.Len(t, items, 1, "the direct list must keep working while the watch is down")
+	assert.Equal(t, "api-1", items[0].Name)
+}
+
+// TestInformerCache_WatchFailureCooldownExpires covers the other half: the
+// block is a cooldown, not a life sentence. Once it lapses the GVR may open
+// a watch again, so a network blip does not cost the cache for the session.
+func TestInformerCache_WatchFailureCooldownExpires(t *testing.T) {
+	c := NewTestClient(nil, newFakeDynClient(pod("api-1", "team-a")))
+	c.SetInformerCacheMode(InformerCacheAuto)
+	t.Cleanup(c.Shutdown)
+	withWatchFailureTuning(c, 1, 20*time.Millisecond)
+	gvr := podGVR()
+
+	c.informers.noteWatchFailure("", gvr, errReset)
+	require.True(t, c.informers.cacheBlocked("", gvr))
+
+	time.Sleep(40 * time.Millisecond)
+	assert.False(t, c.informers.cacheBlocked("", gvr), "the cooldown must lapse")
+}
+
+// TestInformerCache_WatchSuccessResetsFailureCount guards the "consecutive"
+// in the threshold. A watch that recovers between failures must not
+// accumulate them across the recovery, or a long session on a slightly
+// lossy link would eventually demote every GVR.
+func TestInformerCache_WatchSuccessResetsFailureCount(t *testing.T) {
+	c := NewTestClient(nil, newFakeDynClient(pod("api-1", "team-a")))
+	c.SetInformerCacheMode(InformerCacheAuto)
+	t.Cleanup(c.Shutdown)
+	withWatchFailureTuning(c, 3, time.Hour)
+	gvr := podGVR()
+
+	c.informers.noteWatchFailure("", gvr, errReset)
+	c.informers.noteWatchFailure("", gvr, errReset)
+	c.informers.noteWatchSuccess("", gvr)
+	c.informers.noteWatchFailure("", gvr, errReset)
+	c.informers.noteWatchFailure("", gvr, errReset)
+
+	assert.False(t, c.informers.cacheBlocked("", gvr),
+		"two failures after a recovery must not trip a threshold of three")
+
+	c.informers.noteWatchFailure("", gvr, errReset)
+	assert.True(t, c.informers.cacheBlocked("", gvr))
+}
+
+// TestInformerCache_WatchFailureLogsOnce keeps the reflector's retry storm
+// out of the user's log. The give-up is worth one line, not one per retry.
+func TestInformerCache_WatchFailureLogsOnce(t *testing.T) {
+	logger.ResetDedupForTest()
+	drainUIChan()
+
+	c := NewTestClient(nil, newFakeDynClient(pod("api-1", "team-a")))
+	c.SetInformerCacheMode(InformerCacheAuto)
+	t.Cleanup(c.Shutdown)
+	withWatchFailureTuning(c, 1, time.Hour)
+	gvr := podGVR()
+
+	for range 5 {
+		c.informers.noteWatchFailure("", gvr, errReset)
+	}
+
+	warnings := 0
+	for {
+		select {
+		case e := <-logger.UIChan():
+			if e.Level == "WRN" {
+				warnings++
+			}
+		case <-time.After(200 * time.Millisecond):
+			assert.Equal(t, 1, warnings, "the give-up should surface exactly one warning")
+			return
+		}
+	}
+}

--- a/internal/k8s/informer_watchfail.go
+++ b/internal/k8s/informer_watchfail.go
@@ -1,0 +1,84 @@
+// Package k8s — informer_watchfail.go
+// Give-up policy for informer watches that keep dying on the network, as
+// opposed to denyGVR's permanent verdict on an RBAC or API-surface refusal.
+package k8s
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// Lists and watches to one apiserver share a single HTTP/2 connection, so a
+// proxy that resets the watch resets the lists beside it, and the reflector
+// retries forever (issue #694). Three clears a leader election, not a bad path.
+const (
+	defaultMaxWatchFailures     = 3
+	defaultWatchFailureCooldown = 10 * time.Minute
+)
+
+// blockedLocked reports whether a watch give-up still holds. Caller holds
+// state.mu.
+func (s *gvrAutoState) blockedLocked() bool {
+	return !s.cooldownUntil.IsZero() && time.Now().Before(s.cooldownUntil)
+}
+
+// cacheBlocked reports whether the router must send (contextName, gvr)
+// straight to a direct list. Covers both give-up kinds: denyGVR's permanent
+// RBAC verdict and noteWatchFailure's expiring network cooldown.
+func (ic *informerCache) cacheBlocked(contextName string, gvr schema.GroupVersionResource) bool {
+	state := ic.getAutoState(contextName, gvr)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.denied || state.blockedLocked()
+}
+
+// noteWatchSuccess clears the failure run once a watch syncs, so only
+// consecutive failures count toward the give-up.
+func (ic *informerCache) noteWatchSuccess(contextName string, gvr schema.GroupVersionResource) {
+	state := ic.getAutoState(contextName, gvr)
+	state.mu.Lock()
+	state.watchFailures = 0
+	state.mu.Unlock()
+}
+
+// noteWatchFailure records a watch error no status check explains. Stopping
+// the informer matters more than blocking the cache: while it lives, the
+// reflector retries and re-breaks the shared connection.
+func (ic *informerCache) noteWatchFailure(contextName string, gvr schema.GroupVersionResource, err error) {
+	state := ic.getAutoState(contextName, gvr)
+	state.mu.Lock()
+	if state.denied || state.blockedLocked() {
+		state.mu.Unlock()
+		return
+	}
+	state.watchFailures++
+	trip := state.watchFailures >= ic.maxWatchFailures
+	if trip {
+		state.watchFailures = 0
+		state.hot = false
+		state.promoted = false
+		state.cooldownUntil = time.Now().Add(ic.watchFailureCooldown)
+	}
+	state.mu.Unlock()
+
+	if !trip {
+		return
+	}
+	ic.stopOne(contextName, gvr)
+
+	logger.WarnOnce("informer-watch-unreachable", contextName+"/"+gvr.String(),
+		"Watch kept failing; falling back to direct lists for this resource",
+		"context", contextName, "gvr", gvr.String(),
+		"cooldown", ic.watchFailureCooldown.String(), "error", err)
+}
+
+// hasEntry reports whether a live informer exists for (contextName, gvr).
+func (ic *informerCache) hasEntry(contextName string, gvr schema.GroupVersionResource) bool {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+	_, ok := ic.entries[contextName][gvr]
+	return ok
+}

--- a/internal/k8s/informer_watchfail.go
+++ b/internal/k8s/informer_watchfail.go
@@ -17,6 +17,10 @@ import (
 const (
 	defaultMaxWatchFailures     = 3
 	defaultWatchFailureCooldown = 10 * time.Minute
+	// The reflector backs off to at most 30s between retries, so failures
+	// from one broken connection land inside two minutes. A wider gap means
+	// the watch ran in between, which is a recovery client-go never reports.
+	defaultWatchFailureWindow = 2 * time.Minute
 )
 
 // blockedLocked reports whether a watch give-up still holds. Caller holds
@@ -41,6 +45,7 @@ func (ic *informerCache) noteWatchSuccess(contextName string, gvr schema.GroupVe
 	state := ic.getAutoState(contextName, gvr)
 	state.mu.Lock()
 	state.watchFailures = 0
+	state.lastWatchFailure = time.Time{}
 	state.mu.Unlock()
 }
 
@@ -48,19 +53,27 @@ func (ic *informerCache) noteWatchSuccess(contextName string, gvr schema.GroupVe
 // the informer matters more than blocking the cache: while it lives, the
 // reflector retries and re-breaks the shared connection.
 func (ic *informerCache) noteWatchFailure(contextName string, gvr schema.GroupVersionResource, err error) {
+	now := time.Now()
 	state := ic.getAutoState(contextName, gvr)
 	state.mu.Lock()
 	if state.denied || state.blockedLocked() {
 		state.mu.Unlock()
 		return
 	}
+	// noteWatchSuccess only fires at the initial sync, so a stale previous
+	// failure is the sole evidence that the watch recovered in between.
+	if !state.lastWatchFailure.IsZero() && now.Sub(state.lastWatchFailure) > ic.watchFailureWindow {
+		state.watchFailures = 0
+	}
+	state.lastWatchFailure = now
 	state.watchFailures++
 	trip := state.watchFailures >= ic.maxWatchFailures
 	if trip {
 		state.watchFailures = 0
+		state.lastWatchFailure = time.Time{}
 		state.hot = false
 		state.promoted = false
-		state.cooldownUntil = time.Now().Add(ic.watchFailureCooldown)
+		state.cooldownUntil = now.Add(ic.watchFailureCooldown)
 	}
 	state.mu.Unlock()
 

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -293,6 +293,7 @@ func applyDataAccessConfig(cfg configFile) {
 	if cfg.SecretLazyLoading != nil {
 		ConfigSecretLazyLoading = *cfg.SecretLazyLoading
 	}
+	applyDisableHTTP2(cfg)
 	if cfg.Kubeshark != nil {
 		// Trim before checking emptiness so a YAML value like `namespace: " "`
 		// doesn't silently overwrite the default with whitespace — the K8s

--- a/internal/ui/config_http2.go
+++ b/internal/ui/config_http2.go
@@ -1,0 +1,15 @@
+// Package ui — config_http2.go
+// The disable_http2 setting and its apply hook.
+package ui
+
+// ConfigDisableHTTP2 escapes a proxy that cannot carry a watch: on HTTP/2
+// every list and watch shares one connection, so resetting the watch takes
+// the lists with it (#694). main.go relays it as the DISABLE_HTTP2 env var.
+var ConfigDisableHTTP2 bool
+
+// applyDisableHTTP2 wires the config field into its runtime global.
+func applyDisableHTTP2(cfg configFile) {
+	if cfg.DisableHTTP2 != nil {
+		ConfigDisableHTTP2 = *cfg.DisableHTTP2
+	}
+}

--- a/internal/ui/config_load.go
+++ b/internal/ui/config_load.go
@@ -205,6 +205,10 @@ type configFile struct {
 	// the trade-off is a per-hover GET and a brief blank-data frame until the
 	// fetch resolves.
 	SecretLazyLoading *bool `json:"secret_lazy_loading" yaml:"secret_lazy_loading"`
+	// DisableHTTP2 drops API-server connections to HTTP/1.1. On HTTP/2 one
+	// connection carries every list and watch, so a proxy that resets a
+	// long-lived watch resets the lists beside it (issue #694).
+	DisableHTTP2 *bool `json:"disable_http2" yaml:"disable_http2"`
 	// InformerCache controls how lists are routed: "off" round-trips every
 	// time (matches kubectl), "auto" (default) starts in direct mode per
 	// (context, GVR) and promotes to a shared informer once a list crosses

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -80,6 +80,7 @@ metrics_sparkline_width: 8
 metrics_sparkline_interval: 45s
 no_color: true
 secret_lazy_loading: true
+disable_http2: true
 informer_cache: always
 min_contrast_ratio: 0.5
 read_only: true
@@ -260,6 +261,7 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	assert.Equal(t, 45*time.Second, ConfigSparklineInterval, "metrics_sparkline_interval")
 	assert.True(t, ConfigNoColor, "no_color")
 	assert.True(t, ConfigSecretLazyLoading, "secret_lazy_loading")
+	assert.True(t, ConfigDisableHTTP2, "disable_http2")
 	assert.Equal(t, InformerCacheAlways, ConfigInformerCacheMode, "informer_cache")
 	assert.InDelta(t, 0.5, ConfigMinContrastRatio, 1e-9, "min_contrast_ratio")
 	assert.True(t, ConfigReadOnly, "read_only")
@@ -463,6 +465,7 @@ var wiringCoveredFields = map[string]string{
 	"clusters":                   "TestLoadConfig_AllSettingsWired",
 	"no_color":                   "TestLoadConfig_AllSettingsWired",
 	"secret_lazy_loading":        "TestLoadConfig_AllSettingsWired",
+	"disable_http2":              "TestLoadConfig_AllSettingsWired",
 	"informer_cache":             "TestLoadConfig_AllSettingsWired",
 	"min_contrast_ratio":         "TestLoadConfig_AllSettingsWired",
 	"read_only":                  "TestLoadConfig_AllSettingsWired",
@@ -577,6 +580,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 	origKubeconfig := ConfigKubeconfigDirs
 	origKubeconfigExclusive := ConfigKubeconfigExclusive
 	origSecretLazy := ConfigSecretLazyLoading
+	origDisableHTTP2 := ConfigDisableHTTP2
 	origKubeshark := ConfigKubesharkNamespace
 	origInformer := ConfigInformerCacheMode
 	origContrast := ConfigMinContrastRatio
@@ -678,6 +682,7 @@ func snapshotAllConfigGlobals(t *testing.T) func() {
 		ConfigKubeconfigDirs = origKubeconfig
 		ConfigKubeconfigExclusive = origKubeconfigExclusive
 		ConfigSecretLazyLoading = origSecretLazy
+		ConfigDisableHTTP2 = origDisableHTTP2
 		ConfigKubesharkNamespace = origKubeshark
 		ConfigInformerCacheMode = origInformer
 		ConfigMinContrastRatio = origContrast

--- a/main.go
+++ b/main.go
@@ -126,6 +126,21 @@ func newDemoKubectlCommand() *cobra.Command {
 // --context validation entirely — the demo cluster has no kubeconfig to
 // read and a fixed set of contexts. This is the only place startup diverts
 // on opts.Demo. Otherwise it runs the real kubeconfig discovery path.
+// applyHTTP2Preference relays disable_http2 to the env var apimachinery reads
+// in SetTransportDefaults. Must run before resolveStartupClient builds the
+// first REST client. An env value already set wins, to keep the per-run override.
+func applyHTTP2Preference() {
+	if !ui.ConfigDisableHTTP2 {
+		return
+	}
+	if os.Getenv("DISABLE_HTTP2") != "" {
+		return
+	}
+	if err := os.Setenv("DISABLE_HTTP2", "1"); err != nil {
+		logger.Warn("Could not disable HTTP/2", "error", err)
+	}
+}
+
 func resolveStartupClient(opts app.StartupOptions) (*k8s.Client, error) {
 	if opts.Demo {
 		// Redirect every kubectl call site (internal/k8s.KubectlPath) at this
@@ -180,6 +195,7 @@ func runTUI(opts app.StartupOptions) error {
 	ui.LoadConfig(opts.Config)
 	// Viewer toggles the user pressed last session outrank the config file.
 	app.ApplyViewerPrefs()
+	applyHTTP2Preference()
 
 	if opts.Kubeconfig != "" {
 		if _, err := os.Stat(opts.Kubeconfig); err != nil {

--- a/main_http2_test.go
+++ b/main_http2_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+func TestApplyHTTP2Preference(t *testing.T) {
+	tests := []struct {
+		name     string
+		disable  bool
+		env      string
+		expected string
+	}{
+		{name: "off by default", disable: false, env: "", expected: ""},
+		{name: "config sets the env var", disable: true, env: "", expected: "1"},
+		{name: "an env value already set wins", disable: true, env: "0", expected: "0"},
+		{name: "config false leaves the env alone", disable: false, env: "1", expected: "1"},
+	}
+
+	orig := ui.ConfigDisableHTTP2
+	t.Cleanup(func() { ui.ConfigDisableHTTP2 = orig })
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DISABLE_HTTP2", tc.env)
+			if tc.env == "" {
+				// t.Setenv cannot unset, and apimachinery keys off emptiness.
+				assert.NoError(t, os.Unsetenv("DISABLE_HTTP2"))
+			}
+			ui.ConfigDisableHTTP2 = tc.disable
+
+			applyHTTP2Preference()
+
+			assert.Equal(t, tc.expected, os.Getenv("DISABLE_HTTP2"))
+		})
+	}
+}


### PR DESCRIPTION
Two fixes for #694, where every list failed with "connection reset by peer" from the moment lfk started, but only on the reporter's corporate VPN.

## Why it broke

Lists and watches to one apiserver share a single HTTP/2 connection. 0.18.0 started holding watch streams open on every cluster, and a watch is one HTTP response that never ends. A TLS-inspecting proxy resets it, which takes the plain lists riding beside it down too.

The informer's watch error handler only gave up on `Forbidden`, `MethodNotSupported` and `NotFound`. A transport error matches none of those, so the reflector retried the watch for the rest of the session and each retry re-broke the connection. That is what turned a bad minute into an unusable session.

## What changed

**Give up on a watch that keeps failing on the network.** Three consecutive non-status failures tear the informer down and route that resource type to direct lists for ten minutes. A successful sync clears the run, so only consecutive failures count. Tearing the informer down is the part that matters: while it lives, the reflector keeps retrying.

**New `disable_http2` config key.** HTTP/1.1 gives each request its own connection, which costs more sockets but survives a proxy that cannot hold a watch open. apimachinery already reads `DISABLE_HTTP2` when it builds a transport, so the key relays it after the config loads and before the first REST client is built. An env value already set still wins.

**Docs correction.** The field table and the trade-off table both claimed `auto` promotes a resource type only above 1000 items, and that small clusters never promote. Watch-tick refreshes have promoted regardless of size since #659. The prose section below them already said so.

## What this does not change

The reporter's VPN still resets the watch. lfk now survives it instead of dying, and `disable_http2` sidesteps it. Whether the Go 1.27 HTTP/2 client is also involved is still open on #694 — 0.18.0 moved to Go 1.27, which replaced the bundled `x/net/http2` with an in-tree implementation, so 0.17.5 and 0.18.0 talk to the apiserver through different stacks. A `-tags http2legacy` build is with the reporter to settle that half.

## Test plan

- [x] `TestInformerCache_WatchNetworkErrorsDemote` is mutation-proven: unwiring `noteWatchFailure` makes it fail in 10.8s, wired it passes in 1.8s
- [x] Cooldown lapse, consecutive-failure reset, and log-once each covered
- [x] `TestApplyHTTP2Preference` covers all four config/env combinations
- [x] `TestLoadConfig_AllSettingsWired` covers `disable_http2`, recorded in `wiringCoveredFields`
- [x] The escape hatch checked against a live TLS server on Go 1.27: apimachinery logs "HTTP2 has been explicitly disabled" and the client sends `GET / HTTP/1.1`
- [x] Build clean, 26 packages pass with `-race`, `golangci-lint` reports 0 issues

Closes nothing yet — leaving #694 open until the reporter confirms.
