### PR TITLE
test: assert what the state lock promises about concurrent writers

### DIFF
--- a/internal/app/state_lock_test.go
+++ b/internal/app/state_lock_test.go
@@ -50,20 +50,40 @@ func TestWithStateFileLock_GivesUpWhenHeld(t *testing.T) {
 	}
 }
 
-// TestPersistViewerPref_ConcurrentTogglesAllSurvive is the case the lock exists
-// for. Each writer opens the lock file separately, the way two lfk processes
-// would. Without the lock the last writer wins and the others' toggles vanish.
-func TestPersistViewerPref_ConcurrentTogglesAllSurvive(t *testing.T) {
+// TestPersistViewerPref_ConcurrentWritersKeepEachOthersToggles is the case the
+// lock exists for. Each writer opens the lock file separately, the way two lfk
+// processes would. Without the lock the last writer wins and the others'
+// toggles vanish.
+//
+// The assertion covers the writers that got the lock, not all of them. Each
+// write loads, merges and fsyncs, so on a slow machine a writer can wait out
+// stateLockBudget and skip, which withStateFileLock documents as the right
+// move: better to drop this write than clobber the other process.
+func TestPersistViewerPref_ConcurrentWritersKeepEachOthersToggles(t *testing.T) {
 	isolateViewerPrefs(t)
 
+	wrote := make([]bool, numViewerPrefs)
 	var wg sync.WaitGroup
 	for i := range int(numViewerPrefs) {
-		wg.Go(func() { persistViewerPref(viewerPref(i), true) })
+		wg.Go(func() { wrote[i] = persistViewerPref(viewerPref(i), true) })
 	}
 	wg.Wait()
 
+	got := 0
+	for _, ok := range wrote {
+		if ok {
+			got++
+		}
+	}
+	if got < 2 {
+		t.Fatalf("%d of %d writers got the lock, too few to prove a merge", got, numViewerPrefs)
+	}
+
 	s := loadViewerPrefsState()
 	for i, b := range viewerPrefBindings {
+		if !wrote[i] {
+			continue // this writer waited out the budget and skipped
+		}
 		v := *b.field(&s)
 		if v == nil {
 			t.Errorf("pref %d was dropped: a concurrent writer overwrote it", i)

--- a/internal/app/viewer_prefs.go
+++ b/internal/app/viewer_prefs.go
@@ -193,7 +193,7 @@ func saveViewerPrefs(s ViewerPrefsState) {
 // drift apart.
 func (m *Model) setViewerPref(p viewerPref, v bool) {
 	m.viewerPrefs[p] = v
-	persistViewerPref(p, v)
+	_ = persistViewerPref(p, v)
 }
 
 // persistViewerPref records one runtime toggle so the next start reopens the
@@ -205,12 +205,14 @@ func (m *Model) setViewerPref(p viewerPref, v bool) {
 // The load and the save sit inside one interprocess lock. Two lfk instances
 // share a state directory, so an unlocked merge lets the later writer drop a
 // toggle the other instance recorded between its read and its write.
-func persistViewerPref(p viewerPref, v bool) {
+// It reports whether the toggle reached disk. A write that waits out the lock
+// budget is skipped, so the answer is not always yes.
+func persistViewerPref(p viewerPref, v bool) bool {
 	path := viewerPrefsFilePath()
 	if path == "" {
-		return
+		return false
 	}
-	withStateFileLock(path, func() {
+	return withStateFileLock(path, func() {
 		s := loadViewerPrefsState()
 		*viewerPrefBindings[p].field(&s) = &v
 		saveViewerPrefs(s)


### PR DESCRIPTION
Unblocks the 0.18.4 release PR (#703), whose `build-and-test` job fails on this test.

## The failure

`TestPersistViewerPref_ConcurrentTogglesAllSurvive` started one goroutine per
viewer pref, thirteen of them, each doing a load and an fsynced save inside the
same interprocess lock. `withStateFileLock` waits 250 ms and then skips the
write, which it documents as the right move:

> on a timeout the caller skips the write rather than clobbering the other process

On a slow runner the tail writers hit that timeout, so the test failed. It
dropped one pref on #702 and six on #703. The assertion was stronger than the
lock promises, so a re-run was never a fix.

## The change

`persistViewerPref` reports whether the toggle reached disk. The test asserts
the merge for the writers that got the lock, and refuses to pass when fewer
than two got in.

Not touched: the 250 ms budget. It is sized for the Bubble Tea Update
goroutine, where a longer wait stalls the frame.

## Test plan

- [x] 40 runs under 16 busy-loops saturating the CPU: green
- [x] Mutation, drop the lock: test fails, so it still guards the merge it exists for
- [x] Mutation, report every write as successful: test fails under load, so the tolerance is not a rubber stamp
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` — 26 packages pass
- [x] `golangci-lint run ./...` — 0 issues