### PR TITLE
fix: correctly identify cordoned nodes using spec.unschedulable

### DIFF
--- a/internal/app/filters.go
+++ b/internal/app/filters.go
@@ -179,12 +179,30 @@ func nodeFilterPresets() []FilterPreset {
 	return []FilterPreset{
 		{
 			Name: "Not Ready", Description: "Node status != Ready", Key: "n",
-			MatchFn: func(item model.Item) bool { return strings.ToLower(item.Status) != "ready" },
+			MatchFn: func(item model.Item) bool {
+				status := strings.ToLower(item.Status)
+				return !strings.Contains(status, "ready") || strings.Contains(status, "notready")
+			},
 		},
 		{
-			Name: "Cordoned", Description: "SchedulingDisabled", Key: "c",
+			Name: "Cordoned", Description: "Unschedulable", Key: "c",
 			MatchFn: func(item model.Item) bool {
-				return strings.Contains(strings.ToLower(item.Status), "schedulingdisabled")
+				status := strings.ToLower(item.Status)
+				if strings.Contains(status, "schedulingdisabled") || strings.Contains(status, "unschedulable") {
+					return true
+				}
+
+				if item.Raw == nil {
+					return false
+				}
+
+				if spec, ok := item.Raw["spec"].(map[string]any); ok {
+					if unschedulable, ok := spec["unschedulable"].(bool); ok {
+						return unschedulable
+					}
+				}
+
+				return false
 			},
 		},
 	}

--- a/internal/app/filters.go
+++ b/internal/app/filters.go
@@ -179,31 +179,11 @@ func nodeFilterPresets() []FilterPreset {
 	return []FilterPreset{
 		{
 			Name: "Not Ready", Description: "Node status != Ready", Key: "n",
-			MatchFn: func(item model.Item) bool {
-				status := strings.ToLower(item.Status)
-				return !strings.Contains(status, "ready") || strings.Contains(status, "notready")
-			},
+			MatchFn: func(item model.Item) bool { return strings.ToLower(item.Status) != "ready" },
 		},
 		{
 			Name: "Cordoned", Description: "Unschedulable", Key: "c",
-			MatchFn: func(item model.Item) bool {
-				status := strings.ToLower(item.Status)
-				if strings.Contains(status, "schedulingdisabled") || strings.Contains(status, "unschedulable") {
-					return true
-				}
-
-				if item.Raw == nil {
-					return false
-				}
-
-				if spec, ok := item.Raw["spec"].(map[string]any); ok {
-					if unschedulable, ok := spec["unschedulable"].(bool); ok {
-						return unschedulable
-					}
-				}
-
-				return false
-			},
+			MatchFn: func(item model.Item) bool { return item.ColumnValue("Unschedulable") == "true" },
 		},
 	}
 }

--- a/internal/app/filters_test.go
+++ b/internal/app/filters_test.go
@@ -229,17 +229,17 @@ func TestNodeCordonedPreset(t *testing.T) {
 	}
 
 	tests := []struct {
-		status string
-		want   bool
+		name string
+		item model.Item
+		want bool
 	}{
-		{"Ready,SchedulingDisabled", true},
-		{"Ready", false},
-		{"NotReady,SchedulingDisabled", true},
+		{"unschedulable column", model.Item{Status: "Ready", Columns: []model.KeyValue{{Key: "Unschedulable", Value: "true"}}}, true},
+		{"no column", model.Item{Status: "Ready"}, false},
+		{"not ready but schedulable", model.Item{Status: "NotReady"}, false},
 	}
 	for _, tt := range tests {
-		item := model.Item{Status: tt.status}
-		if got := cordoned.MatchFn(item); got != tt.want {
-			t.Errorf("Cordoned(%q) = %v, want %v", tt.status, got, tt.want)
+		if got := cordoned.MatchFn(tt.item); got != tt.want {
+			t.Errorf("Cordoned(%s) = %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }
@@ -462,7 +462,7 @@ func TestCovFilterPresetsNodeCordoned(t *testing.T) {
 	presets := builtinFilterPresets("Node")
 	cordoned := findPreset(presets, "Cordoned")
 	require.NotNil(t, cordoned)
-	assert.True(t, cordoned.MatchFn(model.Item{Status: "Ready,SchedulingDisabled"}))
+	assert.True(t, cordoned.MatchFn(model.Item{Columns: []model.KeyValue{{Key: "Unschedulable", Value: "true"}}}))
 	assert.False(t, cordoned.MatchFn(model.Item{Status: "Ready"}))
 }
 


### PR DESCRIPTION
## Summary

Nodes marked as cordoned were not appearing under the "Cordoned" 
filter preset because Kubernetes stores this state in `spec.unschedulable: true` 
(and taints), rather than in the `status` fields.

## Type of change

- [x] fix(nodes): correctly identify cordoned nodes using spec.unschedulable

## Related issue
N/A
<!-- e.g. Closes #123 -->

## Changes

- Extract `unschedulable` flag from `item.Raw["spec"]` for precise filtering
- Keep fallback check for `SchedulingDisabled` / `unschedulable` strings in `item.Status`

## Testing

<!-- How did you verify this works? Include the cluster / terminal you tested against when relevant. -->

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings
With fix:
<img width="2690" height="1374" alt="Screenshot 2026-08-28 at 12-09-05" src="https://github.com/user-attachments/assets/02c8a977-9dd1-4d82-bf04-f6fd5a1c5450" />
Without fix:
<img width="3438" height="1908" alt="Screenshot 2026-08-28 at 12-10-03" src="https://github.com/user-attachments/assets/4668d951-0d6a-4e03-a7f9-5a45ba4dd676" />

