### PR TITLE
docs: explain how to get a stable right-sizing recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 - Multi-select with `Space`, range with `Ctrl+Space`, then bulk delete, scale, or restart: [keybindings.md](docs/keybindings.md#multi-selection)
 - Custom shell actions per resource type: [config-reference.md](docs/config-reference.md#custom-actions)
 - Port forwarding, with active forwards listed under the Networking group: [keybindings.md](docs/keybindings.md#action-menu-items)
-- Right-sizing Advisor with `x` -> `z`: [keybindings.md](docs/keybindings.md#right-sizing-advisor)
+- Right-sizing Advisor with `x` -> `z`: [features.md](docs/features.md#right-sizing-advisor), keys in [keybindings.md](docs/keybindings.md#right-sizing-advisor)
 - Network policy visualizer with `x` -> `N`, Cilium aware: [keybindings.md](docs/keybindings.md#network-policy-visualizer)
 - Traffic capture with `c` on a Pod or Service: [usage.md](docs/usage.md#traffic-capture)
 
@@ -495,7 +495,7 @@ All of them accept pasted text (`Cmd+V` on macOS, `Ctrl+Shift+V` on Linux). A mu
 - Spin up a throwaway kind, k3d, or minikube cluster with `Ctrl+N` at the cluster list
 - Capture a Pod's network traffic with `c`: live decode plus pcap export
 - Flip the RBAC question: inside the Can-I browser (`U`), `Tab` opens Who-Can, every subject allowed to run a verb on a resource
-- Get per-container CPU and memory recommendations with `x` -> `z` (Right-sizing Advisor, VPA-backed when available)
+- Get per-container CPU and memory recommendations with `x` -> `z` (Right-sizing Advisor, from a VPA or Prometheus when available, see [features.md](docs/features.md#right-sizing-advisor))
 - Watch an ArgoCD Application roll out wave by wave: `x` -> `W` opens the Sync Wave Timeline
 - Try a new look without restarting: `T` live-previews 460+ themes
 - Waiting for a rollout? `:nyan` and `:kubetris` are real commands

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,6 +48,18 @@ Pause and unpause ScaledObjects and ScaledJobs.
 
 Force a refresh of ExternalSecrets, ClusterExternalSecrets, and PushSecrets.
 
+## Right-sizing advisor
+
+`x` -> `z` suggests CPU and memory requests and limits per container. The suggestion is only as good as the strategy behind it, shown in the `Strategy:` chip.
+
+| Strategy | Source | Use it for |
+|---|---|---|
+| `snapshot` | One metrics-server reading over the window shown in the header (usually 10-30s) | A quick look. Two runs minutes apart can disagree by 10x on a bursty container. |
+| `1d-max`, `1d-avg`, `7d-p95` | Prometheus range queries | Sizing decisions. `7d-p95` is the safest default for requests. |
+| `vpa` | VerticalPodAutoscaler recommender | Sizing decisions when a VPA already targets the workload. |
+
+The chip shows `snapshot` with no `[N/M]` counter when it is the only strategy available. To unlock the others, point lfk at Prometheus or VictoriaMetrics (see [config-reference.md](config-reference.md#monitoring)) or create a VPA in `Off` mode for the workload. Then cycle with `[` and `]`. Keys and headroom are in [keybindings.md](keybindings.md#right-sizing-advisor).
+
 ## Embedded terminal
 
 Exec and shell sessions run in an embedded PTY by default. A session keeps running in the background when you switch tabs, so you can leave it and come back. `Ctrl+T` cycles the mode, see [config-reference.md](config-reference.md#terminal-mode).


### PR DESCRIPTION
## Summary
- Add a Right-sizing advisor section to `docs/features.md` that names the strategies and says which ones are fit for sizing decisions
- Explain that `snapshot` is a single metrics-server sample and how to unlock the Prometheus and VPA strategies
- Point the README entries at the new section

Closes #705

## Test plan
- [x] Anchors `config-reference.md#monitoring` and `keybindings.md#right-sizing-advisor` exist
- [x] `go test ./...` doc tests pass