### PR TITLE
fix: list every probed Prometheus target in the proxy error

### DIFF
--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -194,20 +194,32 @@ func (c *Client) runPrometheusProxy(ctx context.Context, contextName, path strin
 		}
 		promSvcCache.Delete(contextName)
 	}
-	var lastErr error
-	for _, t := range promTargets {
+	data, hit, err := probePrometheusTargets(promTargets, doQuery)
+	if err != nil {
+		return nil, err
+	}
+	promSvcCache.Store(contextName, hit)
+	return data, nil
+}
+
+// probePrometheusTargets tries each target in order and returns the first
+// answer. On failure the error lists every target with what it answered:
+// the last guess in the list is always prometheus-operated, so reporting only
+// its error hides why the discovered Service was rejected.
+func probePrometheusTargets(targets []monitoringTarget, doQuery func(monitoringTarget) ([]byte, error)) ([]byte, monitoringTarget, error) {
+	if len(targets) == 0 {
+		return nil, monitoringTarget{}, fmt.Errorf("no prometheus service found")
+	}
+	failures := make([]string, 0, len(targets))
+	for _, t := range targets {
 		data, err := doQuery(t)
-		if err != nil {
-			lastErr = err
-			continue
+		if err == nil {
+			return data, t, nil
 		}
-		promSvcCache.Store(contextName, t)
-		return data, nil
+		failures = append(failures, t.String()+": "+err.Error())
 	}
-	if lastErr != nil {
-		return nil, lastErr
-	}
-	return nil, fmt.Errorf("no prometheus service found")
+	return nil, monitoringTarget{}, fmt.Errorf("no prometheus target answered (tried %d targets): %s",
+		len(targets), strings.Join(failures, "; "))
 }
 
 // parsePrometheusContainerResponse extracts the per-container value

--- a/internal/k8s/monitoring_targets.go
+++ b/internal/k8s/monitoring_targets.go
@@ -26,6 +26,12 @@ type monitoringTarget struct {
 }
 
 // path returns the proxy path for one Prometheus or Alertmanager API path.
+// String renders the target the way the API server proxy path does, so a log
+// line can be pasted into a kubectl get --raw probe.
+func (t monitoringTarget) String() string {
+	return t.Namespace + "/" + t.Service + ":" + t.Port + t.Prefix
+}
+
 func (t monitoringTarget) path(apiPath string) string {
 	return t.Prefix + apiPath
 }
@@ -133,6 +139,8 @@ func cachedMonitoringDiscovery(ctx context.Context, cs kubernetes.Interface, con
 		monitoringDiscoveryCache.Delete(contextName)
 	}
 	prom, am = discoverMonitoringServices(ctx, cs, namespaces)
+	logger.Debug("monitoring service discovery finished",
+		"context", contextName, "prometheus", prom, "alertmanager", am)
 	monitoringDiscoveryCache.Store(contextName, monitoringDiscoveryEntry{prom: prom, am: am, at: time.Now()})
 	return prom, am
 }

--- a/internal/k8s/monitoring_targets.go
+++ b/internal/k8s/monitoring_targets.go
@@ -26,8 +26,9 @@ type monitoringTarget struct {
 }
 
 // path returns the proxy path for one Prometheus or Alertmanager API path.
-// String renders the target the way the API server proxy path does, so a log
-// line can be pasted into a kubectl get --raw probe.
+// String renders the target as namespace/service:port plus any API prefix,
+// the same pieces a user fills into the service proxy path when they probe
+// it with kubectl get --raw.
 func (t monitoringTarget) String() string {
 	return t.Namespace + "/" + t.Service + ":" + t.Port + t.Prefix
 }

--- a/internal/k8s/monitoring_targets_test.go
+++ b/internal/k8s/monitoring_targets_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -544,4 +545,50 @@ func TestDiscoveryPrefersWellKnownNamespaces(t *testing.T) {
 	require.Len(t, prom, 2)
 	assert.Equal(t, "vmsingle-real", prom[0].Service, "the well-known namespace is probed first")
 	assert.Equal(t, "vmsingle-squatter", prom[1].Service)
+}
+
+func TestProbePrometheusTargetsNamesEveryTargetOnFailure(t *testing.T) {
+	targets := []monitoringTarget{
+		{Namespace: "monitoring", Service: "vmselect-vmks", Port: "8481", Prefix: vmSelectTenantPrefix},
+		{Namespace: "monitoring", Service: "prometheus-operated", Port: "9090"},
+	}
+	calls := 0
+	_, _, err := probePrometheusTargets(targets, func(monitoringTarget) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("404 page not found")
+		}
+		return nil, errors.New("the server could not find the requested resource")
+	})
+	require.Error(t, err)
+	assert.Equal(t, 2, calls)
+	// The user reads this line in the log, so it has to name what was
+	// tried and what each answered, not only the last guess.
+	assert.Contains(t, err.Error(), "monitoring/vmselect-vmks:8481/select/0/prometheus: 404 page not found")
+	assert.Contains(t, err.Error(), "monitoring/prometheus-operated:9090: the server could not find the requested resource")
+	assert.Contains(t, err.Error(), "tried 2 targets")
+}
+
+func TestProbePrometheusTargetsReturnsTheFirstHit(t *testing.T) {
+	targets := []monitoringTarget{
+		{Namespace: "monitoring", Service: "a", Port: "9090"},
+		{Namespace: "monitoring", Service: "b", Port: "9090"},
+	}
+	data, hit, err := probePrometheusTargets(targets, func(t monitoringTarget) ([]byte, error) {
+		if t.Service == "b" {
+			return []byte("ok"), nil
+		}
+		return nil, errors.New("nope")
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(data))
+	assert.Equal(t, "b", hit.Service)
+}
+
+func TestProbePrometheusTargetsWithNothingToTry(t *testing.T) {
+	_, _, err := probePrometheusTargets(nil, func(monitoringTarget) ([]byte, error) {
+		t.Fatal("must not be called")
+		return nil, nil
+	})
+	require.ErrorContains(t, err, "no prometheus service found")
 }


### PR DESCRIPTION
- The Prometheus proxy fallback loop returned only the last target's error. The last guess is always `prometheus-operated:9090`, so a user with a discovered VictoriaMetrics or Prometheus Service saw only that in the log (see #699).
- The error now lists every target and its own answer, formatted like the API server proxy path so it pastes into a `kubectl get --raw` probe. Discovery logs what it found at debug level.

Refs #699

## Test plan
- [x] `TestProbePrometheusTargets*` (RED then GREEN)
- [x] `go test ./internal/k8s/ ./internal/app/`, `golangci-lint` clean