### PR TITLE
feat: probe common URL prefixes when reaching Prometheus

### DIFF
--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -287,10 +287,9 @@ monitoring:
 #     services: ["vmselect-vmks"]
 #     port: "8481"
 #     path_prefix: "/select/0/prometheus"
-# Or let lfk read the prefix off the pods behind the discovered Service
-# (needs pod list access):
-#   prometheus:
-#     discover_path_prefix: true
+#     # Or let lfk read the prefix off the pods behind the discovered
+#     # Service instead (needs pod list access):
+#     # discover_path_prefix: true
 #   alertmanager:
 #     namespaces: ["monitoring"]
 #     services: ["vmalertmanager-vmks"]

--- a/docs/config-example.yaml
+++ b/docs/config-example.yaml
@@ -287,6 +287,10 @@ monitoring:
 #     services: ["vmselect-vmks"]
 #     port: "8481"
 #     path_prefix: "/select/0/prometheus"
+# Or let lfk read the prefix off the pods behind the discovered Service
+# (needs pod list access):
+#   prometheus:
+#     discover_path_prefix: true
 #   alertmanager:
 #     namespaces: ["monitoring"]
 #     services: ["vmalertmanager-vmks"]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -317,6 +317,7 @@ Each endpoint (`prometheus` and `alertmanager`) accepts:
 | `services` | list[string] | *(auto-discovery)* | Service names to try. Tried in order within each namespace. |
 | `port` | string | `"9090"` / `"9093"` | Service port (default: `9090` for Prometheus, `9093` for Alertmanager). |
 | `path_prefix` | string | `""` | URL prefix in front of the API path. See [VictoriaMetrics](#victoriametrics). |
+| `discover_path_prefix` | bool | `false` | Read the prefix off the pods behind a discovered Service (`--web.route-prefix`, `-http.pathPrefix`). Needs pod list access. `prometheus` only. |
 
 ### Auto-discovery
 
@@ -343,7 +344,7 @@ When discovery finds nothing, lfk probes these names:
 | Prometheus | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `kube-prometheus-stack-prometheus`, `prometheus-kube-prometheus-prometheus`, `prometheus-server`, `prometheus`, `prometheus-operated` |
 | Alertmanager | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `alertmanager-operated`, `alertmanager`, `prometheus-kube-prometheus-alertmanager`, `alertmanager-main` |
 
-Each Prometheus target is probed on its bare path first, then under `/prometheus` (kube-prometheus-stack `routePrefix`) and `/vm` (VictoriaMetrics `http.pathPrefix`). A configured `path_prefix` is probed as written.
+Each Prometheus target is probed on its bare path first, then under `/prometheus` (kube-prometheus-stack `routePrefix`) and `/vm` (VictoriaMetrics `http.pathPrefix`). A configured `path_prefix` is probed as written. With `discover_path_prefix: true` lfk reads the prefix off the pods behind each discovered Service instead of guessing.
 
 ### Metrics source
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -343,6 +343,8 @@ When discovery finds nothing, lfk probes these names:
 | Prometheus | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `kube-prometheus-stack-prometheus`, `prometheus-kube-prometheus-prometheus`, `prometheus-server`, `prometheus`, `prometheus-operated` |
 | Alertmanager | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `alertmanager-operated`, `alertmanager`, `prometheus-kube-prometheus-alertmanager`, `alertmanager-main` |
 
+Each Prometheus target is probed on its bare path first, then under `/prometheus` (kube-prometheus-stack `routePrefix`) and `/vm` (VictoriaMetrics `http.pathPrefix`). A configured `path_prefix` is probed as written.
+
 ### Metrics source
 
 A discovered Prometheus also decides where pod and node CPU and memory come from. With no `monitoring` config, lfk sends them to Prometheus when discovery found one, and to metrics-server otherwise. An explicit `node_metrics` still wins. The nodes-list `Uptime` column follows the same rule.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -344,7 +344,7 @@ When discovery finds nothing, lfk probes these names:
 | Prometheus | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `kube-prometheus-stack-prometheus`, `prometheus-kube-prometheus-prometheus`, `prometheus-server`, `prometheus`, `prometheus-operated` |
 | Alertmanager | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `alertmanager-operated`, `alertmanager`, `prometheus-kube-prometheus-alertmanager`, `alertmanager-main` |
 
-Each Prometheus target is probed on its bare path first, then under `/prometheus` (kube-prometheus-stack `routePrefix`) and `/vm` (VictoriaMetrics `http.pathPrefix`). A configured `path_prefix` is probed as written. With `discover_path_prefix: true` lfk reads the prefix off the pods behind each discovered Service instead of guessing.
+Each Prometheus target is probed on its bare path first, then under `/prometheus` (kube-prometheus-stack `routePrefix`) and `/vm` (VictoriaMetrics `http.pathPrefix`). A configured `path_prefix` is probed as written. With `discover_path_prefix: true` lfk reads the prefix off the pods behind each discovered Service instead of guessing. If no pod carries a prefix flag, or the pod list is denied, the guesses above still run.
 
 ### Metrics source
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -610,7 +610,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "prometheus": { "$ref": "#/definitions/monitoringEndpoint" },
+        "prometheus": { "$ref": "#/definitions/prometheusEndpoint" },
         "alertmanager": { "$ref": "#/definitions/monitoringEndpoint" },
         "node_metrics": {
           "type": "string",
@@ -640,11 +640,35 @@
         "path_prefix": {
           "type": "string",
           "description": "URL prefix in front of the API path. VictoriaMetrics vmselect serves the Prometheus API below \"/select/<accountID>/prometheus\"."
+        }
+      }
+    },
+    "prometheusEndpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "namespaces": {
+          "type": "array",
+          "description": "Namespaces to search for the monitoring service.",
+          "items": { "type": "string" }
+        },
+        "services": {
+          "type": "array",
+          "description": "Service names to try.",
+          "items": { "type": "string" }
+        },
+        "port": {
+          "type": "string",
+          "description": "Port number (default: \"9090\" for prometheus, \"9093\" for alertmanager)."
+        },
+        "path_prefix": {
+          "type": "string",
+          "description": "URL prefix in front of the API path. VictoriaMetrics vmselect serves the Prometheus API below \"/select/<accountID>/prometheus\"."
         },
         "discover_path_prefix": {
           "type": "boolean",
           "default": false,
-          "description": "Read the URL prefix (--web.route-prefix, -http.pathPrefix) off the pods behind a discovered Prometheus Service. Opt-in because it lists pods. Prometheus endpoint only."
+          "description": "Read the URL prefix (--web.route-prefix, -http.pathPrefix) off the pods behind a discovered Prometheus Service. Opt-in because it lists pods."
         }
       }
     },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -640,6 +640,11 @@
         "path_prefix": {
           "type": "string",
           "description": "URL prefix in front of the API path. VictoriaMetrics vmselect serves the Prometheus API below \"/select/<accountID>/prometheus\"."
+        },
+        "discover_path_prefix": {
+          "type": "boolean",
+          "default": false,
+          "description": "Read the URL prefix (--web.route-prefix, -http.pathPrefix) off the pods behind a discovered Prometheus Service. Opt-in because it lists pods. Prometheus endpoint only."
         }
       }
     },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -668,7 +668,7 @@
         "discover_path_prefix": {
           "type": "boolean",
           "default": false,
-          "description": "Read the URL prefix (--web.route-prefix, -http.pathPrefix) off the pods behind a discovered Prometheus Service. Opt-in because it lists pods."
+          "description": "Read the URL prefix (--web.route-prefix, -http.pathPrefix) off the pods behind a discovered Prometheus or VictoriaMetrics vmselect Service. Opt-in because it lists pods."
         }
       }
     },

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -178,6 +178,7 @@ func (c *Client) runPrometheusProxy(ctx context.Context, contextName, path strin
 		return nil, fmt.Errorf("clientset: %w", err)
 	}
 	promTargets, _ := monitoringTargetsFor(ctx, cs, contextName)
+	promTargets = withCommonPrefixes(promTargets)
 
 	doQuery := func(t monitoringTarget) ([]byte, error) {
 		rctx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/k8s/monitoring_path_prefix.go
+++ b/internal/k8s/monitoring_path_prefix.go
@@ -1,0 +1,65 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// pathPrefixFlags are the flags the Prometheus operator and the
+// VictoriaMetrics operator use to move the query API below a URL prefix.
+var pathPrefixFlags = []string{"--web.route-prefix", "-http.pathPrefix", "--http.pathPrefix"}
+
+// discoveredPathPrefix reads the URL prefix off the pods a Service selects.
+// It returns "" when the Service has no selector, no pod carries a prefix
+// flag, or the list is denied.
+func discoveredPathPrefix(ctx context.Context, cs kubernetes.Interface, svc *corev1.Service) string {
+	if len(svc.Spec.Selector) == 0 {
+		return ""
+	}
+	pods, err := cs.CoreV1().Pods(svc.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(svc.Spec.Selector).String(),
+	})
+	if err != nil {
+		logger.Debug("path prefix discovery failed", "namespace", svc.Namespace, "service", svc.Name, "error", logger.Redact(err.Error()))
+		return ""
+	}
+	for i := range pods.Items {
+		for _, c := range pods.Items[i].Spec.Containers {
+			if p := pathPrefixFromArgs(append(append([]string{}, c.Command...), c.Args...)); p != "" {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+// pathPrefixFromArgs finds a prefix flag in a container's arguments, in
+// either --flag=value or --flag value form, and normalises it to /name.
+func pathPrefixFromArgs(args []string) string {
+	for i, arg := range args {
+		for _, flag := range pathPrefixFlags {
+			var value string
+			switch {
+			case strings.HasPrefix(arg, flag+"="):
+				value = strings.TrimPrefix(arg, flag+"=")
+			case arg == flag && i+1 < len(args):
+				value = args[i+1]
+			default:
+				continue
+			}
+			value = strings.Trim(value, "/")
+			if value == "" {
+				return ""
+			}
+			return "/" + value
+		}
+	}
+	return ""
+}

--- a/internal/k8s/monitoring_targets.go
+++ b/internal/k8s/monitoring_targets.go
@@ -142,7 +142,7 @@ func cachedMonitoringDiscovery(ctx context.Context, cs kubernetes.Interface, con
 		}
 		monitoringDiscoveryCache.Delete(contextName)
 	}
-	prom, am = discoverMonitoringServices(ctx, cs, namespaces)
+	prom, am = discoverMonitoringServices(ctx, cs, namespaces, pathPrefixDiscoverer(ctx, cs, contextName))
 	logger.Debug("monitoring service discovery finished",
 		"context", contextName, "prometheus", prom, "alertmanager", am)
 	monitoringDiscoveryCache.Store(contextName, monitoringDiscoveryEntry{prom: prom, am: am, at: time.Now()})
@@ -177,12 +177,22 @@ var monitoringSelectors = []string{
 // discoverMonitoringServices finds monitoring Services by their component
 // labels. The cluster-wide list comes first because it also finds a stack
 // outside the well-known namespaces, but a user may lack that permission.
-func discoverMonitoringServices(ctx context.Context, cs kubernetes.Interface, namespaces []string) (prom, am []monitoringTarget) {
+func discoverMonitoringServices(ctx context.Context, cs kubernetes.Interface, namespaces []string, prefixFor func(*corev1.Service) string) (prom, am []monitoringTarget) {
 	found := make([]corev1.Service, 0, len(monitoringSelectors))
 	for _, selector := range monitoringSelectors {
 		found = append(found, listMonitoringServices(ctx, cs, namespaces, selector)...)
 	}
-	return targetsFromServices(preferWellKnownNamespaces(dedupeServices(found), namespaces))
+	return targetsFromServices(preferWellKnownNamespaces(dedupeServices(found), namespaces), prefixFor)
+}
+
+// pathPrefixDiscoverer returns the pod-args lookup when the context opted in
+// with discover_path_prefix, and nil otherwise.
+func pathPrefixDiscoverer(ctx context.Context, cs kubernetes.Interface, contextName string) func(*corev1.Service) string {
+	mc, ok := monitoringConfigFor(contextName)
+	if !ok || mc.Prometheus == nil || !mc.Prometheus.DiscoverPathPrefix {
+		return nil
+	}
+	return func(svc *corev1.Service) string { return discoveredPathPrefix(ctx, cs, svc) }
 }
 
 // preferWellKnownNamespaces stably moves Services in the namespaces an
@@ -282,7 +292,7 @@ func serviceRole(svc *corev1.Service) monitoringRole {
 
 // targetsFromServices turns discovered Services into probe targets. The port
 // comes from the Service itself, so a stack on a non-default port still works.
-func targetsFromServices(services []corev1.Service) (prom, am []monitoringTarget) {
+func targetsFromServices(services []corev1.Service, prefixFor func(*corev1.Service) string) (prom, am []monitoringTarget) {
 	for i := range services {
 		svc := &services[i]
 		p := servicePort(svc)
@@ -290,13 +300,19 @@ func targetsFromServices(services []corev1.Service) (prom, am []monitoringTarget
 			continue
 		}
 		base := monitoringTarget{Namespace: svc.Namespace, Service: svc.Name, Port: p}
-		switch serviceRole(svc) {
+		role := serviceRole(svc)
+		if prefixFor != nil && (role == rolePrometheus || role == roleVMSelect) {
+			if found := prefixFor(svc); found != "" {
+				base.Prefix, base.fixedPrefix = found, true
+			}
+		}
+		switch role {
 		case rolePrometheus:
 			prom = append(prom, base)
 		case roleVMSelect:
 			prom = append(prom,
-				withPrefix(base, vmSelectTenantPrefix),
-				withPrefix(base, vmSelectMultitenantPrefix))
+				withPrefix(base, base.Prefix+vmSelectTenantPrefix),
+				withPrefix(base, base.Prefix+vmSelectMultitenantPrefix))
 		case roleAlertmanager:
 			am = append(am, base)
 		case roleNone:

--- a/internal/k8s/monitoring_targets.go
+++ b/internal/k8s/monitoring_targets.go
@@ -23,6 +23,9 @@ type monitoringTarget struct {
 	Service   string
 	Port      string
 	Prefix    string
+	// fixedPrefix marks a Prefix the user wrote in config. Discovery then
+	// probes exactly that path instead of guessing around it.
+	fixedPrefix bool
 }
 
 // path returns the proxy path for one Prometheus or Alertmanager API path.
@@ -307,6 +310,28 @@ func withPrefix(t monitoringTarget, prefix string) monitoringTarget {
 	return t
 }
 
+// commonAPIPrefixes are URL prefixes a chart commonly puts in front of the
+// query API: kube-prometheus-stack's routePrefix and the VictoriaMetrics
+// http.pathPrefix flag. Same idea as the namespace guesses.
+var commonAPIPrefixes = []string{"/prometheus", "/vm"}
+
+// withCommonPrefixes returns every target on its bare path first, then the
+// whole list again under each common prefix. Bare paths lead because most
+// installs use none, and a wrong prefix costs a fast 404 from the proxy.
+func withCommonPrefixes(targets []monitoringTarget) []monitoringTarget {
+	out := make([]monitoringTarget, 0, len(targets)*(1+len(commonAPIPrefixes)))
+	out = append(out, targets...)
+	for _, p := range commonAPIPrefixes {
+		for _, t := range targets {
+			if t.fixedPrefix {
+				continue
+			}
+			out = append(out, withPrefix(t, p+t.Prefix))
+		}
+	}
+	return out
+}
+
 // servicePort picks the HTTP port of a monitoring Service. The named port wins
 // because an Alertmanager Service also exposes its gossip port, and that one
 // answers no API request. Its gossip port carries the same name on UDP as on
@@ -401,7 +426,9 @@ func endpointTargets(ep *model.MonitoringEndpoint, defaultServices []string, def
 	targets := make([]monitoringTarget, 0, len(namespaces)*len(services))
 	for _, ns := range namespaces {
 		for _, svc := range services {
-			targets = append(targets, monitoringTarget{Namespace: ns, Service: svc, Port: port, Prefix: prefix})
+			targets = append(targets, monitoringTarget{
+				Namespace: ns, Service: svc, Port: port, Prefix: prefix, fixedPrefix: prefix != "",
+			})
 		}
 	}
 	return targets

--- a/internal/k8s/monitoring_targets_test.go
+++ b/internal/k8s/monitoring_targets_test.go
@@ -269,7 +269,7 @@ func TestResolveMonitoringEndpointsPathPrefix(t *testing.T) {
 	prom, _ := resolveMonitoringEndpoints("any-ctx")
 
 	require.Len(t, prom, 1)
-	assert.Equal(t, monitoringTarget{Namespace: "vm", Service: "vmselect-vmks", Port: "8481", Prefix: "/select/0/prometheus"}, prom[0])
+	assert.Equal(t, monitoringTarget{Namespace: "vm", Service: "vmselect-vmks", Port: "8481", Prefix: "/select/0/prometheus", fixedPrefix: true}, prom[0])
 	assert.Equal(t, "/select/0/prometheus/api/v1/query", prom[0].path("/api/v1/query"))
 }
 
@@ -591,4 +591,35 @@ func TestProbePrometheusTargetsWithNothingToTry(t *testing.T) {
 		return nil, nil
 	})
 	require.ErrorContains(t, err, "no prometheus service found")
+}
+
+func TestWithCommonPrefixesTriesBarePathsFirst(t *testing.T) {
+	in := []monitoringTarget{
+		{Namespace: "monitoring", Service: "prometheus-operated", Port: "9090"},
+		{Namespace: "monitoring", Service: "vmselect-vmks", Port: "8481", Prefix: vmSelectTenantPrefix},
+	}
+	got := withCommonPrefixes(in)
+	want := []monitoringTarget{
+		in[0], in[1],
+		{Namespace: "monitoring", Service: "prometheus-operated", Port: "9090", Prefix: "/prometheus"},
+		{Namespace: "monitoring", Service: "vmselect-vmks", Port: "8481", Prefix: "/prometheus" + vmSelectTenantPrefix},
+		{Namespace: "monitoring", Service: "prometheus-operated", Port: "9090", Prefix: "/vm"},
+		{Namespace: "monitoring", Service: "vmselect-vmks", Port: "8481", Prefix: "/vm" + vmSelectTenantPrefix},
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestWithCommonPrefixesKeepsAConfiguredPrefixAlone(t *testing.T) {
+	orig := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = orig })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"ctx-fixed": {Prometheus: &model.MonitoringEndpoint{
+			Namespaces: []string{"vm"}, Services: []string{"vmselect-vmks"}, Port: "8481",
+			PathPrefix: "/vm/select/0/prometheus",
+		}},
+	}
+	prom, _ := resolveMonitoringEndpoints("ctx-fixed")
+	got := withCommonPrefixes(prom)
+	require.Len(t, got, 1)
+	assert.Equal(t, "/vm/select/0/prometheus", got[0].Prefix)
 }

--- a/internal/k8s/monitoring_targets_test.go
+++ b/internal/k8s/monitoring_targets_test.go
@@ -68,7 +68,7 @@ func TestTargetsFromServices(t *testing.T) {
 	t.Run("maps vmselect to the tenant query prefixes", func(t *testing.T) {
 		svcs := []corev1.Service{*monitoringSvc("monitoring", "vmselect-vmks", "vmselect", port("http", 8481))}
 
-		prom, am := targetsFromServices(svcs)
+		prom, am := targetsFromServices(svcs, nil)
 
 		assert.Empty(t, am)
 		require.Len(t, prom, 2)
@@ -79,7 +79,7 @@ func TestTargetsFromServices(t *testing.T) {
 	t.Run("maps vmsingle to the root query path", func(t *testing.T) {
 		svcs := []corev1.Service{*monitoringSvc("vm", "vmsingle-vmks", "vmsingle", port("http", 8428))}
 
-		prom, _ := targetsFromServices(svcs)
+		prom, _ := targetsFromServices(svcs, nil)
 
 		require.Len(t, prom, 1)
 		assert.Equal(t, monitoringTarget{Namespace: "vm", Service: "vmsingle-vmks", Port: "8428", Prefix: ""}, prom[0])
@@ -89,7 +89,7 @@ func TestTargetsFromServices(t *testing.T) {
 		svcs := []corev1.Service{*monitoringSvc("monitoring", "vmalertmanager-vmks", "vmalertmanager",
 			port("web", 9093), port("tcp-mesh", 9094))}
 
-		prom, am := targetsFromServices(svcs)
+		prom, am := targetsFromServices(svcs, nil)
 
 		assert.Empty(t, prom)
 		require.Len(t, am, 1)
@@ -102,7 +102,7 @@ func TestTargetsFromServices(t *testing.T) {
 			*monitoringSvc("monitoring", "kps-alertmanager", "alertmanager", port("http-web", 9093)),
 		}
 
-		prom, am := targetsFromServices(svcs)
+		prom, am := targetsFromServices(svcs, nil)
 
 		require.Len(t, prom, 1)
 		require.Len(t, am, 1)
@@ -117,7 +117,7 @@ func TestTargetsFromServices(t *testing.T) {
 			*monitoringSvc("monitoring", "vmselect-broken", "vmselect"),
 		}
 
-		prom, am := targetsFromServices(svcs)
+		prom, am := targetsFromServices(svcs, nil)
 
 		assert.Empty(t, prom)
 		assert.Empty(t, am)
@@ -133,7 +133,7 @@ func TestDiscoverMonitoringServices(t *testing.T) {
 			monitoringSvc("default", "web", "nginx", port("http", 80)),
 		)
 
-		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"})
+		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
 
 		assert.Empty(t, am)
 		require.Len(t, prom, 2)
@@ -149,7 +149,7 @@ func TestDiscoverMonitoringServices(t *testing.T) {
 			return false, nil, nil
 		})
 
-		prom, _ := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"})
+		prom, _ := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
 
 		require.Len(t, prom, 1)
 		assert.Equal(t, "vmsingle-vmks", prom[0].Service)
@@ -161,7 +161,7 @@ func TestDiscoverMonitoringServices(t *testing.T) {
 			return true, nil, assert.AnError
 		})
 
-		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"})
+		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
 
 		assert.Empty(t, prom)
 		assert.Empty(t, am)
@@ -510,7 +510,7 @@ func TestDiscoverKubePrometheusStack(t *testing.T) {
 
 	cs := k8sfake.NewClientset(promOperated, amOperated, chartProm)
 
-	prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"})
+	prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
 
 	require.Len(t, prom, 1)
 	assert.Equal(t, "prometheus-operated", prom[0].Service)
@@ -525,7 +525,7 @@ func TestDiscoverMonitoringServicesDedupes(t *testing.T) {
 	svc := monitoringSvc("monitoring", "prometheus-operated", "prometheus", port("web", 9090))
 	svc.Labels["operated-prometheus"] = "true"
 
-	prom, _ := discoverMonitoringServices(t.Context(), k8sfake.NewClientset(svc), []string{"monitoring"})
+	prom, _ := discoverMonitoringServices(t.Context(), k8sfake.NewClientset(svc), []string{"monitoring"}, nil)
 
 	assert.Len(t, prom, 1)
 }
@@ -540,7 +540,7 @@ func TestDiscoveryPrefersWellKnownNamespaces(t *testing.T) {
 		monitoringSvc("monitoring", "vmsingle-real", "vmsingle", port("http", 8428)),
 	)
 
-	prom, _ := discoverMonitoringServices(t.Context(), cs, defaultMonitoringNamespaces)
+	prom, _ := discoverMonitoringServices(t.Context(), cs, defaultMonitoringNamespaces, nil)
 
 	require.Len(t, prom, 2)
 	assert.Equal(t, "vmsingle-real", prom[0].Service, "the well-known namespace is probed first")
@@ -622,4 +622,79 @@ func TestWithCommonPrefixesKeepsAConfiguredPrefixAlone(t *testing.T) {
 	got := withCommonPrefixes(prom)
 	require.Len(t, got, 1)
 	assert.Equal(t, "/vm/select/0/prometheus", got[0].Prefix)
+}
+
+func TestPathPrefixFromArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"prometheus operator route prefix", []string{"--config.file=/etc/p.yml", "--web.route-prefix=/prometheus"}, "/prometheus"},
+		{"vmselect path prefix", []string{"-http.pathPrefix=/vm", "-storageNode=x"}, "/vm"},
+		{"double dash vm flag", []string{"--http.pathPrefix=/vm/"}, "/vm"},
+		{"value in the next arg", []string{"--web.route-prefix", "/prometheus"}, "/prometheus"},
+		{"root prefix means none", []string{"--web.route-prefix=/"}, ""},
+		{"missing leading slash is added", []string{"-http.pathPrefix=vm"}, "/vm"},
+		{"no flag", []string{"--web.enable-lifecycle"}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pathPrefixFromArgs(tc.args))
+		})
+	}
+}
+
+func TestDiscoveredPathPrefixReadsThePodsBehindTheService(t *testing.T) {
+	svc := monitoringSvc("monitoring", "prometheus-operated", "prometheus", port("http", 9090))
+	svc.Spec.Selector = map[string]string{"app.kubernetes.io/name": "prometheus"}
+	pod := &corev1.Pod{
+		Name: "prometheus-0", Namespace: "monitoring",
+		Labels: map[string]string{"app.kubernetes.io/name": "prometheus"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "config-reloader", Args: []string{"--listen-address=:8080"}},
+			{Name: "prometheus", Args: []string{"--web.route-prefix=/prometheus"}},
+		}},
+	}
+	other := &corev1.Pod{
+		Name: "grafana-0", Namespace: "monitoring",
+		Labels: map[string]string{"app.kubernetes.io/name": "grafana"},
+		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "g", Args: []string{"--web.route-prefix=/grafana"}}}},
+	}
+	cs := k8sfake.NewClientset(svc, pod, other)
+	assert.Equal(t, "/prometheus", discoveredPathPrefix(t.Context(), cs, svc))
+
+	t.Run("a service with no selector yields nothing", func(t *testing.T) {
+		bare := monitoringSvc("monitoring", "ext", "prometheus", port("http", 9090))
+		assert.Equal(t, "", discoveredPathPrefix(t.Context(), k8sfake.NewClientset(bare), bare))
+	})
+}
+
+func TestDiscoverMonitoringServicesAppliesTheFoundPrefixWhenOptedIn(t *testing.T) {
+	resetMonitoringDiscoveryCache()
+	orig := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = orig })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"ctx-pp": {Prometheus: &model.MonitoringEndpoint{DiscoverPathPrefix: true}},
+	}
+	svc := monitoringSvc("monitoring", "vmselect-vmks", "vmselect", port("http", 8481))
+	svc.Spec.Selector = map[string]string{"app.kubernetes.io/name": "vmselect"}
+	pod := &corev1.Pod{
+		Name: "vmselect-0", Namespace: "monitoring",
+		Labels: map[string]string{"app.kubernetes.io/name": "vmselect"},
+		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "vmselect", Args: []string{"-http.pathPrefix=/vm"}}}},
+	}
+	cs := k8sfake.NewClientset(svc, pod)
+
+	prom, _ := discoveredMonitoringTargets(t.Context(), cs, "ctx-pp")
+	require.Len(t, prom, 2)
+	assert.Equal(t, "/vm"+vmSelectTenantPrefix, prom[0].Prefix)
+	assert.True(t, prom[0].fixedPrefix, "a discovered prefix is not guessed around")
+	// The same cluster with the flag off keeps the bare tenant prefix.
+	resetMonitoringDiscoveryCache()
+	model.ConfigMonitoring = nil
+	prom, _ = discoveredMonitoringTargets(t.Context(), cs, "ctx-pp")
+	require.Len(t, prom, 2)
+	assert.Equal(t, vmSelectTenantPrefix, prom[0].Prefix)
+	assert.False(t, prom[0].fixedPrefix)
 }

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -696,6 +696,9 @@ type MonitoringEndpoint struct {
 	// PathPrefix goes in front of the API path. VictoriaMetrics vmselect
 	// serves the Prometheus API below "/select/<accountID>/prometheus".
 	PathPrefix string `json:"path_prefix" yaml:"path_prefix"`
+	// DiscoverPathPrefix reads the prefix off the pods behind a discovered
+	// Service (--web.route-prefix, -http.pathPrefix). Opt-in: it lists pods.
+	DiscoverPathPrefix bool `json:"discover_path_prefix" yaml:"discover_path_prefix"`
 }
 
 // MonitoringConfig defines per-cluster monitoring endpoints.

--- a/internal/ui/config_wiring_test.go
+++ b/internal/ui/config_wiring_test.go
@@ -126,6 +126,7 @@ monitoring:
       services: [prom]
       port: "9090"
       path_prefix: /select/0/prometheus
+      discover_path_prefix: true
 kubeshark:
   namespace: traffic-ns
 security:
@@ -305,6 +306,7 @@ func TestLoadConfig_AllSettingsWired(t *testing.T) {
 	assert.Equal(t, "prometheus", model.ConfigMonitoring["_global"].NodeMetrics)
 	require.NotNil(t, model.ConfigMonitoring["_global"].Prometheus, "monitoring.prometheus")
 	assert.Equal(t, "/select/0/prometheus", model.ConfigMonitoring["_global"].Prometheus.PathPrefix, "monitoring.prometheus.path_prefix")
+	assert.True(t, model.ConfigMonitoring["_global"].Prometheus.DiscoverPathPrefix, "monitoring.prometheus.discover_path_prefix")
 
 	// union_sets (map form).
 	require.Len(t, ConfigUnionSets, 1, "union_sets")


### PR DESCRIPTION
- kube-prometheus-stack `routePrefix: /prometheus` and VictoriaMetrics `http.pathPrefix: /vm` move the query API below a prefix. Discovery found the Service but every probe 404'd (#699).
- Each Prometheus target is now probed on its bare path first, then under `/prometheus` and `/vm`, the same way namespaces and service names are guessed. A configured `path_prefix` is probed as written.
- New opt-in `monitoring.<ctx>.prometheus.discover_path_prefix: true` reads the prefix off the pods behind a discovered Service (`--web.route-prefix`, `-http.pathPrefix`) for installs with an unusual prefix. Off by default because it lists pods.

Refs #699

## Test plan
- [x] `TestWithCommonPrefixes*`, `TestPathPrefixFromArgs`, `TestDiscoveredPathPrefix*`, `TestDiscoverMonitoringServicesAppliesTheFoundPrefixWhenOptedIn` (RED then GREEN)
- [x] `TestLoadConfig_AllSettingsWired` covers `discover_path_prefix`
- [x] `go test ./internal/k8s/ ./internal/ui/ ./internal/app/`, `golangci-lint` clean
- [ ] macrokernel confirms on the VM and Prometheus clusters