### PR TITLE
fix: keep the right-sizing window across a workload rollout

### DIFF
--- a/internal/k8s/client_rightsizing.go
+++ b/internal/k8s/client_rightsizing.go
@@ -161,7 +161,7 @@ func (c *Client) GetRightsizing(ctx context.Context, contextName, namespace, kin
 	case model.StrategyVPA:
 		c.applyVPAStrategy(ctx, contextName, namespace, kind, name, headroom, out)
 	case model.StrategyPromMax1D, model.StrategyPromAvg1D, model.StrategyPromP957D:
-		c.applyPrometheusStrategy(ctx, contextName, namespace, pods, strategy, headroom, out)
+		c.applyPrometheusStrategy(ctx, contextName, namespace, kind, name, strategy, headroom, out)
 	case model.StrategySnapshot:
 		c.applySnapshotStrategy(ctx, contextName, namespace, pods, headroom, out)
 	}

--- a/internal/k8s/client_rightsizing_pods.go
+++ b/internal/k8s/client_rightsizing_pods.go
@@ -4,8 +4,38 @@ import (
 	"context"
 	"fmt"
 
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// workloadIsIndexed reports whether the workload's pods carry a
+// completion-index segment in their names. False on any lookup error,
+// which yields the narrower pod pattern.
+func (c *Client) workloadIsIndexed(ctx context.Context, contextName, namespace, kind, name string) bool {
+	cs, err := c.clientsetForContext(contextName)
+	if err != nil {
+		return false
+	}
+	switch kind {
+	case "Job":
+		job, err := cs.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return isIndexedCompletion(job.Spec.CompletionMode)
+	case "CronJob":
+		cj, err := cs.BatchV1().CronJobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return isIndexedCompletion(cj.Spec.JobTemplate.Spec.CompletionMode)
+	}
+	return false
+}
+
+func isIndexedCompletion(mode *batchv1.CompletionMode) bool {
+	return mode != nil && *mode == batchv1.IndexedCompletion
+}
 
 // resolvePodsForWorkload returns the names of pods backing the given
 // workload. Strategy varies by kind:

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -23,8 +23,9 @@ import (
 // gets set to "1d" or "7d" depending on the strategy so the header
 // can show the user what time range backs the recommendation.
 func (c *Client) applyPrometheusStrategy(ctx context.Context, contextName, namespace, kind, name string, strategy model.RightsizingStrategy, headroom float64, out *model.Rightsizing) {
-	cpuQuery := buildPromContainerQuery(namespace, kind, name, strategy, "cpu")
-	memQuery := buildPromContainerQuery(namespace, kind, name, strategy, "memory")
+	indexed := c.workloadIsIndexed(ctx, contextName, namespace, kind, name)
+	cpuQuery := buildPromContainerQuery(namespace, kind, name, indexed, strategy, "cpu")
+	memQuery := buildPromContainerQuery(namespace, kind, name, indexed, strategy, "memory")
 	if cpuQuery == "" && memQuery == "" {
 		return
 	}
@@ -80,8 +81,8 @@ func promStrategyWindow(s model.RightsizingStrategy) string {
 //
 // Returns "" for a kind podsRegexForWorkload cannot describe, so the
 // caller skips the query rather than selecting the whole namespace.
-func buildPromContainerQuery(namespace, kind, name string, strategy model.RightsizingStrategy, resourceKind string) string {
-	podRegex := podsRegexForWorkload(kind, name)
+func buildPromContainerQuery(namespace, kind, name string, indexed bool, strategy model.RightsizingStrategy, resourceKind string) string {
+	podRegex := podsRegexForWorkload(kind, name, indexed)
 	if podRegex == "" {
 		return ""
 	}
@@ -133,9 +134,15 @@ const promRawQuote = "`"
 // podsRegexForWorkload also matches pods from revisions that no longer
 // exist, so a 1d or 7d window survives the rollout that applying a
 // recommendation triggers. "" for a kind it cannot describe.
-func podsRegexForWorkload(kind, name string) string {
+func podsRegexForWorkload(kind, name string, indexed bool) string {
 	n := regexp.QuoteMeta(name)
 	gen := k8sGeneratedChars
+	// Only an Indexed Job puts a digit segment here. Always-on, that
+	// group would also swallow a sibling workload named "<name>-3".
+	index := ""
+	if indexed {
+		index = "[0-9]+-"
+	}
 	switch kind {
 	case "Pod":
 		return "^" + n + "$"
@@ -148,12 +155,11 @@ func podsRegexForWorkload(kind, name string) string {
 	case "StatefulSet":
 		return "^" + n + "-[0-9]+$"
 	case "Job":
-		// The optional digit group is an Indexed job's completion index.
-		return "^" + n + "-(?:[0-9]+-)?" + gen + "{5}$"
+		return "^" + n + "-" + index + gen + "{5}$"
 	case "CronJob":
 		// The CronJob controller names each Job after its scheduled time
 		// in minutes since the epoch, then the Job names its own pods.
-		return "^" + n + "-[0-9]+-(?:[0-9]+-)?" + gen + "{5}$"
+		return "^" + n + "-[0-9]+-" + index + gen + "{5}$"
 	}
 	return ""
 }

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -22,18 +22,18 @@ import (
 // the user still sees Current and Usage columns. The Window field
 // gets set to "1d" or "7d" depending on the strategy so the header
 // can show the user what time range backs the recommendation.
-func (c *Client) applyPrometheusStrategy(ctx context.Context, contextName, namespace string, pods []string, strategy model.RightsizingStrategy, headroom float64, out *model.Rightsizing) {
-	if len(pods) == 0 {
+func (c *Client) applyPrometheusStrategy(ctx context.Context, contextName, namespace, kind, name string, strategy model.RightsizingStrategy, headroom float64, out *model.Rightsizing) {
+	cpuQuery := buildPromContainerQuery(namespace, kind, name, strategy, "cpu")
+	memQuery := buildPromContainerQuery(namespace, kind, name, strategy, "memory")
+	if cpuQuery == "" && memQuery == "" {
 		return
 	}
 	out.Window = promStrategyWindow(strategy)
 
-	cpuQuery := buildPromContainerQuery(namespace, pods, strategy, "cpu")
 	cpuResult, err := c.queryPromContainerMetric(ctx, contextName, cpuQuery)
 	if err != nil {
 		logger.Debug("rightsizing: Prometheus CPU query failed", "err", err)
 	}
-	memQuery := buildPromContainerQuery(namespace, pods, strategy, "memory")
 	memResult, err := c.queryPromContainerMetric(ctx, contextName, memQuery)
 	if err != nil {
 		logger.Debug("rightsizing: Prometheus memory query failed", "err", err)
@@ -72,24 +72,24 @@ func promStrategyWindow(s model.RightsizingStrategy) string {
 }
 
 // buildPromContainerQuery returns the PromQL query for the requested
-// strategy + resource. The query aggregates per container across the
-// pods named in `pods` (escaped into a regex alternation).
+// strategy + resource, aggregated per container.
 //
-// CPU uses container_cpu_usage_seconds_total wrapped in rate(...) over
-// a 5-minute window so the inner sample is cores/sec. The outer
-// aggregation (max_over_time / avg_over_time / quantile_over_time)
-// folds those samples across the strategy's window.
+// CPU wraps container_cpu_usage_seconds_total in rate(...) over 5m so
+// the inner sample is cores/sec. Memory reads
+// container_memory_working_set_bytes directly because it is a gauge.
 //
-// Memory uses container_memory_working_set_bytes directly because it's
-// a gauge (no rate() needed).
-func buildPromContainerQuery(namespace string, pods []string, strategy model.RightsizingStrategy, resourceKind string) string {
-	podRegex := podsRegex(pods)
-	// PromQL string literal uses single-backslash escapes (similar to
-	// JSON / shell double-quoted strings). fmt's %q would Go-escape and
-	// emit `\\.` for a literal `\.` regex — wrong for PromQL. Build the
-	// label selector with a manual quote-wrap instead so the regex
-	// metacharacter survives intact.
-	commonLabels := `namespace="` + namespace + `",pod=~"` + podRegex + `",container!="POD",container!=""`
+// Returns "" for a kind podsRegexForWorkload cannot describe, so the
+// caller skips the query rather than selecting the whole namespace.
+func buildPromContainerQuery(namespace, kind, name string, strategy model.RightsizingStrategy, resourceKind string) string {
+	podRegex := podsRegexForWorkload(kind, name)
+	if podRegex == "" {
+		return ""
+	}
+	// A raw PromQL literal, so the `\.` QuoteMeta emits for a dotted
+	// workload name survives: a double-quoted literal processes escapes
+	// and rejects `\.` as unknown.
+	podMatcher := fmt.Sprintf("pod=~%s%s%s", promRawQuote, podRegex, promRawQuote)
+	commonLabels := fmt.Sprintf(`namespace=%q,%s,container!="POD",container!=""`, namespace, podMatcher)
 	var inner string
 	switch resourceKind {
 	case "cpu":
@@ -122,20 +122,40 @@ func wrapPromAggregation(s model.RightsizingStrategy, subquery string) string {
 	return subquery
 }
 
-// podsRegex builds a regex alternation from a slice of pod names. The
-// `(p1|p2|p3)` form matches the exact pods backing the workload — no
-// label-prefix wildcards. Pod names with regex metacharacters get
-// escaped so the query is well-formed even when a controller emits
-// names with `.` (rare but valid).
-func podsRegex(pods []string) string {
-	if len(pods) == 0 {
-		return ""
+// k8sGeneratedChars is rand.alphanums. Its lack of vowels is what keeps
+// a Deployment "foo" pattern off the pods of a sibling "foo-api".
+const k8sGeneratedChars = `[bcdfghjklmnpqrstvwxz2456789]`
+
+// promRawQuote opens and closes a PromQL raw string literal. Named
+// because a bare backtick cannot appear inside one.
+const promRawQuote = "`"
+
+// podsRegexForWorkload also matches pods from revisions that no longer
+// exist, so a 1d or 7d window survives the rollout that applying a
+// recommendation triggers. "" for a kind it cannot describe.
+func podsRegexForWorkload(kind, name string) string {
+	n := regexp.QuoteMeta(name)
+	gen := k8sGeneratedChars
+	switch kind {
+	case "Pod":
+		return "^" + n + "$"
+	case "Deployment":
+		// <deployment>-<pod-template-hash>-<suffix>. The hash is a uint32
+		// rendered through the same alphabet, so 1-10 characters.
+		return "^" + n + "-" + gen + "{1,10}-" + gen + "{5}$"
+	case "DaemonSet":
+		return "^" + n + "-" + gen + "{5}$"
+	case "StatefulSet":
+		return "^" + n + "-[0-9]+$"
+	case "Job":
+		// The optional digit group is an Indexed job's completion index.
+		return "^" + n + "-(?:[0-9]+-)?" + gen + "{5}$"
+	case "CronJob":
+		// The CronJob controller names each Job after its scheduled time
+		// in minutes since the epoch, then the Job names its own pods.
+		return "^" + n + "-[0-9]+-(?:[0-9]+-)?" + gen + "{5}$"
 	}
-	escaped := make([]string, len(pods))
-	for i, p := range pods {
-		escaped[i] = regexp.QuoteMeta(p)
-	}
-	return "^(" + strings.Join(escaped, "|") + ")$"
+	return ""
 }
 
 // queryPromContainerMetric runs an instant PromQL query and returns a

--- a/internal/k8s/client_rightsizing_prom_test.go
+++ b/internal/k8s/client_rightsizing_prom_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -22,36 +23,30 @@ import (
 // --- buildPromContainerQuery ---
 
 func TestBuildPromContainerQuery_StrategyToPromQL(t *testing.T) {
-	pods := []string{"frontend-a", "frontend-b"}
-
-	maxQ := buildPromContainerQuery("default", pods, model.StrategyPromMax1D, "cpu")
+	maxQ := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromMax1D, "cpu")
 	assert.Contains(t, maxQ, "max_over_time", "1d-max strategy must use max_over_time")
 	assert.Contains(t, maxQ, "[1d:", "1d window in subquery range")
 	assert.Contains(t, maxQ, "container_cpu_usage_seconds_total", "CPU query targets cpu metric")
 	assert.Contains(t, maxQ, `namespace="default"`, "namespace label filter")
-	assert.Contains(t, maxQ, "frontend-a", "pod name in regex")
-	assert.Contains(t, maxQ, "frontend-b")
+	assert.Contains(t, maxQ, "frontend", "workload name in pod regex")
 
-	avgQ := buildPromContainerQuery("default", pods, model.StrategyPromAvg1D, "cpu")
+	avgQ := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromAvg1D, "cpu")
 	assert.Contains(t, avgQ, "avg_over_time", "1d-avg strategy must use avg_over_time")
 	assert.Contains(t, avgQ, "[1d:")
 
-	p95Q := buildPromContainerQuery("default", pods, model.StrategyPromP957D, "cpu")
+	p95Q := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromP957D, "cpu")
 	assert.Contains(t, p95Q, "quantile_over_time(0.95", "p95 strategy uses quantile_over_time")
 	assert.Contains(t, p95Q, "[7d:", "7d window in subquery range")
 
-	memQ := buildPromContainerQuery("default", pods, model.StrategyPromMax1D, "memory")
+	memQ := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromMax1D, "memory")
 	assert.Contains(t, memQ, "container_memory_working_set_bytes", "memory query targets memory metric")
 	assert.NotContains(t, memQ, "rate(", "memory uses gauge, no rate() wrapper")
 }
 
 func TestBuildPromContainerQuery_PodRegexEscapesSpecialChars(t *testing.T) {
-	// Pod names rarely have regex metacharacters, but a safety harness
-	// keeps the query well-formed if a name ever contains a `.` (StatefulSet
-	// names with dots are valid k8s identifiers in some controllers).
-	pods := []string{"app.v1", "app-2"}
-	q := buildPromContainerQuery("default", pods, model.StrategyPromMax1D, "cpu")
+	q := buildPromContainerQuery("default", "Deployment", "app.v1", model.StrategyPromMax1D, "cpu")
 	assert.Contains(t, q, `app\.v1`, "regex metacharacters must be escaped")
+	assert.Contains(t, q, "pod=~`", "the matcher uses a raw PromQL literal so `\\.` survives unprocessed")
 }
 
 // --- parsePrometheusContainerResponse ---
@@ -236,4 +231,108 @@ func TestGetRightsizing_PrometheusQueryFailureLeavesSuggestionEmpty(t *testing.T
 	require.Len(t, out.Containers, 1)
 	assert.Empty(t, out.Containers[0].CPU.RecommendedRequest)
 	assert.Empty(t, out.Containers[0].Mem.RecommendedRequest)
+}
+
+// --- podsRegexForWorkload ---
+
+func TestPodsRegexForWorkload_MatchesControllerPodShapes(t *testing.T) {
+	cases := []struct {
+		kind   string
+		name   string
+		match  []string
+		reject []string
+	}{
+		{
+			kind:  "Deployment",
+			name:  "frontend",
+			match: []string{"frontend-7d9fkp2xz4-b5tqm", "frontend-b-jkl29"},
+			reject: []string{
+				"frontend",
+				"frontend-7d9fkp2xz4",
+				"frontend-api-7d9fkp2xz4-b5tqm",
+				"frontend-canary-7d9fkp2xz4-b5tqm",
+			},
+		},
+		{
+			kind:   "DaemonSet",
+			name:   "node-agent",
+			match:  []string{"node-agent-k4n2p"},
+			reject: []string{"node-agent", "node-agent-7d9fkp2xz4-b5tqm"},
+		},
+		{
+			kind:   "StatefulSet",
+			name:   "postgres",
+			match:  []string{"postgres-0", "postgres-12"},
+			reject: []string{"postgres", "postgres-k4n2p"},
+		},
+		{
+			kind:   "Job",
+			name:   "backup",
+			match:  []string{"backup-k4n2p", "backup-3-k4n2p"},
+			reject: []string{"backup", "backup-k4n2p-x5tqm"},
+		},
+		{
+			kind: "CronJob",
+			name: "nightly",
+			// The second form is a CronJob whose job template sets
+			// completionMode: Indexed, which inserts the index.
+			match:  []string{"nightly-29358720-k4n2p", "nightly-29358720-3-k4n2p"},
+			reject: []string{"nightly", "nightly-k4n2p"},
+		},
+		{
+			kind:   "Pod",
+			name:   "standalone",
+			match:  []string{"standalone"},
+			reject: []string{"standalone-k4n2p"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			re, err := regexp.Compile(podsRegexForWorkload(tc.kind, tc.name))
+			require.NoError(t, err, "generated regex must compile")
+			for _, p := range tc.match {
+				assert.True(t, re.MatchString(p), "%s should match", p)
+			}
+			for _, p := range tc.reject {
+				assert.False(t, re.MatchString(p), "%s should not match", p)
+			}
+		})
+	}
+}
+
+func TestPodsRegexForWorkload_SurvivesRollout(t *testing.T) {
+	// Applying a recommendation rolls the workload, so every pod name
+	// changes and a selector pinned to the old names loses the window.
+	re := regexp.MustCompile(podsRegexForWorkload("Deployment", "frontend"))
+	assert.True(t, re.MatchString("frontend-5x9dkm2t7b-q4wzn"), "pod from the revision before the edit")
+	assert.True(t, re.MatchString("frontend-7fkp2xz4d9-m5tqb"), "pod from the revision after the edit")
+}
+
+func TestPodsRegexForWorkload_EscapesDotsInWorkloadName(t *testing.T) {
+	// Deployment names are DNS subdomains, so a dot is legal and would
+	// otherwise match any character in that position.
+	re := regexp.MustCompile(podsRegexForWorkload("Deployment", "app.v1"))
+	assert.True(t, re.MatchString("app.v1-7d9fkp2xz4-b5tqm"))
+	assert.False(t, re.MatchString("appxv1-7d9fkp2xz4-b5tqm"), "dot must not act as a wildcard")
+}
+
+func TestPodsRegexForWorkload_UnsupportedKindMatchesNothing(t *testing.T) {
+	assert.Empty(t, podsRegexForWorkload("ReplicaSet", "frontend"),
+		"an unknown kind must not fall back to a namespace-wide selector")
+}
+
+func TestBuildPromContainerQuery_NotPinnedToCurrentPodNames(t *testing.T) {
+	q := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromP957D, "cpu")
+	assert.Contains(t, q, "[7d:", "7d window in subquery range")
+
+	matcher := regexp.MustCompile("pod=~`([^`]+)`").FindStringSubmatch(q)
+	require.Len(t, matcher, 2, "query must carry a pod matcher in a raw literal")
+	re, err := regexp.Compile(matcher[1])
+	require.NoError(t, err)
+	assert.True(t, re.MatchString("frontend-5x9dkm2t7b-q4wzn"), "pod from the revision before the edit")
+	assert.True(t, re.MatchString("frontend-7fkp2xz4d9-m5tqb"), "pod from the revision after the edit")
+}
+
+func TestBuildPromContainerQuery_EmptyForUnsupportedKind(t *testing.T) {
+	assert.Empty(t, buildPromContainerQuery("default", "ReplicaSet", "frontend", model.StrategyPromP957D, "cpu"))
 }

--- a/internal/k8s/client_rightsizing_prom_test.go
+++ b/internal/k8s/client_rightsizing_prom_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,28 +24,28 @@ import (
 // --- buildPromContainerQuery ---
 
 func TestBuildPromContainerQuery_StrategyToPromQL(t *testing.T) {
-	maxQ := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromMax1D, "cpu")
+	maxQ := buildPromContainerQuery("default", "Deployment", "frontend", false, model.StrategyPromMax1D, "cpu")
 	assert.Contains(t, maxQ, "max_over_time", "1d-max strategy must use max_over_time")
 	assert.Contains(t, maxQ, "[1d:", "1d window in subquery range")
 	assert.Contains(t, maxQ, "container_cpu_usage_seconds_total", "CPU query targets cpu metric")
 	assert.Contains(t, maxQ, `namespace="default"`, "namespace label filter")
 	assert.Contains(t, maxQ, "frontend", "workload name in pod regex")
 
-	avgQ := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromAvg1D, "cpu")
+	avgQ := buildPromContainerQuery("default", "Deployment", "frontend", false, model.StrategyPromAvg1D, "cpu")
 	assert.Contains(t, avgQ, "avg_over_time", "1d-avg strategy must use avg_over_time")
 	assert.Contains(t, avgQ, "[1d:")
 
-	p95Q := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromP957D, "cpu")
+	p95Q := buildPromContainerQuery("default", "Deployment", "frontend", false, model.StrategyPromP957D, "cpu")
 	assert.Contains(t, p95Q, "quantile_over_time(0.95", "p95 strategy uses quantile_over_time")
 	assert.Contains(t, p95Q, "[7d:", "7d window in subquery range")
 
-	memQ := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromMax1D, "memory")
+	memQ := buildPromContainerQuery("default", "Deployment", "frontend", false, model.StrategyPromMax1D, "memory")
 	assert.Contains(t, memQ, "container_memory_working_set_bytes", "memory query targets memory metric")
 	assert.NotContains(t, memQ, "rate(", "memory uses gauge, no rate() wrapper")
 }
 
 func TestBuildPromContainerQuery_PodRegexEscapesSpecialChars(t *testing.T) {
-	q := buildPromContainerQuery("default", "Deployment", "app.v1", model.StrategyPromMax1D, "cpu")
+	q := buildPromContainerQuery("default", "Deployment", "app.v1", false, model.StrategyPromMax1D, "cpu")
 	assert.Contains(t, q, `app\.v1`, "regex metacharacters must be escaped")
 	assert.Contains(t, q, "pod=~`", "the matcher uses a raw PromQL literal so `\\.` survives unprocessed")
 }
@@ -237,10 +238,11 @@ func TestGetRightsizing_PrometheusQueryFailureLeavesSuggestionEmpty(t *testing.T
 
 func TestPodsRegexForWorkload_MatchesControllerPodShapes(t *testing.T) {
 	cases := []struct {
-		kind   string
-		name   string
-		match  []string
-		reject []string
+		kind    string
+		name    string
+		indexed bool
+		match   []string
+		reject  []string
 	}{
 		{
 			kind:  "Deployment",
@@ -266,18 +268,32 @@ func TestPodsRegexForWorkload_MatchesControllerPodShapes(t *testing.T) {
 			reject: []string{"postgres", "postgres-k4n2p"},
 		},
 		{
-			kind:   "Job",
-			name:   "backup",
-			match:  []string{"backup-k4n2p", "backup-3-k4n2p"},
-			reject: []string{"backup", "backup-k4n2p-x5tqm"},
+			kind:  "Job",
+			name:  "backup",
+			match: []string{"backup-k4n2p"},
+			// The last entry is a pod of a sibling Job "backup-3".
+			reject: []string{"backup", "backup-k4n2p-x5tqm", "backup-3-k4n2p"},
 		},
 		{
-			kind: "CronJob",
-			name: "nightly",
-			// The second form is a CronJob whose job template sets
-			// completionMode: Indexed, which inserts the index.
-			match:  []string{"nightly-29358720-k4n2p", "nightly-29358720-3-k4n2p"},
-			reject: []string{"nightly", "nightly-k4n2p"},
+			kind:    "Job",
+			name:    "backup",
+			indexed: true,
+			match:   []string{"backup-3-k4n2p"},
+			reject:  []string{"backup", "backup-k4n2p"},
+		},
+		{
+			kind:  "CronJob",
+			name:  "nightly",
+			match: []string{"nightly-29358720-k4n2p"},
+			// The last entry is a pod of a sibling CronJob "nightly-2".
+			reject: []string{"nightly", "nightly-k4n2p", "nightly-2-29358720-k4n2p"},
+		},
+		{
+			kind:    "CronJob",
+			name:    "nightly",
+			indexed: true,
+			match:   []string{"nightly-29358720-3-k4n2p"},
+			reject:  []string{"nightly", "nightly-29358720-k4n2p"},
 		},
 		{
 			kind:   "Pod",
@@ -287,8 +303,12 @@ func TestPodsRegexForWorkload_MatchesControllerPodShapes(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.kind, func(t *testing.T) {
-			re, err := regexp.Compile(podsRegexForWorkload(tc.kind, tc.name))
+		label := tc.kind
+		if tc.indexed {
+			label += "_indexed"
+		}
+		t.Run(label, func(t *testing.T) {
+			re, err := regexp.Compile(podsRegexForWorkload(tc.kind, tc.name, tc.indexed))
 			require.NoError(t, err, "generated regex must compile")
 			for _, p := range tc.match {
 				assert.True(t, re.MatchString(p), "%s should match", p)
@@ -303,7 +323,7 @@ func TestPodsRegexForWorkload_MatchesControllerPodShapes(t *testing.T) {
 func TestPodsRegexForWorkload_SurvivesRollout(t *testing.T) {
 	// Applying a recommendation rolls the workload, so every pod name
 	// changes and a selector pinned to the old names loses the window.
-	re := regexp.MustCompile(podsRegexForWorkload("Deployment", "frontend"))
+	re := regexp.MustCompile(podsRegexForWorkload("Deployment", "frontend", false))
 	assert.True(t, re.MatchString("frontend-5x9dkm2t7b-q4wzn"), "pod from the revision before the edit")
 	assert.True(t, re.MatchString("frontend-7fkp2xz4d9-m5tqb"), "pod from the revision after the edit")
 }
@@ -311,18 +331,18 @@ func TestPodsRegexForWorkload_SurvivesRollout(t *testing.T) {
 func TestPodsRegexForWorkload_EscapesDotsInWorkloadName(t *testing.T) {
 	// Deployment names are DNS subdomains, so a dot is legal and would
 	// otherwise match any character in that position.
-	re := regexp.MustCompile(podsRegexForWorkload("Deployment", "app.v1"))
+	re := regexp.MustCompile(podsRegexForWorkload("Deployment", "app.v1", false))
 	assert.True(t, re.MatchString("app.v1-7d9fkp2xz4-b5tqm"))
 	assert.False(t, re.MatchString("appxv1-7d9fkp2xz4-b5tqm"), "dot must not act as a wildcard")
 }
 
 func TestPodsRegexForWorkload_UnsupportedKindMatchesNothing(t *testing.T) {
-	assert.Empty(t, podsRegexForWorkload("ReplicaSet", "frontend"),
+	assert.Empty(t, podsRegexForWorkload("ReplicaSet", "frontend", false),
 		"an unknown kind must not fall back to a namespace-wide selector")
 }
 
 func TestBuildPromContainerQuery_NotPinnedToCurrentPodNames(t *testing.T) {
-	q := buildPromContainerQuery("default", "Deployment", "frontend", model.StrategyPromP957D, "cpu")
+	q := buildPromContainerQuery("default", "Deployment", "frontend", false, model.StrategyPromP957D, "cpu")
 	assert.Contains(t, q, "[7d:", "7d window in subquery range")
 
 	matcher := regexp.MustCompile("pod=~`([^`]+)`").FindStringSubmatch(q)
@@ -333,6 +353,35 @@ func TestBuildPromContainerQuery_NotPinnedToCurrentPodNames(t *testing.T) {
 	assert.True(t, re.MatchString("frontend-7fkp2xz4d9-m5tqb"), "pod from the revision after the edit")
 }
 
+func TestWorkloadIsIndexed_ReadsCompletionMode(t *testing.T) {
+	indexed := batchv1.IndexedCompletion
+	nonIndexed := batchv1.NonIndexedCompletion
+	cs := fake.NewSimpleClientset(
+		&batchv1.Job{
+			Name: "wide", Namespace: "default",
+			Spec: batchv1.JobSpec{CompletionMode: &indexed},
+		},
+		&batchv1.Job{
+			Name: "plain", Namespace: "default",
+			Spec: batchv1.JobSpec{CompletionMode: &nonIndexed},
+		},
+		&batchv1.CronJob{
+			Name: "fanout", Namespace: "default",
+			Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{CompletionMode: &indexed},
+			}},
+		},
+	)
+	c := NewTestClient(cs, nil)
+
+	assert.True(t, c.workloadIsIndexed(t.Context(), "test-ctx", "default", "Job", "wide"))
+	assert.False(t, c.workloadIsIndexed(t.Context(), "test-ctx", "default", "Job", "plain"))
+	assert.True(t, c.workloadIsIndexed(t.Context(), "test-ctx", "default", "CronJob", "fanout"))
+	assert.False(t, c.workloadIsIndexed(t.Context(), "test-ctx", "default", "Job", "missing"),
+		"a lookup failure falls back to the narrower pattern")
+	assert.False(t, c.workloadIsIndexed(t.Context(), "test-ctx", "default", "Deployment", "wide"))
+}
+
 func TestBuildPromContainerQuery_EmptyForUnsupportedKind(t *testing.T) {
-	assert.Empty(t, buildPromContainerQuery("default", "ReplicaSet", "frontend", model.StrategyPromP957D, "cpu"))
+	assert.Empty(t, buildPromContainerQuery("default", "ReplicaSet", "frontend", false, model.StrategyPromP957D, "cpu"))
 }


### PR DESCRIPTION
Closes the bug reported in #705 (comment of 2026-08-31): applying a `7d-p95` recommendation and re-checking in the same mode produced a second recommendation about 40 percent different.

## Cause

`buildPromContainerQuery` built its selector from `resolvePodsForWorkload`, which returns the pods running at query time:

```promql
pod=~"^(frontend-5x9dkm2t7b-q4wzn|frontend-5x9dkm2t7b-j2vbn)$"
```

Applying new requests or limits changes the pod spec, so the Deployment rolls and every pod name changes. The next query matched only pods that were minutes old, and `quantile_over_time(0.95, ...[7d:5m])` returned the p95 of those minutes. The overlay header still printed `window: 7d`, so nothing showed that the window was empty.

This also hits any workload that restarted inside the window, not only one that was just resized, and it applies to `1d-peak` and `1d-avg` as well.

## Fix

Select pods by the name shape the controller produces, so the window also covers revisions that no longer exist:

```promql
pod=~`^frontend-[bcdfghjklmnpqrstvwxz2456789]{1,10}-[bcdfghjklmnpqrstvwxz2456789]{5}$`
```

`podsRegexForWorkload` has a pattern per kind, following each controller's naming rule: Deployment (`<name>-<pod-template-hash>-<suffix>`), StatefulSet (ordinal), DaemonSet, Job (with the optional Indexed completion index), CronJob (Job named after its scheduled minute), and bare Pod. An unsupported kind returns `""` and the caller skips the query rather than selecting the whole namespace.

The character class is `rand.alphanums` from `k8s.io/apimachinery/pkg/util/rand`, the alphabet k8s generates name segments from. It has no vowels, which is what keeps a `foo` pattern off the pods of a sibling `foo-api`.

The pod matcher also moves into a raw PromQL literal (backticks). A double-quoted literal processes escapes and rejects the `\.` that `regexp.QuoteMeta` emits for a dotted workload name.

## Trade-offs

- The query now also reads pods from earlier revisions, which is where the history lives. A workload that was OOMKilled at its old limit will have its memory p95 capped by that limit, so the recommendation reads low. That was already true of any window longer than the current pods' age.
- Matching by shape is a heuristic, not a guarantee. A sibling workload whose extra name segment is all consonants and digits could match. Requires an unusual name and the same namespace.
- A workload name long enough for k8s to truncate the ReplicaSet name will not match its own pods. Noted in the code.

## Not in this PR

The overlay header still reports the selected window rather than the span the data actually covers. Filed separately.

## Test plan

- [x] `podsRegexForWorkload` table test: match and reject cases for all six kinds, including an Indexed Job and an Indexed CronJob
- [x] `TestPodsRegexForWorkload_SurvivesRollout`: pods from two different pod-template-hashes both match
- [x] `TestBuildPromContainerQuery_NotPinnedToCurrentPodNames`: extracts the matcher from the built query and checks both revisions against it
- [x] Every new test verified red against the old pinned-pod behaviour, not just green against the new code
- [x] `go test ./...` green, `make lint` reports 0 issues