### PR TITLE
fix: honor a configured path_prefix on discovered Prometheus services

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -345,7 +345,7 @@ When discovery finds nothing, lfk probes these names:
 | Prometheus | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `kube-prometheus-stack-prometheus`, `prometheus-kube-prometheus-prometheus`, `prometheus-server`, `prometheus`, `prometheus-operated` |
 | Alertmanager | `monitoring`, `prometheus`, `observability`, `kube-prometheus-stack` | `alertmanager-operated`, `alertmanager`, `prometheus-kube-prometheus-alertmanager`, `alertmanager-main` |
 
-Each Prometheus target is probed on its bare path first, then under `/prometheus` (kube-prometheus-stack `routePrefix`) and `/vm` (VictoriaMetrics `http.pathPrefix`). A configured `path_prefix` is probed as written. With `discover_path_prefix: true` lfk reads the prefix off the pods behind each discovered Service instead of guessing. If no pod carries a prefix flag, or the pod list is denied, the guesses above still run.
+Each Prometheus target is probed on its bare path first, then under `/prometheus` (kube-prometheus-stack `routePrefix`) and `/vm` (VictoriaMetrics `http.pathPrefix`). A configured `path_prefix` is probed as written, on named and discovered Services alike. With `discover_path_prefix: true` lfk reads the prefix off the pods behind each discovered Service instead of guessing. If no pod carries a prefix flag, or the pod list is denied, the guesses above still run.
 
 ### Metrics source
 

--- a/internal/k8s/monitoring_targets.go
+++ b/internal/k8s/monitoring_targets.go
@@ -142,7 +142,7 @@ func cachedMonitoringDiscovery(ctx context.Context, cs kubernetes.Interface, con
 		}
 		monitoringDiscoveryCache.Delete(contextName)
 	}
-	prom, am = discoverMonitoringServices(ctx, cs, namespaces, pathPrefixDiscoverer(ctx, cs, contextName))
+	prom, am = discoverMonitoringServices(ctx, cs, namespaces, configuredPathPrefix(contextName), pathPrefixDiscoverer(ctx, cs, contextName))
 	logger.Debug("monitoring service discovery finished",
 		"context", contextName, "prometheus", prom, "alertmanager", am)
 	monitoringDiscoveryCache.Store(contextName, monitoringDiscoveryEntry{prom: prom, am: am, at: time.Now()})
@@ -177,12 +177,22 @@ var monitoringSelectors = []string{
 // discoverMonitoringServices finds monitoring Services by their component
 // labels. The cluster-wide list comes first because it also finds a stack
 // outside the well-known namespaces, but a user may lack that permission.
-func discoverMonitoringServices(ctx context.Context, cs kubernetes.Interface, namespaces []string, prefixFor func(*corev1.Service) string) (prom, am []monitoringTarget) {
+func discoverMonitoringServices(ctx context.Context, cs kubernetes.Interface, namespaces []string, configured string, prefixFor func(*corev1.Service) string) (prom, am []monitoringTarget) {
 	found := make([]corev1.Service, 0, len(monitoringSelectors))
 	for _, selector := range monitoringSelectors {
 		found = append(found, listMonitoringServices(ctx, cs, namespaces, selector)...)
 	}
-	return targetsFromServices(preferWellKnownNamespaces(dedupeServices(found), namespaces), prefixFor)
+	return targetsFromServices(preferWellKnownNamespaces(dedupeServices(found), namespaces), configured, prefixFor)
+}
+
+// configuredPathPrefix returns the prometheus.path_prefix the context set, or
+// "" when it left the prefix to discovery.
+func configuredPathPrefix(contextName string) string {
+	mc, ok := monitoringConfigFor(contextName)
+	if !ok || mc.Prometheus == nil {
+		return ""
+	}
+	return mc.Prometheus.PathPrefix
 }
 
 // pathPrefixDiscoverer returns the pod-args lookup when the context opted in
@@ -292,7 +302,9 @@ func serviceRole(svc *corev1.Service) monitoringRole {
 
 // targetsFromServices turns discovered Services into probe targets. The port
 // comes from the Service itself, so a stack on a non-default port still works.
-func targetsFromServices(services []corev1.Service, prefixFor func(*corev1.Service) string) (prom, am []monitoringTarget) {
+// A configured prefix already holds the vmselect tenant segment, unlike the
+// server flag the pod-args lookup yields, so it is probed as written.
+func targetsFromServices(services []corev1.Service, configured string, prefixFor func(*corev1.Service) string) (prom, am []monitoringTarget) {
 	for i := range services {
 		svc := &services[i]
 		p := servicePort(svc)
@@ -301,7 +313,11 @@ func targetsFromServices(services []corev1.Service, prefixFor func(*corev1.Servi
 		}
 		base := monitoringTarget{Namespace: svc.Namespace, Service: svc.Name, Port: p}
 		role := serviceRole(svc)
-		if prefixFor != nil && (role == rolePrometheus || role == roleVMSelect) {
+		queryRole := role == rolePrometheus || role == roleVMSelect
+		switch {
+		case queryRole && configured != "":
+			base.Prefix, base.fixedPrefix = configured, true
+		case queryRole && prefixFor != nil:
 			if found := prefixFor(svc); found != "" {
 				base.Prefix, base.fixedPrefix = found, true
 			}
@@ -310,6 +326,10 @@ func targetsFromServices(services []corev1.Service, prefixFor func(*corev1.Servi
 		case rolePrometheus:
 			prom = append(prom, base)
 		case roleVMSelect:
+			if configured != "" {
+				prom = append(prom, base)
+				continue
+			}
 			prom = append(prom,
 				withPrefix(base, base.Prefix+vmSelectTenantPrefix),
 				withPrefix(base, base.Prefix+vmSelectMultitenantPrefix))

--- a/internal/k8s/monitoring_targets_test.go
+++ b/internal/k8s/monitoring_targets_test.go
@@ -68,7 +68,7 @@ func TestTargetsFromServices(t *testing.T) {
 	t.Run("maps vmselect to the tenant query prefixes", func(t *testing.T) {
 		svcs := []corev1.Service{*monitoringSvc("monitoring", "vmselect-vmks", "vmselect", port("http", 8481))}
 
-		prom, am := targetsFromServices(svcs, nil)
+		prom, am := targetsFromServices(svcs, "", nil)
 
 		assert.Empty(t, am)
 		require.Len(t, prom, 2)
@@ -79,7 +79,7 @@ func TestTargetsFromServices(t *testing.T) {
 	t.Run("maps vmsingle to the root query path", func(t *testing.T) {
 		svcs := []corev1.Service{*monitoringSvc("vm", "vmsingle-vmks", "vmsingle", port("http", 8428))}
 
-		prom, _ := targetsFromServices(svcs, nil)
+		prom, _ := targetsFromServices(svcs, "", nil)
 
 		require.Len(t, prom, 1)
 		assert.Equal(t, monitoringTarget{Namespace: "vm", Service: "vmsingle-vmks", Port: "8428", Prefix: ""}, prom[0])
@@ -89,7 +89,7 @@ func TestTargetsFromServices(t *testing.T) {
 		svcs := []corev1.Service{*monitoringSvc("monitoring", "vmalertmanager-vmks", "vmalertmanager",
 			port("web", 9093), port("tcp-mesh", 9094))}
 
-		prom, am := targetsFromServices(svcs, nil)
+		prom, am := targetsFromServices(svcs, "", nil)
 
 		assert.Empty(t, prom)
 		require.Len(t, am, 1)
@@ -102,7 +102,7 @@ func TestTargetsFromServices(t *testing.T) {
 			*monitoringSvc("monitoring", "kps-alertmanager", "alertmanager", port("http-web", 9093)),
 		}
 
-		prom, am := targetsFromServices(svcs, nil)
+		prom, am := targetsFromServices(svcs, "", nil)
 
 		require.Len(t, prom, 1)
 		require.Len(t, am, 1)
@@ -117,10 +117,42 @@ func TestTargetsFromServices(t *testing.T) {
 			*monitoringSvc("monitoring", "vmselect-broken", "vmselect"),
 		}
 
-		prom, am := targetsFromServices(svcs, nil)
+		prom, am := targetsFromServices(svcs, "", nil)
 
 		assert.Empty(t, prom)
 		assert.Empty(t, am)
+	})
+
+	t.Run("a configured prefix replaces the vmselect tenant guesses", func(t *testing.T) {
+		svcs := []corev1.Service{*monitoringSvc("monitoring", "vmselect-vmks", "vmselect", port("http", 8481))}
+
+		prom, _ := targetsFromServices(svcs, "/vm/select/0/prometheus", nil)
+
+		require.Len(t, prom, 1)
+		assert.Equal(t, monitoringTarget{
+			Namespace: "monitoring", Service: "vmselect-vmks", Port: "8481",
+			Prefix: "/vm/select/0/prometheus", fixedPrefix: true,
+		}, prom[0])
+	})
+
+	t.Run("a configured prefix pins a prometheus service and beats the pod lookup", func(t *testing.T) {
+		svcs := []corev1.Service{*monitoringSvc("monitoring", "kps-prometheus", "prometheus", port("http-web", 9090))}
+		fromPods := func(*corev1.Service) string { return "/from-pods" }
+
+		prom, _ := targetsFromServices(svcs, "/prometheus", fromPods)
+
+		require.Len(t, prom, 1)
+		assert.Equal(t, "/prometheus", prom[0].Prefix)
+		assert.True(t, prom[0].fixedPrefix)
+	})
+
+	t.Run("a configured prefix leaves alertmanager alone", func(t *testing.T) {
+		svcs := []corev1.Service{*monitoringSvc("monitoring", "vmalertmanager-vmks", "vmalertmanager", port("web", 9093))}
+
+		_, am := targetsFromServices(svcs, "/vm/select/0/prometheus", nil)
+
+		require.Len(t, am, 1)
+		assert.Equal(t, "", am[0].Prefix)
 	})
 }
 
@@ -133,7 +165,7 @@ func TestDiscoverMonitoringServices(t *testing.T) {
 			monitoringSvc("default", "web", "nginx", port("http", 80)),
 		)
 
-		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
+		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, "", nil)
 
 		assert.Empty(t, am)
 		require.Len(t, prom, 2)
@@ -149,7 +181,7 @@ func TestDiscoverMonitoringServices(t *testing.T) {
 			return false, nil, nil
 		})
 
-		prom, _ := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
+		prom, _ := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, "", nil)
 
 		require.Len(t, prom, 1)
 		assert.Equal(t, "vmsingle-vmks", prom[0].Service)
@@ -161,7 +193,7 @@ func TestDiscoverMonitoringServices(t *testing.T) {
 			return true, nil, assert.AnError
 		})
 
-		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
+		prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, "", nil)
 
 		assert.Empty(t, prom)
 		assert.Empty(t, am)
@@ -510,7 +542,7 @@ func TestDiscoverKubePrometheusStack(t *testing.T) {
 
 	cs := k8sfake.NewClientset(promOperated, amOperated, chartProm)
 
-	prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, nil)
+	prom, am := discoverMonitoringServices(t.Context(), cs, []string{"monitoring"}, "", nil)
 
 	require.Len(t, prom, 1)
 	assert.Equal(t, "prometheus-operated", prom[0].Service)
@@ -525,7 +557,7 @@ func TestDiscoverMonitoringServicesDedupes(t *testing.T) {
 	svc := monitoringSvc("monitoring", "prometheus-operated", "prometheus", port("web", 9090))
 	svc.Labels["operated-prometheus"] = "true"
 
-	prom, _ := discoverMonitoringServices(t.Context(), k8sfake.NewClientset(svc), []string{"monitoring"}, nil)
+	prom, _ := discoverMonitoringServices(t.Context(), k8sfake.NewClientset(svc), []string{"monitoring"}, "", nil)
 
 	assert.Len(t, prom, 1)
 }
@@ -540,7 +572,7 @@ func TestDiscoveryPrefersWellKnownNamespaces(t *testing.T) {
 		monitoringSvc("monitoring", "vmsingle-real", "vmsingle", port("http", 8428)),
 	)
 
-	prom, _ := discoverMonitoringServices(t.Context(), cs, defaultMonitoringNamespaces, nil)
+	prom, _ := discoverMonitoringServices(t.Context(), cs, defaultMonitoringNamespaces, "", nil)
 
 	require.Len(t, prom, 2)
 	assert.Equal(t, "vmsingle-real", prom[0].Service, "the well-known namespace is probed first")
@@ -697,4 +729,32 @@ func TestDiscoverMonitoringServicesAppliesTheFoundPrefixWhenOptedIn(t *testing.T
 	require.Len(t, prom, 2)
 	assert.Equal(t, vmSelectTenantPrefix, prom[0].Prefix)
 	assert.False(t, prom[0].fixedPrefix)
+}
+
+// Issue #699: a context that sets path_prefix but names no services still
+// runs discovery, and the discovered vmselect must be probed at the configured
+// path only. The bare tenant guesses log a warning on every poll otherwise.
+func TestDiscoveredTargetsUseTheConfiguredPathPrefix(t *testing.T) {
+	resetMonitoringDiscoveryCache()
+	orig := model.ConfigMonitoring
+	t.Cleanup(func() { model.ConfigMonitoring = orig })
+	model.ConfigMonitoring = map[string]model.MonitoringConfig{
+		"_global":    {Prometheus: &model.MonitoringEndpoint{PathPrefix: "/prometheus"}},
+		"vm-cluster": {Prometheus: &model.MonitoringEndpoint{PathPrefix: "/vm/select/0/prometheus"}},
+	}
+	cs := k8sfake.NewClientset(
+		monitoringSvc("monitoring", "vmselect-vmks", "vmselect", port("http", 8481)),
+		monitoringSvc("monitoring", "vmalertmanager-vmks", "vmalertmanager", port("web", 9093)),
+	)
+
+	prom, am := monitoringTargetsFor(t.Context(), cs, "vm-cluster")
+
+	require.NotEmpty(t, prom)
+	assert.Equal(t, "/vm/select/0/prometheus/api/v1/query", prom[0].path("/api/v1/query"))
+	for _, tgt := range prom {
+		assert.Equal(t, "/vm/select/0/prometheus", tgt.Prefix, "every probe carries the configured prefix: %s", tgt)
+		assert.True(t, tgt.fixedPrefix, "%s", tgt)
+	}
+	require.NotEmpty(t, am)
+	assert.Equal(t, "", am[0].Prefix)
 }


### PR DESCRIPTION
## Summary

- A context that sets `prometheus.path_prefix` but names no services still runs label discovery. The discovered vmselect targets were probed with the built-in tenant guesses (`/select/0/prometheus`, `/select/multitenant/prometheus`) and ignored the configured prefix. On a VictoriaMetrics install behind `-http.pathPrefix` each poll logged two missing-prefix warnings on the server side before the `/vm` fallback landed.
- Discovered Prometheus and vmselect targets now take the configured prefix as a fixed path and skip the tenant guesses. The configured prefix beats `discover_path_prefix`.
- One sentence in `docs/config-reference.md` says the prefix applies to discovered Services too.

Fixes #699

## Test plan

- [x] `TestTargetsFromServices` gains cases for a configured prefix on vmselect, on Prometheus with the pod lookup present, and for Alertmanager staying untouched
- [x] `TestDiscoveredTargetsUseTheConfiguredPathPrefix` reproduces the reporter's config through `monitoringTargetsFor` and asserts every Prometheus probe carries `/vm/select/0/prometheus`
- [x] `go test ./...` and `golangci-lint run` green
- [ ] Reporter confirms the vmselect warnings stop with their config on the release build
