### PR TITLE
fix: refresh the nix vendorHash and fail CI when it goes stale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,21 @@ jobs:
 
       - name: Run govulncheck
         run: govulncheck ./...
+
+  # A dependency bump changes go.sum and invalidates the flake's vendorHash.
+  # Failing the PR here keeps a stale hash out of main and out of every
+  # release tag (#62, #284, #341, #719).
+  verify-vendor-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Verify vendorHash matches go.sum
+        run: make verify-vendor-hash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,13 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      # pipefail is required: without it the step reports tee's exit code, and
+      # 0.18.6 shipped with a stale vendorHash past a green build (#719).
       - name: Build flake
         id: build
-        run: nix build .#default --no-link 2>&1 | tee build.log
+        run: |
+          set -o pipefail
+          nix build .#default --no-link 2>&1 | tee build.log
 
       - name: Explain stale-hash failure
         if: failure() && steps.build.outcome == 'failure'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Typical flow:
    2. Run `make refresh-vendor-hash` so `vendorHash` matches the new vendored module set.
    3. Push the change to the PR branch.
 
-   (`verify-flake-build` in `release.yml` catches a stale hash if you forget this step.)
+   (`verify-vendor-hash` in `ci.yml` fails any PR that carries a stale hash, and `verify-flake-build` in `release.yml` builds the full flake before publishing.)
 4. Merge the Release PR. release-please tags the merge commit (e.g. `v0.9.33`), and `release.yml` takes over to publish the release.
 
 For emergency manual releases (skipping the bot), `make bump-version VERSION=X.Y.Z` and `make release VERSION=X.Y.Z` remain available. The `verify-flake-version` job in `release.yml` is the safety net that prevents a tag/`flake.nix` mismatch.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint lint-fix test e2e coverage fuzz build generate-themes sonar bump-version refresh-vendor-hash release goreleaser-check
+.PHONY: setup lint lint-fix test e2e coverage fuzz build generate-themes sonar bump-version refresh-vendor-hash verify-vendor-hash release goreleaser-check
 
 setup:
 	git config core.hooksPath .githooks
@@ -36,6 +36,20 @@ refresh-vendor-hash: ## Recompute vendorHash in flake.nix from current go.sum (r
 	rm flake.nix.orig; \
 	echo "Updated vendorHash to $$NEW_HASH"
 	@grep -n "vendorHash" flake.nix
+
+# Builds only the vendored-modules derivation, so a stale hash surfaces in
+# about a minute without compiling lfk. CI runs this on every PR (#719).
+verify-vendor-hash: ## Check that vendorHash in flake.nix matches go.sum (requires nix)
+	@command -v nix >/dev/null 2>&1 || { \
+		echo "error: nix is required to verify vendorHash (https://nixos.org/download)"; exit 1; \
+	}
+	@nix build .#default.goModules --no-link --extra-experimental-features 'nix-command flakes' || { \
+		echo ""; \
+		echo "error: nix could not fetch the vendored modules recorded in flake.nix."; \
+		echo "       'hash mismatch' above means vendorHash is stale: run 'make refresh-vendor-hash' and commit flake.nix."; \
+		exit 1; \
+	}
+	@echo "vendorHash matches go.sum"
 
 release: setup ## Bump version, commit, and create tag in one step (usage: make release VERSION=0.9.23)
 	@if [ -z "$(VERSION)" ]; then \

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-UBm+debRps5XRCJBXjik1akjUgoY5prQ+2v0Hzy9jfQ=";
+            vendorHash = "sha256-MG3CKXdDoqyV9uissBW51rEHBBDGec1kbl1kqTHx9+I=";
 
             subPackages = [ "." ];
 


### PR DESCRIPTION
Closes #719.

## Summary

- Refresh `vendorHash` in `flake.nix` so `nix build github:janosmiko/lfk` works again on 0.18.6.
- Fix the release gate that let the stale hash through. `verify-flake-build` piped `nix build` through `tee` in a step with no `pipefail`, so the v0.18.6 run logged `hash mismatch` and still passed. The step now sets `pipefail`.
- Add a `verify-vendor-hash` job to `ci.yml`. It runs `make verify-vendor-hash`, which builds only the vendored-modules derivation (`.#default.goModules`), so a dependency bump with a stale hash fails the PR in about a minute instead of failing everyone's `nix build` after the release.

## Why the old gate did not fire

The default `run:` shell in GitHub Actions is `bash -e` without `pipefail`. The pipeline `nix build ... | tee build.log` reports tee's exit code, which is 0. The v0.18.6 release run shows the mismatch in the `verify-flake-build` log with a green job.

## Test plan

- [x] `nix build .#default` on this branch builds and `lfk --version` reports v0.18.6
- [x] `make verify-vendor-hash` passes with the real hash and fails with a clear message when `vendorHash` is set to a fake value
- [x] `actionlint` on both workflows
- [x] `verify-vendor-hash` job is green on this PR (39s)

After merge, add `verify-vendor-hash` to the required status checks on the `main` ruleset so a red dependabot PR cannot be merged.
