### PR TITLE
fix: keep the right-sizing overlay loading after a picker press mid-fetch

### DIFF
--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -312,8 +312,8 @@ type syncWaveState struct {
 //     yet" and the overlay shows a loading state.
 //   - loading is true while a fetch is in flight.
 //   - err surfaces a non-recoverable error from the fetch.
-//   - gen guards against stale-fetch races (overlay closed + reopened
-//     with a different workload before a slow fetch returns).
+//   - gen drops a strategy probe that answers a previous overlay open.
+//     Data fetches are matched by cache key instead.
 //   - scroll is the visible-row offset within the overlay's table when
 //     it overflows the visible height.
 //   - strategy is the currently-selected recommendation algorithm.

--- a/internal/app/commands_load_overlays.go
+++ b/internal/app/commands_load_overlays.go
@@ -31,9 +31,9 @@ func rightsizingCacheKey(ctx, ns, kind, name string, strategy model.RightsizingS
 // first frame; cache miss runs the GetRightsizing call in a
 // goroutine via a tea.Cmd.
 //
-// The generation token is captured at dispatch and round-tripped
-// through the msg so the handler can drop late responses (overlay
-// closed + reopened with a different workload before this finished).
+// The task name carries strategy and headroom: the scheduler folds a
+// submission into a running task with the same name, so a shared name
+// would leave a picker press during a slow fetch with no fetch at all.
 func (m Model) loadRightsizing() tea.Cmd {
 	ctx := m.actionCtx
 	if ctx.kind == "" || ctx.name == "" {
@@ -42,11 +42,10 @@ func (m Model) loadRightsizing() tea.Cmd {
 	strategy := m.rightsizing.strategy
 	headroom := m.rightsizing.headroom
 	key := rightsizingCacheKey(ctx.context, ctx.namespace, ctx.kind, ctx.name, strategy, headroom)
-	gen := m.rightsizing.gen
 
 	if cached, ok := m.rightsizingCache[key]; ok && cached != nil {
 		return func() tea.Msg {
-			return rightsizingLoadedMsg{key: key, data: cached, generation: gen}
+			return rightsizingLoadedMsg{key: key, data: cached}
 		}
 	}
 
@@ -54,11 +53,11 @@ func (m Model) loadRightsizing() tea.Cmd {
 	return m.scheduleK8sCall(
 		scheduler.PriorityLow,
 		scheduler.KindMetrics,
-		"Rightsizing: "+ctx.name,
+		fmt.Sprintf("Rightsizing: %s (%s, %gx)", ctx.name, strategy.HumanLabel(), headroom),
 		bgtaskTarget(ctx.context, ctx.namespace),
 		func(reqCtx context.Context) tea.Msg {
 			data, err := client.GetRightsizing(reqCtx, ctx.context, ctx.namespace, ctx.kind, ctx.name, strategy, headroom)
-			return rightsizingLoadedMsg{key: key, data: data, err: err, generation: gen}
+			return rightsizingLoadedMsg{key: key, data: data, err: err}
 		},
 	)
 }

--- a/internal/app/commands_load_overlays_test.go
+++ b/internal/app/commands_load_overlays_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -26,7 +28,6 @@ func TestLoadRightsizing_CacheHitReturnsSync(t *testing.T) {
 	assert.Equal(t, key, msg.key)
 	assert.Same(t, cached, msg.data, "cache hit returns the same pointer (no copy)")
 	assert.NoError(t, msg.err)
-	assert.Equal(t, 7, msg.generation, "generation captured at dispatch time")
 }
 
 func TestRightsizingCacheKey_IncludesStrategy(t *testing.T) {
@@ -63,54 +64,75 @@ func TestLoadRightsizing_NoActionContext_ReturnsNil(t *testing.T) {
 	assert.Nil(t, cmd, "no actionCtx → no fetch")
 }
 
-func TestUpdateRightsizingLoaded_StaleGenDiscarded(t *testing.T) {
-	m := Model{rightsizingCache: make(map[string]*model.Rightsizing)}
-	m.rightsizing.gen = 5
-	existing := &model.Rightsizing{Source: "VPA", PodCount: 2}
-	m.rightsizing.data = existing
+// The scheduler folds a resubmission into a running task with the same
+// identity, so a shared name would leave a `]` press with no fetch (#705).
+func TestLoadRightsizing_StrategyAndHeadroomChangeTaskIdentity(t *testing.T) {
+	m := newRightsizingTestModel()
+	m.rightsizing.data = nil
+	m.scheduler = scheduler.New(0)
 
-	stale := rightsizingLoadedMsg{
-		key:        "ctx/ns/Pod/p",
-		data:       &model.Rightsizing{Source: "estimated"},
-		generation: 3, // older than current gen
+	require.NotNil(t, m.loadRightsizing())
+	m.rightsizing.strategy = model.StrategySnapshot
+	require.NotNil(t, m.loadRightsizing())
+	m.rightsizing.headroom = 1.5
+	require.NotNil(t, m.loadRightsizing())
+
+	names := map[string]bool{}
+	for _, e := range m.scheduler.QueueSnapshot() {
+		names[e.Name] = true
 	}
-	r := m.updateRightsizingLoaded(stale)
-	assert.Same(t, existing, r.rightsizing.data, "stale msg must NOT replace current data")
-	_, present := r.rightsizingCache["ctx/ns/Pod/p"]
-	assert.False(t, present, "stale msg must NOT populate cache")
+	assert.Len(t, names, 3, "each strategy/headroom pair must be its own scheduler task")
 }
 
-func TestUpdateRightsizingLoaded_FreshSetsDataAndCaches(t *testing.T) {
-	m := Model{rightsizingCache: make(map[string]*model.Rightsizing)}
-	m.rightsizing.gen = 5
+func TestUpdateRightsizingLoaded_OtherKeyOnlyWarmsCache(t *testing.T) {
+	m := newRightsizingTestModel()
+	existing := m.rightsizing.data
 	m.rightsizing.loading = true
 
+	other := rightsizingLoadedMsg{
+		key:  "ctx/ns/Pod/p",
+		data: &model.Rightsizing{Source: "estimated"},
+	}
+	r := m.updateRightsizingLoaded(other)
+	assert.Same(t, existing, r.rightsizing.data, "other-key msg must NOT replace current data")
+	assert.True(t, r.rightsizing.loading, "other-key msg must NOT end the current fetch's loading state")
+	assert.Same(t, other.data, r.rightsizingCache["ctx/ns/Pod/p"], "other-key msg still warms the cache")
+}
+
+// The scheduler may have folded a newer submission into an older fetch,
+// so the gen that dispatched a result must not decide whether it is shown.
+func TestUpdateRightsizingLoaded_MatchingKeyAcceptedAcrossGen(t *testing.T) {
+	m := newRightsizingTestModel()
+	m.rightsizing.data = nil
+	m.rightsizing.loading = true
+	m.rightsizing.gen = 5
+	key := rightsizingCacheKey("c", "ns", "Pod", "pod-a", model.StrategyVPA, model.DefaultRightsizingHeadroom)
+
 	fresh := rightsizingLoadedMsg{
-		key:        "ctx/ns/Pod/p",
-		data:       &model.Rightsizing{Source: "VPA", PodCount: 3},
-		generation: 5, // matches current gen
+		key:  key,
+		data: &model.Rightsizing{Source: "VPA", PodCount: 3},
 	}
 	r := m.updateRightsizingLoaded(fresh)
-	assert.False(t, r.rightsizing.loading, "fresh msg flips loading off")
+	assert.False(t, r.rightsizing.loading, "matching key ends the loading state")
 	assert.Equal(t, "VPA", r.rightsizing.data.Source)
-	cached := r.rightsizingCache["ctx/ns/Pod/p"]
+	cached := r.rightsizingCache[key]
 	assert.NotNil(t, cached)
 	assert.Equal(t, 3, cached.PodCount)
 }
 
 func TestUpdateRightsizingLoaded_ErrorSurfacedNotCached(t *testing.T) {
-	m := Model{rightsizingCache: make(map[string]*model.Rightsizing)}
-	m.rightsizing.gen = 5
+	m := newRightsizingTestModel()
+	m.rightsizing.data = nil
 	m.rightsizing.loading = true
+	key := rightsizingCacheKey("c", "ns", "Pod", "pod-a", model.StrategyVPA, model.DefaultRightsizingHeadroom)
 
 	errMsg := rightsizingLoadedMsg{
-		key:        "ctx/ns/Pod/p",
-		err:        assert.AnError,
-		generation: 5,
+		key: key,
+		err: assert.AnError,
 	}
 	r := m.updateRightsizingLoaded(errMsg)
 	assert.False(t, r.rightsizing.loading)
 	assert.NotNil(t, r.rightsizing.err)
-	_, present := r.rightsizingCache["ctx/ns/Pod/p"]
+	_, present := r.rightsizingCache[key]
 	assert.False(t, present, "error response must NOT pollute the cache")
 }

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -416,13 +416,12 @@ type secretDataLoadedMsg struct {
 }
 
 // rightsizingLoadedMsg carries the lazily-fetched right-sizing
-// recommendations. Generation token guards against stale-fetch
-// races (see Model.rightsizing.gen).
+// recommendations. The handler shows the result only when key still
+// names the view on screen. A successful result is cached either way.
 type rightsizingLoadedMsg struct {
-	key        string // cache key the fetch was dispatched for
-	data       *model.Rightsizing
-	err        error
-	generation int
+	key  string // cache key the fetch was dispatched for
+	data *model.Rightsizing
+	err  error
 }
 
 // rightsizingStrategiesProbedMsg carries the result of an async probe

--- a/internal/app/update_actions_rightsizing.go
+++ b/internal/app/update_actions_rightsizing.go
@@ -12,8 +12,8 @@ import (
 // current actionCtx. Cache hit pre-fills m.rightsizing.data so the
 // overlay opens with data on the first frame; cache miss flips
 // m.rightsizing.loading=true while loadRightsizing fetches in a
-// goroutine. The generation token is bumped before dispatch so any
-// in-flight fetch from a previous open is dropped on arrival.
+// goroutine. The generation token is bumped before dispatch so a
+// strategy probe from a previous open is dropped on arrival.
 //
 // Strategy availability (VPA reachable, Prometheus configured,
 // snapshot always) is probed ASYNCHRONOUSLY — the underlying
@@ -70,7 +70,7 @@ func (m Model) executeActionRightsizing() (tea.Model, tea.Cmd) {
 
 	// Reset the per-workload transient fields. data is recomputed by
 	// the loader (cache hit short-circuits below); err / scroll start
-	// fresh; gen bumps so a slow fetch from a prior open is ignored.
+	// fresh. gen bumps so a slow probe from a prior open is ignored.
 	m.rightsizing.data = nil
 	m.rightsizing.err = nil
 	m.rightsizing.scroll = 0

--- a/internal/app/update_metrics_msgs.go
+++ b/internal/app/update_metrics_msgs.go
@@ -483,28 +483,29 @@ func ensureNodeMetricsColumnsPlaceholder(item *model.Item) {
 	item.Columns = newCols
 }
 
-// updateRightsizingLoaded handles the rightsizingLoadedMsg. Stale
-// generation discarded (overlay closed + reopened with a different
-// workload before this fetch returned). Otherwise stores the result
-// in m.rightsizing (or m.rightsizing.err) and caches it for re-opens.
-//
-// Errors are NOT cached — the next overlay open will retry instead
-// of replaying the stale failure.
+// updateRightsizingLoaded handles the rightsizingLoadedMsg. The key,
+// not a generation counter, decides whether the result is shown: the
+// scheduler may fold a newer submission into an older fetch of the
+// same key. Errors are NOT cached so the next open retries.
 func (m Model) updateRightsizingLoaded(msg rightsizingLoadedMsg) Model {
-	if msg.generation != m.rightsizing.gen {
-		return m // late response from a previous overlay open — discard
-	}
-	m.rightsizing.loading = false
+	current := rightsizingCacheKey(m.actionCtx.context, m.actionCtx.namespace, m.actionCtx.kind, m.actionCtx.name, m.rightsizing.strategy, m.rightsizing.headroom)
 	if msg.err != nil {
-		m.rightsizing.err = msg.err
+		if msg.key == current {
+			m.rightsizing.loading = false
+			m.rightsizing.err = msg.err
+		}
 		return m
 	}
-	m.rightsizing.err = nil
-	m.rightsizing.data = msg.data
 	if m.rightsizingCache == nil {
 		m.rightsizingCache = make(map[string]*model.Rightsizing)
 	}
 	m.rightsizingCache[msg.key] = msg.data
+	if msg.key != current {
+		return m
+	}
+	m.rightsizing.loading = false
+	m.rightsizing.err = nil
+	m.rightsizing.data = msg.data
 	return m
 }
 
@@ -528,18 +529,15 @@ func (m Model) updateRightsizingStrategiesProbed(msg rightsizingStrategiesProbed
 	m.rightsizing.available = msg.available
 	if slices.Contains(msg.available, m.rightsizing.strategy) {
 		// Sticky strategy survived the probe — no-op reconciliation.
-		// Don't bump gen / fire another load: the data fetch dispatched
-		// alongside the probe is still valid.
+		// Don't fire another load: the data fetch dispatched alongside
+		// the probe is still valid.
 		return m, nil
 	}
 	// Sticky strategy is unavailable on this workload. Re-pick from
-	// the fresh list and reload data for the new strategy. Bumping
-	// gen ensures the original load (which will be for the wrong
-	// strategy) is dropped on arrival. Clearing err prevents a stale
-	// error from the optimistic-strategy load from masking the
-	// re-picked strategy's data.
+	// the fresh list and reload data for the new strategy. Clearing
+	// err prevents a stale error from the optimistic-strategy load
+	// from masking the re-picked strategy's data.
 	m.rightsizing.strategy = pickRightsizingStrategy(m.rightsizing.strategy, msg.available)
-	m.rightsizing.gen++
 	m.rightsizing.scroll = 0
 	m.rightsizing.err = nil
 

--- a/internal/app/update_overlays_rightsizing.go
+++ b/internal/app/update_overlays_rightsizing.go
@@ -42,7 +42,6 @@ func (m Model) handleRightsizingOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.
 		m.rightsizing.data = nil
 		m.rightsizing.err = nil
 		m.rightsizing.loading = true
-		m.rightsizing.gen++
 		return m, m.loadRightsizing()
 	case "y":
 		yaml := buildRightsizingYAML(m.rightsizing.data)
@@ -142,11 +141,8 @@ func (m Model) cycleRightsizingHeadroom(direction int) (tea.Model, tea.Cmd) {
 	)
 
 	// Fast path 1: cache hit — swap to the cluster-fresh entry without
-	// flashing through a loading state. Bump gen so any in-flight prior
-	// fetch (e.g. from the previous strategy/headroom open) is dropped
-	// on arrival rather than overwriting the cache hit.
+	// flashing through a loading state.
 	if cached, ok := m.rightsizingCache[cacheKey]; ok && cached != nil {
-		m.rightsizing.gen++
 		m.rightsizing.data = cached
 		m.rightsizing.err = nil
 		m.rightsizing.loading = false
@@ -189,7 +185,6 @@ func (m Model) cycleRightsizingHeadroom(direction int) (tea.Model, tea.Cmd) {
 	m.rightsizing.data = nil
 	m.rightsizing.err = nil
 	m.rightsizing.loading = true
-	m.rightsizing.gen++
 	return m, m.loadRightsizing()
 }
 
@@ -273,12 +268,8 @@ func (m Model) cycleRightsizingStrategy(direction int) (tea.Model, tea.Cmd) {
 	)
 
 	// Fast path: cache hit on the new strategy + same headroom — swap
-	// to the cluster-fresh entry without flashing. Bump gen so any
-	// in-flight prior strategy fetch is dropped on arrival rather
-	// than overwriting the cache hit (the late response would still
-	// match the old generation otherwise and silently win).
+	// to the cluster-fresh entry without flashing.
 	if cached, ok := m.rightsizingCache[cacheKey]; ok && cached != nil {
-		m.rightsizing.gen++
 		m.rightsizing.data = cached
 		m.rightsizing.err = nil
 		m.rightsizing.loading = false
@@ -295,7 +286,6 @@ func (m Model) cycleRightsizingStrategy(direction int) (tea.Model, tea.Cmd) {
 	m.rightsizing.err = nil
 	m.rightsizing.scroll = 0
 	m.rightsizing.loading = true
-	m.rightsizing.gen++
 	return m, m.loadRightsizing()
 }
 

--- a/internal/app/update_overlays_rightsizing_test.go
+++ b/internal/app/update_overlays_rightsizing_test.go
@@ -479,18 +479,15 @@ func TestUpdateOverlayRightsizing_HeadroomPickerSkipsRescaleWhileLoading(t *test
 	// that window must NOT rescale-and-cache the stale payload under
 	// the new (strategy, headroom) key — the in-flight response will
 	// land later and overwrite the user's selection. Fall through to
-	// the async path instead and bump gen so the older fetch is
-	// dropped on arrival.
+	// the async path instead.
 	m := newRightsizingTestModel()
 	m.rightsizing.headroom = model.DefaultRightsizingHeadroom
 	m.rightsizing.loading = true // simulate mid-fetch from a prior strategy switch
-	prevGen := m.rightsizing.gen
 
 	ret, cmd := m.handleRightsizingOverlayKey(runeKey('>'))
 	r := ret.(Model)
 	assert.NotNil(t, cmd, "loading=true → must take the async fetch path, not rescale stale data")
 	assert.True(t, r.rightsizing.loading)
-	assert.Greater(t, r.rightsizing.gen, prevGen, "async path must bump gen so the prior fetch is dropped")
 	// The new (strategy, 1.5) cache key must NOT be populated by a stale rescale.
 	cacheKey := rightsizingCacheKey("c", "ns", "Pod", "pod-a", r.rightsizing.strategy, 1.5)
 	_, ok := r.rightsizingCache[cacheKey]
@@ -507,12 +504,10 @@ func TestUpdateOverlayRightsizing_HeadroomPickerSkipsRescaleOnStrategyMismatch(t
 	m.rightsizing.strategy = model.StrategyVPA
 	// Data was generated for the SNAPSHOT strategy (mismatch).
 	m.rightsizing.data.Strategy = model.StrategySnapshot
-	prevGen := m.rightsizing.gen
 
 	ret, cmd := m.handleRightsizingOverlayKey(runeKey('>'))
 	r := ret.(Model)
 	assert.NotNil(t, cmd, "strategy mismatch → must take async path, not rescale across strategies")
-	assert.Greater(t, r.rightsizing.gen, prevGen)
 	cacheKey := rightsizingCacheKey("c", "ns", "Pod", "pod-a", r.rightsizing.strategy, 1.5)
 	_, ok := r.rightsizingCache[cacheKey]
 	assert.False(t, ok, "cross-strategy rescale would poison the cache — must not happen")
@@ -526,18 +521,16 @@ func TestUpdateOverlayRightsizing_HeadroomPickerSkipsRescaleOnHeadroomMismatch(t
 	m.rightsizing.headroom = model.DefaultRightsizingHeadroom // 1.25
 	// Data was generated at headroom 2.0 — doesn't match current 1.25.
 	m.rightsizing.data.Headroom = 2.0
-	prevGen := m.rightsizing.gen
 
 	ret, cmd := m.handleRightsizingOverlayKey(runeKey('>'))
 	r := ret.(Model)
 	assert.NotNil(t, cmd, "headroom mismatch → must take async path, not rescale from wrong baseline")
-	assert.Greater(t, r.rightsizing.gen, prevGen)
+	assert.True(t, r.rightsizing.loading)
 }
 
-func TestUpdateOverlayRightsizing_StrategyPickerCacheHitBumpsGen(t *testing.T) {
-	// A cache hit on the new strategy must bump m.rightsizing.gen so
-	// any in-flight prior strategy fetch is dropped on arrival rather
-	// than overwriting the cache hit.
+func TestUpdateOverlayRightsizing_StrategyPickerCacheHitSurvivesLateFetch(t *testing.T) {
+	// A fetch for the previous strategy that lands after the cache hit
+	// must not overwrite the entry the user just switched to.
 	m := newRightsizingTestModel()
 	m.rightsizing.strategy = model.StrategyVPA
 	m.rightsizing.available = []model.RightsizingStrategy{
@@ -553,18 +546,21 @@ func TestUpdateOverlayRightsizing_StrategyPickerCacheHitBumpsGen(t *testing.T) {
 	}
 	cacheKey := rightsizingCacheKey("c", "ns", "Pod", "pod-a", model.StrategyPromMax1D, m.rightsizing.headroom)
 	m.rightsizingCache[cacheKey] = cached
-	prevGen := m.rightsizing.gen
 
 	ret, _ := m.handleRightsizingOverlayKey(runeKey(']'))
 	r := ret.(Model)
-	assert.Greater(t, r.rightsizing.gen, prevGen,
-		"strategy cache hit must bump gen to invalidate any in-flight prior fetch")
-	assert.Same(t, cached, r.rightsizing.data, "cache hit still wins the data slot")
+	assert.Same(t, cached, r.rightsizing.data, "cache hit wins the data slot")
+
+	late := rightsizingLoadedMsg{
+		key:  rightsizingCacheKey("c", "ns", "Pod", "pod-a", model.StrategyVPA, m.rightsizing.headroom),
+		data: &model.Rightsizing{Strategy: model.StrategyVPA},
+	}
+	r = r.updateRightsizingLoaded(late)
+	assert.Same(t, cached, r.rightsizing.data, "late fetch for the old strategy must not replace the cache hit")
 }
 
-func TestUpdateOverlayRightsizing_HeadroomPickerCacheHitBumpsGen(t *testing.T) {
-	// Same race guard for the headroom fast-path: a cache hit must
-	// bump gen so the prior in-flight fetch can't overwrite it.
+func TestUpdateOverlayRightsizing_HeadroomPickerCacheHitSurvivesLateFetch(t *testing.T) {
+	// Same race guard for the headroom fast-path.
 	m := newRightsizingTestModel()
 	m.rightsizing.headroom = model.DefaultRightsizingHeadroom
 	cached := &model.Rightsizing{
@@ -577,13 +573,17 @@ func TestUpdateOverlayRightsizing_HeadroomPickerCacheHitBumpsGen(t *testing.T) {
 	}
 	cacheKey := rightsizingCacheKey("c", "ns", "Pod", "pod-a", m.rightsizing.strategy, 1.5)
 	m.rightsizingCache[cacheKey] = cached
-	prevGen := m.rightsizing.gen
 
 	ret, _ := m.handleRightsizingOverlayKey(runeKey('>'))
 	r := ret.(Model)
-	assert.Greater(t, r.rightsizing.gen, prevGen,
-		"headroom cache hit must bump gen to invalidate any in-flight prior fetch")
-	assert.Same(t, cached, r.rightsizing.data, "cache hit still wins the data slot")
+	assert.Same(t, cached, r.rightsizing.data, "cache hit wins the data slot")
+
+	late := rightsizingLoadedMsg{
+		key:  rightsizingCacheKey("c", "ns", "Pod", "pod-a", m.rightsizing.strategy, model.DefaultRightsizingHeadroom),
+		data: &model.Rightsizing{Strategy: m.rightsizing.strategy},
+	}
+	r = r.updateRightsizingLoaded(late)
+	assert.Same(t, cached, r.rightsizing.data, "late fetch for the old headroom must not replace the cache hit")
 }
 
 // --- Headroom seeded on overlay open ---


### PR DESCRIPTION
Refs #705 (follow-up comment: the advisor works once or twice, then stays on "Computing right-sizing…").

## Summary
- Every right-sizing fetch used the scheduler task name `Rightsizing: <pod>`. The scheduler folds a resubmission into a running task with the same name, so a `]`, `<`/`>`, or `r` press during a slow fetch queued nothing. The running result was then discarded as stale, and the overlay never left the loading state.
- The task name now carries strategy and headroom, so distinct work has a distinct identity.
- The loaded handler accepts a result by cache key instead of a generation counter. A result for another key only warms the cache. The counter remains for the async strategy probe only.

## Test plan
- [x] New tests: distinct scheduler task per strategy/headroom, same-key result accepted across gen bumps, other-key result only warms the cache, late fetch for the old key does not replace a cache hit
- [x] `go test -race ./internal/app/`
- [x] `golangci-lint run ./internal/app/...`
- [ ] Manual: open right-sizing on a pod with a slow Prometheus, press `]` and `>` while it loads, close and reopen the overlay on the same pod