### PR TITLE
feat(nodes): show cordon state in the node Status column

### DIFF
--- a/internal/app/commands_dashboard_sections.go
+++ b/internal/app/commands_dashboard_sections.go
@@ -144,7 +144,7 @@ func fetchDashboardNodes(ctx context.Context, kctx string, client *k8s.Client) d
 		data.nodeCount = len(nodeItems)
 		data.podCapacity = sumPodCapacity(nodeItems)
 		for _, n := range nodeItems {
-			if n.Status == "Ready" {
+			if model.NodeReady(n.Status) {
 				data.readyNodes++
 			}
 		}
@@ -538,7 +538,7 @@ func dashboardNodesSection(lines []string, data dashboardData, w dashboardWidths
 // nodeStatusDot returns a colored dot indicating whether a node is Ready.
 func nodeStatusDot(nodeItems []model.Item, name string) string {
 	for _, ni := range nodeItems {
-		if ni.Name == name && ni.Status != "Ready" {
+		if ni.Name == name && !model.NodeReady(ni.Status) {
 			return ui.StatusFailed.Render("●")
 		}
 	}
@@ -624,7 +624,7 @@ func dashboardWarningsColumn(data dashboardData) []string {
 func countNotReadyWorkerNodes(nodeItems []model.Item) int {
 	count := 0
 	for _, ni := range nodeItems {
-		if ni.Status != "Ready" {
+		if !model.NodeReady(ni.Status) {
 			isControlPlane := false
 			for _, kv := range ni.Columns {
 				if kv.Key == "Role" && strings.Contains(kv.Value, "control-plane") {

--- a/internal/app/commands_dashboard_sections_test.go
+++ b/internal/app/commands_dashboard_sections_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestCountNotReadyWorkerNodesIgnoresCordon(t *testing.T) {
+	nodes := []model.Item{
+		{Name: "w1", Status: "Ready"},
+		{Name: "w2", Status: "Ready,SchedulingDisabled"},
+		{Name: "w3", Status: "NotReady"},
+		{Name: "cp1", Status: "NotReady", Columns: []model.KeyValue{{Key: "Role", Value: "control-plane"}}},
+	}
+	assert.Equal(t, 1, countNotReadyWorkerNodes(nodes))
+}
+
+func TestNodeStatusDotIgnoresCordon(t *testing.T) {
+	nodes := []model.Item{
+		{Name: "w1", Status: "Ready"},
+		{Name: "w2", Status: "Ready,SchedulingDisabled"},
+		{Name: "w3", Status: "NotReady,SchedulingDisabled"},
+	}
+	healthy := nodeStatusDot(nodes, "w1")
+	assert.Equal(t, healthy, nodeStatusDot(nodes, "w2"), "a cordoned but ready node is not a failure")
+	assert.NotEqual(t, healthy, nodeStatusDot(nodes, "w3"))
+}

--- a/internal/app/filters.go
+++ b/internal/app/filters.go
@@ -179,7 +179,7 @@ func nodeFilterPresets() []FilterPreset {
 	return []FilterPreset{
 		{
 			Name: "Not Ready", Description: "Node status != Ready", Key: "n",
-			MatchFn: func(item model.Item) bool { return strings.ToLower(item.Status) != "ready" },
+			MatchFn: func(item model.Item) bool { return !model.NodeReady(item.Status) },
 		},
 		{
 			Name: "Cordoned", Description: "Unschedulable", Key: "c",

--- a/internal/app/filters_test.go
+++ b/internal/app/filters_test.go
@@ -244,6 +244,30 @@ func TestNodeCordonedPreset(t *testing.T) {
 	}
 }
 
+func TestNodeNotReadyPresetIgnoresCordonSuffix(t *testing.T) {
+	presets := builtinFilterPresets("Node")
+	notReady := findPreset(presets, "Not Ready")
+	if notReady == nil {
+		t.Fatal("Not Ready preset not found")
+	}
+
+	tests := []struct {
+		name string
+		item model.Item
+		want bool
+	}{
+		{"ready", model.Item{Status: "Ready"}, false},
+		{"ready and cordoned", model.Item{Status: "Ready,SchedulingDisabled"}, false},
+		{"not ready", model.Item{Status: "NotReady"}, true},
+		{"not ready and cordoned", model.Item{Status: "NotReady,SchedulingDisabled"}, true},
+	}
+	for _, tt := range tests {
+		if got := notReady.MatchFn(tt.item); got != tt.want {
+			t.Errorf("NotReady(%s) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestEventWarningsPreset(t *testing.T) {
 	presets := builtinFilterPresets("Event")
 	warnings := findPreset(presets, "Warnings")

--- a/internal/k8s/client_populate_kinds.go
+++ b/internal/k8s/client_populate_kinds.go
@@ -16,15 +16,31 @@ func populateNodeDetails(ti *model.Item, obj map[string]any, status, spec map[st
 	populateNodeStatus(ti, status)
 	populateNodeUnschedulable(ti, spec)
 	populateNodeTaints(ti, spec)
-	if s := nodeReadyStatus(status); s != "" {
+	if s := nodeStatus(status, spec); s != "" {
 		ti.Status = s
 	}
 }
 
+// schedulingDisabled is the cordon marker kubectl appends to a node's STATUS.
+const schedulingDisabled = "SchedulingDisabled"
+
+// nodeStatus mirrors `kubectl get nodes`, so a cordon is visible without the
+// Unschedulable column. The marker stands alone when the Ready condition is
+// missing, otherwise a cordoned node would report no status at all.
+func nodeStatus(status, spec map[string]any) string {
+	ready := nodeReadyStatus(status)
+	if !nodeUnschedulable(spec) {
+		return ready
+	}
+	if ready == "" {
+		return schedulingDisabled
+	}
+	return ready + "," + schedulingDisabled
+}
+
 // nodeReadyStatus derives a node's at-a-glance status ("Ready"/"NotReady") from
 // its Ready condition. Returns "" when the condition is absent so callers leave
-// Status untouched. Cordon state is surfaced separately via the Unschedulable
-// column, keeping the status (and its rollup) to clean Ready/NotReady buckets.
+// Status untouched.
 func nodeReadyStatus(status map[string]any) string {
 	conds, _ := status["conditions"].([]any)
 	for _, c := range conds {
@@ -106,11 +122,16 @@ func populateNodeStatus(ti *model.Item, status map[string]any) {
 	}
 }
 
-func populateNodeUnschedulable(ti *model.Item, spec map[string]any) {
+func nodeUnschedulable(spec map[string]any) bool {
 	if spec == nil {
-		return
+		return false
 	}
-	if val, ok := spec["unschedulable"].(bool); ok && val {
+	val, _ := spec["unschedulable"].(bool)
+	return val
+}
+
+func populateNodeUnschedulable(ti *model.Item, spec map[string]any) {
+	if nodeUnschedulable(spec) {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Unschedulable", Value: "true"})
 	}
 }

--- a/internal/k8s/client_populate_node_namespace_test.go
+++ b/internal/k8s/client_populate_node_namespace_test.go
@@ -29,6 +29,36 @@ func TestNodeReadyStatus(t *testing.T) {
 	assert.Equal(t, "", nodeReadyStatus(nil))
 }
 
+func TestNodeStatusCordoned(t *testing.T) {
+	ready := map[string]any{
+		"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+	}
+	notReady := map[string]any{
+		"conditions": []any{map[string]any{"type": "Ready", "status": "False"}},
+	}
+	cordoned := map[string]any{"unschedulable": true}
+
+	assert.Equal(t, "Ready", nodeStatus(ready, nil))
+	assert.Equal(t, "Ready", nodeStatus(ready, map[string]any{"unschedulable": false}))
+	assert.Equal(t, "Ready,SchedulingDisabled", nodeStatus(ready, cordoned))
+	assert.Equal(t, "NotReady,SchedulingDisabled", nodeStatus(notReady, cordoned))
+
+	// No Ready condition: the cordon still shows, on its own.
+	assert.Equal(t, "SchedulingDisabled", nodeStatus(nil, cordoned))
+	assert.Equal(t, "", nodeStatus(nil, nil))
+}
+
+func TestPopulateNodeDetailsCordonedStatus(t *testing.T) {
+	ti := &model.Item{Kind: "Node"}
+	status := map[string]any{
+		"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+	}
+	populateNodeDetails(ti, map[string]any{}, status, map[string]any{"unschedulable": true})
+
+	assert.Equal(t, "Ready,SchedulingDisabled", ti.Status)
+	assert.Equal(t, "true", ti.ColumnValue("Unschedulable"))
+}
+
 func TestPopulateNamespaceDetails(t *testing.T) {
 	ti := &model.Item{Kind: "Namespace"}
 	populateNamespaceDetails(ti, map[string]any{"phase": "Active"})

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -342,6 +342,14 @@ func (i Item) ColumnValue(key string) string {
 // this single constant.
 const MissingRefStatus = "MissingRef"
 
+// NodeReady reports whether a node Status means Ready. A cordoned node carries
+// a ",SchedulingDisabled" suffix that says nothing about readiness, so callers
+// must not compare the whole string.
+func NodeReady(status string) bool {
+	ready, _, _ := strings.Cut(status, ",")
+	return strings.EqualFold(ready, "Ready")
+}
+
 // ResourceNode represents a node in a resource relationship tree.
 type ResourceNode struct {
 	Name      string

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -514,3 +514,12 @@ func TestItemColumnValue(t *testing.T) {
 	assert.Equal(t, "", item.ColumnValue("severity"),
 		"match is case-sensitive — callers store keys with stable casing")
 }
+
+func TestNodeReady(t *testing.T) {
+	assert.True(t, NodeReady("Ready"))
+	assert.True(t, NodeReady("Ready,SchedulingDisabled"))
+	assert.False(t, NodeReady("NotReady"))
+	assert.False(t, NodeReady("NotReady,SchedulingDisabled"))
+	assert.False(t, NodeReady("SchedulingDisabled"))
+	assert.False(t, NodeReady(""))
+}

--- a/internal/ui/explorer_format.go
+++ b/internal/ui/explorer_format.go
@@ -137,6 +137,10 @@ var statusAbbreviations = map[string]string{
 	"CreateContainerError":       "CtrErr",
 	"Succeeded":                  "Done",
 	"Completed":                  "Done",
+	// The status column caps at 20, so the kubectl spelling rarely fits.
+	"Ready,SchedulingDisabled":    "Ready,Cordoned",
+	"NotReady,SchedulingDisabled": "NotReady,Cordoned",
+	"SchedulingDisabled":          "Cordoned",
 }
 
 // AbbreviateStatusForWidth returns a status label that fits within w

--- a/internal/ui/explorer_format_test.go
+++ b/internal/ui/explorer_format_test.go
@@ -764,3 +764,12 @@ func TestParseResourceValueOK_PlainValuesUnaffected(t *testing.T) {
 	_, ok = ParseResourceValueOK("n/a", true)
 	assert.False(t, ok)
 }
+
+func TestAbbreviateStatusForWidthCordoned(t *testing.T) {
+	// The status column caps at 20 columns, so the kubectl-length string only
+	// fits once a wide layout gives it room.
+	assert.Equal(t, "Ready,Cordoned", AbbreviateStatusForWidth("Ready,SchedulingDisabled", 19))
+	assert.Equal(t, "NotReady,Cordoned", AbbreviateStatusForWidth("NotReady,SchedulingDisabled", 19))
+	assert.Equal(t, "Cordoned", AbbreviateStatusForWidth("SchedulingDisabled", 10))
+	assert.Equal(t, "Ready,SchedulingDisabled", AbbreviateStatusForWidth("Ready,SchedulingDisabled", 30))
+}

--- a/internal/ui/styles_status.go
+++ b/internal/ui/styles_status.go
@@ -44,6 +44,7 @@ func statusSeverity(status string) statusSev {
 		"Waiting", "Init", "NotReady",
 		"Progressing", "Progressing/Synced", "Progressing/OutOfSync",
 		"Missing", "Suspended", "Unknown", "Reconciling",
+		"Ready,SchedulingDisabled", "NotReady,SchedulingDisabled", "SchedulingDisabled",
 		"Healthy/OutOfSync", "Missing/OutOfSync", "Suspended/OutOfSync",
 		"OutOfSync",
 		"Pending-install", "Pending-upgrade", "Pending-rollback", "Uninstalling",

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -198,6 +198,10 @@ func TestStatusSeverity_FreeFormPhrases(t *testing.T) {
 		// Exact matches keep precedence over word scanning.
 		{"Failed", sevFailed},
 		{"Running", sevRunning},
+		// A cordoned node is amber, not the green its "Ready" word would give.
+		{"Ready,SchedulingDisabled", sevProgressing},
+		{"NotReady,SchedulingDisabled", sevProgressing},
+		{"SchedulingDisabled", sevProgressing},
 	}
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {


### PR DESCRIPTION
Closes #723

A cordoned node read as plain `Ready` in the node list. Cordon state only reached the optional `Unschedulable` column, and that column disappeared once no node carried the value, so scheduling could be off with nothing on screen to say so.

## What changed

- Node `Status` now carries kubectl's `,SchedulingDisabled` suffix, so it picks up the existing status color, row tint, summary band, and severity sort with no column configuration.
- The status column caps at 20, so the value abbreviates to `Ready,Cordoned` / `NotReady,Cordoned` in the usual layout and shows in full on wide ones.
- The composite values map to the amber progressing bucket. Without an explicit entry they would have matched the `ready` word and rendered green.
- Three places compared the whole `Status` string to `"Ready"` and would have read a cordoned healthy node as not ready: the node `Not Ready` filter preset, the dashboard ready-node count, and the dashboard node dot. They share a new `model.NodeReady` helper that compares the readiness segment only.
- The `Unschedulable` column and the `Cordoned` filter preset are untouched.

## Test plan

- [x] `go build ./...`, `go vet ./...`, full `go test ./...`
- [x] `golangci-lint run` on the touched packages: 0 issues
- [x] Unit tests for `nodeStatus`, `NodeReady`, the abbreviations, the severity bucket, the filter preset, and both dashboard counters
- [x] Live on a kind cluster: `kubectl cordon` flipped the row to `Ready,Cordoned` through the watch, `kubectl uncordon` returned it to `Ready`
- [x] Security review: no findings