### PR TITLE
chore: bump Go to 1.27.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Setup, build, and release steps for `lfk` contributors.
 
 ## Prerequisites
 
-- Go 1.27.0 or later
+- Go 1.27.1 or later
 - Access to a Kubernetes cluster (for testing)
 - `kubectl` configured and working
 - `golangci-lint`

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787259059,
-        "narHash": "sha256-m2n0DF6rPrKTsCrqfgmrrSrsVOpkcCu6+h4ImJE77Xo=",
+        "lastModified": 1788838835,
+        "narHash": "sha256-4o6mac+px1jbYbqdm5t559JO3883E7/FFezvxsD112A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8f11a4638c910374042f478beb9baa2bda53fa",
+        "rev": "cd9a5ec96e6744e2ce5db97c00ddeee327e429c7",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/janosmiko/lfk
 
-go 1.27.0
+go 1.27.1
 
 require (
 	charm.land/bubbles/v2 v2.2.1


### PR DESCRIPTION
## Summary
- Bump the \`go\` directive in \`go.mod\` to 1.27.1 and update the version note in CONTRIBUTING.md.
- Update the \`flake.lock\` nixpkgs input so \`go_1_27\` resolves to 1.27.1. With the old pin, \`buildGoModule\` fails on \`GOTOOLCHAIN=local\`.
- \`vendorHash\` is unchanged. The Dockerfile builder image already moved to 1.27.1 in #726.

## Test plan
- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` on go1.27.1 (26 packages ok)
- [x] \`golangci-lint run\` 0 issues
- [x] \`make verify-vendor-hash\` passes
- [x] \`nix build .#default\` produces a working \`lfk --version\`