### PR TITLE
feat: browse MutatingAdmissionPolicy and binding objects

### DIFF
--- a/internal/k8s/client_populate_admission.go
+++ b/internal/k8s/client_populate_admission.go
@@ -1,0 +1,101 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// populateMutatingAdmissionPolicy adds a compact match-resources summary and
+// a mutation count to a MutatingAdmissionPolicy's list columns.
+func populateMutatingAdmissionPolicy(ti *model.Item, spec map[string]any) {
+	if spec == nil {
+		return
+	}
+	if matchConstraints, ok := spec["matchConstraints"].(map[string]any); ok {
+		if summary := admissionResourceRulesSummary(matchConstraints); summary != "" {
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Match Resources", Value: summary})
+		}
+	}
+	mutations, _ := spec["mutations"].([]any)
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Mutations", Value: fmt.Sprintf("%d", len(mutations))})
+}
+
+// populateMutatingAdmissionPolicyBinding adds the bound policy name and a
+// compact match-namespaces summary to a MutatingAdmissionPolicyBinding's
+// list columns.
+func populateMutatingAdmissionPolicyBinding(ti *model.Item, spec map[string]any) {
+	if spec == nil {
+		return
+	}
+	if policyName, ok := spec["policyName"].(string); ok && policyName != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Policy Name", Value: policyName})
+	}
+	matchResources, _ := spec["matchResources"].(map[string]any)
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Match Namespaces", Value: admissionNamespaceSelectorSummary(matchResources)})
+}
+
+// admissionResourceRulesSummary renders spec.matchConstraints.resourceRules
+// as a compact "group/resources" entry per rule.
+func admissionResourceRulesSummary(matchConstraints map[string]any) string {
+	rules, ok := matchConstraints["resourceRules"].([]any)
+	if !ok || len(rules) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(rules))
+	for _, r := range rules {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		groups := stringsFromAny(rule["apiGroups"])
+		resources := stringsFromAny(rule["resources"])
+		if len(groups) == 0 && len(resources) == 0 {
+			continue
+		}
+		parts = append(parts, strings.Join(groups, ",")+"/"+strings.Join(resources, ","))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// admissionNamespaceSelectorSummary renders
+// spec.matchResources.namespaceSelector as a compact label selector string.
+// An unset or empty selector matches every namespace, so it renders as "all".
+func admissionNamespaceSelectorSummary(matchResources map[string]any) string {
+	if matchResources == nil {
+		return "all"
+	}
+	nsSelector, ok := matchResources["namespaceSelector"].(map[string]any)
+	if !ok || len(nsSelector) == 0 {
+		return "all"
+	}
+	var ls metav1.LabelSelector
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(nsSelector, &ls); err != nil {
+		return "all"
+	}
+	formatted := metav1.FormatLabelSelector(&ls)
+	if formatted == "<none>" {
+		return "all"
+	}
+	return formatted
+}
+
+// stringsFromAny converts a JSON-decoded []any of strings into []string,
+// skipping non-string elements.
+func stringsFromAny(v any) []string {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/k8s/client_populate_admission_test.go
+++ b/internal/k8s/client_populate_admission_test.go
@@ -52,6 +52,7 @@ func TestPopulateResourceDetailsExt_MutatingAdmissionPolicy(t *testing.T) {
 			},
 			wantCols: map[string]string{
 				"Match Resources": "/pods",
+				"Mutations":       "0",
 			},
 		},
 		{
@@ -72,6 +73,7 @@ func TestPopulateResourceDetailsExt_MutatingAdmissionPolicy(t *testing.T) {
 			},
 			wantCols: map[string]string{
 				"Match Resources": "apps/deployments,statefulsets; /pods",
+				"Mutations":       "0",
 			},
 		},
 		{
@@ -92,11 +94,10 @@ func TestPopulateResourceDetailsExt_MutatingAdmissionPolicy(t *testing.T) {
 			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "MutatingAdmissionPolicy", nil, tt.spec)
 
 			colMap := columnsToMap(ti.Columns)
-			for k, v := range tt.wantCols {
-				assert.Equal(t, v, colMap[k], "column %q mismatch", k)
-			}
-			if tt.spec == nil {
-				assert.Empty(t, ti.Columns)
+			if tt.wantCols == nil {
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
 			}
 		})
 	}
@@ -163,11 +164,10 @@ func TestPopulateResourceDetailsExt_MutatingAdmissionPolicyBinding(t *testing.T)
 			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "MutatingAdmissionPolicyBinding", nil, tt.spec)
 
 			colMap := columnsToMap(ti.Columns)
-			for k, v := range tt.wantCols {
-				assert.Equal(t, v, colMap[k], "column %q mismatch", k)
-			}
 			if tt.wantCols == nil {
-				assert.Empty(t, ti.Columns)
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
 			}
 		})
 	}

--- a/internal/k8s/client_populate_admission_test.go
+++ b/internal/k8s/client_populate_admission_test.go
@@ -1,0 +1,174 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// --- populateResourceDetailsExt: MutatingAdmissionPolicy ---
+
+func TestPopulateResourceDetailsExt_MutatingAdmissionPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "single resource rule and two mutations",
+			spec: map[string]any{
+				"matchConstraints": map[string]any{
+					"resourceRules": []any{
+						map[string]any{
+							"apiGroups":   []any{"apps"},
+							"apiVersions": []any{"v1"},
+							"resources":   []any{"deployments"},
+						},
+					},
+				},
+				"mutations": []any{
+					map[string]any{"patchType": "ApplyConfiguration"},
+					map[string]any{"patchType": "JSONPatch"},
+				},
+			},
+			wantCols: map[string]string{
+				"Match Resources": "apps/deployments",
+				"Mutations":       "2",
+			},
+		},
+		{
+			name: "core group resource rule renders empty group",
+			spec: map[string]any{
+				"matchConstraints": map[string]any{
+					"resourceRules": []any{
+						map[string]any{
+							"apiGroups": []any{""},
+							"resources": []any{"pods"},
+						},
+					},
+				},
+			},
+			wantCols: map[string]string{
+				"Match Resources": "/pods",
+			},
+		},
+		{
+			name: "multiple resource rules join compactly",
+			spec: map[string]any{
+				"matchConstraints": map[string]any{
+					"resourceRules": []any{
+						map[string]any{
+							"apiGroups": []any{"apps"},
+							"resources": []any{"deployments", "statefulsets"},
+						},
+						map[string]any{
+							"apiGroups": []any{""},
+							"resources": []any{"pods"},
+						},
+					},
+				},
+			},
+			wantCols: map[string]string{
+				"Match Resources": "apps/deployments,statefulsets; /pods",
+			},
+		},
+		{
+			name:     "nil spec produces no columns",
+			spec:     nil,
+			wantCols: nil,
+		},
+		{
+			name:     "empty spec still reports zero mutations",
+			spec:     map[string]any{},
+			wantCols: map[string]string{"Mutations": "0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "MutatingAdmissionPolicy", nil, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			for k, v := range tt.wantCols {
+				assert.Equal(t, v, colMap[k], "column %q mismatch", k)
+			}
+			if tt.spec == nil {
+				assert.Empty(t, ti.Columns)
+			}
+		})
+	}
+}
+
+// --- populateResourceDetailsExt: MutatingAdmissionPolicyBinding ---
+
+func TestPopulateResourceDetailsExt_MutatingAdmissionPolicyBinding(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "policy name with no match resources means all namespaces",
+			spec: map[string]any{
+				"policyName": "demo-policy",
+			},
+			wantCols: map[string]string{
+				"Policy Name":      "demo-policy",
+				"Match Namespaces": "all",
+			},
+		},
+		{
+			name: "namespace selector with match labels",
+			spec: map[string]any{
+				"policyName": "demo-policy",
+				"matchResources": map[string]any{
+					"namespaceSelector": map[string]any{
+						"matchLabels": map[string]any{
+							"environment": "prod",
+						},
+					},
+				},
+			},
+			wantCols: map[string]string{
+				"Policy Name":      "demo-policy",
+				"Match Namespaces": "environment=prod",
+			},
+		},
+		{
+			name: "empty namespace selector means all namespaces",
+			spec: map[string]any{
+				"policyName": "demo-policy",
+				"matchResources": map[string]any{
+					"namespaceSelector": map[string]any{},
+				},
+			},
+			wantCols: map[string]string{
+				"Policy Name":      "demo-policy",
+				"Match Namespaces": "all",
+			},
+		},
+		{
+			name:     "nil spec produces no columns",
+			spec:     nil,
+			wantCols: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "MutatingAdmissionPolicyBinding", nil, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			for k, v := range tt.wantCols {
+				assert.Equal(t, v, colMap[k], "column %q mismatch", k)
+			}
+			if tt.wantCols == nil {
+				assert.Empty(t, ti.Columns)
+			}
+		})
+	}
+}

--- a/internal/k8s/client_populate_ext.go
+++ b/internal/k8s/client_populate_ext.go
@@ -72,6 +72,12 @@ func populateResourceDetailsExt(ti *model.Item, obj map[string]any, kind string,
 	case "Workflow":
 		populateArgoWorkflow(ti, status)
 
+	case "MutatingAdmissionPolicy":
+		populateMutatingAdmissionPolicy(ti, spec)
+
+	case "MutatingAdmissionPolicyBinding":
+		populateMutatingAdmissionPolicyBinding(ti, spec)
+
 	default:
 		populateGenericCRDResource(ti, status)
 	}

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -155,6 +155,8 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"admissionregistration.k8s.io/validatingwebhookconfigurations":   {Category: "Config", DisplayName: "ValidatingWebhookConfigurations", Icon: Icon{Unicode: "⚙", Simple: "[Wh]", Emoji: "🔧", NerdFont: "\U000f0494"}, Rare: true},
 	"admissionregistration.k8s.io/validatingadmissionpolicies":       {Category: "Config", DisplayName: "ValidatingAdmissionPolicies", Icon: Icon{Unicode: "⚙", Simple: "[Wh]", Emoji: "🔧", NerdFont: "\U000f0494"}, Rare: true},
 	"admissionregistration.k8s.io/validatingadmissionpolicybindings": {Category: "Config", DisplayName: "ValidatingAdmissionPolicyBindings", Icon: Icon{Unicode: "⚙", Simple: "[Wh]", Emoji: "🔧", NerdFont: "\U000f0494"}, Rare: true},
+	"admissionregistration.k8s.io/mutatingadmissionpolicies":         {Category: "Config", DisplayName: "MutatingAdmissionPolicies", Icon: Icon{Unicode: "⚙", Simple: "[Wh]", Emoji: "🔧", NerdFont: "\U000f0494"}, Rare: true},
+	"admissionregistration.k8s.io/mutatingadmissionpolicybindings":   {Category: "Config", DisplayName: "MutatingAdmissionPolicyBindings", Icon: Icon{Unicode: "⚙", Simple: "[Wh]", Emoji: "🔧", NerdFont: "\U000f0494"}, Rare: true},
 	"flowcontrol.apiserver.k8s.io/flowschemas":                       {Category: "Config", DisplayName: "FlowSchemas", Icon: Icon{Unicode: "⚙", Simple: "[Wh]", Emoji: "🔧", NerdFont: "\U000f0494"}, Rare: true},
 	"flowcontrol.apiserver.k8s.io/prioritylevelconfigurations":       {Category: "Config", DisplayName: "PriorityLevelConfigurations", Icon: Icon{Unicode: "⚙", Simple: "[Wh]", Emoji: "🔧", NerdFont: "\U000f0494"}, Rare: true},
 
@@ -402,8 +404,10 @@ var BuiltInOrderRank = map[string]int{
 	"admissionregistration.k8s.io/validatingwebhookconfigurations":   41,
 	"admissionregistration.k8s.io/validatingadmissionpolicies":       42,
 	"admissionregistration.k8s.io/validatingadmissionpolicybindings": 43,
-	"flowcontrol.apiserver.k8s.io/flowschemas":                       44,
-	"flowcontrol.apiserver.k8s.io/prioritylevelconfigurations":       45,
+	"admissionregistration.k8s.io/mutatingadmissionpolicies":         44,
+	"admissionregistration.k8s.io/mutatingadmissionpolicybindings":   45,
+	"flowcontrol.apiserver.k8s.io/flowschemas":                       46,
+	"flowcontrol.apiserver.k8s.io/prioritylevelconfigurations":       47,
 
 	// Networking
 	"/services":                                    50,

--- a/internal/model/metadata_test.go
+++ b/internal/model/metadata_test.go
@@ -239,6 +239,8 @@ var allowListedUnicodeCollisions = map[string]string{
 	"admissionregistration.k8s.io/validatingwebhookconfigurations":   "admission-flow",
 	"admissionregistration.k8s.io/validatingadmissionpolicies":       "admission-flow",
 	"admissionregistration.k8s.io/validatingadmissionpolicybindings": "admission-flow",
+	"admissionregistration.k8s.io/mutatingadmissionpolicies":         "admission-flow",
+	"admissionregistration.k8s.io/mutatingadmissionpolicybindings":   "admission-flow",
 	"flowcontrol.apiserver.k8s.io/flowschemas":                       "admission-flow",
 	"flowcontrol.apiserver.k8s.io/prioritylevelconfigurations":       "admission-flow",
 


### PR DESCRIPTION
## Summary
- Register MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding (admissionregistration.k8s.io/v1, GA in Kubernetes 1.36) as rare Config types next to the validating pair.
- Policies list a match-resources summary and mutation count. Bindings list the policy name and namespace selector.
- Unit tests cover both populate functions with static spec maps.

## Test plan
- [x] go build, go vet, go test -race ./..., golangci-lint clean
- [ ] Manual: apply a policy and binding on a 1.36+ kind cluster, press H in the sidebar, check both lists