### PR TITLE
fix: treat HPA minReplicas 0 as scaled to zero

### DIFF
--- a/internal/k8s/client_hpa_scale_to_zero_test.go
+++ b/internal/k8s/client_hpa_scale_to_zero_test.go
@@ -1,0 +1,76 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// At 0 replicas Kubernetes resolves minAvailable to 0, so Available stays True.
+func TestBuildResourceItem_DeploymentScaledToZero_NotFailed(t *testing.T) {
+	c := &Client{}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": "web", "namespace": "default"},
+		"spec":       map[string]any{"replicas": int64(0)},
+		"status": map[string]any{
+			"replicas":      int64(0),
+			"readyReplicas": int64(0),
+			"conditions": []any{
+				map[string]any{"type": "Progressing", "status": "True", "reason": "NewReplicaSetAvailable"},
+				map[string]any{"type": "Available", "status": "True", "reason": "MinimumReplicasAvailable"},
+			},
+		},
+	}}
+	rt := &model.ResourceTypeEntry{Kind: "Deployment", Namespaced: true}
+
+	ti := c.buildResourceItem(obj, rt)
+
+	assert.Equal(t, "Available", ti.Status)
+	assert.Equal(t, "0/0", ti.Ready)
+}
+
+// StatefulSets do not populate status.conditions in normal operation.
+func TestBuildResourceItem_StatefulSetScaledToZero_NotFailed(t *testing.T) {
+	c := &Client{}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "StatefulSet",
+		"metadata":   map[string]any{"name": "db", "namespace": "default"},
+		"spec":       map[string]any{"replicas": int64(0)},
+		"status": map[string]any{
+			"replicas":      int64(0),
+			"readyReplicas": int64(0),
+		},
+	}}
+	rt := &model.ResourceTypeEntry{Kind: "StatefulSet", Namespaced: true}
+
+	ti := c.buildResourceItem(obj, rt)
+
+	assert.Empty(t, ti.Status)
+	assert.Equal(t, "0/0", ti.Ready)
+}
+
+func TestBuildResourceItem_ReplicaSetScaledToZero_NotFailed(t *testing.T) {
+	c := &Client{}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "ReplicaSet",
+		"metadata":   map[string]any{"name": "web-abc123", "namespace": "default"},
+		"spec":       map[string]any{"replicas": int64(0)},
+		"status": map[string]any{
+			"replicas":      int64(0),
+			"readyReplicas": int64(0),
+		},
+	}}
+	rt := &model.ResourceTypeEntry{Kind: "ReplicaSet", Namespaced: true}
+
+	ti := c.buildResourceItem(obj, rt)
+
+	assert.Empty(t, ti.Status)
+	assert.Equal(t, "0/0", ti.Ready)
+}

--- a/internal/k8s/client_populate_hpa.go
+++ b/internal/k8s/client_populate_hpa.go
@@ -35,6 +35,29 @@ func populateHPAReady(ti *model.Item, status, spec map[string]any) {
 		}
 	}
 	ti.Ready = fmt.Sprintf("%d/%d (%d-%d)", currentR, desiredR, minR, maxR)
+	if hpaConditionTrue(status, "ScaledToZero") {
+		ti.Ready += " (scaled to zero)"
+	}
+}
+
+// hpaConditionTrue reports whether status.conditions contains condType with status "True".
+func hpaConditionTrue(status map[string]any, condType string) bool {
+	conditions, ok := status["conditions"].([]any)
+	if !ok {
+		return false
+	}
+	for _, c := range conditions {
+		cMap, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		cType, _ := cMap["type"].(string)
+		cStatus, _ := cMap["status"].(string)
+		if cType == condType && cStatus == "True" {
+			return true
+		}
+	}
+	return false
 }
 
 func populateHPASpecColumns(ti *model.Item, spec map[string]any) {

--- a/internal/k8s/client_populate_hpa_test.go
+++ b/internal/k8s/client_populate_hpa_test.go
@@ -1,0 +1,57 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestPopulateHPAReady_ScaledToZero(t *testing.T) {
+	ti := &model.Item{}
+	spec := map[string]any{
+		"minReplicas": float64(0),
+		"maxReplicas": float64(5),
+	}
+	status := map[string]any{
+		"currentReplicas": float64(0),
+		"desiredReplicas": float64(0),
+		"conditions": []any{
+			map[string]any{"type": "ScaledToZero", "status": "True", "reason": "ScalingLimited"},
+		},
+	}
+	populateHPAReady(ti, status, spec)
+	assert.Equal(t, "0/0 (0-5) (scaled to zero)", ti.Ready)
+}
+
+func TestPopulateHPAReady_ScaledToZeroConditionFalse(t *testing.T) {
+	ti := &model.Item{}
+	spec := map[string]any{
+		"minReplicas": float64(0),
+		"maxReplicas": float64(5),
+	}
+	status := map[string]any{
+		"currentReplicas": float64(1),
+		"desiredReplicas": float64(1),
+		"conditions": []any{
+			map[string]any{"type": "ScaledToZero", "status": "False"},
+		},
+	}
+	populateHPAReady(ti, status, spec)
+	assert.Equal(t, "1/1 (0-5)", ti.Ready)
+}
+
+func TestPopulateHPAReady_MinReplicasZeroNoConditions(t *testing.T) {
+	ti := &model.Item{}
+	spec := map[string]any{
+		"minReplicas": float64(0),
+		"maxReplicas": float64(5),
+	}
+	status := map[string]any{
+		"currentReplicas": float64(2),
+		"desiredReplicas": float64(2),
+	}
+	populateHPAReady(ti, status, spec)
+	assert.Equal(t, "2/2 (0-5)", ti.Ready)
+}

--- a/internal/security/advisor/checks_scaling_test.go
+++ b/internal/security/advisor/checks_scaling_test.go
@@ -79,6 +79,20 @@ func TestPDBVsHPAMin(t *testing.T) {
 	assert.True(t, checks["prod/PodDisruptionBudget/pdb-e"]["pdb_vs_hpa_min"])
 }
 
+// TestPDBVsHPAMinScaleToZero: an HPA with an explicit minReplicas: 0 (scale to
+// zero) must compare against 0, not the nil-default of 1, so any positive
+// integer minAvailable fires the finding.
+func TestPDBVsHPAMinScaleToZero(t *testing.T) {
+	one := intstr.FromInt32(1)
+	checks := fetchChecks(t,
+		deployment("prod", "z", 0, map[string]string{"app": "z"}, hardened("web")),
+		pdb("pdb-z", map[string]string{"app": "z"}, &one, nil),
+		hpaScaled("prod", "hpa-z", "z", 0, 10, 0),
+	)
+	assert.True(t, checks["prod/PodDisruptionBudget/pdb-z"]["pdb_vs_hpa_min"],
+		"minAvailable 1 > minReplicas 0 must fire")
+}
+
 func withReplicasOwner(dep *appsv1.Deployment, manager, fields string) *appsv1.Deployment {
 	dep.ManagedFields = []metav1.ManagedFieldsEntry{{
 		Manager:    manager,

--- a/internal/security/advisor/checks_tier1_test.go
+++ b/internal/security/advisor/checks_tier1_test.go
@@ -169,13 +169,27 @@ func TestQuotaNearLimit(t *testing.T) {
 }
 
 func hpaScaled(ns, name, target string, minReplicas, maxReplicas, desired int32) *autoscalingv2.HorizontalPodAutoscaler {
+	spec := autoscalingv2.HorizontalPodAutoscalerSpec{
+		ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: target},
+		MinReplicas:    &minReplicas,
+		MaxReplicas:    maxReplicas,
+	}
+	if minReplicas == 0 {
+		// The Kubernetes API only admits minReplicas: 0 when the HPA has an Object or External metric.
+		spec.Metrics = []autoscalingv2.MetricSpec{{
+			Type: autoscalingv2.ExternalMetricSourceType,
+			External: &autoscalingv2.ExternalMetricSource{
+				Metric: autoscalingv2.MetricIdentifier{Name: "queue_length"},
+				Target: autoscalingv2.MetricTarget{
+					Type:         autoscalingv2.AverageValueMetricType,
+					AverageValue: resource.NewQuantity(10, resource.DecimalSI),
+				},
+			},
+		}}
+	}
 	return &autoscalingv2.HorizontalPodAutoscaler{
 		Namespace: ns, Name: name,
-		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: target},
-			MinReplicas:    &minReplicas,
-			MaxReplicas:    maxReplicas,
-		},
+		Spec:   spec,
 		Status: autoscalingv2.HorizontalPodAutoscalerStatus{DesiredReplicas: desired},
 	}
 }

--- a/internal/security/advisor/checks_tier1_test.go
+++ b/internal/security/advisor/checks_tier1_test.go
@@ -193,6 +193,20 @@ func TestHPAAtMaxAndFixed(t *testing.T) {
 		"a pinned HPA is hpa_fixed, not hpa_at_max")
 }
 
+// TestHPAScaleToZero: minReplicas: 0 with maxReplicas > 0 can still scale, so
+// it must not be flagged hpa_fixed. It can still be flagged hpa_at_max once
+// desired reaches the ceiling.
+func TestHPAScaleToZero(t *testing.T) {
+	got := fetchChecks(t,
+		hpaScaled("prod", "idle", "a", 0, 5, 0),
+		hpaScaled("prod", "capped-from-zero", "b", 0, 5, 5),
+	)
+	assert.False(t, got["prod/HorizontalPodAutoscaler/idle"]["hpa_fixed"],
+		"minReplicas 0 and maxReplicas 5 can still scale")
+	assert.False(t, got["prod/HorizontalPodAutoscaler/idle"]["hpa_at_max"])
+	assert.True(t, got["prod/HorizontalPodAutoscaler/capped-from-zero"]["hpa_at_max"])
+}
+
 func TestOrphanPDB(t *testing.T) {
 	web := map[string]string{"app": "web"}
 	ds := map[string]string{"app": "node-agent"}

--- a/internal/ui/row_tint_test.go
+++ b/internal/ui/row_tint_test.go
@@ -41,6 +41,8 @@ func TestRowTintForStatus_ForegroundMode(t *testing.T) {
 
 	_, ok = RowTintForStatus("Running")
 	assert.False(t, ok, "running rows never tint")
+	_, ok = RowTintForStatus("Available")
+	assert.False(t, ok, "a scaled-to-zero Deployment (Available:True) never tints")
 	_, ok = RowTintForStatus("")
 	assert.False(t, ok, "blank status never tints")
 }


### PR DESCRIPTION
## Summary
- HPAScaleToZero is default-on since Kubernetes 1.36. The HPA READY column now appends `(scaled to zero)` when the ScaledToZero condition is True.
- Regression tests lock in that the advisor checks (`pdb_vs_hpa_min`, `hpa_fixed`) and the workload row tint accept `minReplicas: 0`. Those paths needed no code change.

## Test plan
- [x] go build, go vet, go test -race ./..., golangci-lint clean
- [ ] Manual: HPA with minReplicas 0 on a 1.36+ cluster, check the READY column and the advisor findings