### PR TITLE
fix: show a real Changed age on container rows

### DIFF
--- a/internal/app/changed_column.go
+++ b/internal/app/changed_column.go
@@ -18,6 +18,9 @@ const ChangedColumnKey = ui.ChangedColumnName
 // that someone wrote, so it serves kinds with no conditions and no restarts.
 func changeAt(it model.Item) (time.Time, bool) {
 	last := it.LastRestartAt
+	if it.ChangedAt.After(last) {
+		last = it.ChangedAt
+	}
 	for _, c := range it.Conditions {
 		if c.LastTransitionTime.After(last) {
 			last = c.LastTransitionTime

--- a/internal/app/changed_column_test.go
+++ b/internal/app/changed_column_test.go
@@ -116,6 +116,34 @@ func TestChangedAgeReportsNothingWithoutAnySource(t *testing.T) {
 	}
 }
 
+func TestChangedAgeUsesChangedAtForContainers(t *testing.T) {
+	now := time.Now()
+	// A container: no conditions, no raw object, only the status timestamp.
+	it := model.Item{Name: "app", Kind: "Container", ChangedAt: now.Add(-45 * time.Second)}
+
+	age, ok := changeAge(it, now)
+	if !ok {
+		t.Fatal("a container with a status timestamp must report a change time")
+	}
+	if age != 45*time.Second {
+		t.Fatalf("want the status timestamp, got %v", age)
+	}
+}
+
+func TestChangedAgePrefersTheNewestOfChangedAtAndRestart(t *testing.T) {
+	now := time.Now()
+	it := model.Item{
+		Name: "app", Kind: "Container",
+		ChangedAt:     now.Add(-time.Hour),
+		LastRestartAt: now.Add(-20 * time.Second),
+	}
+
+	age, _ := changeAge(it, now)
+	if age != 20*time.Second {
+		t.Fatalf("the newest of the two must win, got %v", age)
+	}
+}
+
 func TestChangedAgeSurvivesMalformedRaw(t *testing.T) {
 	now := time.Now()
 	cases := []map[string]any{

--- a/internal/k8s/client_crd.go
+++ b/internal/k8s/client_crd.go
@@ -161,6 +161,10 @@ func buildContainerItem(c corev1.Container, statuses []corev1.ContainerStatus, i
 			item.CreatedAt = cs.State.Running.StartedAt.Time
 			item.Age = formatAge(time.Since(cs.State.Running.StartedAt.Time))
 		}
+		item.ChangedAt = containerChangedAt(cs)
+		if lt := cs.LastTerminationState.Terminated; lt != nil {
+			item.LastRestartAt = lt.FinishedAt.Time
+		}
 
 		// Add reason to columns if not ready.
 		if !cs.Ready {
@@ -225,6 +229,22 @@ func buildContainerItem(c corev1.Container, statuses []corev1.ContainerStatus, i
 	}
 
 	return item
+}
+
+// containerChangedAt returns the newest timestamp in the container status.
+// A waiting container with no history has none.
+func containerChangedAt(cs corev1.ContainerStatus) time.Time {
+	var last time.Time
+	if r := cs.State.Running; r != nil && r.StartedAt.After(last) {
+		last = r.StartedAt.Time
+	}
+	if t := cs.State.Terminated; t != nil && t.FinishedAt.After(last) {
+		last = t.FinishedAt.Time
+	}
+	if lt := cs.LastTerminationState.Terminated; lt != nil && lt.FinishedAt.After(last) {
+		last = lt.FinishedAt.Time
+	}
+	return last
 }
 
 func containerStateString(ready bool, waiting *corev1.ContainerStateWaiting, running *corev1.ContainerStateRunning, terminated *corev1.ContainerStateTerminated) string {

--- a/internal/k8s/client_crd_test.go
+++ b/internal/k8s/client_crd_test.go
@@ -691,3 +691,55 @@ func TestExtractStatus_ConditionsWithInvalidEntry(t *testing.T) {
 	// Non-map entry should be skipped; last valid condition is "Ready".
 	assert.Equal(t, "Ready", extractStatus(obj))
 }
+
+func TestBuildContainerItemChangedAt(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	c := corev1.Container{Name: "app", Image: "myapp:v1"}
+
+	t.Run("running container changed when it started", func(t *testing.T) {
+		statuses := []corev1.ContainerStatus{{
+			Name: "app", Ready: true,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-10 * time.Minute))}},
+		}}
+		item := buildContainerItem(c, statuses, false, false, false)
+
+		assert.Equal(t, now.Add(-10*time.Minute), item.ChangedAt)
+		assert.True(t, item.LastRestartAt.IsZero(), "a plain start is not a restart")
+	})
+
+	t.Run("restarted container changed when the last run finished", func(t *testing.T) {
+		statuses := []corev1.ContainerStatus{{
+			Name: "app", Ready: true, RestartCount: 1,
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-2 * time.Minute))}},
+			LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Error", ExitCode: 1, FinishedAt: metav1.NewTime(now.Add(-3 * time.Minute)),
+			}},
+		}}
+		item := buildContainerItem(c, statuses, false, false, false)
+
+		assert.Equal(t, now.Add(-2*time.Minute), item.ChangedAt, "the newest timestamp wins")
+		assert.Equal(t, now.Add(-3*time.Minute), item.LastRestartAt)
+	})
+
+	t.Run("terminated container changed when it finished", func(t *testing.T) {
+		statuses := []corev1.ContainerStatus{{
+			Name: "app",
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				Reason: "Completed", StartedAt: metav1.NewTime(now.Add(-time.Hour)), FinishedAt: metav1.NewTime(now.Add(-30 * time.Minute)),
+			}},
+		}}
+		item := buildContainerItem(c, statuses, false, false, false)
+
+		assert.Equal(t, now.Add(-30*time.Minute), item.ChangedAt)
+	})
+
+	t.Run("waiting container without history has no change time", func(t *testing.T) {
+		statuses := []corev1.ContainerStatus{{
+			Name:  "app",
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+		}}
+		item := buildContainerItem(c, statuses, false, false, false)
+
+		assert.True(t, item.ChangedAt.IsZero())
+	})
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -255,6 +255,7 @@ type Item struct {
 	Ready         string    // Ready count (e.g., "2/3" for pods or deployments)
 	Restarts      string    // Restart count (for pods)
 	LastRestartAt time.Time // Most recent container restart time
+	ChangedAt     time.Time // Newest status timestamp for kinds with no conditions (containers)
 	CreatedAt     time.Time // Creation timestamp for sorting (Events: first observed timestamp in the series)
 	LastSeen      time.Time // Most recent observation (Events only — drives the "Last Seen" column)
 	// BootedAt is when a node last booted (Nodes only, from Prometheus


### PR DESCRIPTION
## Summary

The Changed column in the container view was blank on every row. Container items never carried a timestamp `changeAt` could read, so the cell was always empty and sorting by it compared empty strings. Containers now report the newest container status timestamp.

## Type of change

- [ ] feat: new user-facing feature
- [x] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

None. Found while diagnosing container detail rows.

## Changes

- Add `Item.ChangedAt`, the newest status timestamp for kinds with no conditions.
- `changeAt` folds `ChangedAt` in next to `LastRestartAt` and the conditions.
- `buildContainerItem` sets `ChangedAt` from the newest of running start, terminated finish, and last terminated finish.
- Containers set `LastRestartAt` from the last terminated state with the same rule pods use, so the recent-restart row tint applies to them too.
- Pod and node Changed values are unchanged.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (with `-race`)
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed (no doc describes the column)
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (none changed)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)