### PR TITLE
feat: browse Dynamic Resource Allocation objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 ### Resource type list
 
-- Groups: Dashboards, Workloads, Networking, Config, Storage, ArgoCD, Helm, Access Control, Cluster, Custom Resources
+- Groups: Dashboards, Workloads, Networking, Config, Storage, Hardware, ArgoCD, Helm, Access Control, Cluster, Custom Resources
 - Discovered CRDs grouped by API group, for example `argoproj.io`, `longhorn.io`
 - Pin a type with `p`: [keybindings.md](docs/keybindings.md#navigation)
 - Pin a type's dashboard summary with `x`: [config-reference.md](docs/config-reference.md#top-level-fields)

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,6 +48,10 @@ Pause and unpause ScaledObjects and ScaledJobs.
 
 Force a refresh of ExternalSecrets, ClusterExternalSecrets, and PushSecrets.
 
+## Dynamic Resource Allocation
+
+The Hardware category lists ResourceClaims, ResourceClaimTemplates, ResourceSlices, and DeviceClasses. A pod's detail pane shows the resource claims it uses.
+
 ## Right-sizing advisor
 
 `x` -> `z` suggests CPU and memory requests and limits per container. The suggestion is only as good as the strategy behind it, shown in the `Strategy:` chip.

--- a/internal/k8s/client_dra_test.go
+++ b/internal/k8s/client_dra_test.go
@@ -1,0 +1,167 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+var draGVRs = map[schema.GroupVersionResource]string{
+	{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaims"}:         "ResourceClaimList",
+	{Group: "resource.k8s.io", Version: "v1", Resource: "resourceclaimtemplates"}: "ResourceClaimTemplateList",
+	{Group: "resource.k8s.io", Version: "v1", Resource: "resourceslices"}:         "ResourceSliceList",
+	{Group: "resource.k8s.io", Version: "v1", Resource: "deviceclasses"}:          "DeviceClassList",
+}
+
+func newResourceClaim(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "resource.k8s.io/v1",
+		"kind":       "ResourceClaim",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"status": map[string]any{
+			"allocation": map[string]any{
+				"devices": map[string]any{
+					"results": []any{
+						map[string]any{"driver": "gpu.example.com", "pool": "pool-a", "device": "gpu-0"},
+					},
+				},
+			},
+		},
+	}}
+}
+
+func newResourceClaimTemplate(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "resource.k8s.io/v1",
+		"kind":       "ResourceClaimTemplate",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec": map[string]any{
+			"spec": map[string]any{
+				"devices": map[string]any{
+					"requests": []any{map[string]any{"name": "gpu"}},
+				},
+			},
+		},
+	}}
+}
+
+func newResourceSlice(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "resource.k8s.io/v1",
+		"kind":       "ResourceSlice",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"driver":   "gpu.example.com",
+			"nodeName": "node-1",
+			"devices":  []any{map[string]any{"name": "gpu-0"}},
+		},
+	}}
+}
+
+func newDeviceClass(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "resource.k8s.io/v1",
+		"kind":       "DeviceClass",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"selectors": []any{map[string]any{"cel": map[string]any{"expression": "true"}}},
+		},
+	}}
+}
+
+func TestGetResources_ResourceClaim(t *testing.T) {
+	dc := newFakeDynClientWith(draGVRs, newResourceClaim("gpu-claim", "default"))
+	c := newFakeClient(nil, dc)
+
+	rt := model.ResourceTypeEntry{
+		APIGroup: "resource.k8s.io", APIVersion: "v1", Resource: "resourceclaims", Kind: "ResourceClaim", Namespaced: true,
+	}
+	items, err := c.GetResources(t.Context(), "", "default", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	colMap := columnsToMap(items[0].Columns)
+	assert.Equal(t, "gpu.example.com", colMap["Driver"])
+	assert.Equal(t, "pool-a", colMap["Pool"])
+	assert.Equal(t, "gpu-0", colMap["Device"])
+}
+
+func TestGetResources_ResourceClaimTemplate(t *testing.T) {
+	dc := newFakeDynClientWith(draGVRs, newResourceClaimTemplate("gpu-template", "default"))
+	c := newFakeClient(nil, dc)
+
+	rt := model.ResourceTypeEntry{
+		APIGroup: "resource.k8s.io", APIVersion: "v1", Resource: "resourceclaimtemplates", Kind: "ResourceClaimTemplate", Namespaced: true,
+	}
+	items, err := c.GetResources(t.Context(), "", "default", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	colMap := columnsToMap(items[0].Columns)
+	assert.Equal(t, "1", colMap["Devices"])
+}
+
+func TestGetResources_ResourceSlice(t *testing.T) {
+	dc := newFakeDynClientWith(draGVRs, newResourceSlice("node-1-slice"))
+	c := newFakeClient(nil, dc)
+
+	rt := model.ResourceTypeEntry{
+		APIGroup: "resource.k8s.io", APIVersion: "v1", Resource: "resourceslices", Kind: "ResourceSlice", Namespaced: false,
+	}
+	items, err := c.GetResources(t.Context(), "", "", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	colMap := columnsToMap(items[0].Columns)
+	assert.Equal(t, "gpu.example.com", colMap["Driver"])
+	assert.Equal(t, "node-1", colMap["Node or Pool"])
+	assert.Equal(t, "1", colMap["Devices"])
+}
+
+func TestGetResources_DeviceClass(t *testing.T) {
+	dc := newFakeDynClientWith(draGVRs, newDeviceClass("gpu-class"))
+	c := newFakeClient(nil, dc)
+
+	rt := model.ResourceTypeEntry{
+		APIGroup: "resource.k8s.io", APIVersion: "v1", Resource: "deviceclasses", Kind: "DeviceClass", Namespaced: false,
+	}
+	items, err := c.GetResources(t.Context(), "", "", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	colMap := columnsToMap(items[0].Columns)
+	assert.Equal(t, "1", colMap["Selectors"])
+}
+
+func TestGetResources_Pod_ResourceClaimsColumn(t *testing.T) {
+	pod := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "gpu-pod", "namespace": "default"},
+		"spec": map[string]any{
+			"resourceClaims": []any{
+				map[string]any{"name": "gpu", "resourceClaimTemplateName": "gpu-template"},
+			},
+		},
+		"status": map[string]any{
+			"resourceClaimStatuses": []any{
+				map[string]any{"name": "gpu", "resourceClaimName": "gpu-pod-gpu"},
+			},
+		},
+	}}
+	dc := newFakeDynClient(pod)
+	c := newFakeClient(nil, dc)
+
+	rt := model.ResourceTypeEntry{APIGroup: "", APIVersion: "v1", Resource: "pods", Kind: "Pod", Namespaced: true}
+	items, err := c.GetResources(t.Context(), "", "default", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	colMap := columnsToMap(items[0].Columns)
+	assert.Equal(t, "gpu-pod-gpu", colMap["Resource Claims"])
+}

--- a/internal/k8s/client_populate_dra.go
+++ b/internal/k8s/client_populate_dra.go
@@ -1,0 +1,141 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// populateResourceClaim adds the allocated device summary and the Ready
+// condition to a ResourceClaim's list columns. An unallocated claim has no
+// status.allocation, so the allocation columns are left blank.
+func populateResourceClaim(ti *model.Item, status map[string]any) {
+	if status == nil {
+		return
+	}
+	if allocation, ok := status["allocation"].(map[string]any); ok {
+		populateResourceClaimAllocation(ti, allocation)
+	}
+	if conditions, ok := status["conditions"].([]any); ok {
+		extractGenericConditions(ti, conditions)
+	}
+}
+
+func populateResourceClaimAllocation(ti *model.Item, allocation map[string]any) {
+	if devices, ok := allocation["devices"].(map[string]any); ok {
+		if results, ok := devices["results"].([]any); ok {
+			var drivers, pools, deviceNames []string
+			for _, r := range results {
+				result, ok := r.(map[string]any)
+				if !ok {
+					continue
+				}
+				if v, ok := result["driver"].(string); ok {
+					drivers = append(drivers, v)
+				}
+				if v, ok := result["pool"].(string); ok {
+					pools = append(pools, v)
+				}
+				if v, ok := result["device"].(string); ok {
+					deviceNames = append(deviceNames, v)
+				}
+			}
+			if len(drivers) > 0 {
+				ti.Columns = append(ti.Columns, model.KeyValue{Key: "Driver", Value: strings.Join(drivers, ", ")})
+			}
+			if len(pools) > 0 {
+				ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pool", Value: strings.Join(pools, ", ")})
+			}
+			if len(deviceNames) > 0 {
+				ti.Columns = append(ti.Columns, model.KeyValue{Key: "Device", Value: strings.Join(deviceNames, ", ")})
+			}
+		}
+	}
+	if node := resourceClaimAllocationNode(allocation); node != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Node", Value: node})
+	}
+}
+
+// resourceClaimAllocationNode extracts the node name a claim was allocated
+// to from status.allocation.nodeSelector, which the API server expresses as
+// a matchFields term on "metadata.name" rather than a dedicated field.
+func resourceClaimAllocationNode(allocation map[string]any) string {
+	nodeSelector, ok := allocation["nodeSelector"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	terms, ok := nodeSelector["nodeSelectorTerms"].([]any)
+	if !ok {
+		return ""
+	}
+	var names []string
+	for _, t := range terms {
+		term, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		matchFields, ok := term["matchFields"].([]any)
+		if !ok {
+			continue
+		}
+		for _, f := range matchFields {
+			field, ok := f.(map[string]any)
+			if !ok {
+				continue
+			}
+			if key, _ := field["key"].(string); key != "metadata.name" {
+				continue
+			}
+			names = append(names, stringsFromAny(field["values"])...)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+// populateResourceClaimTemplate adds the number of device requests a
+// generated ResourceClaim will carry to a ResourceClaimTemplate's list
+// columns.
+func populateResourceClaimTemplate(ti *model.Item, spec map[string]any) {
+	if spec == nil {
+		return
+	}
+	claimSpec, _ := spec["spec"].(map[string]any)
+	devices, _ := claimSpec["devices"].(map[string]any)
+	requests, _ := devices["requests"].([]any)
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Devices", Value: fmt.Sprintf("%d", len(requests))})
+}
+
+// populateResourceSlice adds the publishing driver, the node or pool the
+// slice belongs to, and its device count to a ResourceSlice's list columns.
+func populateResourceSlice(ti *model.Item, spec map[string]any) {
+	if spec == nil {
+		return
+	}
+	if driver, ok := spec["driver"].(string); ok && driver != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Driver", Value: driver})
+	}
+	nodeOrPool := ""
+	if nodeName, ok := spec["nodeName"].(string); ok && nodeName != "" {
+		nodeOrPool = nodeName
+	} else if pool, ok := spec["pool"].(map[string]any); ok {
+		if name, ok := pool["name"].(string); ok {
+			nodeOrPool = name
+		}
+	}
+	if nodeOrPool != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Node or Pool", Value: nodeOrPool})
+	}
+	devices, _ := spec["devices"].([]any)
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Devices", Value: fmt.Sprintf("%d", len(devices))})
+}
+
+// populateDeviceClass adds the number of device selectors to a DeviceClass's
+// list columns.
+func populateDeviceClass(ti *model.Item, spec map[string]any) {
+	if spec == nil {
+		return
+	}
+	selectors, _ := spec["selectors"].([]any)
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Selectors", Value: fmt.Sprintf("%d", len(selectors))})
+}

--- a/internal/k8s/client_populate_dra_test.go
+++ b/internal/k8s/client_populate_dra_test.go
@@ -1,0 +1,248 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// --- populateResourceDetailsExt: ResourceClaim ---
+
+func TestPopulateResourceDetailsExt_ResourceClaim(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		status   map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "allocated single device with node selector and ready condition",
+			status: map[string]any{
+				"allocation": map[string]any{
+					"devices": map[string]any{
+						"results": []any{
+							map[string]any{"driver": "gpu.example.com", "pool": "pool-a", "device": "gpu-0"},
+						},
+					},
+					"nodeSelector": map[string]any{
+						"nodeSelectorTerms": []any{
+							map[string]any{
+								"matchFields": []any{
+									map[string]any{"key": "metadata.name", "operator": "In", "values": []any{"node-1"}},
+								},
+							},
+						},
+					},
+				},
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True"},
+				},
+			},
+			wantCols: map[string]string{
+				"Driver": "gpu.example.com",
+				"Pool":   "pool-a",
+				"Device": "gpu-0",
+				"Node":   "node-1",
+				"Ready":  "True",
+			},
+		},
+		{
+			name: "allocated multiple devices join with comma",
+			status: map[string]any{
+				"allocation": map[string]any{
+					"devices": map[string]any{
+						"results": []any{
+							map[string]any{"driver": "gpu.example.com", "pool": "pool-a", "device": "gpu-0"},
+							map[string]any{"driver": "gpu.example.com", "pool": "pool-a", "device": "gpu-1"},
+						},
+					},
+				},
+			},
+			wantCols: map[string]string{
+				"Driver": "gpu.example.com, gpu.example.com",
+				"Pool":   "pool-a, pool-a",
+				"Device": "gpu-0, gpu-1",
+			},
+		},
+		{
+			name:     "unallocated claim leaves allocation columns blank",
+			status:   map[string]any{},
+			wantCols: nil,
+		},
+		{
+			name:     "nil status produces no columns",
+			status:   nil,
+			wantCols: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec, "status": tt.status}, "ResourceClaim", tt.status, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			if tt.wantCols == nil {
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
+			}
+		})
+	}
+}
+
+// --- populateResourceDetailsExt: ResourceClaimTemplate ---
+
+func TestPopulateResourceDetailsExt_ResourceClaimTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "two device requests",
+			spec: map[string]any{
+				"spec": map[string]any{
+					"devices": map[string]any{
+						"requests": []any{
+							map[string]any{"name": "gpu"},
+							map[string]any{"name": "nic"},
+						},
+					},
+				},
+			},
+			wantCols: map[string]string{"Devices": "2"},
+		},
+		{
+			name: "no device requests",
+			spec: map[string]any{
+				"spec": map[string]any{},
+			},
+			wantCols: map[string]string{"Devices": "0"},
+		},
+		{
+			name:     "nil spec produces no columns",
+			spec:     nil,
+			wantCols: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "ResourceClaimTemplate", nil, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			if tt.wantCols == nil {
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
+			}
+		})
+	}
+}
+
+// --- populateResourceDetailsExt: ResourceSlice ---
+
+func TestPopulateResourceDetailsExt_ResourceSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "node-scoped slice",
+			spec: map[string]any{
+				"driver":   "gpu.example.com",
+				"nodeName": "node-1",
+				"devices":  []any{map[string]any{"name": "gpu-0"}, map[string]any{"name": "gpu-1"}},
+			},
+			wantCols: map[string]string{
+				"Driver":       "gpu.example.com",
+				"Node or Pool": "node-1",
+				"Devices":      "2",
+			},
+		},
+		{
+			name: "pool-scoped slice falls back to pool name",
+			spec: map[string]any{
+				"driver": "gpu.example.com",
+				"pool":   map[string]any{"name": "pool-a"},
+				"devices": []any{
+					map[string]any{"name": "gpu-0"},
+				},
+			},
+			wantCols: map[string]string{
+				"Driver":       "gpu.example.com",
+				"Node or Pool": "pool-a",
+				"Devices":      "1",
+			},
+		},
+		{
+			name:     "nil spec produces no columns",
+			spec:     nil,
+			wantCols: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "ResourceSlice", nil, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			if tt.wantCols == nil {
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
+			}
+		})
+	}
+}
+
+// --- populateResourceDetailsExt: DeviceClass ---
+
+func TestPopulateResourceDetailsExt_DeviceClass(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "two selectors",
+			spec: map[string]any{
+				"selectors": []any{
+					map[string]any{"cel": map[string]any{"expression": "true"}},
+					map[string]any{"cel": map[string]any{"expression": "device.driver == \"gpu.example.com\""}},
+				},
+			},
+			wantCols: map[string]string{"Selectors": "2"},
+		},
+		{
+			name:     "no selectors",
+			spec:     map[string]any{},
+			wantCols: map[string]string{"Selectors": "0"},
+		},
+		{
+			name:     "nil spec produces no columns",
+			spec:     nil,
+			wantCols: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "DeviceClass", nil, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			if tt.wantCols == nil {
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
+			}
+		})
+	}
+}

--- a/internal/k8s/client_populate_ext.go
+++ b/internal/k8s/client_populate_ext.go
@@ -78,6 +78,18 @@ func populateResourceDetailsExt(ti *model.Item, obj map[string]any, kind string,
 	case "MutatingAdmissionPolicyBinding":
 		populateMutatingAdmissionPolicyBinding(ti, spec)
 
+	case "ResourceClaim":
+		populateResourceClaim(ti, status)
+
+	case "ResourceClaimTemplate":
+		populateResourceClaimTemplate(ti, spec)
+
+	case "ResourceSlice":
+		populateResourceSlice(ti, spec)
+
+	case "DeviceClass":
+		populateDeviceClass(ti, spec)
+
 	default:
 		populateGenericCRDResource(ti, status)
 	}

--- a/internal/k8s/client_populate_workloads.go
+++ b/internal/k8s/client_populate_workloads.go
@@ -121,6 +121,52 @@ func populatePodExtraColumns(ti *model.Item, _ map[string]any, status, spec map[
 	if nodeName, ok := spec["nodeName"].(string); ok {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Node", Value: nodeName})
 	}
+	populatePodResourceClaims(ti, status, spec)
+}
+
+// A template-backed claim has no name until the controller generates one,
+// so it is resolved through status.resourceClaimStatuses.
+func populatePodResourceClaims(ti *model.Item, status, spec map[string]any) {
+	claims, ok := spec["resourceClaims"].([]any)
+	if !ok || len(claims) == 0 {
+		return
+	}
+	statuses, _ := status["resourceClaimStatuses"].([]any)
+	var names []string
+	for _, c := range claims {
+		claim, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name := resolvePodResourceClaimName(claim, statuses); name != "" {
+			names = append(names, name)
+		}
+	}
+	if len(names) > 0 {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Resource Claims", Value: strings.Join(names, ", ")})
+	}
+}
+
+func resolvePodResourceClaimName(claim map[string]any, statuses []any) string {
+	if direct, ok := claim["resourceClaimName"].(string); ok && direct != "" {
+		return direct
+	}
+	claimName, _ := claim["name"].(string)
+	for _, s := range statuses {
+		st, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := st["name"].(string); name != claimName {
+			continue
+		}
+		if resolved, ok := st["resourceClaimName"].(string); ok && resolved != "" {
+			return resolved
+		}
+		break
+	}
+	tmpl, _ := claim["resourceClaimTemplateName"].(string)
+	return tmpl
 }
 
 func populateDeploymentDetails(ti *model.Item, obj, status, spec map[string]any) {

--- a/internal/k8s/client_populate_workloads_dra_test.go
+++ b/internal/k8s/client_populate_workloads_dra_test.go
@@ -1,0 +1,85 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestPopulatePodExtraColumns_ResourceClaims(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   map[string]any
+		spec     map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "direct claim reference",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimName": "shared-gpu-claim"},
+				},
+			},
+			wantCols: map[string]string{"Resource Claims": "shared-gpu-claim"},
+		},
+		{
+			name: "template-backed claim resolves through status",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimTemplateName": "gpu-template"},
+				},
+			},
+			status: map[string]any{
+				"resourceClaimStatuses": []any{
+					map[string]any{"name": "gpu", "resourceClaimName": "pod-abc-gpu"},
+				},
+			},
+			wantCols: map[string]string{"Resource Claims": "pod-abc-gpu"},
+		},
+		{
+			name: "template-backed claim falls back to template name when unresolved",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimTemplateName": "gpu-template"},
+				},
+			},
+			wantCols: map[string]string{"Resource Claims": "gpu-template"},
+		},
+		{
+			name: "multiple claims join with comma",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimName": "shared-gpu-claim"},
+					map[string]any{"name": "nic", "resourceClaimTemplateName": "nic-template"},
+				},
+			},
+			status: map[string]any{
+				"resourceClaimStatuses": []any{
+					map[string]any{"name": "nic", "resourceClaimName": "pod-abc-nic"},
+				},
+			},
+			wantCols: map[string]string{"Resource Claims": "shared-gpu-claim, pod-abc-nic"},
+		},
+		{
+			name:     "no claims omits the column",
+			spec:     map[string]any{},
+			wantCols: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populatePodExtraColumns(ti, nil, tt.status, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			assert.Equal(t, tt.wantCols["Resource Claims"], colMap["Resource Claims"])
+			if tt.wantCols["Resource Claims"] == "" {
+				_, ok := colMap["Resource Claims"]
+				assert.False(t, ok, "Resource Claims column must be absent")
+			}
+		})
+	}
+}

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -12,6 +12,7 @@ var CoreCategories = []string{
 	"Config",
 	"Networking",
 	"Storage",
+	"Hardware",
 	"Access Control",
 	"Helm",
 	"API and CRDs",
@@ -185,6 +186,12 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"storage.k8s.io/csinodes":             {Category: "Storage", DisplayName: "CSINodes", Icon: Icon{Unicode: "▤", Simple: "[Cs]", Emoji: "🧩", NerdFont: "\U000f0431"}, Rare: true},
 	"storage.k8s.io/csistoragecapacities": {Category: "Storage", DisplayName: "CSIStorageCapacities", Icon: Icon{Unicode: "▤", Simple: "[Cs]", Emoji: "🧩", NerdFont: "\U000f0431"}, Rare: true},
 	"storage.k8s.io/volumeattachments":    {Category: "Storage", DisplayName: "VolumeAttachments", Icon: Icon{Unicode: "▤", Simple: "[Cs]", Emoji: "🧩", NerdFont: "\U000f0431"}, Rare: true},
+
+	// ---- Hardware ----
+	"resource.k8s.io/resourceclaims":         {Category: "Hardware", DisplayName: "ResourceClaims", Icon: Icon{Unicode: "⎔", Simple: "[Cl]", Emoji: "🎫", NerdFont: "\U000f035b"}},
+	"resource.k8s.io/resourceclaimtemplates": {Category: "Hardware", DisplayName: "ResourceClaimTemplates", Icon: Icon{Unicode: "⌸", Simple: "[Ct]", Emoji: "📇", NerdFont: "\U000f0ede"}},
+	"resource.k8s.io/resourceslices":         {Category: "Hardware", DisplayName: "ResourceSlices", Icon: Icon{Unicode: "▰", Simple: "[Sl]", Emoji: "🔲", NerdFont: "\U000f0ee0"}},
+	"resource.k8s.io/deviceclasses":          {Category: "Hardware", DisplayName: "DeviceClasses", Icon: Icon{Unicode: "⌲", Simple: "[Dc]", Emoji: "🎛️", NerdFont: "\U000f0464"}},
 
 	// ---- Access Control ----
 	"/serviceaccounts":                              {Category: "Access Control", DisplayName: "ServiceAccounts", Icon: Icon{Unicode: "⚇", Simple: "[SA]", Emoji: "👤", NerdFont: "\U000f0004"}},
@@ -459,6 +466,13 @@ var BuiltInOrderRank = map[string]int{
 	"_security/findings-advisor":   110,
 	"_security/findings-heuristic": 111,
 	"_security/findings-rbac":      112,
+
+	// Hardware. Rank orders within a category only, so the block takes the
+	// next free decade instead of squeezing between Storage and Access Control.
+	"resource.k8s.io/resourceclaims":         120,
+	"resource.k8s.io/resourceclaimtemplates": 121,
+	"resource.k8s.io/resourceslices":         122,
+	"resource.k8s.io/deviceclasses":          123,
 }
 
 // PseudoResources returns the LFK-only resource types that are not served

--- a/internal/model/metadata_test.go
+++ b/internal/model/metadata_test.go
@@ -86,6 +86,26 @@ func TestBuiltInMetadata_CoversGatewayAPI(t *testing.T) {
 	}
 }
 
+// TestBuiltInMetadata_CoversHardware asserts the DRA kinds
+// (resource.k8s.io/*) carry the Hardware category and a sort rank.
+func TestBuiltInMetadata_CoversHardware(t *testing.T) {
+	required := []string{
+		"resource.k8s.io/resourceclaims",
+		"resource.k8s.io/resourceclaimtemplates",
+		"resource.k8s.io/resourceslices",
+		"resource.k8s.io/deviceclasses",
+	}
+	for _, key := range required {
+		meta, ok := BuiltInMetadata[key]
+		if assert.True(t, ok, "BuiltInMetadata must contain %s", key) {
+			assert.Equal(t, "Hardware", meta.Category,
+				"%s must be in the Hardware category", key)
+		}
+		_, ranked := BuiltInOrderRank[key]
+		assert.True(t, ranked, "BuiltInOrderRank must contain %s", key)
+	}
+}
+
 // TestBuiltInMetadataCatalogIntegrity enforces that every entry in
 // BuiltInMetadata has all four curated Icon variants populated: the
 // canonical Unicode glyph, the ASCII Simple label, the Emoji glyph,


### PR DESCRIPTION
## Summary

DRA went GA and GPU clusters carry ResourceClaim, ResourceClaimTemplate, ResourceSlice and DeviceClass objects that lfk showed nothing for. The four kinds now sit in a Hardware sidebar group, and a pod's detail pane lists its resource claims.

## Type of change

- [x] feat: new user-facing feature
- [ ] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

None.

## Changes

- New Hardware core category between Storage and Access Control with the four resource.k8s.io/v1 kinds.
- ResourceClaim columns: Driver, Pool, Device, Node, Ready. ResourceSlice columns: Driver, Node or Pool, Devices. Templates and DeviceClasses show request and selector counts.
- Pod detail pane gains a Resource Claims row, resolving template-backed claims through the pod status.
- Fake dynamic-client tests for all four kinds and the pod detail path.
- README groups list and a Dynamic Resource Allocation section in docs/features.md.

Jumping from a pod to its claim with a key is left for a follow-up, since it needs a new keybinding.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (with `-race`)
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (none changed)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)