### PR TITLE
feat: browse PodCertificateRequest and ClusterTrustBundle objects

### DIFF
--- a/internal/app/jump_history.go
+++ b/internal/app/jump_history.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"maps"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -28,6 +29,10 @@ type navSnapshot struct {
 	leftScroll       int // ui.ActiveLeftScroll
 	expandedGroup    string
 	filterText       string
+	// Namespace scope the teleport departed from, restored on jump-back.
+	allNamespaces      bool
+	namespace          string
+	selectedNamespaces map[string]bool
 	// securityActiveGroup preserves the security finding group whose
 	// affected-resources view the snapshot was taken in, so a jump-back
 	// reloads affected resources instead of owned children.
@@ -57,6 +62,9 @@ func (m *Model) captureNavSnapshot() navSnapshot {
 		leftScroll:             ui.ActiveLeftScroll,
 		expandedGroup:          m.expandedGroup,
 		filterText:             m.filterText,
+		allNamespaces:          m.allNamespaces,
+		namespace:              m.namespace,
+		selectedNamespaces:     maps.Clone(m.selectedNamespaces),
 		securityActiveGroup:    m.securityActiveGroup,
 		securityActiveSource:   m.securityActiveSource,
 		securityResourceFilter: append([]security.ResourceRef(nil), m.securityResourceFilter...),
@@ -80,6 +88,7 @@ func (s navSnapshot) clone() navSnapshot {
 	out := s
 	out.leftItems = append([]model.Item(nil), s.leftItems...)
 	out.middleItems = append([]model.Item(nil), s.middleItems...)
+	out.selectedNamespaces = maps.Clone(s.selectedNamespaces)
 	out.securityResourceFilter = append([]security.ResourceRef(nil), s.securityResourceFilter...)
 	out.ownedParentStack = append([]ownedParentState(nil), s.ownedParentStack...)
 	out.leftItemsHistory = make([][]model.Item, len(s.leftItemsHistory))
@@ -114,16 +123,49 @@ func (m *Model) pushJumpHistory() {
 	}
 }
 
+// resolveOwnerResourceTypeEntry lets a caller resolve and fail before
+// pushJumpHistory, so a bad kind never leaves a partial mutation behind.
+func (m Model) resolveOwnerResourceTypeEntry(kind, apiVersion string) (model.ResourceTypeEntry, bool) {
+	crds := m.discoveredResources[m.discoveryContext()]
+	return resolveOwnerResourceType(kind, apiVersion, crds)
+}
+
+// teleportToResourceType performs the climb-to-sidebar-then-descend dance
+// shared by navigateToOwner and its callers. The caller must have already
+// called pushJumpHistory.
+func (m Model) teleportToResourceType(rt model.ResourceTypeEntry, name string) (tea.Model, tea.Cmd) {
+	// Navigate back to resource types level.
+	for m.nav.Level > model.LevelResourceTypes {
+		ret, _ := m.navigateParent()
+		m = ret.(Model)
+	}
+
+	// Find and select the target resource type in middle items.
+	for i, item := range m.middleItems {
+		if item.Extra == rt.ResourceRef() {
+			m.setCursor(i)
+			break
+		}
+	}
+
+	// Set pending target to auto-select the owner resource after load.
+	m.pendingTarget = name
+
+	// Navigate into the resource type.
+	return m.navigateChild()
+}
+
 // restoreNavSnapshot applies a snapshot back onto the Model and returns a
 // command that reloads data for the restored level. Restore is graceful: if the
 // snapshot targets a level deeper than LevelClusters but its context is no
 // longer known, it falls back to the nearest valid level and surfaces a status
 // message instead of crashing.
 func (m *Model) restoreNavSnapshot(snap navSnapshot) tea.Cmd {
-	// Graceful fallback: a snapshot below the cluster picker needs a context
-	// that still exists. If discovery no longer knows it, drop to the cluster
-	// picker rather than restoring into a dead context.
-	if snap.nav.Level > model.LevelClusters && snap.nav.Context != "" {
+	// Graceful fallback: drop to the cluster picker if the snapshot's context
+	// no longer exists. The sentinel is exempt only while union mode is still
+	// on. jumpBackStack isn't cleared when union mode ends.
+	if snap.nav.Level > model.LevelClusters && snap.nav.Context != "" &&
+		(!m.unionMode || snap.nav.Context != UnionContextSentinel) {
 		if !m.contextStillValid(snap.nav.Context) {
 			// A jump-back is a navigation transition: cancel in-flight work and
 			// bump requestGen so async responses from the pre-fallback view
@@ -176,6 +218,9 @@ func (m *Model) restoreNavSnapshot(snap navSnapshot) tea.Cmd {
 	}
 	m.cursors = snap.cursors
 	m.expandedGroup = snap.expandedGroup
+	m.allNamespaces = snap.allNamespaces
+	m.namespace = snap.namespace
+	m.selectedNamespaces = maps.Clone(snap.selectedNamespaces)
 	m.securityActiveGroup = snap.securityActiveGroup
 	m.securityActiveSource = snap.securityActiveSource
 	m.securityResourceFilter = append([]security.ResourceRef(nil), snap.securityResourceFilter...)

--- a/internal/app/update_bookmarks_test.go
+++ b/internal/app/update_bookmarks_test.go
@@ -2312,3 +2312,32 @@ func TestNavigateToBookmark_FailedJumpRecordsNoHistory(t *testing.T) {
 	assert.Empty(t, rm.jumpBackStack,
 		"a failed bookmark jump must not record a jump-history entry")
 }
+
+// TestNavigateToBookmark_JumpBackRestoresOriginNamespace verifies jump-back
+// after a bookmark jump returns to the pre-bookmark namespace scope.
+func TestNavigateToBookmark_JumpBackRestoresOriginNamespace(t *testing.T) {
+	m := baseFinalModel()
+	podRT := model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1", Namespaced: true}
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{podRT}
+	m.namespace = "namespace-a"
+	m.allNamespaces = true
+	m.selectedNamespaces = map[string]bool{"namespace-a": true}
+	m.bookmarkLoadNamespace = true
+
+	bm := model.Bookmark{
+		Slot:         "P",
+		ResourceType: podRT.ResourceRef(),
+		Namespace:    "namespace-b",
+	}
+
+	result, _ := m.navigateToBookmark(bm)
+	rm := result.(Model)
+	require.Equal(t, "namespace-b", rm.namespace, "precondition: bookmark jump applies the saved namespace")
+	require.False(t, rm.allNamespaces, "precondition: the bookmark scoped to a single namespace")
+
+	back, _ := rm.jumpBack()
+	bm2 := back.(Model)
+
+	assert.Equal(t, "namespace-a", bm2.namespace, "jump-back must return to the pre-bookmark namespace")
+	assert.True(t, bm2.allNamespaces, "jump-back must restore the pre-bookmark all-namespaces flag")
+}

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -242,8 +242,7 @@ func resolveOwnerResourceType(kind, apiVersion string, discovered []model.Resour
 // for callers that only know a built-in Kind ("Pod", "Node"). See
 // resolveOwnerResourceType.
 func (m Model) navigateToOwner(kind, name, apiVersion string) (tea.Model, tea.Cmd) {
-	crds := m.discoveredResources[m.discoveryContext()]
-	rt, ok := resolveOwnerResourceType(kind, apiVersion, crds)
+	rt, ok := m.resolveOwnerResourceTypeEntry(kind, apiVersion)
 	if !ok {
 		m.setStatusMessage(fmt.Sprintf("Unknown resource type: %s", kind), true)
 		return m, scheduleStatusClear()
@@ -252,25 +251,7 @@ func (m Model) navigateToOwner(kind, name, apiVersion string) (tea.Model, tea.Cm
 	// Record the origin so jump_back can return here after this teleport.
 	m.pushJumpHistory()
 
-	// Navigate back to resource types level.
-	for m.nav.Level > model.LevelResourceTypes {
-		ret, _ := m.navigateParent()
-		m = ret.(Model)
-	}
-
-	// Find and select the target resource type in middle items.
-	for i, item := range m.middleItems {
-		if item.Extra == rt.ResourceRef() {
-			m.setCursor(i)
-			break
-		}
-	}
-
-	// Set pending target to auto-select the owner resource after load.
-	m.pendingTarget = name
-
-	// Navigate into the resource type.
-	return m.navigateChild()
+	return m.teleportToResourceType(rt, name)
 }
 
 func (m Model) navigateChild() (tea.Model, tea.Cmd) {
@@ -579,13 +560,21 @@ func (m Model) navigateChildResource(sel *model.Item) (tea.Model, tea.Cmd) {
 		if podName == "" || sel.Namespace == "" {
 			return m, nil
 		}
-		// The namespace switch lands before navigateToOwner pushes the
-		// jump history. navSnapshot does not record namespace fields, so
-		// jump_back cannot restore them either way.
+		rt, ok := m.resolveOwnerResourceTypeEntry("Pod", "v1")
+		if !ok {
+			m.setStatusMessage("Unknown resource type: Pod", true)
+			return m, scheduleStatusClear()
+		}
+		// Push history before switching scope, so jump-back restores the
+		// origin namespace/cluster scope rather than the Pod's.
+		m.pushJumpHistory()
+		if m.unionMode && sel.ClusterName != "" {
+			m.nav.Context = sel.ClusterName
+		}
 		m.allNamespaces = false
 		m.namespace = sel.Namespace
 		m.selectedNamespaces = map[string]bool{sel.Namespace: true}
-		return m.navigateToOwner("Pod", podName, "v1")
+		return m.teleportToResourceType(rt, podName)
 	}
 	if !m.resourceTypeHasChildren() && m.nav.ResourceType.Kind != "Pod" {
 		return m, nil

--- a/internal/app/update_navigation.go
+++ b/internal/app/update_navigation.go
@@ -574,6 +574,19 @@ func (m Model) navigateChildResource(sel *model.Item) (tea.Model, tea.Cmd) {
 		}
 		return m, m.loadPreview()
 	}
+	if sel.Kind == "PodCertificateRequest" {
+		podName := sel.ColumnValue("Pod")
+		if podName == "" || sel.Namespace == "" {
+			return m, nil
+		}
+		// The namespace switch lands before navigateToOwner pushes the
+		// jump history. navSnapshot does not record namespace fields, so
+		// jump_back cannot restore them either way.
+		m.allNamespaces = false
+		m.namespace = sel.Namespace
+		m.selectedNamespaces = map[string]bool{sel.Namespace: true}
+		return m.navigateToOwner("Pod", podName, "v1")
+	}
 	if !m.resourceTypeHasChildren() && m.nav.ResourceType.Kind != "Pod" {
 		return m, nil
 	}

--- a/internal/app/update_navigation_test.go
+++ b/internal/app/update_navigation_test.go
@@ -857,3 +857,48 @@ func TestPgUpKeyScrollsFullPageUp(t *testing.T) {
 	assert.Less(t, rm.cursor(), 30, "PgUp must move the cursor backwards")
 	assert.GreaterOrEqual(t, rm.cursor(), 0)
 }
+
+// Must scope the namespace to the item's own, not the current all-namespaces view.
+func TestNavigateChildResource_PodCertificateRequestJumpsToPod(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "PodCertificateRequest", APIGroup: "certificates.k8s.io", APIVersion: "v1",
+		Resource: "podcertificaterequests", Namespaced: true,
+	}
+	m.namespace = "default"
+	m.allNamespaces = true
+	m.leftItemsHistory = [][]model.Item{{{Name: "test-ctx"}}}
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}
+
+	sel := &model.Item{
+		Name: "pcr-1", Namespace: "ns-a", Kind: "PodCertificateRequest",
+		Columns: []model.KeyValue{{Key: "Pod", Value: "target-pod"}},
+	}
+	result, _ := m.navigateChildResource(sel)
+	rm := result.(Model)
+
+	assert.False(t, rm.allNamespaces, "must switch off all-namespaces so the Pod list loads scoped")
+	assert.Equal(t, "ns-a", rm.namespace, "must use the request's own namespace, not the current view")
+	assert.True(t, rm.selectedNamespaces["ns-a"])
+	assert.Equal(t, "target-pod", rm.pendingTarget)
+}
+
+func TestNavigateChildResource_PodCertificateRequestNoPodColumnNoOp(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "PodCertificateRequest", APIGroup: "certificates.k8s.io", APIVersion: "v1",
+		Resource: "podcertificaterequests", Namespaced: true,
+	}
+	m.namespace = "default"
+
+	sel := &model.Item{Name: "pcr-1", Namespace: "ns-a", Kind: "PodCertificateRequest"}
+	result, cmd := m.navigateChildResource(sel)
+	rm := result.(Model)
+
+	assert.Equal(t, model.LevelResources, rm.nav.Level, "must not navigate without a Pod column")
+	assert.Nil(t, cmd)
+}

--- a/internal/app/update_navigation_test.go
+++ b/internal/app/update_navigation_test.go
@@ -902,3 +902,124 @@ func TestNavigateChildResource_PodCertificateRequestNoPodColumnNoOp(t *testing.T
 	assert.Equal(t, model.LevelResources, rm.nav.Level, "must not navigate without a Pod column")
 	assert.Nil(t, cmd)
 }
+
+// Round trip: a PodCertificateRequest jump scopes to the request's own
+// namespace, and jumping back must restore the origin all-namespaces scope
+// rather than stranding the user in the Pod's single namespace.
+func TestNavigateChildResource_PodCertificateRequestJumpBackRestoresNamespaceScope(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "PodCertificateRequest", APIGroup: "certificates.k8s.io", APIVersion: "v1",
+		Resource: "podcertificaterequests", Namespaced: true,
+	}
+	m.allNamespaces = true
+	m.namespace = ""
+	m.selectedNamespaces = map[string]bool{"team-a": true, "team-b": true}
+	m.leftItemsHistory = [][]model.Item{{{Name: "test-ctx"}}}
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}
+
+	sel := &model.Item{
+		Name: "pcr-1", Namespace: "ns-a", Kind: "PodCertificateRequest",
+		Columns: []model.KeyValue{{Key: "Pod", Value: "target-pod"}},
+	}
+	result, _ := m.navigateChildResource(sel)
+	rm := result.(Model)
+	require.False(t, rm.allNamespaces, "the teleport must scope to the request's own namespace")
+	require.Equal(t, "ns-a", rm.namespace)
+
+	back, _ := rm.jumpBack()
+	bm := back.(Model)
+
+	assert.True(t, bm.allNamespaces, "jump-back must restore the origin all-namespaces scope")
+	assert.Empty(t, bm.namespace)
+	assert.Equal(t, map[string]bool{"team-a": true, "team-b": true}, bm.selectedNamespaces)
+}
+
+// The row carries its source cluster in ClusterName. The pod load must
+// target that cluster rather than fanning out via the union sentinel.
+func TestNavigateChildResource_PodCertificateRequestUnionRoutesToSourceCluster(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "PodCertificateRequest", APIGroup: "certificates.k8s.io", APIVersion: "v1",
+		Resource: "podcertificaterequests", Namespaced: true,
+	}
+	m.unionMode = true
+	m.nav.Context = UnionContextSentinel
+	m.unionContexts = []string{"blue", "green"}
+	m.leftItemsHistory = [][]model.Item{{{Name: "union"}}}
+	m.discoveredResources["blue"] = []model.ResourceTypeEntry{
+		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}
+
+	sel := &model.Item{
+		Name: "pcr-1", Namespace: "ns-a", Kind: "PodCertificateRequest", ClusterName: "green",
+		Columns: []model.KeyValue{{Key: "Pod", Value: "target-pod"}},
+	}
+	result, _ := m.navigateChildResource(sel)
+	rm := result.(Model)
+
+	assert.Equal(t, "green", rm.nav.Context,
+		"must route the pod load to the row's source cluster, not the union sentinel")
+}
+
+// A union-mode PodCertificateRequest jump must be reversible: jump-back
+// restores the union sentinel view, not the source cluster it teleported to.
+func TestNavigateChildResource_PodCertificateRequestUnionJumpBackRestoresUnionContext(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.nav.ResourceType = model.ResourceTypeEntry{
+		Kind: "PodCertificateRequest", APIGroup: "certificates.k8s.io", APIVersion: "v1",
+		Resource: "podcertificaterequests", Namespaced: true,
+	}
+	m.unionMode = true
+	m.nav.Context = UnionContextSentinel
+	m.unionContexts = []string{"blue", "green"}
+	m.leftItemsHistory = [][]model.Item{{{Name: "union"}}}
+	m.discoveredResources["blue"] = []model.ResourceTypeEntry{
+		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}
+
+	sel := &model.Item{
+		Name: "pcr-1", Namespace: "ns-a", Kind: "PodCertificateRequest", ClusterName: "green",
+		Columns: []model.KeyValue{{Key: "Pod", Value: "target-pod"}},
+	}
+	result, _ := m.navigateChildResource(sel)
+	rm := result.(Model)
+	require.Equal(t, "green", rm.nav.Context)
+
+	back, _ := rm.jumpBack()
+	bm := back.(Model)
+
+	assert.Equal(t, UnionContextSentinel, bm.nav.Context,
+		"jump-back must restore the union view, not strand the user in the source cluster")
+}
+
+// jumpBackStack isn't cleared when union mode ends (navigateParentFromPickerUnion),
+// so a stale union-mode snapshot restored after leaving union mode must be
+// rejected like any other unknown context, not exempted via the sentinel alone.
+func TestJumpBackUnionSnapshotAfterUnionModeOffFallsBackLikeUnknownContext(t *testing.T) {
+	m := basePush80Model()
+	m.nav.Level = model.LevelResources
+	m.unionMode = true
+	m.nav.Context = UnionContextSentinel
+	m.unionContexts = []string{"blue", "green"}
+	m.leftItemsHistory = [][]model.Item{{{Name: "union"}}}
+
+	m.pushJumpHistory()
+
+	m.unionMode = false
+	m.nav.Context = "blue"
+
+	result, _ := m.jumpBack()
+	rm := result.(Model)
+
+	assert.NotEqual(t, UnionContextSentinel, rm.nav.Context,
+		"jump-back must not leave the sentinel in nav.Context once union mode is off")
+	assert.Equal(t, model.LevelClusters, rm.nav.Level,
+		"a stale union snapshot outside union mode falls back to the cluster picker like any unknown context")
+	assert.True(t, rm.hasStatusMessage(), "fallback must surface a status message")
+}

--- a/internal/k8s/client_populate_certificates.go
+++ b/internal/k8s/client_populate_certificates.go
@@ -1,0 +1,59 @@
+package k8s
+
+import (
+	"encoding/pem"
+	"fmt"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// notBefore/notAfter are copied verbatim, matching cert-manager Certificate's
+// "Expires" column (no relative-time conversion).
+func populatePodCertificateRequest(ti *model.Item, spec, status map[string]any) {
+	if spec != nil {
+		if podName, ok := spec["podName"].(string); ok && podName != "" {
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pod", Value: podName})
+		}
+		if signerName, ok := spec["signerName"].(string); ok && signerName != "" {
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Signer", Value: signerName})
+		}
+	}
+	if status != nil {
+		if notBefore, ok := status["notBefore"].(string); ok && notBefore != "" {
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Issued", Value: notBefore})
+		}
+		if notAfter, ok := status["notAfter"].(string); ok && notAfter != "" {
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: "Expires", Value: notAfter})
+		}
+	}
+}
+
+// Signer is always shown, even empty, since an anonymous bundle is valid.
+func populateClusterTrustBundle(ti *model.Item, spec map[string]any) {
+	if spec == nil {
+		return
+	}
+	signerName, _ := spec["signerName"].(string)
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Signer", Value: signerName})
+
+	trustBundle, _ := spec["trustBundle"].(string)
+	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Certificates", Value: fmt.Sprintf("%d", countPEMCertificates(trustBundle))})
+}
+
+// countPEMCertificates counts CERTIFICATE-type PEM blocks in data. Malformed
+// or non-PEM input decodes to zero blocks.
+func countPEMCertificates(data string) int {
+	count := 0
+	rest := []byte(data)
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/k8s/client_populate_certificates_test.go
+++ b/internal/k8s/client_populate_certificates_test.go
@@ -1,0 +1,235 @@
+package k8s
+
+import (
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// --- populateResourceDetailsExt: PodCertificateRequest ---
+
+func TestPopulateResourceDetailsExt_PodCertificateRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		status   map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "pod, signer, and issued/expiry columns",
+			spec: map[string]any{
+				"podName":    "web-1",
+				"signerName": "example.com/signer",
+			},
+			status: map[string]any{
+				"notBefore": "2026-01-01T00:00:00Z",
+				"notAfter":  "2026-01-02T00:00:00Z",
+			},
+			wantCols: map[string]string{
+				"Pod":     "web-1",
+				"Signer":  "example.com/signer",
+				"Issued":  "2026-01-01T00:00:00Z",
+				"Expires": "2026-01-02T00:00:00Z",
+			},
+		},
+		{
+			name: "no status yields no issued/expiry columns",
+			spec: map[string]any{
+				"podName":    "web-1",
+				"signerName": "example.com/signer",
+			},
+			status: nil,
+			wantCols: map[string]string{
+				"Pod":    "web-1",
+				"Signer": "example.com/signer",
+			},
+		},
+		{
+			name:   "no spec yields no pod/signer columns",
+			spec:   nil,
+			status: map[string]any{"notBefore": "2026-01-01T00:00:00Z"},
+			wantCols: map[string]string{
+				"Issued": "2026-01-01T00:00:00Z",
+			},
+		},
+		{
+			name:     "nil spec and status produce no columns",
+			spec:     nil,
+			status:   nil,
+			wantCols: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec, "status": tt.status}, "PodCertificateRequest", tt.status, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			if tt.wantCols == nil {
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
+			}
+		})
+	}
+}
+
+// --- populateResourceDetailsExt: ClusterTrustBundle ---
+
+func pemCertBlock(t *testing.T, payload string) string {
+	t.Helper()
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte(payload)}))
+}
+
+func TestPopulateResourceDetailsExt_ClusterTrustBundle(t *testing.T) {
+	twoCerts := pemCertBlock(t, "cert-one") + pemCertBlock(t, "cert-two")
+	oneCert := pemCertBlock(t, "cert-one")
+
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		wantCols map[string]string
+	}{
+		{
+			name: "signer set with two certificates",
+			spec: map[string]any{
+				"signerName":  "example.com/signer",
+				"trustBundle": twoCerts,
+			},
+			wantCols: map[string]string{
+				"Signer":       "example.com/signer",
+				"Certificates": "2",
+			},
+		},
+		{
+			name: "empty signer means anonymous bundle, still reported",
+			spec: map[string]any{
+				"signerName":  "",
+				"trustBundle": oneCert,
+			},
+			wantCols: map[string]string{
+				"Signer":       "",
+				"Certificates": "1",
+			},
+		},
+		{
+			name: "malformed PEM counts zero certificates",
+			spec: map[string]any{
+				"signerName":  "example.com/signer",
+				"trustBundle": "not a pem bundle",
+			},
+			wantCols: map[string]string{
+				"Signer":       "example.com/signer",
+				"Certificates": "0",
+			},
+		},
+		{
+			name:     "nil spec produces no columns",
+			spec:     nil,
+			wantCols: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populateResourceDetailsExt(ti, map[string]any{"spec": tt.spec}, "ClusterTrustBundle", nil, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			if tt.wantCols == nil {
+				assert.Empty(t, colMap)
+			} else {
+				assert.Equal(t, tt.wantCols, colMap)
+			}
+		})
+	}
+}
+
+// --- GetResources end to end: PodCertificateRequest ---
+
+var podCertificateRequestGVR = schema.GroupVersionResource{
+	Group: "certificates.k8s.io", Version: "v1", Resource: "podcertificaterequests",
+}
+
+func TestGetResources_PodCertificateRequestColumns(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		podCertificateRequestGVR: "PodCertificateRequestList",
+	}
+	pcr := &unstructured.Unstructured{}
+	pcr.SetUnstructuredContent(map[string]any{
+		"apiVersion": "certificates.k8s.io/v1",
+		"kind":       "PodCertificateRequest",
+		"metadata":   map[string]any{"name": "pcr-1", "namespace": "default"},
+		"spec": map[string]any{
+			"podName":    "web-1",
+			"signerName": "example.com/signer",
+		},
+		"status": map[string]any{
+			"notBefore": "2026-01-01T00:00:00Z",
+			"notAfter":  "2026-01-02T00:00:00Z",
+		},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, pcr)
+	c := newFakeClient(nil, dyn)
+
+	rt := model.ResourceTypeEntry{
+		Kind: "PodCertificateRequest", APIGroup: "certificates.k8s.io", APIVersion: "v1",
+		Resource: "podcertificaterequests", Namespaced: true,
+	}
+	items, err := c.GetResources(t.Context(), "test-ctx", "default", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	colMap := columnsToMap(items[0].Columns)
+	assert.Equal(t, "web-1", colMap["Pod"])
+	assert.Equal(t, "example.com/signer", colMap["Signer"])
+	assert.Equal(t, "2026-01-01T00:00:00Z", colMap["Issued"])
+	assert.Equal(t, "2026-01-02T00:00:00Z", colMap["Expires"])
+}
+
+// --- GetResources end to end: ClusterTrustBundle ---
+
+var clusterTrustBundleGVR = schema.GroupVersionResource{
+	Group: "certificates.k8s.io", Version: "v1", Resource: "clustertrustbundles",
+}
+
+func TestGetResources_ClusterTrustBundleColumns(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvrs := map[schema.GroupVersionResource]string{
+		clusterTrustBundleGVR: "ClusterTrustBundleList",
+	}
+	ctb := &unstructured.Unstructured{}
+	ctb.SetUnstructuredContent(map[string]any{
+		"apiVersion": "certificates.k8s.io/v1",
+		"kind":       "ClusterTrustBundle",
+		"metadata":   map[string]any{"name": "example.com:signer:v1"},
+		"spec": map[string]any{
+			"signerName":  "example.com/signer",
+			"trustBundle": pemCertBlock(t, "cert-one") + pemCertBlock(t, "cert-two"),
+		},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs, ctb)
+	c := newFakeClient(nil, dyn)
+
+	rt := model.ResourceTypeEntry{
+		Kind: "ClusterTrustBundle", APIGroup: "certificates.k8s.io", APIVersion: "v1",
+		Resource: "clustertrustbundles", Namespaced: false,
+	}
+	items, err := c.GetResources(t.Context(), "test-ctx", "", rt)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	colMap := columnsToMap(items[0].Columns)
+	assert.Equal(t, "example.com/signer", colMap["Signer"])
+	assert.Equal(t, "2", colMap["Certificates"])
+}

--- a/internal/k8s/client_populate_ext.go
+++ b/internal/k8s/client_populate_ext.go
@@ -78,17 +78,8 @@ func populateResourceDetailsExt(ti *model.Item, obj map[string]any, kind string,
 	case "MutatingAdmissionPolicyBinding":
 		populateMutatingAdmissionPolicyBinding(ti, spec)
 
-	case "ResourceClaim":
-		populateResourceClaim(ti, status)
-
-	case "ResourceClaimTemplate":
-		populateResourceClaimTemplate(ti, spec)
-
-	case "ResourceSlice":
-		populateResourceSlice(ti, spec)
-
-	case "DeviceClass":
-		populateDeviceClass(ti, spec)
+	case "ResourceClaim", "ResourceClaimTemplate", "ResourceSlice", "DeviceClass":
+		populateDRAResource(ti, kind, status, spec)
 
 	case "PodCertificateRequest":
 		populatePodCertificateRequest(ti, spec, status)
@@ -98,6 +89,21 @@ func populateResourceDetailsExt(ti *model.Item, obj map[string]any, kind string,
 
 	default:
 		populateGenericCRDResource(ti, status)
+	}
+}
+
+// populateDRAResource keeps the resource.k8s.io kinds out of the main switch,
+// which sits at the gocyclo cap.
+func populateDRAResource(ti *model.Item, kind string, status, spec map[string]any) {
+	switch kind {
+	case "ResourceClaim":
+		populateResourceClaim(ti, status)
+	case "ResourceClaimTemplate":
+		populateResourceClaimTemplate(ti, spec)
+	case "ResourceSlice":
+		populateResourceSlice(ti, spec)
+	case "DeviceClass":
+		populateDeviceClass(ti, spec)
 	}
 }
 

--- a/internal/k8s/client_populate_ext.go
+++ b/internal/k8s/client_populate_ext.go
@@ -90,6 +90,12 @@ func populateResourceDetailsExt(ti *model.Item, obj map[string]any, kind string,
 	case "DeviceClass":
 		populateDeviceClass(ti, spec)
 
+	case "PodCertificateRequest":
+		populatePodCertificateRequest(ti, spec, status)
+
+	case "ClusterTrustBundle":
+		populateClusterTrustBundle(ti, spec)
+
 	default:
 		populateGenericCRDResource(ti, status)
 	}

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -199,6 +199,8 @@ var BuiltInMetadata = map[string]DisplayMetadata{
 	"rbac.authorization.k8s.io/rolebindings":        {Category: "Access Control", DisplayName: "RoleBindings", Icon: Icon{Unicode: "⊷", Simple: "[Rb]", Emoji: "🔗", NerdFont: "\U000f0339"}},
 	"rbac.authorization.k8s.io/clusterroles":        {Category: "Access Control", DisplayName: "ClusterRoles", Icon: Icon{Unicode: "⚿", Simple: "[Ro]", Emoji: "🔑", NerdFont: "\U000f0be4"}},
 	"rbac.authorization.k8s.io/clusterrolebindings": {Category: "Access Control", DisplayName: "ClusterRoleBindings", Icon: Icon{Unicode: "⊷", Simple: "[Rb]", Emoji: "🔗", NerdFont: "\U000f0339"}},
+	"certificates.k8s.io/podcertificaterequests":    {Category: "Access Control", DisplayName: "PodCertificateRequests", Icon: Icon{Unicode: "⌖", Simple: "[Pc]", Emoji: "📜", NerdFont: "\U000f0a36"}, Rare: true},
+	"certificates.k8s.io/clustertrustbundles":       {Category: "Access Control", DisplayName: "ClusterTrustBundles", Icon: Icon{Unicode: "▩", Simple: "[Tb]", Emoji: "🔏", NerdFont: "\U000f0bfa"}, Rare: true},
 
 	// ---- API and CRDs ----
 	"apiregistration.k8s.io/apiservices":             {Category: "API and CRDs", DisplayName: "API Services", Icon: Icon{Unicode: "⟐", Simple: "[AS]", Emoji: "🔌", NerdFont: "\U000f109b"}, Rare: true},
@@ -453,6 +455,8 @@ var BuiltInOrderRank = map[string]int{
 	"rbac.authorization.k8s.io/rolebindings":        82,
 	"rbac.authorization.k8s.io/clusterroles":        83,
 	"rbac.authorization.k8s.io/clusterrolebindings": 84,
+	"certificates.k8s.io/podcertificaterequests":    85,
+	"certificates.k8s.io/clustertrustbundles":       86,
 
 	// Helm
 	"_helm/releases": 90,

--- a/internal/model/metadata_test.go
+++ b/internal/model/metadata_test.go
@@ -57,6 +57,25 @@ func TestBuiltInMetadata_CoversCoreK8sResources(t *testing.T) {
 	}
 }
 
+// TestBuiltInMetadata_CoversPodCertificates asserts that the certificates.k8s.io
+// rare kinds (PodCertificateRequest, ClusterTrustBundle) are registered under
+// Access Control, next to the other rare RBAC/identity kinds.
+func TestBuiltInMetadata_CoversPodCertificates(t *testing.T) {
+	for _, tc := range []struct {
+		key         string
+		displayName string
+	}{
+		{"certificates.k8s.io/podcertificaterequests", "PodCertificateRequests"},
+		{"certificates.k8s.io/clustertrustbundles", "ClusterTrustBundles"},
+	} {
+		meta, ok := BuiltInMetadata[tc.key]
+		require.True(t, ok, "BuiltInMetadata must contain %s", tc.key)
+		assert.Equal(t, "Access Control", meta.Category)
+		assert.Equal(t, tc.displayName, meta.DisplayName)
+		assert.True(t, meta.Rare, "%s should be a rare resource", tc.key)
+	}
+}
+
 // TestBuiltInMetadata_CoversGatewayAPI asserts that the full set of
 // Gateway API resources (gateway.networking.k8s.io/*) surfaced by LFK
 // are present in BuiltInMetadata and carry the Networking category, so


### PR DESCRIPTION
## Summary

PodCertificateRequest and ClusterTrustBundle went GA in Kubernetes 1.37. Both are now rare Access Control kinds with list columns, and Enter on a request row opens the requesting pod.

## Type of change

- [x] feat: new user-facing feature
- [ ] fix: bug fix
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

None.

## Changes

- Register certificates.k8s.io/v1 podcertificaterequests and clustertrustbundles under Access Control as rare types.
- PodCertificateRequest columns: Pod, Signer, Issued, Expires (from the status timestamps).
- ClusterTrustBundle columns: Signer, Certificates (PEM block count).
- Enter on a request row opens the pod in its own namespace and cluster.
- Jump back now restores the namespace scope you had before any jump (owner, bookmark, orphan), and a union view is restored only while union mode is still on.
- Fake dynamic-client tests for both kinds, plus a navigation test.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (with `-race`)
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed (no per-kind table exists, rare types are already described)
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed (none changed)
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)