### PR TITLE
fix: log the kubeconfig_dir shape instead of its raw value

### DIFF
--- a/internal/ui/config_kubeconfig.go
+++ b/internal/ui/config_kubeconfig.go
@@ -64,12 +64,39 @@ func applyKubeconfigDirsSetting(s *kubeconfigDirsSetting) {
 	}
 	if s.invalid {
 		logger.Warn("unrecognised kubeconfig_dir value in config; ignored",
-			"value", s.raw,
+			"value_shape", kubeconfigDirsValueShape(s.raw),
 			"valid", "string or list of strings")
 		return
 	}
 	if len(s.paths) > 0 {
 		ConfigKubeconfigDirs = s.paths
+	}
+}
+
+// kubeconfigDirsValueShape describes the JSON shape of an unrecognised
+// kubeconfig_dir value without echoing the value itself, so a pasted secret
+// never lands in the log file (CWE-532).
+func kubeconfigDirsValueShape(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "empty"
+	}
+	switch trimmed[0] {
+	case '{':
+		return "map"
+	case '[':
+		return "list"
+	case '"':
+		return "string"
+	case 't', 'f':
+		return "bool"
+	case 'n':
+		return "null"
+	default:
+		if trimmed[0] == '-' || (trimmed[0] >= '0' && trimmed[0] <= '9') {
+			return "number"
+		}
+		return "unknown"
 	}
 }
 

--- a/internal/ui/config_kubeconfig_test.go
+++ b/internal/ui/config_kubeconfig_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression guard (CWE-532): a pasted secret under kubeconfig_dir must
+// never reach the log file, only a description of its shape.
+func TestApplyKubeconfigDirsSetting_InvalidValueNotLogged(t *testing.T) {
+	origLogger := logger.Logger
+	t.Cleanup(func() { logger.Logger = origLogger })
+
+	origDirs := ConfigKubeconfigDirs
+	t.Cleanup(func() { ConfigKubeconfigDirs = origDirs })
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantLog string
+	}{
+		{
+			name:    "map with secret token",
+			raw:     `{"token":"super-secret-value-12345"}`,
+			wantLog: "map",
+		},
+		{
+			name:    "number",
+			raw:     "42",
+			wantLog: "number",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger.Logger = slog.New(slog.NewTextHandler(&buf, nil))
+
+			applyKubeconfigDirsSetting(&kubeconfigDirsSetting{raw: tc.raw, invalid: true})
+
+			out := buf.String()
+			assert.NotContains(t, out, tc.raw, "raw config value must not be logged")
+			assert.Contains(t, out, tc.wantLog, "log must describe the unrecognised shape")
+		})
+	}
+}

--- a/internal/ui/config_kubeconfig_test.go
+++ b/internal/ui/config_kubeconfig_test.go
@@ -32,8 +32,8 @@ func TestApplyKubeconfigDirsSetting_InvalidValueNotLogged(t *testing.T) {
 		},
 		{
 			name:    "number",
-			raw:     "42",
-			secret:  "42",
+			raw:     "9876543210",
+			secret:  "9876543210",
 			wantLog: "number",
 		},
 	}

--- a/internal/ui/config_kubeconfig_test.go
+++ b/internal/ui/config_kubeconfig_test.go
@@ -21,16 +21,19 @@ func TestApplyKubeconfigDirsSetting_InvalidValueNotLogged(t *testing.T) {
 	tests := []struct {
 		name    string
 		raw     string
+		secret  string
 		wantLog string
 	}{
 		{
 			name:    "map with secret token",
 			raw:     `{"token":"super-secret-value-12345"}`,
+			secret:  "super-secret-value-12345",
 			wantLog: "map",
 		},
 		{
 			name:    "number",
 			raw:     "42",
+			secret:  "42",
 			wantLog: "number",
 		},
 	}
@@ -44,6 +47,7 @@ func TestApplyKubeconfigDirsSetting_InvalidValueNotLogged(t *testing.T) {
 
 			out := buf.String()
 			assert.NotContains(t, out, tc.raw, "raw config value must not be logged")
+			assert.NotContains(t, out, tc.secret, "secret value must not be logged")
 			assert.Contains(t, out, tc.wantLog, "log must describe the unrecognised shape")
 		})
 	}


### PR DESCRIPTION
## Summary
- An unrecognised YAML shape under `kubeconfig_dir` (a map or a number) used to be echoed raw into the log file, so a pasted secret could land there (CWE-532, surfaced by a CodeRabbit review).
- The warning now carries only a shape description (`value_shape: map|number|bool`), never the value.
- Regression test asserts the raw value never reaches the log.

## Test plan
- [x] `go test ./... -race` green
- [x] `golangci-lint run ./...` 0 issues
- [ ] Manual: set `kubeconfig_dir` to a map with a fake token, start lfk, grep the log for the token (no hit) and for `value_shape` (hit)