### PR TITLE
feat: show the right-sizing data span when it is shorter than the window

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -62,6 +62,8 @@ The Hardware category lists ResourceClaims, ResourceClaimTemplates, ResourceSlic
 | `1d-max`, `1d-avg`, `7d-p95` | Prometheus range queries | Sizing decisions. `7d-p95` is the safest default for requests. |
 | `vpa` | VerticalPodAutoscaler recommender | Sizing decisions when a VPA already targets the workload. |
 
+When Prometheus holds less history than the window, the header adds the real span, for example `over last 7d (data: 5h)`. A new workload therefore cannot pass for a week of evidence.
+
 The chip shows `snapshot` with no `[N/M]` counter when it is the only strategy available. To unlock the others, point lfk at Prometheus or VictoriaMetrics (see [config-reference.md](config-reference.md#monitoring)) or create a VPA in `Off` mode for the workload. Then cycle with `[` and `]`. Keys and headroom are in [keybindings.md](keybindings.md#right-sizing-advisor).
 
 ## Embedded terminal

--- a/internal/k8s/client_rightsizing_prom.go
+++ b/internal/k8s/client_rightsizing_prom.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/janosmiko/lfk/internal/logger"
@@ -31,14 +32,28 @@ func (c *Client) applyPrometheusStrategy(ctx context.Context, contextName, names
 	}
 	out.Window = promStrategyWindow(strategy)
 
-	cpuResult, err := c.queryPromContainerMetric(ctx, contextName, cpuQuery)
-	if err != nil {
-		logger.Debug("rightsizing: Prometheus CPU query failed", "err", err)
-	}
-	memResult, err := c.queryPromContainerMetric(ctx, contextName, memQuery)
-	if err != nil {
-		logger.Debug("rightsizing: Prometheus memory query failed", "err", err)
-	}
+	// Each proxy round trip carries its own 10s timeout, so in series a
+	// slow Prometheus would hold the overlay blank for three of them.
+	var (
+		cpuResult, memResult map[string]float64
+		span                 string
+		wg                   sync.WaitGroup
+	)
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		cpuResult = c.promContainerValues(ctx, contextName, cpuQuery, "cpu")
+	}()
+	go func() {
+		defer wg.Done()
+		memResult = c.promContainerValues(ctx, contextName, memQuery, "memory")
+	}()
+	go func() {
+		defer wg.Done()
+		span = c.promDataSpan(ctx, contextName, namespace, kind, name, indexed, strategy)
+	}()
+	wg.Wait()
+	out.DataSpan = span
 
 	for i := range out.Containers {
 		cr := &out.Containers[i]
@@ -57,6 +72,16 @@ func (c *Client) applyPrometheusStrategy(ctx context.Context, contextName, names
 			cr.Mem.RecommendedLimit = scaleLimitFromRatio(cr.Mem.CurrentRequest, cr.Mem.CurrentLimit, rec)
 		}
 	}
+}
+
+// promContainerValues swallows the query error after logging it: the
+// SUGGESTION cells go empty rather than the whole overlay failing.
+func (c *Client) promContainerValues(ctx context.Context, contextName, query, resourceKind string) map[string]float64 {
+	result, err := c.queryPromContainerMetric(ctx, contextName, query)
+	if err != nil {
+		logger.Debug("rightsizing: Prometheus query failed", "resource", resourceKind, "err", err)
+	}
+	return result
 }
 
 // promStrategyWindow returns the human-readable window label for the
@@ -86,11 +111,7 @@ func buildPromContainerQuery(namespace, kind, name string, indexed bool, strateg
 	if podRegex == "" {
 		return ""
 	}
-	// A raw PromQL literal, so the `\.` QuoteMeta emits for a dotted
-	// workload name survives: a double-quoted literal processes escapes
-	// and rejects `\.` as unknown.
-	podMatcher := fmt.Sprintf("pod=~%s%s%s", promRawQuote, podRegex, promRawQuote)
-	commonLabels := fmt.Sprintf(`namespace=%q,%s,container!="POD",container!=""`, namespace, podMatcher)
+	commonLabels := promWorkloadSelector(namespace, podRegex)
 	var inner string
 	switch resourceKind {
 	case "cpu":
@@ -104,6 +125,13 @@ func buildPromContainerQuery(namespace, kind, name string, indexed bool, strateg
 	subquery := fmt.Sprintf(`%s[%s:5m]`, inner, window)
 	aggregated := wrapPromAggregation(strategy, subquery)
 	return fmt.Sprintf(`max by (container) (%s)`, aggregated)
+}
+
+// promWorkloadSelector puts the pod matcher in a raw PromQL literal: a
+// double-quoted one rejects the `\.` QuoteMeta emits for a dotted name.
+func promWorkloadSelector(namespace, podRegex string) string {
+	podMatcher := fmt.Sprintf("pod=~%s%s%s", promRawQuote, podRegex, promRawQuote)
+	return fmt.Sprintf(`namespace=%q,%s,container!="POD",container!=""`, namespace, podMatcher)
 }
 
 // wrapPromAggregation wraps the inner subquery expression with the

--- a/internal/k8s/client_rightsizing_prom_span.go
+++ b/internal/k8s/client_rightsizing_prom_span.go
@@ -1,0 +1,96 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// dataSpanFullFraction is the share of the window the samples must cover
+// to count as complete. The probe's subquery step makes even a fully
+// covered window read a little short, so a small gap stays quiet.
+const dataSpanFullFraction = 0.9
+
+// promDataSpan returns "" unless the samples fall short of the window,
+// so only a workload with too little history flags itself in the header.
+func (c *Client) promDataSpan(ctx context.Context, contextName, namespace, kind, name string, indexed bool, strategy model.RightsizingStrategy) string {
+	query := buildPromDataSpanQuery(namespace, kind, name, indexed, strategy)
+	if query == "" {
+		return ""
+	}
+	span, err := c.queryPromDataSpan(ctx, contextName, query)
+	if err != nil {
+		logger.Debug("rightsizing: Prometheus data span probe failed", "err", err)
+		return ""
+	}
+	return shortDataSpanLabel(span, promStrategyWindowDuration(strategy))
+}
+
+// buildPromDataSpanQuery asks Prometheus for the age of the oldest
+// sample in the window. Prometheus does the subtraction, so a clock skew
+// between this host and the server cannot shorten the reported span.
+func buildPromDataSpanQuery(namespace, kind, name string, indexed bool, strategy model.RightsizingStrategy) string {
+	podRegex := podsRegexForWorkload(kind, name, indexed)
+	window := promStrategyWindow(strategy)
+	if podRegex == "" || window == "" {
+		return ""
+	}
+	selector := promWorkloadSelector(namespace, podRegex)
+	return fmt.Sprintf("time() - min(min_over_time(timestamp(container_memory_working_set_bytes{%s})[%s:%s]))",
+		selector, window, promSpanProbeStep(strategy))
+}
+
+// promSpanProbeStep keeps the probe under a few hundred evaluations. The
+// span is rendered coarsely, so a step this wide costs no visible detail.
+func promSpanProbeStep(s model.RightsizingStrategy) string {
+	switch s {
+	case model.StrategyPromMax1D, model.StrategyPromAvg1D:
+		return "5m"
+	case model.StrategyPromP957D:
+		return "1h"
+	}
+	return ""
+}
+
+// promStrategyWindowDuration is promStrategyWindow parsed, for comparing
+// against a measured span.
+func promStrategyWindowDuration(s model.RightsizingStrategy) time.Duration {
+	switch s {
+	case model.StrategyPromMax1D, model.StrategyPromAvg1D:
+		return 24 * time.Hour
+	case model.StrategyPromP957D:
+		return 7 * 24 * time.Hour
+	}
+	return 0
+}
+
+// queryPromDataSpan reads the single unlabelled sample the span query
+// returns, in seconds.
+func (c *Client) queryPromDataSpan(ctx context.Context, contextName, query string) (time.Duration, error) {
+	body, err := c.runPrometheusQuery(ctx, contextName, query)
+	if err != nil {
+		return 0, err
+	}
+	vec, err := parsePrometheusVector(body, func(map[string]string) (string, bool) {
+		return "span", true
+	})
+	if err != nil {
+		return 0, err
+	}
+	seconds, ok := vec["span"]
+	if !ok || math.IsNaN(seconds) || seconds <= 0 {
+		return 0, fmt.Errorf("prometheus returned no usable data span")
+	}
+	return time.Duration(seconds * float64(time.Second)), nil
+}
+
+func shortDataSpanLabel(span, window time.Duration) string {
+	if span <= 0 || window <= 0 || span >= time.Duration(float64(window)*dataSpanFullFraction) {
+		return ""
+	}
+	return formatAge(span)
+}

--- a/internal/k8s/client_rightsizing_prom_test.go
+++ b/internal/k8s/client_rightsizing_prom_test.go
@@ -2,9 +2,13 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -144,9 +148,12 @@ func makeDepFixture() (*appsv1.Deployment, []*corev1.Pod) {
 
 func TestGetRightsizing_PrometheusMax1D(t *testing.T) {
 	dep, pods := makeDepFixture()
-	calls := 0
+	var calls atomic.Int32
 	stub := func(_ context.Context, _ string, query string) ([]byte, error) {
-		calls++
+		calls.Add(1)
+		if isPromSpanProbe(query) {
+			return promSpanResponse("86400"), nil
+		}
 		// CPU returns 0.08 cores (= 80m); Memory returns ~200Mi worth of bytes.
 		if strings.Contains(query, "container_cpu_usage_seconds_total") {
 			return []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"container":"app"},"value":[1700000000,"0.08"]}]}}`), nil
@@ -170,12 +177,16 @@ func TestGetRightsizing_PrometheusMax1D(t *testing.T) {
 	assert.Equal(t, "100m", rec.CPU.RecommendedRequest)
 	// 200Mi * 1.2 = 240Mi
 	assert.Equal(t, "240Mi", rec.Mem.RecommendedRequest)
-	assert.Equal(t, 2, calls, "expects one CPU + one memory PromQL call")
+	assert.EqualValues(t, 3, calls.Load(), "expects one CPU + one memory + one data-span PromQL call")
+	assert.Empty(t, out.DataSpan, "a full 1d of samples leaves the header unchanged")
 }
 
 func TestGetRightsizing_PrometheusAvg1D(t *testing.T) {
 	dep, pods := makeDepFixture()
 	stub := func(_ context.Context, _ string, query string) ([]byte, error) {
+		if isPromSpanProbe(query) {
+			return promSpanResponse("86400"), nil
+		}
 		assert.Contains(t, query, "avg_over_time", "avg strategy must use avg_over_time")
 		assert.Contains(t, query, "[1d:")
 		if strings.Contains(query, "container_cpu_usage_seconds_total") {
@@ -198,6 +209,9 @@ func TestGetRightsizing_PrometheusAvg1D(t *testing.T) {
 func TestGetRightsizing_PrometheusP957D(t *testing.T) {
 	dep, pods := makeDepFixture()
 	stub := func(_ context.Context, _ string, query string) ([]byte, error) {
+		if isPromSpanProbe(query) {
+			return promSpanResponse("604800"), nil
+		}
 		assert.Contains(t, query, "quantile_over_time(0.95")
 		assert.Contains(t, query, "[7d:")
 		if strings.Contains(query, "container_cpu_usage_seconds_total") {
@@ -232,6 +246,157 @@ func TestGetRightsizing_PrometheusQueryFailureLeavesSuggestionEmpty(t *testing.T
 	require.Len(t, out.Containers, 1)
 	assert.Empty(t, out.Containers[0].CPU.RecommendedRequest)
 	assert.Empty(t, out.Containers[0].Mem.RecommendedRequest)
+}
+
+// --- data span probe ---
+
+// isPromSpanProbe separates the data-span probe from the two usage
+// queries: only the probe wraps the metric in timestamp().
+func isPromSpanProbe(query string) bool { return strings.Contains(query, "timestamp(") }
+
+func promSpanResponse(seconds string) []byte {
+	return []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1700000000,"` + seconds + `"]}]}}`)
+}
+
+// newSpanProbeClient answers the p95/7d usage queries with fixed values
+// and the data-span probe with the caller's body or error.
+func newSpanProbeClient(t *testing.T, spanBody []byte, spanErr error) *Client {
+	t.Helper()
+	dep, pods := makeDepFixture()
+	stub := func(_ context.Context, _ string, query string) ([]byte, error) {
+		if isPromSpanProbe(query) {
+			return spanBody, spanErr
+		}
+		if strings.Contains(query, "container_cpu_usage_seconds_total") {
+			return []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"container":"app"},"value":[1700000000,"0.05"]}]}}`), nil
+		}
+		return []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"container":"app"},"value":[1700000000,"268435456"]}]}}`), nil
+	}
+	return newPromTestClient(t, pods, dep, stub)
+}
+
+func TestBuildPromDataSpanQuery_ProbesEarliestSampleInWindow(t *testing.T) {
+	q := buildPromDataSpanQuery("default", "Deployment", "frontend", false, model.StrategyPromP957D)
+	assert.Contains(t, q, "timestamp(", "the probe reads sample timestamps, not values")
+	assert.Contains(t, q, "min_over_time", "earliest sample in the window")
+	assert.Contains(t, q, "container_memory_working_set_bytes", "a gauge needs no rate() wrapper")
+	assert.Contains(t, q, "[7d:", "probe covers the strategy's window")
+	assert.Contains(t, q, "time() -", "Prometheus subtracts, so clock skew cannot shorten the span")
+	assert.Contains(t, q, `namespace="default"`)
+	assert.Contains(t, q, "pod=~`", "the matcher uses a raw PromQL literal")
+
+	oneDay := buildPromDataSpanQuery("default", "Deployment", "frontend", false, model.StrategyPromMax1D)
+	assert.Contains(t, oneDay, "[1d:")
+}
+
+func TestBuildPromDataSpanQuery_EmptyForUnsupportedKind(t *testing.T) {
+	assert.Empty(t, buildPromDataSpanQuery("default", "ReplicaSet", "frontend", false, model.StrategyPromP957D))
+	assert.Empty(t, buildPromDataSpanQuery("default", "Deployment", "frontend", false, model.StrategySnapshot))
+}
+
+func TestGetRightsizing_PrometheusShortHistoryReportsDataSpan(t *testing.T) {
+	// A workload Prometheus has only watched for 5h must not look like
+	// it carries a full 7d of history behind its recommendation.
+	c := newSpanProbeClient(t, promSpanResponse("18000"), nil)
+
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromP957D, 1.2)
+	require.NoError(t, err)
+	assert.Equal(t, "7d", out.Window)
+	assert.Equal(t, "5h", out.DataSpan, "measured span reported when it falls short of the window")
+}
+
+func TestGetRightsizing_PrometheusFullWindowLeavesDataSpanEmpty(t *testing.T) {
+	c := newSpanProbeClient(t, promSpanResponse("604800"), nil)
+
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromP957D, 1.2)
+	require.NoError(t, err)
+	assert.Equal(t, "7d", out.Window)
+	assert.Empty(t, out.DataSpan, "a covered window leaves the header unchanged")
+}
+
+func TestGetRightsizing_PrometheusSpanProbeFailureLeavesDataSpanEmpty(t *testing.T) {
+	c := newSpanProbeClient(t, nil, assert.AnError)
+
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromP957D, 1.2)
+	require.NoError(t, err, "a failed probe must not fail the recommendation")
+	assert.Empty(t, out.DataSpan)
+	assert.Equal(t, "60m", out.Containers[0].CPU.RecommendedRequest, "usage queries still land")
+}
+
+func TestGetRightsizing_PrometheusEmptySpanProbeLeavesDataSpanEmpty(t *testing.T) {
+	c := newSpanProbeClient(t, []byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`), nil)
+
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromP957D, 1.2)
+	require.NoError(t, err)
+	assert.Empty(t, out.DataSpan)
+}
+
+// promQueryBarrier holds every caller until `want` of them have arrived,
+// so a serial caller can never get past its first query.
+type promQueryBarrier struct {
+	mu      sync.Mutex
+	arrived int
+	want    int
+	all     chan struct{}
+}
+
+func newPromQueryBarrier(want int) *promQueryBarrier {
+	return &promQueryBarrier{want: want, all: make(chan struct{})}
+}
+
+// wait reports whether every caller arrived before the timeout.
+func (b *promQueryBarrier) wait(timeout time.Duration) bool {
+	b.mu.Lock()
+	b.arrived++
+	if b.arrived == b.want {
+		close(b.all)
+	}
+	b.mu.Unlock()
+	select {
+	case <-b.all:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func TestGetRightsizing_PrometheusQueriesRunConcurrently(t *testing.T) {
+	// Each proxy round trip carries its own 10s timeout, so running the
+	// cpu, memory and span queries in series would triple the worst-case
+	// wait before the overlay paints.
+	dep, pods := makeDepFixture()
+	barrier := newPromQueryBarrier(3)
+	stub := func(_ context.Context, _ string, query string) ([]byte, error) {
+		if !barrier.wait(3 * time.Second) {
+			return nil, fmt.Errorf("query ran alone, the other two never arrived")
+		}
+		if isPromSpanProbe(query) {
+			return promSpanResponse("18000"), nil
+		}
+		if strings.Contains(query, "container_cpu_usage_seconds_total") {
+			return []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"container":"app"},"value":[1700000000,"0.05"]}]}}`), nil
+		}
+		return []byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"container":"app"},"value":[1700000000,"268435456"]}]}}`), nil
+	}
+	c := newPromTestClient(t, pods, dep, stub)
+
+	out, err := c.GetRightsizing(t.Context(), "test-ctx", "default", "Deployment", "frontend", model.StrategyPromP957D, 1.2)
+	require.NoError(t, err)
+	assert.Equal(t, "5h", out.DataSpan, "span probe answered, so it overlapped the usage queries")
+	assert.Equal(t, "60m", out.Containers[0].CPU.RecommendedRequest)
+	assert.Equal(t, "308Mi", out.Containers[0].Mem.RecommendedRequest)
+}
+
+func TestShortDataSpanLabel_ReportsOnlyAMeaningfulGap(t *testing.T) {
+	week := 7 * 24 * time.Hour
+	assert.Equal(t, "5h", shortDataSpanLabel(5*time.Hour, week))
+	assert.Equal(t, "3d", shortDataSpanLabel(3*24*time.Hour, week))
+	// The subquery step makes a covered window read slightly short, so a
+	// near-full span stays quiet.
+	assert.Empty(t, shortDataSpanLabel(week-2*time.Hour, week))
+	assert.Empty(t, shortDataSpanLabel(week, week))
+	assert.Empty(t, shortDataSpanLabel(0, week))
+	assert.Empty(t, shortDataSpanLabel(time.Hour, 0))
 }
 
 // --- podsRegexForWorkload ---

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -526,6 +526,7 @@ type Rightsizing struct {
 	Headroom            float64               // headroom multiplier that produced these numbers (e.g. 1.25 = 25% padding above usage)
 	PodCount            int                   // pods aggregated (always 1 for Pod kind)
 	Window              string                // sampling window (e.g. "30s" for metrics-server, "1d"/"7d" for Prometheus). Empty for VPA
+	DataSpan            string                // how far back the samples reach, set only when that is meaningfully shorter than Window
 	Containers          []ContainerRec
 }
 

--- a/internal/ui/rightsizing_overlay.go
+++ b/internal/ui/rightsizing_overlay.go
@@ -221,6 +221,9 @@ func rightsizingMethodologyHint(data *model.Rightsizing) string {
 		if data.Strategy == model.StrategySnapshot && data.Window != "" {
 			hint += " (window: " + data.Window + ")"
 		}
+		if data.DataSpan != "" {
+			hint += " (data: " + data.DataSpan + ")"
+		}
 		hint += headroomMethodologySuffix(data.Strategy, data.Headroom)
 		return hint
 	}

--- a/internal/ui/rightsizing_overlay_test.go
+++ b/internal/ui/rightsizing_overlay_test.go
@@ -399,6 +399,38 @@ func TestRenderRightsizingOverlay_HeaderHeadroomChipAlwaysShown(t *testing.T) {
 	assert.Contains(t, out, "[6/6]", "2.0 is the last preset → 6/6")
 }
 
+// --- Data span in header ---
+
+func promHeaderFixture(dataSpan string) *model.Rightsizing {
+	return &model.Rightsizing{
+		Source:              "7d-p95",
+		Strategy:            model.StrategyPromP957D,
+		AvailableStrategies: []model.RightsizingStrategy{model.StrategyPromP957D, model.StrategySnapshot},
+		Headroom:            1.25,
+		PodCount:            2,
+		Window:              "7d",
+		DataSpan:            dataSpan,
+		Containers: []model.ContainerRec{{
+			Name: "app",
+			CPU:  model.ResourceRec{CurrentRequest: "100m", RecommendedRequest: "60m"},
+		}},
+	}
+}
+
+func TestRenderRightsizingOverlay_HeaderShowsShortDataSpan(t *testing.T) {
+	// Prometheus only holds 5h for this workload, so the header must not
+	// let a 7d label imply a week of evidence.
+	out := stripANSI(RenderRightsizingOverlay(promHeaderFixture("5h"), false, nil, 0, 200, 40))
+	assert.Contains(t, out, "over last 7d (data: 5h)", "header reports the real span next to the window")
+	assert.Contains(t, out, "x 1.25 headroom", "headroom suffix still trails the methodology hint")
+}
+
+func TestRenderRightsizingOverlay_HeaderOmitsDataSpanOnFullWindow(t *testing.T) {
+	out := stripANSI(RenderRightsizingOverlay(promHeaderFixture(""), false, nil, 0, 200, 40))
+	assert.Contains(t, out, "over last 7d")
+	assert.NotContains(t, out, "data:", "a covered window leaves the header unchanged")
+}
+
 func TestRenderRightsizingOverlay_VPAMethodologyAt1RawNote(t *testing.T) {
 	// When VPA is the active strategy AND headroom == 1.0, the
 	// methodology hint should signal "raw" so the user understands the


### PR DESCRIPTION
## Summary
- The right-sizing overlay header printed `over last 7d` even when Prometheus held only a few hours for the workload, so a new Deployment got a confident-looking recommendation backed by almost no data (split out of #705 / #717).
- One extra instant query probes the earliest sample in the window. When the span covers less than 90% of the window the header reads `Prometheus p95 over last 7d (data: 5h) x 1.25 headroom`. A full window leaves the header unchanged.
- The cpu, memory and span queries now run concurrently, so the probe adds no serial round trip. A probe failure leaves the header as before.

## Test plan
- [x] `go test ./... -race` green, includes a barrier test proving the three queries overlap
- [x] `golangci-lint run ./...` 0 issues
- [ ] Manual: open `x` then `z` on a Deployment younger than a day with the 7d p95 strategy, expect `(data: Nh)` in the header; on a week-old Deployment expect no suffix