### PR TITLE
fix: drop kubeconfig files that declare no clusters, users or contexts

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -198,7 +198,7 @@ Precedence (replacement, not merge): `--kubeconfig-dir` flag > `KUBECONFIG_DIR` 
 
 lfk validates every directory exists at startup and errors out loudly on a typo. The `--kubeconfig` flag bypasses all directory discovery entirely.
 
-lfk skips known non-kubeconfig files in a scanned directory. It then drops any remaining file that fails to parse. A file you name with `--kubeconfig` or `KUBECONFIG` still fails loudly when it is broken.
+lfk skips known non-kubeconfig files in a scanned directory. It then drops any remaining file that fails to parse, and any file that declares no clusters, no users and no contexts, such as a credential cache. A split kubeconfig fragment declares at least one of the three, so it survives. A file you name with `--kubeconfig` or `KUBECONFIG` still fails loudly when it is broken.
 
 The skip list holds these glob patterns by default, matched against a file's base name, case-insensitively:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -198,7 +198,7 @@ Precedence (replacement, not merge): `--kubeconfig-dir` flag > `KUBECONFIG_DIR` 
 
 lfk validates every directory exists at startup and errors out loudly on a typo. The `--kubeconfig` flag bypasses all directory discovery entirely.
 
-lfk skips known non-kubeconfig files in a scanned directory. It then drops any remaining file that fails to parse, and any file that declares no clusters, no users and no contexts, such as a credential cache. A split kubeconfig fragment declares at least one of the three, so it survives. A file you name with `--kubeconfig` or `KUBECONFIG` still fails loudly when it is broken.
+lfk skips known non-kubeconfig files in a scanned directory. It then drops any remaining file that fails to parse, and any file that declares no clusters, no users, no contexts and no current-context, such as a credential cache. A split kubeconfig fragment declares at least one of the four, so it survives. A file you name with `--kubeconfig` or `KUBECONFIG` still fails loudly when it is broken.
 
 The skip list holds these glob patterns by default, matched against a file's base name, case-insensitively:
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -446,10 +446,10 @@ func (c *Client) ApplyManifest(ctx context.Context, contextName, defaultNamespac
 // kubeconfigOverride (--kubeconfig) beats everything: when non-empty it is
 // the only file loaded.
 func NewClient(kubeconfigOverride string, kubeconfigDirs []string, kubeconfigExclusive bool, kubeconfigIgnore []string) (*Client, error) {
-	kubeconfigPaths := resolveKubeconfigPaths(kubeconfigOverride, kubeconfigDirs, kubeconfigExclusive, kubeconfigIgnore)
+	kubeconfigSources := resolveKubeconfigSources(kubeconfigOverride, kubeconfigDirs, kubeconfigExclusive, kubeconfigIgnore)
 
 	loadingRules := &clientcmd.ClientConfigLoadingRules{
-		Precedence: kubeconfigPaths,
+		Precedence: sourcePaths(kubeconfigSources),
 	}
 
 	configOverrides := &clientcmd.ConfigOverrides{}
@@ -460,7 +460,7 @@ func NewClient(kubeconfigOverride string, kubeconfigDirs []string, kubeconfigExc
 		return nil, fmt.Errorf("loading kubeconfig: %w", err)
 	}
 
-	contexts, order, current := collectContexts(kubeconfigPaths, rawConfig.CurrentContext)
+	contexts, order, current := collectContexts(kubeconfigSources, rawConfig.CurrentContext)
 
 	return &Client{
 		rawConfig:      rawConfig,
@@ -496,7 +496,7 @@ func (c *Client) ReloadKubeconfig() error {
 		// just restart lfk.
 		return nil
 	}
-	contexts, order, current := collectContexts(c.loadingRules.Precedence, rawConfig.CurrentContext)
+	contexts, order, current := collectContexts(sourcesFromPaths(c.loadingRules.Precedence), rawConfig.CurrentContext)
 	c.configMu.Lock()
 	c.rawConfig = rawConfig
 	c.contexts = contexts

--- a/internal/k8s/client_kubeconfig.go
+++ b/internal/k8s/client_kubeconfig.go
@@ -9,9 +9,40 @@ import (
 	"strings"
 
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/janosmiko/lfk/internal/logger"
 )
+
+// kubeconfigSource is a kubeconfig path plus the Config discovery already
+// parsed from it. cfg is nil for files nothing read yet (KUBECONFIG entries,
+// ~/.kube/config, and every path on a reload).
+type kubeconfigSource struct {
+	path string
+	cfg  *clientcmdapi.Config
+}
+
+func sourcePaths(sources []kubeconfigSource) []string {
+	if len(sources) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(sources))
+	for _, s := range sources {
+		out = append(out, s.path)
+	}
+	return out
+}
+
+func sourcesFromPaths(paths []string) []kubeconfigSource {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]kubeconfigSource, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, kubeconfigSource{path: p})
+	}
+	return out
+}
 
 // KubeconfigPaths returns the colon-separated kubeconfig paths used by this client.
 func (c *Client) KubeconfigPaths() string {
@@ -104,7 +135,7 @@ func (c *Client) HostForContext(displayName string) string {
 // already resolved (first-writer-wins). collectContexts uses it to decide
 // which display name should be marked "current" when multiple files declare
 // the same name. If no file sets a current-context, it returns "".
-func collectContexts(paths []string, fallbackCurrent string) (map[string]contextInfo, []string, string) {
+func collectContexts(sources []kubeconfigSource, fallbackCurrent string) (map[string]contextInfo, []string, string) {
 	type fileContext struct {
 		sourcePath string
 		original   string
@@ -119,10 +150,15 @@ func collectContexts(paths []string, fallbackCurrent string) (map[string]context
 	entriesByName := make(map[string][]fileContext)
 	var orderedNames []string
 
-	for _, path := range paths {
-		cfg, err := clientcmd.LoadFromFile(path)
-		if err != nil {
-			continue
+	for _, src := range sources {
+		path := src.path
+		cfg := src.cfg
+		if cfg == nil {
+			loaded, err := clientcmd.LoadFromFile(path)
+			if err != nil {
+				continue
+			}
+			cfg = loaded
 		}
 		names := make([]string, 0, len(cfg.Contexts))
 		for name := range cfg.Contexts {
@@ -199,9 +235,9 @@ func collectContexts(paths []string, fallbackCurrent string) (map[string]context
 			current = info.display
 		} else {
 			// Disambiguated: walk paths in order, pick first match.
-			for _, path := range paths {
+			for _, src := range sources {
 				for _, info := range contexts {
-					if info.original == fallbackCurrent && info.sourcePath == path {
+					if info.original == fallbackCurrent && info.sourcePath == src.path {
 						current = info.display
 						break
 					}
@@ -230,7 +266,7 @@ func contextDisplayHint(path string) string {
 	return base
 }
 
-// buildKubeconfigPaths assembles the list of kubeconfig file paths to load.
+// buildKubeconfigSources assembles the list of kubeconfig files to load.
 //
 // Resolution order:
 //  1. KUBECONFIG env var (colon-separated).
@@ -248,23 +284,23 @@ func contextDisplayHint(path string) string {
 // implicit defaults. Passing exclusive=false (kubeconfig_exclusive: false /
 // --kubeconfig-exclusive=false / LFK_KUBECONFIG_EXCLUSIVE=false) restores
 // the historical merge-everything behavior.
-func buildKubeconfigPaths(kubeconfigDirs []string, exclusive bool, ignore []string) []string {
+func buildKubeconfigSources(kubeconfigDirs []string, exclusive bool, ignore []string) []kubeconfigSource {
 	ignore = ResolveKubeconfigIgnore(ignore)
-	var paths []string
+	var sources []kubeconfigSource
 
 	// KUBECONFIG env var (colon-separated on unix). Empty entries (a stray
 	// "KUBECONFIG=:" or a trailing colon) are dropped. When nothing
 	// non-empty remains the variable counts as unset, so the default
 	// discovery still applies instead of silently loading zero clusters.
 	envPaths := trimNonEmpty(filepath.SplitList(os.Getenv("KUBECONFIG")))
-	paths = append(paths, envPaths...)
+	sources = append(sources, sourcesFromPaths(envPaths)...)
 	kubeconfigExclusive := exclusive && len(envPaths) > 0
 
 	home, homeErr := os.UserHomeDir()
 	if homeErr == nil && !kubeconfigExclusive {
 		// Default kubeconfig. The dedup pass below collapses it when
 		// KUBECONFIG already lists the same file.
-		paths = append(paths, filepath.Join(home, ".kube", "config"))
+		sources = append(sources, kubeconfigSource{path: filepath.Join(home, ".kube", "config")})
 		// Fall back to the default discovery directory when no override.
 		if len(kubeconfigDirs) == 0 {
 			kubeconfigDirs = []string{filepath.Join(home, ".kube", "config.d")}
@@ -282,7 +318,7 @@ func buildKubeconfigPaths(kubeconfigDirs []string, exclusive bool, ignore []stri
 		if strings.HasPrefix(dir, "~") && homeErr != nil {
 			continue
 		}
-		paths = append(paths, filterParseableKubeconfigs(collectConfigDirPaths(expandTilde(dir, home), ignore))...)
+		sources = append(sources, filterParseableKubeconfigs(collectConfigDirPaths(expandTilde(dir, home), ignore))...)
 	}
 
 	// Dedup by canonical path. The same kubeconfig can land in `paths`
@@ -292,10 +328,10 @@ func buildKubeconfigPaths(kubeconfigDirs []string, exclusive bool, ignore []stri
 	// two --kubeconfig-dir entries point at overlapping trees. Without
 	// this pass collectContexts loads the same file twice and emits each
 	// context as two "disambiguated" rows in the cluster list.
-	return dedupKubeconfigPaths(paths)
+	return dedupKubeconfigSources(sources)
 }
 
-// dedupKubeconfigPaths removes paths that resolve to the same underlying
+// dedupKubeconfigSources removes paths that resolve to the same underlying
 // file, preserving the first occurrence's order. Comparison uses
 // filepath.EvalSymlinks (canonical absolute path) so cosmetic differences
 // like trailing slashes, "./" prefixes, or symlink redirection collapse to
@@ -303,19 +339,19 @@ func buildKubeconfigPaths(kubeconfigDirs []string, exclusive bool, ignore []stri
 // keep their original spelling — clientcmd will still try to load them and
 // log an error if the file isn't readable, which is more informative than
 // silently dropping them here.
-func dedupKubeconfigPaths(paths []string) []string {
-	seen := make(map[string]struct{}, len(paths))
-	out := make([]string, 0, len(paths))
-	for _, p := range paths {
-		key := p
-		if resolved, err := filepath.EvalSymlinks(p); err == nil {
+func dedupKubeconfigSources(sources []kubeconfigSource) []kubeconfigSource {
+	seen := make(map[string]struct{}, len(sources))
+	out := make([]kubeconfigSource, 0, len(sources))
+	for _, s := range sources {
+		key := s.path
+		if resolved, err := filepath.EvalSymlinks(s.path); err == nil {
 			key = resolved
 		}
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		out = append(out, p)
+		out = append(out, s)
 	}
 	return out
 }
@@ -365,19 +401,27 @@ func ValidateKubeconfigIgnore(patterns []string) error {
 	return nil
 }
 
-// filterParseableKubeconfigs drops paths clientcmd cannot parse, for scanned
-// files only: a typo in --kubeconfig must still fail loudly. clientcmd keeps a
-// file it skipped in its aggregate error, which NewClient treats as fatal.
-func filterParseableKubeconfigs(paths []string) []string {
-	var out []string
+// filterParseableKubeconfigs keeps scanned files that parse and declare at least one
+// cluster, user or context, and carries each one's Config on so nothing re-reads it.
+// Scanned files only: clientcmd reports a file it skipped in the aggregate error
+// NewClient treats as fatal, while a typo in --kubeconfig must still fail loudly.
+func filterParseableKubeconfigs(paths []string) []kubeconfigSource {
+	var out []kubeconfigSource
 	for _, p := range paths {
-		if _, err := clientcmd.LoadFromFile(p); err != nil {
+		cfg, err := clientcmd.LoadFromFile(p)
+		if err != nil {
 			// A YAML error can quote the line it choked on, and kubeconfigs hold tokens.
 			logger.Warn("ignoring unparseable file in kubeconfig directory",
 				"path", p, "error", logger.Redact(err.Error()))
 			continue
 		}
-		out = append(out, p)
+		// The codec ignores unrecognised fields, so a flat JSON credential cache
+		// decodes into an empty Config and would reach a subprocess KUBECONFIG.
+		if len(cfg.Clusters) == 0 && len(cfg.AuthInfos) == 0 && len(cfg.Contexts) == 0 {
+			logger.Debug("ignoring file with no kubeconfig entries", "path", p)
+			continue
+		}
+		out = append(out, kubeconfigSource{path: p, cfg: cfg})
 	}
 	return out
 }
@@ -514,14 +558,14 @@ func ValidateKubeconfigDir(path string) error {
 	return nil
 }
 
-// resolveKubeconfigPaths returns the kubeconfig file list for NewClient:
+// resolveKubeconfigSources returns the kubeconfig file list for NewClient:
 // an explicit --kubeconfig override wins outright. Otherwise discovery
-// runs via buildKubeconfigPaths.
-func resolveKubeconfigPaths(override string, kubeconfigDirs []string, exclusive bool, ignore []string) []string {
+// runs via buildKubeconfigSources.
+func resolveKubeconfigSources(override string, kubeconfigDirs []string, exclusive bool, ignore []string) []kubeconfigSource {
 	if override != "" {
-		return []string{override}
+		return []kubeconfigSource{{path: override}}
 	}
-	return buildKubeconfigPaths(kubeconfigDirs, exclusive, ignore)
+	return buildKubeconfigSources(kubeconfigDirs, exclusive, ignore)
 }
 
 // ResolveKubeconfigExclusive resolves whether a set KUBECONFIG suppresses

--- a/internal/k8s/client_kubeconfig.go
+++ b/internal/k8s/client_kubeconfig.go
@@ -402,7 +402,8 @@ func ValidateKubeconfigIgnore(patterns []string) error {
 }
 
 // filterParseableKubeconfigs keeps scanned files that parse and declare at least one
-// cluster, user or context, and carries each one's Config on so nothing re-reads it.
+// cluster, user or context, or a current-context, and carries each one's Config on so
+// nothing re-reads it.
 // Scanned files only: clientcmd reports a file it skipped in the aggregate error
 // NewClient treats as fatal, while a typo in --kubeconfig must still fail loudly.
 func filterParseableKubeconfigs(paths []string) []kubeconfigSource {
@@ -417,7 +418,10 @@ func filterParseableKubeconfigs(paths []string) []kubeconfigSource {
 		}
 		// The codec ignores unrecognised fields, so a flat JSON credential cache
 		// decodes into an empty Config and would reach a subprocess KUBECONFIG.
-		if len(cfg.Clusters) == 0 && len(cfg.AuthInfos) == 0 && len(cfg.Contexts) == 0 {
+		// CurrentContext counts: a split kubeconfig may hold only the selection
+		// of a context another file declares, and dropping it loses that choice.
+		if len(cfg.Clusters) == 0 && len(cfg.AuthInfos) == 0 && len(cfg.Contexts) == 0 &&
+			cfg.CurrentContext == "" {
 			logger.Debug("ignoring file with no kubeconfig entries", "path", p)
 			continue
 		}

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/janosmiko/lfk/internal/model"
 )
@@ -781,7 +782,13 @@ func TestExtractGenericConditions(t *testing.T) {
 	})
 }
 
-// --- buildKubeconfigPaths ---
+// --- buildKubeconfigSources ---
+
+// buildKubeconfigPathList keeps these path-level assertions readable: they
+// care about which files discovery returns, not the configs it parsed.
+func buildKubeconfigPathList(kubeconfigDirs []string, exclusive bool) []string {
+	return sourcePaths(buildKubeconfigSources(kubeconfigDirs, exclusive, nil))
+}
 
 func TestBuildKubeconfigPaths(t *testing.T) {
 	t.Run("includes default kubeconfig path", func(t *testing.T) {
@@ -792,7 +799,7 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 			t.Setenv("KUBECONFIG", origKubeconfig)
 		}()
 
-		paths := buildKubeconfigPaths(nil, true, nil)
+		paths := buildKubeconfigPathList(nil, true)
 
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -812,7 +819,7 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 
 		t.Setenv("KUBECONFIG", cfg1+string(os.PathListSeparator)+cfg2)
 
-		paths := buildKubeconfigPaths(nil, true, nil)
+		paths := buildKubeconfigPathList(nil, true)
 
 		assert.Contains(t, paths, cfg1)
 		assert.Contains(t, paths, cfg2)
@@ -829,7 +836,7 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 
 		t.Setenv("KUBECONFIG", defaultPath)
 
-		paths := buildKubeconfigPaths(nil, false, nil)
+		paths := buildKubeconfigPathList(nil, false)
 
 		count := 0
 		for _, p := range paths {
@@ -852,14 +859,14 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		assert.NoError(t, os.MkdirAll(configD, 0o755))
 		assert.NoError(t, os.WriteFile(defaultPath, []byte(""), 0o600))
 		configDCfg := filepath.Join(configD, "seeded-cluster")
-		assert.NoError(t, os.WriteFile(configDCfg, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(configDCfg, []byte(stubKubeconfig("seeded")), 0o600))
 
 		tmpDir := t.TempDir()
 		env := filepath.Join(tmpDir, "env-config")
 		assert.NoError(t, os.WriteFile(env, []byte(""), 0o600))
 		t.Setenv("KUBECONFIG", env)
 
-		paths := buildKubeconfigPaths(nil, true, nil)
+		paths := buildKubeconfigPathList(nil, true)
 
 		assert.Equal(t, []string{env}, paths,
 			"KUBECONFIG must fully determine the file list, excluding ~/.kube/config and config.d")
@@ -880,9 +887,9 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 
 		explicitDir := t.TempDir()
 		dirCfg := filepath.Join(explicitDir, "team-cluster")
-		assert.NoError(t, os.WriteFile(dirCfg, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(dirCfg, []byte(stubKubeconfig("team")), 0o600))
 
-		paths := buildKubeconfigPaths([]string{explicitDir}, true, nil)
+		paths := buildKubeconfigPathList([]string{explicitDir}, true)
 
 		resolvedDirCfg, err := filepath.EvalSymlinks(dirCfg)
 		assert.NoError(t, err)
@@ -901,13 +908,13 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		assert.NoError(t, os.MkdirAll(configD, 0o755))
 		assert.NoError(t, os.WriteFile(defaultPath, []byte(""), 0o600))
 		seeded := filepath.Join(configD, "seeded-cluster")
-		assert.NoError(t, os.WriteFile(seeded, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(seeded, []byte(stubKubeconfig("seeded")), 0o600))
 
 		env := filepath.Join(t.TempDir(), "env-config")
 		assert.NoError(t, os.WriteFile(env, []byte(""), 0o600))
 		t.Setenv("KUBECONFIG", env)
 
-		paths := buildKubeconfigPaths(nil, false, nil)
+		paths := buildKubeconfigPathList(nil, false)
 
 		resolvedSeeded, err := filepath.EvalSymlinks(seeded)
 		assert.NoError(t, err)
@@ -927,14 +934,14 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		assert.NoError(t, os.WriteFile(defaultPath, []byte(""), 0o600))
 
 		t.Setenv("KUBECONFIG", ":")
-		paths := buildKubeconfigPaths(nil, true, nil)
+		paths := buildKubeconfigPathList(nil, true)
 		assert.NotContains(t, paths, "", "no empty path entries")
 		assert.Contains(t, paths, defaultPath, "all-empty KUBECONFIG behaves as unset")
 
 		env := filepath.Join(t.TempDir(), "env-config")
 		assert.NoError(t, os.WriteFile(env, []byte(""), 0o600))
 		t.Setenv("KUBECONFIG", env+string(os.PathListSeparator))
-		paths = buildKubeconfigPaths(nil, true, nil)
+		paths = buildKubeconfigPathList(nil, true)
 		assert.Equal(t, []string{env}, paths, "trailing separator adds no empty entry")
 	})
 
@@ -946,7 +953,7 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		override := filepath.Join(t.TempDir(), "override-config")
 		assert.NoError(t, os.WriteFile(override, []byte(""), 0o600))
 
-		paths := resolveKubeconfigPaths(override, []string{t.TempDir()}, true, nil)
+		paths := sourcePaths(resolveKubeconfigSources(override, []string{t.TempDir()}, true, nil))
 		assert.Equal(t, []string{override}, paths,
 			"--kubeconfig short-circuits KUBECONFIG, dirs, and defaults")
 	})
@@ -957,14 +964,14 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		configD := filepath.Join(tmpHome, ".kube", "config.d")
 		assert.NoError(t, os.MkdirAll(configD, 0o755))
 		extraCfg := filepath.Join(configD, "extra-cluster")
-		assert.NoError(t, os.WriteFile(extraCfg, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(extraCfg, []byte(stubKubeconfig("extra")), 0o600))
 
 		// This test verifies the WalkDir mechanism by checking the real home dir.
 		// Since we cannot override UserHomeDir, we test that the function runs without error
 		// and returns at least the default path.
 		t.Setenv("KUBECONFIG", "")
 
-		paths := buildKubeconfigPaths(nil, true, nil)
+		paths := buildKubeconfigPathList(nil, true)
 
 		assert.NotEmpty(t, paths, "should return at least the default kubeconfig path")
 	})
@@ -977,7 +984,7 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		via := filepath.Join(tmpDir, ".", "config.yaml")
 		t.Setenv("KUBECONFIG", cfg+string(os.PathListSeparator)+via)
 
-		paths := buildKubeconfigPaths(nil, true, nil)
+		paths := buildKubeconfigPathList(nil, true)
 		count := 0
 		for _, p := range paths {
 			if p == cfg || p == via {
@@ -1001,7 +1008,7 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		assert.NoError(t, os.Symlink(cfg, viaSymlink))
 		t.Setenv("KUBECONFIG", cfg+string(os.PathListSeparator)+viaSymlink)
 
-		paths := buildKubeconfigPaths(nil, true, nil)
+		paths := buildKubeconfigPathList(nil, true)
 		// Both entries point at the same underlying file; only one should
 		// remain after dedup. Compare via EvalSymlinks on both sides so
 		// we don't trip over /tmp → /private/tmp on macOS.
@@ -1026,11 +1033,11 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		customDir := filepath.Join(tmpDir, "custom-config.d")
 		assert.NoError(t, os.MkdirAll(customDir, 0o755))
 		extraCfg := filepath.Join(customDir, "extra-cluster")
-		assert.NoError(t, os.WriteFile(extraCfg, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(extraCfg, []byte(stubKubeconfig("extra")), 0o600))
 
 		t.Setenv("KUBECONFIG", "")
 
-		paths := buildKubeconfigPaths([]string{customDir}, true, nil)
+		paths := buildKubeconfigPathList([]string{customDir}, true)
 		// collectConfigDirPaths resolves symlinks, so on macOS /tmp may
 		// become /private/tmp — compare via EvalSymlinks to avoid failing.
 		resolvedExtraCfg, err := filepath.EvalSymlinks(extraCfg)
@@ -1046,11 +1053,11 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		customDir := filepath.Join(tmpHome, "custom-k8s")
 		assert.NoError(t, os.MkdirAll(customDir, 0o755))
 		extraCfg := filepath.Join(customDir, "extra-cluster")
-		assert.NoError(t, os.WriteFile(extraCfg, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(extraCfg, []byte(stubKubeconfig("extra")), 0o600))
 
 		t.Setenv("KUBECONFIG", "")
 
-		paths := buildKubeconfigPaths([]string{"~/custom-k8s"}, true, nil)
+		paths := buildKubeconfigPathList([]string{"~/custom-k8s"}, true)
 		resolvedExtraCfg, err := filepath.EvalSymlinks(extraCfg)
 		assert.NoError(t, err)
 		assert.Contains(t, paths, resolvedExtraCfg,
@@ -1065,10 +1072,10 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		dirA, dirB := t.TempDir(), t.TempDir()
 		cfgA := filepath.Join(dirA, "team-a")
 		cfgB := filepath.Join(dirB, "team-b")
-		assert.NoError(t, os.WriteFile(cfgA, []byte(""), 0o600))
-		assert.NoError(t, os.WriteFile(cfgB, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(cfgA, []byte(stubKubeconfig("team-a")), 0o600))
+		assert.NoError(t, os.WriteFile(cfgB, []byte(stubKubeconfig("team-b")), 0o600))
 
-		paths := buildKubeconfigPaths([]string{dirA, dirB}, true, nil)
+		paths := buildKubeconfigPathList([]string{dirA, dirB}, true)
 
 		resA, _ := filepath.EvalSymlinks(cfgA)
 		resB, _ := filepath.EvalSymlinks(cfgB)
@@ -1085,9 +1092,9 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 
 		customDir := t.TempDir()
 		extraCfg := filepath.Join(customDir, "extra-cluster")
-		assert.NoError(t, os.WriteFile(extraCfg, []byte(""), 0o600))
+		assert.NoError(t, os.WriteFile(extraCfg, []byte(stubKubeconfig("extra")), 0o600))
 
-		paths := buildKubeconfigPaths([]string{customDir}, true, nil)
+		paths := buildKubeconfigPathList([]string{customDir}, true)
 		resolvedExtraCfg, err := filepath.EvalSymlinks(extraCfg)
 		assert.NoError(t, err)
 		assert.Contains(t, paths, resolvedExtraCfg,
@@ -1102,7 +1109,7 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 		t.Setenv("USERPROFILE", "")
 		t.Setenv("KUBECONFIG", "")
 
-		paths := buildKubeconfigPaths([]string{"~/some/dir"}, true, nil)
+		paths := buildKubeconfigPathList([]string{"~/some/dir"}, true)
 		// Result is whatever KUBECONFIG provides (empty here); the tilde
 		// path is silently skipped because expansion isn't possible.
 		for _, p := range paths {
@@ -1112,22 +1119,22 @@ func TestBuildKubeconfigPaths(t *testing.T) {
 	})
 }
 
-func TestDedupKubeconfigPaths(t *testing.T) {
+func TestDedupKubeconfigSources(t *testing.T) {
 	t.Run("preserves order, drops later duplicates", func(t *testing.T) {
 		tmp := t.TempDir()
 		a := filepath.Join(tmp, "a.yaml")
 		b := filepath.Join(tmp, "b.yaml")
 		assert.NoError(t, os.WriteFile(a, []byte(""), 0o600))
 		assert.NoError(t, os.WriteFile(b, []byte(""), 0o600))
-		got := dedupKubeconfigPaths([]string{a, b, a, b})
-		assert.Equal(t, []string{a, b}, got)
+		got := dedupKubeconfigSources(sourcesFromPaths([]string{a, b, a, b}))
+		assert.Equal(t, []string{a, b}, sourcePaths(got))
 	})
 
 	t.Run("keeps unresolvable paths as-is", func(t *testing.T) {
 		// Missing/dangling paths should still pass through (clientcmd will
 		// surface a clear error later) — they shouldn't crash the dedup.
-		got := dedupKubeconfigPaths([]string{"/no/such/file", "/no/such/file", "/another"})
-		assert.Equal(t, []string{"/no/such/file", "/another"}, got)
+		got := dedupKubeconfigSources(sourcesFromPaths([]string{"/no/such/file", "/no/such/file", "/another"}))
+		assert.Equal(t, []string{"/no/such/file", "/another"}, sourcePaths(got))
 	})
 }
 
@@ -2011,8 +2018,8 @@ func TestKubeconfigIgnoreIsConfigurable(t *testing.T) {
 
 // --- filterParseableKubeconfigs ---
 
-// stubKubeconfig is a minimal kubeconfig declaring one of everything, named
-// after ctx so callers can put two of them in one merge without colliding.
+// stubKubeconfig names everything after ctx so two of them can share one merge.
+// Discovery drops a file declaring no clusters, users and contexts, so scanned-directory fixtures need this content.
 func stubKubeconfig(ctx string) string {
 	return fmt.Sprintf(`apiVersion: v1
 kind: Config
@@ -2040,7 +2047,7 @@ func TestFilterParseableKubeconfigs(t *testing.T) {
 		assert.NoError(t, os.WriteFile(good, []byte(stubKubeconfig("ctx1")), 0o600))
 		assert.NoError(t, os.WriteFile(bad, []byte{0x00, 0x01, 0x02}, 0o600))
 
-		assert.Equal(t, []string{good}, filterParseableKubeconfigs([]string{good, bad}))
+		assert.Equal(t, []string{good}, sourcePaths(filterParseableKubeconfigs([]string{good, bad})))
 	})
 
 	t.Run("drops plain text that is not a kubeconfig", func(t *testing.T) {
@@ -2050,7 +2057,7 @@ func TestFilterParseableKubeconfigs(t *testing.T) {
 		assert.NoError(t, os.WriteFile(good, []byte(stubKubeconfig("ctx1")), 0o600))
 		assert.NoError(t, os.WriteFile(readme, []byte("# Clusters\n\nProd lives here.\n"), 0o600))
 
-		assert.Equal(t, []string{good}, filterParseableKubeconfigs([]string{good, readme}))
+		assert.Equal(t, []string{good}, sourcePaths(filterParseableKubeconfigs([]string{good, readme})))
 	})
 
 	t.Run("keeps a fragment declaring only users", func(t *testing.T) {
@@ -2060,15 +2067,49 @@ func TestFilterParseableKubeconfigs(t *testing.T) {
 		frag := filepath.Join(tmp, "users-only.yaml")
 		assert.NoError(t, os.WriteFile(frag, []byte("apiVersion: v1\nkind: Config\nusers:\n- name: u1\n  user: {}\n"), 0o600))
 
-		assert.Equal(t, []string{frag}, filterParseableKubeconfigs([]string{frag}))
+		assert.Equal(t, []string{frag}, sourcePaths(filterParseableKubeconfigs([]string{frag})))
 	})
 
-	t.Run("keeps an empty file", func(t *testing.T) {
+	t.Run("keeps a fragment declaring only clusters", func(t *testing.T) {
+		tmp := t.TempDir()
+		frag := filepath.Join(tmp, "clusters-only.yaml")
+		body := "apiVersion: v1\nkind: Config\nclusters:\n- name: c1\n  cluster:\n    server: https://c1.test\n"
+		assert.NoError(t, os.WriteFile(frag, []byte(body), 0o600))
+
+		assert.Equal(t, []string{frag}, sourcePaths(filterParseableKubeconfigs([]string{frag})))
+	})
+
+	t.Run("drops a credential cache that parses into an empty config", func(t *testing.T) {
+		// A gcloud auth plugin token cache is flat JSON. The k8s codec
+		// ignores every unknown field, so it decodes without error into a
+		// Config that would hand a subprocess a KUBECONFIG with no clusters.
+		tmp := t.TempDir()
+		good := filepath.Join(tmp, "good.yaml")
+		cache := filepath.Join(tmp, "gke_token_cache")
+		assert.NoError(t, os.WriteFile(good, []byte(stubKubeconfig("ctx1")), 0o600))
+		assert.NoError(t, os.WriteFile(cache,
+			[]byte(`{"access_token":"redacted","token_expiry":"2026-01-01T00:00:00Z"}`), 0o600))
+
+		assert.Equal(t, []string{good}, sourcePaths(filterParseableKubeconfigs([]string{good, cache})))
+	})
+
+	t.Run("drops an empty file", func(t *testing.T) {
 		tmp := t.TempDir()
 		empty := filepath.Join(tmp, "empty.yaml")
 		assert.NoError(t, os.WriteFile(empty, []byte(""), 0o600))
 
-		assert.Equal(t, []string{empty}, filterParseableKubeconfigs([]string{empty}))
+		assert.Nil(t, filterParseableKubeconfigs([]string{empty}))
+	})
+
+	t.Run("returns the config it parsed for every kept file", func(t *testing.T) {
+		tmp := t.TempDir()
+		p := filepath.Join(tmp, "one.yaml")
+		assert.NoError(t, os.WriteFile(p, []byte(stubKubeconfig("ctx1")), 0o600))
+
+		got := filterParseableKubeconfigs([]string{p})
+		require.Len(t, got, 1)
+		require.NotNil(t, got[0].cfg, "discovery must hand its parsed config on so nothing re-reads the file")
+		assert.Contains(t, got[0].cfg.Contexts, "ctx1")
 	})
 
 	t.Run("preserves order and returns nil for no input", func(t *testing.T) {
@@ -2079,8 +2120,38 @@ func TestFilterParseableKubeconfigs(t *testing.T) {
 			assert.NoError(t, os.WriteFile(p, []byte(stubKubeconfig("ctx1")), 0o600))
 			want = append(want, p)
 		}
-		assert.Equal(t, want, filterParseableKubeconfigs(want))
+		assert.Equal(t, want, sourcePaths(filterParseableKubeconfigs(want)))
 		assert.Nil(t, filterParseableKubeconfigs(nil))
+	})
+}
+
+func TestCollectContextsReusesDiscoveredConfig(t *testing.T) {
+	t.Run("reads nothing when discovery already parsed the file", func(t *testing.T) {
+		// The path is never written, so a context can only reach the result
+		// through the config discovery handed over.
+		cfg := clientcmdapi.NewConfig()
+		cfg.Contexts["preparsed"] = &clientcmdapi.Context{Cluster: "c1", AuthInfo: "u1", Namespace: "team"}
+		cfg.CurrentContext = "preparsed"
+		missing := filepath.Join(t.TempDir(), "never-written.yaml")
+
+		contexts, order, current := collectContexts([]kubeconfigSource{{path: missing, cfg: cfg}}, "preparsed")
+
+		assert.Equal(t, []string{"preparsed"}, order)
+		assert.Equal(t, "preparsed", current)
+		assert.Equal(t, "team", contexts["preparsed"].namespace)
+		assert.Equal(t, missing, contexts["preparsed"].sourcePath)
+	})
+
+	t.Run("loads from disk when no config is attached", func(t *testing.T) {
+		// ReloadKubeconfig has no preparsed configs: it must see disk state.
+		p := filepath.Join(t.TempDir(), "reloaded.yaml")
+		assert.NoError(t, os.WriteFile(p, []byte(stubKubeconfig("ctx1")), 0o600))
+
+		contexts, order, current := collectContexts(sourcesFromPaths([]string{p}), "ctx1")
+
+		assert.Equal(t, []string{"ctx1"}, order)
+		assert.Equal(t, "ctx1", current)
+		assert.Equal(t, p, contexts["ctx1"].sourcePath)
 	})
 }
 

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -2079,6 +2079,17 @@ func TestFilterParseableKubeconfigs(t *testing.T) {
 		assert.Equal(t, []string{frag}, sourcePaths(filterParseableKubeconfigs([]string{frag})))
 	})
 
+	t.Run("keeps a fragment declaring only current-context", func(t *testing.T) {
+		// A split kubeconfig may hold nothing but the selection of a
+		// context another file declares.
+		tmp := t.TempDir()
+		frag := filepath.Join(tmp, "current-only.yaml")
+		body := "apiVersion: v1\nkind: Config\ncurrent-context: ctx1\n"
+		assert.NoError(t, os.WriteFile(frag, []byte(body), 0o600))
+
+		assert.Equal(t, []string{frag}, sourcePaths(filterParseableKubeconfigs([]string{frag})))
+	})
+
 	t.Run("drops a credential cache that parses into an empty config", func(t *testing.T) {
 		// A gcloud auth plugin token cache is flat JSON. The k8s codec
 		// ignores every unknown field, so it decodes without error into a
@@ -2179,6 +2190,42 @@ func TestNewClientDiscoveryTolerance(t *testing.T) {
 		assert.NotContains(t, client.KubeconfigPaths(), ".DS_Store")
 		// The good neighbour must survive, not just the junk be dropped.
 		assert.Contains(t, client.contexts, "from-dir")
+	})
+
+	t.Run("a discovered fragment setting only current-context still selects", func(t *testing.T) {
+		tmpHome := t.TempDir()
+		t.Setenv("HOME", tmpHome)
+		t.Setenv("KUBECONFIG", "")
+
+		dir := t.TempDir()
+		// The walk is lexical, so the fragment leads the precedence list
+		// and its current-context wins the clientcmd merge.
+		frag := filepath.Join(dir, "00-current.yaml")
+		assert.NoError(t, os.WriteFile(frag,
+			[]byte("apiVersion: v1\nkind: Config\ncurrent-context: from-dir\n"), 0o600))
+		declaring := filepath.Join(dir, "10-team.yaml")
+		assert.NoError(t, os.WriteFile(declaring, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: from-dir-cluster
+  cluster:
+    server: https://from-dir.test
+contexts:
+- name: from-dir
+  context:
+    cluster: from-dir-cluster
+    user: from-dir-user
+users:
+- name: from-dir-user
+  user: {}
+`), 0o600))
+
+		client, err := NewClient("", []string{dir}, true, nil)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.Contains(t, client.KubeconfigPaths(), frag,
+			"a fragment that only selects a context must stay in the precedence list")
+		assert.Equal(t, "from-dir", client.CurrentContext())
 	})
 
 	t.Run("an unparseable file named by KUBECONFIG still errors", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Kubeconfig directory discovery kept every scanned file that clientcmd parsed without error. A flat JSON credential cache (for example a gcloud auth plugin token cache) decodes into an empty Config because unknown fields are ignored, so it rode along in the precedence list and could reach a subprocess `KUBECONFIG` through the per-context path fallback.
- Discovery now drops a scanned file that declares no clusters, users and contexts. Split fragments that declare any one of the three still merge. Explicit `KUBECONFIG` entries and the primary config are not subject to the filter.
- Discovery hands the already parsed Config to context collection, so each scanned file is read and decoded once at startup instead of twice.
- `docs/usage.md` describes the filter.

## Test plan
- [x] `go test ./... -race` green, new cases for the drop, the kept fragments, and the single-read reuse
- [x] `golangci-lint run ./...` 0 issues
- [ ] Manual: put a fake token cache JSON into the scanned directory, start lfk, expect it absent from the context list and a debug log line `ignoring file with no kubeconfig entries`