### PR TITLE
fix: show the resources a Helm release manages in its resource map

### DIFF
--- a/internal/k8s/client_fakeclient_extra_test.go
+++ b/internal/k8s/client_fakeclient_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"maps"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1607,6 +1608,136 @@ func TestGetResourceTree_Node(t *testing.T) {
 	root, err := c.GetResourceTree(t.Context(), "", "", "Node", "node-1")
 	require.NoError(t, err)
 	assert.Equal(t, "node-1", root.Name)
+}
+
+// helmTreeManifest mixes a workload that owns a ReplicaSet/Pod subtree, two
+// namespaced leaves (one outside the release namespace) and a cluster-scoped
+// leaf that must keep an empty namespace.
+const helmTreeManifest = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-config
+  namespace: web-data
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: web-reader
+`
+
+func findTreeChild(root *model.ResourceNode, kind, name string) *model.ResourceNode {
+	for _, ch := range root.Children {
+		if ch.Kind == kind && ch.Name == name {
+			return ch
+		}
+	}
+	return nil
+}
+
+func TestGetResourceTree_HelmRelease(t *testing.T) {
+	rs := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "ReplicaSet",
+			"metadata": map[string]any{
+				"name": "web-abc", "namespace": "default",
+				"ownerReferences": []any{
+					map[string]any{"kind": "Deployment", "name": "web"},
+				},
+			},
+		},
+	}
+	pod := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name": "web-abc-1", "namespace": "default",
+				"ownerReferences": []any{
+					map[string]any{"kind": "ReplicaSet", "name": "web-abc"},
+				},
+			},
+		},
+	}
+
+	blob := makeHelmBlobWithManifest(
+		"web-release", "web", "1.0.0", "1.0.0",
+		"deployed", "Install complete", helmTreeManifest, 1,
+	)
+	secret := newFakeHelmReleaseSecret(
+		t, "sh.helm.release.v1.web-release.v1", "web-release", "deployed", "1", blob, time.Now(),
+	)
+	cs := k8sfake.NewClientset(secret)
+	dc := newFakeDynClient(rs, pod)
+	c := newFakeClient(cs, dc)
+
+	root, err := c.GetResourceTree(t.Context(), "", "default", "HelmRelease", "web-release")
+	require.NoError(t, err)
+	require.NotEmpty(t, root.Children, "helm release tree must list the resources the release owns")
+
+	depNode := findTreeChild(root, "Deployment", "web")
+	require.NotNil(t, depNode, "manifest Deployment missing from tree")
+	rsNode := findTreeChild(depNode, "ReplicaSet", "web-abc")
+	require.NotNil(t, rsNode, "Deployment child must recurse into its ReplicaSet")
+	require.NotNil(t, findTreeChild(rsNode, "Pod", "web-abc-1"), "ReplicaSet child must recurse into its Pod")
+
+	svcNode := findTreeChild(root, "Service", "web-svc")
+	require.NotNil(t, svcNode, "manifest Service missing from tree")
+	assert.Equal(t, "default", svcNode.Namespace)
+	assert.Empty(t, svcNode.Children)
+
+	cmNode := findTreeChild(root, "ConfigMap", "web-config")
+	require.NotNil(t, cmNode, "manifest ConfigMap missing from tree")
+	assert.Equal(t, "web-data", cmNode.Namespace, "child keeps its own namespace, not the release namespace")
+	assert.Empty(t, cmNode.Children)
+
+	crNode := findTreeChild(root, "ClusterRole", "web-reader")
+	require.NotNil(t, crNode, "cluster-scoped ClusterRole missing from tree")
+	assert.Empty(t, crNode.Namespace, "cluster-scoped kinds keep an empty namespace")
+}
+
+// TestGetResourceTree_HelmReleaseLabelFallback covers the release whose blob
+// cannot be decoded: discovery falls back to instance labels and the tree must
+// still list what it finds.
+func TestGetResourceTree_HelmReleaseLabelFallback(t *testing.T) {
+	secret := &corev1.Secret{
+		Name: "sh.helm.release.v1.legacy.v1", Namespace: "default",
+		Labels: map[string]string{
+			"owner": "helm", "name": "legacy", "status": "deployed", "version": "1",
+		},
+		Data: map[string][]byte{"release": []byte("not-a-helm-blob")},
+		Type: "helm.sh/release.v1",
+	}
+	dep := &appsv1.Deployment{
+		Name: "legacy-web", Namespace: "default",
+		Labels: map[string]string{"app.kubernetes.io/instance": "legacy"},
+		Spec:   appsv1.DeploymentSpec{Replicas: new(int32(1))},
+		Status: appsv1.DeploymentStatus{AvailableReplicas: 1, ReadyReplicas: 1},
+	}
+	cs := k8sfake.NewClientset(secret, dep)
+	dc := newFakeDynClient()
+	c := newFakeClient(cs, dc)
+
+	root, err := c.GetResourceTree(t.Context(), "", "default", "HelmRelease", "legacy")
+	require.NoError(t, err)
+	require.NotEmpty(t, root.Children, "label fallback must still produce tree nodes")
+
+	depNode := findTreeChild(root, "Deployment", "legacy-web")
+	require.NotNil(t, depNode, "label-discovered Deployment missing from tree")
+	assert.Equal(t, "default", depNode.Namespace, "label-discovered items inherit the release namespace")
 }
 
 func TestGetResourceTree_Pod(t *testing.T) {

--- a/internal/k8s/helm.go
+++ b/internal/k8s/helm.go
@@ -309,6 +309,13 @@ func (c *Client) collectHelmResourcesByLabels(ctx context.Context, cs kubernetes
 		collectHelmSimpleResources(&items, seen, cs, ctx, namespace, opts)
 	}
 
+	// The collectHelm* helpers list from a single namespace and leave
+	// Item.Namespace unset, so callers cannot tell these apart from the
+	// cluster-scoped entries the manifest path reports with no namespace.
+	for i := range items {
+		items[i].Namespace = namespace
+	}
+
 	if len(items) == 0 {
 		logger.Info("Helm: no managed resources found for release", "release", releaseName, "namespace", namespace)
 	}

--- a/internal/k8s/resources_tree.go
+++ b/internal/k8s/resources_tree.go
@@ -76,6 +76,8 @@ func (c *Client) GetResourceTree(ctx context.Context, contextName, namespace, ki
 		err = c.buildServiceTree(ctx, contextName, namespace, name, root)
 	case "Node":
 		err = c.buildNodeTree(ctx, dynClient, name, root)
+	case "HelmRelease":
+		err = c.buildHelmReleaseTree(ctx, dynClient, contextName, namespace, name, root)
 	case "Pod":
 		err = c.buildPodTree(ctx, contextName, namespace, name, root)
 	default:

--- a/internal/k8s/resources_tree_helm.go
+++ b/internal/k8s/resources_tree_helm.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/client-go/dynamic"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// A helm release is not an API object, so nothing carries an ownerReference
+// back to it: membership comes from the rendered manifest in the release
+// secret, and only the workload children below have an owner chain to walk.
+func (c *Client) buildHelmReleaseTree(ctx context.Context, dynClient dynamic.Interface, contextName, namespace, releaseName string, root *model.ResourceNode) error {
+	items, err := c.getHelmManagedResources(ctx, contextName, namespace, releaseName)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range items {
+		node := &model.ResourceNode{
+			Name:      item.Name,
+			Kind:      item.Kind,
+			Namespace: item.Namespace,
+			Status:    item.Status,
+		}
+		root.Children = append(root.Children, node)
+
+		// Cluster-scoped manifest entries have no namespace and no workload
+		// children, so the release namespace is only a lookup fallback here.
+		childNS := item.Namespace
+		if childNS == "" {
+			childNS = namespace
+		}
+		if childErr := c.buildHelmWorkloadChildren(ctx, dynClient, childNS, item.Kind, item.Name, node); childErr != nil {
+			// The release tree still renders without this workload's pods.
+			logger.Warn("Resource tree: building helm workload children failed; pods skipped",
+				"release", releaseName, "kind", item.Kind, "name", item.Name,
+				"namespace", childNS, "error", childErr)
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) buildHelmWorkloadChildren(ctx context.Context, dynClient dynamic.Interface, namespace, kind, name string, node *model.ResourceNode) error {
+	switch kind {
+	case "Deployment":
+		return c.buildDeploymentTree(ctx, dynClient, namespace, name, node)
+	case "StatefulSet", "DaemonSet", "Job", "ReplicaSet":
+		return c.buildPodOwnerTree(ctx, dynClient, namespace, kind, name, node)
+	case "CronJob":
+		return c.buildCronJobTree(ctx, dynClient, namespace, name, node)
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Pressing `M` on a Helm release rendered "(no owned resources)". The resource tree had no Helm case and fell into the ownerReferences walk, which nothing points at for a release. The preview pane already decodes the release manifest, so the tree now builds from that same source and recurses into the existing workload builders, so ReplicaSets and Pods show under a Deployment.
- Label-discovered items now carry the release namespace, so an empty namespace means cluster-scoped in both discovery paths.
- Side effect: the old fallback issued eight namespace-wide list calls per `M` press on a release, all wasted. The Helm case removes them.

Fixes #742

## Test plan
- [x] `go test ./... -race` green, new tree tests cover the manifest path with a ReplicaSet to Pod subtree and the label fallback
- [x] `golangci-lint run ./...` 0 issues
- [ ] Manual: `helm install probe oci://registry-1.docker.io/bitnamicharts/nginx`, `:helm`, select `probe`, press `M`, expect Deployment with ReplicaSet and Pod plus Service and ConfigMap leaves