### PR TITLE
fix: keep user-supplied values out of config warnings

### DIFF
--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -735,6 +735,8 @@ func schedulerKindByName(name string) (scheduler.Kind, bool) {
 func sanitizeUnionSets(in []UnionSetConfig) []UnionSetConfig {
 	out := make([]UnionSetConfig, 0, len(in))
 	seen := make(map[string]int, len(in))
+	// Warnings cite entries by position: a name or context string is user
+	// input, and the log file must not carry what the user typed.
 	for i, s := range in {
 		s.Name = strings.TrimSpace(s.Name)
 		s.Namespace = strings.TrimSpace(s.Namespace)
@@ -748,35 +750,35 @@ func sanitizeUnionSets(in []UnionSetConfig) []UnionSetConfig {
 		// are either empty (untinted) or a valid ClusterColorNames value.
 		cleanCtxs := make([]UnionSetContextConfig, 0, len(s.Contexts))
 		seenCtx := make(map[string]struct{}, len(s.Contexts))
-		for _, c := range s.Contexts {
+		for j, c := range s.Contexts {
 			c.Context = strings.TrimSpace(c.Context)
 			c.Color = strings.TrimSpace(c.Color)
 			c.Namespace = strings.TrimSpace(c.Namespace)
 			if c.Context == "" {
-				logger.Warn("union_sets entry has nameless context; skipping that entry", "set", s.Name)
+				logger.Warn("union_sets entry has nameless context; skipping that entry", "set", i)
 				continue
 			}
 			if _, dup := seenCtx[c.Context]; dup {
 				logger.Warn("union_sets entry repeats a context; keeping first occurrence",
-					"set", s.Name, "context", c.Context)
+					"set", i, "context", j)
 				continue
 			}
 			seenCtx[c.Context] = struct{}{}
 			if c.Color != "" && !IsValidClusterColor(c.Color) {
 				logger.Warn("union_sets entry has unknown color; leaving cluster untinted",
-					"set", s.Name, "context", c.Context,
+					"set", i, "context", j,
 					"valid", ClusterColorNames)
 				c.Color = ""
 			}
 			cleanCtxs = append(cleanCtxs, c)
 		}
 		if len(cleanCtxs) == 0 {
-			logger.Warn("union_sets entry has no usable contexts; skipping", "name", s.Name)
+			logger.Warn("union_sets entry has no usable contexts; skipping", "set", i)
 			continue
 		}
 		s.Contexts = cleanCtxs
 		if idx, dup := seen[s.Name]; dup {
-			logger.Warn("duplicate union_sets name; later definition wins", "name", s.Name)
+			logger.Warn("duplicate union_sets name; later definition wins", "set", i)
 			out[idx] = s
 			continue
 		}

--- a/internal/ui/config_apply.go
+++ b/internal/ui/config_apply.go
@@ -115,7 +115,6 @@ func applyConfigOptions(cfg configFile) {
 		}
 		if clamped != v {
 			logger.Warn("scrollback_lines out of range; clamped",
-				"value", v,
 				"min", ScrollbackLinesMin,
 				"max", ScrollbackLinesMax,
 				"applied", clamped)
@@ -348,7 +347,6 @@ func applyLogMaxLines(src *int) {
 	}
 	if clamped != v {
 		logger.Warn("log_viewer.max_lines out of range; clamped",
-			"value", v,
 			"min", LogMaxLinesMin,
 			"max", LogMaxLinesMax,
 			"applied", clamped)
@@ -580,7 +578,6 @@ func applyRightsizingDefaults(cfg *RightsizingDefaultsConfig) {
 			model.ConfigDefaultRightsizingStrategy = s
 		} else {
 			logger.Warn("unknown rightsizing_defaults.strategy in config; ignored",
-				"value", cfg.Strategy,
 				"valid", rightsizingStrategyLiterals())
 		}
 	}
@@ -590,7 +587,6 @@ func applyRightsizingDefaults(cfg *RightsizingDefaultsConfig) {
 			model.ConfigDefaultRightsizingHeadroom = h
 		} else {
 			logger.Warn("invalid rightsizing_defaults.headroom in config; ignored",
-				"value", cfg.Headroom,
 				"valid", model.RightsizingHeadrooms)
 		}
 	}
@@ -739,11 +735,11 @@ func schedulerKindByName(name string) (scheduler.Kind, bool) {
 func sanitizeUnionSets(in []UnionSetConfig) []UnionSetConfig {
 	out := make([]UnionSetConfig, 0, len(in))
 	seen := make(map[string]int, len(in))
-	for _, s := range in {
+	for i, s := range in {
 		s.Name = strings.TrimSpace(s.Name)
 		s.Namespace = strings.TrimSpace(s.Namespace)
 		if s.Name == "" {
-			logger.Warn("union_sets entry has no name; skipping", "contexts", s.Contexts)
+			logger.Warn("union_sets entry has no name; skipping", "index", i)
 			continue
 		}
 		// Drop nameless cluster entries, drop invalid color names, dedupe
@@ -768,7 +764,7 @@ func sanitizeUnionSets(in []UnionSetConfig) []UnionSetConfig {
 			seenCtx[c.Context] = struct{}{}
 			if c.Color != "" && !IsValidClusterColor(c.Color) {
 				logger.Warn("union_sets entry has unknown color; leaving cluster untinted",
-					"set", s.Name, "context", c.Context, "color", c.Color,
+					"set", s.Name, "context", c.Context,
 					"valid", ClusterColorNames)
 				c.Color = ""
 			}

--- a/internal/ui/config_warnings_redact_test.go
+++ b/internal/ui/config_warnings_redact_test.go
@@ -97,11 +97,17 @@ func TestConfigWarnings_NeverEchoUserValue(t *testing.T) {
 	prevHeadroom := model.ConfigDefaultRightsizingHeadroom
 	prevViews := ConfigViews
 	prevSets := ConfigUnionSets
+	prevScrollback := ConfigScrollbackLines
+	prevLogMax := ConfigLogMaxLines
+	prevResourceColumns := ConfigResourceColumns
 	t.Cleanup(func() {
 		model.ConfigDefaultRightsizingStrategy = prevStrategy
 		model.ConfigDefaultRightsizingHeadroom = prevHeadroom
 		ConfigViews = prevViews
 		ConfigUnionSets = prevSets
+		ConfigScrollbackLines = prevScrollback
+		ConfigLogMaxLines = prevLogMax
+		ConfigResourceColumns = prevResourceColumns
 	})
 
 	for _, tc := range tests {

--- a/internal/ui/config_warnings_redact_test.go
+++ b/internal/ui/config_warnings_redact_test.go
@@ -62,6 +62,18 @@ func TestConfigWarnings_NeverEchoUserValue(t *testing.T) {
 			want:  "no name",
 		},
 		{
+			name:  "union_sets duplicate context",
+			yaml:  "union_sets:\n  - name: " + secret + "\n    contexts:\n      - context: " + secret + "\n      - context: " + secret + "\n",
+			leaks: []string{secret},
+			want:  "repeats a context",
+		},
+		{
+			name:  "union_sets duplicate set name",
+			yaml:  "union_sets:\n  - name: " + secret + "\n    contexts:\n      - context: a\n  - name: " + secret + "\n    contexts:\n      - context: b\n",
+			leaks: []string{secret},
+			want:  "duplicate union_sets name",
+		},
+		{
 			name:  "views invalid column spec",
 			yaml:  "views:\n  pods:\n    columns:\n      - \"" + secret + "|Z\"\n",
 			leaks: []string{secret},

--- a/internal/ui/config_warnings_redact_test.go
+++ b/internal/ui/config_warnings_redact_test.go
@@ -1,0 +1,109 @@
+package ui
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression guard (CWE-532): a config warning reports which key is wrong,
+// never what the user typed there. A secret pasted into the wrong key must
+// stay out of the log file.
+func TestConfigWarnings_NeverEchoUserValue(t *testing.T) {
+	origLogger := logger.Logger
+	t.Cleanup(func() { logger.Logger = origLogger })
+
+	const secret = "hunter2-secret-token-xyz"
+
+	tests := []struct {
+		name  string
+		yaml  string
+		leaks []string
+		want  string
+	}{
+		{
+			name:  "rightsizing strategy",
+			yaml:  "rightsizing_defaults:\n  strategy: " + secret + "\n",
+			leaks: []string{secret},
+			want:  "rightsizing_defaults.strategy",
+		},
+		{
+			name:  "rightsizing headroom",
+			yaml:  "rightsizing_defaults:\n  headroom: 987654.321\n",
+			leaks: []string{"987654.321", "987654"},
+			want:  "rightsizing_defaults.headroom",
+		},
+		{
+			name:  "scrollback_lines clamp",
+			yaml:  "scrollback_lines: 987654321\n",
+			leaks: []string{"987654321"},
+			want:  "scrollback_lines",
+		},
+		{
+			name:  "log_viewer.max_lines clamp",
+			yaml:  "log_viewer:\n  max_lines: 987654321\n",
+			leaks: []string{"987654321"},
+			want:  "log_viewer.max_lines",
+		},
+		{
+			name:  "union_sets unknown color",
+			yaml:  "union_sets:\n  - name: prod\n    contexts:\n      - context: a\n        color: " + secret + "\n",
+			leaks: []string{secret},
+			want:  "unknown color",
+		},
+		{
+			name:  "union_sets nameless entry",
+			yaml:  "union_sets:\n  - contexts:\n      - context: " + secret + "\n",
+			leaks: []string{secret},
+			want:  "no name",
+		},
+		{
+			name:  "views invalid column spec",
+			yaml:  "views:\n  pods:\n    columns:\n      - \"" + secret + "|Z\"\n",
+			leaks: []string{secret},
+			want:  "invalid view config",
+		},
+		{
+			name:  "views invalid jsonpath",
+			yaml:  "views:\n  pods:\n    columns:\n      - \"col:" + secret + "\"\n",
+			leaks: []string{secret},
+			want:  "invalid view config",
+		},
+		{
+			name:  "resource_columns invalid column spec",
+			yaml:  "resource_columns:\n  pods:\n    - \"" + secret + "|Z\"\n",
+			leaks: []string{secret},
+			want:  "invalid resource_columns config",
+		},
+	}
+
+	prevStrategy := model.ConfigDefaultRightsizingStrategy
+	prevHeadroom := model.ConfigDefaultRightsizingHeadroom
+	prevViews := ConfigViews
+	prevSets := ConfigUnionSets
+	t.Cleanup(func() {
+		model.ConfigDefaultRightsizingStrategy = prevStrategy
+		model.ConfigDefaultRightsizingHeadroom = prevHeadroom
+		ConfigViews = prevViews
+		ConfigUnionSets = prevSets
+	})
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger.Logger = slog.New(slog.NewTextHandler(&buf, nil))
+
+			LoadConfig(writeConfigFile(t, tc.yaml))
+
+			out := buf.String()
+			assert.Contains(t, out, tc.want, "warning must name the offending key")
+			for _, leak := range tc.leaks {
+				assert.NotContains(t, out, leak, "raw config value must not be logged")
+			}
+		})
+	}
+}

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -166,16 +166,18 @@ func BuildView(cv *configView) (*View, error) {
 		return nil, nil
 	}
 	v := &View{SortAsc: true}
-	for _, raw := range cv.Columns {
+	// Errors name the column by position, never by content: the warning
+	// they feed lands in the log file, and a config value can hold a secret.
+	for i, raw := range cv.Columns {
 		spec, ok := ParseColumnSpec(raw)
 		if !ok {
-			return nil, fmt.Errorf("invalid column spec %q", raw)
+			return nil, fmt.Errorf("column %d: invalid column spec", i+1)
 		}
 		rc := ResolvedColumn{ColumnSpec: spec}
 		if spec.IsCustom() {
 			jp, err := CompileJSONPath(spec.JSONPath)
 			if err != nil {
-				return nil, fmt.Errorf("compile %q: %w", spec.Name, err)
+				return nil, fmt.Errorf("column %d: invalid JSONPath", i+1)
 			}
 			rc.Compiled = jp
 		}


### PR DESCRIPTION
## Summary
- Config warnings name the offending key and the accepted values, and no longer echo what the user typed. A secret pasted into the wrong key stayed out of the log for kubeconfig_dir after #739; this applies the same rule to rightsizing_defaults, the scrollback and max_lines clamps, union_sets and view column specs.
- BuildView errors cite the column position instead of the spec text. union_sets warnings cite the entry index instead of the set name or context.
- Regression test loads each bad value through LoadConfig and asserts it never reaches the log.

## Test plan
- [x] `go test -race ./internal/ui/`
- [x] `golangci-lint run ./internal/ui/`
- [x] Full `go test -race ./...` (one timing flake in TestExplainFetchesStopWhenTheViewCloses under load, passes alone)