### PR TITLE
fix: drop kubeconfig files whose only cluster has no server

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -198,7 +198,7 @@ Precedence (replacement, not merge): `--kubeconfig-dir` flag > `KUBECONFIG_DIR` 
 
 lfk validates every directory exists at startup and errors out loudly on a typo. The `--kubeconfig` flag bypasses all directory discovery entirely.
 
-lfk skips known non-kubeconfig files in a scanned directory. It then drops any remaining file that fails to parse, and any file that declares no clusters, no users, no contexts and no current-context, such as a credential cache. A split kubeconfig fragment declares at least one of the four, so it survives. A file you name with `--kubeconfig` or `KUBECONFIG` still fails loudly when it is broken.
+lfk skips known non-kubeconfig files in a scanned directory. It then drops any remaining file that fails to parse, and any file that declares no users, no contexts, no current-context and no cluster with a server URL, such as a credential cache. A split kubeconfig fragment declares at least one of the four, so it survives. A file you name with `--kubeconfig` or `KUBECONFIG` still fails loudly when it is broken.
 
 The skip list holds these glob patterns by default, matched against a file's base name, case-insensitively:
 

--- a/internal/k8s/client_kubeconfig.go
+++ b/internal/k8s/client_kubeconfig.go
@@ -402,8 +402,8 @@ func ValidateKubeconfigIgnore(patterns []string) error {
 }
 
 // filterParseableKubeconfigs keeps scanned files that parse and declare at least one
-// cluster, user or context, or a current-context, and carries each one's Config on so
-// nothing re-reads it.
+// user, context, current-context, or cluster with a server, and carries each one's
+// Config on so nothing re-reads it.
 // Scanned files only: clientcmd reports a file it skipped in the aggregate error
 // NewClient treats as fatal, while a typo in --kubeconfig must still fail loudly.
 func filterParseableKubeconfigs(paths []string) []kubeconfigSource {
@@ -416,18 +416,32 @@ func filterParseableKubeconfigs(paths []string) []kubeconfigSource {
 				"path", p, "error", logger.Redact(err.Error()))
 			continue
 		}
-		// The codec ignores unrecognised fields, so a flat JSON credential cache
-		// decodes into an empty Config and would reach a subprocess KUBECONFIG.
-		// CurrentContext counts: a split kubeconfig may hold only the selection
-		// of a context another file declares, and dropping it loses that choice.
-		if len(cfg.Clusters) == 0 && len(cfg.AuthInfos) == 0 && len(cfg.Contexts) == 0 &&
-			cfg.CurrentContext == "" {
+		if !declaresKubeconfigEntries(cfg) {
 			logger.Debug("ignoring file with no kubeconfig entries", "path", p)
 			continue
 		}
 		out = append(out, kubeconfigSource{path: p, cfg: cfg})
 	}
 	return out
+}
+
+// declaresKubeconfigEntries reports whether a parsed file carries anything a
+// merged kubeconfig can use. The codec ignores unrecognised fields, so a flat
+// JSON credential cache decodes into an empty Config and would reach a
+// subprocess KUBECONFIG. CurrentContext counts: a split kubeconfig may hold
+// only the selection of a context another file declares. A cluster counts only
+// with a server URL: clientcmd rejects one without at validation time, so a
+// file whose sole content is a placeholder cluster is a cache, not a fragment.
+func declaresKubeconfigEntries(cfg *clientcmdapi.Config) bool {
+	if len(cfg.AuthInfos) > 0 || len(cfg.Contexts) > 0 || cfg.CurrentContext != "" {
+		return true
+	}
+	for _, c := range cfg.Clusters {
+		if c != nil && c.Server != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // collectConfigDirPaths returns all file paths under dir. If dir is a symlink

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -2104,6 +2104,38 @@ func TestFilterParseableKubeconfigs(t *testing.T) {
 		assert.Equal(t, []string{good}, sourcePaths(filterParseableKubeconfigs([]string{good, cache})))
 	})
 
+	t.Run("drops a file whose only cluster has no server", func(t *testing.T) {
+		// A credential cache that also declares one placeholder cluster
+		// would otherwise pass. clientcmd rejects a cluster without a
+		// server at validation time, so no real fragment is lost.
+		tmp := t.TempDir()
+		good := filepath.Join(tmp, "good.yaml")
+		stub := filepath.Join(tmp, "stub.yaml")
+		body := "apiVersion: v1\nkind: Config\nclusters:\n- name: placeholder\n  cluster: {}\n"
+		assert.NoError(t, os.WriteFile(good, []byte(stubKubeconfig("ctx1")), 0o600))
+		assert.NoError(t, os.WriteFile(stub, []byte(body), 0o600))
+
+		assert.Equal(t, []string{good}, sourcePaths(filterParseableKubeconfigs([]string{good, stub})))
+	})
+
+	t.Run("keeps a serverless cluster when the file also declares a user", func(t *testing.T) {
+		tmp := t.TempDir()
+		frag := filepath.Join(tmp, "mixed.yaml")
+		body := "apiVersion: v1\nkind: Config\nclusters:\n- name: c1\n  cluster: {}\nusers:\n- name: u1\n  user: {}\n"
+		assert.NoError(t, os.WriteFile(frag, []byte(body), 0o600))
+
+		assert.Equal(t, []string{frag}, sourcePaths(filterParseableKubeconfigs([]string{frag})))
+	})
+
+	t.Run("keeps a file when one of several clusters has a server", func(t *testing.T) {
+		tmp := t.TempDir()
+		frag := filepath.Join(tmp, "two-clusters.yaml")
+		body := "apiVersion: v1\nkind: Config\nclusters:\n- name: c1\n  cluster: {}\n- name: c2\n  cluster:\n    server: https://c2.test\n"
+		assert.NoError(t, os.WriteFile(frag, []byte(body), 0o600))
+
+		assert.Equal(t, []string{frag}, sourcePaths(filterParseableKubeconfigs([]string{frag})))
+	})
+
 	t.Run("drops an empty file", func(t *testing.T) {
 		tmp := t.TempDir()
 		empty := filepath.Join(tmp, "empty.yaml")


### PR DESCRIPTION
## Summary
- Directory discovery kept any scanned file that declared a cluster, so a credential cache carrying one placeholder cluster could still reach a subprocess KUBECONFIG. A cluster now counts only when it has a server URL.
- clientcmd rejects a cluster without a server at validation time, so no real split-kubeconfig fragment is lost. Users-only, contexts-only and current-context-only fragments are kept as before.
- docs/usage.md describes the rule.

## Test plan
- [x] `go test -race ./internal/k8s/` (three new subtests in TestFilterParseableKubeconfigs)
- [x] `golangci-lint run ./internal/k8s/`