### PR TITLE
feat: jump from a pod to its ResourceClaim with c

### DIFF
--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -454,6 +454,7 @@
         "preview_down": { "type": "string" },
         "preview_up": { "type": "string" },
         "jump_owner": { "type": "string" },
+        "jump_claim": { "type": "string" },
         "jump_back": { "type": "string" },
         "help": { "type": "string" },
         "filter": { "type": "string" },

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -20,6 +20,7 @@ Complete list of all keybindings in `lfk`. All keybindings can be overridden in 
 | `0` / `1` / `2` | Jump to clusters / types / resources level, per cluster and both ways |
 | `J` / `K` | Scroll preview pane down / up |
 | `o` / `O` | Jump to owner/controller / open Object Explorer |
+| `c` | Jump to a pod's resource claim, cycling through multiple claims on repeated presses |
 | `Backspace` | Jump back through teleport history |
 
 In the Events list, `z` toggles event grouping instead of expand/collapse.
@@ -1384,6 +1385,7 @@ keybindings:
   preview_down: "J"      # Scroll preview down
   preview_up: "K"        # Scroll preview up
   jump_owner: "o"        # Jump to owner
+  jump_claim: "c"        # Jump to resource claim (cycles on repeated presses)
   jump_back: "backspace"     # Jump back through teleport history
   toggle_rare: "H"       # Toggle rarely used resource types in the sidebar
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -240,13 +240,10 @@ type Model struct {
 	objectExplorerTree                          bool             // session tree-view pref (T)
 	viewerPrefs                                 viewerPrefValues // live viewer toggles; see viewer_prefs.go
 
-	// Read-only mode: blocks all mutating actions for the active tab. Mirrors
-	// the active TabState.readOnly. Re-evaluated on context switch and tab
-	// switch.
-	readOnly bool
-	// cliReadOnly is the value of --read-only at startup. Sticky for the life
-	// of the process so context switches can't drop it.
-	cliReadOnly bool
+	// readOnly blocks mutating actions for the active tab (mirrors the active
+	// TabState.readOnly, re-evaluated on context/tab switch). cliReadOnly is
+	// the --read-only startup value, sticky so context switches can't drop it.
+	readOnly, cliReadOnly bool
 	// contextROOverrides holds session-scoped per-context read-only state set
 	// by the user via Ctrl+R on a row in the cluster picker. A present entry
 	// wins over per-context and global config when entering that context;
@@ -742,6 +739,7 @@ type Model struct {
 
 	// Jump history: back stack for "teleport" jumps. jump_back pops it. Capped at jumpHistoryCap.
 	jumpBackStack []navSnapshot
+	claimJump     claimJumpState // last pod+claim jumped to, so repeated presses cycle (update_keys_jump_claim.go)
 	// Level memory: the view each cluster was left at, so the 1 and 2 keys walk back down (level_memory.go).
 	levelMem levelMemory
 

--- a/internal/app/copy_format_picker.go
+++ b/internal/app/copy_format_picker.go
@@ -226,6 +226,7 @@ func isInternalCopyColumnKey(key string) bool {
 	case strings.HasPrefix(key, "__"),
 		strings.HasPrefix(key, "secret:"),
 		strings.HasPrefix(key, "owner:"),
+		strings.HasPrefix(key, "claim:"),
 		strings.HasPrefix(key, "data:"),
 		strings.HasPrefix(key, "condition:"),
 		strings.HasPrefix(key, "step:"),

--- a/internal/app/status_clear.go
+++ b/internal/app/status_clear.go
@@ -38,7 +38,7 @@ func (m Model) clearStatusOnNavigationKey(msg tea.KeyPressMsg) Model {
 		kb.PageDown, kb.PageUp, kb.PageForward, kb.PageBack, "pgdown", "pgup", "shift+down", "shift+up",
 		kb.PreviewDown, kb.PreviewUp,
 		kb.LevelCluster, kb.LevelTypes, kb.LevelResources,
-		kb.JumpBack, kb.JumpOwner,
+		kb.JumpBack, kb.JumpOwner, kb.JumpClaim,
 		kb.NextMatch, kb.PrevMatch,
 		kb.NextTab, kb.PrevTab, kb.NewTab, kb.MoveTabLeft, kb.MoveTabRight:
 		m.clearTransientStatus()

--- a/internal/app/update_column_toggle.go
+++ b/internal/app/update_column_toggle.go
@@ -253,7 +253,8 @@ func (m *Model) collectExtraToggleEntries(items []model.Item) []columnToggleEntr
 	for _, item := range items {
 		for _, kv := range item.Columns {
 			if strings.HasPrefix(kv.Key, "__") || strings.HasPrefix(kv.Key, "secret:") ||
-				strings.HasPrefix(kv.Key, "owner:") || strings.HasPrefix(kv.Key, "data:") ||
+				strings.HasPrefix(kv.Key, "owner:") || strings.HasPrefix(kv.Key, "claim:") ||
+				strings.HasPrefix(kv.Key, "data:") ||
 				strings.HasPrefix(kv.Key, "condition:") || strings.HasPrefix(kv.Key, "step:") ||
 				strings.HasPrefix(kv.Key, "cond:") {
 				continue

--- a/internal/app/update_keys_actions.go
+++ b/internal/app/update_keys_actions.go
@@ -64,6 +64,8 @@ func (m Model) handleExplorerNavKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, b
 		return m.handleExplorerActionKeyPreviewUp()
 	case kb.JumpOwner:
 		return m.handleExplorerActionKeyJumpOwner()
+	case kb.JumpClaim:
+		return m.handleExplorerActionKeyJumpClaim()
 	case kb.SortNext:
 		return m.handleExplorerActionKeySortNext()
 	case kb.SortPrev:

--- a/internal/app/update_keys_jump_claim.go
+++ b/internal/app/update_keys_jump_claim.go
@@ -10,7 +10,7 @@ import (
 // last jumped to, so a repeated press on the same pod advances through its
 // remaining claims instead of always landing on the first one.
 type claimJumpState struct {
-	podKey string // "namespace/name" of the pod the last jump started from
+	podKey string // cluster, namespace and name of the pod the last jump started from
 	index  int    // claim index to use on the next press for that pod
 }
 
@@ -41,7 +41,9 @@ func (m Model) handleExplorerActionKeyJumpClaim() (tea.Model, tea.Cmd, bool) {
 		return m, scheduleStatusClear(), true
 	}
 
-	podKey := sel.Namespace + "/" + sel.Name
+	// The cluster is part of the key: in union mode two clusters can hold a
+	// pod with the same namespace and name.
+	podKey := claimJumpPodKey(sel.ClusterName, sel.Namespace, sel.Name)
 	idx := 0
 	if m.claimJump.podKey == podKey && m.claimJump.index < len(claims) {
 		idx = m.claimJump.index
@@ -54,4 +56,8 @@ func (m Model) handleExplorerActionKeyJumpClaim() (tea.Model, tea.Cmd, bool) {
 
 	ret, cmd := m.navigateToOwner("ResourceClaim", claims[idx], "resource.k8s.io/v1")
 	return ret, cmd, true
+}
+
+func claimJumpPodKey(cluster, namespace, name string) string {
+	return cluster + "\x00" + namespace + "\x00" + name
 }

--- a/internal/app/update_keys_jump_claim.go
+++ b/internal/app/update_keys_jump_claim.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// claimJumpState remembers which pod and claim index handleExplorerActionKeyJumpClaim
+// last jumped to, so a repeated press on the same pod advances through its
+// remaining claims instead of always landing on the first one.
+type claimJumpState struct {
+	podKey string // "namespace/name" of the pod the last jump started from
+	index  int    // claim index to use on the next press for that pod
+}
+
+// Repeated presses on the same pod cycle through its "claim:N" columns
+// (populatePodResourceClaims), wrapping back to the first after the last.
+func (m Model) handleExplorerActionKeyJumpClaim() (tea.Model, tea.Cmd, bool) {
+	sel := m.selectedMiddleItem()
+	if sel == nil {
+		return m, nil, true
+	}
+
+	var claims []string
+	for _, kv := range sel.Columns {
+		if strings.HasPrefix(kv.Key, "claim:") {
+			claims = append(claims, kv.Value)
+		}
+	}
+	if len(claims) == 0 {
+		m.setStatusMessage("No resource claims on this pod", true)
+		return m, scheduleStatusClear(), true
+	}
+
+	podKey := sel.Namespace + "/" + sel.Name
+	idx := 0
+	if m.claimJump.podKey == podKey && m.claimJump.index < len(claims) {
+		idx = m.claimJump.index
+	}
+	next := idx + 1
+	if next >= len(claims) {
+		next = 0
+	}
+	m.claimJump = claimJumpState{podKey: podKey, index: next}
+
+	ret, cmd := m.navigateToOwner("ResourceClaim", claims[idx], "resource.k8s.io/v1")
+	return ret, cmd, true
+}

--- a/internal/app/update_keys_jump_claim.go
+++ b/internal/app/update_keys_jump_claim.go
@@ -23,13 +23,21 @@ func (m Model) handleExplorerActionKeyJumpClaim() (tea.Model, tea.Cmd, bool) {
 	}
 
 	var claims []string
+	hasUnresolvedClaims := false
 	for _, kv := range sel.Columns {
 		if strings.HasPrefix(kv.Key, "claim:") {
 			claims = append(claims, kv.Value)
 		}
+		if kv.Key == "Resource Claims" {
+			hasUnresolvedClaims = true
+		}
 	}
 	if len(claims) == 0 {
-		m.setStatusMessage("No resource claims on this pod", true)
+		if hasUnresolvedClaims {
+			m.setStatusMessage("Resource claim not created yet", true)
+		} else {
+			m.setStatusMessage("No resource claims on this pod", true)
+		}
 		return m, scheduleStatusClear(), true
 	}
 

--- a/internal/app/update_keys_jump_claim_test.go
+++ b/internal/app/update_keys_jump_claim_test.go
@@ -50,6 +50,22 @@ func TestActionKeyJumpClaimNoClaimsOnPod(t *testing.T) {
 	assert.Equal(t, "No resource claims on this pod", rm.statusMessage)
 }
 
+func TestActionKeyJumpClaimUnresolvedClaimsOnPod(t *testing.T) {
+	m := claimJumpTestModel()
+	m.middleItems = append(m.middleItems, model.Item{
+		Name: "pod-3", Namespace: "default", Kind: "Pod", Status: "Running",
+		Columns: []model.KeyValue{{Key: "Resource Claims", Value: "gpu-template"}},
+	})
+	m.setCursor(2) // pod-3 has claims pending but none resolved to a claim: column
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpClaim()
+	assert.True(t, handled)
+	require.NotNil(t, cmd)
+	rm := ret.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.Equal(t, "Resource claim not created yet", rm.statusMessage)
+}
+
 func TestActionKeyJumpClaimTeleportsToFirstClaim(t *testing.T) {
 	m := claimJumpTestModel()
 	m.setCursor(0)

--- a/internal/app/update_keys_jump_claim_test.go
+++ b/internal/app/update_keys_jump_claim_test.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func claimJumpTestModel() Model {
+	m := basePush80Model()
+	m.leftItemsHistory = [][]model.Item{{{Name: "test-ctx"}}}
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "ResourceClaim", APIGroup: "resource.k8s.io", APIVersion: "v1", Resource: "resourceclaims", Namespaced: true},
+	}
+	m.middleItems = []model.Item{
+		{
+			Name: "pod-1", Namespace: "default", Kind: "Pod", Status: "Running",
+			Columns: []model.KeyValue{
+				{Key: "claim:0", Value: "gpu-claim"},
+				{Key: "claim:1", Value: "nic-claim"},
+			},
+		},
+		{Name: "pod-2", Namespace: "default", Kind: "Pod", Status: "Running"},
+	}
+	return m
+}
+
+func TestActionKeyJumpClaimNoSelection(t *testing.T) {
+	m := claimJumpTestModel()
+	m.setCursor(99) // out of range: selectedMiddleItem returns nil
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpClaim()
+	assert.True(t, handled)
+	assert.Nil(t, cmd)
+	_ = ret.(Model)
+}
+
+func TestActionKeyJumpClaimNoClaimsOnPod(t *testing.T) {
+	m := claimJumpTestModel()
+	m.setCursor(1) // pod-2 has no claim: columns
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpClaim()
+	assert.True(t, handled)
+	require.NotNil(t, cmd)
+	rm := ret.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.Equal(t, "No resource claims on this pod", rm.statusMessage)
+}
+
+func TestActionKeyJumpClaimTeleportsToFirstClaim(t *testing.T) {
+	m := claimJumpTestModel()
+	m.setCursor(0)
+
+	ret, _, handled := m.handleExplorerActionKeyJumpClaim()
+	assert.True(t, handled)
+	rm := ret.(Model)
+	assert.Equal(t, "gpu-claim", rm.pendingTarget)
+	assert.Len(t, rm.jumpBackStack, 1, "must push jump history so jump_back returns to the pod list")
+}
+
+func TestActionKeyJumpClaimCyclesOnRepeatedPress(t *testing.T) {
+	m := claimJumpTestModel()
+	m.setCursor(0)
+
+	ret1, _, _ := m.handleExplorerActionKeyJumpClaim()
+	rm1 := ret1.(Model)
+	assert.Equal(t, "gpu-claim", rm1.pendingTarget, "first press jumps to the first claim")
+
+	// Restore explorer state as if jump_back happened, but keep the cycling
+	// memory (claimJump), and re-select the same pod for the second press.
+	rm1.nav.Level = model.LevelResources
+	rm1.middleItems = m.middleItems
+	ret2, _, _ := rm1.handleExplorerActionKeyJumpClaim()
+	rm2 := ret2.(Model)
+	assert.Equal(t, "nic-claim", rm2.pendingTarget, "second press on the same pod jumps to the next claim")
+
+	rm2.nav.Level = model.LevelResources
+	rm2.middleItems = m.middleItems
+	ret3, _, _ := rm2.handleExplorerActionKeyJumpClaim()
+	rm3 := ret3.(Model)
+	assert.Equal(t, "gpu-claim", rm3.pendingTarget, "a third press wraps back to the first claim")
+}
+
+func TestActionKeyJumpClaimResetsIndexForDifferentPod(t *testing.T) {
+	m := claimJumpTestModel()
+	m.claimJump = claimJumpState{podKey: "default/pod-1", index: 1}
+	m.middleItems = append(m.middleItems, model.Item{
+		Name: "pod-3", Namespace: "default", Kind: "Pod", Status: "Running",
+		Columns: []model.KeyValue{{Key: "claim:0", Value: "other-claim"}},
+	})
+	m.setCursor(2)
+
+	ret, _, _ := m.handleExplorerActionKeyJumpClaim()
+	rm := ret.(Model)
+	assert.Equal(t, "other-claim", rm.pendingTarget, "a different pod always starts at its first claim")
+}
+
+func TestActionKeyCJumpsToClaim(t *testing.T) {
+	m := claimJumpTestModel()
+	m.setCursor(0)
+
+	ret, _, handled := m.handleExplorerActionKey(runeKey('c'))
+	assert.True(t, handled)
+	rm := ret.(Model)
+	assert.Equal(t, "gpu-claim", rm.pendingTarget)
+}

--- a/internal/app/update_keys_jump_claim_test.go
+++ b/internal/app/update_keys_jump_claim_test.go
@@ -102,7 +102,7 @@ func TestActionKeyJumpClaimCyclesOnRepeatedPress(t *testing.T) {
 
 func TestActionKeyJumpClaimResetsIndexForDifferentPod(t *testing.T) {
 	m := claimJumpTestModel()
-	m.claimJump = claimJumpState{podKey: "default/pod-1", index: 1}
+	m.claimJump = claimJumpState{podKey: claimJumpPodKey("", "default", "pod-1"), index: 1}
 	m.middleItems = append(m.middleItems, model.Item{
 		Name: "pod-3", Namespace: "default", Kind: "Pod", Status: "Running",
 		Columns: []model.KeyValue{{Key: "claim:0", Value: "other-claim"}},
@@ -112,6 +112,19 @@ func TestActionKeyJumpClaimResetsIndexForDifferentPod(t *testing.T) {
 	ret, _, _ := m.handleExplorerActionKeyJumpClaim()
 	rm := ret.(Model)
 	assert.Equal(t, "other-claim", rm.pendingTarget, "a different pod always starts at its first claim")
+}
+
+// In union mode two clusters can hold a pod with the same namespace and
+// name. A jump from one must not advance the claim index on the other.
+func TestActionKeyJumpClaimKeysBySameNamedPodInAnotherCluster(t *testing.T) {
+	m := claimJumpTestModel()
+	m.middleItems[0].ClusterName = "cluster-a"
+	m.claimJump = claimJumpState{podKey: claimJumpPodKey("cluster-b", "default", "pod-1"), index: 1}
+	m.setCursor(0)
+
+	ret, _, _ := m.handleExplorerActionKeyJumpClaim()
+	rm := ret.(Model)
+	assert.Equal(t, "gpu-claim", rm.pendingTarget, "a same-named pod in another cluster starts at its first claim")
 }
 
 func TestActionKeyCJumpsToClaim(t *testing.T) {

--- a/internal/app/update_search.go
+++ b/internal/app/update_search.go
@@ -254,6 +254,7 @@ func isInternalColumnKey(key string) bool {
 		strings.HasPrefix(key, "secret:") ||
 		strings.HasPrefix(key, "data:") ||
 		strings.HasPrefix(key, "owner:") ||
+		strings.HasPrefix(key, "claim:") ||
 		strings.HasPrefix(key, "condition:") ||
 		strings.HasPrefix(key, "step:") ||
 		strings.HasPrefix(key, "cond:")

--- a/internal/app/whichkey_registry.go
+++ b/internal/app/whichkey_registry.go
@@ -616,7 +616,7 @@ func whichKeyExcludedBindings() map[string]string {
 		"PageDown": "navigation", "PageUp": "navigation", "PageForward": "navigation", "PageBack": "navigation",
 		"LevelCluster": "navigation", "LevelTypes": "navigation", "LevelResources": "navigation",
 		"PreviewDown": "navigation", "PreviewUp": "navigation",
-		"JumpOwner": "navigation", "JumpBack": "navigation", "ExpandCollapse": "navigation",
+		"JumpOwner": "navigation", "JumpClaim": "navigation", "JumpBack": "navigation", "ExpandCollapse": "navigation",
 		"NextMatch": "navigation within search", "PrevMatch": "navigation within search",
 
 		// The leader itself: pressing it opens the panel rather than running a

--- a/internal/k8s/client_populate_workloads.go
+++ b/internal/k8s/client_populate_workloads.go
@@ -133,26 +133,35 @@ func populatePodResourceClaims(ti *model.Item, status, spec map[string]any) {
 	}
 	statuses, _ := status["resourceClaimStatuses"].([]any)
 	var names []string
+	var claimNames []string
 	for _, c := range claims {
 		claim, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
-		if name := resolvePodResourceClaimName(claim, statuses); name != "" {
-			// "claim:N" is read by handleExplorerActionKeyJumpClaim to jump
-			// from a pod row to its ResourceClaim, cycling on repeated presses.
-			ti.Columns = append(ti.Columns, model.KeyValue{Key: fmt.Sprintf("claim:%d", len(names)), Value: name})
-			names = append(names, name)
+		name, resolved := resolvePodResourceClaimName(claim, statuses)
+		if name == "" {
+			continue
 		}
+		if resolved {
+			// "claim:N" is read by handleExplorerActionKeyJumpClaim.
+			// A template name is not a real object to navigate to.
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: fmt.Sprintf("claim:%d", len(claimNames)), Value: name})
+			claimNames = append(claimNames, name)
+		}
+		names = append(names, name)
 	}
 	if len(names) > 0 {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Resource Claims", Value: strings.Join(names, ", ")})
 	}
 }
 
-func resolvePodResourceClaimName(claim map[string]any, statuses []any) string {
+// resolvePodResourceClaimName returns the display name for a pod's claim
+// entry and whether that name is a resolved ResourceClaim object (as
+// opposed to a template name the controller has not realized yet).
+func resolvePodResourceClaimName(claim map[string]any, statuses []any) (string, bool) {
 	if direct, ok := claim["resourceClaimName"].(string); ok && direct != "" {
-		return direct
+		return direct, true
 	}
 	claimName, _ := claim["name"].(string)
 	for _, s := range statuses {
@@ -164,12 +173,12 @@ func resolvePodResourceClaimName(claim map[string]any, statuses []any) string {
 			continue
 		}
 		if resolved, ok := st["resourceClaimName"].(string); ok && resolved != "" {
-			return resolved
+			return resolved, true
 		}
 		break
 	}
 	tmpl, _ := claim["resourceClaimTemplateName"].(string)
-	return tmpl
+	return tmpl, false
 }
 
 func populateDeploymentDetails(ti *model.Item, obj, status, spec map[string]any) {

--- a/internal/k8s/client_populate_workloads.go
+++ b/internal/k8s/client_populate_workloads.go
@@ -139,6 +139,9 @@ func populatePodResourceClaims(ti *model.Item, status, spec map[string]any) {
 			continue
 		}
 		if name := resolvePodResourceClaimName(claim, statuses); name != "" {
+			// "claim:N" is read by handleExplorerActionKeyJumpClaim to jump
+			// from a pod row to its ResourceClaim, cycling on repeated presses.
+			ti.Columns = append(ti.Columns, model.KeyValue{Key: fmt.Sprintf("claim:%d", len(names)), Value: name})
 			names = append(names, name)
 		}
 	}

--- a/internal/k8s/client_populate_workloads_dra_test.go
+++ b/internal/k8s/client_populate_workloads_dra_test.go
@@ -83,3 +83,73 @@ func TestPopulatePodExtraColumns_ResourceClaims(t *testing.T) {
 		})
 	}
 }
+
+func TestPopulatePodResourceClaims_HiddenClaimColumns(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     map[string]any
+		spec       map[string]any
+		wantClaims map[string]string
+	}{
+		{
+			name: "direct claim gets claim:0",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimName": "shared-gpu-claim"},
+				},
+			},
+			wantClaims: map[string]string{"claim:0": "shared-gpu-claim"},
+		},
+		{
+			name: "template-backed claim resolves the object name through status",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimTemplateName": "gpu-template"},
+				},
+			},
+			status: map[string]any{
+				"resourceClaimStatuses": []any{
+					map[string]any{"name": "gpu", "resourceClaimName": "pod-abc-gpu"},
+				},
+			},
+			wantClaims: map[string]string{"claim:0": "pod-abc-gpu"},
+		},
+		{
+			name: "multiple claims are indexed sequentially from 0",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimName": "shared-gpu-claim"},
+					map[string]any{"name": "nic", "resourceClaimTemplateName": "nic-template"},
+				},
+			},
+			status: map[string]any{
+				"resourceClaimStatuses": []any{
+					map[string]any{"name": "nic", "resourceClaimName": "pod-abc-nic"},
+				},
+			},
+			wantClaims: map[string]string{"claim:0": "shared-gpu-claim", "claim:1": "pod-abc-nic"},
+		},
+		{
+			name:       "no claims produces no hidden columns",
+			spec:       map[string]any{},
+			wantClaims: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{}
+			populatePodExtraColumns(ti, nil, tt.status, tt.spec)
+
+			colMap := columnsToMap(ti.Columns)
+			for key, want := range tt.wantClaims {
+				assert.Equal(t, want, colMap[key], "column %q", key)
+			}
+			if len(tt.wantClaims) == 0 {
+				for _, kv := range ti.Columns {
+					assert.NotContains(t, kv.Key, "claim:", "no claim: column expected")
+				}
+			}
+		})
+	}
+}

--- a/internal/k8s/client_populate_workloads_dra_test.go
+++ b/internal/k8s/client_populate_workloads_dra_test.go
@@ -134,6 +134,15 @@ func TestPopulatePodResourceClaims_HiddenClaimColumns(t *testing.T) {
 			spec:       map[string]any{},
 			wantClaims: map[string]string{},
 		},
+		{
+			name: "template-backed claim produces no hidden column when unresolved",
+			spec: map[string]any{
+				"resourceClaims": []any{
+					map[string]any{"name": "gpu", "resourceClaimTemplateName": "gpu-template"},
+				},
+			},
+			wantClaims: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -29,7 +29,10 @@ type Keybindings struct {
 	PreviewDown    string `json:"preview_down" yaml:"preview_down"`
 	PreviewUp      string `json:"preview_up" yaml:"preview_up"`
 	JumpOwner      string `json:"jump_owner" yaml:"jump_owner"`
-	JumpBack       string `json:"jump_back" yaml:"jump_back"`
+	// JumpClaim jumps from a pod row to its ResourceClaim. Repeated presses
+	// on the same pod cycle through the pod's remaining claims.
+	JumpClaim string `json:"jump_claim" yaml:"jump_claim"`
+	JumpBack  string `json:"jump_back" yaml:"jump_back"`
 
 	// Views and Modes
 	Help          string `json:"help" yaml:"help"`
@@ -223,7 +226,8 @@ func DefaultKeybindings() Keybindings {
 		PageForward: "ctrl+f", PageBack: "ctrl+b",
 		LevelCluster: "0", LevelTypes: "1", LevelResources: "2",
 		PreviewDown: "J", PreviewUp: "K", JumpOwner: "o",
-		JumpBack: "backspace",
+		JumpClaim: "c",
+		JumpBack:  "backspace",
 
 		// Views
 		Help: "?", Filter: "f", Search: "/",

--- a/internal/ui/explorer_format_columns.go
+++ b/internal/ui/explorer_format_columns.go
@@ -493,6 +493,7 @@ func isHiddenColumnPrefix(key string) bool {
 	return strings.HasPrefix(key, "__") ||
 		strings.HasPrefix(key, "secret:") ||
 		strings.HasPrefix(key, "owner:") ||
+		strings.HasPrefix(key, "claim:") ||
 		strings.HasPrefix(key, "data:") ||
 		strings.HasPrefix(key, "condition:") ||
 		strings.HasPrefix(key, "step:")

--- a/internal/ui/explorer_table_format.go
+++ b/internal/ui/explorer_table_format.go
@@ -64,7 +64,7 @@ func RenderContainerDetail(item *model.Item, width, height int) string {
 	// the metrics pair swap position depending on which ran last. Order on the
 	// key, as the list table does, or these rows jump every few seconds.
 	for _, kv := range stableDetailColumns(item.Columns) {
-		if strings.HasPrefix(kv.Key, "__") || strings.HasPrefix(kv.Key, "owner:") || strings.HasPrefix(kv.Key, "secret:") || strings.HasPrefix(kv.Key, "data:") {
+		if strings.HasPrefix(kv.Key, "__") || strings.HasPrefix(kv.Key, "owner:") || strings.HasPrefix(kv.Key, "claim:") || strings.HasPrefix(kv.Key, "secret:") || strings.HasPrefix(kv.Key, "data:") {
 			continue
 		}
 		rows = append(rows, row{SanitizeTerminalText(kv.Key), SanitizeTerminalText(kv.Value), valueStyle})

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -81,6 +81,7 @@ func explorerHelpSections(kb Keybindings) []helpSection {
 				{kb.Enter, "Open YAML view / navigate into"},
 				{kb.LevelCluster + "/" + kb.LevelTypes + "/" + kb.LevelResources, "Jump to cluster/type/resource level"},
 				{kb.JumpOwner, "Jump to owner/controller"},
+				{kb.JumpClaim, "Jump to resource claim (repeat to cycle)"},
 				{kb.JumpBack, "Jump back through teleport history"},
 				{kb.PreviewDown + "/" + kb.PreviewUp, "Scroll preview pane down / up"},
 				{kb.ExpandCollapse, "Expand / collapse all groups (Events: group duplicates)"},


### PR DESCRIPTION
## Summary
- Pressing `c` on a pod row opens its ResourceClaim. Pressing it again on the same pod cycles to the next claim and wraps.
- Pod rows carry hidden `claim:N` columns with the real claim names. Claims created from a template count only once status reports their name, so the key says "Resource claim not created yet" instead of opening a name that does not exist. A pod without claims shows "No resource claims on this pod".
- New `jump_claim` keybinding with schema, wiring test, whichkey, help and docs/keybindings.md entries.

## Test plan
- [x] `go test -race ./internal/k8s/ ./internal/app/ ./internal/ui/`
- [x] `golangci-lint run ./...`
- [ ] Manual: on a cluster with DRA, press `c` on a pod with one, several and no claims