### PR TITLE
feat: resize pod container resources in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 
 ### Resource actions
 
-- Action menu `x`: logs, exec, attach, debug, scale, restart, delete, describe, edit, events, port-forward, vuln scan, PVC resize: [keybindings.md](docs/keybindings.md#action-menu-items)
+- Action menu `x`: logs, exec, attach, debug, scale, restart, delete, describe, edit, events, port-forward, vuln scan, PVC resize, Pod resize: [keybindings.md](docs/keybindings.md#action-menu-items)
 - Multi-select with `Space`, range with `Ctrl+Space`, then bulk delete, scale, or restart: [keybindings.md](docs/keybindings.md#multi-selection)
 - Custom shell actions per resource type: [config-reference.md](docs/config-reference.md#custom-actions)
 - Port forwarding, with active forwards listed under the Networking group: [keybindings.md](docs/keybindings.md#action-menu-items)

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1244,7 +1244,9 @@ Locked rows offer no choice — keeping them yields a manifest that will not app
 The template picker (`a`): `Enter` create, `/` filter, `d` delete the highlighted saved template after a confirmation, `Esc`/`q` close. `d` works on your own templates only — the built-ins have no file behind them.
 
 ### Pod actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies whose pod selector matches this pod), `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `X` Force Delete, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies whose pod selector matches this pod), `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `r` Resize (in-place CPU/memory), `D` Delete, `X` Force Delete, `V` Events
+
+The Resize overlay (`r`) edits each container's CPU/memory requests and limits in place, via the `pods/resize` subresource (Kubernetes 1.33+). Pod-level `spec.resources` shows read-only. `j`/`k` or `Tab` move between fields; `Enter` applies. A container whose `resizePolicy` requires `RestartContainer` is flagged before you confirm.
 
 ### Deployment actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `R` Rollback, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events

--- a/docs/views-and-overlays.md
+++ b/docs/views-and-overlays.md
@@ -115,6 +115,7 @@ category, and every entry maps to a constant in `app_types.go`.
 | `overlayLabelEditor`     | `i` on a resource              | Add / remove labels and annotations.                |
 | `overlayBatchLabel`      | `i` with multi-selection       | Apply labels and annotations to selected items.     |
 | `overlayPVCResize`       | resize on PVC (action menu)    | New PVC size input.                                 |
+| `overlayPodResize`       | `r` on Pod (action menu)       | Per-container CPU/memory resize.                    |
 
 ### Action menus
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -154,11 +154,11 @@ type Model struct {
 	// Action context: which resource/kind the action targets.
 	actionCtx actionContext
 
-	// Scale input state.
-	scaleInput TextInput
-	hpaScale   hpaScaleState // HPA scale overlay: min/max bounds + target replicas
-	// PVC resize: current size displayed in the overlay.
-	pvcCurrentSize string
+	// Scale / resize overlay inputs.
+	scaleInput     TextInput
+	hpaScale       hpaScaleState // HPA scale overlay: min/max bounds + target replicas
+	pvcCurrentSize string        // current size displayed in the PVC resize overlay
+	podResize      podResizeState
 
 	// Port forward input state.
 	portForwardInput TextInput

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -109,6 +109,7 @@ const (
 	overlayTaintPresets       // common-taint picker over the taint editor (p key)
 	overlayExportTemplate     // destination picker for Export Template (clipboard / file / template list)
 	overlayExportStrip        // field-category picker over the Export Template destinations (s key)
+	overlayPodResize          // in-place Pod CPU/memory resize (action menu key r on a Pod)
 )
 
 // whoCanState groups the reverse-RBAC ("Who-Can") fields so they live

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/janosmiko/lfk/internal/app/scheduler"
 	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
@@ -157,6 +158,20 @@ func (m Model) resizePVC(newSize string) tea.Cmd {
 			return actionResultMsg{err: err}
 		}
 		return actionResultMsg{message: fmt.Sprintf("Resize requested for %s to %s", name, newSize)}
+	})
+}
+
+func (m Model) resizePodResources(specs []model.ContainerResources) tea.Cmd {
+	kctx := m.actionCtx.context
+	ns := m.actionNamespace()
+	name := m.actionCtx.name
+	logger.Info("Resizing pod resources", "name", name, "namespace", ns, "context", kctx)
+	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Resize Pod: "+name, bgtaskTarget(kctx, ns), func(ctx context.Context) tea.Msg {
+		err := m.client.ResizePodResources(ctx, kctx, ns, name, specs)
+		if err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: "Resize requested for " + name}
 	})
 }
 

--- a/internal/app/commands_exec_misc.go
+++ b/internal/app/commands_exec_misc.go
@@ -161,13 +161,13 @@ func (m Model) resizePVC(newSize string) tea.Cmd {
 	})
 }
 
-func (m Model) resizePodResources(specs []model.ContainerResources) tea.Cmd {
+func (m Model) resizePodResources(specs []model.ContainerResources, resourceVersion string) tea.Cmd {
 	kctx := m.actionCtx.context
 	ns := m.actionNamespace()
 	name := m.actionCtx.name
 	logger.Info("Resizing pod resources", "name", name, "namespace", ns, "context", kctx)
 	return m.scheduleK8sCall(scheduler.PriorityCritical, scheduler.KindMutation, "Resize Pod: "+name, bgtaskTarget(kctx, ns), func(ctx context.Context) tea.Msg {
-		err := m.client.ResizePodResources(ctx, kctx, ns, name, specs)
+		err := m.client.ResizePodResources(ctx, kctx, ns, name, specs, resourceVersion)
 		if err != nil {
 			return actionResultMsg{err: err}
 		}

--- a/internal/app/overlay_hintbar.go
+++ b/internal/app/overlay_hintbar.go
@@ -57,6 +57,13 @@ func (m Model) overlayHintBarDialog() string {
 			{Key: "Enter", Desc: "resize"},
 			{Key: "esc", Desc: "cancel"},
 		})
+	case overlayPodResize:
+		return m.renderHints([]ui.HintEntry{
+			{Key: "j/k", Desc: "field"},
+			{Key: "Tab", Desc: "next"},
+			{Key: "Enter", Desc: "apply"},
+			{Key: "esc", Desc: "cancel"},
+		})
 	case overlayBatchLabel:
 		return m.renderHints([]ui.HintEntry{
 			{Key: "Tab", Desc: "toggle add/remove"},

--- a/internal/app/pod_resize.go
+++ b/internal/app/pod_resize.go
@@ -23,12 +23,13 @@ type podResizeRow struct {
 // podResizeState is the Resize Pod overlay: one podResizeRow per container,
 // plus the pod-level spec.resources shown read-only.
 type podResizeState struct {
-	name        string
-	containers  []podResizeRow
-	podLevel    []model.KeyValue
-	field       int
-	scroll      int
-	restartWarn []string // container names whose resizePolicy requires a restart
+	name            string
+	resourceVersion string
+	containers      []podResizeRow
+	podLevel        []model.KeyValue
+	field           int
+	scroll          int
+	restartWarn     []string // container names whose resizePolicy requires a restart
 }
 
 // buildPodResizeState reads a Pod's raw object into the overlay's prefill
@@ -39,6 +40,7 @@ func buildPodResizeState(raw map[string]any) podResizeState {
 		return st
 	}
 	st.name, _, _ = unstructured.NestedString(raw, "metadata", "name")
+	st.resourceVersion, _, _ = unstructured.NestedString(raw, "metadata", "resourceVersion")
 
 	spec, _ := raw["spec"].(map[string]any)
 	if spec == nil {
@@ -134,16 +136,16 @@ func parsePodResizeForm(st podResizeState) ([]model.ContainerResources, error) {
 
 		spec := model.ContainerResources{Name: row.name}
 		var err error
-		if spec.CPURequest, err = parseQuantityField(row.name, "cpu request", cur[0]); err != nil {
+		if spec.CPURequest, err = parseQuantityField(row.name, "cpu request", row.orig[0], cur[0]); err != nil {
 			return nil, err
 		}
-		if spec.CPULimit, err = parseQuantityField(row.name, "cpu limit", cur[1]); err != nil {
+		if spec.CPULimit, err = parseQuantityField(row.name, "cpu limit", row.orig[1], cur[1]); err != nil {
 			return nil, err
 		}
-		if spec.MemRequest, err = parseQuantityField(row.name, "memory request", cur[2]); err != nil {
+		if spec.MemRequest, err = parseQuantityField(row.name, "memory request", row.orig[2], cur[2]); err != nil {
 			return nil, err
 		}
-		if spec.MemLimit, err = parseQuantityField(row.name, "memory limit", cur[3]); err != nil {
+		if spec.MemLimit, err = parseQuantityField(row.name, "memory limit", row.orig[3], cur[3]); err != nil {
 			return nil, err
 		}
 		specs = append(specs, spec)
@@ -151,11 +153,14 @@ func parsePodResizeForm(st podResizeState) ([]model.ContainerResources, error) {
 	return specs, nil
 }
 
-// parseQuantityField validates a non-empty field with resource.ParseQuantity
-// and returns it unchanged (the API wants the original string form, not a
-// re-rendered quantity). An empty field is left out of the patch.
-func parseQuantityField(containerName, field, value string) (string, error) {
+// parseQuantityField returns value unchanged (the API wants the original
+// string form). The resize subresource can't remove a request/limit that
+// was already set, so clearing a previously non-empty field is rejected.
+func parseQuantityField(containerName, field, orig, value string) (string, error) {
 	if value == "" {
+		if orig != "" {
+			return "", fmt.Errorf("%s %s: cannot be cleared, set a value", containerName, field)
+		}
 		return "", nil
 	}
 	if _, err := resource.ParseQuantity(value); err != nil {

--- a/internal/app/pod_resize.go
+++ b/internal/app/pod_resize.go
@@ -1,0 +1,165 @@
+package app
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// podResizeRow is one container's editable CPU/memory request and limit
+// fields in the Resize Pod overlay.
+type podResizeRow struct {
+	name   string
+	cpuReq TextInput
+	cpuLim TextInput
+	memReq TextInput
+	memLim TextInput
+	orig   [4]string // cpuReq, cpuLim, memReq, memLim as prefilled
+}
+
+// podResizeState is the Resize Pod overlay: one podResizeRow per container,
+// plus the pod-level spec.resources shown read-only.
+type podResizeState struct {
+	name        string
+	containers  []podResizeRow
+	podLevel    []model.KeyValue
+	field       int
+	scroll      int
+	restartWarn []string // container names whose resizePolicy requires a restart
+}
+
+// buildPodResizeState reads a Pod's raw object into the overlay's prefill
+// state. A nil raw (synthetic item / test) yields an empty state.
+func buildPodResizeState(raw map[string]any) podResizeState {
+	var st podResizeState
+	if raw == nil {
+		return st
+	}
+	st.name, _, _ = unstructured.NestedString(raw, "metadata", "name")
+
+	spec, _ := raw["spec"].(map[string]any)
+	if spec == nil {
+		return st
+	}
+	if podResources, ok := spec["resources"].(map[string]any); ok {
+		st.podLevel = resourceMapToKeyValues(podResources)
+	}
+
+	containers, _ := spec["containers"].([]any)
+	for _, c := range containers {
+		cMap, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		row := buildPodResizeRow(cMap)
+		st.containers = append(st.containers, row)
+		if containerRequiresRestart(cMap) {
+			st.restartWarn = append(st.restartWarn, row.name)
+		}
+	}
+	return st
+}
+
+func buildPodResizeRow(cMap map[string]any) podResizeRow {
+	row := podResizeRow{}
+	row.name, _ = cMap["name"].(string)
+
+	resources, _ := cMap["resources"].(map[string]any)
+	requests, _ := resources["requests"].(map[string]any)
+	limits, _ := resources["limits"].(map[string]any)
+	cpuReq, _ := requests["cpu"].(string)
+	cpuLim, _ := limits["cpu"].(string)
+	memReq, _ := requests["memory"].(string)
+	memLim, _ := limits["memory"].(string)
+
+	row.cpuReq.Set(cpuReq)
+	row.cpuLim.Set(cpuLim)
+	row.memReq.Set(memReq)
+	row.memLim.Set(memLim)
+	row.orig = [4]string{cpuReq, cpuLim, memReq, memLim}
+	return row
+}
+
+// containerRequiresRestart reports whether any of the container's
+// resizePolicy entries need a container restart to take effect.
+func containerRequiresRestart(cMap map[string]any) bool {
+	policies, _ := cMap["resizePolicy"].([]any)
+	for _, p := range policies {
+		pMap, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if restartPolicy, _ := pMap["restartPolicy"].(string); restartPolicy == "RestartContainer" {
+			return true
+		}
+	}
+	return false
+}
+
+// resourceMapToKeyValues flattens a resources.requests/limits map (as read
+// from spec.resources) into display rows, requests before limits.
+func resourceMapToKeyValues(resources map[string]any) []model.KeyValue {
+	var kvs []model.KeyValue
+	if requests, ok := resources["requests"].(map[string]any); ok {
+		if cpu, ok := requests["cpu"].(string); ok {
+			kvs = append(kvs, model.KeyValue{Key: "cpu", Value: cpu})
+		}
+		if mem, ok := requests["memory"].(string); ok {
+			kvs = append(kvs, model.KeyValue{Key: "memory", Value: mem})
+		}
+	}
+	if limits, ok := resources["limits"].(map[string]any); ok {
+		if cpu, ok := limits["cpu"].(string); ok {
+			kvs = append(kvs, model.KeyValue{Key: "cpu limit", Value: cpu})
+		}
+		if mem, ok := limits["memory"].(string); ok {
+			kvs = append(kvs, model.KeyValue{Key: "memory limit", Value: mem})
+		}
+	}
+	return kvs
+}
+
+// parsePodResizeForm skips unchanged containers so the patch only touches
+// what the user edited.
+func parsePodResizeForm(st podResizeState) ([]model.ContainerResources, error) {
+	var specs []model.ContainerResources
+	for _, row := range st.containers {
+		cur := [4]string{row.cpuReq.Value, row.cpuLim.Value, row.memReq.Value, row.memLim.Value}
+		if cur == row.orig {
+			continue
+		}
+
+		spec := model.ContainerResources{Name: row.name}
+		var err error
+		if spec.CPURequest, err = parseQuantityField(row.name, "cpu request", cur[0]); err != nil {
+			return nil, err
+		}
+		if spec.CPULimit, err = parseQuantityField(row.name, "cpu limit", cur[1]); err != nil {
+			return nil, err
+		}
+		if spec.MemRequest, err = parseQuantityField(row.name, "memory request", cur[2]); err != nil {
+			return nil, err
+		}
+		if spec.MemLimit, err = parseQuantityField(row.name, "memory limit", cur[3]); err != nil {
+			return nil, err
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+// parseQuantityField validates a non-empty field with resource.ParseQuantity
+// and returns it unchanged (the API wants the original string form, not a
+// re-rendered quantity). An empty field is left out of the patch.
+func parseQuantityField(containerName, field, value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	if _, err := resource.ParseQuantity(value); err != nil {
+		return "", fmt.Errorf("%s %s: %w", containerName, field, err)
+	}
+	return value, nil
+}

--- a/internal/app/pod_resize_keys.go
+++ b/internal/app/pod_resize_keys.go
@@ -7,9 +7,9 @@ import (
 )
 
 // podResizeCharset covers every letter used in a Kubernetes quantity
-// suffix (Ki/Mi/.../Ei, k/M/.../E, e/E, m/u/n); resource.ParseQuantity is
-// still the final validator at submit.
-const podResizeCharset = "0123456789.eEinumkKMGTPE"
+// suffix (Ki/Mi/.../Ei, k/M/.../E, e/E, m/u/n) and the exponent signs;
+// resource.ParseQuantity is still the final validator at submit.
+const podResizeCharset = "0123456789.+-eEinumkKMGTPE"
 
 // podResizeMaxLen bounds a quantity field. The longest sensible value
 // ("1234567.5Mi") is far shorter, and a cap keeps a held key from growing

--- a/internal/app/pod_resize_keys.go
+++ b/internal/app/pod_resize_keys.go
@@ -117,9 +117,9 @@ func (m Model) applyPodResizeOverlay() (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 
-	// Belt-and-suspenders read-only gate: the dispatcher blocks "Resize"
-	// upstream for PVCs, but Pod resize is only gated here since the
-	// action label is shared between the two kinds (D4).
+	// This is the only read-only gate for the resize action: "Resize" is
+	// not in mutatingActions, so the dispatcher lets the form open and the
+	// check has to happen at submit, as the PVC path does.
 	if m.actionTargetBlockedByReadOnly() {
 		m.overlay = overlayNone
 		m.podResize = podResizeState{}

--- a/internal/app/pod_resize_keys.go
+++ b/internal/app/pod_resize_keys.go
@@ -6,10 +6,10 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-// podResizeCharset is the set of characters a quantity field accepts:
-// digits, the decimal point, and the Kubernetes quantity suffix letters
-// this overlay supports (m, k, M, G, i).
-const podResizeCharset = "0123456789.mkMGi"
+// podResizeCharset covers every letter used in a Kubernetes quantity
+// suffix (Ki/Mi/.../Ei, k/M/.../E, e/E, m/u/n); resource.ParseQuantity is
+// still the final validator at submit.
+const podResizeCharset = "0123456789.eEinumkKMGTPE"
 
 // podResizeMaxLen bounds a quantity field. The longest sensible value
 // ("1234567.5Mi") is far shorter, and a cap keeps a held key from growing
@@ -133,8 +133,9 @@ func (m Model) applyPodResizeOverlay() (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 
+	resourceVersion := m.podResize.resourceVersion
 	m.overlay = overlayNone
 	m.loading = true
 	m.podResize = podResizeState{}
-	return m, m.resizePodResources(specs)
+	return m, m.resizePodResources(specs, resourceVersion)
 }

--- a/internal/app/pod_resize_keys.go
+++ b/internal/app/pod_resize_keys.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// podResizeCharset is the set of characters a quantity field accepts:
+// digits, the decimal point, and the Kubernetes quantity suffix letters
+// this overlay supports (m, k, M, G, i).
+const podResizeCharset = "0123456789.mkMGi"
+
+// podResizeFieldCount is the number of editable rows per container (cpu
+// req, cpu lim, mem req, mem lim), matching podResizeRow's field order.
+const podResizeFieldCount = 4
+
+// totalFields returns the number of editable rows across every container.
+func (s *podResizeState) totalFields() int {
+	return len(s.containers) * podResizeFieldCount
+}
+
+// active returns a pointer to the currently focused input.
+func (s *podResizeState) active() *TextInput {
+	return s.containers[s.field/podResizeFieldCount].fieldAt(s.field % podResizeFieldCount)
+}
+
+// fieldAt returns the row's cpuReq/cpuLim/memReq/memLim input by index,
+// matching podResizeFieldCount's field order.
+func (r *podResizeRow) fieldAt(i int) *TextInput {
+	switch i {
+	case 0:
+		return &r.cpuReq
+	case 1:
+		return &r.cpuLim
+	case 2:
+		return &r.memReq
+	default:
+		return &r.memLim
+	}
+}
+
+// clampPodResizeScroll keeps the cursor within the visible window via the
+// shared vim-style scrolloff viewport.
+func (m *Model) clampPodResizeScroll() {
+	overlayListScroll(&m.podResize.scroll, m.podResize.field, m.podResize.totalFields(), m.podResizeMaxVisible())
+}
+
+// podResizeMaxVisible caps the field rows shown at once, leaving room for
+// the pod-level read-only rows and the restart-warning note.
+func (m Model) podResizeMaxVisible() int {
+	return min(12, max(m.height-14, 3))
+}
+
+// handlePodResizeOverlayKey routes a keypress in the Resize Pod overlay:
+// j/k and tab move between fields, arrows move the cursor, digits and unit
+// letters type, enter applies, esc cancels.
+func (m Model) handlePodResizeOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		m.overlay = overlayNone
+		m.podResize = podResizeState{}
+		return m, nil
+	case "ctrl+c":
+		return m.closeTabOrQuit()
+	case "j", "down", "tab":
+		return m.movePodResizeField(1), nil
+	case "k", "up":
+		return m.movePodResizeField(-1), nil
+	case "left":
+		m.podResize.active().Left()
+		return m, nil
+	case "right":
+		m.podResize.active().Right()
+		return m, nil
+	case "enter":
+		return m.applyPodResizeOverlay()
+	case "backspace":
+		m.podResize.active().Backspace()
+		return m, nil
+	case "ctrl+w":
+		m.podResize.active().DeleteWord()
+		return m, nil
+	default:
+		key := msg.String()
+		if len(key) == 1 && strings.ContainsRune(podResizeCharset, rune(key[0])) {
+			m.podResize.active().Insert(key)
+		}
+		return m, nil
+	}
+}
+
+// movePodResizeField steps the focused field by delta rows, wrapping, and
+// keeps the scroll window in sync.
+func (m Model) movePodResizeField(delta int) Model {
+	total := m.podResize.totalFields()
+	if total == 0 {
+		return m
+	}
+	m.podResize.field = (m.podResize.field + delta + total) % total
+	m.clampPodResizeScroll()
+	return m
+}
+
+// applyPodResizeOverlay validates the form and dispatches the resize patch
+// for whichever containers changed.
+func (m Model) applyPodResizeOverlay() (tea.Model, tea.Cmd) {
+	specs, err := parsePodResizeForm(m.podResize)
+	if err != nil {
+		m.setStatusMessage("Resize: "+err.Error(), true)
+		return m, scheduleStatusClear()
+	}
+	if len(specs) == 0 {
+		m.overlay = overlayNone
+		m.podResize = podResizeState{}
+		m.setStatusMessage("No changes", false)
+		return m, scheduleStatusClear()
+	}
+
+	// Belt-and-suspenders read-only gate: the dispatcher blocks "Resize"
+	// upstream for PVCs, but Pod resize is only gated here since the
+	// action label is shared between the two kinds (D4).
+	if m.actionTargetBlockedByReadOnly() {
+		m.overlay = overlayNone
+		m.podResize = podResizeState{}
+		m.setStatusMessage(readOnlyBlockedMessage("Resize"), true)
+		return m, scheduleStatusClear()
+	}
+
+	m.overlay = overlayNone
+	m.loading = true
+	m.podResize = podResizeState{}
+	return m, m.resizePodResources(specs)
+}

--- a/internal/app/pod_resize_keys.go
+++ b/internal/app/pod_resize_keys.go
@@ -11,6 +11,11 @@ import (
 // this overlay supports (m, k, M, G, i).
 const podResizeCharset = "0123456789.mkMGi"
 
+// podResizeMaxLen bounds a quantity field. The longest sensible value
+// ("1234567.5Mi") is far shorter, and a cap keeps a held key from growing
+// the row past the overlay width.
+const podResizeMaxLen = 20
+
 // podResizeFieldCount is the number of editable rows per container (cpu
 // req, cpu lim, mem req, mem lim), matching podResizeRow's field order.
 const podResizeFieldCount = 4
@@ -83,8 +88,9 @@ func (m Model) handlePodResizeOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		return m, nil
 	default:
 		key := msg.String()
-		if len(key) == 1 && strings.ContainsRune(podResizeCharset, rune(key[0])) {
-			m.podResize.active().Insert(key)
+		in := m.podResize.active()
+		if len(key) == 1 && strings.ContainsRune(podResizeCharset, rune(key[0])) && len(in.Value) < podResizeMaxLen {
+			in.Insert(key)
 		}
 		return m, nil
 	}

--- a/internal/app/pod_resize_overlay_test.go
+++ b/internal/app/pod_resize_overlay_test.go
@@ -44,6 +44,18 @@ func TestPodResizeOverlay_CapsFieldLength(t *testing.T) {
 	assert.LessOrEqual(t, len(m.podResize.active().Value), podResizeMaxLen)
 }
 
+func TestPodResizeOverlay_AcceptsKiSuffix(t *testing.T) {
+	m := podResizeOverlayModel()
+	m.podResize.active().Clear()
+
+	for _, r := range "1Ki" {
+		ret, _ := m.handlePodResizeOverlayKey(runeKey(r))
+		m = ret.(Model)
+	}
+
+	assert.Equal(t, "1Ki", m.podResize.active().Value)
+}
+
 func TestPodResizeOverlay_ShowsRestartWarning(t *testing.T) {
 	m := podResizeOverlayModel()
 	require.Equal(t, []string{"web"}, m.podResize.restartWarn)

--- a/internal/app/pod_resize_overlay_test.go
+++ b/internal/app/pod_resize_overlay_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func podResizeOverlayModel() Model {
+	m := basePush80Model()
+	m.podResize = buildPodResizeState(podResizeRawFixture())
+	m.overlay = overlayPodResize
+	return m
+}
+
+func TestPodResizeOverlay_RendersPrefilledRows(t *testing.T) {
+	m := podResizeOverlayModel()
+
+	view := stripANSI(m.View().Content)
+	assert.Contains(t, view, "web")
+	assert.Contains(t, view, "200m")
+}
+
+func TestPodResizeOverlay_ShowsRestartWarning(t *testing.T) {
+	m := podResizeOverlayModel()
+	require.Equal(t, []string{"web"}, m.podResize.restartWarn)
+
+	view := stripANSI(m.View().Content)
+	assert.Contains(t, view, "restart")
+}
+
+func TestPodResizeOverlay_HintBarListsApply(t *testing.T) {
+	m := podResizeOverlayModel()
+
+	hints := stripANSI(m.overlayHintBar())
+	assert.Contains(t, hints, "apply")
+	assert.Contains(t, hints, "cancel")
+}
+
+func TestPodResizeOverlay_EscClearsState(t *testing.T) {
+	m := podResizeOverlayModel()
+	require.NotEmpty(t, m.podResize.containers)
+
+	mdl, _ := m.handlePodResizeOverlayKey(keyMsg("esc"))
+	m2, ok := mdl.(Model)
+	require.True(t, ok)
+	assert.Equal(t, overlayNone, m2.overlay)
+	assert.Empty(t, m2.podResize.containers)
+}

--- a/internal/app/pod_resize_overlay_test.go
+++ b/internal/app/pod_resize_overlay_test.go
@@ -22,6 +22,19 @@ func TestPodResizeOverlay_RendersPrefilledRows(t *testing.T) {
 	assert.Contains(t, view, "200m")
 }
 
+// Names from the API object are untrusted terminal text and must not reach
+// the screen with their escape sequences intact.
+func TestPodResizeOverlay_SanitizesNamesFromTheObject(t *testing.T) {
+	m := podResizeOverlayModel()
+	m.podResize.name = "pod\x1b]0;evil\x07"
+	m.podResize.containers[0].name = "web\x1b[31m"
+	m.podResize.restartWarn = []string{"web\x1b[31m"}
+
+	view := m.View().Content
+	assert.NotContains(t, view, "\x1b]0;evil")
+	assert.NotContains(t, view, "web\x1b[31m")
+}
+
 func TestPodResizeOverlay_ShowsRestartWarning(t *testing.T) {
 	m := podResizeOverlayModel()
 	require.Equal(t, []string{"web"}, m.podResize.restartWarn)

--- a/internal/app/pod_resize_overlay_test.go
+++ b/internal/app/pod_resize_overlay_test.go
@@ -35,6 +35,15 @@ func TestPodResizeOverlay_SanitizesNamesFromTheObject(t *testing.T) {
 	assert.NotContains(t, view, "web\x1b[31m")
 }
 
+func TestPodResizeOverlay_CapsFieldLength(t *testing.T) {
+	m := podResizeOverlayModel()
+	for range podResizeMaxLen + 5 {
+		ret, _ := m.handlePodResizeOverlayKey(runeKey('1'))
+		m = ret.(Model)
+	}
+	assert.LessOrEqual(t, len(m.podResize.active().Value), podResizeMaxLen)
+}
+
 func TestPodResizeOverlay_ShowsRestartWarning(t *testing.T) {
 	m := podResizeOverlayModel()
 	require.Equal(t, []string{"web"}, m.podResize.restartWarn)

--- a/internal/app/pod_resize_overlay_test.go
+++ b/internal/app/pod_resize_overlay_test.go
@@ -44,16 +44,18 @@ func TestPodResizeOverlay_CapsFieldLength(t *testing.T) {
 	assert.LessOrEqual(t, len(m.podResize.active().Value), podResizeMaxLen)
 }
 
-func TestPodResizeOverlay_AcceptsKiSuffix(t *testing.T) {
-	m := podResizeOverlayModel()
-	m.podResize.active().Clear()
+func TestPodResizeOverlay_AcceptsQuantityForms(t *testing.T) {
+	for _, want := range []string{"1Ki", "1e-3", "1E+3"} {
+		m := podResizeOverlayModel()
+		m.podResize.active().Clear()
 
-	for _, r := range "1Ki" {
-		ret, _ := m.handlePodResizeOverlayKey(runeKey(r))
-		m = ret.(Model)
+		for _, r := range want {
+			ret, _ := m.handlePodResizeOverlayKey(runeKey(r))
+			m = ret.(Model)
+		}
+
+		assert.Equal(t, want, m.podResize.active().Value)
 	}
-
-	assert.Equal(t, "1Ki", m.podResize.active().Value)
 }
 
 func TestPodResizeOverlay_ShowsRestartWarning(t *testing.T) {

--- a/internal/app/pod_resize_submit_test.go
+++ b/internal/app/pod_resize_submit_test.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestExecuteActionResize_PodOpensPodResizeOverlay(t *testing.T) {
+	m := withActionCtx(baseModelWithFakeClient(), "my-pod", "default", "Pod", model.ResourceTypeEntry{})
+	m.actionCtx.raw = podResizeRawFixture()
+
+	mdl, _ := m.executeActionResize()
+	m2, ok := mdl.(Model)
+	require.True(t, ok)
+
+	assert.Equal(t, overlayPodResize, m2.overlay)
+	require.Len(t, m2.podResize.containers, 2)
+	assert.Equal(t, "web", m2.podResize.containers[0].name)
+}
+
+func TestExecuteActionResize_PVCStillOpensOverlayPVCResize(t *testing.T) {
+	m := withActionCtx(baseModelWithFakeClient(), "my-pvc", "default", "PersistentVolumeClaim", model.ResourceTypeEntry{})
+	m.actionCtx.columns = []model.KeyValue{{Key: "Capacity", Value: "10Gi"}}
+
+	mdl, _ := m.executeActionResize()
+	m2, ok := mdl.(Model)
+	require.True(t, ok)
+
+	assert.Equal(t, overlayPVCResize, m2.overlay)
+	assert.Equal(t, "10Gi", m2.pvcCurrentSize)
+}
+
+func podResizeSubmitModel() Model {
+	m := withActionCtx(baseModelWithFakeClient(), "my-pod", "default", "Pod", model.ResourceTypeEntry{})
+	m.actionCtx.raw = podResizeRawFixture()
+	mdl, _ := m.executeActionResize()
+	m2 := mdl.(Model)
+	m2.podResize.containers[0].cpuReq.Set("500m")
+	return m2
+}
+
+func TestPodResizeSubmit_BlockedByReadOnly(t *testing.T) {
+	m := podResizeSubmitModel()
+	m.cliReadOnly = true
+
+	mdl, _ := m.handlePodResizeOverlayKey(keyMsg("enter"))
+	m2, ok := mdl.(Model)
+	require.True(t, ok)
+
+	assert.Equal(t, overlayNone, m2.overlay)
+	assert.True(t, m2.statusMessageErr)
+	assert.Contains(t, m2.statusMessage, "Read-only")
+}
+
+func TestPodResizeSubmit_SchedulesOneMutation(t *testing.T) {
+	m := podResizeSubmitModel()
+
+	mdl, cmd := m.handlePodResizeOverlayKey(keyMsg("enter"))
+	m2, ok := mdl.(Model)
+	require.True(t, ok)
+
+	assertSchedulesOne(t, m2, cmd)
+	assert.Equal(t, overlayNone, m2.overlay)
+}
+
+func TestPodResizeSubmit_SurfacesAPIError(t *testing.T) {
+	m := baseModelWithFakeClient()
+
+	mdl, _ := m.updateActionResult(actionResultMsg{err: errors.New("Pod QoS is immutable")})
+	m2, ok := mdl.(Model)
+	require.True(t, ok)
+
+	assert.True(t, m2.statusMessageErr)
+	assert.Contains(t, m2.statusMessage, "Pod QoS is immutable")
+}

--- a/internal/app/pod_resize_test.go
+++ b/internal/app/pod_resize_test.go
@@ -10,7 +10,8 @@ import (
 func podResizeRawFixture() map[string]any {
 	return map[string]any{
 		"metadata": map[string]any{
-			"name": "my-pod",
+			"name":            "my-pod",
+			"resourceVersion": "999",
 		},
 		"spec": map[string]any{
 			"resources": map[string]any{
@@ -43,6 +44,7 @@ func TestBuildPodResizeState_PrefillsFromRaw(t *testing.T) {
 	st := buildPodResizeState(podResizeRawFixture())
 
 	assert.Equal(t, "my-pod", st.name)
+	assert.Equal(t, "999", st.resourceVersion)
 	require.Len(t, st.containers, 2)
 
 	web := st.containers[0]
@@ -94,6 +96,29 @@ func TestParsePodResizeForm_OnlyChangedContainers(t *testing.T) {
 	assert.Equal(t, "500m", specs[0].CPURequest)
 	assert.Equal(t, "1", specs[0].CPULimit)
 	assert.Equal(t, "256Mi", specs[0].MemRequest)
+	assert.Equal(t, "", specs[0].MemLimit)
+}
+
+func TestParsePodResizeForm_RejectsClearingASetField(t *testing.T) {
+	st := buildPodResizeState(podResizeRawFixture())
+	st.containers[0].cpuReq.Set("")
+
+	_, err := parsePodResizeForm(st)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "web")
+	assert.Contains(t, err.Error(), "cpu request")
+	assert.Contains(t, err.Error(), "cannot be cleared")
+}
+
+func TestParsePodResizeForm_AllowsAnEmptyFieldToStayEmpty(t *testing.T) {
+	st := buildPodResizeState(podResizeRawFixture())
+	// web.memLim starts empty (see fixture); changing cpuReq keeps memLim
+	// in the diff without ever setting it.
+	st.containers[0].cpuReq.Set("500m")
+
+	specs, err := parsePodResizeForm(st)
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
 	assert.Equal(t, "", specs[0].MemLimit)
 }
 

--- a/internal/app/pod_resize_test.go
+++ b/internal/app/pod_resize_test.go
@@ -1,0 +1,106 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func podResizeRawFixture() map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{
+			"name": "my-pod",
+		},
+		"spec": map[string]any{
+			"resources": map[string]any{
+				"requests": map[string]any{"cpu": "50m"},
+			},
+			"containers": []any{
+				map[string]any{
+					"name": "web",
+					"resources": map[string]any{
+						"requests": map[string]any{"cpu": "200m", "memory": "256Mi"},
+						"limits":   map[string]any{"cpu": "1"},
+					},
+					"resizePolicy": []any{
+						map[string]any{"resourceName": "cpu", "restartPolicy": "RestartContainer"},
+						map[string]any{"resourceName": "memory", "restartPolicy": "NotRequired"},
+					},
+				},
+				map[string]any{
+					"name": "sidecar",
+					"resources": map[string]any{
+						"requests": map[string]any{"cpu": "10m"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildPodResizeState_PrefillsFromRaw(t *testing.T) {
+	st := buildPodResizeState(podResizeRawFixture())
+
+	assert.Equal(t, "my-pod", st.name)
+	require.Len(t, st.containers, 2)
+
+	web := st.containers[0]
+	assert.Equal(t, "web", web.name)
+	assert.Equal(t, "200m", web.cpuReq.Value)
+	assert.Equal(t, "1", web.cpuLim.Value)
+	assert.Equal(t, "256Mi", web.memReq.Value)
+	assert.Equal(t, "", web.memLim.Value)
+	assert.Equal(t, [4]string{"200m", "1", "256Mi", ""}, web.orig)
+
+	sidecar := st.containers[1]
+	assert.Equal(t, "sidecar", sidecar.name)
+	assert.Equal(t, "10m", sidecar.cpuReq.Value)
+
+	require.Len(t, st.podLevel, 1)
+	assert.Equal(t, "cpu", st.podLevel[0].Key)
+	assert.Equal(t, "50m", st.podLevel[0].Value)
+}
+
+func TestBuildPodResizeState_FlagsRestartContainer(t *testing.T) {
+	st := buildPodResizeState(podResizeRawFixture())
+	assert.Equal(t, []string{"web"}, st.restartWarn)
+}
+
+func TestBuildPodResizeState_NilRaw(t *testing.T) {
+	st := buildPodResizeState(nil)
+	assert.Empty(t, st.containers)
+	assert.Empty(t, st.restartWarn)
+}
+
+func TestParsePodResizeForm_RejectsBadQuantity(t *testing.T) {
+	st := buildPodResizeState(podResizeRawFixture())
+	st.containers[0].cpuReq.Set("12x")
+
+	_, err := parsePodResizeForm(st)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "web")
+	assert.Contains(t, err.Error(), "cpu")
+}
+
+func TestParsePodResizeForm_OnlyChangedContainers(t *testing.T) {
+	st := buildPodResizeState(podResizeRawFixture())
+	st.containers[0].cpuReq.Set("500m")
+
+	specs, err := parsePodResizeForm(st)
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+	assert.Equal(t, "web", specs[0].Name)
+	assert.Equal(t, "500m", specs[0].CPURequest)
+	assert.Equal(t, "1", specs[0].CPULimit)
+	assert.Equal(t, "256Mi", specs[0].MemRequest)
+	assert.Equal(t, "", specs[0].MemLimit)
+}
+
+func TestParsePodResizeForm_NoChanges(t *testing.T) {
+	st := buildPodResizeState(podResizeRawFixture())
+
+	specs, err := parsePodResizeForm(st)
+	require.NoError(t, err)
+	assert.Empty(t, specs)
+}

--- a/internal/app/update_actions_exec_pod.go
+++ b/internal/app/update_actions_exec_pod.go
@@ -238,8 +238,15 @@ func (m Model) executeActionCancelEviction() (tea.Model, tea.Cmd) { //nolint:unp
 	return m, nil
 }
 
-// executeActionResize handles the "Resize" action.
+// executeActionResize handles the "Resize" action, shared by PersistentVolumeClaim
+// (storage size) and Pod (in-place CPU/memory).
 func (m Model) executeActionResize() (tea.Model, tea.Cmd) { //nolint:unparam // consistent action handler signature
+	if m.actionCtx.kind == "Pod" {
+		m.podResize = buildPodResizeState(m.actionCtx.raw)
+		m.overlay = overlayPodResize
+		return m, nil
+	}
+
 	// Extract current PVC size from columns for display in the overlay.
 	m.pvcCurrentSize = ""
 	for _, kv := range m.actionCtx.columns {

--- a/internal/app/update_actions_test.go
+++ b/internal/app/update_actions_test.go
@@ -847,6 +847,7 @@ func TestCovExecuteActionScale(t *testing.T) {
 
 func TestCovExecuteActionResize(t *testing.T) {
 	m := testModelExec()
+	m.actionCtx.kind = "PersistentVolumeClaim"
 	m.actionCtx.columns = []model.KeyValue{{Key: "Capacity", Value: "5Gi"}}
 	result, cmd := m.executeAction("Resize")
 	rm := result.(Model)
@@ -857,6 +858,7 @@ func TestCovExecuteActionResize(t *testing.T) {
 
 func TestCovExecuteActionResizeNoCap(t *testing.T) {
 	m := testModelExec()
+	m.actionCtx.kind = "PersistentVolumeClaim"
 	result, cmd := m.executeAction("Resize")
 	rm := result.(Model)
 	assert.Nil(t, cmd)
@@ -1709,6 +1711,7 @@ func TestFinalExecuteActionScale(t *testing.T) {
 
 func TestFinalExecuteActionResize(t *testing.T) {
 	m := baseFinalModel()
+	m.actionCtx.kind = "PersistentVolumeClaim"
 	m.actionCtx.columns = []model.KeyValue{{Key: "Capacity", Value: "10Gi"}}
 	result, cmd := m.executeAction("Resize")
 	assert.Nil(t, cmd)
@@ -1719,6 +1722,7 @@ func TestFinalExecuteActionResize(t *testing.T) {
 
 func TestFinalExecuteActionResizeCapacity(t *testing.T) {
 	m := baseFinalModel()
+	m.actionCtx.kind = "PersistentVolumeClaim"
 	m.actionCtx.columns = []model.KeyValue{{Key: "CAPACITY", Value: "5Gi"}}
 	result, _ := m.executeAction("Resize")
 	rm := result.(Model)
@@ -1727,6 +1731,7 @@ func TestFinalExecuteActionResizeCapacity(t *testing.T) {
 
 func TestFinalExecuteActionResizeNoCapacity(t *testing.T) {
 	m := baseFinalModel()
+	m.actionCtx.kind = "PersistentVolumeClaim"
 	m.actionCtx.columns = []model.KeyValue{{Key: "Other", Value: "5Gi"}}
 	result, _ := m.executeAction("Resize")
 	rm := result.(Model)

--- a/internal/app/update_overlays.go
+++ b/internal/app/update_overlays.go
@@ -139,6 +139,9 @@ func (m Model) handleOverlayKeyPrimary(msg tea.KeyPressMsg) (tea.Model, tea.Cmd,
 	case overlayPVCResize:
 		mdl, cmd := m.handlePVCResizeOverlayKey(msg)
 		return mdl, cmd, true
+	case overlayPodResize:
+		mdl, cmd := m.handlePodResizeOverlayKey(msg)
+		return mdl, cmd, true
 	case overlayPortForward:
 		mdl, cmd := m.handlePortForwardOverlayKey(msg)
 		return mdl, cmd, true

--- a/internal/app/view_overlay_pod_resize.go
+++ b/internal/app/view_overlay_pod_resize.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// podResizeFieldLabels returns one label per editable row, in field-index
+// order (matching podResizeRow.fieldAt).
+func podResizeFieldLabels(st podResizeState) []string {
+	labels := make([]string, 0, st.totalFields())
+	for _, c := range st.containers {
+		labels = append(labels,
+			c.name+" CPU Req:",
+			c.name+" CPU Lim:",
+			c.name+" Mem Req:",
+			c.name+" Mem Lim:",
+		)
+	}
+	return labels
+}
+
+// podResizeVisibleWindow returns the [start, end) slice of field indices to
+// render, keeping the focused field inside the window.
+func podResizeVisibleWindow(scroll, total, maxVisible int) (int, int) {
+	if total <= maxVisible {
+		return 0, total
+	}
+	start := min(max(scroll, 0), total-maxVisible)
+	return start, start + maxVisible
+}
+
+// renderPodResizeOverlay paints the Resize Pod overlay: the pod-level
+// spec.resources read-only, one editable row per container per field, and a
+// restart-required note for containers whose resizePolicy demands it.
+func renderPodResizeOverlay(m Model) (string, int, int) {
+	st := m.podResize
+	w := min(60, m.width-10)
+	innerW := max(w-4, 10)
+
+	fieldLabels := podResizeFieldLabels(st)
+	podLabels := make([]string, len(st.podLevel))
+	for i, kv := range st.podLevel {
+		podLabels[i] = "Pod " + kv.Key + ":"
+	}
+	labelWidth := 0
+	for _, l := range fieldLabels {
+		labelWidth = max(labelWidth, len(l))
+	}
+	for _, l := range podLabels {
+		labelWidth = max(labelWidth, len(l))
+	}
+	labelWidth++ // trailing space before the value
+
+	rows := make([]ui.OverlayInputRow, 0, len(st.podLevel)+min(len(fieldLabels), m.podResizeMaxVisible()))
+	for i, kv := range st.podLevel {
+		rows = append(rows, ui.OverlayInputRow{Label: padRight(podLabels[i], labelWidth), Input: kv.Value, ReadOnly: true})
+	}
+
+	start, end := podResizeVisibleWindow(st.scroll, len(fieldLabels), m.podResizeMaxVisible())
+	for i := start; i < end; i++ {
+		row := &st.containers[i/podResizeFieldCount]
+		input := row.fieldAt(i % podResizeFieldCount)
+		rows = append(rows, ui.OverlayInputRow{
+			Label:      padRight(fieldLabels[i], labelWidth),
+			Input:      input.Value,
+			ShowCursor: i == st.field,
+			Cursor:     input.Cursor,
+		})
+	}
+
+	var notes []ui.ConfirmNote
+	if len(st.restartWarn) > 0 {
+		notes = append(notes, ui.ConfirmNote{
+			Label: "Restart",
+			Text:  strings.Join(st.restartWarn, ", ") + " will restart to apply",
+			Warn:  true,
+		})
+	}
+
+	content := ui.RenderOverlayInput(ui.OverlayInputConfig{
+		Title:    "Resize Pod",
+		Subtitle: st.name,
+		Width:    innerW,
+		Rows:     rows,
+		Notes:    notes,
+	})
+	h := min(lipgloss.Height(content)+2, max(m.height-4, 3))
+	return content, w, h
+}

--- a/internal/app/view_overlay_pod_resize.go
+++ b/internal/app/view_overlay_pod_resize.go
@@ -13,11 +13,14 @@ import (
 func podResizeFieldLabels(st podResizeState) []string {
 	labels := make([]string, 0, st.totalFields())
 	for _, c := range st.containers {
+		// Container names come from the API object, so they are untrusted
+		// terminal text. The patch body still uses the raw name.
+		name := ui.SanitizeTerminalText(c.name)
 		labels = append(labels,
-			c.name+" CPU Req:",
-			c.name+" CPU Lim:",
-			c.name+" Mem Req:",
-			c.name+" Mem Lim:",
+			name+" CPU Req:",
+			name+" CPU Lim:",
+			name+" Mem Req:",
+			name+" Mem Lim:",
 		)
 	}
 	return labels
@@ -76,14 +79,14 @@ func renderPodResizeOverlay(m Model) (string, int, int) {
 	if len(st.restartWarn) > 0 {
 		notes = append(notes, ui.ConfirmNote{
 			Label: "Restart",
-			Text:  strings.Join(st.restartWarn, ", ") + " will restart to apply",
+			Text:  ui.SanitizeTerminalText(strings.Join(st.restartWarn, ", ")) + " will restart to apply",
 			Warn:  true,
 		})
 	}
 
 	content := ui.RenderOverlayInput(ui.OverlayInputConfig{
 		Title:    "Resize Pod",
-		Subtitle: st.name,
+		Subtitle: ui.SanitizeTerminalText(st.name),
 		Width:    innerW,
 		Rows:     rows,
 		Notes:    notes,

--- a/internal/app/view_overlays.go
+++ b/internal/app/view_overlays.go
@@ -198,6 +198,9 @@ func (m Model) renderOverlayContent() (string, int, int, bool) {
 			Hint:  hint,
 			Rows:  []ui.OverlayInputRow{{Label: "New size: ", Input: m.scaleInput.Value, Placeholder: "e.g. 10Gi"}},
 		}), min(45, m.width-10), min(10, m.height-6), true
+	case overlayPodResize:
+		content, w, h := renderPodResizeOverlay(m)
+		return content, w, h, true
 	case overlayPortForward:
 		content := renderPortForwardOverlay(m)
 		return content, min(55, m.width-10), min(5+len(m.pfAvailablePorts)+4, m.height-6), true

--- a/internal/k8s/client_pod_resize.go
+++ b/internal/k8s/client_pod_resize.go
@@ -14,7 +14,12 @@ import (
 )
 
 type podResizePatch struct {
-	Spec podResizePatchSpec `json:"spec"`
+	Metadata *podResizePatchMetadata `json:"metadata,omitempty"`
+	Spec     podResizePatchSpec      `json:"spec"`
+}
+
+type podResizePatchMetadata struct {
+	ResourceVersion string `json:"resourceVersion"`
 }
 
 type podResizePatchSpec struct {
@@ -32,15 +37,16 @@ type podResizePatchLimits struct {
 }
 
 // ResizePodResources uses the pods/resize subresource, since a running
-// Pod's spec.containers[].resources is otherwise immutable.
-func (c *Client) ResizePodResources(ctx context.Context, contextName, namespace, name string, specs []model.ContainerResources) error {
+// Pod's spec.containers[].resources is otherwise immutable. resourceVersion,
+// when set, makes the API server reject a stale patch with a 409.
+func (c *Client) ResizePodResources(ctx context.Context, contextName, namespace, name string, specs []model.ContainerResources, resourceVersion string) error {
 	logger.Info("Resizing pod resources", "context", contextName, "namespace", namespace, "name", name)
 	dynClient, err := c.dynamicForContext(contextName)
 	if err != nil {
 		return err
 	}
 
-	body, err := json.Marshal(buildPodResizePatch(specs))
+	body, err := json.Marshal(buildPodResizePatch(specs, resourceVersion))
 	if err != nil {
 		return fmt.Errorf("building resize patch for pod %s: %w", name, err)
 	}
@@ -55,7 +61,7 @@ func (c *Client) ResizePodResources(ctx context.Context, contextName, namespace,
 	return nil
 }
 
-func buildPodResizePatch(specs []model.ContainerResources) podResizePatch {
+func buildPodResizePatch(specs []model.ContainerResources, resourceVersion string) podResizePatch {
 	containers := make([]podResizePatchContainer, 0, len(specs))
 	for _, spec := range specs {
 		requests := map[string]string{}
@@ -83,5 +89,9 @@ func buildPodResizePatch(specs []model.ContainerResources) podResizePatch {
 			Resources: podResizePatchLimits{Requests: requests, Limits: limits},
 		})
 	}
-	return podResizePatch{Spec: podResizePatchSpec{Containers: containers}}
+	patch := podResizePatch{Spec: podResizePatchSpec{Containers: containers}}
+	if resourceVersion != "" {
+		patch.Metadata = &podResizePatchMetadata{ResourceVersion: resourceVersion}
+	}
+	return patch
 }

--- a/internal/k8s/client_pod_resize.go
+++ b/internal/k8s/client_pod_resize.go
@@ -1,0 +1,87 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/janosmiko/lfk/internal/logger"
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+type podResizePatch struct {
+	Spec podResizePatchSpec `json:"spec"`
+}
+
+type podResizePatchSpec struct {
+	Containers []podResizePatchContainer `json:"containers"`
+}
+
+type podResizePatchContainer struct {
+	Name      string               `json:"name"`
+	Resources podResizePatchLimits `json:"resources"`
+}
+
+type podResizePatchLimits struct {
+	Requests map[string]string `json:"requests,omitempty"`
+	Limits   map[string]string `json:"limits,omitempty"`
+}
+
+// ResizePodResources uses the pods/resize subresource, since a running
+// Pod's spec.containers[].resources is otherwise immutable.
+func (c *Client) ResizePodResources(ctx context.Context, contextName, namespace, name string, specs []model.ContainerResources) error {
+	logger.Info("Resizing pod resources", "context", contextName, "namespace", namespace, "name", name)
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(buildPodResizePatch(specs))
+	if err != nil {
+		return fmt.Errorf("building resize patch for pod %s: %w", name, err)
+	}
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
+		ctx, name, k8stypes.StrategicMergePatchType, body, metav1.PatchOptions{FieldManager: FieldManager()}, "resize",
+	)
+	if err != nil {
+		return fmt.Errorf("resizing pod %s: %w", name, err)
+	}
+	return nil
+}
+
+func buildPodResizePatch(specs []model.ContainerResources) podResizePatch {
+	containers := make([]podResizePatchContainer, 0, len(specs))
+	for _, spec := range specs {
+		requests := map[string]string{}
+		if spec.CPURequest != "" {
+			requests["cpu"] = spec.CPURequest
+		}
+		if spec.MemRequest != "" {
+			requests["memory"] = spec.MemRequest
+		}
+		limits := map[string]string{}
+		if spec.CPULimit != "" {
+			limits["cpu"] = spec.CPULimit
+		}
+		if spec.MemLimit != "" {
+			limits["memory"] = spec.MemLimit
+		}
+		if len(requests) == 0 {
+			requests = nil
+		}
+		if len(limits) == 0 {
+			limits = nil
+		}
+		containers = append(containers, podResizePatchContainer{
+			Name:      spec.Name,
+			Resources: podResizePatchLimits{Requests: requests, Limits: limits},
+		})
+	}
+	return podResizePatch{Spec: podResizePatchSpec{Containers: containers}}
+}

--- a/internal/k8s/client_pod_resize_test.go
+++ b/internal/k8s/client_pod_resize_test.go
@@ -38,7 +38,7 @@ func TestResizePodResources_PatchBody(t *testing.T) {
 	specs := []model.ContainerResources{
 		{Name: "web", CPURequest: "200m", CPULimit: "1", MemRequest: "256Mi"},
 	}
-	err := c.ResizePodResources(t.Context(), "", "default", "my-pod", specs)
+	err := c.ResizePodResources(t.Context(), "", "default", "my-pod", specs, "42")
 	require.NoError(t, err)
 	require.NotNil(t, captured)
 
@@ -48,6 +48,9 @@ func TestResizePodResources_PatchBody(t *testing.T) {
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(captured.GetPatch(), &body))
 	expected := map[string]any{
+		"metadata": map[string]any{
+			"resourceVersion": "42",
+		},
 		"spec": map[string]any{
 			"containers": []any{
 				map[string]any{
@@ -91,7 +94,7 @@ func TestResizePodResources_OmitsEmptyFields(t *testing.T) {
 	specs := []model.ContainerResources{
 		{Name: "web", CPURequest: "200m"},
 	}
-	err := c.ResizePodResources(t.Context(), "", "default", "my-pod", specs)
+	err := c.ResizePodResources(t.Context(), "", "default", "my-pod", specs, "")
 	require.NoError(t, err)
 	require.NotNil(t, captured)
 
@@ -112,4 +115,5 @@ func TestResizePodResources_OmitsEmptyFields(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, body)
+	assert.NotContains(t, body, "metadata")
 }

--- a/internal/k8s/client_pod_resize_test.go
+++ b/internal/k8s/client_pod_resize_test.go
@@ -1,0 +1,115 @@
+package k8s
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestResizePodResources_PatchBody(t *testing.T) {
+	pod := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      "my-pod",
+				"namespace": "default",
+			},
+		},
+	}
+	dc := newFakeDynClient(pod)
+
+	var captured k8stesting.PatchAction
+	dc.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		captured = action.(k8stesting.PatchAction)
+		return true, pod, nil
+	})
+	c := newFakeClient(nil, dc)
+
+	specs := []model.ContainerResources{
+		{Name: "web", CPURequest: "200m", CPULimit: "1", MemRequest: "256Mi"},
+	}
+	err := c.ResizePodResources(t.Context(), "", "default", "my-pod", specs)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	assert.Equal(t, "resize", captured.GetSubresource())
+	assert.Equal(t, k8stypes.StrategicMergePatchType, captured.GetPatchType())
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(captured.GetPatch(), &body))
+	expected := map[string]any{
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name": "web",
+					"resources": map[string]any{
+						"limits": map[string]any{
+							"cpu": "1",
+						},
+						"requests": map[string]any{
+							"cpu":    "200m",
+							"memory": "256Mi",
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, body)
+}
+
+func TestResizePodResources_OmitsEmptyFields(t *testing.T) {
+	pod := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      "my-pod",
+				"namespace": "default",
+			},
+		},
+	}
+	dc := newFakeDynClient(pod)
+
+	var captured k8stesting.PatchAction
+	dc.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		captured = action.(k8stesting.PatchAction)
+		return true, pod, nil
+	})
+	c := newFakeClient(nil, dc)
+
+	specs := []model.ContainerResources{
+		{Name: "web", CPURequest: "200m"},
+	}
+	err := c.ResizePodResources(t.Context(), "", "default", "my-pod", specs)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(captured.GetPatch(), &body))
+	expected := map[string]any{
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name": "web",
+					"resources": map[string]any{
+						"requests": map[string]any{
+							"cpu": "200m",
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, body)
+}

--- a/internal/k8s/client_populate_helpers.go
+++ b/internal/k8s/client_populate_helpers.go
@@ -301,6 +301,36 @@ func extractTemplateResources(spec map[string]any) (cpuReq, cpuLim, memReq, memL
 	return extractContainerResources(containers)
 }
 
+// addPodLevelResourceColumns reads spec.resources, distinct from the
+// per-container sums addResourceColumns appends.
+func addPodLevelResourceColumns(ti *model.Item, spec map[string]any) {
+	resources, ok := spec["resources"].(map[string]any)
+	if !ok {
+		return
+	}
+	var cpuReq, cpuLim, memReq, memLim string
+	if requests, ok := resources["requests"].(map[string]any); ok {
+		cpuReq, _ = requests["cpu"].(string)
+		memReq, _ = requests["memory"].(string)
+	}
+	if limits, ok := resources["limits"].(map[string]any); ok {
+		cpuLim, _ = limits["cpu"].(string)
+		memLim, _ = limits["memory"].(string)
+	}
+	if cpuReq != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pod CPU Req", Value: cpuReq})
+	}
+	if cpuLim != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pod CPU Lim", Value: cpuLim})
+	}
+	if memReq != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pod Mem Req", Value: memReq})
+	}
+	if memLim != "" {
+		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Pod Mem Lim", Value: memLim})
+	}
+}
+
 // addResourceColumns appends CPU/memory request/limit columns to an item if they are non-empty.
 func addResourceColumns(ti *model.Item, cpuReq, cpuLim, memReq, memLim string) {
 	if cpuReq != "" {

--- a/internal/k8s/client_populate_pod_resize_test.go
+++ b/internal/k8s/client_populate_pod_resize_test.go
@@ -1,0 +1,105 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestPopulatePodDetails_PodLevelResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      map[string]any
+		wantCols map[string]string
+		absent   []string
+	}{
+		{
+			name: "present",
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "app"},
+					},
+					"resources": map[string]any{
+						"requests": map[string]any{"cpu": "500m", "memory": "1Gi"},
+						"limits":   map[string]any{"cpu": "1", "memory": "2Gi"},
+					},
+				},
+				"status": map[string]any{},
+			},
+			wantCols: map[string]string{
+				"Pod CPU Req": "500m",
+				"Pod CPU Lim": "1",
+				"Pod Mem Req": "1Gi",
+				"Pod Mem Lim": "2Gi",
+			},
+		},
+		{
+			name: "absent",
+			obj: map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "app"},
+					},
+				},
+				"status": map[string]any{},
+			},
+			absent: []string{"Pod CPU Req", "Pod CPU Lim", "Pod Mem Req", "Pod Mem Lim"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := &model.Item{Status: "Running"}
+			populateResourceDetails(ti, tt.obj, "Pod")
+
+			colMap := columnsToMap(ti.Columns)
+			for k, v := range tt.wantCols {
+				assert.Equal(t, v, colMap[k], "column %q mismatch", k)
+			}
+			for _, k := range tt.absent {
+				_, ok := colMap[k]
+				assert.False(t, ok, "column %q should be absent", k)
+			}
+		})
+	}
+}
+
+func TestPopulatePodDetails_ResizeConditions(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{"name": "app"},
+			},
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":    "PodResizePending",
+					"status":  "True",
+					"reason":  "Infeasible",
+					"message": "Node does not have enough capacity",
+				},
+				map[string]any{
+					"type":    "PodResizeInProgress",
+					"status":  "True",
+					"reason":  "",
+					"message": "Resize in progress",
+				},
+			},
+		},
+	}
+
+	ti := &model.Item{Status: "Running"}
+	populateResourceDetails(ti, obj, "Pod")
+
+	require.Len(t, ti.Conditions, 2)
+	assert.Equal(t, "PodResizePending", ti.Conditions[0].Type)
+	assert.Equal(t, "Infeasible", ti.Conditions[0].Reason)
+	assert.Equal(t, "Node does not have enough capacity", ti.Conditions[0].Message)
+	assert.Equal(t, "PodResizeInProgress", ti.Conditions[1].Type)
+	assert.Equal(t, "Resize in progress", ti.Conditions[1].Message)
+}

--- a/internal/k8s/client_populate_workloads.go
+++ b/internal/k8s/client_populate_workloads.go
@@ -121,6 +121,7 @@ func populatePodExtraColumns(ti *model.Item, _ map[string]any, status, spec map[
 	if nodeName, ok := spec["nodeName"].(string); ok {
 		ti.Columns = append(ti.Columns, model.KeyValue{Key: "Node", Value: nodeName})
 	}
+	addPodLevelResourceColumns(ti, spec)
 	populatePodResourceClaims(ti, status, spec)
 }
 

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -129,6 +129,7 @@ func actionsForCoreKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Describe", Description: "Describe resource", Key: "v"},
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Right-sizing", Description: "Per-container CPU/Mem recommendations", Key: "z"},
+			{Label: "Resize", Description: "Resize container CPU/memory in place", Key: "r"},
 			{Label: "Security Findings", Description: "List security findings for this resource", Key: "y"},
 			{Label: "Delete", Description: "Delete this pod", Key: "D"},
 			{Label: "Force Delete", Description: "Force delete this pod", Key: "X"},

--- a/internal/model/actions_pod_resize_test.go
+++ b/internal/model/actions_pod_resize_test.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionsForKind_PodHasResize(t *testing.T) {
+	items := ActionsForKind("Pod")
+
+	var resize *ActionMenuItem
+	seenKeys := map[string]string{}
+	for i, it := range items {
+		if it.Label == "Resize" {
+			resize = &items[i]
+		}
+		if _, dup := seenKeys[it.Key]; dup {
+			t.Fatalf("Pod action key %q used by more than one action", it.Key)
+		}
+		seenKeys[it.Key] = it.Label
+	}
+
+	require.NotNil(t, resize, "Pod actions must include a Resize entry")
+	assert.Equal(t, "r", resize.Key)
+}

--- a/internal/model/pod_resize.go
+++ b/internal/model/pod_resize.go
@@ -1,0 +1,12 @@
+package model
+
+// ContainerResources holds one container's CPU/memory request and limit
+// values for the pods/resize subresource patch. Empty fields are omitted
+// from the patch so a blank form field never clears an unset value.
+type ContainerResources struct {
+	Name       string
+	CPURequest string
+	CPULimit   string
+	MemRequest string
+	MemLimit   string
+}

--- a/internal/ui/styles_condition.go
+++ b/internal/ui/styles_condition.go
@@ -40,6 +40,9 @@ var conditionPolarities = map[string]condPolarity{
 	"reconciling": condInfo,
 	"stalled":     condError,
 	"healthy":     condReady,
+	// In-place pod resize (Kubernetes 1.33+).
+	"podresizepending":    condWarning,
+	"podresizeinprogress": condInfo,
 }
 
 var (

--- a/internal/ui/styles_condition.go
+++ b/internal/ui/styles_condition.go
@@ -40,7 +40,7 @@ var conditionPolarities = map[string]condPolarity{
 	"reconciling": condInfo,
 	"stalled":     condError,
 	"healthy":     condReady,
-	// In-place pod resize (Kubernetes 1.33+).
+	// In-place pod resize (GA in Kubernetes 1.35).
 	"podresizepending":    condWarning,
 	"podresizeinprogress": condInfo,
 }

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -125,6 +125,11 @@ func TestConditionStyle(t *testing.T) {
 		// Warning suffix wins regardless of status.
 		{"DeprecationWarning", "True", amber, "warning suffix"},
 
+		// In-place pod resize (curated, since the keyword heuristic alone
+		// would leave Pending as neutral info instead of a warning).
+		{"PodResizePending", "True", amber, "resize blocked, needs attention"},
+		{"PodResizeInProgress", "True", blue, "resize actively applying"},
+
 		// Unknown status is always neutral.
 		{"Ready", "Unknown", dim, "unknown is neutral"},
 		{"ComparisonError", "Unknown", dim, "unknown is neutral"},


### PR DESCRIPTION
## Summary
- Pressing `r` on a pod opens a form pre-filled with each container's CPU and memory requests and limits. Enter validates every field with resource.ParseQuantity and patches the pod `resize` subresource (GA in Kubernetes 1.35). The status bar reports success or the API error text.
- The form warns when a container's resizePolicy is RestartContainer. Pod-level spec.resources are shown read-only in the form and as detail columns. PodResizePending and PodResizeInProgress conditions render with reason and message, Pending in warning color.
- Read-only mode blocks the submit. Names from the object are sanitized before rendering. The PVC resize path is unchanged.

## Test plan
- [x] `go test -race ./...` (patch body via reactor, form parsing, overlay render, submit gating, condition polarity)
- [x] `golangci-lint run ./...`, app.go stays at 800 lines
- [ ] Manual on a 1.35+ cluster: resize a running pod, watch the conditions in the detail pane