### PR TITLE
fix: scope the instant metrics throttle by namespace

### DIFF
--- a/internal/app/metrics_throttle.go
+++ b/internal/app/metrics_throttle.go
@@ -41,8 +41,10 @@ func (m *Model) listMetricsCmds(kind string) []tea.Cmd {
 // run now, and stamps it when it does. metrics-server recomputes roughly every
 // 15s, so most 2s watch ticks refetch identical numbers. Only suppressed
 // refreshes are throttled, so a first load and a manual refresh always fetch.
+// The key carries the namespace scope, otherwise a namespace switch inside
+// the interval keeps showing the previous list's numbers.
 func (m *Model) allowMetricsFetch(kind string) bool {
-	key := m.nav.Context + "/" + kind
+	key := m.nav.Context + "/" + kind + sparklineScope(m, kind)
 	if interval := ui.ConfigMetricsInterval; interval > 0 && m.suppressBgtasks {
 		if last, ok := m.metricsLastFetch[key]; ok && time.Since(last) < interval {
 			return false

--- a/internal/app/metrics_throttle.go
+++ b/internal/app/metrics_throttle.go
@@ -60,13 +60,15 @@ func (m *Model) allowMetricsFetch(kind string) bool {
 // sparklineScope returns the part of the throttle key that identifies which
 // series the range query asks for. Without it a namespace switch, or opening a
 // second pod's containers, reuses the previous stamp and the new view sits
-// without history until the interval expires.
+// without history until the interval expires. The full selection fingerprint
+// is used rather than the effective namespace, which is empty for every
+// multi-namespace selection and would make them share one stamp.
 func sparklineScope(m *Model, kind string) string {
 	switch kind {
 	case "Pod":
-		return "/" + m.effectiveNamespace()
+		return "/" + m.fetchFingerprint()
 	case "Container":
-		return "/" + m.effectiveNamespace() + "/" + m.nav.OwnedName
+		return "/" + m.fetchFingerprint() + "/" + m.nav.OwnedName
 	default:
 		// Node and Cluster queries are not namespaced, so the context already
 		// identifies them.

--- a/internal/app/metrics_throttle_test.go
+++ b/internal/app/metrics_throttle_test.go
@@ -105,6 +105,44 @@ func TestAllowMetricsFetch_KeyedByContextAndKind(t *testing.T) {
 		"another cluster's metrics keep their own stamp")
 }
 
+// A namespace switch inside the interval asks for a different pod list, so it
+// must not reuse the previous namespace's stamp.
+func TestAllowMetricsFetch_NamespaceSwitchIsNotThrottled(t *testing.T) {
+	setMetricsInterval(t, time.Hour)
+	m := newMetricsThrottleModel("Pod")
+	m.suppressBgtasks = true
+	m.namespace = "team-a"
+	require.True(t, m.allowMetricsFetch("Pod"))
+	m.namespace = "team-b"
+	assert.True(t, m.allowMetricsFetch("Pod"),
+		"a namespace switch inside the interval must fetch the new list's metrics")
+	m.namespace = "team-a"
+	assert.False(t, m.allowMetricsFetch("Pod"),
+		"switching back inside the interval keeps the first namespace's stamp")
+}
+
+func TestAllowMetricsFetch_ContainerKeyedByOwner(t *testing.T) {
+	setMetricsInterval(t, time.Hour)
+	m := newMetricsThrottleModel("Container")
+	m.suppressBgtasks = true
+	m.nav.OwnedName = "pod-1"
+	require.True(t, m.allowMetricsFetch("Container"))
+	m.nav.OwnedName = "pod-2"
+	assert.True(t, m.allowMetricsFetch("Container"),
+		"another pod's containers keep their own stamp")
+}
+
+func TestAllowMetricsFetch_NodeIgnoresNamespace(t *testing.T) {
+	setMetricsInterval(t, time.Hour)
+	m := newMetricsThrottleModel("Node")
+	m.suppressBgtasks = true
+	m.namespace = "team-a"
+	require.True(t, m.allowMetricsFetch("Node"))
+	m.namespace = "team-b"
+	assert.False(t, m.allowMetricsFetch("Node"),
+		"node metrics are cluster-wide, a namespace switch must not refetch them")
+}
+
 // secondTickQueue runs two list loads on a fresh model and returns the names of
 // the cluster calls the second load submitted. Reading the queue beats counting
 // the returned cmds: tea.Batch collapses a single-cmd batch into that cmd, and

--- a/internal/app/metrics_throttle_test.go
+++ b/internal/app/metrics_throttle_test.go
@@ -121,6 +121,22 @@ func TestAllowMetricsFetch_NamespaceSwitchIsNotThrottled(t *testing.T) {
 		"switching back inside the interval keeps the first namespace's stamp")
 }
 
+// Two multi-namespace selections both have no single effective namespace,
+// yet they list different pods, so they must not share a stamp.
+func TestAllowMetricsFetch_MultiNamespaceSelectionsKeepOwnStamps(t *testing.T) {
+	setMetricsInterval(t, time.Hour)
+	m := newMetricsThrottleModel("Pod")
+	m.suppressBgtasks = true
+	m.selectedNamespaces = map[string]bool{"a": true, "b": true}
+	require.True(t, m.allowMetricsFetch("Pod"))
+	m.selectedNamespaces = map[string]bool{"c": true, "d": true}
+	assert.True(t, m.allowMetricsFetch("Pod"),
+		"a different multi-namespace selection must fetch its own metrics")
+	m.allNamespaces = true
+	assert.True(t, m.allowMetricsFetch("Pod"),
+		"all namespaces is yet another list")
+}
+
 func TestAllowMetricsFetch_ContainerKeyedByOwner(t *testing.T) {
 	setMetricsInterval(t, time.Hour)
 	m := newMetricsThrottleModel("Container")


### PR DESCRIPTION
## Summary
- The list-wide CPU and memory throttle keyed its stamp by context and kind only, so a namespace switch inside metrics_interval kept showing the previous list's numbers until the interval ran out. The key now carries the same scope the sparkline throttle uses.
- That shared scope now uses the full namespace selection fingerprint instead of the effective namespace, which is empty for every multi-namespace and all-namespace selection and made them share one stamp. This fixes the same gap in the sparkline throttle.
- Node and cluster-wide keys are unchanged, so a namespace switch does not refetch them.

## Test plan
- [x] `go test -race ./internal/app/` (four new throttle tests, the namespace ones fail without the fix)
- [x] `golangci-lint run ./internal/app/`