### PR TITLE
feat: quarantine a pod out of its Service selectors

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -66,6 +66,10 @@ When Prometheus holds less history than the window, the header adds the real spa
 
 The chip shows `snapshot` with no `[N/M]` counter when it is the only strategy available. To unlock the others, point lfk at Prometheus or VictoriaMetrics (see [config-reference.md](config-reference.md#monitoring)) or create a VPA in `Off` mode for the workload. Then cycle with `[` and `]`. Keys and headroom are in [keybindings.md](keybindings.md#right-sizing-advisor).
 
+## Pod quarantine
+
+`x` -> `Q` strips the label keys a pod's Services select on, so they stop routing traffic to it without deleting the pod, then records what it removed in the `lfk.janosmiko.dev/quarantined-labels` annotation. `Q` then reads Restore and puts the labels back. Keys are in [keybindings.md](keybindings.md#pod-actions).
+
 ## Embedded terminal
 
 Exec and shell sessions run in an embedded PTY by default. A session keeps running in the background when you switch tabs, so you can leave it and come back. `Ctrl+T` cycles the mode, see [config-reference.md](config-reference.md#terminal-mode).

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1244,9 +1244,11 @@ Locked rows offer no choice — keeping them yields a manifest that will not app
 The template picker (`a`): `Enter` create, `/` filter, `d` delete the highlighted saved template after a confirmation, `Esc`/`q` close. `d` works on your own templates only — the built-ins have no file behind them.
 
 ### Pod actions
-`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies whose pod selector matches this pod), `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `r` Resize (in-place CPU/memory), `D` Delete, `X` Force Delete, `V` Events
+`l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `B` Debug, `b` Debug Pod, `p` Port Forward, `c` Capture Traffic, `N` Network Policies (policies whose pod selector matches this pod), `S` Startup Analysis, `I` Crash Investigator, `v` Describe, `E` Edit, `z` Right-sizing, `r` Resize (in-place CPU/memory), `Q` Quarantine / Restore, `D` Delete, `X` Force Delete, `V` Events
 
 The Resize overlay (`r`) edits each container's CPU/memory requests and limits in place, via the `pods/resize` subresource (Kubernetes 1.33+). Pod-level `spec.resources` shows read-only. `j`/`k` or `Tab` move between fields; `Enter` applies. A container whose `resizePolicy` requires `RestartContainer` is flagged before you confirm.
+
+Quarantine (`Q`) strips the label keys that the pod's Services select on, so they stop routing traffic to it without deleting it, and records what it removed in the `lfk.janosmiko.dev/quarantined-labels` annotation. Once quarantined, `Q` reads Restore instead and puts the labels back. Both go through a confirm box; a pod with no matching Service selector reports that there is nothing to quarantine instead of opening one.
 
 ### Deployment actions
 `l` Tail Logs (last N lines + follow), `L` Logs (full), `s` Exec, `A` Attach, `S` Scale, `r` Restart, `R` Rollback, `p` Port Forward, `v` Describe, `E` Edit, `z` Right-sizing, `D` Delete, `b` Debug Pod, `V` Events

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -159,6 +159,7 @@ type Model struct {
 	hpaScale       hpaScaleState // HPA scale overlay: min/max bounds + target replicas
 	pvcCurrentSize string        // current size displayed in the PVC resize overlay
 	podResize      podResizeState
+	quarantine     quarantineState
 
 	// Port forward input state.
 	portForwardInput TextInput

--- a/internal/app/commands_quarantine.go
+++ b/internal/app/commands_quarantine.go
@@ -135,10 +135,10 @@ func (m Model) updateQuarantineTargetsChanged() (tea.Model, tea.Cmd) {
 	return m, scheduleStatusClear()
 }
 
-// quarantinePodCmd commits the Quarantine confirm. keys is passed
-// explicitly: the caller resets m.quarantine before this cmd's closure
-// runs. It re-runs QuarantineTargets first, refusing to patch on drift.
-func (m Model) quarantinePodCmd(keys []string) tea.Cmd {
+// quarantinePodCmd commits the Quarantine confirm. Both services and keys
+// must still match at commit time: same keys behind a renamed Service is
+// still a mismatch the confirm box never named.
+func (m Model) quarantinePodCmd(services, keys []string) tea.Cmd {
 	client := m.client
 	ctxName := m.actionCtx.context
 	namespace := m.actionCtx.namespace
@@ -151,11 +151,11 @@ func (m Model) quarantinePodCmd(keys []string) tea.Cmd {
 		"Quarantine: "+name,
 		bgtaskTarget(ctxName, namespace),
 		func(ctx context.Context) tea.Msg {
-			_, freshKeys, err := client.QuarantineTargets(ctx, ctxName, namespace, podLabels)
+			freshServices, freshKeys, err := client.QuarantineTargets(ctx, ctxName, namespace, podLabels)
 			if err != nil {
 				return actionResultMsg{err: err}
 			}
-			if !slices.Equal(freshKeys, keys) {
+			if !sortedStringsEqual(freshServices, services) || !sortedStringsEqual(freshKeys, keys) {
 				return quarantineTargetsChangedMsg{}
 			}
 			if _, err := client.QuarantinePod(ctx, ctxName, namespace, name, keys); err != nil {
@@ -164,6 +164,19 @@ func (m Model) quarantinePodCmd(keys []string) tea.Cmd {
 			return actionResultMsg{message: "Quarantined " + safeName}
 		},
 	)
+}
+
+// sortedStringsEqual compares ignoring order: QuarantineTargets sorts its
+// results, but a caller's confirmed figures are not guaranteed to be.
+func sortedStringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sa := slices.Clone(a)
+	sb := slices.Clone(b)
+	slices.Sort(sa)
+	slices.Sort(sb)
+	return slices.Equal(sa, sb)
 }
 
 // restorePodCmd commits the Restore confirm: puts back the label pairs

--- a/internal/app/commands_quarantine.go
+++ b/internal/app/commands_quarantine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -19,13 +20,16 @@ import (
 var errNoQuarantineTarget = errors.New("quarantine targets are not available for this action")
 
 // quarantineTargetsMsg carries the Services and label keys a Quarantine
-// would touch. req numbers the fetch so a stale reply cannot land on a
-// dialog the user already closed and reopened.
+// would touch. req, context, namespace and name together identify the
+// fetch a reply belongs to, so a stale or mismatched pod reply is dropped.
 type quarantineTargetsMsg struct {
-	req      uint64
-	services []string
-	keys     []string
-	err      error
+	req       uint64
+	context   string
+	namespace string
+	name      string
+	services  []string
+	keys      []string
+	err       error
 }
 
 // loadQuarantineTargets fetches which Services route to the target pod.
@@ -39,7 +43,9 @@ func (m Model) loadQuarantineTargets() tea.Cmd {
 	name := m.actionCtx.name
 	podLabels, _, _ := unstructured.NestedStringMap(m.actionCtx.raw, "metadata", "labels")
 	if client == nil {
-		return func() tea.Msg { return quarantineTargetsMsg{req: req, err: errNoQuarantineTarget} }
+		return func() tea.Msg {
+			return quarantineTargetsMsg{req: req, context: ctxName, namespace: namespace, name: name, err: errNoQuarantineTarget}
+		}
 	}
 	return m.scheduleK8sCall(
 		scheduler.PriorityHigh,
@@ -48,7 +54,10 @@ func (m Model) loadQuarantineTargets() tea.Cmd {
 		bgtaskTarget(ctxName, namespace),
 		func(ctx context.Context) tea.Msg {
 			services, keys, err := client.QuarantineTargets(ctx, ctxName, namespace, podLabels)
-			return quarantineTargetsMsg{req: req, services: services, keys: keys, err: err}
+			return quarantineTargetsMsg{
+				req: req, context: ctxName, namespace: namespace, name: name,
+				services: services, keys: keys, err: err,
+			}
 		},
 	)
 }
@@ -88,6 +97,9 @@ func (m Model) updateQuarantineTargets(msg quarantineTargetsMsg) (tea.Model, tea
 	if msg.req != m.quarantine.req {
 		return m, nil // an older fetch answering late
 	}
+	if msg.context != m.actionCtx.context || msg.namespace != m.actionCtx.namespace || msg.name != m.actionCtx.name {
+		return m, nil // a reply for a pod the menu no longer targets
+	}
 	if msg.err != nil {
 		m.setErrorFromErr("Quarantine: ", msg.err)
 		return m, scheduleStatusClear()
@@ -109,13 +121,29 @@ func (m Model) updateQuarantineTargets(msg quarantineTargetsMsg) (tea.Model, tea
 	return m, nil
 }
 
+// quarantineTargetsChangedMsg means the Services routing to the pod (or
+// their selector keys) changed between the confirm box opening and Enter,
+// so the confirmed keys no longer match what a quarantine would touch.
+type quarantineTargetsChangedMsg struct{}
+
+// updateQuarantineTargetsChanged aborts a stale Quarantine commit: nothing
+// was patched, so only the loading/confirm state needs unwinding.
+func (m Model) updateQuarantineTargetsChanged() (tea.Model, tea.Cmd) {
+	m.loading = false
+	m.quarantine.reset()
+	m.setStatusMessage("Services changed since the confirm box, run Quarantine again", true)
+	return m, scheduleStatusClear()
+}
+
 // quarantinePodCmd commits the Quarantine confirm. keys is passed
-// explicitly: the caller resets m.quarantine before this cmd's closure runs.
+// explicitly: the caller resets m.quarantine before this cmd's closure
+// runs. It re-runs QuarantineTargets first, refusing to patch on drift.
 func (m Model) quarantinePodCmd(keys []string) tea.Cmd {
 	client := m.client
 	ctxName := m.actionCtx.context
 	namespace := m.actionCtx.namespace
 	name := m.actionCtx.name
+	podLabels, _, _ := unstructured.NestedStringMap(m.actionCtx.raw, "metadata", "labels")
 	safeName := ui.SanitizeTerminalText(name)
 	return m.scheduleK8sCall(
 		scheduler.PriorityCritical,
@@ -123,6 +151,13 @@ func (m Model) quarantinePodCmd(keys []string) tea.Cmd {
 		"Quarantine: "+name,
 		bgtaskTarget(ctxName, namespace),
 		func(ctx context.Context) tea.Msg {
+			_, freshKeys, err := client.QuarantineTargets(ctx, ctxName, namespace, podLabels)
+			if err != nil {
+				return actionResultMsg{err: err}
+			}
+			if !slices.Equal(freshKeys, keys) {
+				return quarantineTargetsChangedMsg{}
+			}
 			if _, err := client.QuarantinePod(ctx, ctxName, namespace, name, keys); err != nil {
 				return actionResultMsg{err: err}
 			}

--- a/internal/app/commands_quarantine.go
+++ b/internal/app/commands_quarantine.go
@@ -1,0 +1,165 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// errNoQuarantineTarget means there is no client to ask, so QuarantineTargets
+// cannot run.
+var errNoQuarantineTarget = errors.New("quarantine targets are not available for this action")
+
+// quarantineTargetsMsg carries the Services and label keys a Quarantine
+// would touch. req numbers the fetch so a stale reply cannot land on a
+// dialog the user already closed and reopened.
+type quarantineTargetsMsg struct {
+	req      uint64
+	services []string
+	keys     []string
+	err      error
+}
+
+// loadQuarantineTargets fetches which Services route to the target pod.
+// Runs before the confirm overlay opens: "no Services match" is answered
+// with a status message instead of a confirm asking about nothing.
+func (m Model) loadQuarantineTargets() tea.Cmd {
+	req := m.quarantine.req
+	client := m.client
+	ctxName := m.actionCtx.context
+	namespace := m.actionCtx.namespace
+	name := m.actionCtx.name
+	podLabels, _, _ := unstructured.NestedStringMap(m.actionCtx.raw, "metadata", "labels")
+	if client == nil {
+		return func() tea.Msg { return quarantineTargetsMsg{req: req, err: errNoQuarantineTarget} }
+	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindYAMLFetch,
+		"Quarantine targets: "+name,
+		bgtaskTarget(ctxName, namespace),
+		func(ctx context.Context) tea.Msg {
+			services, keys, err := client.QuarantineTargets(ctx, ctxName, namespace, podLabels)
+			return quarantineTargetsMsg{req: req, services: services, keys: keys, err: err}
+		},
+	)
+}
+
+// executeActionQuarantine handles the "Quarantine" action: it fetches the
+// affected Services first and opens the confirm overlay only once the reply
+// names them (updateQuarantineTargets).
+func (m Model) executeActionQuarantine() (tea.Model, tea.Cmd) {
+	m.quarantine.reset()
+	return m, m.loadQuarantineTargets()
+}
+
+// executeActionRestore handles the "Restore" action. Unlike Quarantine, the
+// confirm question is static and needs no cluster fetch: the pairs to put
+// back are already on the pod's annotation (D5).
+func (m Model) executeActionRestore() (tea.Model, tea.Cmd) {
+	m.quarantine.reset()
+	restored, ok := quarantinedLabels(m.actionCtx.raw)
+	if !ok {
+		m.setStatusMessage("This pod is not quarantined", false)
+		return m, scheduleStatusClear()
+	}
+	m.quarantine.restore = restored
+	name := ui.SanitizeTerminalText(m.actionCtx.name)
+	m.confirmAction = m.actionCtx.name
+	m.confirmTitle = "Confirm Restore"
+	m.confirmQuestion = fmt.Sprintf("Restore %s?", name)
+	m.overlay = overlayConfirm
+	m.pendingAction = model.ActionLabelRestore
+	return m, nil
+}
+
+// updateQuarantineTargets stores the fetch's reply and opens the confirm
+// overlay, unless a pod with no matching Service selector has nothing to
+// quarantine, in which case a status message replaces the dialog.
+func (m Model) updateQuarantineTargets(msg quarantineTargetsMsg) (tea.Model, tea.Cmd) {
+	if msg.req != m.quarantine.req {
+		return m, nil // an older fetch answering late
+	}
+	if msg.err != nil {
+		m.setErrorFromErr("Quarantine: ", msg.err)
+		return m, scheduleStatusClear()
+	}
+	if len(msg.services) == 0 {
+		name := ui.SanitizeTerminalText(m.actionCtx.name)
+		m.setStatusMessage("Nothing to quarantine: no Service selector matches "+name, false)
+		return m, scheduleStatusClear()
+	}
+
+	m.quarantine.services = msg.services
+	m.quarantine.keys = msg.keys
+	name := ui.SanitizeTerminalText(m.actionCtx.name)
+	m.confirmAction = m.actionCtx.name
+	m.confirmTitle = "Confirm Quarantine"
+	m.confirmQuestion = fmt.Sprintf("Quarantine %s?", name)
+	m.overlay = overlayConfirm
+	m.pendingAction = model.ActionLabelQuarantine
+	return m, nil
+}
+
+// quarantinePodCmd commits the Quarantine confirm. keys is passed
+// explicitly: the caller resets m.quarantine before this cmd's closure runs.
+func (m Model) quarantinePodCmd(keys []string) tea.Cmd {
+	client := m.client
+	ctxName := m.actionCtx.context
+	namespace := m.actionCtx.namespace
+	name := m.actionCtx.name
+	safeName := ui.SanitizeTerminalText(name)
+	return m.scheduleK8sCall(
+		scheduler.PriorityCritical,
+		scheduler.KindMutation,
+		"Quarantine: "+name,
+		bgtaskTarget(ctxName, namespace),
+		func(ctx context.Context) tea.Msg {
+			if _, err := client.QuarantinePod(ctx, ctxName, namespace, name, keys); err != nil {
+				return actionResultMsg{err: err}
+			}
+			return actionResultMsg{message: "Quarantined " + safeName}
+		},
+	)
+}
+
+// restorePodCmd commits the Restore confirm: puts back the label pairs
+// QuarantinePod recorded and clears the annotation.
+func (m Model) restorePodCmd() tea.Cmd {
+	client := m.client
+	ctxName := m.actionCtx.context
+	namespace := m.actionCtx.namespace
+	name := m.actionCtx.name
+	safeName := ui.SanitizeTerminalText(name)
+	return m.scheduleK8sCall(
+		scheduler.PriorityCritical,
+		scheduler.KindMutation,
+		"Restore: "+name,
+		bgtaskTarget(ctxName, namespace),
+		func(ctx context.Context) tea.Msg {
+			if _, err := client.RestorePod(ctx, ctxName, namespace, name); err != nil {
+				return actionResultMsg{err: err}
+			}
+			return actionResultMsg{message: "Restored " + safeName}
+		},
+	)
+}
+
+// quarantineNullLabelsJSON renders the label keys a Quarantine patch nulls
+// out, for the debug log line only — the patch itself is built with
+// json.Marshal in the k8s package.
+func quarantineNullLabelsJSON(keys []string) string {
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%q:null", k)
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/app/commands_quarantine_test.go
+++ b/internal/app/commands_quarantine_test.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func quarantineTestActionCtx() actionContext {
+	return actionContext{
+		kind:      "Pod",
+		name:      "pod-1",
+		namespace: "default",
+		context:   "test-ctx",
+		raw: map[string]any{
+			"metadata": map[string]any{
+				"name":      "pod-1",
+				"namespace": "default",
+				"labels":    map[string]any{"app": "web"},
+			},
+		},
+	}
+}
+
+func TestExecuteActionQuarantine_SchedulesOneFetch(t *testing.T) {
+	m := baseModelWithFakeClient(&corev1.Service{
+		Name: "svc-web", Namespace: "default",
+		Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+	})
+	m.actionCtx = quarantineTestActionCtx()
+
+	mdl, cmd := m.executeActionQuarantine()
+	out := mdl.(Model)
+
+	assertSchedulesOne(t, out, cmd)
+	assert.Equal(t, overlayNone, out.overlay, "the overlay opens only after the fetch replies")
+}
+
+func TestUpdateQuarantineTargets_NoServices_ReportsAndOpensNoOverlay(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.actionCtx = quarantineTestActionCtx()
+	m.quarantine.reset()
+
+	mdl, cmd := m.updateQuarantineTargets(quarantineTargetsMsg{req: m.quarantine.req})
+	out := mdl.(Model)
+
+	assert.Equal(t, overlayNone, out.overlay)
+	assert.Contains(t, out.statusMessage, "Nothing to quarantine")
+	assert.Contains(t, out.statusMessage, "pod-1")
+	require.NotNil(t, cmd, "status clear is still scheduled")
+}
+
+func TestUpdateQuarantineTargets_StaleReqIgnored(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.actionCtx = quarantineTestActionCtx()
+	m.quarantine.reset()
+	stale := m.quarantine.req
+	m.quarantine.reset() // dialog closed and reopened: a newer req is now current
+
+	mdl, cmd := m.updateQuarantineTargets(quarantineTargetsMsg{
+		req:      stale,
+		services: []string{"svc-web"},
+		keys:     []string{"app"},
+	})
+	out := mdl.(Model)
+
+	assert.Equal(t, overlayNone, out.overlay)
+	assert.Nil(t, out.quarantine.services)
+	assert.Nil(t, cmd)
+}

--- a/internal/app/commands_quarantine_test.go
+++ b/internal/app/commands_quarantine_test.go
@@ -44,7 +44,9 @@ func TestUpdateQuarantineTargets_NoServices_ReportsAndOpensNoOverlay(t *testing.
 	m.actionCtx = quarantineTestActionCtx()
 	m.quarantine.reset()
 
-	mdl, cmd := m.updateQuarantineTargets(quarantineTargetsMsg{req: m.quarantine.req})
+	mdl, cmd := m.updateQuarantineTargets(quarantineTargetsMsg{
+		req: m.quarantine.req, context: m.actionCtx.context, namespace: m.actionCtx.namespace, name: m.actionCtx.name,
+	})
 	out := mdl.(Model)
 
 	assert.Equal(t, overlayNone, out.overlay)
@@ -69,5 +71,34 @@ func TestUpdateQuarantineTargets_StaleReqIgnored(t *testing.T) {
 
 	assert.Equal(t, overlayNone, out.overlay)
 	assert.Nil(t, out.quarantine.services)
+	assert.Nil(t, cmd)
+}
+
+// A single fetch means req alone cannot catch pod-a's reply landing on
+// pod-b's confirm box. context/namespace/name must also match.
+func TestUpdateQuarantineTargets_StaleActionCtxIgnored(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.actionCtx = quarantineTestActionCtx() // pod-a
+	m.quarantine.reset()
+	reqForA := m.quarantine.req
+	ctxForA := m.actionCtx.context
+	nsForA := m.actionCtx.namespace
+	nameForA := m.actionCtx.name
+
+	m.actionCtx.name = "pod-b" // action menu reopened on a different pod
+
+	mdl, cmd := m.updateQuarantineTargets(quarantineTargetsMsg{
+		req:       reqForA,
+		context:   ctxForA,
+		namespace: nsForA,
+		name:      nameForA,
+		services:  []string{"svc-web"},
+		keys:      []string{"app"},
+	})
+	out := mdl.(Model)
+
+	assert.Equal(t, overlayNone, out.overlay, "pod-a's result must not open a confirm meant for pod-b")
+	assert.Nil(t, out.quarantine.services)
+	assert.Nil(t, out.quarantine.keys)
 	assert.Nil(t, cmd)
 }

--- a/internal/app/quarantine.go
+++ b/internal/app/quarantine.go
@@ -13,10 +13,6 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// quarantineServiceListMax mirrors dependentSummaryKinds: past this many, a
-// confirm box states a count instead of a half-listed set of names.
-const quarantineServiceListMax = 3
-
 // quarantineState is what the open Quarantine/Restore confirm dialog knows:
 // the Services and label keys a quarantine would touch, or the label pairs
 // a restore would put back.
@@ -125,13 +121,12 @@ func quarantineRestoreNotes(restored map[string]string) []ui.ConfirmNote {
 	return []ui.ConfirmNote{{Label: "Scope", Text: quarantineLabelScope(keys)}}
 }
 
-// quarantineServiceScope names the Services a quarantine stops routing to,
-// falling back to a count past quarantineServiceListMax.
+// quarantineServiceScope names every Service a quarantine stops routing to,
+// so the confirm box never hides a Service behind a count.
 func quarantineServiceScope(services []string) string {
-	if len(services) > quarantineServiceListMax {
-		return fmt.Sprintf("%d Services", len(services))
-	}
-	return ui.SanitizeTerminalText(strings.Join(services, ", "))
+	sorted := append([]string(nil), services...)
+	sort.Strings(sorted)
+	return ui.SanitizeTerminalText(strings.Join(sorted, ", "))
 }
 
 // quarantineLabelScope states how many label keys move, and which ones.

--- a/internal/app/quarantine.go
+++ b/internal/app/quarantine.go
@@ -1,0 +1,144 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// quarantineServiceListMax mirrors dependentSummaryKinds: past this many, a
+// confirm box states a count instead of a half-listed set of names.
+const quarantineServiceListMax = 3
+
+// quarantineState is what the open Quarantine/Restore confirm dialog knows:
+// the Services and label keys a quarantine would touch, or the label pairs
+// a restore would put back.
+type quarantineState struct {
+	services []string
+	keys     []string
+	restore  map[string]string
+	// req numbers each fetch, so a reply for a dialog the user already
+	// closed and reopened cannot land on the new one.
+	req uint64
+}
+
+// reset clears the figures and retires the request they belong to.
+func (q *quarantineState) reset() {
+	q.services = nil
+	q.keys = nil
+	q.restore = nil
+	q.req++
+}
+
+// rewriteQuarantineMenuItem swaps an already-quarantined pod's Quarantine
+// entry for Restore in place. Status (the hotkey chip, "Q") is kept so
+// sortActionMenuItems still places it where the chip letter says it belongs.
+func rewriteQuarantineMenuItem(items []model.Item, raw map[string]any) {
+	if _, quarantined := quarantinedLabels(raw); !quarantined {
+		return
+	}
+	for i, item := range items {
+		if item.Name == model.ActionLabelQuarantine {
+			items[i].Name = model.ActionLabelRestore
+			items[i].Extra = "Put back the labels removed by Quarantine"
+			return
+		}
+	}
+}
+
+// quarantinedLabels reports whether a pod carries QuarantinePod's
+// annotation, and decodes its recorded label pairs when it does.
+func quarantinedLabels(raw map[string]any) (map[string]string, bool) {
+	if raw == nil {
+		return nil, false
+	}
+	annotations, ok, err := unstructured.NestedStringMap(raw, "metadata", "annotations")
+	if err != nil || !ok {
+		return nil, false
+	}
+	value, ok := annotations[k8s.QuarantinedLabelsAnnotation]
+	if !ok || value == "" {
+		return nil, false
+	}
+	var removed map[string]string
+	if err := json.Unmarshal([]byte(value), &removed); err != nil {
+		return nil, false
+	}
+	return removed, true
+}
+
+// podHasController reports whether a pod's ownerReferences name a
+// controller. IsController=true is what tells the confirm box a
+// replacement pod is coming, versus an orphan pod nothing recreates.
+func podHasController(raw map[string]any) bool {
+	refs, ok, err := unstructured.NestedSlice(raw, "metadata", "ownerReferences")
+	if err != nil || !ok {
+		return false
+	}
+	for _, r := range refs {
+		ref, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if controller, _ := ref["controller"].(bool); controller {
+			return true
+		}
+	}
+	return false
+}
+
+// quarantineConfirmNotes builds the Quarantine/Restore confirm rows in the
+// grammar of confirmCostNotes: Scope, Availability, Risk.
+func quarantineConfirmNotes(st quarantineState, ownedByController bool) []ui.ConfirmNote {
+	if len(st.restore) > 0 {
+		return quarantineRestoreNotes(st.restore)
+	}
+	if len(st.services) == 0 {
+		return nil
+	}
+	riskText := "nothing recreates this pod"
+	if ownedByController {
+		riskText = "its controller creates a replacement pod"
+	}
+	return []ui.ConfirmNote{
+		{Label: "Scope", Text: quarantineServiceScope(st.services)},
+		{Label: "Availability", Text: quarantineLabelScope(st.keys)},
+		{Label: "Risk", Text: riskText, Warn: true},
+	}
+}
+
+// quarantineRestoreNotes names the label pairs a Restore puts back. Routing
+// resumes rather than being taken away, so there is nothing to warn about.
+func quarantineRestoreNotes(restored map[string]string) []ui.ConfirmNote {
+	keys := make([]string, 0, len(restored))
+	for k := range restored {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return []ui.ConfirmNote{{Label: "Scope", Text: quarantineLabelScope(keys)}}
+}
+
+// quarantineServiceScope names the Services a quarantine stops routing to,
+// falling back to a count past quarantineServiceListMax.
+func quarantineServiceScope(services []string) string {
+	if len(services) > quarantineServiceListMax {
+		return fmt.Sprintf("%d Services", len(services))
+	}
+	return ui.SanitizeTerminalText(strings.Join(services, ", "))
+}
+
+// quarantineLabelScope states how many label keys move, and which ones.
+func quarantineLabelScope(keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d %s: %s", len(keys), plural(len(keys), "label", "labels"),
+		ui.SanitizeTerminalText(strings.Join(keys, ", ")))
+}

--- a/internal/app/quarantine_confirm_test.go
+++ b/internal/app/quarantine_confirm_test.go
@@ -1,0 +1,76 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestQuarantineConfirmNotes_NamesEveryServiceAndTheReplacement(t *testing.T) {
+	cases := []struct {
+		name              string
+		services          []string
+		ownedByController bool
+		wantRisk          string
+	}{
+		{"one service, owned", []string{"svc-a"}, true, "its controller creates a replacement pod"},
+		{"two services, owned", []string{"svc-a", "svc-b"}, true, "its controller creates a replacement pod"},
+		{"five services, orphan", []string{"svc-a", "svc-b", "svc-c", "svc-d", "svc-e"}, false, "nothing recreates this pod"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := quarantineState{services: tc.services, keys: []string{"app"}}
+			notes := quarantineConfirmNotes(st, tc.ownedByController)
+
+			var scope, risk string
+			for _, n := range notes {
+				switch n.Label {
+				case "Scope":
+					scope = n.Text
+				case "Risk":
+					risk = n.Text
+					assert.True(t, n.Warn, "the risk row always warns, whichever branch it takes")
+				}
+			}
+
+			if len(tc.services) <= 3 {
+				for _, svc := range tc.services {
+					assert.Contains(t, scope, svc)
+				}
+			} else {
+				assert.Contains(t, scope, "5 Services")
+			}
+			assert.Equal(t, tc.wantRisk, risk)
+		})
+	}
+}
+
+func TestRenderOverlayConfirm_QuarantineShowsServices(t *testing.T) {
+	m := Model{
+		width:           80,
+		height:          24,
+		pendingAction:   model.ActionLabelQuarantine,
+		confirmAction:   "web-1",
+		confirmTitle:    "Confirm Quarantine",
+		confirmQuestion: "Quarantine web-1?",
+	}
+	m.actionCtx.kind = "Pod"
+	m.actionCtx.raw = map[string]any{
+		"metadata": map[string]any{
+			"ownerReferences": []any{
+				map[string]any{"kind": "ReplicaSet", "name": "web", "controller": true},
+			},
+		},
+	}
+	m.quarantine.services = []string{"svc-web", "svc-web-internal"}
+	m.quarantine.keys = []string{"app"}
+
+	box := confirmBox(m)
+
+	assert.Contains(t, box, "svc-web")
+	assert.Contains(t, box, "svc-web-internal")
+	assert.Contains(t, box, "its controller creates a replacement pod")
+}

--- a/internal/app/quarantine_confirm_test.go
+++ b/internal/app/quarantine_confirm_test.go
@@ -36,12 +36,8 @@ func TestQuarantineConfirmNotes_NamesEveryServiceAndTheReplacement(t *testing.T)
 				}
 			}
 
-			if len(tc.services) <= 3 {
-				for _, svc := range tc.services {
-					assert.Contains(t, scope, svc)
-				}
-			} else {
-				assert.Contains(t, scope, "5 Services")
+			for _, svc := range tc.services {
+				assert.Contains(t, scope, svc)
 			}
 			assert.Equal(t, tc.wantRisk, risk)
 		})

--- a/internal/app/quarantine_test.go
+++ b/internal/app/quarantine_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func annotatedQuarantinedPodItem() model.Item {
+	return model.Item{
+		Name:      "pod-1",
+		Namespace: "default",
+		Kind:      "Pod",
+		Raw: map[string]any{
+			"metadata": map[string]any{
+				"name":      "pod-1",
+				"namespace": "default",
+				"annotations": map[string]any{
+					"lfk.janosmiko.dev/quarantined-labels": `{"app":"web"}`,
+				},
+			},
+		},
+	}
+}
+
+func TestOpenResourceActionMenu_AnnotatedPodShowsRestore(t *testing.T) {
+	m := withMiddleItem(basePush80Model(), annotatedQuarantinedPodItem())
+
+	out := m.openResourceActionMenu()
+
+	names := make(map[string]bool, len(out.overlayItems))
+	for _, item := range out.overlayItems {
+		names[item.Name] = true
+	}
+	assert.True(t, names[model.ActionLabelRestore], "an annotated pod should offer Restore")
+	assert.False(t, names[model.ActionLabelQuarantine], "an annotated pod should not still offer Quarantine")
+}
+
+func TestOpenResourceActionMenu_PlainPodShowsQuarantine(t *testing.T) {
+	m := withMiddleItem(basePush80Model(), model.Item{Name: "pod-1", Namespace: "default", Kind: "Pod"})
+
+	out := m.openResourceActionMenu()
+
+	names := make(map[string]bool, len(out.overlayItems))
+	for _, item := range out.overlayItems {
+		names[item.Name] = true
+	}
+	assert.True(t, names[model.ActionLabelQuarantine], "a plain pod should offer Quarantine")
+	assert.False(t, names[model.ActionLabelRestore], "a plain pod should not offer Restore")
+}

--- a/internal/app/readonly.go
+++ b/internal/app/readonly.go
@@ -86,6 +86,10 @@ var mutatingActions = map[string]bool{
 	// Helm release mutations.
 	"Edit Values": true,
 	"Upgrade":     true,
+
+	// Pod service quarantine.
+	"Quarantine": true,
+	"Restore":    true,
 }
 
 // isUnionAllowedActionForKind reports whether an action is allowed at the

--- a/internal/app/readonly_test.go
+++ b/internal/app/readonly_test.go
@@ -37,6 +37,8 @@ func TestIsMutatingAction(t *testing.T) {
 		"Reconcile",
 		// Helm.
 		"Edit Values", "Upgrade",
+		// Pod service quarantine.
+		"Quarantine", "Restore",
 	}
 	for _, label := range mutating {
 		assert.True(t, isMutatingAction(label), "%q should be classified mutating", label)
@@ -108,6 +110,26 @@ func TestExecuteAction_ReadOnly_BlocksMutating(t *testing.T) {
 			// state (e.g., overlayConfirm for Delete).
 			assert.NotEqual(t, overlayConfirm, result.overlay)
 			assert.NotEqual(t, overlayScaleInput, result.overlay)
+		})
+	}
+}
+
+func TestExecuteAction_ReadOnly_BlocksQuarantine(t *testing.T) {
+	for _, label := range []string{"Quarantine", "Restore"} {
+		t.Run(label, func(t *testing.T) {
+			m := baseModelWithFakeClient()
+			m.readOnly = true
+			m.actionCtx = actionContext{kind: "Pod", name: "pod-1", namespace: "default", context: "test-ctx"}
+
+			ret, cmd := m.executeAction(label)
+			result := ret.(Model)
+
+			assert.Equal(t, readOnlyBlockedMessage(label), result.statusMessage)
+			assert.True(t, result.statusMessageErr)
+			assert.Equal(t, overlayNone, result.overlay)
+			require.NotNil(t, cmd, "a status-clear cmd is still returned")
+			assert.Zero(t, result.scheduler.QueueLen(result.nav.Context),
+				"a blocked action must not submit any k8s call")
 		})
 	}
 }

--- a/internal/app/readonly_union_closure_test.go
+++ b/internal/app/readonly_union_closure_test.go
@@ -95,6 +95,11 @@ func TestIsUnionAllowedActionForKind_ClosureOverMutatingActions(t *testing.T) {
 		"Activate":             nil,
 		"Edit Values":          nil,
 		"Upgrade":              nil,
+
+		// Quarantine/Restore rewrite Service-selected labels on a single
+		// Pod, like Labels / Annotations above — hard-blocked in union.
+		"Quarantine": nil,
+		"Restore":    nil,
 	}
 
 	probeKinds := []string{"Pod", "Deployment", "StatefulSet", "DaemonSet", "Service", "ConfigMap"}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -164,6 +164,9 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case quarantineTargetsMsg:
 		mdl, cmd := m.updateQuarantineTargets(msg)
 		return mdl, cmd, true
+	case quarantineTargetsChangedMsg:
+		mdl, cmd := m.updateQuarantineTargetsChanged()
+		return mdl, cmd, true
 	case dependentsLoadedMsg:
 		mdl, cmd := m.updateDependentsLoaded(msg)
 		return mdl, cmd, true

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -161,6 +161,9 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case blastRadiusLoadedMsg:
 		mdl, cmd := m.updateBlastRadiusLoaded(msg)
 		return mdl, cmd, true
+	case quarantineTargetsMsg:
+		mdl, cmd := m.updateQuarantineTargets(msg)
+		return mdl, cmd, true
 	case dependentsLoadedMsg:
 		mdl, cmd := m.updateDependentsLoaded(msg)
 		return mdl, cmd, true

--- a/internal/app/update_actions.go
+++ b/internal/app/update_actions.go
@@ -107,6 +107,8 @@ func (m Model) openResourceActionMenu() Model {
 		}
 	}
 
+	rewriteQuarantineMenuItem(items, sel.Raw)
+
 	sortActionMenuItems(items)
 	m.overlay = overlayAction
 	m.overlayItems = items
@@ -598,6 +600,12 @@ func (m Model) executeActionCoreOps(actionLabel string) (tea.Model, tea.Cmd, boo
 		return mdl, cmd, true
 	case "Vuln Scan":
 		mdl, cmd := m.executeActionVulnScan()
+		return mdl, cmd, true
+	case model.ActionLabelQuarantine:
+		mdl, cmd := m.executeActionQuarantine()
+		return mdl, cmd, true
+	case model.ActionLabelRestore:
+		mdl, cmd := m.executeActionRestore()
 		return mdl, cmd, true
 	}
 	return m, nil, false

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -49,8 +49,9 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		m.overlay = overlayNone
 		m.loading = true
 		// The figures belong to the action being committed here. A later
-		// confirm must not open showing them. quarantineKeys is captured
-		// before the reset, since the Quarantine branch below still needs it.
+		// confirm must not open showing them. quarantineServices/Keys are
+		// captured before the reset, since the Quarantine branch below still needs them.
+		quarantineServices := m.quarantine.services
 		quarantineKeys := m.quarantine.keys
 		m.blast.reset()
 		m.deps.reset()
@@ -117,7 +118,7 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		case model.ActionLabelQuarantine:
 			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch pod %s --type merge -p '{\"metadata\":{\"labels\":{%s},\"annotations\":{%q:...}}}'%s --context %s",
 				name, quarantineNullLabelsJSON(quarantineKeys), k8s.QuarantinedLabelsAnnotation, nsArg, ctx))
-			return m, m.quarantinePodCmd(quarantineKeys)
+			return m, m.quarantinePodCmd(quarantineServices, quarantineKeys)
 		case model.ActionLabelRestore:
 			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch pod %s --type merge -p '{\"metadata\":{\"labels\":{...}},\"annotations\":{%q:null}}}'%s --context %s",
 				name, k8s.QuarantinedLabelsAnnotation, nsArg, ctx))

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -7,6 +7,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -35,6 +36,7 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 			m.overlay = overlayNone
 			m.blast.reset()
 			m.deps.reset()
+			m.quarantine.reset()
 			label := m.pendingAction
 			m.pendingAction = ""
 			m.confirmAction = ""
@@ -46,10 +48,13 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		}
 		m.overlay = overlayNone
 		m.loading = true
-		// The figures belong to the action being committed here; a later
-		// confirm must not open showing them.
+		// The figures belong to the action being committed here. A later
+		// confirm must not open showing them. quarantineKeys is captured
+		// before the reset, since the Quarantine branch below still needs it.
+		quarantineKeys := m.quarantine.keys
 		m.blast.reset()
 		m.deps.reset()
+		m.quarantine.reset()
 		action := m.pendingAction
 		m.pendingAction = ""
 		m.confirmAction = ""
@@ -109,6 +114,14 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		case "Cancel Eviction":
 			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch %s.longhorn.io %s --type merge -p '{\"spec\":{\"evictionRequested\":false}}'%s --context %s", rt.Resource, name, nsArg, ctx))
 			return m, m.setLonghornNodeEviction(false)
+		case model.ActionLabelQuarantine:
+			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch pod %s --type merge -p '{\"metadata\":{\"labels\":{%s},\"annotations\":{%q:...}}}'%s --context %s",
+				name, quarantineNullLabelsJSON(quarantineKeys), k8s.QuarantinedLabelsAnnotation, nsArg, ctx))
+			return m, m.quarantinePodCmd(quarantineKeys)
+		case model.ActionLabelRestore:
+			m.addLogEntry("DBG", fmt.Sprintf("$ kubectl patch pod %s --type merge -p '{\"metadata\":{\"labels\":{...}},\"annotations\":{%q:null}}}'%s --context %s",
+				name, k8s.QuarantinedLabelsAnnotation, nsArg, ctx))
+			return m, m.restorePodCmd()
 		}
 
 		// Regular delete.
@@ -135,6 +148,7 @@ func (m Model) handleConfirmOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		m.pendingAction = ""
 		m.blast.reset()
 		m.deps.reset()
+		m.quarantine.reset()
 		m.resetBulkAction()
 		if returnToTaints {
 			m.overlay = overlayTaintEditor
@@ -166,6 +180,7 @@ func (m Model) handleConfirmTypeOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.
 		m.resetBulkAction()
 		m.blast.reset()
 		m.deps.reset()
+		m.quarantine.reset()
 		return m, nil
 	case "ctrl+c":
 		return m.closeTabOrQuit()

--- a/internal/app/update_overlays_confirm_quarantine_test.go
+++ b/internal/app/update_overlays_confirm_quarantine_test.go
@@ -1,15 +1,21 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	tea "charm.land/bubbletea/v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	fake "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -74,11 +80,33 @@ func quarantineFakePod() *unstructured.Unstructured {
 	}}
 }
 
-func TestQuarantinePodCmd_EndToEnd(t *testing.T) {
-	m := baseModelWithFakeDynamic(map[schema.GroupVersionResource]string{
+// quarantineModelWithService wires a Model whose dynamic client serves
+// quarantineFakePod and whose clientset serves the given Services, so the
+// pre-patch QuarantineTargets re-check has real data to compare against.
+func quarantineModelWithService(services ...runtime.Object) Model {
+	cs := fake.NewClientset(services...)
+	scheme := newFakeScheme()
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
 		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
 	}, quarantineFakePod())
-	m.actionCtx = actionContext{context: "test-ctx", kind: "Pod", name: "pod-1", namespace: "default"}
+
+	m := baseModelCov()
+	m.client = k8s.NewTestClient(cs, dyn)
+	m.nav.Context = "test-ctx"
+	m.namespace = "default"
+	m.reqCtx = context.Background()
+	m.actionCtx = actionContext{
+		context: "test-ctx", kind: "Pod", name: "pod-1", namespace: "default",
+		raw: quarantineFakePod().Object,
+	}
+	return m
+}
+
+func TestQuarantinePodCmd_EndToEnd(t *testing.T) {
+	m := quarantineModelWithService(&corev1.Service{
+		Name: "svc-web", Namespace: "default",
+		Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+	})
 
 	cmd := m.quarantinePodCmd([]string{"app"})
 
@@ -86,6 +114,27 @@ func TestQuarantinePodCmd_EndToEnd(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, msg.err)
 	assert.Contains(t, msg.message, "Quarantined pod-1")
+}
+
+// The confirm box showed keys ["app"], but by commit time the only
+// matching Service selects on "tier" instead.
+func TestQuarantineCommit_AbortsWhenTargetsChanged(t *testing.T) {
+	m := quarantineModelWithService(&corev1.Service{
+		Name: "svc-tier", Namespace: "default",
+		Spec: corev1.ServiceSpec{Selector: map[string]string{"tier": "backend"}},
+	})
+
+	cmd := m.quarantinePodCmd([]string{"app"})
+
+	msg := execScheduled(t, m, cmd)
+	_, changed := msg.(quarantineTargetsChangedMsg)
+	assert.True(t, changed, "expected quarantineTargetsChangedMsg, got %T", msg)
+
+	mdl, _ := m.updateQuarantineTargetsChanged()
+	out := mdl.(Model)
+	assert.True(t, out.statusMessageErr)
+	assert.Contains(t, out.statusMessage, "run Quarantine again")
+	assert.Nil(t, out.quarantine.keys)
 }
 
 func TestRestorePodCmd_EndToEnd(t *testing.T) {

--- a/internal/app/update_overlays_confirm_quarantine_test.go
+++ b/internal/app/update_overlays_confirm_quarantine_test.go
@@ -108,7 +108,7 @@ func TestQuarantinePodCmd_EndToEnd(t *testing.T) {
 		Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
 	})
 
-	cmd := m.quarantinePodCmd([]string{"app"})
+	cmd := m.quarantinePodCmd([]string{"svc-web"}, []string{"app"})
 
 	msg, ok := execScheduled(t, m, cmd).(actionResultMsg)
 	require.True(t, ok)
@@ -124,7 +124,7 @@ func TestQuarantineCommit_AbortsWhenTargetsChanged(t *testing.T) {
 		Spec: corev1.ServiceSpec{Selector: map[string]string{"tier": "backend"}},
 	})
 
-	cmd := m.quarantinePodCmd([]string{"app"})
+	cmd := m.quarantinePodCmd([]string{"svc-web"}, []string{"app"})
 
 	msg := execScheduled(t, m, cmd)
 	_, changed := msg.(quarantineTargetsChangedMsg)
@@ -135,6 +135,22 @@ func TestQuarantineCommit_AbortsWhenTargetsChanged(t *testing.T) {
 	assert.True(t, out.statusMessageErr)
 	assert.Contains(t, out.statusMessage, "run Quarantine again")
 	assert.Nil(t, out.quarantine.keys)
+}
+
+// svc-a is confirmed by name, but by commit time the matching Service is
+// svc-b — same selector keys, different Service. The confirm box never
+// listed svc-b, so the patch must be refused rather than silently retargeted.
+func TestQuarantineCommit_AbortsWhenServiceNameChanged(t *testing.T) {
+	m := quarantineModelWithService(&corev1.Service{
+		Name: "svc-b", Namespace: "default",
+		Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+	})
+
+	cmd := m.quarantinePodCmd([]string{"svc-a"}, []string{"app"})
+
+	msg := execScheduled(t, m, cmd)
+	_, changed := msg.(quarantineTargetsChangedMsg)
+	assert.True(t, changed, "expected quarantineTargetsChangedMsg, got %T", msg)
 }
 
 func TestRestorePodCmd_EndToEnd(t *testing.T) {

--- a/internal/app/update_overlays_confirm_quarantine_test.go
+++ b/internal/app/update_overlays_confirm_quarantine_test.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tea "charm.land/bubbletea/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+func TestConfirmEnter_Quarantine_DispatchesPatch(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.overlay = overlayConfirm
+	m.pendingAction = model.ActionLabelQuarantine
+	m.actionCtx = actionContext{
+		context:      "test-ctx",
+		kind:         "Pod",
+		name:         "pod-1",
+		namespace:    "default",
+		resourceType: model.ResourceTypeEntry{Resource: "pods", Namespaced: true},
+	}
+	m.quarantine.services = []string{"svc-web"}
+	m.quarantine.keys = []string{"app"}
+
+	mdl, cmd := m.handleConfirmOverlayKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	out := mdl.(Model)
+
+	assertSchedulesOne(t, out, cmd)
+	assert.Equal(t, overlayNone, out.overlay)
+	assert.Empty(t, out.pendingAction)
+	require.NotEmpty(t, out.errorLog)
+	assert.Contains(t, out.errorLog[len(out.errorLog)-1].Message, "kubectl patch pod pod-1",
+		"an unrecognized pendingAction must not silently fall through to the regular-delete branch")
+}
+
+func TestConfirmEnter_Restore_DispatchesPatch(t *testing.T) {
+	m := baseModelWithFakeClient()
+	m.overlay = overlayConfirm
+	m.pendingAction = model.ActionLabelRestore
+	m.actionCtx = actionContext{
+		context:      "test-ctx",
+		kind:         "Pod",
+		name:         "pod-1",
+		namespace:    "default",
+		resourceType: model.ResourceTypeEntry{Resource: "pods", Namespaced: true},
+	}
+	m.quarantine.restore = map[string]string{"app": "web"}
+
+	mdl, cmd := m.handleConfirmOverlayKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	out := mdl.(Model)
+
+	assertSchedulesOne(t, out, cmd)
+	assert.Equal(t, overlayNone, out.overlay)
+	assert.Empty(t, out.pendingAction)
+	require.NotEmpty(t, out.errorLog)
+	assert.Contains(t, out.errorLog[len(out.errorLog)-1].Message, "kubectl patch pod pod-1",
+		"an unrecognized pendingAction must not silently fall through to the regular-delete branch")
+}
+
+func quarantineFakePod() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "pod-1",
+			"namespace": "default",
+			"labels":    map[string]any{"app": "web"},
+		},
+	}}
+}
+
+func TestQuarantinePodCmd_EndToEnd(t *testing.T) {
+	m := baseModelWithFakeDynamic(map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}, quarantineFakePod())
+	m.actionCtx = actionContext{context: "test-ctx", kind: "Pod", name: "pod-1", namespace: "default"}
+
+	cmd := m.quarantinePodCmd([]string{"app"})
+
+	msg, ok := execScheduled(t, m, cmd).(actionResultMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	assert.Contains(t, msg.message, "Quarantined pod-1")
+}
+
+func TestRestorePodCmd_EndToEnd(t *testing.T) {
+	pod := quarantineFakePod()
+	pod.Object["metadata"].(map[string]any)["annotations"] = map[string]any{
+		"lfk.janosmiko.dev/quarantined-labels": `{"app":"web"}`,
+	}
+	m := baseModelWithFakeDynamic(map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	}, pod)
+	m.actionCtx = actionContext{context: "test-ctx", kind: "Pod", name: "pod-1", namespace: "default"}
+
+	cmd := m.restorePodCmd()
+
+	msg, ok := execScheduled(t, m, cmd).(actionResultMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	assert.Contains(t, msg.message, "Restored pod-1")
+}
+
+func TestConfirmEsc_Quarantine_ResetsState(t *testing.T) {
+	m := Model{overlay: overlayConfirm, pendingAction: model.ActionLabelQuarantine}
+	m.quarantine.services = []string{"svc-web"}
+	m.quarantine.keys = []string{"app"}
+
+	mdl, cmd := m.handleConfirmOverlayKey(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	out := mdl.(Model)
+
+	assert.Equal(t, overlayNone, out.overlay)
+	assert.Nil(t, out.quarantine.services)
+	assert.Nil(t, out.quarantine.keys)
+	require.Nil(t, cmd)
+}

--- a/internal/app/view_overlay_confirm.go
+++ b/internal/app/view_overlay_confirm.go
@@ -27,7 +27,13 @@ func (m Model) renderOverlayConfirm() (string, int, int, bool) {
 	// it costs two extra rows when present. Width is settled before anything
 	// is fitted to it.
 	showsPolicy := m.deleteConfirmShowsPolicy()
-	notes := confirmCostNotes(m.buildConfirmCost(showsPolicy, m.pendingAction == "Drain"))
+	var notes []ui.ConfirmNote
+	switch m.pendingAction {
+	case model.ActionLabelQuarantine, model.ActionLabelRestore:
+		notes = quarantineConfirmNotes(m.quarantine, podHasController(m.actionCtx.raw))
+	default:
+		notes = confirmCostNotes(m.buildConfirmCost(showsPolicy, m.pendingAction == "Drain"))
+	}
 	if len(notes) > 0 {
 		// The risk row carries a resource name, which does not fit the
 		// 50-column box a plain y/n question needs.

--- a/internal/k8s/client_quarantine.go
+++ b/internal/k8s/client_quarantine.go
@@ -98,7 +98,8 @@ func (c *Client) QuarantinePod(ctx context.Context, contextName, namespace, name
 	}
 	patchData, err := json.Marshal(map[string]any{
 		"metadata": map[string]any{
-			"labels": labelPatch,
+			"resourceVersion": obj.GetResourceVersion(),
+			"labels":          labelPatch,
 			"annotations": map[string]any{
 				QuarantinedLabelsAnnotation: string(removedJSON),
 			},
@@ -149,7 +150,8 @@ func (c *Client) RestorePod(ctx context.Context, contextName, namespace, name st
 	}
 	patchData, err := json.Marshal(map[string]any{
 		"metadata": map[string]any{
-			"labels": labelPatch,
+			"resourceVersion": obj.GetResourceVersion(),
+			"labels":          labelPatch,
 			"annotations": map[string]any{
 				QuarantinedLabelsAnnotation: nil,
 			},

--- a/internal/k8s/client_quarantine.go
+++ b/internal/k8s/client_quarantine.go
@@ -1,0 +1,156 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/janosmiko/lfk/internal/logger"
+)
+
+// QuarantinedLabelsAnnotation records the label pairs QuarantinePod removed,
+// so RestorePod can put back the exact values later.
+const QuarantinedLabelsAnnotation = "lfk.janosmiko.dev/quarantined-labels"
+
+// ErrNotQuarantined means the pod carries no quarantine annotation, or its
+// value does not parse — RestorePod has nothing to put back.
+var ErrNotQuarantined = errors.New("pod is not quarantined")
+
+// QuarantineTargets finds the Services that route to a pod by its labels,
+// and which label keys their selectors use. A selector-less Service is
+// wired via Endpoints/EndpointSlice, not label matching, so it is skipped.
+func (c *Client) QuarantineTargets(ctx context.Context, contextName, namespace string, podLabels map[string]string) (services []string, keys []string, err error) {
+	cs, err := c.clientsetForContext(contextName)
+	if err != nil {
+		return nil, nil, err
+	}
+	list, err := cs.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing services: %w", err)
+	}
+
+	keySet := make(map[string]struct{})
+	for _, svc := range list.Items {
+		if len(svc.Spec.Selector) == 0 {
+			continue
+		}
+		if !labels.SelectorFromSet(svc.Spec.Selector).Matches(labels.Set(podLabels)) {
+			continue
+		}
+		services = append(services, svc.Name)
+		for k := range svc.Spec.Selector {
+			keySet[k] = struct{}{}
+		}
+	}
+	sort.Strings(services)
+
+	keys = make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return services, keys, nil
+}
+
+// QuarantinePod strips the given label keys from a pod so the Services that
+// select it stop routing traffic there, and records the removed pairs in
+// QuarantinedLabelsAnnotation so RestorePod can put them back exactly.
+func (c *Client) QuarantinePod(ctx context.Context, contextName, namespace, name string, keys []string) (removed map[string]string, err error) {
+	logger.Info("Quarantining pod", "context", contextName, "namespace", namespace, "name", name, "keys", len(keys))
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := dynClient.Resource(podsGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting pod %s: %w", name, err)
+	}
+
+	podLabels := obj.GetLabels()
+	removed = make(map[string]string, len(keys))
+	labelPatch := make(map[string]any, len(keys))
+	for _, k := range keys {
+		if v, ok := podLabels[k]; ok {
+			removed[k] = v
+		}
+		labelPatch[k] = nil
+	}
+
+	removedJSON, err := json.Marshal(removed)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling quarantine annotation: %w", err)
+	}
+	patchData, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": labelPatch,
+			"annotations": map[string]any{
+				QuarantinedLabelsAnnotation: string(removedJSON),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling quarantine patch: %w", err)
+	}
+
+	_, err = dynClient.Resource(podsGVR).Namespace(namespace).Patch(
+		ctx, name, k8stypes.MergePatchType, patchData, metav1.PatchOptions{FieldManager: FieldManager()},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("quarantining pod %s: %w", name, err)
+	}
+	return removed, nil
+}
+
+// RestorePod puts back the label pairs QuarantinePod recorded and clears
+// the annotation, overwriting any key already put back by something else:
+// the annotation is the source of truth for what quarantine took.
+func (c *Client) RestorePod(ctx context.Context, contextName, namespace, name string) (restored map[string]string, err error) {
+	logger.Info("Restoring pod", "context", contextName, "namespace", namespace, "name", name)
+	dynClient, err := c.dynamicForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := dynClient.Resource(podsGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting pod %s: %w", name, err)
+	}
+
+	raw, ok := obj.GetAnnotations()[QuarantinedLabelsAnnotation]
+	if !ok || raw == "" {
+		return nil, ErrNotQuarantined
+	}
+	restored = make(map[string]string)
+	if unmarshalErr := json.Unmarshal([]byte(raw), &restored); unmarshalErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotQuarantined, unmarshalErr)
+	}
+
+	labelPatch := make(map[string]any, len(restored))
+	for k, v := range restored {
+		labelPatch[k] = v
+	}
+	patchData, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": labelPatch,
+			"annotations": map[string]any{
+				QuarantinedLabelsAnnotation: nil,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling restore patch: %w", err)
+	}
+
+	_, err = dynClient.Resource(podsGVR).Namespace(namespace).Patch(
+		ctx, name, k8stypes.MergePatchType, patchData, metav1.PatchOptions{FieldManager: FieldManager()},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("restoring pod %s: %w", name, err)
+	}
+	return restored, nil
+}

--- a/internal/k8s/client_quarantine.go
+++ b/internal/k8s/client_quarantine.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/janosmiko/lfk/internal/logger"
 )
@@ -21,6 +22,15 @@ const QuarantinedLabelsAnnotation = "lfk.janosmiko.dev/quarantined-labels"
 // ErrNotQuarantined means the pod carries no quarantine annotation, or its
 // value does not parse — RestorePod has nothing to put back.
 var ErrNotQuarantined = errors.New("pod is not quarantined")
+
+// ErrTamperedAnnotation means the annotation holds a pair that is not a
+// valid label, or more pairs than a quarantine ever removes — anyone who
+// can edit the pod can edit this annotation too.
+var ErrTamperedAnnotation = errors.New("quarantine annotation is not a valid label set")
+
+// maxRestoredLabelEntries: past this many, an oversized annotation is a
+// tampering signal, not a legitimate restore.
+const maxRestoredLabelEntries = 64
 
 // QuarantineTargets finds the Services that route to a pod by its labels,
 // and which label keys their selectors use. A selector-less Service is
@@ -129,6 +139,9 @@ func (c *Client) RestorePod(ctx context.Context, contextName, namespace, name st
 	if unmarshalErr := json.Unmarshal([]byte(raw), &restored); unmarshalErr != nil {
 		return nil, fmt.Errorf("%w: %w", ErrNotQuarantined, unmarshalErr)
 	}
+	if err := validateRestoredLabels(restored); err != nil {
+		return nil, fmt.Errorf("restoring pod %s: %w", name, err)
+	}
 
 	labelPatch := make(map[string]any, len(restored))
 	for k, v := range restored {
@@ -153,4 +166,27 @@ func (c *Client) RestorePod(ctx context.Context, contextName, namespace, name st
 		return nil, fmt.Errorf("restoring pod %s: %w", name, err)
 	}
 	return restored, nil
+}
+
+// validateRestoredLabels runs before the patch: the annotation is editable
+// by anyone who can edit the pod, so it cannot be trusted unchecked.
+func validateRestoredLabels(restored map[string]string) error {
+	if len(restored) > maxRestoredLabelEntries {
+		return fmt.Errorf("%w: %d entries, more than a quarantine ever removes",
+			ErrTamperedAnnotation, len(restored))
+	}
+	var invalidKeys, invalidValues int
+	for k, v := range restored {
+		if errs := validation.IsQualifiedName(k); len(errs) > 0 {
+			invalidKeys++
+		}
+		if errs := validation.IsValidLabelValue(v); len(errs) > 0 {
+			invalidValues++
+		}
+	}
+	if invalidKeys > 0 || invalidValues > 0 {
+		return fmt.Errorf("%w: %d invalid key(s), %d invalid value(s)",
+			ErrTamperedAnnotation, invalidKeys, invalidValues)
+	}
+	return nil
 }

--- a/internal/k8s/client_quarantine.go
+++ b/internal/k8s/client_quarantine.go
@@ -28,6 +28,16 @@ var ErrNotQuarantined = errors.New("pod is not quarantined")
 // can edit the pod can edit this annotation too.
 var ErrTamperedAnnotation = errors.New("quarantine annotation is not a valid label set")
 
+// ErrTooManyLabels means the keys passed to QuarantinePod would remove more
+// entries than RestorePod's cap allows it to store, so a later restore of
+// this pod would be refused.
+var ErrTooManyLabels = errors.New("quarantine would remove more labels than can be restored")
+
+// ErrAlreadyQuarantined means the pod already carries a quarantine
+// annotation. Patching over it would discard the first set of removed
+// labels, so QuarantinePod refuses instead.
+var ErrAlreadyQuarantined = errors.New("pod is already quarantined")
+
 // maxRestoredLabelEntries: past this many, an oversized annotation is a
 // tampering signal, not a legitimate restore.
 const maxRestoredLabelEntries = 64
@@ -81,6 +91,9 @@ func (c *Client) QuarantinePod(ctx context.Context, contextName, namespace, name
 	if err != nil {
 		return nil, fmt.Errorf("getting pod %s: %w", name, err)
 	}
+	if existing := obj.GetAnnotations()[QuarantinedLabelsAnnotation]; existing != "" {
+		return nil, fmt.Errorf("quarantining pod %s: %w", name, ErrAlreadyQuarantined)
+	}
 
 	podLabels := obj.GetLabels()
 	removed = make(map[string]string, len(keys))
@@ -90,6 +103,10 @@ func (c *Client) QuarantinePod(ctx context.Context, contextName, namespace, name
 			removed[k] = v
 		}
 		labelPatch[k] = nil
+	}
+	if len(removed) > maxRestoredLabelEntries {
+		return nil, fmt.Errorf("quarantining pod %s: %w: %d labels, more than a restore can accept",
+			name, ErrTooManyLabels, len(removed))
 	}
 
 	removedJSON, err := json.Marshal(removed)

--- a/internal/k8s/client_quarantine_test.go
+++ b/internal/k8s/client_quarantine_test.go
@@ -10,10 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestQuarantineTargets_MatchesOnlySelectorServices(t *testing.T) {
@@ -71,6 +75,67 @@ func TestQuarantinePod_StripsKeysAndRecordsAnnotation(t *testing.T) {
 	assert.NotContains(t, obj.GetLabels(), "app")
 	assert.Equal(t, "backend", obj.GetLabels()["tier"])
 	assert.Equal(t, `{"app":"web"}`, obj.GetAnnotations()[QuarantinedLabelsAnnotation])
+}
+
+func TestQuarantinePod_PatchCarriesResourceVersion(t *testing.T) {
+	pod := quarantineTestPod()
+	pod.SetResourceVersion("42")
+	dc := newFakeDynClient(pod)
+
+	var captured k8stesting.PatchAction
+	dc.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		captured = action.(k8stesting.PatchAction)
+		return true, pod, nil
+	})
+	c := newFakeClient(nil, dc)
+
+	_, err := c.QuarantinePod(t.Context(), "", "default", "my-pod", []string{"app"})
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(captured.GetPatch(), &body))
+	metadata, ok := body["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "42", metadata["resourceVersion"])
+}
+
+func TestQuarantinePod_ConflictSurfacesError(t *testing.T) {
+	dc := newFakeDynClient(quarantineTestPod())
+	patchCount := 0
+	dc.PrependReactor("patch", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		patchCount++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, "my-pod", errors.New("stale resourceVersion"))
+	})
+	c := newFakeClient(nil, dc)
+
+	_, err := c.QuarantinePod(t.Context(), "", "default", "my-pod", []string{"app"})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
+	assert.Equal(t, 1, patchCount, "a conflict must not be retried with a second patch")
+}
+
+func TestRestorePod_PatchCarriesResourceVersion(t *testing.T) {
+	pod := quarantineTestPodWithAnnotation(`{"app":"web"}`)
+	pod.SetResourceVersion("99")
+	dc := newFakeDynClient(pod)
+
+	var captured k8stesting.PatchAction
+	dc.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		captured = action.(k8stesting.PatchAction)
+		return true, pod, nil
+	})
+	c := newFakeClient(nil, dc)
+
+	_, err := c.RestorePod(t.Context(), "", "default", "my-pod")
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(captured.GetPatch(), &body))
+	metadata, ok := body["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "99", metadata["resourceVersion"])
 }
 
 func TestRestorePod_RestoresExactPairsAndClearsAnnotation(t *testing.T) {

--- a/internal/k8s/client_quarantine_test.go
+++ b/internal/k8s/client_quarantine_test.go
@@ -200,6 +200,50 @@ func TestRestorePod_RefusesInvalidLabelValue(t *testing.T) {
 	assert.False(t, hasPatchAction(dc), "an invalid value must not reach a patch call")
 }
 
+func quarantineTestPodWithLabels(count int) (*unstructured.Unstructured, []string) {
+	pod := quarantineTestPod()
+	labels := pod.Object["metadata"].(map[string]any)["labels"].(map[string]any)
+	keys := make([]string, 0, count)
+	for i := range count {
+		k := fmt.Sprintf("extra-%d", i)
+		labels[k] = "value"
+		keys = append(keys, k)
+	}
+	return pod, keys
+}
+
+func TestQuarantinePod_AcceptsMaxLabelEntries(t *testing.T) {
+	pod, keys := quarantineTestPodWithLabels(maxRestoredLabelEntries)
+	dc := newFakeDynClient(pod)
+	c := newFakeClient(nil, dc)
+
+	removed, err := c.QuarantinePod(t.Context(), "", "default", "my-pod", keys)
+	require.NoError(t, err)
+	assert.Len(t, removed, maxRestoredLabelEntries)
+	assert.True(t, hasPatchAction(dc))
+}
+
+func TestQuarantinePod_RefusesTooManyLabelEntries(t *testing.T) {
+	pod, keys := quarantineTestPodWithLabels(maxRestoredLabelEntries + 1)
+	dc := newFakeDynClient(pod)
+	c := newFakeClient(nil, dc)
+
+	_, err := c.QuarantinePod(t.Context(), "", "default", "my-pod", keys)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTooManyLabels))
+	assert.False(t, hasPatchAction(dc), "an oversized label set must not reach a patch call")
+}
+
+func TestQuarantinePod_RefusesAlreadyQuarantinedPod(t *testing.T) {
+	dc := newFakeDynClient(quarantineTestPodWithAnnotation(`{"tier":"backend"}`))
+	c := newFakeClient(nil, dc)
+
+	_, err := c.QuarantinePod(t.Context(), "", "default", "my-pod", []string{"app"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAlreadyQuarantined))
+	assert.False(t, hasPatchAction(dc), "an already-quarantined pod must not be patched again")
+}
+
 func TestRestorePod_RefusesOversizedAnnotation(t *testing.T) {
 	pairs := make(map[string]string, maxRestoredLabelEntries+1)
 	for i := range maxRestoredLabelEntries + 1 {

--- a/internal/k8s/client_quarantine_test.go
+++ b/internal/k8s/client_quarantine_test.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -93,4 +96,58 @@ func TestRestorePod_NoAnnotation_ReturnsErrNotQuarantined(t *testing.T) {
 
 	_, err := c.RestorePod(t.Context(), "", "default", "my-pod")
 	assert.True(t, errors.Is(err, ErrNotQuarantined))
+}
+
+func quarantineTestPodWithAnnotation(rawAnnotation string) *unstructured.Unstructured {
+	pod := quarantineTestPod()
+	pod.Object["metadata"].(map[string]any)["annotations"] = map[string]any{
+		QuarantinedLabelsAnnotation: rawAnnotation,
+	}
+	return pod
+}
+
+func hasPatchAction(dc *dynamicfake.FakeDynamicClient) bool {
+	for _, action := range dc.Actions() {
+		if action.GetVerb() == "patch" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRestorePod_RefusesInvalidLabelKey(t *testing.T) {
+	dc := newFakeDynClient(quarantineTestPodWithAnnotation(`{"bad key!":"value"}`))
+	c := newFakeClient(nil, dc)
+
+	_, err := c.RestorePod(t.Context(), "", "default", "my-pod")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTamperedAnnotation))
+	assert.False(t, hasPatchAction(dc), "an invalid key must not reach a patch call")
+}
+
+func TestRestorePod_RefusesInvalidLabelValue(t *testing.T) {
+	dc := newFakeDynClient(quarantineTestPodWithAnnotation(`{"app":"has spaces"}`))
+	c := newFakeClient(nil, dc)
+
+	_, err := c.RestorePod(t.Context(), "", "default", "my-pod")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTamperedAnnotation))
+	assert.False(t, hasPatchAction(dc), "an invalid value must not reach a patch call")
+}
+
+func TestRestorePod_RefusesOversizedAnnotation(t *testing.T) {
+	pairs := make(map[string]string, maxRestoredLabelEntries+1)
+	for i := range maxRestoredLabelEntries + 1 {
+		pairs[fmt.Sprintf("key-%d", i)] = "value"
+	}
+	raw, err := json.Marshal(pairs)
+	require.NoError(t, err)
+
+	dc := newFakeDynClient(quarantineTestPodWithAnnotation(string(raw)))
+	c := newFakeClient(nil, dc)
+
+	_, err = c.RestorePod(t.Context(), "", "default", "my-pod")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTamperedAnnotation))
+	assert.False(t, hasPatchAction(dc), "an oversized annotation must not reach a patch call")
 }

--- a/internal/k8s/client_quarantine_test.go
+++ b/internal/k8s/client_quarantine_test.go
@@ -1,0 +1,96 @@
+package k8s
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestQuarantineTargets_MatchesOnlySelectorServices(t *testing.T) {
+	podLabels := map[string]string{"app": "web", "tier": "backend"}
+
+	cs := k8sfake.NewClientset(
+		&corev1.Service{
+			Name: "svc-match", Namespace: "default",
+			Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+		},
+		&corev1.Service{
+			Name: "svc-nomatch", Namespace: "default",
+			Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "other"}},
+		},
+		&corev1.Service{
+			Name: "svc-manual-endpoints", Namespace: "default",
+			Spec: corev1.ServiceSpec{Selector: map[string]string{}},
+		},
+	)
+	c := newFakeClient(cs, nil)
+
+	services, keys, err := c.QuarantineTargets(t.Context(), "", "default", podLabels)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"svc-match"}, services)
+	assert.Equal(t, []string{"app"}, keys)
+}
+
+func quarantineTestPod() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      "my-pod",
+				"namespace": "default",
+				"labels": map[string]any{
+					"app":  "web",
+					"tier": "backend",
+				},
+			},
+		},
+	}
+}
+
+func TestQuarantinePod_StripsKeysAndRecordsAnnotation(t *testing.T) {
+	dc := newFakeDynClient(quarantineTestPod())
+	c := newFakeClient(nil, dc)
+
+	removed, err := c.QuarantinePod(t.Context(), "", "default", "my-pod", []string{"app"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "web"}, removed)
+
+	obj, err := dc.Resource(podsGVR).Namespace("default").Get(t.Context(), "my-pod", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, obj.GetLabels(), "app")
+	assert.Equal(t, "backend", obj.GetLabels()["tier"])
+	assert.Equal(t, `{"app":"web"}`, obj.GetAnnotations()[QuarantinedLabelsAnnotation])
+}
+
+func TestRestorePod_RestoresExactPairsAndClearsAnnotation(t *testing.T) {
+	dc := newFakeDynClient(quarantineTestPod())
+	c := newFakeClient(nil, dc)
+
+	_, err := c.QuarantinePod(t.Context(), "", "default", "my-pod", []string{"app"})
+	require.NoError(t, err)
+
+	restored, err := c.RestorePod(t.Context(), "", "default", "my-pod")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "web"}, restored)
+
+	obj, err := dc.Resource(podsGVR).Namespace("default").Get(t.Context(), "my-pod", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "web", "tier": "backend"}, obj.GetLabels())
+	assert.NotContains(t, obj.GetAnnotations(), QuarantinedLabelsAnnotation)
+}
+
+func TestRestorePod_NoAnnotation_ReturnsErrNotQuarantined(t *testing.T) {
+	dc := newFakeDynClient(quarantineTestPod())
+	c := newFakeClient(nil, dc)
+
+	_, err := c.RestorePod(t.Context(), "", "default", "my-pod")
+	assert.True(t, errors.Is(err, ErrNotQuarantined))
+}

--- a/internal/model/actions.go
+++ b/internal/model/actions.go
@@ -63,6 +63,14 @@ func ActionsForKind(kind string) []ActionMenuItem {
 // applies elsewhere. Exported so the app-layer dispatcher can switch on it.
 const ActionLabelExportTemplate = "Export Template"
 
+// ActionLabelQuarantine and ActionLabelRestore are exported so the app-layer
+// dispatcher and the menu-item rewrite (Quarantine <-> Restore) can switch
+// on them without repeating the label strings.
+const (
+	ActionLabelQuarantine = "Quarantine"
+	ActionLabelRestore    = "Restore"
+)
+
 // exportTemplateAction is appended to every kind's menu: any object can be
 // turned into a template, and the export writes nothing to the cluster, so it
 // is not gated by read-only mode.
@@ -130,6 +138,7 @@ func actionsForCoreKind(kind string) ([]ActionMenuItem, bool) {
 			{Label: "Edit", Description: "Edit resource YAML", Key: "E"},
 			{Label: "Right-sizing", Description: "Per-container CPU/Mem recommendations", Key: "z"},
 			{Label: "Resize", Description: "Resize container CPU/memory in place", Key: "r"},
+			{Label: ActionLabelQuarantine, Description: "Remove the labels that put this pod behind its Services", Key: "Q"},
 			{Label: "Security Findings", Description: "List security findings for this resource", Key: "y"},
 			{Label: "Delete", Description: "Delete this pod", Key: "D"},
 			{Label: "Force Delete", Description: "Force delete this pod", Key: "X"},

--- a/internal/model/actions_quarantine_test.go
+++ b/internal/model/actions_quarantine_test.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionsForKind_PodHasQuarantine(t *testing.T) {
+	items := ActionsForKind("Pod")
+
+	var found *ActionMenuItem
+	for i := range items {
+		if items[i].Label == ActionLabelQuarantine {
+			found = &items[i]
+			continue
+		}
+		assert.NotEqual(t, "Q", items[i].Key, "another Pod action already uses key Q: %q", items[i].Label)
+	}
+	if assert.NotNil(t, found, "Pod menu is missing the Quarantine action") {
+		assert.Equal(t, "Q", found.Key)
+	}
+}


### PR DESCRIPTION
## Summary
- New pod action Quarantine (`Q`): removes only the label keys that a Service selector in the namespace matches, so traffic moves elsewhere while exec, logs and a heap dump stay available. Services with an empty selector are skipped. A pod no selector matches reports "nothing to quarantine" and makes no patch.
- The confirm box names every Service that stops routing to the pod and states that a controller-owned pod gets a replacement. The removed pairs are stored in the `lfk.janosmiko.dev/quarantined-labels` annotation, so the same key shows Restore afterwards and works after an lfk restart or from kubectl.
- Restore puts back exactly the recorded pairs and clears the annotation. It refuses an annotation whose entries are not valid label syntax or that holds more than 64 pairs, since anyone who can edit the pod can write it. Both actions are mutating and refused in read-only mode.

## Test plan
- [x] `go test -race ./...` (selector matching, both patches via fake client, restore round trip and refusals, confirm notes, read-only gate, no-match path)
- [x] `golangci-lint run ./...`, app.go at 799 lines
- [ ] Manual on a cluster: quarantine a Deployment pod, watch the ReplicaSet add a replacement, restore it