### PR TITLE
docs: state why the cluster history maps are updated in place

### DIFF
--- a/internal/app/metrics_series.go
+++ b/internal/app/metrics_series.go
@@ -24,6 +24,12 @@ const sparklineColumnCap = 20
 // metricsSeriesCache holds the CPU and memory history the current sparkline
 // mode draws from, keyed the same way the instant metrics maps are:
 // "namespace/pod" for pods, node name for nodes.
+//
+// The maps are updated in place on purpose. The cache is model-wide, not part
+// of TabState, and no goroutine or rendered frame keeps an earlier Model, so
+// no snapshot can observe a later write. Copy on write would allocate on
+// every metrics tick, times the member count of a union dashboard.
+// TestMetricsSeriesCacheIsNotSnapshottedPerTab guards the premise.
 type metricsSeriesCache struct {
 	// cpu and mem hold either pod or node series depending on which list is
 	// active, never both: a "namespace/pod" key always contains a slash and a

--- a/internal/app/metrics_series_snapshot_test.go
+++ b/internal/app/metrics_series_snapshot_test.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// metricsSeriesCache mutates its maps in place. That is only safe while no
+// retained copy of the Model can observe the write, which holds as long as the
+// cache is not carried by TabState. Adding it there means the maps must become
+// copy on write first.
+func TestMetricsSeriesCacheIsNotSnapshottedPerTab(t *testing.T) {
+	cacheType := reflect.TypeFor[metricsSeriesCache]()
+	for f := range reflect.TypeFor[TabState]().Fields() {
+		assert.NotEqual(t, cacheType, f.Type,
+			"TabState.%s snapshots the series cache; make its maps copy on write before keeping this", f.Name)
+	}
+}

--- a/internal/app/metrics_series_snapshot_test.go
+++ b/internal/app/metrics_series_snapshot_test.go
@@ -14,7 +14,8 @@ import (
 func TestMetricsSeriesCacheIsNotSnapshottedPerTab(t *testing.T) {
 	cacheType := reflect.TypeFor[metricsSeriesCache]()
 	for f := range reflect.TypeFor[TabState]().Fields() {
-		assert.NotEqual(t, cacheType, f.Type,
+		held := f.Type == cacheType || f.Type == reflect.PointerTo(cacheType)
+		assert.False(t, held,
 			"TabState.%s snapshots the series cache; make its maps copy on write before keeping this", f.Name)
 	}
 }


### PR DESCRIPTION
## Summary
- An automated review flagged the two in-place map writes in updateClusterMetricsRange against the immutability rule. Checked: the series cache is model-wide, not part of TabState, and no goroutine or rendered frame keeps an earlier Model, so no retained snapshot can observe a later write. Copy on write would allocate on every metrics tick, times the member count of a union dashboard.
- Decision: keep the in-place update, as the Go language note in the coding style rule allows. The type comment now says why.
- A test guards the premise: if the cache is ever added to TabState, it fails and asks for copy on write first.

## Test plan
- [x] `go test ./internal/app/ -run TestMetricsSeriesCacheIsNotSnapshottedPerTab`
- [x] `golangci-lint run ./internal/app/`