### PR TITLE
test: restore ui.ConfigDashboard after the preview-loading coverage tests

### DIFF
--- a/internal/app/commands_load_preview_test.go
+++ b/internal/app/commands_load_preview_test.go
@@ -31,19 +31,25 @@ func TestCovBoost2LoadPreviewClusters(t *testing.T) {
 }
 
 func TestCovBoost2LoadPreviewRTOverview(t *testing.T) {
+	orig := ui.ConfigDashboard
+	ui.ConfigDashboard = true
+	t.Cleanup(func() { ui.ConfigDashboard = orig })
+
 	m := baseModelBoost2()
 	m.nav.Level = model.LevelResourceTypes
 	m.middleItems = []model.Item{{Name: "Cluster Dashboard", Extra: "__overview__"}}
-	ui.ConfigDashboard = true
 	cmd := m.loadPreview()
 	assert.NotNil(t, cmd)
 }
 
 func TestCovBoost2LoadPreviewRTOverviewDisabled(t *testing.T) {
+	orig := ui.ConfigDashboard
+	ui.ConfigDashboard = false
+	t.Cleanup(func() { ui.ConfigDashboard = orig })
+
 	m := baseModelBoost2()
 	m.nav.Level = model.LevelResourceTypes
 	m.middleItems = []model.Item{{Name: "Cluster Dashboard", Extra: "__overview__"}}
-	ui.ConfigDashboard = false
 	cmd := m.loadPreview()
 	assert.Nil(t, cmd)
 }
@@ -201,10 +207,13 @@ func TestCovLoadPreviewClusters(t *testing.T) {
 }
 
 func TestCovLoadPreviewResourceTypesOverview(t *testing.T) {
+	orig := ui.ConfigDashboard
+	ui.ConfigDashboard = true
+	t.Cleanup(func() { ui.ConfigDashboard = orig })
+
 	m := baseModelWithFakeClient()
 	m.nav.Level = model.LevelResourceTypes
 	m = withMiddleItem(m, model.Item{Extra: "__overview__"})
-	ui.ConfigDashboard = true
 	cmd := m.loadPreview()
 	assert.NotNil(t, cmd)
 }

--- a/internal/app/idle_render_loop_test.go
+++ b/internal/app/idle_render_loop_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
 )
 
 // A previewLoading flag that clearRight() arms and no handler clears leaves the
@@ -143,6 +144,13 @@ func TestUserRefreshArmsPreviewLoading(t *testing.T) {
 // the cluster dashboard, the page issue #646 reports.
 func runResourceTypesRefresh(t *testing.T, silent bool) (Model, tea.Cmd) {
 	t.Helper()
+	// The cluster-dashboard overview row only dispatches a preview load when
+	// this is on (commands_load_preview.go). Pinned explicitly so this test
+	// is hermetic under -shuffle regardless of what other tests leave behind.
+	orig := ui.ConfigDashboard
+	ui.ConfigDashboard = true
+	t.Cleanup(func() { ui.ConfigDashboard = orig })
+
 	m := newTestModelWithScheduler()
 	m.nav.Level = model.LevelResourceTypes
 	m.nav.Context = "test-ctx"


### PR DESCRIPTION
## Summary
- `go test -shuffle=on ./internal/app/` failed on some seeds in TestUserRefreshArmsPreviewLoading and TestSilentRefreshDoesNotArmPreviewLoading. Root cause: three coverage tests in commands_load_preview_test.go set ui.ConfigDashboard and never restored it. When the disabling one ran first, loadPreviewResourceTypes returned no command and previewLoading never armed. The pinned-summaries lead in the task was a red herring.
- The three tests now save and restore the flag with t.Cleanup, and the shared refresh helper pins it so both victims pass in any order.
- Seed 1789019658580745000 reproduced the failure and passes now. Ten shuffled runs: the two tests never failed. An unrelated header-click sort flake in update_mouse_test.go showed up twice and is tracked separately.

## Test plan
- [x] `go test -shuffle=1789019658580745000 -count=1 ./internal/app/`
- [x] `go test -race ./internal/app/`
- [x] `golangci-lint run ./internal/app/`