### PR TITLE
feat: show what constrains the selected object

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Cloudsmith is a hosted package management service that stores and serves package
 - Object Explorer with `O` for the live object: [keybindings.md](docs/keybindings.md#object-explorer)
 - API Explorer with `I` for the resource schema: [keybindings.md](docs/keybindings.md#api-explorer)
 - Describe with `v`, relationship map with `M`, events with `V` plus warnings-only and grouping toggles: [keybindings.md](docs/keybindings.md#actions)
+- Constraints view with `b`: quotas, PDBs, priority, node placement, and webhooks that would block or admit the resource: [keybindings.md](docs/keybindings.md#constraints-view)
 
 ### Logs and shells
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -501,6 +501,7 @@
         "toggle_rare": { "type": "string" },
         "orphan_overlay": { "type": "string" },
         "session_manager": { "type": "string" },
+        "constraints": { "type": "string" },
         "namespace_selector": { "type": "string" },
         "all_namespaces": { "type": "string" },
         "action_menu": { "type": "string" },

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -531,7 +531,7 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 
 ## Constraints View
 
-Press `b` on a resource to see what constrains it: ResourceQuotas and LimitRanges against its container requests, PodDisruptionBudgets, its PriorityClass and any preemption events, node selector / affinity / taint mismatches, and admission webhooks that would intercept it. A row that names no single object (a node selector or affinity mismatch) can't be jumped to; a row for a real object (quota, PDB, PriorityClass, node, webhook config) can. Sources denied by RBAC are named in a banner instead of being silently omitted.
+Press `b` on a resource to see what constrains it: ResourceQuotas and LimitRanges against its container requests, PodDisruptionBudgets, its PriorityClass and any preemption events, node selector / affinity / taint mismatches, and admission webhooks that would intercept it. A row that names no single object (a node selector or affinity mismatch) can't be jumped to; a row for a real object (quota, PDB, PriorityClass, node, webhook config) can. Sources denied by RBAC are named in a `skipped (denied: ...)` banner instead of being silently omitted. A source that broke for any other reason is named as `failed: ...` in the same banner, and the rows other sources found stay visible, so a short list means unread sources, not absent constraints.
 
 | Key | Action |
 |---|---|

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -85,6 +85,7 @@ chords, which all start with `g`; re-point the ones you use at the new prefix.
 | `O` | Object Explorer (browse the selected resource's live object as a drill-in tree) |
 | `U` | RBAC permissions browser (can-i) |
 | `Shift+Z` | Open the cluster-wide Orphan overview |
+| `b` | What constrains this object (quotas, PDBs, priority, node placement, webhooks) |
 | `C` | Session manager (save/switch/delete named workspace sessions) |
 | `Ctrl+G` | Finalizer search and remove |
 | `!` | Error log |
@@ -526,6 +527,20 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 | `>` | Toggle line wrapping (configurable via `toggle_wrap`) |
 | `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `F1` | Full help |
+| `q` / `Esc` | Back to explorer |
+
+## Constraints View
+
+Press `b` on a resource to see what constrains it: ResourceQuotas and LimitRanges against its container requests, PodDisruptionBudgets, its PriorityClass and any preemption events, node selector / affinity / taint mismatches, and admission webhooks that would intercept it. A row that names no single object (a node selector or affinity mismatch) can't be jumped to; a row for a real object (quota, PDB, PriorityClass, node, webhook config) can. Sources denied by RBAC are named in a banner instead of being silently omitted.
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Move cursor down / up |
+| `g` / `G` | Jump to top / bottom |
+| `Ctrl+D` / `Ctrl+U` | Half page down / up |
+| `Enter` | Jump to the row's object |
+| `R` | Re-run the scan |
+| `?` | Which-key panel for this view — see [Which-Key Panel](#which-key-panel) |
 | `q` / `Esc` | Back to explorer |
 
 ## Log Viewer

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -331,6 +331,9 @@ type Model struct {
 	// but showing actual values. Driven entirely from objectexplorer.go.
 	objectExplorerView objectExplorerState
 
+	// Full-screen "what constrains this object" view. See constraintsview.go.
+	constraints constraintsViewState
+
 	// objectExplorerReturnMode is the mode the Object Explorer returns to on
 	// q/esc. It is the explorer by default but the YAML viewer when the Object
 	// Explorer was opened from there (P), so closing returns to the opener.
@@ -783,14 +786,8 @@ type Model struct {
 	// canIState (embedded, not named) — Can-I/Who-Can RBAC explorer state. See cani_state.go.
 	canIState
 
-	// Finalizer search overlay state.
-	finalizerSearchPattern      string
-	finalizerSearchResults      []k8s.FinalizerMatch
-	finalizerSearchCursor       int
-	finalizerSearchSelected     map[string]bool // "ns/kind/name" keys
-	finalizerSearchLoading      bool
-	finalizerSearchFilter       string
-	finalizerSearchFilterActive bool
+	// Finalizer search overlay state. See finalizerSearchState in app_types.go.
+	finalizerSearch finalizerSearchState
 	// Column toggle overlay state. See columnToggleState in update_column_toggle.go.
 	columnToggleState
 	// Easter egg state (Konami, nyan, credits, kubetris).

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -32,6 +32,7 @@ const (
 	modeCredits
 	modeObjectExplorer
 	modeLogTop
+	modeConstraints
 )
 
 // wheelBurst tracks a single mouse/trackpad wheel burst. Trackpad momentum
@@ -360,6 +361,19 @@ const (
 	bookmarkModeConfirmDeleteAll
 )
 
+// finalizerSearchState groups the finalizer-search overlay's fields so
+// they live together on Model without bloating the main struct over the
+// file-length cap. Mirrors kvEditorSearchState.
+type finalizerSearchState struct {
+	pattern      string
+	results      []k8s.FinalizerMatch
+	cursor       int
+	selected     map[string]bool // "ns/kind/name" keys
+	loading      bool
+	filter       string
+	filterActive bool
+}
+
 // kvEditorSearchState backs the / search + multi-row selection +
 // Shift+Y format-picker for the K/V editor overlays (secret,
 // configmap, label). All state lives here because only one editor
@@ -641,6 +655,9 @@ type TabState struct {
 	logTopFilterQuery string
 	logTopColOrder    []string
 	logTopColHidden   []string // serialized (sorted key) form of the runtime colHidden map[string]bool
+
+	// Full-screen constraints view state (per-tab). See constraintsview.go.
+	constraints constraintsViewState
 
 	// Security feature state — per-tab so two tabs pointing at different
 	// clusters keep their own source manager and availability map.

--- a/internal/app/commands_builtin.go
+++ b/internal/app/commands_builtin.go
@@ -3,12 +3,12 @@ package app
 // openFinalizerSearch opens the finalizer search overlay in search prompt mode.
 // The user types a pattern and presses enter to start scanning.
 func (m *Model) openFinalizerSearch() {
-	m.finalizerSearchPattern = ""
-	m.finalizerSearchResults = nil
-	m.finalizerSearchSelected = make(map[string]bool)
-	m.finalizerSearchCursor = 0
-	m.finalizerSearchFilter = ""
-	m.finalizerSearchFilterActive = true // start in search/input mode
-	m.finalizerSearchLoading = false
+	m.finalizerSearch.pattern = ""
+	m.finalizerSearch.results = nil
+	m.finalizerSearch.selected = make(map[string]bool)
+	m.finalizerSearch.cursor = 0
+	m.finalizerSearch.filter = ""
+	m.finalizerSearch.filterActive = true // start in search/input mode
+	m.finalizerSearch.loading = false
 	m.overlay = overlayFinalizerSearch
 }

--- a/internal/app/commands_constraints.go
+++ b/internal/app/commands_constraints.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"context"
+	"errors"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
+)
+
+var errConstraintsNoClient = errors.New("no cluster client available")
+
+// constraintsLoadedMsg carries a DetectConstraints result. gen guards
+// against a reply landing on a view the user has since closed and
+// reopened for a different object.
+type constraintsLoadedMsg struct {
+	gen    uint64
+	report k8s.ConstraintReport
+	err    error
+}
+
+// loadConstraints fetches every constraint source for m.constraints.target.
+func (m Model) loadConstraints(name string) tea.Cmd {
+	client := m.client
+	kubeCtx := m.nav.Context
+	target := m.constraints.target
+	gen := m.constraints.gen
+	if client == nil {
+		return func() tea.Msg { return constraintsLoadedMsg{gen: gen, err: errConstraintsNoClient} }
+	}
+	return m.scheduleK8sCall(
+		scheduler.PriorityHigh,
+		scheduler.KindResourceTree,
+		"Constraints: "+name,
+		bgtaskTarget(kubeCtx, target.Namespace),
+		func(ctx context.Context) tea.Msg {
+			report, err := client.DetectConstraints(ctx, kubeCtx, target)
+			return constraintsLoadedMsg{gen: gen, report: report, err: err}
+		},
+	)
+}
+
+//nolint:unparam // consistent message handler signature, the caller passes the Cmd on
+func (m Model) updateConstraintsLoaded(msg constraintsLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.constraints.gen {
+		return m, nil
+	}
+	m.constraints.loading = false
+	m.constraints.err = msg.err
+	m.constraints.report = msg.report
+	m.constraints.clampCursor()
+	return m, nil
+}

--- a/internal/app/commands_constraints.go
+++ b/internal/app/commands_constraints.go
@@ -13,10 +13,11 @@ import (
 var errConstraintsNoClient = errors.New("no cluster client available")
 
 // constraintsLoadedMsg carries a DetectConstraints result. gen guards
-// against a reply landing on a view the user has since closed and
-// reopened for a different object.
+// against a reply landing on a view reopened for another object, tabUID
+// against one landing on another tab, as gen is only unique per tab.
 type constraintsLoadedMsg struct {
 	gen    uint64
+	tabUID uint64
 	report k8s.ConstraintReport
 	err    error
 }
@@ -24,11 +25,12 @@ type constraintsLoadedMsg struct {
 // loadConstraints fetches every constraint source for m.constraints.target.
 func (m Model) loadConstraints(name string) tea.Cmd {
 	client := m.client
-	kubeCtx := m.nav.Context
+	kubeCtx := m.effectiveContext()
 	target := m.constraints.target
 	gen := m.constraints.gen
+	tabUID := m.currentTabUID()
 	if client == nil {
-		return func() tea.Msg { return constraintsLoadedMsg{gen: gen, err: errConstraintsNoClient} }
+		return func() tea.Msg { return constraintsLoadedMsg{gen: gen, tabUID: tabUID, err: errConstraintsNoClient} }
 	}
 	return m.scheduleK8sCall(
 		scheduler.PriorityHigh,
@@ -37,19 +39,20 @@ func (m Model) loadConstraints(name string) tea.Cmd {
 		bgtaskTarget(kubeCtx, target.Namespace),
 		func(ctx context.Context) tea.Msg {
 			report, err := client.DetectConstraints(ctx, kubeCtx, target)
-			return constraintsLoadedMsg{gen: gen, report: report, err: err}
+			return constraintsLoadedMsg{gen: gen, tabUID: tabUID, report: report, err: err}
 		},
 	)
 }
 
 //nolint:unparam // consistent message handler signature, the caller passes the Cmd on
 func (m Model) updateConstraintsLoaded(msg constraintsLoadedMsg) (tea.Model, tea.Cmd) {
-	if msg.gen != m.constraints.gen {
+	if msg.gen != m.constraints.gen || msg.tabUID != m.currentTabUID() {
 		return m, nil
 	}
 	m.constraints.loading = false
 	m.constraints.err = msg.err
 	m.constraints.report = msg.report
 	m.constraints.clampCursor()
+	m.constraints.clampScroll(m.constraintsViewportHeight())
 	return m, nil
 }

--- a/internal/app/commands_constraints_test.go
+++ b/internal/app/commands_constraints_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/janosmiko/lfk/internal/app/scheduler"
@@ -14,4 +15,35 @@ func TestLoadConstraints_SchedulesOneCall(t *testing.T) {
 	m.constraints.target = k8s.ConstraintTarget{Namespace: "default"}
 
 	assertSchedulesOne(t, m, m.loadConstraints("pod-1"))
+}
+
+func TestUpdateConstraintsLoaded_PartialReportShowsBannerAndRows(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.constraints.loading = true
+	m.constraints.title = "web-1"
+	msg := constraintsLoadedMsg{
+		gen: m.constraints.gen,
+		report: k8s.ConstraintReport{
+			Rows: []k8s.ConstraintRow{{
+				Source: "Quota", Kind: "ResourceQuota", Namespace: "default", Name: "compute-quota",
+				Detail: "requests 500m cpu", Headroom: "1",
+			}},
+			Skipped: []string{"poddisruptionbudgets"},
+		},
+	}
+
+	result, _ := m.updateConstraintsLoaded(msg)
+	updated, ok := result.(Model)
+	if !ok {
+		t.Fatalf("expected Model, got %T", result)
+	}
+
+	out := stripANSI(updated.View().Content)
+	if !strings.Contains(out, "poddisruptionbudgets") {
+		t.Errorf("expected the banner to name the skipped source, got:\n%s", out)
+	}
+	if !strings.Contains(out, "compute-quota") {
+		t.Errorf("expected the surviving row to still render, got:\n%s", out)
+	}
 }

--- a/internal/app/commands_constraints_test.go
+++ b/internal/app/commands_constraints_test.go
@@ -17,13 +17,70 @@ func TestLoadConstraints_SchedulesOneCall(t *testing.T) {
 	assertSchedulesOne(t, m, m.loadConstraints("pod-1"))
 }
 
+func TestUpdateConstraintsLoaded_RejectsAnotherTabsResult(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.tabs = []TabState{m.cloneCurrentTab()}
+	m.activeTab = 0
+	m.constraints.loading = true
+
+	msg := constraintsLoadedMsg{
+		gen:    m.constraints.gen,
+		tabUID: m.currentTabUID() + 1,
+		report: k8s.ConstraintReport{
+			Rows: []k8s.ConstraintRow{{Source: "Quota", Name: "from-other-tab"}},
+		},
+	}
+
+	result, _ := m.updateConstraintsLoaded(msg)
+	updated, ok := result.(Model)
+	if !ok {
+		t.Fatalf("expected Model, got %T", result)
+	}
+	if len(updated.constraints.report.Rows) != 0 {
+		t.Errorf("a same-generation result from another tab must not apply, got %+v", updated.constraints.report.Rows)
+	}
+	if !updated.constraints.loading {
+		t.Error("the pending load must stay pending when a foreign result is dropped")
+	}
+}
+
+func TestUpdateConstraintsLoaded_ClampsScrollToTheRefreshedReport(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.constraints.scroll = 40
+	m.constraints.cursor = 40
+
+	msg := constraintsLoadedMsg{
+		gen:    m.constraints.gen,
+		tabUID: m.currentTabUID(),
+		report: k8s.ConstraintReport{
+			Rows: []k8s.ConstraintRow{{Source: "Quota", Name: "only-row"}},
+		},
+	}
+
+	result, _ := m.updateConstraintsLoaded(msg)
+	updated, ok := result.(Model)
+	if !ok {
+		t.Fatalf("expected Model, got %T", result)
+	}
+	if updated.constraints.scroll != 0 {
+		t.Errorf("scroll = %d, want 0 for a one-row report", updated.constraints.scroll)
+	}
+	// A scroll past the last row makes the renderer's row count negative.
+	if out := stripANSI(updated.View().Content); !strings.Contains(out, "only-row") {
+		t.Errorf("expected the surviving row to render, got:\n%s", out)
+	}
+}
+
 func TestUpdateConstraintsLoaded_PartialReportShowsBannerAndRows(t *testing.T) {
 	m := basePush80Model()
 	m.mode = modeConstraints
 	m.constraints.loading = true
 	m.constraints.title = "web-1"
 	msg := constraintsLoadedMsg{
-		gen: m.constraints.gen,
+		gen:    m.constraints.gen,
+		tabUID: m.currentTabUID(),
 		report: k8s.ConstraintReport{
 			Rows: []k8s.ConstraintRow{{
 				Source: "Quota", Kind: "ResourceQuota", Namespace: "default", Name: "compute-quota",

--- a/internal/app/commands_constraints_test.go
+++ b/internal/app/commands_constraints_test.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/janosmiko/lfk/internal/app/scheduler"
+	"github.com/janosmiko/lfk/internal/k8s"
+)
+
+func TestLoadConstraints_SchedulesOneCall(t *testing.T) {
+	m := basePush80Model()
+	m.scheduler = scheduler.New(0)
+	m.scheduler.StopWorkers()
+	m.constraints.target = k8s.ConstraintTarget{Namespace: "default"}
+
+	assertSchedulesOne(t, m, m.loadConstraints("pod-1"))
+}

--- a/internal/app/commands_finalizer.go
+++ b/internal/app/commands_finalizer.go
@@ -50,12 +50,12 @@ func (m Model) searchFinalizers(pattern string) tea.Cmd {
 func (m Model) bulkRemoveFinalizer() tea.Cmd {
 	client := m.client
 	kctx := m.nav.Context
-	selected := make(map[string]bool, len(m.finalizerSearchSelected))
-	maps.Copy(selected, m.finalizerSearchSelected)
+	selected := make(map[string]bool, len(m.finalizerSearch.selected))
+	maps.Copy(selected, m.finalizerSearch.selected)
 
 	// Collect the matching results for selected items.
 	var targets []finalizerTarget
-	for _, result := range m.finalizerSearchResults {
+	for _, result := range m.finalizerSearch.results {
 		key := finalizerMatchKey(result)
 		if selected[key] {
 			targets = append(targets, finalizerTarget{match: result})

--- a/internal/app/commands_finalizer_test.go
+++ b/internal/app/commands_finalizer_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestCovBulkRemoveFinalizer(t *testing.T) {
 	m := baseModelWithFakeClient()
-	m.finalizerSearchResults = []k8s.FinalizerMatch{
+	m.finalizerSearch.results = []k8s.FinalizerMatch{
 		{Namespace: "default", Kind: "Pod", Name: "pod-1", Matched: "test/finalizer"},
 		{Namespace: "default", Kind: "Pod", Name: "pod-2", Matched: "test/finalizer"},
 	}
-	m.finalizerSearchSelected = map[string]bool{
+	m.finalizerSearch.selected = map[string]bool{
 		"default/Pod/pod-1": true,
 	}
 	cmd := m.bulkRemoveFinalizer()
@@ -29,10 +29,10 @@ func TestCovBulkRemoveFinalizer(t *testing.T) {
 
 func TestCovBulkRemoveFinalizerNoneSelected(t *testing.T) {
 	m := baseModelWithFakeClient()
-	m.finalizerSearchResults = []k8s.FinalizerMatch{
+	m.finalizerSearch.results = []k8s.FinalizerMatch{
 		{Namespace: "default", Kind: "Pod", Name: "pod-1", Matched: "test/finalizer"},
 	}
-	m.finalizerSearchSelected = map[string]bool{}
+	m.finalizerSearch.selected = map[string]bool{}
 	cmd := m.bulkRemoveFinalizer()
 	msg := execCmd(t, cmd)
 	result, ok := msg.(finalizerRemoveResultMsg)

--- a/internal/app/constraintsview.go
+++ b/internal/app/constraintsview.go
@@ -32,3 +32,10 @@ func (s *constraintsViewState) clampCursor() {
 		s.cursor = 0
 	}
 }
+
+// clampScroll keeps the window inside a report that shrank under it. A
+// scroll past the last row makes the renderer's row count negative.
+func (s *constraintsViewState) clampScroll(viewportHeight int) {
+	maxScroll := max(len(s.visibleRows())-max(viewportHeight, 1), 0)
+	s.scroll = min(max(s.scroll, 0), maxScroll)
+}

--- a/internal/app/constraintsview.go
+++ b/internal/app/constraintsview.go
@@ -1,0 +1,34 @@
+package app
+
+import "github.com/janosmiko/lfk/internal/k8s"
+
+// constraintsViewState backs the fullscreen "what constrains this
+// object" view (modeConstraints). Mirrors describeViewState/diffViewState.
+type constraintsViewState struct {
+	report     k8s.ConstraintReport
+	loading    bool
+	err        error
+	cursor     int
+	scroll     int
+	returnMode viewMode
+	title      string
+	name       string // the object's own name, so kb.Refresh can re-issue the load
+	target     k8s.ConstraintTarget
+	// gen guards a load result against a superseded open — bumped on every
+	// loadConstraints dispatch, echoed back by constraintsLoadedMsg.
+	gen uint64
+}
+
+func (s constraintsViewState) visibleRows() []k8s.ConstraintRow {
+	return s.report.Rows
+}
+
+func (s *constraintsViewState) clampCursor() {
+	last := len(s.visibleRows()) - 1
+	switch {
+	case s.cursor > last:
+		s.cursor = last
+	case s.cursor < 0:
+		s.cursor = 0
+	}
+}

--- a/internal/app/overlay_hintbar_overlays.go
+++ b/internal/app/overlay_hintbar_overlays.go
@@ -279,7 +279,7 @@ func (m Model) overlayHintBarOverlayLabelEditor() string {
 }
 
 func (m Model) overlayHintBarOverlayFinalizerSearch() string {
-	if m.finalizerSearchFilterActive {
+	if m.finalizerSearch.filterActive {
 		return m.renderHints([]ui.HintEntry{
 			{Key: "type", Desc: "filter"},
 			{Key: "enter", Desc: "apply"},

--- a/internal/app/spinner_gate.go
+++ b/internal/app/spinner_gate.go
@@ -7,7 +7,7 @@ import tea "charm.land/bubbletea/v2"
 // tracked background task in the scheduler indicator.
 func (m Model) spinnerNeeded() bool {
 	if m.loading || m.previewLoading || m.metricsLoading ||
-		m.helmRevisionsLoading || m.finalizerSearchLoading ||
+		m.helmRevisionsLoading || m.finalizerSearch.loading ||
 		m.commandBarNameLoading != "" {
 		return true
 	}

--- a/internal/app/tab_state.go
+++ b/internal/app/tab_state.go
@@ -174,6 +174,7 @@ func (m *Model) saveCurrentTab() {
 	t.diffRightName = m.diffView.rightName
 	t.diffScroll = m.diffView.scroll
 	t.diffUnified = m.diffView.unified
+	t.constraints = m.constraints
 	t.execPTY = m.execPTY
 	t.execTerm = m.execTerm
 	t.execTitle = m.execTitle
@@ -332,6 +333,7 @@ func (m *Model) loadTab(idx int) tea.Cmd {
 	m.diffView.rightName = t.diffRightName
 	m.diffView.scroll = t.diffScroll
 	m.diffView.unified = t.diffUnified
+	m.constraints = t.constraints
 	m.execPTY = t.execPTY
 	m.execTerm = t.execTerm
 	m.execTitle = t.execTitle

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -269,12 +269,12 @@ func baseModelFinalizer() Model {
 		execMu:              &sync.Mutex{},
 	}
 	m.overlay = overlayFinalizerSearch
-	m.finalizerSearchResults = []k8s.FinalizerMatch{
+	m.finalizerSearch.results = []k8s.FinalizerMatch{
 		{Name: "pod-1", Namespace: "default", Kind: "Pod", Matched: "kubernetes.io/pv-protection"},
 		{Name: "pod-2", Namespace: "default", Kind: "Pod", Matched: "kubernetes.io/pv-protection"},
 		{Name: "pod-3", Namespace: "kube-system", Kind: "Pod", Matched: "finalizer.example.com"},
 	}
-	m.finalizerSearchSelected = make(map[string]bool)
+	m.finalizerSearch.selected = make(map[string]bool)
 	return m
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -167,6 +167,9 @@ func (m Model) updateResourceMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) { //nol
 	case quarantineTargetsChangedMsg:
 		mdl, cmd := m.updateQuarantineTargetsChanged()
 		return mdl, cmd, true
+	case constraintsLoadedMsg:
+		mdl, cmd := m.updateConstraintsLoaded(msg)
+		return mdl, cmd, true
 	case dependentsLoadedMsg:
 		mdl, cmd := m.updateDependentsLoaded(msg)
 		return mdl, cmd, true

--- a/internal/app/update_constraints.go
+++ b/internal/app/update_constraints.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+const constraintsScrollOff = 3
+
+// openConstraintsView opens the "what constrains this object" fullscreen
+// view for the currently selected middle-column row.
+func (m Model) openConstraintsView() (tea.Model, tea.Cmd) {
+	if m.nav.Level < model.LevelResources {
+		m.setStatusMessage("Select a resource first", true)
+		return m, scheduleStatusClear()
+	}
+	sel := m.selectedMiddleItem()
+	if sel == nil || sel.Raw == nil {
+		m.setStatusMessage("No resource data available", true)
+		return m, scheduleStatusClear()
+	}
+
+	target := k8s.TargetFromRaw(sel.Raw)
+	target.Namespace = sel.Namespace
+	target.Kind = sel.Kind
+	target.GVR = schema.GroupVersionResource{
+		Group:    m.nav.ResourceType.APIGroup,
+		Version:  m.nav.ResourceType.APIVersion,
+		Resource: m.nav.ResourceType.Resource,
+	}
+
+	m.constraints = constraintsViewState{
+		title:      resourceTitleLabel(sel.Kind, sel.Namespace, sel.Name),
+		name:       sel.Name,
+		target:     target,
+		loading:    true,
+		returnMode: m.mode,
+		gen:        m.constraints.gen + 1,
+	}
+	m.mode = modeConstraints
+	return m, m.loadConstraints(sel.Name)
+}
+
+// handleConstraintsKey handles input for the fullscreen constraints view.
+func (m Model) handleConstraintsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	kb := ui.ActiveKeybindings
+	rows := m.constraints.visibleRows()
+	maxIdx := len(rows) - 1
+	half := max(m.constraintsViewportHeight()/2, 1)
+
+	switch msg.String() {
+	case kb.Down, "j", "down":
+		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, 1, maxIdx)
+	case kb.Up, "k", "up":
+		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, -1, maxIdx)
+	case kb.JumpTop, "g":
+		if m.pendingG {
+			m.pendingG = false
+			m.constraints.cursor = 0
+		} else {
+			m.pendingG = true
+			return m, nil
+		}
+	case kb.JumpBottom, "G":
+		m.constraints.cursor = maxIdx
+	case kb.PageDown, "ctrl+d":
+		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, half, maxIdx)
+	case kb.PageUp, "ctrl+u":
+		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, -half, maxIdx)
+	case "enter":
+		return m.jumpFromConstraintsRow()
+	case kb.Refresh:
+		m.constraints.loading = true
+		m.constraints.gen++
+		return m, m.loadConstraints(m.constraints.name)
+	case "q", "esc":
+		m.mode = m.constraints.returnMode
+		return m, nil
+	default:
+		return m, nil
+	}
+	m.pendingG = false
+	m.constraints.scroll = ui.VimScrollOff(
+		m.constraints.scroll, m.constraints.cursor, len(rows),
+		m.constraintsViewportHeight(), constraintsScrollOff,
+		func(from, to int) int { return to - from },
+	)
+	return m, nil
+}
+
+// jumpFromConstraintsRow reuses jumpToOrphan's recipe: resolve the row's
+// Kind via discovery, record jump history, switch namespace, climb to
+// LevelResourceTypes, then drill into the row's object by name.
+func (m Model) jumpFromConstraintsRow() (tea.Model, tea.Cmd) {
+	rows := m.constraints.visibleRows()
+	if m.constraints.cursor < 0 || m.constraints.cursor >= len(rows) {
+		return m, nil
+	}
+	row := rows[m.constraints.cursor]
+	if row.Kind == "" || row.Name == "" {
+		m.setStatusMessage("This row names no single object to jump to", true)
+		return m, scheduleStatusClear()
+	}
+
+	rt, ok := model.FindResourceTypeByKind(row.Kind, m.discoveredResources[m.nav.Context])
+	if !ok {
+		m.setStatusMessage(
+			fmt.Sprintf("Cannot jump to %s/%s — resource type not yet discovered, retry in a moment",
+				row.Kind, row.Name), true)
+		return m, scheduleStatusClear()
+	}
+
+	m.pushJumpHistory()
+	m.mode = m.constraints.returnMode
+
+	if row.Namespace != "" {
+		m.allNamespaces = false
+		m.namespace = row.Namespace
+		m.selectedNamespaces = map[string]bool{row.Namespace: true}
+	}
+
+	for m.nav.Level > model.LevelResourceTypes {
+		ret, _ := m.navigateParent()
+		m = ret.(Model)
+	}
+	if m.nav.Level < model.LevelResourceTypes {
+		m.setStatusMessage("Cannot jump: enter a context first", true)
+		return m, scheduleStatusClear()
+	}
+
+	for i, item := range m.middleItems {
+		if item.Extra == rt.ResourceRef() {
+			m.setCursor(i)
+			m.pendingTarget = row.Name
+			ret, cmd := m.navigateChild()
+			next, ok := ret.(Model)
+			if !ok {
+				return m, cmd
+			}
+			return next, cmd
+		}
+	}
+
+	m.setStatusMessage(
+		fmt.Sprintf("Cannot jump: %s not in sidebar (toggle rare resources with H?)", row.Kind), true)
+	return m, scheduleStatusClear()
+}

--- a/internal/app/update_constraints.go
+++ b/internal/app/update_constraints.go
@@ -54,26 +54,29 @@ func (m Model) handleConstraintsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	maxIdx := len(rows) - 1
 	half := max(m.constraintsViewportHeight()/2, 1)
 
+	// Cleared up front so no exit path leaves a half-typed gg armed for the
+	// explorer to complete after the view closes.
+	pendingG := m.pendingG
+	m.pendingG = false
+
 	switch msg.String() {
 	case kb.Down, "j", "down":
 		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, 1, maxIdx)
 	case kb.Up, "k", "up":
 		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, -1, maxIdx)
 	case kb.JumpTop, "g":
-		if m.pendingG {
-			m.pendingG = false
-			m.constraints.cursor = 0
-		} else {
+		if !pendingG {
 			m.pendingG = true
 			return m, nil
 		}
+		m.constraints.cursor = 0
 	case kb.JumpBottom, "G":
 		m.constraints.cursor = maxIdx
 	case kb.PageDown, "ctrl+d":
 		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, half, maxIdx)
 	case kb.PageUp, "ctrl+u":
 		m.constraints.cursor = clampOverlayCursor(m.constraints.cursor, -half, maxIdx)
-	case "enter":
+	case kb.Enter, "enter":
 		return m.jumpFromConstraintsRow()
 	case kb.Refresh:
 		m.constraints.loading = true
@@ -85,7 +88,6 @@ func (m Model) handleConstraintsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	default:
 		return m, nil
 	}
-	m.pendingG = false
 	m.constraints.scroll = ui.VimScrollOff(
 		m.constraints.scroll, m.constraints.cursor, len(rows),
 		m.constraintsViewportHeight(), constraintsScrollOff,
@@ -116,29 +118,33 @@ func (m Model) jumpFromConstraintsRow() (tea.Model, tea.Cmd) {
 		return m, scheduleStatusClear()
 	}
 
-	m.pushJumpHistory()
-	m.mode = m.constraints.returnMode
+	// Every navigation change lands on a candidate copy, so a jump that
+	// cannot resolve its target leaves the view, namespace and jump
+	// history as the user left them.
+	cand := m
+	cand.pushJumpHistory()
+	cand.mode = m.constraints.returnMode
 
 	if row.Namespace != "" {
-		m.allNamespaces = false
-		m.namespace = row.Namespace
-		m.selectedNamespaces = map[string]bool{row.Namespace: true}
+		cand.allNamespaces = false
+		cand.namespace = row.Namespace
+		cand.selectedNamespaces = map[string]bool{row.Namespace: true}
 	}
 
-	for m.nav.Level > model.LevelResourceTypes {
-		ret, _ := m.navigateParent()
-		m = ret.(Model)
+	for cand.nav.Level > model.LevelResourceTypes {
+		ret, _ := cand.navigateParent()
+		cand = ret.(Model)
 	}
-	if m.nav.Level < model.LevelResourceTypes {
+	if cand.nav.Level < model.LevelResourceTypes {
 		m.setStatusMessage("Cannot jump: enter a context first", true)
 		return m, scheduleStatusClear()
 	}
 
-	for i, item := range m.middleItems {
+	for i, item := range cand.middleItems {
 		if item.Extra == rt.ResourceRef() {
-			m.setCursor(i)
-			m.pendingTarget = row.Name
-			ret, cmd := m.navigateChild()
+			cand.setCursor(i)
+			cand.pendingTarget = row.Name
+			ret, cmd := cand.navigateChild()
 			next, ok := ret.(Model)
 			if !ok {
 				return m, cmd

--- a/internal/app/update_constraints_test.go
+++ b/internal/app/update_constraints_test.go
@@ -37,6 +37,48 @@ func TestConstraintsView_EnterJumpsToRowObject(t *testing.T) {
 	assert.Len(t, updated.jumpBackStack, 1, "jump must record where it came from")
 }
 
+func TestConstraintsView_HiddenTargetLeavesNavigationUntouched(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.constraints.returnMode = modeExplorer
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: []k8s.ConstraintRow{{Kind: "Pod", Namespace: "kube-system", Name: "naked", Source: "PriorityClass"}},
+	}
+	m.nav.Context = "test"
+	m.nav.Level = model.LevelResourceTypes
+	m.namespace = "default"
+	m.discoveredResources = map[string][]model.ResourceTypeEntry{
+		"test": {{Kind: "Pod", Resource: "pods", APIVersion: "v1"}},
+	}
+	m.middleItems = nil // the Pods row is filtered out of the sidebar
+
+	result, _ := m.handleConstraintsKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated, ok := result.(Model)
+	require.True(t, ok)
+
+	assert.Equal(t, modeConstraints, updated.mode, "a failed jump must keep the view open")
+	assert.Equal(t, "default", updated.namespace, "a failed jump must not switch namespace")
+	assert.Empty(t, updated.jumpBackStack, "a failed jump must not record history")
+}
+
+func TestConstraintsView_QuitClearsPendingG(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.constraints.returnMode = modeExplorer
+
+	armed, _ := m.handleConstraintsKey(tea.KeyPressMsg{Code: 'g', Text: "g"})
+	m, ok := armed.(Model)
+	require.True(t, ok)
+	require.True(t, m.pendingG, "the first g arms the gg prefix")
+
+	quit, _ := m.handleConstraintsKey(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	closed, ok := quit.(Model)
+	require.True(t, ok)
+
+	assert.Equal(t, modeExplorer, closed.mode)
+	assert.False(t, closed.pendingG, "closing the view must not leave gg half-typed for the explorer")
+}
+
 func TestConstraintsView_RendersHeadroomAndOmitsDeniedSource(t *testing.T) {
 	m := basePush80Model()
 	m.mode = modeConstraints

--- a/internal/app/update_constraints_test.go
+++ b/internal/app/update_constraints_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstraintsView_EnterJumpsToRowObject(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: []k8s.ConstraintRow{{Kind: "Pod", Namespace: "kube-system", Name: "naked", Source: "PriorityClass"}},
+	}
+	m.constraints.cursor = 0
+	m.nav.Context = "test"
+	m.nav.Level = model.LevelResourceTypes
+
+	podRT := model.ResourceTypeEntry{Kind: "Pod", Resource: "pods", APIVersion: "v1"}
+	m.discoveredResources = map[string][]model.ResourceTypeEntry{"test": {podRT}}
+	m.middleItems = []model.Item{{Name: "Pods", Extra: podRT.ResourceRef()}}
+
+	require.Empty(t, m.jumpBackStack)
+
+	result, _ := m.handleConstraintsKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated, ok := result.(Model)
+	require.True(t, ok)
+
+	assert.Equal(t, modeExplorer, updated.mode, "closing the view returns to the pre-open mode")
+	assert.Equal(t, "kube-system", updated.namespace)
+	assert.Equal(t, "naked", updated.pendingTarget)
+	assert.Len(t, updated.jumpBackStack, 1, "jump must record where it came from")
+}
+
+func TestConstraintsView_RendersHeadroomAndOmitsDeniedSource(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.constraints.title = "web-1"
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: []k8s.ConstraintRow{{
+			Source: "Quota", Kind: "ResourceQuota", Namespace: "default", Name: "compute-quota",
+			Detail: "requests 500m cpu", Headroom: "1",
+		}},
+		Skipped: []string{"poddisruptionbudgets"},
+	}
+
+	out := stripANSI(m.View().Content)
+
+	assert.Contains(t, out, "poddisruptionbudgets", "Skipped sources must show in the banner")
+	assert.Contains(t, out, "compute-quota", "a populated source's row must still render")
+	assert.NotContains(t, out, "web-pdb", "no row should exist for a source that was skipped")
+}

--- a/internal/app/update_dispatch_msgs.go
+++ b/internal/app/update_dispatch_msgs.go
@@ -79,13 +79,13 @@ func (m Model) updateBulkActionResult(msg bulkActionResultMsg) (tea.Model, tea.C
 }
 
 func (m Model) updateFinalizerSearchResult(msg finalizerSearchResultMsg) (tea.Model, tea.Cmd) {
-	m.finalizerSearchLoading = false
+	m.finalizerSearch.loading = false
 	if msg.err != nil {
 		m.setErrorFromErr("Finalizer search: ", msg.err)
 		m.overlay = overlayNone
 		return m, scheduleStatusClear()
 	}
-	m.finalizerSearchResults = msg.results
+	m.finalizerSearch.results = msg.results
 	if len(msg.results) == 0 {
 		m.setStatusMessage("No resources found with matching finalizer", false)
 		m.overlay = overlayNone
@@ -101,8 +101,8 @@ func (m Model) updateFinalizerRemoveResult(msg finalizerRemoveResultMsg) (tea.Mo
 	} else {
 		m.setStatusMessage(fmt.Sprintf("Removed finalizer from %d resources", msg.succeeded), false)
 	}
-	m.finalizerSearchResults = nil
-	m.finalizerSearchSelected = nil
+	m.finalizerSearch.results = nil
+	m.finalizerSearch.selected = nil
 	return m, tea.Batch(m.refreshCurrentLevel(), scheduleStatusClear())
 }
 

--- a/internal/app/update_finalizer.go
+++ b/internal/app/update_finalizer.go
@@ -15,7 +15,7 @@ func (m Model) handleFinalizerSearchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 	key := msg.String()
 
 	// When filter input is active, handle text input first.
-	if m.finalizerSearchFilterActive {
+	if m.finalizerSearch.filterActive {
 		return m.handleFinalizerSearchFilterKey(msg)
 	}
 
@@ -25,69 +25,69 @@ func (m Model) handleFinalizerSearchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 	switch key {
 	case "esc", "q":
 		m.overlay = overlayNone
-		m.finalizerSearchResults = nil
-		m.finalizerSearchSelected = nil
-		m.finalizerSearchFilter = ""
-		m.finalizerSearchFilterActive = false
+		m.finalizerSearch.results = nil
+		m.finalizerSearch.selected = nil
+		m.finalizerSearch.filter = ""
+		m.finalizerSearch.filterActive = false
 		return m, nil
 
 	case "j", "down":
-		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, 1, maxIdx)
+		m.finalizerSearch.cursor = clampOverlayCursor(m.finalizerSearch.cursor, 1, maxIdx)
 		return m, nil
 
 	case "k", "up":
-		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, -1, maxIdx)
+		m.finalizerSearch.cursor = clampOverlayCursor(m.finalizerSearch.cursor, -1, maxIdx)
 		return m, nil
 
 	case "g":
 		// gg to top.
 		if m.pendingG {
 			m.pendingG = false
-			m.finalizerSearchCursor = 0
+			m.finalizerSearch.cursor = 0
 			return m, nil
 		}
 		m.pendingG = true
 		return m, nil
 
 	case "G":
-		m.finalizerSearchCursor = maxIdx
+		m.finalizerSearch.cursor = maxIdx
 		return m, nil
 
 	case "ctrl+d", "shift+down":
-		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, 10, maxIdx)
+		m.finalizerSearch.cursor = clampOverlayCursor(m.finalizerSearch.cursor, 10, maxIdx)
 		return m, nil
 
 	case "ctrl+u", "shift+up":
-		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, -10, maxIdx)
+		m.finalizerSearch.cursor = clampOverlayCursor(m.finalizerSearch.cursor, -10, maxIdx)
 		return m, nil
 
 	case "ctrl+f":
-		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, 20, maxIdx)
+		m.finalizerSearch.cursor = clampOverlayCursor(m.finalizerSearch.cursor, 20, maxIdx)
 		return m, nil
 
 	case "ctrl+b":
-		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, -20, maxIdx)
+		m.finalizerSearch.cursor = clampOverlayCursor(m.finalizerSearch.cursor, -20, maxIdx)
 		return m, nil
 
 	case "space":
 		// Toggle selection on the current item and advance cursor.
-		if m.finalizerSearchCursor >= 0 && m.finalizerSearchCursor < len(filtered) {
-			match := filtered[m.finalizerSearchCursor]
+		if m.finalizerSearch.cursor >= 0 && m.finalizerSearch.cursor < len(filtered) {
+			match := filtered[m.finalizerSearch.cursor]
 			k := finalizerMatchKey(match)
-			if m.finalizerSearchSelected[k] {
-				delete(m.finalizerSearchSelected, k)
+			if m.finalizerSearch.selected[k] {
+				delete(m.finalizerSearch.selected, k)
 			} else {
-				m.finalizerSearchSelected[k] = true
+				m.finalizerSearch.selected[k] = true
 			}
 		}
-		m.finalizerSearchCursor = clampOverlayCursor(m.finalizerSearchCursor, 1, maxIdx)
+		m.finalizerSearch.cursor = clampOverlayCursor(m.finalizerSearch.cursor, 1, maxIdx)
 		return m, nil
 
 	case "ctrl+a":
 		// Select/deselect all visible (filtered) results.
 		allSelected := true
 		for _, match := range filtered {
-			if !m.finalizerSearchSelected[finalizerMatchKey(match)] {
+			if !m.finalizerSearch.selected[finalizerMatchKey(match)] {
 				allSelected = false
 				break
 			}
@@ -95,19 +95,19 @@ func (m Model) handleFinalizerSearchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		if allSelected {
 			// Deselect all.
 			for _, match := range filtered {
-				delete(m.finalizerSearchSelected, finalizerMatchKey(match))
+				delete(m.finalizerSearch.selected, finalizerMatchKey(match))
 			}
 		} else {
 			// Select all.
 			for _, match := range filtered {
-				m.finalizerSearchSelected[finalizerMatchKey(match)] = true
+				m.finalizerSearch.selected[finalizerMatchKey(match)] = true
 			}
 		}
 		return m, nil
 
 	case "enter":
 		// Confirm removal: open a type-to-confirm overlay.
-		selectedCount := len(m.finalizerSearchSelected)
+		selectedCount := len(m.finalizerSearch.selected)
 		if selectedCount == 0 {
 			m.setStatusMessage("No resources selected", true)
 			return m, scheduleStatusClear()
@@ -123,7 +123,7 @@ func (m Model) handleFinalizerSearchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		return m, nil
 
 	case "/":
-		m.finalizerSearchFilterActive = true
+		m.finalizerSearch.filterActive = true
 		return m, nil
 
 	case "ctrl+c":
@@ -143,63 +143,63 @@ func (m Model) handleFinalizerSearchFilterKey(msg tea.KeyPressMsg) (tea.Model, t
 	if isPaste(msg) {
 		pasted := strings.TrimRight(msg.Text, "\n")
 		if !strings.ContainsAny(pasted, "\n\r") {
-			m.finalizerSearchFilter += pasted
-			m.finalizerSearchCursor = 0
+			m.finalizerSearch.filter += pasted
+			m.finalizerSearch.cursor = 0
 		}
 		return m, nil
 	}
 	key := msg.String()
 	switch key {
 	case "esc":
-		if m.finalizerSearchFilter != "" {
-			m.finalizerSearchFilter = ""
-			m.finalizerSearchCursor = 0
-		} else if m.finalizerSearchResults == nil && m.finalizerSearchPattern == "" {
+		if m.finalizerSearch.filter != "" {
+			m.finalizerSearch.filter = ""
+			m.finalizerSearch.cursor = 0
+		} else if m.finalizerSearch.results == nil && m.finalizerSearch.pattern == "" {
 			// No search performed yet — close the overlay entirely.
-			m.finalizerSearchFilterActive = false
+			m.finalizerSearch.filterActive = false
 			m.overlay = overlayNone
 		} else {
-			m.finalizerSearchFilterActive = false
+			m.finalizerSearch.filterActive = false
 		}
 		return m, nil
 	case "enter":
-		if m.finalizerSearchResults == nil && m.finalizerSearchPattern == "" {
+		if m.finalizerSearch.results == nil && m.finalizerSearch.pattern == "" {
 			// Initial search prompt: use filter text as the search pattern.
-			pattern := strings.TrimSpace(m.finalizerSearchFilter)
+			pattern := strings.TrimSpace(m.finalizerSearch.filter)
 			if pattern == "" {
 				return m, nil
 			}
-			m.finalizerSearchPattern = pattern
-			m.finalizerSearchFilter = ""
-			m.finalizerSearchFilterActive = false
-			m.finalizerSearchLoading = true
+			m.finalizerSearch.pattern = pattern
+			m.finalizerSearch.filter = ""
+			m.finalizerSearch.filterActive = false
+			m.finalizerSearch.loading = true
 			return m, m.searchFinalizers(pattern)
 		}
-		m.finalizerSearchFilterActive = false
+		m.finalizerSearch.filterActive = false
 		return m, nil
 	case "backspace":
-		if len(m.finalizerSearchFilter) > 0 {
-			m.finalizerSearchFilter = m.finalizerSearchFilter[:len(m.finalizerSearchFilter)-1]
-			m.finalizerSearchCursor = 0
+		if len(m.finalizerSearch.filter) > 0 {
+			m.finalizerSearch.filter = m.finalizerSearch.filter[:len(m.finalizerSearch.filter)-1]
+			m.finalizerSearch.cursor = 0
 		}
 		return m, nil
 	case "ctrl+w":
 		// Delete word.
-		f := m.finalizerSearchFilter
+		f := m.finalizerSearch.filter
 		f = strings.TrimRight(f, " ")
 		if idx := strings.LastIndex(f, " "); idx >= 0 {
-			m.finalizerSearchFilter = f[:idx+1]
+			m.finalizerSearch.filter = f[:idx+1]
 		} else {
-			m.finalizerSearchFilter = ""
+			m.finalizerSearch.filter = ""
 		}
-		m.finalizerSearchCursor = 0
+		m.finalizerSearch.cursor = 0
 		return m, nil
 	case "ctrl+c":
 		return m.closeTabOrQuit()
 	default:
 		if msg.Text != "" {
-			m.finalizerSearchFilter += msg.Text
-			m.finalizerSearchCursor = 0
+			m.finalizerSearch.filter += msg.Text
+			m.finalizerSearch.cursor = 0
 		}
 		return m, nil
 	}
@@ -208,12 +208,12 @@ func (m Model) handleFinalizerSearchFilterKey(msg tea.KeyPressMsg) (tea.Model, t
 // filteredFinalizerResults returns the finalizer search results filtered
 // by the current filter text (matching name, namespace, or kind).
 func (m Model) filteredFinalizerResults() []k8s.FinalizerMatch {
-	if m.finalizerSearchFilter == "" {
-		return m.finalizerSearchResults
+	if m.finalizerSearch.filter == "" {
+		return m.finalizerSearch.results
 	}
-	rawQuery := m.finalizerSearchFilter
+	rawQuery := m.finalizerSearch.filter
 	var filtered []k8s.FinalizerMatch
-	for _, r := range m.finalizerSearchResults {
+	for _, r := range m.finalizerSearch.results {
 		if ui.MatchLine(r.Name, rawQuery) ||
 			ui.MatchLine(r.Namespace, rawQuery) ||
 			ui.MatchLine(r.Kind, rawQuery) ||

--- a/internal/app/update_finalizer_test.go
+++ b/internal/app/update_finalizer_test.go
@@ -11,12 +11,12 @@ func TestCovOpenFinalizerSearch(t *testing.T) {
 	m.openFinalizerSearch()
 
 	assert.Equal(t, overlayFinalizerSearch, m.overlay)
-	assert.True(t, m.finalizerSearchFilterActive)
-	assert.False(t, m.finalizerSearchLoading)
-	assert.Empty(t, m.finalizerSearchPattern)
-	assert.Empty(t, m.finalizerSearchResults)
-	assert.NotNil(t, m.finalizerSearchSelected)
-	assert.Equal(t, 0, m.finalizerSearchCursor)
+	assert.True(t, m.finalizerSearch.filterActive)
+	assert.False(t, m.finalizerSearch.loading)
+	assert.Empty(t, m.finalizerSearch.pattern)
+	assert.Empty(t, m.finalizerSearch.results)
+	assert.NotNil(t, m.finalizerSearch.selected)
+	assert.Equal(t, 0, m.finalizerSearch.cursor)
 }
 
 func TestCovFinalizerKeyEsc(t *testing.T) {
@@ -24,91 +24,91 @@ func TestCovFinalizerKeyEsc(t *testing.T) {
 	result, _ := m.handleFinalizerSearchKey(keyMsg("esc"))
 	rm := result.(Model)
 	assert.Equal(t, overlayNone, rm.overlay)
-	assert.Nil(t, rm.finalizerSearchResults)
+	assert.Nil(t, rm.finalizerSearch.results)
 }
 
 func TestCovFinalizerKeyDown(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchCursor = 0
+	m.finalizerSearch.cursor = 0
 	result, _ := m.handleFinalizerSearchKey(keyMsg("j"))
 	rm := result.(Model)
-	assert.Equal(t, 1, rm.finalizerSearchCursor)
+	assert.Equal(t, 1, rm.finalizerSearch.cursor)
 }
 
 func TestCovFinalizerKeyUp(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchCursor = 2
+	m.finalizerSearch.cursor = 2
 	result, _ := m.handleFinalizerSearchKey(keyMsg("k"))
 	rm := result.(Model)
-	assert.Equal(t, 1, rm.finalizerSearchCursor)
+	assert.Equal(t, 1, rm.finalizerSearch.cursor)
 }
 
 func TestCovFinalizerKeyGG(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchCursor = 2
+	m.finalizerSearch.cursor = 2
 	result, _ := m.handleFinalizerSearchKey(keyMsg("g"))
 	rm := result.(Model)
 	assert.True(t, rm.pendingG)
 	result, _ = rm.handleFinalizerSearchKey(keyMsg("g"))
 	rm = result.(Model)
-	assert.Equal(t, 0, rm.finalizerSearchCursor)
+	assert.Equal(t, 0, rm.finalizerSearch.cursor)
 }
 
 func TestCovFinalizerKeyBigG(t *testing.T) {
 	m := baseModelFinalizer()
 	result, _ := m.handleFinalizerSearchKey(keyMsg("G"))
 	rm := result.(Model)
-	assert.Equal(t, 2, rm.finalizerSearchCursor)
+	assert.Equal(t, 2, rm.finalizerSearch.cursor)
 }
 
 func TestCovFinalizerKeyCtrlD(t *testing.T) {
 	m := baseModelFinalizer()
 	result, _ := m.handleFinalizerSearchKey(keyMsg("ctrl+d"))
 	rm := result.(Model)
-	assert.LessOrEqual(t, rm.finalizerSearchCursor, 2)
+	assert.LessOrEqual(t, rm.finalizerSearch.cursor, 2)
 }
 
 func TestCovFinalizerKeyCtrlU(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchCursor = 2
+	m.finalizerSearch.cursor = 2
 	result, _ := m.handleFinalizerSearchKey(keyMsg("ctrl+u"))
 	rm := result.(Model)
-	assert.GreaterOrEqual(t, rm.finalizerSearchCursor, 0)
+	assert.GreaterOrEqual(t, rm.finalizerSearch.cursor, 0)
 }
 
 func TestCovFinalizerKeyCtrlF(t *testing.T) {
 	m := baseModelFinalizer()
 	result, _ := m.handleFinalizerSearchKey(keyMsg("ctrl+f"))
 	rm := result.(Model)
-	assert.LessOrEqual(t, rm.finalizerSearchCursor, 2)
+	assert.LessOrEqual(t, rm.finalizerSearch.cursor, 2)
 }
 
 func TestCovFinalizerKeyCtrlB(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchCursor = 2
+	m.finalizerSearch.cursor = 2
 	result, _ := m.handleFinalizerSearchKey(keyMsg("ctrl+b"))
 	rm := result.(Model)
-	assert.GreaterOrEqual(t, rm.finalizerSearchCursor, 0)
+	assert.GreaterOrEqual(t, rm.finalizerSearch.cursor, 0)
 }
 
 func TestCovFinalizerKeySpace(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchCursor = 0
+	m.finalizerSearch.cursor = 0
 	result, _ := m.handleFinalizerSearchKey(keyMsg(" "))
 	rm := result.(Model)
 	// Should have toggled selection on first item
-	k := finalizerMatchKey(rm.finalizerSearchResults[0])
-	assert.True(t, rm.finalizerSearchSelected[k])
+	k := finalizerMatchKey(rm.finalizerSearch.results[0])
+	assert.True(t, rm.finalizerSearch.selected[k])
 }
 
 func TestCovFinalizerKeySpaceDeselect(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchCursor = 0
-	k := finalizerMatchKey(m.finalizerSearchResults[0])
-	m.finalizerSearchSelected[k] = true
+	m.finalizerSearch.cursor = 0
+	k := finalizerMatchKey(m.finalizerSearch.results[0])
+	m.finalizerSearch.selected[k] = true
 	result, _ := m.handleFinalizerSearchKey(keyMsg(" "))
 	rm := result.(Model)
-	assert.False(t, rm.finalizerSearchSelected[k])
+	assert.False(t, rm.finalizerSearch.selected[k])
 }
 
 func TestCovFinalizerKeyCtrlA(t *testing.T) {
@@ -116,19 +116,19 @@ func TestCovFinalizerKeyCtrlA(t *testing.T) {
 	result, _ := m.handleFinalizerSearchKey(keyMsg("ctrl+a"))
 	rm := result.(Model)
 	// Should have selected all
-	for _, match := range rm.finalizerSearchResults {
-		assert.True(t, rm.finalizerSearchSelected[finalizerMatchKey(match)])
+	for _, match := range rm.finalizerSearch.results {
+		assert.True(t, rm.finalizerSearch.selected[finalizerMatchKey(match)])
 	}
 }
 
 func TestCovFinalizerKeyCtrlADeselectAll(t *testing.T) {
 	m := baseModelFinalizer()
-	for _, match := range m.finalizerSearchResults {
-		m.finalizerSearchSelected[finalizerMatchKey(match)] = true
+	for _, match := range m.finalizerSearch.results {
+		m.finalizerSearch.selected[finalizerMatchKey(match)] = true
 	}
 	result, _ := m.handleFinalizerSearchKey(keyMsg("ctrl+a"))
 	rm := result.(Model)
-	assert.Empty(t, rm.finalizerSearchSelected)
+	assert.Empty(t, rm.finalizerSearch.selected)
 }
 
 func TestCovFinalizerKeyEnterNoSelection(t *testing.T) {
@@ -139,8 +139,8 @@ func TestCovFinalizerKeyEnterNoSelection(t *testing.T) {
 
 func TestCovFinalizerKeyEnterWithSelection(t *testing.T) {
 	m := baseModelFinalizer()
-	k := finalizerMatchKey(m.finalizerSearchResults[0])
-	m.finalizerSearchSelected[k] = true
+	k := finalizerMatchKey(m.finalizerSearch.results[0])
+	m.finalizerSearch.selected[k] = true
 	result, _ := m.handleFinalizerSearchKey(keyMsg("enter"))
 	rm := result.(Model)
 	assert.Equal(t, overlayConfirmType, rm.overlay)
@@ -151,24 +151,24 @@ func TestCovFinalizerKeySlash(t *testing.T) {
 	m := baseModelFinalizer()
 	result, _ := m.handleFinalizerSearchKey(keyMsg("/"))
 	rm := result.(Model)
-	assert.True(t, rm.finalizerSearchFilterActive)
+	assert.True(t, rm.finalizerSearch.filterActive)
 }
 
 func TestCovFinalizerFilterEscClearsFilter(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchFilter = "test"
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.filter = "test"
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("esc"))
 	rm := result.(Model)
-	assert.Empty(t, rm.finalizerSearchFilter)
+	assert.Empty(t, rm.finalizerSearch.filter)
 }
 
 func TestCovFinalizerFilterEscClosesOverlay(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchFilter = ""
-	m.finalizerSearchResults = nil
-	m.finalizerSearchPattern = ""
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.filter = ""
+	m.finalizerSearch.results = nil
+	m.finalizerSearch.pattern = ""
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("esc"))
 	rm := result.(Model)
 	assert.Equal(t, overlayNone, rm.overlay)
@@ -176,67 +176,67 @@ func TestCovFinalizerFilterEscClosesOverlay(t *testing.T) {
 
 func TestCovFinalizerFilterEscDeactivatesFilter(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchFilter = ""
-	m.finalizerSearchPattern = "something"
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.filter = ""
+	m.finalizerSearch.pattern = "something"
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("esc"))
 	rm := result.(Model)
-	assert.False(t, rm.finalizerSearchFilterActive)
+	assert.False(t, rm.finalizerSearch.filterActive)
 }
 
 func TestCovFinalizerFilterEnterInitialSearch(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchResults = nil
-	m.finalizerSearchPattern = ""
-	m.finalizerSearchFilter = "pv-protection"
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.results = nil
+	m.finalizerSearch.pattern = ""
+	m.finalizerSearch.filter = "pv-protection"
 	_, cmd := m.handleFinalizerSearchFilterKey(keyMsg("enter"))
 	assert.NotNil(t, cmd)
 }
 
 func TestCovFinalizerFilterEnterEmptyPattern(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchResults = nil
-	m.finalizerSearchPattern = ""
-	m.finalizerSearchFilter = ""
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.results = nil
+	m.finalizerSearch.pattern = ""
+	m.finalizerSearch.filter = ""
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("enter"))
 	_ = result.(Model)
 }
 
 func TestCovFinalizerFilterEnterWithExistingResults(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchPattern = "existing"
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.pattern = "existing"
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("enter"))
 	rm := result.(Model)
-	assert.False(t, rm.finalizerSearchFilterActive)
+	assert.False(t, rm.finalizerSearch.filterActive)
 }
 
 func TestCovFinalizerFilterBackspace(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchFilter = "abc"
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.filter = "abc"
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("backspace"))
 	rm := result.(Model)
-	assert.Equal(t, "ab", rm.finalizerSearchFilter)
+	assert.Equal(t, "ab", rm.finalizerSearch.filter)
 }
 
 func TestCovFinalizerFilterCtrlW(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
-	m.finalizerSearchFilter = "foo bar"
+	m.finalizerSearch.filterActive = true
+	m.finalizerSearch.filter = "foo bar"
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("ctrl+w"))
 	rm := result.(Model)
-	assert.NotEqual(t, "foo bar", rm.finalizerSearchFilter)
+	assert.NotEqual(t, "foo bar", rm.finalizerSearch.filter)
 }
 
 func TestCovFinalizerFilterTyping(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
+	m.finalizerSearch.filterActive = true
 	result, _ := m.handleFinalizerSearchFilterKey(keyMsg("x"))
 	rm := result.(Model)
-	assert.Equal(t, "x", rm.finalizerSearchFilter)
+	assert.Equal(t, "x", rm.finalizerSearch.filter)
 }
 
 func TestCovFilteredFinalizerResultsNoFilter(t *testing.T) {
@@ -247,7 +247,7 @@ func TestCovFilteredFinalizerResultsNoFilter(t *testing.T) {
 
 func TestCovFilteredFinalizerResultsWithFilter(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilter = "kube-system"
+	m.finalizerSearch.filter = "kube-system"
 	results := m.filteredFinalizerResults()
 	assert.Len(t, results, 1)
 	assert.Equal(t, "pod-3", results[0].Name)
@@ -255,8 +255,8 @@ func TestCovFilteredFinalizerResultsWithFilter(t *testing.T) {
 
 func TestCovFinalizerSearchKeyDispatchToFilter(t *testing.T) {
 	m := baseModelFinalizer()
-	m.finalizerSearchFilterActive = true
+	m.finalizerSearch.filterActive = true
 	result, _ := m.handleFinalizerSearchKey(keyMsg("x"))
 	rm := result.(Model)
-	assert.Contains(t, rm.finalizerSearchFilter, "x")
+	assert.Contains(t, rm.finalizerSearch.filter, "x")
 }

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -263,6 +263,9 @@ func (m Model) handleModeKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
 	case modeLogTop:
 		mdl, cmd := m.handleLogTopKey(msg)
 		return mdl, cmd, true
+	case modeConstraints:
+		mdl, cmd := m.handleConstraintsKey(msg)
+		return mdl, cmd, true
 	case modeCredits:
 		// Any key exits the credits screen.
 		m.mode = modeExplorer

--- a/internal/app/update_keys_explorer.go
+++ b/internal/app/update_keys_explorer.go
@@ -433,6 +433,9 @@ func (m Model) handleExplorerUIKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, boo
 	case kb.OrphanOverlay:
 		mdl, cmd := m.openOrphansOverlay()
 		return mdl, cmd, true
+	case kb.Constraints:
+		mdl, cmd := m.openConstraintsView()
+		return mdl, cmd, true
 	case kb.SessionManager:
 		mdl, cmd := m.openSessionsOverlay()
 		return mdl, cmd, true

--- a/internal/app/update_msg_test.go
+++ b/internal/app/update_msg_test.go
@@ -2576,7 +2576,7 @@ func TestCovUpdateFinalizerSearch(t *testing.T) {
 		results: []k8s.FinalizerMatch{{Namespace: "default", Kind: "Pod", Name: "stuck-pod"}},
 	})
 	rm := result.(Model)
-	assert.Len(t, rm.finalizerSearchResults, 1)
+	assert.Len(t, rm.finalizerSearch.results, 1)
 }
 
 func TestCovUpdateEventTimeline(t *testing.T) {

--- a/internal/app/update_overlays_confirm.go
+++ b/internal/app/update_overlays_confirm.go
@@ -242,8 +242,8 @@ func (m Model) handleConfirmTypeOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.
 			case "Finalizer Remove":
 				m.loading = false
 				m.overlay = overlayFinalizerSearch
-				selectedCount := len(m.finalizerSearchSelected)
-				m.addLogEntry("DBG", fmt.Sprintf("Removing finalizer %q from %d resources", m.finalizerSearchPattern, selectedCount))
+				selectedCount := len(m.finalizerSearch.selected)
+				m.addLogEntry("DBG", fmt.Sprintf("Removing finalizer %q from %d resources", m.finalizerSearch.pattern, selectedCount))
 				return m, m.bulkRemoveFinalizer()
 			case "Disrupt":
 				// Karpenter NodeClaim disrupt: kubectl delete nodeclaim.

--- a/internal/app/update_overlays_test.go
+++ b/internal/app/update_overlays_test.go
@@ -2166,8 +2166,8 @@ func TestCovOverlayKeyDispatchQuitConfirm(t *testing.T) {
 func TestCovOverlayKeyDispatchFinalizerSearch(t *testing.T) {
 	m := baseModelOverlay()
 	m.overlay = overlayFinalizerSearch
-	m.finalizerSearchResults = nil
-	m.finalizerSearchSelected = make(map[string]bool)
+	m.finalizerSearch.results = nil
+	m.finalizerSearch.selected = make(map[string]bool)
 	result, _ := m.handleOverlayKey(keyMsg("esc"))
 	rm := result.(Model)
 	assert.Equal(t, overlayNone, rm.overlay)

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -53,7 +53,7 @@ func replaceLastLine(view, line string) string {
 // (with its own title/tab/hint bars) rather than the three-pane explorer.
 func isFullscreenRenderMode(mode viewMode) bool {
 	switch mode {
-	case modeYAML, modeLogs, modeDescribe, modeDiff, modeExec, modeExplain, modeEventViewer, modeObjectExplorer, modeLogTop:
+	case modeYAML, modeLogs, modeDescribe, modeDiff, modeExec, modeExplain, modeEventViewer, modeObjectExplorer, modeLogTop, modeConstraints:
 		return true
 	default:
 		return false
@@ -140,6 +140,8 @@ func (m Model) renderView() string {
 			content = m.viewObjectExplorer()
 		case modeLogTop:
 			content = m.viewLogTop()
+		case modeConstraints:
+			content = m.viewConstraints()
 		}
 
 		var parts []string

--- a/internal/app/view_modes_constraints.go
+++ b/internal/app/view_modes_constraints.go
@@ -26,7 +26,7 @@ func (m Model) viewConstraints() string {
 	} else if m.constraints.err != nil {
 		body = append(body, ui.ErrorStyle.Render("  "+ui.SanitizeTerminalText(m.constraints.err.Error())))
 	} else {
-		body = append(body, constraintsBanner(m.constraints.report.Skipped))
+		body = append(body, constraintsBanner(m.constraints.report.Skipped, m.constraints.report.Failed))
 		body = append(body, m.renderConstraintsRows()...)
 	}
 
@@ -40,17 +40,29 @@ func (m Model) viewConstraints() string {
 	return lipgloss.JoinVertical(lipgloss.Left, title, content, m.constraintsHintBar())
 }
 
-// constraintsBanner names the sources RBAC (or another failure) kept the
-// scan from reading — one line, never a per-source row implying "absent".
-func constraintsBanner(skipped []string) string {
-	if len(skipped) == 0 {
+// constraintsBanner names the sources the scan couldn't read — one line,
+// never a per-source row implying "absent". Denied and failed sources are
+// named separately so an RBAC gap doesn't read as a bug, or vice versa.
+func constraintsBanner(skipped, failed []string) string {
+	if len(skipped) == 0 && len(failed) == 0 {
 		return ""
 	}
-	names := make([]string, len(skipped))
-	for i, s := range skipped {
-		names[i] = ui.SanitizeTerminalText(s)
+	var parts []string
+	if len(skipped) > 0 {
+		parts = append(parts, "denied: "+strings.Join(sanitizedConstraintNames(skipped), ", "))
 	}
-	return ui.StatusWarning.Render("  skipped (denied or unreachable): " + strings.Join(names, ", "))
+	if len(failed) > 0 {
+		parts = append(parts, "failed: "+strings.Join(sanitizedConstraintNames(failed), ", "))
+	}
+	return ui.StatusWarning.Render("  skipped (" + strings.Join(parts, "; ") + ")")
+}
+
+func sanitizedConstraintNames(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = ui.SanitizeTerminalText(n)
+	}
+	return out
 }
 
 func (m Model) renderConstraintsRows() []string {

--- a/internal/app/view_modes_constraints.go
+++ b/internal/app/view_modes_constraints.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/janosmiko/lfk/internal/k8s"
+	"github.com/janosmiko/lfk/internal/ui"
+)
+
+// constraintsViewportHeight is the number of table rows visible at once —
+// shared by the key handler (scroll math) and the renderer (page size) so
+// they agree on what "one page" means.
+func (m Model) constraintsViewportHeight() int {
+	return max(m.height-4, 3)
+}
+
+func (m Model) viewConstraints() string {
+	title := ui.ViewTitle(m.width, m.constraints.title+" — what constrains this object")
+
+	var body []string
+	if m.constraints.loading {
+		body = append(body, ui.DimStyle.Render("  loading..."))
+	} else if m.constraints.err != nil {
+		body = append(body, ui.ErrorStyle.Render("  "+ui.SanitizeTerminalText(m.constraints.err.Error())))
+	} else {
+		body = append(body, constraintsBanner(m.constraints.report.Skipped))
+		body = append(body, m.renderConstraintsRows()...)
+	}
+
+	maxLines := m.constraintsViewportHeight()
+	for len(body) < maxLines {
+		body = append(body, "")
+	}
+	borderStyle := ui.FullscreenBorderStyle(m.width, maxLines)
+	content := borderStyle.Render(strings.Join(body, "\n"))
+
+	return lipgloss.JoinVertical(lipgloss.Left, title, content, m.constraintsHintBar())
+}
+
+// constraintsBanner names the sources RBAC (or another failure) kept the
+// scan from reading — one line, never a per-source row implying "absent".
+func constraintsBanner(skipped []string) string {
+	if len(skipped) == 0 {
+		return ""
+	}
+	names := make([]string, len(skipped))
+	for i, s := range skipped {
+		names[i] = ui.SanitizeTerminalText(s)
+	}
+	return ui.StatusWarning.Render("  skipped (denied or unreachable): " + strings.Join(names, ", "))
+}
+
+func (m Model) renderConstraintsRows() []string {
+	rows := m.constraints.visibleRows()
+	if len(rows) == 0 {
+		return []string{ui.DimStyle.Render("  no constraints found")}
+	}
+	width := max(m.width-4, 20)
+	scroll := m.constraints.scroll
+	height := m.constraintsViewportHeight() - 1 // banner line
+	end := min(scroll+height, len(rows))
+
+	out := make([]string, 0, end-scroll)
+	for i := scroll; i < end; i++ {
+		out = append(out, formatConstraintRow(rows[i], i == m.constraints.cursor, width))
+	}
+	return out
+}
+
+func formatConstraintRow(row k8s.ConstraintRow, isCursor bool, width int) string {
+	gutter := " "
+	if isCursor {
+		gutter = ui.YamlCursorIndicatorStyle.Render("▎")
+	}
+	nsName := ui.SanitizeTerminalText(row.Namespace)
+	if row.Name != "" {
+		if nsName != "" {
+			nsName += "/"
+		}
+		nsName += ui.SanitizeTerminalText(row.Name)
+	}
+	line := fmt.Sprintf("%-9s %-26s %-28s %-10s  %s",
+		ui.Truncate(row.Source, 9),
+		ui.Truncate(ui.SanitizeTerminalText(row.Kind), 26),
+		ui.Truncate(nsName, 28),
+		ui.Truncate(row.Headroom, 10),
+		ui.Truncate(ui.SanitizeTerminalText(row.Detail), max(width-80, 10)),
+	)
+	if row.Blocking {
+		line = ui.StatusFailed.Render(line)
+	}
+	return gutter + line
+}
+
+func (m Model) constraintsHintBar() string {
+	if m.hasStatusMessage() {
+		return m.renderStatusHint()
+	}
+	return ui.RenderHintBar([]ui.HintEntry{
+		{Key: "j/k g/G", Desc: "navigate"},
+		{Key: "ctrl+d/u", Desc: "half page"},
+		{Key: "enter", Desc: "jump to object"},
+		{Key: "q/esc", Desc: "back"},
+	}, m.width)
+}

--- a/internal/app/view_modes_constraints.go
+++ b/internal/app/view_modes_constraints.go
@@ -71,18 +71,47 @@ func (m Model) renderConstraintsRows() []string {
 		return []string{ui.DimStyle.Render("  no constraints found")}
 	}
 	width := max(m.width-4, 20)
-	scroll := m.constraints.scroll
 	height := m.constraintsViewportHeight() - 1 // banner line
+	scroll := min(max(m.constraints.scroll, 0), max(len(rows)-1, 0))
 	end := min(scroll+height, len(rows))
 
-	out := make([]string, 0, end-scroll)
+	cols := constraintsColumns(width)
+	out := make([]string, 0, max(end-scroll, 0))
 	for i := scroll; i < end; i++ {
-		out = append(out, formatConstraintRow(rows[i], i == m.constraints.cursor, width))
+		out = append(out, formatConstraintRow(rows[i], i == m.constraints.cursor, cols))
 	}
 	return out
 }
 
-func formatConstraintRow(row k8s.ConstraintRow, isCursor bool, width int) string {
+// constraintColumns holds the per-row column widths, recomputed for the
+// terminal width so a narrow window still renders one row per line.
+type constraintColumns struct {
+	source, kind, name, headroom, detail, line int
+}
+
+// constraintsColumns hands cells back to the detail column, widest first,
+// until the row fits. Gaps between the five columns cost 5 cells.
+func constraintsColumns(width int) constraintColumns {
+	const (
+		gaps        = 5
+		detailFloor = 10
+	)
+	cols := constraintColumns{source: 9, kind: 26, name: 28, headroom: 10, line: width - 1}
+
+	shrinkable := []*int{&cols.name, &cols.kind, &cols.headroom, &cols.source}
+	floors := []int{6, 6, 4, 4}
+	for i, col := range shrinkable {
+		over := cols.source + cols.kind + cols.name + cols.headroom + gaps + detailFloor - cols.line
+		if over <= 0 {
+			break
+		}
+		*col -= min(*col-floors[i], over)
+	}
+	cols.detail = max(cols.line-(cols.source+cols.kind+cols.name+cols.headroom+gaps), 1)
+	return cols
+}
+
+func formatConstraintRow(row k8s.ConstraintRow, isCursor bool, cols constraintColumns) string {
 	gutter := " "
 	if isCursor {
 		gutter = ui.YamlCursorIndicatorStyle.Render("▎")
@@ -94,13 +123,16 @@ func formatConstraintRow(row k8s.ConstraintRow, isCursor bool, width int) string
 		}
 		nsName += ui.SanitizeTerminalText(row.Name)
 	}
-	line := fmt.Sprintf("%-9s %-26s %-28s %-10s  %s",
-		ui.Truncate(row.Source, 9),
-		ui.Truncate(ui.SanitizeTerminalText(row.Kind), 26),
-		ui.Truncate(nsName, 28),
-		ui.Truncate(row.Headroom, 10),
-		ui.Truncate(ui.SanitizeTerminalText(row.Detail), max(width-80, 10)),
+	line := fmt.Sprintf("%-*s %-*s %-*s %-*s  %s",
+		cols.source, ui.Truncate(row.Source, cols.source),
+		cols.kind, ui.Truncate(ui.SanitizeTerminalText(row.Kind), cols.kind),
+		cols.name, ui.Truncate(nsName, cols.name),
+		cols.headroom, ui.Truncate(row.Headroom, cols.headroom),
+		ui.Truncate(ui.SanitizeTerminalText(row.Detail), cols.detail),
 	)
+	// The floors can still overrun a very narrow terminal, and a row wider
+	// than the box wraps into the border.
+	line = ui.Truncate(line, cols.line)
 	if row.Blocking {
 		line = ui.StatusFailed.Render(line)
 	}

--- a/internal/app/view_modes_constraints_test.go
+++ b/internal/app/view_modes_constraints_test.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConstraintsBanner_DistinguishesDeniedFromFailed(t *testing.T) {
+	out := stripANSI(constraintsBanner([]string{"poddisruptionbudgets"}, []string{"nodes"}))
+
+	if !strings.Contains(out, "denied") || !strings.Contains(out, "poddisruptionbudgets") {
+		t.Errorf("expected the denied group to name poddisruptionbudgets, got %q", out)
+	}
+	if !strings.Contains(out, "failed") || !strings.Contains(out, "nodes") {
+		t.Errorf("expected the failed group to name nodes, got %q", out)
+	}
+}
+
+func TestConstraintsBanner_EmptyWhenNothingSkippedOrFailed(t *testing.T) {
+	if out := constraintsBanner(nil, nil); out != "" {
+		t.Errorf("expected an empty banner, got %q", out)
+	}
+}

--- a/internal/app/view_modes_constraints_test.go
+++ b/internal/app/view_modes_constraints_test.go
@@ -1,8 +1,13 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/janosmiko/lfk/internal/k8s"
 )
 
 func TestConstraintsBanner_DistinguishesDeniedFromFailed(t *testing.T) {
@@ -13,6 +18,26 @@ func TestConstraintsBanner_DistinguishesDeniedFromFailed(t *testing.T) {
 	}
 	if !strings.Contains(out, "failed") || !strings.Contains(out, "nodes") {
 		t.Errorf("expected the failed group to name nodes, got %q", out)
+	}
+}
+
+func TestFormatConstraintRow_FitsTheAvailableWidth(t *testing.T) {
+	row := k8s.ConstraintRow{
+		Source:    "Quota",
+		Kind:      "ResourceQuota",
+		Namespace: "a-rather-long-namespace-name",
+		Name:      "compute-quota-with-a-long-name",
+		Headroom:  "1500m",
+		Detail:    "requests 500m cpu (hard 4, used 3) and then some more text to overflow",
+	}
+
+	for _, width := range []int{20, 40, 60, 80, 120, 200} {
+		t.Run(fmt.Sprintf("width-%d", width), func(t *testing.T) {
+			line := stripANSI(formatConstraintRow(row, true, constraintsColumns(width)))
+			if got := lipgloss.Width(line); got > width {
+				t.Errorf("row width = %d, want at most %d: %q", got, width, line)
+			}
+		})
 	}
 }
 

--- a/internal/app/view_overlays_fullscreen.go
+++ b/internal/app/view_overlays_fullscreen.go
@@ -148,9 +148,9 @@ func (m Model) renderOverlayFinalizerSearch() (string, int, int) {
 	}
 	h := min(m.height-4, m.height*70/100)
 	return ui.RenderFinalizerSearchOverlay(
-		entries, m.finalizerSearchCursor, m.finalizerSearchSelected,
-		m.finalizerSearchPattern, m.finalizerSearchFilter, m.finalizerSearchFilterActive,
-		m.finalizerSearchLoading, w, h,
+		entries, m.finalizerSearch.cursor, m.finalizerSearch.selected,
+		m.finalizerSearch.pattern, m.finalizerSearch.filter, m.finalizerSearch.filterActive,
+		m.finalizerSearch.loading, w, h,
 	), w, h
 }
 

--- a/internal/app/whichkey_catalog.go
+++ b/internal/app/whichkey_catalog.go
@@ -229,6 +229,7 @@ var whichKeyCatalogList = []whichKeyModeCatalog{
 	{modeObjectExplorer, "Object Explorer", whichKeyObjectExplorerCatalog},
 	{modeLogTop, "Log Top", whichKeyLogTopCatalog},
 	{modeEventViewer, "event viewer", whichKeyEventViewerCatalog},
+	{modeConstraints, "constraints view", whichKeyConstraintsCatalog},
 }
 
 // whichKeyCatalogs indexes whichKeyCatalogList for the render and dispatch

--- a/internal/app/whichkey_constraints.go
+++ b/internal/app/whichkey_constraints.go
@@ -1,0 +1,25 @@
+package app
+
+import "github.com/janosmiko/lfk/internal/ui"
+
+// wkConstraintsCtx is the fullscreen constraints view's which-key context.
+// The view has no gated modes (no visual/search/filter), so it carries
+// nothing beyond the Model pointer every resolver needs.
+type wkConstraintsCtx struct{ m *Model }
+
+func newWKConstraintsCtx(m *Model) *wkConstraintsCtx { return &wkConstraintsCtx{m: m} }
+
+// whichKeyConstraintsActionList excludes Enter: drilling into the row's
+// object is list-viewer navigation, the same exclusion Log Top and the
+// Object/API Explorers apply to their own Enter.
+var whichKeyConstraintsActionList = []wkAction[*wkConstraintsCtx]{
+	{Key: func(kb ui.Keybindings) string { return kb.Refresh }, Label: "Re-run the scan", Group: wkActions},
+	{Key: wkLiteralKey("q"), Label: "Back to explorer", Group: wkViews},
+}
+
+// whichKeyConstraintsCatalog is the constraints view's registry entry.
+// Registered for modeConstraints only.
+var whichKeyConstraintsCatalog = wkCatalog[*wkConstraintsCtx]{
+	resolve: newWKConstraintsCtx,
+	actions: whichKeyConstraintsActionList,
+}

--- a/internal/app/whichkey_registry.go
+++ b/internal/app/whichkey_registry.go
@@ -526,6 +526,7 @@ var whichKeyExplorerActionList = []whichKeyAction{
 	{Key: func(kb ui.Keybindings) string { return kb.TogglePreviewLogs }, Label: "Live log preview", Group: wkViews, Avail: wkTogglePreviewLogsAvailable},
 	{Key: func(kb ui.Keybindings) string { return kb.ResourceMap }, Label: "Resource map", Group: wkViews, Avail: wkLevelResourcesUp},
 	{Key: func(kb ui.Keybindings) string { return kb.ObjectExplorer }, Label: "Object Explorer", Group: wkViews, Avail: func(c *wkCtx) bool { return wkOnRow(c) && c.sel.Raw != nil }},
+	{Key: func(kb ui.Keybindings) string { return kb.Constraints }, Label: "What constrains this object", Group: wkViews, Avail: func(c *wkCtx) bool { return wkOnRow(c) && c.sel.Raw != nil }},
 	{Key: func(kb ui.Keybindings) string { return kb.APIExplorer }, Label: "API Explorer", Group: wkViews, Avail: wkAPIExplorerAvailable},
 	{Key: func(kb ui.Keybindings) string { return kb.RBACBrowser }, Label: "RBAC browser", Group: wkViews},
 	{Key: func(kb ui.Keybindings) string { return kb.OrphanOverlay }, Label: "Orphan overview", Group: wkViews, Avail: func(c *wkCtx) bool { return !c.unionSentinel }},

--- a/internal/app/whichkey_registry_test.go
+++ b/internal/app/whichkey_registry_test.go
@@ -637,6 +637,7 @@ func wkLevelScopingCases() []wkLevelScopingCase {
 		{"Live log preview", "Pod", "", []model.Level{model.LevelResources, model.LevelOwned}},
 		{"Resource map", "", "", []model.Level{model.LevelResources, model.LevelOwned, model.LevelContainers}},
 		{"Object Explorer", "", "", []model.Level{model.LevelResources, model.LevelOwned, model.LevelContainers}},
+		{"What constrains this object", "", "", []model.Level{model.LevelResources, model.LevelOwned, model.LevelContainers}},
 		{"API Explorer", "Pod", "", []model.Level{model.LevelResourceTypes, model.LevelResources, model.LevelOwned, model.LevelContainers}},
 		{"RBAC browser", "", "", allLevels},
 		{"Orphan overview", "", "", allLevels},

--- a/internal/app/whichkey_viewers_test.go
+++ b/internal/app/whichkey_viewers_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/janosmiko/lfk/internal/k8s"
 	"github.com/janosmiko/lfk/internal/logagg"
 	"github.com/janosmiko/lfk/internal/model"
 	"github.com/janosmiko/lfk/internal/ui"
@@ -114,6 +115,13 @@ func whichKeyViewerModel(mode viewMode) Model {
 	m.logTop.colOrder = []string{logagg.FieldPath}
 	m.eventTimelineLines = []string{"10m  Normal  Scheduled  pod/p1", "9m  Warning  BackOff  pod/p1"}
 	m.eventTimelineCursor = 0
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: []k8s.ConstraintRow{
+			{Source: "Quota", Kind: "ResourceQuota", Namespace: "default", Name: "compute-quota", Detail: "requests 500m cpu", Headroom: "1"},
+		},
+	}
+	m.constraints.cursor = 0
+	m.constraints.name = "p1"
 	return m
 }
 
@@ -303,6 +311,17 @@ func wkViewerScenarios(t *testing.T, mode viewMode) []struct {
 			{"cursor off content", func() Model { m := base(); m.eventTimelineCursor = 999; return m }},
 			{"no lines", func() Model { m := base(); m.eventTimelineLines = nil; return m }},
 		}
+	case modeConstraints:
+		return []scenario{
+			{"normal", base},
+			{"cursor off content", func() Model { m := base(); m.constraints.cursor = 999; return m }},
+			{"no rows", func() Model { m := base(); m.constraints.report.Rows = nil; return m }},
+			{"skipped sources", func() Model {
+				m := base()
+				m.constraints.report.Skipped = []string{"poddisruptionbudgets"}
+				return m
+			}},
+		}
 	}
 	t.Fatalf("catalogued mode %q has no scenario set; add one covering every branch its "+
 		"predicates take, or the sweeps that drive off this will pass on nothing",
@@ -369,6 +388,7 @@ func wkTextViewerModes(t *testing.T) map[viewMode]bool {
 		modeExplain:        false,
 		modeObjectExplorer: false,
 		modeLogTop:         false,
+		modeConstraints:    false,
 	}
 	for _, mc := range whichKeyViewerCatalogs() {
 		if _, ok := out[mc.mode]; !ok {
@@ -587,6 +607,7 @@ func wkViewerHelpContexts(t *testing.T) map[viewMode]string {
 		modeLogTop:         "Log Top",
 		modeObjectExplorer: "Object Explorer",
 		modeEventViewer:    "Event Timeline",
+		modeConstraints:    "Constraints View",
 	}
 	for _, mc := range whichKeyViewerCatalogs() {
 		if out[mc.mode] == "" {

--- a/internal/k8s/client_rbac.go
+++ b/internal/k8s/client_rbac.go
@@ -356,6 +356,9 @@ func (c *Client) GetNamespaceQuotas(ctx context.Context, kubeCtx, namespace stri
 		spec, _ := item.Object["spec"].(map[string]any)
 		status, _ := item.Object["status"].(map[string]any)
 
+		qi.Scopes = quotaScopesFromRaw(spec["scopes"])
+		qi.ScopeSelector = quotaScopeSelectorFromRaw(spec["scopeSelector"])
+
 		hardMap, _ := spec["hard"].(map[string]any)
 		usedMap := map[string]any{}
 		if status != nil {

--- a/internal/k8s/client_types.go
+++ b/internal/k8s/client_types.go
@@ -21,6 +21,18 @@ type QuotaInfo struct {
 	Name      string
 	Namespace string
 	Resources []QuotaResource
+	// Scopes and ScopeSelector narrow which objects the quota counts. Both
+	// must match before the quota applies — see quotaAppliesTo.
+	Scopes        []string
+	ScopeSelector []QuotaScopeRequirement
+}
+
+// QuotaScopeRequirement mirrors corev1.ScopedResourceSelectorRequirement,
+// read off a ResourceQuota's raw spec.scopeSelector.
+type QuotaScopeRequirement struct {
+	ScopeName string
+	Operator  string // In, NotIn, Exists, DoesNotExist
+	Values    []string
 }
 
 // QuotaResource holds usage data for a single resource within a quota.

--- a/internal/k8s/constraints.go
+++ b/internal/k8s/constraints.go
@@ -1,0 +1,237 @@
+package k8s
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ConstraintRow is one entry in a "what constrains this object" report: a
+// policy or scheduling rule from one source that already blocks the target
+// or narrows its headroom.
+type ConstraintRow struct {
+	Source    string // "Quota" | "LimitRange" | "PDB" | "PriorityClass" | "Node" | "Webhook"
+	Kind      string
+	Namespace string
+	Name      string
+	Detail    string
+	Headroom  string
+	Blocking  bool
+}
+
+// ConstraintReport is the aggregated result of DetectConstraints.
+// Skipped names the sources a failed list omitted — see DetectConstraints.
+type ConstraintReport struct {
+	Rows    []ConstraintRow
+	Skipped []string
+}
+
+// ContainerRequest holds one container's resource requests/limits as raw
+// quantity strings, matching the string-quantity arithmetic
+// GetNamespaceQuotas already uses.
+type ContainerRequest struct {
+	Name     string
+	Requests map[string]string
+	Limits   map[string]string
+}
+
+// NodeSelectorRequirement mirrors corev1.NodeSelectorRequirement without
+// the JSON tags, read out of a workload's raw object.
+type NodeSelectorRequirement struct {
+	Key      string
+	Operator string // In, NotIn, Exists, DoesNotExist, Gt, Lt
+	Values   []string
+}
+
+// NodeSelectorTerm is one OR-branch of a required node affinity match.
+// Every MatchExpressions entry must match (AND). Preferred terms are
+// dropped upstream — they never block scheduling.
+type NodeSelectorTerm struct {
+	MatchExpressions []NodeSelectorRequirement
+}
+
+// ConstraintTarget is the pod-shaped part of an object (or its pod
+// template) every constraint source is evaluated against.
+type ConstraintTarget struct {
+	Namespace         string
+	Labels            map[string]string // the object's own metadata.labels
+	PodLabels         map[string]string // pod template labels (workloads) or the pod's own labels
+	NodeSelector      map[string]string
+	Affinity          []NodeSelectorTerm
+	Tolerations       []corev1.Toleration
+	Containers        []ContainerRequest
+	PriorityClassName string
+	GVR               schema.GroupVersionResource
+	Kind              string
+	// PodName is the object's own name, set only when Kind is Pod — the
+	// preemption check reads a specific pod's status and events, which a
+	// workload's pod template has no single instance of.
+	PodName string
+}
+
+// TargetFromRaw reads spec.template (a workload controller) or spec (a
+// bare Pod) off the raw object. Namespace, Kind and GVR come from the
+// caller's resource type entry, not from the object itself.
+func TargetFromRaw(raw map[string]any) ConstraintTarget {
+	return targetFromRaw(raw)
+}
+
+func targetFromRaw(raw map[string]any) ConstraintTarget {
+	meta, _ := raw["metadata"].(map[string]any)
+	podSpec, podMeta := podSpecAndMetaFromRaw(raw)
+
+	var podName string
+	if kind, _ := raw["kind"].(string); kind == "Pod" {
+		podName = stringField(meta, "name")
+	}
+
+	return ConstraintTarget{
+		Namespace:         stringField(meta, "namespace"),
+		Labels:            stringMapFromRaw(meta["labels"]),
+		PodLabels:         stringMapFromRaw(podMeta["labels"]),
+		NodeSelector:      stringMapFromRaw(podSpec["nodeSelector"]),
+		PodName:           podName,
+		Affinity:          nodeAffinityTermsFromRaw(podSpec["affinity"]),
+		Tolerations:       tolerationsFromRaw(podSpec["tolerations"]),
+		Containers:        containerRequestsFromRaw(podSpec["containers"]),
+		PriorityClassName: stringField(podSpec, "priorityClassName"),
+	}
+}
+
+// podSpecAndMetaFromRaw picks the Pod spec/metadata for a bare Pod, or the
+// pod template's for anything else.
+func podSpecAndMetaFromRaw(raw map[string]any) (spec, meta map[string]any) {
+	kind, _ := raw["kind"].(string)
+	if kind == "Pod" {
+		spec, _ = raw["spec"].(map[string]any)
+		meta, _ = raw["metadata"].(map[string]any)
+		return spec, meta
+	}
+	topSpec, _ := raw["spec"].(map[string]any)
+	tmpl, _ := topSpec["template"].(map[string]any)
+	spec, _ = tmpl["spec"].(map[string]any)
+	meta, _ = tmpl["metadata"].(map[string]any)
+	return spec, meta
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	s, _ := m[key].(string)
+	return s
+}
+
+func rawSlice(v any) []any {
+	s, _ := v.([]any)
+	return s
+}
+
+func rawMap(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
+}
+
+// stringMapFromRaw drops any value that isn't itself a string — a
+// well-formed label/selector map never holds anything else.
+func stringMapFromRaw(v any) map[string]string {
+	src := rawMap(v)
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for k, val := range src {
+		if s, ok := val.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// nodeAffinityTermsFromRaw reads
+// affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms.
+func nodeAffinityTermsFromRaw(v any) []NodeSelectorTerm {
+	nodeAffinity := rawMap(rawMap(v)["nodeAffinity"])
+	required := rawMap(nodeAffinity["requiredDuringSchedulingIgnoredDuringExecution"])
+	rawTerms := rawSlice(required["nodeSelectorTerms"])
+	if len(rawTerms) == 0 {
+		return nil
+	}
+	out := make([]NodeSelectorTerm, 0, len(rawTerms))
+	for _, rt := range rawTerms {
+		termMap := rawMap(rt)
+		exprs := rawSlice(termMap["matchExpressions"])
+		term := NodeSelectorTerm{MatchExpressions: make([]NodeSelectorRequirement, 0, len(exprs))}
+		for _, e := range exprs {
+			em := rawMap(e)
+			req := NodeSelectorRequirement{
+				Key:      stringField(em, "key"),
+				Operator: stringField(em, "operator"),
+			}
+			for _, val := range rawSlice(em["values"]) {
+				if s, ok := val.(string); ok {
+					req.Values = append(req.Values, s)
+				}
+			}
+			term.MatchExpressions = append(term.MatchExpressions, req)
+		}
+		out = append(out, term)
+	}
+	return out
+}
+
+func tolerationsFromRaw(v any) []corev1.Toleration {
+	rawTolerations := rawSlice(v)
+	if len(rawTolerations) == 0 {
+		return nil
+	}
+	out := make([]corev1.Toleration, 0, len(rawTolerations))
+	for _, rt := range rawTolerations {
+		tm := rawMap(rt)
+		out = append(out, corev1.Toleration{
+			Key:      stringField(tm, "key"),
+			Operator: corev1.TolerationOperator(stringField(tm, "operator")),
+			Value:    stringField(tm, "value"),
+			Effect:   corev1.TaintEffect(stringField(tm, "effect")),
+		})
+	}
+	return out
+}
+
+func containerRequestsFromRaw(v any) []ContainerRequest {
+	rawContainers := rawSlice(v)
+	if len(rawContainers) == 0 {
+		return nil
+	}
+	out := make([]ContainerRequest, 0, len(rawContainers))
+	for _, rc := range rawContainers {
+		cm := rawMap(rc)
+		resources := rawMap(cm["resources"])
+		out = append(out, ContainerRequest{
+			Name:     stringField(cm, "name"),
+			Requests: quantityMapFromRaw(resources["requests"]),
+			Limits:   quantityMapFromRaw(resources["limits"]),
+		})
+	}
+	return out
+}
+
+// quantityMapFromRaw stringifies float64 values — the dynamic client
+// decodes a unitless quantity (e.g. `cpu: 2`) as JSON number, not string.
+func quantityMapFromRaw(v any) map[string]string {
+	src := rawMap(v)
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for k, val := range src {
+		switch t := val.(type) {
+		case string:
+			out[k] = t
+		case float64:
+			out[k] = strconv.FormatFloat(t, 'f', -1, 64)
+		}
+	}
+	return out
+}

--- a/internal/k8s/constraints.go
+++ b/internal/k8s/constraints.go
@@ -21,10 +21,12 @@ type ConstraintRow struct {
 }
 
 // ConstraintReport is the aggregated result of DetectConstraints.
-// Skipped names the sources a failed list omitted — see DetectConstraints.
+// Skipped names sources the caller's RBAC denied. Failed names sources
+// omitted for any other reason. See DetectConstraints.
 type ConstraintReport struct {
 	Rows    []ConstraintRow
 	Skipped []string
+	Failed  []string
 }
 
 // ContainerRequest holds one container's resource requests/limits as raw

--- a/internal/k8s/constraints.go
+++ b/internal/k8s/constraints.go
@@ -64,6 +64,7 @@ type ConstraintTarget struct {
 	Affinity          []NodeSelectorTerm
 	Tolerations       []corev1.Toleration
 	Containers        []ContainerRequest
+	InitContainers    []ContainerRequest
 	PriorityClassName string
 	GVR               schema.GroupVersionResource
 	Kind              string
@@ -98,6 +99,7 @@ func targetFromRaw(raw map[string]any) ConstraintTarget {
 		Affinity:          nodeAffinityTermsFromRaw(podSpec["affinity"]),
 		Tolerations:       tolerationsFromRaw(podSpec["tolerations"]),
 		Containers:        containerRequestsFromRaw(podSpec["containers"]),
+		InitContainers:    containerRequestsFromRaw(podSpec["initContainers"]),
 		PriorityClassName: stringField(podSpec, "priorityClassName"),
 	}
 }

--- a/internal/k8s/constraints.go
+++ b/internal/k8s/constraints.go
@@ -20,9 +20,9 @@ type ConstraintRow struct {
 	Blocking  bool
 }
 
-// ConstraintReport is the aggregated result of DetectConstraints.
-// Skipped names sources the caller's RBAC denied. Failed names sources
-// omitted for any other reason. See DetectConstraints.
+// ConstraintReport is the aggregated result of DetectConstraints. Skipped
+// names sources the caller's RBAC denied, Failed the ones that broke for
+// any other reason — either may still have contributed rows.
 type ConstraintReport struct {
 	Rows    []ConstraintRow
 	Skipped []string
@@ -47,10 +47,11 @@ type NodeSelectorRequirement struct {
 }
 
 // NodeSelectorTerm is one OR-branch of a required node affinity match.
-// Every MatchExpressions entry must match (AND). Preferred terms are
-// dropped upstream — they never block scheduling.
+// Every MatchExpressions and MatchFields entry must match (AND). Preferred
+// terms are dropped upstream — they never block scheduling.
 type NodeSelectorTerm struct {
 	MatchExpressions []NodeSelectorRequirement
+	MatchFields      []NodeSelectorRequirement
 }
 
 // ConstraintTarget is the pod-shaped part of an object (or its pod
@@ -163,22 +164,32 @@ func nodeAffinityTermsFromRaw(v any) []NodeSelectorTerm {
 	out := make([]NodeSelectorTerm, 0, len(rawTerms))
 	for _, rt := range rawTerms {
 		termMap := rawMap(rt)
-		exprs := rawSlice(termMap["matchExpressions"])
-		term := NodeSelectorTerm{MatchExpressions: make([]NodeSelectorRequirement, 0, len(exprs))}
-		for _, e := range exprs {
-			em := rawMap(e)
-			req := NodeSelectorRequirement{
-				Key:      stringField(em, "key"),
-				Operator: stringField(em, "operator"),
-			}
-			for _, val := range rawSlice(em["values"]) {
-				if s, ok := val.(string); ok {
-					req.Values = append(req.Values, s)
-				}
-			}
-			term.MatchExpressions = append(term.MatchExpressions, req)
+		out = append(out, NodeSelectorTerm{
+			MatchExpressions: nodeSelectorRequirementsFromRaw(termMap["matchExpressions"]),
+			MatchFields:      nodeSelectorRequirementsFromRaw(termMap["matchFields"]),
+		})
+	}
+	return out
+}
+
+func nodeSelectorRequirementsFromRaw(v any) []NodeSelectorRequirement {
+	rawReqs := rawSlice(v)
+	if len(rawReqs) == 0 {
+		return nil
+	}
+	out := make([]NodeSelectorRequirement, 0, len(rawReqs))
+	for _, e := range rawReqs {
+		em := rawMap(e)
+		req := NodeSelectorRequirement{
+			Key:      stringField(em, "key"),
+			Operator: stringField(em, "operator"),
 		}
-		out = append(out, term)
+		for _, val := range rawSlice(em["values"]) {
+			if s, ok := val.(string); ok {
+				req.Values = append(req.Values, s)
+			}
+		}
+		out = append(out, req)
 	}
 	return out
 }

--- a/internal/k8s/constraints_detect.go
+++ b/internal/k8s/constraints_detect.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// constraintsFanoutConcurrency caps the number of constraint sources
+// queried at once, bounding growth as more sources are added.
+const constraintsFanoutConcurrency = 4
+
+// constraintSource pairs a lookup with the name its Skipped entry uses —
+// the list resource it depends on, matching kubectl's plural names.
+type constraintSource struct {
+	name string
+	fn   func(context.Context) ([]ConstraintRow, error)
+}
+
+// DetectConstraints runs every constraint source in parallel and merges
+// the rows. A source that errors contributes zero rows and one Skipped
+// entry, never a false "nothing found". Mirrors DetectOrphans.
+func (c *Client) DetectConstraints(ctx context.Context, kubeCtx string, t ConstraintTarget) (ConstraintReport, error) {
+	sources := []constraintSource{
+		{"resourcequotas", func(ctx context.Context) ([]ConstraintRow, error) { return c.quotaConstraintRows(ctx, kubeCtx, t) }},
+		{"limitranges", func(ctx context.Context) ([]ConstraintRow, error) { return c.limitRangeConstraintRows(ctx, kubeCtx, t) }},
+		{"poddisruptionbudgets", func(ctx context.Context) ([]ConstraintRow, error) { return c.pdbConstraintRows(ctx, kubeCtx, t) }},
+		{"priorityclasses", func(ctx context.Context) ([]ConstraintRow, error) { return c.priorityConstraintRows(ctx, kubeCtx, t) }},
+		{"nodes", func(ctx context.Context) ([]ConstraintRow, error) { return c.nodeConstraintRows(ctx, kubeCtx, t) }},
+		{"webhookconfigurations", func(ctx context.Context) ([]ConstraintRow, error) { return c.webhookConstraintRows(ctx, kubeCtx, t) }},
+	}
+
+	rowsBySource := make([][]ConstraintRow, len(sources))
+	errsBySource := make([]error, len(sources))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(constraintsFanoutConcurrency)
+	for i, src := range sources {
+		g.Go(func() error {
+			rowsBySource[i], errsBySource[i] = src.fn(gctx)
+			return nil // per-source errors are swallowed here, never propagated to Wait
+		})
+	}
+	_ = g.Wait()
+
+	var report ConstraintReport
+	var errs []error
+	for i, src := range sources {
+		if err := errsBySource[i]; err != nil {
+			report.Skipped = append(report.Skipped, src.name)
+			errs = append(errs, err)
+			continue
+		}
+		report.Rows = append(report.Rows, rowsBySource[i]...)
+	}
+	return report, errors.Join(errs...)
+}

--- a/internal/k8s/constraints_detect.go
+++ b/internal/k8s/constraints_detect.go
@@ -30,7 +30,12 @@ func (c *Client) DetectConstraints(ctx context.Context, kubeCtx string, t Constr
 		{"poddisruptionbudgets", func(ctx context.Context) ([]ConstraintRow, error) { return c.pdbConstraintRows(ctx, kubeCtx, t) }},
 		{"priorityclasses", func(ctx context.Context) ([]ConstraintRow, error) { return c.priorityConstraintRows(ctx, kubeCtx, t) }},
 		{"nodes", func(ctx context.Context) ([]ConstraintRow, error) { return c.nodeConstraintRows(ctx, kubeCtx, t) }},
-		{"webhookconfigurations", func(ctx context.Context) ([]ConstraintRow, error) { return c.webhookConstraintRows(ctx, kubeCtx, t) }},
+		{"validatingwebhookconfigurations", func(ctx context.Context) ([]ConstraintRow, error) {
+			return c.validatingWebhookConstraintRows(ctx, kubeCtx, t)
+		}},
+		{"mutatingwebhookconfigurations", func(ctx context.Context) ([]ConstraintRow, error) {
+			return c.mutatingWebhookConstraintRows(ctx, kubeCtx, t)
+		}},
 	}
 
 	rowsBySource := make([][]ConstraintRow, len(sources))
@@ -49,9 +54,11 @@ func (c *Client) DetectConstraints(ctx context.Context, kubeCtx string, t Constr
 	var report ConstraintReport
 	var errs []error
 	for i, src := range sources {
+		// Rows a source gathered before it failed are kept: a source that
+		// reports both (preemption lookups) would otherwise lose them.
+		report.Rows = append(report.Rows, rowsBySource[i]...)
 		err := errsBySource[i]
 		if err == nil {
-			report.Rows = append(report.Rows, rowsBySource[i]...)
 			continue
 		}
 		errs = append(errs, err)

--- a/internal/k8s/constraints_detect.go
+++ b/internal/k8s/constraints_detect.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"golang.org/x/sync/errgroup"
 )
 
@@ -19,8 +21,8 @@ type constraintSource struct {
 }
 
 // DetectConstraints runs every constraint source in parallel and merges
-// the rows. A source that errors contributes zero rows and one Skipped
-// entry, never a false "nothing found". Mirrors DetectOrphans.
+// the rows. The returned error is set only when every source failed, so
+// a partial failure shortens the view instead of blanking it.
 func (c *Client) DetectConstraints(ctx context.Context, kubeCtx string, t ConstraintTarget) (ConstraintReport, error) {
 	sources := []constraintSource{
 		{"resourcequotas", func(ctx context.Context) ([]ConstraintRow, error) { return c.quotaConstraintRows(ctx, kubeCtx, t) }},
@@ -47,12 +49,20 @@ func (c *Client) DetectConstraints(ctx context.Context, kubeCtx string, t Constr
 	var report ConstraintReport
 	var errs []error
 	for i, src := range sources {
-		if err := errsBySource[i]; err != nil {
-			report.Skipped = append(report.Skipped, src.name)
-			errs = append(errs, err)
+		err := errsBySource[i]
+		if err == nil {
+			report.Rows = append(report.Rows, rowsBySource[i]...)
 			continue
 		}
-		report.Rows = append(report.Rows, rowsBySource[i]...)
+		errs = append(errs, err)
+		if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+			report.Skipped = append(report.Skipped, src.name)
+		} else {
+			report.Failed = append(report.Failed, src.name)
+		}
 	}
-	return report, errors.Join(errs...)
+	if len(errs) == len(sources) {
+		return report, errors.Join(errs...)
+	}
+	return report, nil
 }

--- a/internal/k8s/constraints_detect_test.go
+++ b/internal/k8s/constraints_detect_test.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"testing"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -127,6 +128,54 @@ func TestDetectConstraints_AllSourcesFailReturnsJoinedError(t *testing.T) {
 	}
 	if len(report.Rows) != 0 {
 		t.Errorf("expected no rows when every source fails, got %+v", report.Rows)
+	}
+}
+
+func TestDetectConstraints_MutatingFailureKeepsValidatingRows(t *testing.T) {
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	cfg := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		Name: "guard",
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name:        "guard.example.com",
+			SideEffects: &sideEffects,
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				APIGroups:  []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"},
+			}},
+		}},
+	}
+	ns := &corev1.Namespace{Name: "default"}
+	cs := k8sfake.NewClientset(ns, cfg)
+	cs.PrependReactor("list", "mutatingwebhookconfigurations", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "admissionregistration.k8s.io", Resource: "mutatingwebhookconfigurations"}, "", nil)
+	})
+	client := newFakeClient(cs, newFakeDynClient())
+
+	target := ConstraintTarget{
+		Namespace: "default",
+		GVR:       schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+	}
+
+	report, err := client.DetectConstraints(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("expected a partial failure to return a nil top-level error, got %v", err)
+	}
+
+	sawWebhook := false
+	for _, row := range report.Rows {
+		if row.Source == "Webhook" && row.Name == "guard" {
+			sawWebhook = true
+		}
+	}
+	if !sawWebhook {
+		t.Errorf("expected the validating webhook row to survive, got %+v", report.Rows)
+	}
+	if !slices.Contains(report.Skipped, "mutatingwebhookconfigurations") {
+		t.Errorf("expected the denied mutating source in Skipped, got %v", report.Skipped)
+	}
+	if slices.Contains(report.Skipped, "validatingwebhookconfigurations") {
+		t.Errorf("the validating source read fine and must not be reported denied, got %v", report.Skipped)
 	}
 }
 

--- a/internal/k8s/constraints_detect_test.go
+++ b/internal/k8s/constraints_detect_test.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"errors"
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -64,5 +66,87 @@ func TestDetectConstraints_ForbiddenListOmitsRowsNotShowsAbsent(t *testing.T) {
 	}
 	if !foundQuota {
 		t.Errorf("expected the quota source to still populate rows, got %+v", report.Rows)
+	}
+}
+
+func TestDetectConstraints_PartialFailureReturnsNilTopLevelError(t *testing.T) {
+	node := &corev1.Node{Name: "node-1"}
+	cs := k8sfake.NewClientset(node)
+	cs.PrependReactor("list", "poddisruptionbudgets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "policy", Resource: "poddisruptionbudgets"}, "", nil)
+	})
+
+	quota := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ResourceQuota",
+			"metadata":   map[string]any{"name": "compute-quota", "namespace": "default"},
+			"spec":       map[string]any{"hard": map[string]any{"cpu": "4"}},
+			"status":     map[string]any{"used": map[string]any{"cpu": "3"}},
+		},
+	}
+	dc := newFakeDynClient(quota)
+	client := newFakeClient(cs, dc)
+
+	target := ConstraintTarget{
+		Namespace:  "default",
+		PodLabels:  map[string]string{"app": "web"},
+		Containers: []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+	}
+
+	report, err := client.DetectConstraints(t.Context(), "", target)
+	if err != nil {
+		t.Errorf("expected a partial failure to return a nil top-level error, got %v", err)
+	}
+	if len(report.Rows) == 0 {
+		t.Errorf("expected surviving sources to still populate rows, got %+v", report)
+	}
+}
+
+func TestDetectConstraints_AllSourcesFailReturnsJoinedError(t *testing.T) {
+	failErr := apierrors.NewForbidden(schema.GroupResource{Resource: "*"}, "", nil)
+	failAll := func(k8stesting.Action) (bool, runtime.Object, error) { return true, nil, failErr }
+
+	cs := k8sfake.NewClientset()
+	cs.PrependReactor("list", "*", failAll)
+	cs.PrependReactor("get", "*", failAll)
+	dc := newFakeDynClient()
+	dc.PrependReactor("list", "*", failAll)
+	client := newFakeClient(cs, dc)
+
+	target := ConstraintTarget{
+		Namespace:         "default",
+		PriorityClassName: "high",
+	}
+
+	report, err := client.DetectConstraints(t.Context(), "", target)
+
+	if err == nil {
+		t.Error("expected a total failure (every source erroring) to return a non-nil error")
+	}
+	if len(report.Rows) != 0 {
+		t.Errorf("expected no rows when every source fails, got %+v", report.Rows)
+	}
+}
+
+func TestDetectConstraints_NonRBACErrorGoesToFailedNotSkipped(t *testing.T) {
+	node := &corev1.Node{Name: "node-1"}
+	cs := k8sfake.NewClientset(node)
+	cs.PrependReactor("list", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection reset by peer")
+	})
+	dc := newFakeDynClient()
+	client := newFakeClient(cs, dc)
+
+	report, err := client.DetectConstraints(t.Context(), "", ConstraintTarget{Namespace: "default"})
+	if err != nil {
+		t.Errorf("expected a partial failure to return a nil top-level error, got %v", err)
+	}
+	if slices.Contains(report.Skipped, "nodes") {
+		t.Errorf("a non-RBAC error must not land in Skipped, got %v", report.Skipped)
+	}
+	if !slices.Contains(report.Failed, "nodes") {
+		t.Errorf("expected Failed to contain nodes, got %v", report.Failed)
 	}
 }

--- a/internal/k8s/constraints_detect_test.go
+++ b/internal/k8s/constraints_detect_test.go
@@ -1,0 +1,68 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestDetectConstraints_ForbiddenListOmitsRowsNotShowsAbsent(t *testing.T) {
+	node := &corev1.Node{Name: "node-1"}
+	cs := k8sfake.NewClientset(node)
+	cs.PrependReactor("list", "poddisruptionbudgets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "policy", Resource: "poddisruptionbudgets"}, "", nil)
+	})
+
+	quota := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ResourceQuota",
+			"metadata":   map[string]any{"name": "compute-quota", "namespace": "default"},
+			"spec":       map[string]any{"hard": map[string]any{"cpu": "4"}},
+			"status":     map[string]any{"used": map[string]any{"cpu": "3"}},
+		},
+	}
+	dc := newFakeDynClient(quota)
+
+	client := newFakeClient(cs, dc)
+
+	target := ConstraintTarget{
+		Namespace:  "default",
+		PodLabels:  map[string]string{"app": "web"},
+		Containers: []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+	}
+
+	report, _ := client.DetectConstraints(t.Context(), "", target)
+
+	for _, row := range report.Rows {
+		if row.Source == "PDB" {
+			t.Errorf("expected no PDB rows, got %+v", row)
+		}
+	}
+	foundSkipped := false
+	for _, s := range report.Skipped {
+		if s == "poddisruptionbudgets" {
+			foundSkipped = true
+		}
+	}
+	if !foundSkipped {
+		t.Errorf("expected Skipped to contain poddisruptionbudgets, got %v", report.Skipped)
+	}
+
+	foundQuota := false
+	for _, row := range report.Rows {
+		if row.Source == "Quota" {
+			foundQuota = true
+		}
+	}
+	if !foundQuota {
+		t.Errorf("expected the quota source to still populate rows, got %+v", report.Rows)
+	}
+}

--- a/internal/k8s/constraints_nodes.go
+++ b/internal/k8s/constraints_nodes.go
@@ -9,6 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // nodeConstraintRows lists every node once and reports the scheduling
@@ -26,10 +27,50 @@ func (c *Client) nodeConstraintRows(ctx context.Context, kubeCtx string, target 
 	nodes := list.Items
 
 	return slices.Concat(
-		nodeSelectorRows(nodes, target.NodeSelector),
-		nodeAffinityRows(nodes, target.Affinity),
+		schedulingRows(nodes, target),
 		taintRows(nodes, target.Tolerations),
 	), nil
+}
+
+// schedulingRows suppresses a row only when one node satisfies the
+// nodeSelector and the required affinity at once: node A matching the
+// selector and node B the affinity still leaves the target unschedulable.
+func schedulingRows(nodes []corev1.Node, target ConstraintTarget) []ConstraintRow {
+	if len(target.NodeSelector) == 0 && len(target.Affinity) == 0 {
+		return nil
+	}
+	selector := labels.SelectorFromSet(labels.Set(target.NodeSelector))
+	for _, n := range nodes {
+		if selector.Matches(labels.Set(n.Labels)) && nodeMatchesAffinity(n, target.Affinity) {
+			return nil
+		}
+	}
+
+	rows := slices.Concat(
+		nodeSelectorRows(nodes, target.NodeSelector),
+		nodeAffinityRows(nodes, target.Affinity),
+	)
+	if len(rows) > 0 {
+		return rows
+	}
+	return []ConstraintRow{{
+		Source:   "Node",
+		Detail:   "nodeSelector and nodeAffinity: no single node satisfies both",
+		Headroom: "0 nodes",
+		Blocking: true,
+	}}
+}
+
+func nodeMatchesAffinity(n corev1.Node, terms []NodeSelectorTerm) bool {
+	if len(terms) == 0 {
+		return true
+	}
+	for _, term := range terms {
+		if nodeSelectorTermMatches(term, n) {
+			return true
+		}
+	}
+	return false
 }
 
 func nodeSelectorRows(nodes []corev1.Node, sel map[string]string) []ConstraintRow {
@@ -49,8 +90,11 @@ func nodeSelectorRows(nodes []corev1.Node, sel map[string]string) []ConstraintRo
 }
 
 func anyNodeHasLabel(nodes []corev1.Node, key, value string) bool {
+	// SelectorFromSet requires the key to be present, so a node missing it
+	// no longer matches an empty selector value.
+	sel := labels.SelectorFromSet(labels.Set{key: value})
 	for _, n := range nodes {
-		if n.Labels[key] == value {
+		if sel.Matches(labels.Set(n.Labels)) {
 			return true
 		}
 	}
@@ -62,10 +106,8 @@ func nodeAffinityRows(nodes []corev1.Node, terms []NodeSelectorTerm) []Constrain
 		return nil
 	}
 	for _, n := range nodes {
-		for _, term := range terms {
-			if nodeSelectorTermMatches(term, n.Labels) {
-				return nil
-			}
+		if nodeMatchesAffinity(n, terms) {
+			return nil
 		}
 	}
 	rows := make([]ConstraintRow, 0, len(terms))
@@ -80,13 +122,32 @@ func nodeAffinityRows(nodes []corev1.Node, terms []NodeSelectorTerm) []Constrain
 	return rows
 }
 
-func nodeSelectorTermMatches(term NodeSelectorTerm, labels map[string]string) bool {
+func nodeSelectorTermMatches(term NodeSelectorTerm, n corev1.Node) bool {
+	// Kubernetes treats a term with neither expressions nor fields as
+	// matching no node at all.
+	if len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0 {
+		return false
+	}
 	for _, req := range term.MatchExpressions {
-		if !nodeSelectorRequirementMatches(req, labels) {
+		if !nodeSelectorRequirementMatches(req, n.Labels) {
 			return false
 		}
 	}
+	if len(term.MatchFields) > 0 {
+		fields := nodeFieldSet(n)
+		for _, req := range term.MatchFields {
+			if !nodeSelectorRequirementMatches(req, fields) {
+				return false
+			}
+		}
+	}
 	return true
+}
+
+// nodeFieldSet is what matchFields selects on. Kubernetes accepts only
+// metadata.name there for a node.
+func nodeFieldSet(n corev1.Node) map[string]string {
+	return map[string]string{"metadata.name": n.Name}
 }
 
 func nodeSelectorRequirementMatches(req NodeSelectorRequirement, labels map[string]string) bool {
@@ -117,8 +178,8 @@ func numericLess(a, b string) bool {
 
 func describeNodeSelectorTerm(term NodeSelectorTerm) string {
 	var out strings.Builder
-	for i, req := range term.MatchExpressions {
-		if i > 0 {
+	for _, req := range slices.Concat(term.MatchExpressions, term.MatchFields) {
+		if out.Len() > 0 {
 			out.WriteString(", ")
 		}
 		fmt.Fprintf(&out, "%s %s %v", req.Key, req.Operator, req.Values)

--- a/internal/k8s/constraints_nodes.go
+++ b/internal/k8s/constraints_nodes.go
@@ -1,0 +1,179 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// nodeConstraintRows lists every node once and reports the scheduling
+// terms no node satisfies (nodeSelector keys, required node affinity) and
+// the taints no toleration covers.
+func (c *Client) nodeConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+	cs, err := c.clientsetForContext(kubeCtx)
+	if err != nil {
+		return nil, err
+	}
+	list, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+	nodes := list.Items
+
+	return slices.Concat(
+		nodeSelectorRows(nodes, target.NodeSelector),
+		nodeAffinityRows(nodes, target.Affinity),
+		taintRows(nodes, target.Tolerations),
+	), nil
+}
+
+func nodeSelectorRows(nodes []corev1.Node, sel map[string]string) []ConstraintRow {
+	var rows []ConstraintRow
+	for k, v := range sel {
+		if anyNodeHasLabel(nodes, k, v) {
+			continue
+		}
+		rows = append(rows, ConstraintRow{
+			Source:   "Node",
+			Detail:   fmt.Sprintf("nodeSelector %s=%s: no node satisfies it", k, v),
+			Headroom: "0 nodes",
+			Blocking: true,
+		})
+	}
+	return rows
+}
+
+func anyNodeHasLabel(nodes []corev1.Node, key, value string) bool {
+	for _, n := range nodes {
+		if n.Labels[key] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeAffinityRows(nodes []corev1.Node, terms []NodeSelectorTerm) []ConstraintRow {
+	if len(terms) == 0 {
+		return nil
+	}
+	for _, n := range nodes {
+		for _, term := range terms {
+			if nodeSelectorTermMatches(term, n.Labels) {
+				return nil
+			}
+		}
+	}
+	rows := make([]ConstraintRow, 0, len(terms))
+	for _, term := range terms {
+		rows = append(rows, ConstraintRow{
+			Source:   "Node",
+			Detail:   "nodeAffinity " + describeNodeSelectorTerm(term) + ": no node satisfies it",
+			Headroom: "0 nodes",
+			Blocking: true,
+		})
+	}
+	return rows
+}
+
+func nodeSelectorTermMatches(term NodeSelectorTerm, labels map[string]string) bool {
+	for _, req := range term.MatchExpressions {
+		if !nodeSelectorRequirementMatches(req, labels) {
+			return false
+		}
+	}
+	return true
+}
+
+func nodeSelectorRequirementMatches(req NodeSelectorRequirement, labels map[string]string) bool {
+	val, exists := labels[req.Key]
+	switch req.Operator {
+	case "In":
+		return exists && slices.Contains(req.Values, val)
+	case "NotIn":
+		return !exists || !slices.Contains(req.Values, val)
+	case "Exists":
+		return exists
+	case "DoesNotExist":
+		return !exists
+	case "Gt":
+		return exists && len(req.Values) == 1 && numericLess(req.Values[0], val)
+	case "Lt":
+		return exists && len(req.Values) == 1 && numericLess(val, req.Values[0])
+	default:
+		return false
+	}
+}
+
+func numericLess(a, b string) bool {
+	av, aerr := strconv.ParseInt(a, 10, 64)
+	bv, berr := strconv.ParseInt(b, 10, 64)
+	return aerr == nil && berr == nil && av < bv
+}
+
+func describeNodeSelectorTerm(term NodeSelectorTerm) string {
+	var out strings.Builder
+	for i, req := range term.MatchExpressions {
+		if i > 0 {
+			out.WriteString(", ")
+		}
+		fmt.Fprintf(&out, "%s %s %v", req.Key, req.Operator, req.Values)
+	}
+	return out.String()
+}
+
+// taintRows reports, per node, the NoSchedule/NoExecute taints none of the
+// target's tolerations cover. PreferNoSchedule is advisory and never
+// blocks scheduling, so it is skipped.
+func taintRows(nodes []corev1.Node, tolerations []corev1.Toleration) []ConstraintRow {
+	var rows []ConstraintRow
+	for _, n := range nodes {
+		for _, taint := range n.Spec.Taints {
+			if taint.Effect == corev1.TaintEffectPreferNoSchedule {
+				continue
+			}
+			if tolerationsTolerateTaint(tolerations, taint) {
+				continue
+			}
+			rows = append(rows, ConstraintRow{
+				Source:   "Node",
+				Kind:     "Node",
+				Name:     n.Name,
+				Detail:   fmt.Sprintf("taint %s=%s:%s not tolerated", taint.Key, taint.Value, taint.Effect),
+				Headroom: "not tolerated",
+				Blocking: true,
+			})
+		}
+	}
+	return rows
+}
+
+func tolerationsTolerateTaint(tolerations []corev1.Toleration, taint corev1.Taint) bool {
+	for _, t := range tolerations {
+		if toleratesTaint(t, taint) {
+			return true
+		}
+	}
+	return false
+}
+
+func toleratesTaint(t corev1.Toleration, taint corev1.Taint) bool {
+	if t.Effect != "" && t.Effect != taint.Effect {
+		return false
+	}
+	if t.Key != "" && t.Key != taint.Key {
+		return false
+	}
+	switch t.Operator {
+	case "", corev1.TolerationOpEqual:
+		return t.Value == taint.Value
+	case corev1.TolerationOpExists:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/k8s/constraints_nodes_test.go
+++ b/internal/k8s/constraints_nodes_test.go
@@ -1,0 +1,64 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeRows_NameTermNoNodeSatisfies(t *testing.T) {
+	node1 := &corev1.Node{
+		Name: "node-1", Labels: map[string]string{"disk": "hdd"},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{{Key: "dedicated", Value: "gpu", Effect: corev1.TaintEffectNoSchedule}},
+		},
+	}
+	node2 := &corev1.Node{
+		Name: "node-2", Labels: map[string]string{"disk": "hdd"},
+	}
+	client := newFakeClient(k8sfake.NewClientset(node1, node2), nil)
+
+	target := ConstraintTarget{NodeSelector: map[string]string{"disk": "nvme"}}
+
+	rows, err := client.nodeConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("nodeConstraintRows: %v", err)
+	}
+
+	var sawSelector, sawTaint bool
+	for _, r := range rows {
+		if strings.Contains(r.Detail, "disk=nvme") {
+			sawSelector = true
+		}
+		if r.Kind == "Node" && r.Name == "node-1" {
+			sawTaint = true
+		}
+	}
+	if !sawSelector {
+		t.Errorf("expected a row naming disk=nvme, got %+v", rows)
+	}
+	if !sawTaint {
+		t.Errorf("expected a Node row for node-1's untolerated taint, got %+v", rows)
+	}
+}
+
+func TestNodeRows_SelectorSatisfiedByOneNodeYieldsNoRow(t *testing.T) {
+	node1 := &corev1.Node{
+		Name: "node-1", Labels: map[string]string{"disk": "nvme"},
+	}
+	client := newFakeClient(k8sfake.NewClientset(node1), nil)
+
+	target := ConstraintTarget{NodeSelector: map[string]string{"disk": "nvme"}}
+
+	rows, err := client.nodeConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("nodeConstraintRows: %v", err)
+	}
+	for _, r := range rows {
+		if r.Kind == "NodeSelector" {
+			t.Errorf("did not expect a NodeSelector row, got %+v", r)
+		}
+	}
+}

--- a/internal/k8s/constraints_nodes_test.go
+++ b/internal/k8s/constraints_nodes_test.go
@@ -44,6 +44,99 @@ func TestNodeRows_NameTermNoNodeSatisfies(t *testing.T) {
 	}
 }
 
+func TestSchedulingRows_SelectorAndAffinityMustMatchTheSameNode(t *testing.T) {
+	selectorOnly := corev1.Node{Name: "node-1", Labels: map[string]string{"disk": "nvme"}}
+	affinityOnly := corev1.Node{Name: "node-2", Labels: map[string]string{"zone": "eu-1"}}
+	both := corev1.Node{Name: "node-3", Labels: map[string]string{"disk": "nvme", "zone": "eu-1"}}
+
+	zoneTerm := NodeSelectorTerm{MatchExpressions: []NodeSelectorRequirement{
+		{Key: "zone", Operator: "In", Values: []string{"eu-1"}},
+	}}
+	target := ConstraintTarget{
+		NodeSelector: map[string]string{"disk": "nvme"},
+		Affinity:     []NodeSelectorTerm{zoneTerm},
+	}
+
+	tests := []struct {
+		name     string
+		nodes    []corev1.Node
+		wantRows bool
+	}{
+		{"split across two nodes", []corev1.Node{selectorOnly, affinityOnly}, true},
+		{"one node satisfies both", []corev1.Node{selectorOnly, affinityOnly, both}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := schedulingRows(tt.nodes, target)
+			if got := len(rows) > 0; got != tt.wantRows {
+				t.Errorf("rows = %+v, want any = %v", rows, tt.wantRows)
+			}
+		})
+	}
+}
+
+func TestNodeSelectorTermMatches_FieldsAndEmptyTerms(t *testing.T) {
+	node := corev1.Node{Name: "node-1", Labels: map[string]string{"disk": "nvme"}}
+
+	tests := []struct {
+		name string
+		term NodeSelectorTerm
+		want bool
+	}{
+		{"empty term matches no node", NodeSelectorTerm{}, false},
+		{
+			"matchFields on the node name",
+			NodeSelectorTerm{MatchFields: []NodeSelectorRequirement{
+				{Key: "metadata.name", Operator: "In", Values: []string{"node-1"}},
+			}},
+			true,
+		},
+		{
+			"matchFields naming another node",
+			NodeSelectorTerm{MatchFields: []NodeSelectorRequirement{
+				{Key: "metadata.name", Operator: "In", Values: []string{"node-9"}},
+			}},
+			false,
+		},
+		{
+			"expressions and fields are ANDed",
+			NodeSelectorTerm{
+				MatchExpressions: []NodeSelectorRequirement{{Key: "disk", Operator: "In", Values: []string{"nvme"}}},
+				MatchFields:      []NodeSelectorRequirement{{Key: "metadata.name", Operator: "In", Values: []string{"node-9"}}},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nodeSelectorTermMatches(tt.term, node); got != tt.want {
+				t.Errorf("nodeSelectorTermMatches = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnyNodeHasLabel_RequiresTheKeyToExist(t *testing.T) {
+	nodes := []corev1.Node{{Name: "node-1", Labels: map[string]string{"disk": "nvme"}}}
+
+	tests := []struct {
+		name       string
+		key, value string
+		want       bool
+	}{
+		{"present key and value", "disk", "nvme", true},
+		{"missing key with an empty value", "gpu", "", false},
+		{"present key, other value", "disk", "hdd", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := anyNodeHasLabel(nodes, tt.key, tt.value); got != tt.want {
+				t.Errorf("anyNodeHasLabel(%q, %q) = %v, want %v", tt.key, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNodeRows_SelectorSatisfiedByOneNodeYieldsNoRow(t *testing.T) {
 	node1 := &corev1.Node{
 		Name: "node-1", Labels: map[string]string{"disk": "nvme"},

--- a/internal/k8s/constraints_pdb.go
+++ b/internal/k8s/constraints_pdb.go
@@ -1,0 +1,33 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+)
+
+// pdbConstraintRows lists the namespace's PodDisruptionBudgets and reports
+// the ones whose selector covers the target's pod labels.
+func (c *Client) pdbConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+	pdbs, err := c.ListPodDisruptionBudgets(ctx, kubeCtx, target.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	var rows []ConstraintRow
+	for i := range pdbs {
+		pdb := &pdbs[i]
+		if !PDBSelectorMatches(pdb, target.PodLabels) {
+			continue
+		}
+		allowed := pdb.Status.DisruptionsAllowed
+		rows = append(rows, ConstraintRow{
+			Source:    "PDB",
+			Kind:      "PodDisruptionBudget",
+			Namespace: pdb.Namespace,
+			Name:      pdb.Name,
+			Detail:    fmt.Sprintf("%d disruptions allowed", allowed),
+			Headroom:  fmt.Sprintf("%d", allowed),
+			Blocking:  allowed == 0,
+		})
+	}
+	return rows, nil
+}

--- a/internal/k8s/constraints_pdb_test.go
+++ b/internal/k8s/constraints_pdb_test.go
@@ -1,0 +1,46 @@
+package k8s
+
+import (
+	"testing"
+
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPDBRows_UseSelectorMatchesAndStateDisruptionsAllowed(t *testing.T) {
+	matching := &policyv1.PodDisruptionBudget{
+		Name: "web-pdb", Namespace: "default",
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		},
+		Status: policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+	}
+	other := &policyv1.PodDisruptionBudget{
+		Name: "api-pdb", Namespace: "default",
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+		},
+		Status: policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: 2},
+	}
+	client := newFakeClient(k8sfake.NewClientset(matching, other), nil)
+
+	target := ConstraintTarget{Namespace: "default", PodLabels: map[string]string{"app": "web"}}
+
+	rows, err := client.pdbConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("pdbConstraintRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].Name != "web-pdb" {
+		t.Errorf("Name = %q, want web-pdb", rows[0].Name)
+	}
+	if !rows[0].Blocking {
+		t.Error("expected row to be Blocking")
+	}
+	if rows[0].Detail != "0 disruptions allowed" {
+		t.Errorf("Detail = %q, want %q", rows[0].Detail, "0 disruptions allowed")
+	}
+}

--- a/internal/k8s/constraints_priority.go
+++ b/internal/k8s/constraints_priority.go
@@ -7,6 +7,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// constraintsEventsLimit caps the Preempted events fetched for one pod,
+// bounding both the API response size and the rows rendered from it.
+const constraintsEventsLimit = 500
+
 // priorityConstraintRows reports the target's PriorityClass value and, for
 // a bare Pod, whether it is already mid-preemption: a set
 // status.nominatedNodeName or a recent Preempted event against it.
@@ -47,9 +51,14 @@ func (c *Client) priorityConstraintRows(ctx context.Context, kubeCtx string, tar
 
 	events, err := cs.CoreV1().Events(target.Namespace).List(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Preempted", target.PodName),
+		Limit:         constraintsEventsLimit,
 	})
 	if err == nil {
-		for _, ev := range events.Items {
+		items := events.Items
+		if len(items) > constraintsEventsLimit {
+			items = items[:constraintsEventsLimit]
+		}
+		for _, ev := range items {
 			rows = append(rows, ConstraintRow{
 				Source:    "PriorityClass",
 				Kind:      "Event",

--- a/internal/k8s/constraints_priority.go
+++ b/internal/k8s/constraints_priority.go
@@ -43,6 +43,7 @@ func (c *Client) priorityConstraintRows(ctx context.Context, kubeCtx string, tar
 	var lookupErrs []error
 
 	pod, err := cs.CoreV1().Pods(target.Namespace).Get(ctx, target.PodName, metav1.GetOptions{})
+	podFound := err == nil
 	switch {
 	case err != nil:
 		lookupErrs = append(lookupErrs, fmt.Errorf("getting pod %s: %w", target.PodName, err))
@@ -57,8 +58,14 @@ func (c *Client) priorityConstraintRows(ctx context.Context, kubeCtx string, tar
 		})
 	}
 
+	// A pod's UID is unique across the reused name, so pinning it excludes
+	// Preempted events left over from an earlier pod with the same name.
+	selector := fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Preempted", target.PodName)
+	if podFound {
+		selector += fmt.Sprintf(",involvedObject.uid=%s", pod.UID)
+	}
 	events, err := cs.CoreV1().Events(target.Namespace).List(ctx, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Preempted", target.PodName),
+		FieldSelector: selector,
 		Limit:         constraintsEventsLimit,
 	})
 	if err != nil {

--- a/internal/k8s/constraints_priority.go
+++ b/internal/k8s/constraints_priority.go
@@ -1,0 +1,64 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// priorityConstraintRows reports the target's PriorityClass value and, for
+// a bare Pod, whether it is already mid-preemption: a set
+// status.nominatedNodeName or a recent Preempted event against it.
+func (c *Client) priorityConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+	if target.PriorityClassName == "" {
+		return nil, nil
+	}
+	cs, err := c.clientsetForContext(kubeCtx)
+	if err != nil {
+		return nil, err
+	}
+	pc, err := cs.SchedulingV1().PriorityClasses().Get(ctx, target.PriorityClassName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	rows := []ConstraintRow{{
+		Source:   "PriorityClass",
+		Kind:     "PriorityClass",
+		Name:     pc.Name,
+		Detail:   fmt.Sprintf("value %d", pc.Value),
+		Headroom: fmt.Sprintf("%d", pc.Value),
+	}}
+
+	if target.PodName == "" {
+		return rows, nil
+	}
+	pod, err := cs.CoreV1().Pods(target.Namespace).Get(ctx, target.PodName, metav1.GetOptions{})
+	if err == nil && pod.Status.NominatedNodeName != "" {
+		rows = append(rows, ConstraintRow{
+			Source:    "PriorityClass",
+			Kind:      "Pod",
+			Namespace: target.Namespace,
+			Name:      target.PodName,
+			Detail:    fmt.Sprintf("nominated for node %s, awaiting preemption", pod.Status.NominatedNodeName),
+			Blocking:  true,
+		})
+	}
+
+	events, err := cs.CoreV1().Events(target.Namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Preempted", target.PodName),
+	})
+	if err == nil {
+		for _, ev := range events.Items {
+			rows = append(rows, ConstraintRow{
+				Source:    "PriorityClass",
+				Kind:      "Event",
+				Namespace: target.Namespace,
+				Name:      target.PodName,
+				Detail:    ev.Message,
+				Blocking:  true,
+			})
+		}
+	}
+	return rows, nil
+}

--- a/internal/k8s/constraints_priority.go
+++ b/internal/k8s/constraints_priority.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,8 +38,15 @@ func (c *Client) priorityConstraintRows(ctx context.Context, kubeCtx string, tar
 	if target.PodName == "" {
 		return rows, nil
 	}
+	// The PriorityClass row above survives a preemption lookup failure:
+	// DetectConstraints keeps a source's rows and still banners its error.
+	var lookupErrs []error
+
 	pod, err := cs.CoreV1().Pods(target.Namespace).Get(ctx, target.PodName, metav1.GetOptions{})
-	if err == nil && pod.Status.NominatedNodeName != "" {
+	switch {
+	case err != nil:
+		lookupErrs = append(lookupErrs, fmt.Errorf("getting pod %s: %w", target.PodName, err))
+	case pod.Status.NominatedNodeName != "":
 		rows = append(rows, ConstraintRow{
 			Source:    "PriorityClass",
 			Kind:      "Pod",
@@ -53,7 +61,9 @@ func (c *Client) priorityConstraintRows(ctx context.Context, kubeCtx string, tar
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Preempted", target.PodName),
 		Limit:         constraintsEventsLimit,
 	})
-	if err == nil {
+	if err != nil {
+		lookupErrs = append(lookupErrs, fmt.Errorf("listing preemption events for %s: %w", target.PodName, err))
+	} else {
 		items := events.Items
 		if len(items) > constraintsEventsLimit {
 			items = items[:constraintsEventsLimit]
@@ -69,5 +79,5 @@ func (c *Client) priorityConstraintRows(ctx context.Context, kubeCtx string, tar
 			})
 		}
 	}
-	return rows, nil
+	return rows, errors.Join(lookupErrs...)
 }

--- a/internal/k8s/constraints_priority_test.go
+++ b/internal/k8s/constraints_priority_test.go
@@ -1,0 +1,76 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPriorityRows_ReportPreemptionFromEventAndNominatedNode(t *testing.T) {
+	pc := &schedulingv1.PriorityClass{
+		Name:  "high",
+		Value: 1000000,
+	}
+	pod := &corev1.Pod{
+		Name: "web-1", Namespace: "default",
+		Status: corev1.PodStatus{NominatedNodeName: "node-2"},
+	}
+	event := &corev1.Event{
+		Name: "web-1.preempt", Namespace: "default",
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod", Name: "web-1", Namespace: "default",
+		},
+		Reason:  "Preempted",
+		Message: "preempted by a higher priority pod",
+	}
+	client := newFakeClient(k8sfake.NewClientset(pc, pod, event), nil)
+
+	target := ConstraintTarget{
+		Namespace:         "default",
+		PodName:           "web-1",
+		PriorityClassName: "high",
+	}
+
+	rows, err := client.priorityConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("priorityConstraintRows: %v", err)
+	}
+	if len(rows) < 3 {
+		t.Fatalf("expected at least 3 rows (class, nominated, event), got %d: %+v", len(rows), rows)
+	}
+	if !strings.Contains(rows[0].Detail, "1000000") {
+		t.Errorf("first row Detail = %q, want the priority value", rows[0].Detail)
+	}
+	var sawNominated, sawEvent bool
+	for _, r := range rows[1:] {
+		if strings.Contains(r.Detail, "node-2") {
+			sawNominated = true
+		}
+		if strings.Contains(r.Detail, "preempted by a higher priority pod") {
+			sawEvent = true
+		}
+		if !r.Blocking {
+			t.Errorf("row %+v should be Blocking", r)
+		}
+	}
+	if !sawNominated {
+		t.Error("expected a row naming the nominated node")
+	}
+	if !sawEvent {
+		t.Error("expected a row from the Preempted event")
+	}
+}
+
+func TestPriorityRows_NoPriorityClassNameYieldsNoRows(t *testing.T) {
+	client := newFakeClient(k8sfake.NewClientset(), nil)
+	rows, err := client.priorityConstraintRows(t.Context(), "", ConstraintTarget{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("priorityConstraintRows: %v", err)
+	}
+	if rows != nil {
+		t.Errorf("expected no rows, got %+v", rows)
+	}
+}

--- a/internal/k8s/constraints_priority_test.go
+++ b/internal/k8s/constraints_priority_test.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -111,6 +112,53 @@ func TestPriorityRows_NoPriorityClassNameYieldsNoRows(t *testing.T) {
 	}
 	if rows != nil {
 		t.Errorf("expected no rows, got %+v", rows)
+	}
+}
+
+func TestPriorityRows_EventsFieldSelectorIncludesPodUID(t *testing.T) {
+	tests := []struct {
+		name       string
+		podUID     string
+		podGetFail bool
+		wantUID    string
+		wantNoUID  bool
+	}{
+		{name: "pod found sets involvedObject.uid", podUID: "pod-uid-123", wantUID: "pod-uid-123"},
+		{name: "pod lookup failure omits involvedObject.uid", podGetFail: true, wantNoUID: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := &schedulingv1.PriorityClass{Name: "high", Value: 100}
+			pod := &corev1.Pod{Name: "web-1", Namespace: "default", UID: types.UID(tt.podUID)}
+			cs := k8sfake.NewClientset(pc, pod)
+			if tt.podGetFail {
+				cs.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "web-1", nil)
+				})
+			}
+
+			var gotSelector string
+			cs.PrependReactor("list", "events", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				listAction, ok := action.(k8stesting.ListActionImpl)
+				if ok {
+					gotSelector = listAction.GetListOptions().FieldSelector
+				}
+				return false, nil, nil
+			})
+			client := newFakeClient(cs, nil)
+
+			target := ConstraintTarget{Namespace: "default", PodName: "web-1", PriorityClassName: "high"}
+			if _, err := client.priorityConstraintRows(t.Context(), "", target); err != nil && !tt.podGetFail {
+				t.Fatalf("priorityConstraintRows: %v", err)
+			}
+
+			if tt.wantUID != "" && !strings.Contains(gotSelector, "involvedObject.uid="+tt.wantUID) {
+				t.Errorf("FieldSelector = %q, want to contain involvedObject.uid=%s", gotSelector, tt.wantUID)
+			}
+			if tt.wantNoUID && strings.Contains(gotSelector, "involvedObject.uid=") {
+				t.Errorf("FieldSelector = %q, want no involvedObject.uid", gotSelector)
+			}
+		})
 	}
 }
 

--- a/internal/k8s/constraints_priority_test.go
+++ b/internal/k8s/constraints_priority_test.go
@@ -7,7 +7,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -64,6 +66,40 @@ func TestPriorityRows_ReportPreemptionFromEventAndNominatedNode(t *testing.T) {
 	}
 	if !sawEvent {
 		t.Error("expected a row from the Preempted event")
+	}
+}
+
+func TestPriorityRows_PreemptionLookupFailureKeepsRowAndReportsError(t *testing.T) {
+	failErr := apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "web-1", nil)
+
+	tests := []struct {
+		name     string
+		verb     string
+		resource string
+	}{
+		{"pod get denied", "get", "pods"},
+		{"event list denied", "list", "events"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := &schedulingv1.PriorityClass{Name: "high", Value: 100}
+			pod := &corev1.Pod{Name: "web-1", Namespace: "default"}
+			cs := k8sfake.NewClientset(pc, pod)
+			cs.PrependReactor(tt.verb, tt.resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, failErr
+			})
+			client := newFakeClient(cs, nil)
+
+			target := ConstraintTarget{Namespace: "default", PodName: "web-1", PriorityClassName: "high"}
+			rows, err := client.priorityConstraintRows(t.Context(), "", target)
+
+			if err == nil {
+				t.Error("expected the failed lookup to surface an error")
+			}
+			if len(rows) != 1 || rows[0].Kind != "PriorityClass" {
+				t.Errorf("expected the PriorityClass row to survive, got %+v", rows)
+			}
+		})
 	}
 }
 

--- a/internal/k8s/constraints_priority_test.go
+++ b/internal/k8s/constraints_priority_test.go
@@ -1,12 +1,15 @@
 package k8s
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestPriorityRows_ReportPreemptionFromEventAndNominatedNode(t *testing.T) {
@@ -72,5 +75,65 @@ func TestPriorityRows_NoPriorityClassNameYieldsNoRows(t *testing.T) {
 	}
 	if rows != nil {
 		t.Errorf("expected no rows, got %+v", rows)
+	}
+}
+
+func TestPriorityRows_EventsListSetsLimit(t *testing.T) {
+	pc := &schedulingv1.PriorityClass{Name: "high", Value: 100}
+	pod := &corev1.Pod{Name: "web-1", Namespace: "default"}
+	cs := k8sfake.NewClientset(pc, pod)
+
+	var gotLimit int64
+	cs.PrependReactor("list", "events", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction, ok := action.(k8stesting.ListActionImpl)
+		if ok {
+			gotLimit = listAction.GetListOptions().Limit
+		}
+		return false, nil, nil
+	})
+	client := newFakeClient(cs, nil)
+
+	target := ConstraintTarget{Namespace: "default", PodName: "web-1", PriorityClassName: "high"}
+	if _, err := client.priorityConstraintRows(t.Context(), "", target); err != nil {
+		t.Fatalf("priorityConstraintRows: %v", err)
+	}
+
+	if gotLimit != constraintsEventsLimit {
+		t.Errorf("events List Limit = %d, want %d", gotLimit, constraintsEventsLimit)
+	}
+}
+
+func TestPriorityRows_CapsEventRowsAtLimit(t *testing.T) {
+	pc := &schedulingv1.PriorityClass{Name: "high", Value: 100}
+	pod := &corev1.Pod{Name: "web-1", Namespace: "default"}
+	objs := make([]runtime.Object, 0, 2+constraintsEventsLimit+5)
+	objs = append(objs, pc, pod)
+	for i := range constraintsEventsLimit + 5 {
+		objs = append(objs, &corev1.Event{
+			Name:      fmt.Sprintf("web-1.preempt-%d", i),
+			Namespace: "default",
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod", Name: "web-1", Namespace: "default",
+			},
+			Reason:  "Preempted",
+			Message: "preempted by a higher priority pod",
+		})
+	}
+	client := newFakeClient(k8sfake.NewClientset(objs...), nil)
+
+	target := ConstraintTarget{Namespace: "default", PodName: "web-1", PriorityClassName: "high"}
+	rows, err := client.priorityConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("priorityConstraintRows: %v", err)
+	}
+
+	eventRows := 0
+	for _, r := range rows {
+		if r.Kind == "Event" {
+			eventRows++
+		}
+	}
+	if eventRows != constraintsEventsLimit {
+		t.Errorf("event rows = %d, want capped at %d", eventRows, constraintsEventsLimit)
 	}
 }

--- a/internal/k8s/constraints_quota.go
+++ b/internal/k8s/constraints_quota.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -23,54 +25,162 @@ func (c *Client) listLimitRanges(ctx context.Context, contextName, namespace str
 }
 
 // quotaConstraintRows reports ResourceQuota objects covering a resource
-// the target requests (trimQuotaResourcePrefix matches "requests.cpu"
+// the target asks for (trimQuotaResourcePrefix matches "requests.cpu"
 // against a container's bare "cpu" key).
 func (c *Client) quotaConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
 	quotas, err := c.GetNamespaceQuotas(ctx, kubeCtx, target.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	totals := totalContainerRequests(target.Containers)
-	if len(totals) == 0 || len(quotas) == 0 {
+	requests := totalContainerRequests(target.Containers)
+	limits := totalContainerLimits(target.Containers)
+	if (len(requests) == 0 && len(limits) == 0) || len(quotas) == 0 {
 		return nil, nil
 	}
 
 	var rows []ConstraintRow
 	for _, quota := range quotas {
+		if !quotaAppliesTo(quota, target) {
+			continue
+		}
 		for _, res := range quota.Resources {
-			resName := trimQuotaResourcePrefix(res.Name)
-			requested, ok := totals[resName]
+			resName, countsLimits := trimQuotaResourcePrefix(res.Name)
+			totals, verb := requests, "requests"
+			if countsLimits {
+				totals, verb = limits, "limits"
+			}
+			asked, ok := totals[resName]
 			if !ok {
 				continue
 			}
-			rows = append(rows, quotaRow(quota, res, requested))
+			rows = append(rows, quotaRow(quota, res, asked, verb))
 		}
 	}
 	return rows, nil
 }
 
-// trimQuotaResourcePrefix strips the "requests."/"limits." prefix
-// ResourceQuota uses for compute resources, so "requests.cpu" and "cpu"
-// both compare equal to a container's raw request key.
-func trimQuotaResourcePrefix(name string) string {
-	for _, prefix := range []string{"requests.", "limits."} {
-		if len(name) > len(prefix) && name[:len(prefix)] == prefix {
-			return name[len(prefix):]
-		}
+// trimQuotaResourcePrefix reports which half of the container spec the
+// quota counts: Kubernetes charges "limits.*" against container limits,
+// "requests.*" and bare "cpu"/"memory" against requests.
+func trimQuotaResourcePrefix(name string) (resourceName string, countsLimits bool) {
+	if trimmed, ok := strings.CutPrefix(name, "limits."); ok && trimmed != "" {
+		return trimmed, true
 	}
-	return name
+	if trimmed, ok := strings.CutPrefix(name, "requests."); ok && trimmed != "" {
+		return trimmed, false
+	}
+	return name, false
 }
 
-func quotaRow(quota QuotaInfo, res QuotaResource, requested string) ConstraintRow {
+// quotaAppliesTo ANDs spec.scopes with spec.scopeSelector. A scope needing
+// pod state this view lacks (Terminating, CrossNamespacePodAffinity) leaves
+// the quota applicable rather than hiding one that may well bind.
+func quotaAppliesTo(quota QuotaInfo, target ConstraintTarget) bool {
+	for _, scope := range quota.Scopes {
+		if !quotaScopeMatches(QuotaScopeRequirement{ScopeName: scope, Operator: string(corev1.ScopeSelectorOpExists)}, target) {
+			return false
+		}
+	}
+	for _, req := range quota.ScopeSelector {
+		if !quotaScopeMatches(req, target) {
+			return false
+		}
+	}
+	return true
+}
+
+func quotaScopeMatches(req QuotaScopeRequirement, target ConstraintTarget) bool {
+	switch corev1.ResourceQuotaScope(req.ScopeName) {
+	case corev1.ResourceQuotaScopePriorityClass:
+		return priorityClassScopeMatches(req, target.PriorityClassName)
+	case corev1.ResourceQuotaScopeBestEffort:
+		return scopePresenceMatches(req.Operator, targetIsBestEffort(target))
+	case corev1.ResourceQuotaScopeNotBestEffort:
+		return scopePresenceMatches(req.Operator, !targetIsBestEffort(target))
+	default:
+		return true
+	}
+}
+
+func priorityClassScopeMatches(req QuotaScopeRequirement, className string) bool {
+	switch corev1.ScopeSelectorOperator(req.Operator) {
+	case corev1.ScopeSelectorOpIn:
+		return slices.Contains(req.Values, className)
+	case corev1.ScopeSelectorOpNotIn:
+		return !slices.Contains(req.Values, className)
+	case corev1.ScopeSelectorOpDoesNotExist:
+		return className == ""
+	default:
+		return className != ""
+	}
+}
+
+func scopePresenceMatches(operator string, has bool) bool {
+	if corev1.ScopeSelectorOperator(operator) == corev1.ScopeSelectorOpDoesNotExist {
+		return !has
+	}
+	return has
+}
+
+// targetIsBestEffort mirrors the BestEffort QoS rule: no container sets
+// any CPU or memory request or limit.
+func targetIsBestEffort(target ConstraintTarget) bool {
+	for _, c := range target.Containers {
+		for _, name := range []string{"cpu", "memory"} {
+			if c.Requests[name] != "" || c.Limits[name] != "" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func quotaScopesFromRaw(v any) []string {
+	rawScopes := rawSlice(v)
+	if len(rawScopes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(rawScopes))
+	for _, s := range rawScopes {
+		if str, ok := s.(string); ok {
+			out = append(out, str)
+		}
+	}
+	return out
+}
+
+func quotaScopeSelectorFromRaw(v any) []QuotaScopeRequirement {
+	rawReqs := rawSlice(rawMap(v)["matchExpressions"])
+	if len(rawReqs) == 0 {
+		return nil
+	}
+	out := make([]QuotaScopeRequirement, 0, len(rawReqs))
+	for _, e := range rawReqs {
+		em := rawMap(e)
+		req := QuotaScopeRequirement{
+			ScopeName: stringField(em, "scopeName"),
+			Operator:  stringField(em, "operator"),
+		}
+		for _, val := range rawSlice(em["values"]) {
+			if s, ok := val.(string); ok {
+				req.Values = append(req.Values, s)
+			}
+		}
+		out = append(out, req)
+	}
+	return out
+}
+
+func quotaRow(quota QuotaInfo, res QuotaResource, asked, verb string) ConstraintRow {
 	headroom := quantityHeadroom(res.Hard, res.Used)
-	requestedQty, errR := resource.ParseQuantity(requested)
-	blocking := errR == nil && headroom.qty != nil && requestedQty.Cmp(*headroom.qty) > 0
+	askedQty, errR := resource.ParseQuantity(asked)
+	blocking := errR == nil && headroom.qty != nil && askedQty.Cmp(*headroom.qty) > 0
 	return ConstraintRow{
 		Source:    "Quota",
 		Kind:      "ResourceQuota",
 		Namespace: quota.Namespace,
 		Name:      quota.Name,
-		Detail:    fmt.Sprintf("requests %s %s (hard %s, used %s)", requested, res.Name, res.Hard, res.Used),
+		Detail:    fmt.Sprintf("%s %s %s (hard %s, used %s)", verb, asked, res.Name, res.Hard, res.Used),
 		Headroom:  headroom.text,
 		Blocking:  blocking,
 	}
@@ -145,9 +255,17 @@ func limitRangeBoundRow(lr corev1.LimitRange, resName, bound string, boundQty re
 // resource name, so a multi-container pod's ask is compared to quota as a
 // whole rather than one container at a time.
 func totalContainerRequests(containers []ContainerRequest) map[string]string {
+	return totalContainerResources(containers, func(c ContainerRequest) map[string]string { return c.Requests })
+}
+
+func totalContainerLimits(containers []ContainerRequest) map[string]string {
+	return totalContainerResources(containers, func(c ContainerRequest) map[string]string { return c.Limits })
+}
+
+func totalContainerResources(containers []ContainerRequest, pick func(ContainerRequest) map[string]string) map[string]string {
 	sums := map[string]resource.Quantity{}
 	for _, c := range containers {
-		for name, qtyStr := range c.Requests {
+		for name, qtyStr := range pick(c) {
 			qty, err := resource.ParseQuantity(qtyStr)
 			if err != nil {
 				continue

--- a/internal/k8s/constraints_quota.go
+++ b/internal/k8s/constraints_quota.go
@@ -1,0 +1,186 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// listLimitRanges lists LimitRange objects in a namespace.
+func (c *Client) listLimitRanges(ctx context.Context, contextName, namespace string) ([]corev1.LimitRange, error) {
+	cs, err := c.clientsetForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	list, err := cs.CoreV1().LimitRanges(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing limitranges: %w", err)
+	}
+	return list.Items, nil
+}
+
+// quotaConstraintRows reports ResourceQuota objects covering a resource
+// the target requests (trimQuotaResourcePrefix matches "requests.cpu"
+// against a container's bare "cpu" key).
+func (c *Client) quotaConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+	quotas, err := c.GetNamespaceQuotas(ctx, kubeCtx, target.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	totals := totalContainerRequests(target.Containers)
+	if len(totals) == 0 || len(quotas) == 0 {
+		return nil, nil
+	}
+
+	var rows []ConstraintRow
+	for _, quota := range quotas {
+		for _, res := range quota.Resources {
+			resName := trimQuotaResourcePrefix(res.Name)
+			requested, ok := totals[resName]
+			if !ok {
+				continue
+			}
+			rows = append(rows, quotaRow(quota, res, requested))
+		}
+	}
+	return rows, nil
+}
+
+// trimQuotaResourcePrefix strips the "requests."/"limits." prefix
+// ResourceQuota uses for compute resources, so "requests.cpu" and "cpu"
+// both compare equal to a container's raw request key.
+func trimQuotaResourcePrefix(name string) string {
+	for _, prefix := range []string{"requests.", "limits."} {
+		if len(name) > len(prefix) && name[:len(prefix)] == prefix {
+			return name[len(prefix):]
+		}
+	}
+	return name
+}
+
+func quotaRow(quota QuotaInfo, res QuotaResource, requested string) ConstraintRow {
+	headroom := quantityHeadroom(res.Hard, res.Used)
+	requestedQty, errR := resource.ParseQuantity(requested)
+	blocking := errR == nil && headroom.qty != nil && requestedQty.Cmp(*headroom.qty) > 0
+	return ConstraintRow{
+		Source:    "Quota",
+		Kind:      "ResourceQuota",
+		Namespace: quota.Namespace,
+		Name:      quota.Name,
+		Detail:    fmt.Sprintf("requests %s %s (hard %s, used %s)", requested, res.Name, res.Hard, res.Used),
+		Headroom:  headroom.text,
+		Blocking:  blocking,
+	}
+}
+
+// limitRangeConstraintRows checks each container's requests against every
+// namespace LimitRange's per-container Min/Max bounds.
+func (c *Client) limitRangeConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+	limitRanges, err := c.listLimitRanges(ctx, kubeCtx, target.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	var rows []ConstraintRow
+	for _, lr := range limitRanges {
+		for _, item := range lr.Spec.Limits {
+			if item.Type != corev1.LimitTypeContainer {
+				continue
+			}
+			rows = append(rows, limitRangeItemRows(lr, item, target.Containers)...)
+		}
+	}
+	return rows, nil
+}
+
+func limitRangeItemRows(lr corev1.LimitRange, item corev1.LimitRangeItem, containers []ContainerRequest) []ConstraintRow {
+	var rows []ConstraintRow
+	for _, c := range containers {
+		for resName, minQty := range item.Min {
+			if row, ok := limitRangeBoundRow(lr, resName.String(), "min", minQty, c, true); ok {
+				rows = append(rows, row)
+			}
+		}
+		for resName, maxQty := range item.Max {
+			if row, ok := limitRangeBoundRow(lr, resName.String(), "max", maxQty, c, false); ok {
+				rows = append(rows, row)
+			}
+		}
+	}
+	return rows
+}
+
+// limitRangeBoundRow reports a container's request against one Min or Max
+// bound. belowIsViolation selects the comparison direction: Min is
+// violated by a smaller request, Max by a larger one.
+func limitRangeBoundRow(lr corev1.LimitRange, resName, bound string, boundQty resource.Quantity, c ContainerRequest, belowIsViolation bool) (ConstraintRow, bool) {
+	reqStr, ok := c.Requests[resName]
+	if !ok {
+		return ConstraintRow{}, false
+	}
+	reqQty, err := resource.ParseQuantity(reqStr)
+	if err != nil {
+		return ConstraintRow{}, false
+	}
+	cmp := reqQty.Cmp(boundQty)
+	violated := (belowIsViolation && cmp < 0) || (!belowIsViolation && cmp > 0)
+	if !violated {
+		return ConstraintRow{}, false
+	}
+	return ConstraintRow{
+		Source:    "LimitRange",
+		Kind:      "LimitRange",
+		Namespace: lr.Namespace,
+		Name:      lr.Name,
+		Detail: fmt.Sprintf("container %s requests %s %s, %s is %s",
+			c.Name, reqStr, resName, bound, boundQty.String()),
+		Headroom: boundQty.String(),
+		Blocking: true,
+	}, true
+}
+
+// totalContainerRequests sums each container's requested amount per
+// resource name, so a multi-container pod's ask is compared to quota as a
+// whole rather than one container at a time.
+func totalContainerRequests(containers []ContainerRequest) map[string]string {
+	sums := map[string]resource.Quantity{}
+	for _, c := range containers {
+		for name, qtyStr := range c.Requests {
+			qty, err := resource.ParseQuantity(qtyStr)
+			if err != nil {
+				continue
+			}
+			sum := sums[name]
+			sum.Add(qty)
+			sums[name] = sum
+		}
+	}
+	if len(sums) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(sums))
+	for name, qty := range sums {
+		out[name] = qty.String()
+	}
+	return out
+}
+
+// quantityHeadroomResult carries both the display string and the
+// resource.Quantity form, so callers can compare a request against it
+// without reparsing.
+type quantityHeadroomResult struct {
+	text string
+	qty  *resource.Quantity
+}
+
+func quantityHeadroom(hardStr, usedStr string) quantityHeadroomResult {
+	hard, errH := resource.ParseQuantity(hardStr)
+	used, errU := resource.ParseQuantity(usedStr)
+	if errH != nil || errU != nil {
+		return quantityHeadroomResult{text: "n/a"}
+	}
+	hard.Sub(used)
+	return quantityHeadroomResult{text: hard.String(), qty: &hard}
+}

--- a/internal/k8s/constraints_quota.go
+++ b/internal/k8s/constraints_quota.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -32,8 +33,8 @@ func (c *Client) quotaConstraintRows(ctx context.Context, kubeCtx string, target
 	if err != nil {
 		return nil, err
 	}
-	requests := totalContainerRequests(target.Containers)
-	limits := totalContainerLimits(target.Containers)
+	requests := effectivePodResources(target.Containers, target.InitContainers, func(c ContainerRequest) map[string]string { return c.Requests })
+	limits := effectivePodResources(target.Containers, target.InitContainers, func(c ContainerRequest) map[string]string { return c.Limits })
 	if (len(requests) == 0 && len(limits) == 0) || len(quotas) == 0 {
 		return nil, nil
 	}
@@ -193,13 +194,17 @@ func (c *Client) limitRangeConstraintRows(ctx context.Context, kubeCtx string, t
 	if err != nil {
 		return nil, err
 	}
+	containers := make([]ContainerRequest, 0, len(target.Containers)+len(target.InitContainers))
+	containers = append(containers, target.Containers...)
+	containers = append(containers, target.InitContainers...)
+
 	var rows []ConstraintRow
 	for _, lr := range limitRanges {
 		for _, item := range lr.Spec.Limits {
 			if item.Type != corev1.LimitTypeContainer {
 				continue
 			}
-			rows = append(rows, limitRangeItemRows(lr, item, target.Containers)...)
+			rows = append(rows, limitRangeItemRows(lr, item, containers)...)
 		}
 	}
 	return rows, nil
@@ -209,12 +214,13 @@ func limitRangeItemRows(lr corev1.LimitRange, item corev1.LimitRangeItem, contai
 	var rows []ConstraintRow
 	for _, c := range containers {
 		for resName, minQty := range item.Min {
-			if row, ok := limitRangeBoundRow(lr, resName.String(), "min", minQty, c, true); ok {
-				rows = append(rows, row)
-			}
+			rows = append(rows, limitRangeBoundRows(lr, resName.String(), "min", minQty, c, true)...)
 		}
 		for resName, maxQty := range item.Max {
-			if row, ok := limitRangeBoundRow(lr, resName.String(), "max", maxQty, c, false); ok {
+			rows = append(rows, limitRangeBoundRows(lr, resName.String(), "max", maxQty, c, false)...)
+		}
+		for resName, ratioQty := range item.MaxLimitRequestRatio {
+			if row, ok := limitRequestRatioRow(lr, resName.String(), ratioQty, c); ok {
 				rows = append(rows, row)
 			}
 		}
@@ -222,19 +228,32 @@ func limitRangeItemRows(lr corev1.LimitRange, item corev1.LimitRangeItem, contai
 	return rows
 }
 
-// limitRangeBoundRow reports a container's request against one Min or Max
-// bound. belowIsViolation selects the comparison direction: Min is
-// violated by a smaller request, Max by a larger one.
-func limitRangeBoundRow(lr corev1.LimitRange, resName, bound string, boundQty resource.Quantity, c ContainerRequest, belowIsViolation bool) (ConstraintRow, bool) {
-	reqStr, ok := c.Requests[resName]
+// limitRangeBoundRows checks a container's requests and limits against one
+// Min or Max bound — the admission plugin applies both to each bound.
+func limitRangeBoundRows(lr corev1.LimitRange, resName, bound string, boundQty resource.Quantity, c ContainerRequest, belowIsViolation bool) []ConstraintRow {
+	var rows []ConstraintRow
+	if row, ok := limitRangeBoundRow(lr, resName, bound, boundQty, c, "requests", c.Requests, belowIsViolation); ok {
+		rows = append(rows, row)
+	}
+	if row, ok := limitRangeBoundRow(lr, resName, bound, boundQty, c, "limits", c.Limits, belowIsViolation); ok {
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// limitRangeBoundRow reports one field (requests or limits) of a container
+// against one Min or Max bound. belowIsViolation selects the comparison
+// direction: Min is violated by a smaller value, Max by a larger one.
+func limitRangeBoundRow(lr corev1.LimitRange, resName, bound string, boundQty resource.Quantity, c ContainerRequest, field string, values map[string]string, belowIsViolation bool) (ConstraintRow, bool) {
+	valStr, ok := values[resName]
 	if !ok {
 		return ConstraintRow{}, false
 	}
-	reqQty, err := resource.ParseQuantity(reqStr)
+	valQty, err := resource.ParseQuantity(valStr)
 	if err != nil {
 		return ConstraintRow{}, false
 	}
-	cmp := reqQty.Cmp(boundQty)
+	cmp := valQty.Cmp(boundQty)
 	violated := (belowIsViolation && cmp < 0) || (!belowIsViolation && cmp > 0)
 	if !violated {
 		return ConstraintRow{}, false
@@ -244,22 +263,105 @@ func limitRangeBoundRow(lr corev1.LimitRange, resName, bound string, boundQty re
 		Kind:      "LimitRange",
 		Namespace: lr.Namespace,
 		Name:      lr.Name,
-		Detail: fmt.Sprintf("container %s requests %s %s, %s is %s",
-			c.Name, reqStr, resName, bound, boundQty.String()),
+		Detail: fmt.Sprintf("container %s %s %s %s, %s is %s",
+			c.Name, field, valStr, resName, bound, boundQty.String()),
 		Headroom: boundQty.String(),
 		Blocking: true,
 	}, true
 }
 
-// totalContainerRequests sums each container's requested amount per
-// resource name, so a multi-container pod's ask is compared to quota as a
-// whole rather than one container at a time.
-func totalContainerRequests(containers []ContainerRequest) map[string]string {
-	return totalContainerResources(containers, func(c ContainerRequest) map[string]string { return c.Requests })
+// limitRequestRatioRow reports a container's limit/request ratio against a
+// MaxLimitRequestRatio bound. The check only applies when both are set, as
+// the admission plugin skips it otherwise.
+func limitRequestRatioRow(lr corev1.LimitRange, resName string, ratioQty resource.Quantity, c ContainerRequest) (ConstraintRow, bool) {
+	reqStr, hasReq := c.Requests[resName]
+	limStr, hasLim := c.Limits[resName]
+	if !hasReq || !hasLim {
+		return ConstraintRow{}, false
+	}
+	reqQty, err := resource.ParseQuantity(reqStr)
+	if err != nil {
+		return ConstraintRow{}, false
+	}
+	limQty, err := resource.ParseQuantity(limStr)
+	if err != nil {
+		return ConstraintRow{}, false
+	}
+	reqFloat := reqQty.AsApproximateFloat64()
+	if reqFloat <= 0 || limQty.AsApproximateFloat64()/reqFloat <= ratioQty.AsApproximateFloat64() {
+		return ConstraintRow{}, false
+	}
+	return ConstraintRow{
+		Source:    "LimitRange",
+		Kind:      "LimitRange",
+		Namespace: lr.Namespace,
+		Name:      lr.Name,
+		Detail: fmt.Sprintf("container %s limit %s / request %s %s exceeds maxLimitRequestRatio %s",
+			c.Name, limStr, reqStr, resName, ratioQty.String()),
+		Headroom: ratioQty.String(),
+		Blocking: true,
+	}, true
 }
 
-func totalContainerLimits(containers []ContainerRequest) map[string]string {
-	return totalContainerResources(containers, func(c ContainerRequest) map[string]string { return c.Limits })
+// effectivePodResources is max(sum of regular containers, largest single
+// init container), matching the scheduler and quota admission: sequential
+// init containers never run alongside the pod's regular ones.
+func effectivePodResources(containers, initContainers []ContainerRequest, pick func(ContainerRequest) map[string]string) map[string]string {
+	return mergeResourceMapsByMax(
+		totalContainerResources(containers, pick),
+		maxContainerResources(initContainers, pick),
+	)
+}
+
+func maxContainerResources(containers []ContainerRequest, pick func(ContainerRequest) map[string]string) map[string]string {
+	maxes := map[string]resource.Quantity{}
+	for _, c := range containers {
+		for name, qtyStr := range pick(c) {
+			qty, err := resource.ParseQuantity(qtyStr)
+			if err != nil {
+				continue
+			}
+			cur, ok := maxes[name]
+			if !ok || qty.Cmp(cur) > 0 {
+				maxes[name] = qty
+			}
+		}
+	}
+	if len(maxes) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(maxes))
+	for name, qty := range maxes {
+		out[name] = qty.String()
+	}
+	return out
+}
+
+// mergeResourceMapsByMax keeps, per resource name, whichever of the two
+// maps' values is larger. A resource name is dropped only if it parses in
+// neither map.
+func mergeResourceMapsByMax(a, b map[string]string) map[string]string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	out := make(map[string]string, len(a)+len(b))
+	maps.Copy(out, a)
+	for name, bStr := range b {
+		aStr, ok := out[name]
+		if !ok {
+			out[name] = bStr
+			continue
+		}
+		aQty, errA := resource.ParseQuantity(aStr)
+		bQty, errB := resource.ParseQuantity(bStr)
+		if errA != nil || (errB == nil && bQty.Cmp(aQty) > 0) {
+			out[name] = bStr
+		}
+	}
+	return out
 }
 
 func totalContainerResources(containers []ContainerRequest, pick func(ContainerRequest) map[string]string) map[string]string {

--- a/internal/k8s/constraints_quota_test.go
+++ b/internal/k8s/constraints_quota_test.go
@@ -54,6 +54,131 @@ func TestQuotaRows_ShowRequestsAgainstHeadroom(t *testing.T) {
 	}
 }
 
+func TestQuotaRows_LimitsResourceCountsContainerLimits(t *testing.T) {
+	quota := scopedQuotaObject(map[string]any{
+		"hard": map[string]any{"limits.cpu": "4", "requests.cpu": "4"},
+	}, map[string]any{"used": map[string]any{"limits.cpu": "0", "requests.cpu": "0"}})
+	client := newFakeClient(nil, newFakeDynClient(quota))
+
+	target := ConstraintTarget{
+		Namespace: "default",
+		Containers: []ContainerRequest{{
+			Name:     "app",
+			Requests: map[string]string{"cpu": "500m"},
+			Limits:   map[string]string{"cpu": "2"},
+		}},
+	}
+
+	rows, err := client.quotaConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("quotaConstraintRows: %v", err)
+	}
+
+	byResource := map[string]string{}
+	for _, r := range rows {
+		switch {
+		case strings.Contains(r.Detail, "limits.cpu"):
+			byResource["limits.cpu"] = r.Detail
+		case strings.Contains(r.Detail, "requests.cpu"):
+			byResource["requests.cpu"] = r.Detail
+		}
+	}
+	if got := byResource["limits.cpu"]; !strings.Contains(got, "limits 2 ") {
+		t.Errorf("limits.cpu row = %q, want the container limit of 2", got)
+	}
+	if got := byResource["requests.cpu"]; !strings.Contains(got, "requests 500m ") {
+		t.Errorf("requests.cpu row = %q, want the container request of 500m", got)
+	}
+}
+
+func TestQuotaAppliesTo_Scopes(t *testing.T) {
+	guaranteed := ConstraintTarget{
+		PriorityClassName: "high",
+		Containers:        []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+	}
+	bestEffort := ConstraintTarget{Containers: []ContainerRequest{{Name: "app"}}}
+
+	tests := []struct {
+		name   string
+		quota  QuotaInfo
+		target ConstraintTarget
+		want   bool
+	}{
+		{"no scopes applies to everything", QuotaInfo{}, guaranteed, true},
+		{
+			"priorityClass In naming another class",
+			QuotaInfo{ScopeSelector: []QuotaScopeRequirement{
+				{ScopeName: "PriorityClass", Operator: "In", Values: []string{"low"}},
+			}},
+			guaranteed, false,
+		},
+		{
+			"priorityClass In naming the target's class",
+			QuotaInfo{ScopeSelector: []QuotaScopeRequirement{
+				{ScopeName: "PriorityClass", Operator: "In", Values: []string{"high"}},
+			}},
+			guaranteed, true,
+		},
+		{
+			"priorityClass NotIn naming the target's class",
+			QuotaInfo{ScopeSelector: []QuotaScopeRequirement{
+				{ScopeName: "PriorityClass", Operator: "NotIn", Values: []string{"high"}},
+			}},
+			guaranteed, false,
+		},
+		{"BestEffort scope against a pod with requests", QuotaInfo{Scopes: []string{"BestEffort"}}, guaranteed, false},
+		{"BestEffort scope against a pod without any", QuotaInfo{Scopes: []string{"BestEffort"}}, bestEffort, true},
+		{"NotBestEffort scope against a pod with requests", QuotaInfo{Scopes: []string{"NotBestEffort"}}, guaranteed, true},
+		{"PriorityClass scope with no class set", QuotaInfo{Scopes: []string{"PriorityClass"}}, bestEffort, false},
+		{"unevaluated scope stays applicable", QuotaInfo{Scopes: []string{"Terminating"}}, guaranteed, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quotaAppliesTo(tt.quota, tt.target); got != tt.want {
+				t.Errorf("quotaAppliesTo = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuotaRows_SkipQuotaScopedToAnotherPriorityClass(t *testing.T) {
+	quota := scopedQuotaObject(map[string]any{
+		"hard": map[string]any{"cpu": "4"},
+		"scopeSelector": map[string]any{
+			"matchExpressions": []any{
+				map[string]any{"scopeName": "PriorityClass", "operator": "In", "values": []any{"low"}},
+			},
+		},
+	}, map[string]any{"used": map[string]any{"cpu": "0"}})
+	client := newFakeClient(nil, newFakeDynClient(quota))
+
+	target := ConstraintTarget{
+		Namespace:         "default",
+		PriorityClassName: "high",
+		Containers:        []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+	}
+
+	rows, err := client.quotaConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("quotaConstraintRows: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected no rows for a quota scoped to another PriorityClass, got %+v", rows)
+	}
+}
+
+func scopedQuotaObject(spec, status map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ResourceQuota",
+			"metadata":   map[string]any{"name": "compute-quota", "namespace": "default"},
+			"spec":       spec,
+			"status":     status,
+		},
+	}
+}
+
 func TestLimitRangeRows_FlagRequestBelowMin(t *testing.T) {
 	lr := &corev1.LimitRange{
 		Name: "container-limits", Namespace: "default",

--- a/internal/k8s/constraints_quota_test.go
+++ b/internal/k8s/constraints_quota_test.go
@@ -103,10 +103,13 @@ func TestQuotaRows_EffectiveRequestIsMaxOfContainerSumAndInitContainerMax(t *tes
 		wantAsked      string
 	}{
 		{
-			name:           "container sum exceeds any single init container",
-			containers:     []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
-			initContainers: []ContainerRequest{{Name: "init", Requests: map[string]string{"cpu": "200m"}}},
-			wantAsked:      "500m",
+			name: "container sum exceeds any single init container",
+			containers: []ContainerRequest{
+				{Name: "app", Requests: map[string]string{"cpu": "300m"}},
+				{Name: "sidecar", Requests: map[string]string{"cpu": "300m"}},
+			},
+			initContainers: []ContainerRequest{{Name: "init", Requests: map[string]string{"cpu": "500m"}}},
+			wantAsked:      "600m",
 		},
 		{
 			name:           "a single init container exceeds the container sum",

--- a/internal/k8s/constraints_quota_test.go
+++ b/internal/k8s/constraints_quota_test.go
@@ -1,0 +1,86 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestQuotaRows_ShowRequestsAgainstHeadroom(t *testing.T) {
+	quota := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ResourceQuota",
+			"metadata": map[string]any{
+				"name":      "compute-quota",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"hard": map[string]any{"cpu": "4"},
+			},
+			"status": map[string]any{
+				"used": map[string]any{"cpu": "3"},
+			},
+		},
+	}
+	dc := newFakeDynClient(quota)
+	client := newFakeClient(nil, dc)
+
+	target := ConstraintTarget{
+		Namespace:  "default",
+		Containers: []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+	}
+
+	rows, err := client.quotaConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("quotaConstraintRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.Source != "Quota" {
+		t.Errorf("Source = %q, want Quota", row.Source)
+	}
+	if !strings.Contains(row.Headroom, "1") {
+		t.Errorf("Headroom = %q, want to contain 1", row.Headroom)
+	}
+	if !strings.Contains(row.Detail, "500m") {
+		t.Errorf("Detail = %q, want to name the request", row.Detail)
+	}
+}
+
+func TestLimitRangeRows_FlagRequestBelowMin(t *testing.T) {
+	lr := &corev1.LimitRange{
+		Name: "container-limits", Namespace: "default",
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypeContainer,
+					Min:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+				},
+			},
+		},
+	}
+	client := newFakeClient(k8sfake.NewClientset(lr), nil)
+
+	target := ConstraintTarget{
+		Namespace:  "default",
+		Containers: []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "100m"}}},
+	}
+
+	rows, err := client.limitRangeConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("limitRangeConstraintRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %+v", len(rows), rows)
+	}
+	if !rows[0].Blocking {
+		t.Error("expected row to be Blocking")
+	}
+}

--- a/internal/k8s/constraints_quota_test.go
+++ b/internal/k8s/constraints_quota_test.go
@@ -91,6 +91,62 @@ func TestQuotaRows_LimitsResourceCountsContainerLimits(t *testing.T) {
 	}
 }
 
+func TestQuotaRows_EffectiveRequestIsMaxOfContainerSumAndInitContainerMax(t *testing.T) {
+	quota := scopedQuotaObject(map[string]any{
+		"hard": map[string]any{"cpu": "10"},
+	}, map[string]any{"used": map[string]any{"cpu": "0"}})
+
+	tests := []struct {
+		name           string
+		containers     []ContainerRequest
+		initContainers []ContainerRequest
+		wantAsked      string
+	}{
+		{
+			name:           "container sum exceeds any single init container",
+			containers:     []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+			initContainers: []ContainerRequest{{Name: "init", Requests: map[string]string{"cpu": "200m"}}},
+			wantAsked:      "500m",
+		},
+		{
+			name:           "a single init container exceeds the container sum",
+			containers:     []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+			initContainers: []ContainerRequest{{Name: "init", Requests: map[string]string{"cpu": "2"}}},
+			wantAsked:      "2",
+		},
+		{
+			name:       "init containers use max, not sum, across each other",
+			containers: []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "100m"}}},
+			initContainers: []ContainerRequest{
+				{Name: "init-a", Requests: map[string]string{"cpu": "300m"}},
+				{Name: "init-b", Requests: map[string]string{"cpu": "1"}},
+			},
+			wantAsked: "1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newFakeClient(nil, newFakeDynClient(quota))
+			target := ConstraintTarget{
+				Namespace:      "default",
+				Containers:     tt.containers,
+				InitContainers: tt.initContainers,
+			}
+
+			rows, err := client.quotaConstraintRows(t.Context(), "", target)
+			if err != nil {
+				t.Fatalf("quotaConstraintRows: %v", err)
+			}
+			if len(rows) != 1 {
+				t.Fatalf("expected 1 row, got %d: %+v", len(rows), rows)
+			}
+			if !strings.Contains(rows[0].Detail, tt.wantAsked+" cpu") {
+				t.Errorf("Detail = %q, want the effective request %s", rows[0].Detail, tt.wantAsked)
+			}
+		})
+	}
+}
+
 func TestQuotaAppliesTo_Scopes(t *testing.T) {
 	guaranteed := ConstraintTarget{
 		PriorityClassName: "high",
@@ -207,5 +263,171 @@ func TestLimitRangeRows_FlagRequestBelowMin(t *testing.T) {
 	}
 	if !rows[0].Blocking {
 		t.Error("expected row to be Blocking")
+	}
+}
+
+func TestLimitRangeRows_ChecksInitContainers(t *testing.T) {
+	lr := &corev1.LimitRange{
+		Name: "container-limits", Namespace: "default",
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypeContainer,
+					Min:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+				},
+			},
+		},
+	}
+	client := newFakeClient(k8sfake.NewClientset(lr), nil)
+
+	target := ConstraintTarget{
+		Namespace:      "default",
+		Containers:     []ContainerRequest{{Name: "app", Requests: map[string]string{"cpu": "500m"}}},
+		InitContainers: []ContainerRequest{{Name: "init", Requests: map[string]string{"cpu": "100m"}}},
+	}
+
+	rows, err := client.limitRangeConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("limitRangeConstraintRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row for the violating init container, got %d: %+v", len(rows), rows)
+	}
+	if !strings.Contains(rows[0].Detail, "init") {
+		t.Errorf("Detail = %q, want it to name the init container", rows[0].Detail)
+	}
+}
+
+func TestLimitRangeRows_ChecksRequestsAndLimits(t *testing.T) {
+	lr := corev1.LimitRange{
+		Name: "container-limits", Namespace: "default",
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypeContainer,
+					Min:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+					Max:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		container     ContainerRequest
+		wantFields    []string
+		wantRowsCount int
+	}{
+		{
+			name:          "request below min only",
+			container:     ContainerRequest{Name: "app", Requests: map[string]string{"cpu": "100m"}},
+			wantFields:    []string{"requests"},
+			wantRowsCount: 1,
+		},
+		{
+			name:          "limit above max only",
+			container:     ContainerRequest{Name: "app", Limits: map[string]string{"cpu": "2"}},
+			wantFields:    []string{"limits"},
+			wantRowsCount: 1,
+		},
+		{
+			name: "request below min and limit above max both reported",
+			container: ContainerRequest{
+				Name:     "app",
+				Requests: map[string]string{"cpu": "100m"},
+				Limits:   map[string]string{"cpu": "2"},
+			},
+			wantFields:    []string{"requests", "limits"},
+			wantRowsCount: 2,
+		},
+		{
+			name:          "requests and limits within bounds produce no rows",
+			container:     ContainerRequest{Name: "app", Requests: map[string]string{"cpu": "500m"}, Limits: map[string]string{"cpu": "500m"}},
+			wantRowsCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newFakeClient(k8sfake.NewClientset(&lr), nil)
+			target := ConstraintTarget{Namespace: "default", Containers: []ContainerRequest{tt.container}}
+
+			rows, err := client.limitRangeConstraintRows(t.Context(), "", target)
+			if err != nil {
+				t.Fatalf("limitRangeConstraintRows: %v", err)
+			}
+			if len(rows) != tt.wantRowsCount {
+				t.Fatalf("expected %d rows, got %d: %+v", tt.wantRowsCount, len(rows), rows)
+			}
+			for _, field := range tt.wantFields {
+				var found bool
+				for _, r := range rows {
+					if strings.Contains(r.Detail, field) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected a row mentioning %q, got %+v", field, rows)
+				}
+			}
+		})
+	}
+}
+
+func TestLimitRangeRows_FlagsMaxLimitRequestRatio(t *testing.T) {
+	lr := &corev1.LimitRange{
+		Name: "container-limits", Namespace: "default",
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type:                 corev1.LimitTypeContainer,
+					MaxLimitRequestRatio: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		container     ContainerRequest
+		wantRowsCount int
+	}{
+		{
+			name: "ratio within bound produces no row",
+			container: ContainerRequest{
+				Name: "app", Requests: map[string]string{"cpu": "500m"}, Limits: map[string]string{"cpu": "1"},
+			},
+			wantRowsCount: 0,
+		},
+		{
+			name: "ratio exceeding bound is flagged",
+			container: ContainerRequest{
+				Name: "app", Requests: map[string]string{"cpu": "100m"}, Limits: map[string]string{"cpu": "1"},
+			},
+			wantRowsCount: 1,
+		},
+		{
+			name: "missing request skips the ratio check",
+			container: ContainerRequest{
+				Name: "app", Limits: map[string]string{"cpu": "1"},
+			},
+			wantRowsCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newFakeClient(k8sfake.NewClientset(lr), nil)
+			target := ConstraintTarget{Namespace: "default", Containers: []ContainerRequest{tt.container}}
+
+			rows, err := client.limitRangeConstraintRows(t.Context(), "", target)
+			if err != nil {
+				t.Fatalf("limitRangeConstraintRows: %v", err)
+			}
+			if len(rows) != tt.wantRowsCount {
+				t.Fatalf("expected %d rows, got %d: %+v", tt.wantRowsCount, len(rows), rows)
+			}
+			if tt.wantRowsCount > 0 && !rows[0].Blocking {
+				t.Error("expected row to be Blocking")
+			}
+		})
 	}
 }

--- a/internal/k8s/constraints_test.go
+++ b/internal/k8s/constraints_test.go
@@ -35,6 +35,38 @@ func TestTargetFromRaw_DeploymentUsesPodTemplate(t *testing.T) {
 	assert.Equal(t, map[string]string{"disk": "nvme"}, target.NodeSelector)
 }
 
+func TestTargetFromRaw_KeepsRequiredAffinityMatchFields(t *testing.T) {
+	raw := map[string]any{
+		"kind": "Pod",
+		"spec": map[string]any{
+			"affinity": map[string]any{
+				"nodeAffinity": map[string]any{
+					"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+						"nodeSelectorTerms": []any{
+							map[string]any{
+								"matchFields": []any{
+									map[string]any{
+										"key": "metadata.name", "operator": "In", "values": []any{"node-1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	target := targetFromRaw(raw)
+
+	if assert.Len(t, target.Affinity, 1) {
+		assert.Empty(t, target.Affinity[0].MatchExpressions)
+		assert.Equal(t, []NodeSelectorRequirement{
+			{Key: "metadata.name", Operator: "In", Values: []string{"node-1"}},
+		}, target.Affinity[0].MatchFields)
+	}
+}
+
 func TestTargetFromRaw_PodUsesOwnSpec(t *testing.T) {
 	raw := map[string]any{
 		"kind": "Pod",

--- a/internal/k8s/constraints_test.go
+++ b/internal/k8s/constraints_test.go
@@ -1,0 +1,72 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTargetFromRaw_DeploymentUsesPodTemplate(t *testing.T) {
+	raw := map[string]any{
+		"kind": "Deployment",
+		"metadata": map[string]any{
+			"namespace": "default",
+			"labels":    map[string]any{"app.kubernetes.io/name": "web"},
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{"app": "web", "tier": "frontend"},
+				},
+				"spec": map[string]any{
+					"priorityClassName": "high",
+					"nodeSelector":      map[string]any{"disk": "nvme"},
+				},
+			},
+		},
+	}
+
+	target := targetFromRaw(raw)
+
+	assert.Equal(t, "default", target.Namespace)
+	assert.Equal(t, map[string]string{"app.kubernetes.io/name": "web"}, target.Labels)
+	assert.Equal(t, map[string]string{"app": "web", "tier": "frontend"}, target.PodLabels)
+	assert.Equal(t, "high", target.PriorityClassName)
+	assert.Equal(t, map[string]string{"disk": "nvme"}, target.NodeSelector)
+}
+
+func TestTargetFromRaw_PodUsesOwnSpec(t *testing.T) {
+	raw := map[string]any{
+		"kind": "Pod",
+		"metadata": map[string]any{
+			"namespace": "default",
+			"labels":    map[string]any{"app": "web"},
+		},
+		"spec": map[string]any{
+			"nodeSelector": map[string]any{"disk": "nvme"},
+			"tolerations": []any{
+				map[string]any{"key": "dedicated", "operator": "Equal", "value": "gpu", "effect": "NoSchedule"},
+			},
+			"containers": []any{
+				map[string]any{
+					"name": "app",
+					"resources": map[string]any{
+						"requests": map[string]any{"cpu": "500m", "memory": float64(1)},
+					},
+				},
+			},
+		},
+	}
+
+	target := targetFromRaw(raw)
+
+	assert.Equal(t, map[string]string{"app": "web"}, target.PodLabels)
+	assert.Equal(t, map[string]string{"disk": "nvme"}, target.NodeSelector)
+	if assert.Len(t, target.Tolerations, 1) {
+		assert.Equal(t, "dedicated", target.Tolerations[0].Key)
+	}
+	if assert.Len(t, target.Containers, 1) {
+		assert.Equal(t, "500m", target.Containers[0].Requests["cpu"])
+		assert.Equal(t, "1", target.Containers[0].Requests["memory"])
+	}
+}

--- a/internal/k8s/constraints_test.go
+++ b/internal/k8s/constraints_test.go
@@ -102,3 +102,33 @@ func TestTargetFromRaw_PodUsesOwnSpec(t *testing.T) {
 		assert.Equal(t, "1", target.Containers[0].Requests["memory"])
 	}
 }
+
+func TestTargetFromRaw_ReadsInitContainersSeparately(t *testing.T) {
+	raw := map[string]any{
+		"kind": "Pod",
+		"spec": map[string]any{
+			"initContainers": []any{
+				map[string]any{
+					"name":      "init",
+					"resources": map[string]any{"requests": map[string]any{"cpu": "2"}},
+				},
+			},
+			"containers": []any{
+				map[string]any{
+					"name":      "app",
+					"resources": map[string]any{"requests": map[string]any{"cpu": "500m"}},
+				},
+			},
+		},
+	}
+
+	target := targetFromRaw(raw)
+
+	if assert.Len(t, target.InitContainers, 1) {
+		assert.Equal(t, "init", target.InitContainers[0].Name)
+		assert.Equal(t, "2", target.InitContainers[0].Requests["cpu"])
+	}
+	if assert.Len(t, target.Containers, 1) {
+		assert.Equal(t, "app", target.Containers[0].Name)
+	}
+}

--- a/internal/k8s/constraints_webhooks.go
+++ b/internal/k8s/constraints_webhooks.go
@@ -203,14 +203,14 @@ func valueOrWildcard(values []string, want string) bool {
 }
 
 // webhookResourceMatches accepts the "resource/subresource" forms a rule
-// may use. "*/*" covers every resource and subresource, "<want>/*" the
-// target resource and its own subresources.
+// may use. want is always a bare resource, so "<want>/*" — a subresource
+// wildcard — never matches it: only an exact resource, "*", or "*/*" do.
 func webhookResourceMatches(resources []string, want string) (matched, wildcard bool) {
 	for _, r := range resources {
 		if r == "*" || r == "*/*" {
 			return true, true
 		}
-		if r == want || r == want+"/*" {
+		if r == want {
 			return true, false
 		}
 	}

--- a/internal/k8s/constraints_webhooks.go
+++ b/internal/k8s/constraints_webhooks.go
@@ -22,56 +22,75 @@ type webhookRuleset struct {
 	objectSelector    *metav1.LabelSelector
 }
 
-// webhookConstraintRows reports webhooks that would intercept an UPDATE
-// or DELETE on the target (D3): GVR/operation match a rule, and any
-// namespaceSelector/objectSelector match too.
-func (c *Client) webhookConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+// validatingWebhookConstraintRows reports configurations that intercept an
+// UPDATE or DELETE on the target (D3). Mutating ones are a separate source,
+// so a denial of one still leaves the other's rows visible.
+func (c *Client) validatingWebhookConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
 	cs, err := c.clientsetForContext(kubeCtx)
 	if err != nil {
 		return nil, err
 	}
-	validating, err := cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+	list, err := cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing validatingwebhookconfigurations: %w", err)
 	}
-	mutating, err := cs.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("listing mutatingwebhookconfigurations: %w", err)
+	var rulesets []webhookRuleset
+	for _, wh := range list.Items {
+		rulesets = append(rulesets, validatingRulesets(wh)...)
 	}
-	nsLabels, err := namespaceLabelsForWebhookMatch(ctx, cs, target.Namespace)
+	return webhookRows(ctx, cs, rulesets, target)
+}
+
+// mutatingWebhookConstraintRows is validatingWebhookConstraintRows for
+// MutatingWebhookConfigurations.
+func (c *Client) mutatingWebhookConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+	cs, err := c.clientsetForContext(kubeCtx)
 	if err != nil {
 		return nil, err
 	}
-
-	rulesets := make([]webhookRuleset, 0, len(validating.Items)+len(mutating.Items))
-	for _, wh := range validating.Items {
-		rulesets = append(rulesets, validatingRulesets(wh)...)
+	list, err := cs.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing mutatingwebhookconfigurations: %w", err)
 	}
-	for _, wh := range mutating.Items {
+	var rulesets []webhookRuleset
+	for _, wh := range list.Items {
 		rulesets = append(rulesets, mutatingRulesets(wh)...)
 	}
+	return webhookRows(ctx, cs, rulesets, target)
+}
 
+func webhookRows(ctx context.Context, cs kubernetes.Interface, rulesets []webhookRuleset, target ConstraintTarget) ([]ConstraintRow, error) {
+	if len(rulesets) == 0 {
+		return nil, nil
+	}
+	nsLabels, nsSelectorApplies, err := namespaceLabelsForWebhookMatch(ctx, cs, target)
+	if err != nil {
+		return nil, err
+	}
 	var rows []ConstraintRow
 	for _, rs := range rulesets {
-		if row, matched := webhookRow(rs, target, nsLabels); matched {
+		if row, matched := webhookRow(rs, target, nsLabels, nsSelectorApplies); matched {
 			rows = append(rows, row)
 		}
 	}
 	return rows, nil
 }
 
-// namespaceLabelsForWebhookMatch fetches the target namespace's labels for
-// namespaceSelector matching. Cluster-scoped targets (namespace == "")
-// skip the call — there is no namespace to match against.
-func namespaceLabelsForWebhookMatch(ctx context.Context, cs kubernetes.Interface, namespace string) (map[string]string, error) {
-	if namespace == "" {
-		return nil, nil
+// namespaceLabelsForWebhookMatch resolves what a namespaceSelector matches
+// against: a namespaced target's namespace, a Namespace object itself, and
+// for any other cluster-scoped kind nothing, so the selector cannot apply.
+func namespaceLabelsForWebhookMatch(ctx context.Context, cs kubernetes.Interface, target ConstraintTarget) (nsLabels map[string]string, applies bool, err error) {
+	if target.Namespace == "" {
+		if target.Kind == "Namespace" {
+			return target.Labels, true, nil
+		}
+		return nil, false, nil
 	}
-	ns, err := cs.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	ns, err := cs.CoreV1().Namespaces().Get(ctx, target.Namespace, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("getting namespace %s: %w", namespace, err)
+		return nil, false, fmt.Errorf("getting namespace %s: %w", target.Namespace, err)
 	}
-	return ns.Labels, nil
+	return ns.Labels, true, nil
 }
 
 func validatingRulesets(wh admissionregistrationv1.ValidatingWebhookConfiguration) []webhookRuleset {
@@ -104,12 +123,12 @@ func mutatingRulesets(wh admissionregistrationv1.MutatingWebhookConfiguration) [
 	return out
 }
 
-func webhookRow(rs webhookRuleset, target ConstraintTarget, nsLabels map[string]string) (ConstraintRow, bool) {
-	matched, allResources := rulesMatchTarget(rs.rules, target.GVR)
+func webhookRow(rs webhookRuleset, target ConstraintTarget, nsLabels map[string]string, nsSelectorApplies bool) (ConstraintRow, bool) {
+	matched, allResources := rulesMatchTarget(rs.rules, target.GVR, targetRuleScope(target))
 	if !matched {
 		return ConstraintRow{}, false
 	}
-	if !selectorMatches(rs.namespaceSelector, nsLabels) {
+	if nsSelectorApplies && !selectorMatches(rs.namespaceSelector, nsLabels) {
 		return ConstraintRow{}, false
 	}
 	if !selectorMatches(rs.objectSelector, target.Labels) {
@@ -128,9 +147,29 @@ func webhookRow(rs webhookRuleset, target ConstraintTarget, nsLabels map[string]
 	}, true
 }
 
-func rulesMatchTarget(rules []admissionregistrationv1.RuleWithOperations, gvr schema.GroupVersionResource) (matched, allResources bool) {
+// targetRuleScope maps the target to the scope a rule selects on. A
+// Namespace object counts as cluster-scoped here, as it does in the API.
+func targetRuleScope(target ConstraintTarget) admissionregistrationv1.ScopeType {
+	if target.Namespace == "" {
+		return admissionregistrationv1.ClusterScope
+	}
+	return admissionregistrationv1.NamespacedScope
+}
+
+// ruleScopeMatches treats an unset rule scope as the API's "*" default.
+func ruleScopeMatches(ruleScope *admissionregistrationv1.ScopeType, target admissionregistrationv1.ScopeType) bool {
+	if ruleScope == nil || *ruleScope == admissionregistrationv1.AllScopes {
+		return true
+	}
+	return *ruleScope == target
+}
+
+func rulesMatchTarget(rules []admissionregistrationv1.RuleWithOperations, gvr schema.GroupVersionResource, scope admissionregistrationv1.ScopeType) (matched, allResources bool) {
 	for _, rule := range rules {
 		if !operationsInclude(rule.Operations) {
+			continue
+		}
+		if !ruleScopeMatches(rule.Scope, scope) {
 			continue
 		}
 		if !valueOrWildcard(rule.APIGroups, gvr.Group) || !valueOrWildcard(rule.APIVersions, gvr.Version) {
@@ -163,12 +202,15 @@ func valueOrWildcard(values []string, want string) bool {
 	return false
 }
 
+// webhookResourceMatches accepts the "resource/subresource" forms a rule
+// may use. "*/*" covers every resource and subresource, "<want>/*" the
+// target resource and its own subresources.
 func webhookResourceMatches(resources []string, want string) (matched, wildcard bool) {
 	for _, r := range resources {
-		if r == "*" {
+		if r == "*" || r == "*/*" {
 			return true, true
 		}
-		if r == want {
+		if r == want || r == want+"/*" {
 			return true, false
 		}
 	}

--- a/internal/k8s/constraints_webhooks.go
+++ b/internal/k8s/constraints_webhooks.go
@@ -1,0 +1,187 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+)
+
+// webhookRuleset normalizes a Validating/MutatingWebhookConfiguration
+// entry so both kinds share one matching path below.
+type webhookRuleset struct {
+	configKind        string
+	configName        string
+	webhookName       string
+	rules             []admissionregistrationv1.RuleWithOperations
+	namespaceSelector *metav1.LabelSelector
+	objectSelector    *metav1.LabelSelector
+}
+
+// webhookConstraintRows reports webhooks that would intercept an UPDATE
+// or DELETE on the target (D3): GVR/operation match a rule, and any
+// namespaceSelector/objectSelector match too.
+func (c *Client) webhookConstraintRows(ctx context.Context, kubeCtx string, target ConstraintTarget) ([]ConstraintRow, error) {
+	cs, err := c.clientsetForContext(kubeCtx)
+	if err != nil {
+		return nil, err
+	}
+	validating, err := cs.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing validatingwebhookconfigurations: %w", err)
+	}
+	mutating, err := cs.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing mutatingwebhookconfigurations: %w", err)
+	}
+	nsLabels, err := namespaceLabelsForWebhookMatch(ctx, cs, target.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	rulesets := make([]webhookRuleset, 0, len(validating.Items)+len(mutating.Items))
+	for _, wh := range validating.Items {
+		rulesets = append(rulesets, validatingRulesets(wh)...)
+	}
+	for _, wh := range mutating.Items {
+		rulesets = append(rulesets, mutatingRulesets(wh)...)
+	}
+
+	var rows []ConstraintRow
+	for _, rs := range rulesets {
+		if row, matched := webhookRow(rs, target, nsLabels); matched {
+			rows = append(rows, row)
+		}
+	}
+	return rows, nil
+}
+
+// namespaceLabelsForWebhookMatch fetches the target namespace's labels for
+// namespaceSelector matching. Cluster-scoped targets (namespace == "")
+// skip the call — there is no namespace to match against.
+func namespaceLabelsForWebhookMatch(ctx context.Context, cs kubernetes.Interface, namespace string) (map[string]string, error) {
+	if namespace == "" {
+		return nil, nil
+	}
+	ns, err := cs.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting namespace %s: %w", namespace, err)
+	}
+	return ns.Labels, nil
+}
+
+func validatingRulesets(wh admissionregistrationv1.ValidatingWebhookConfiguration) []webhookRuleset {
+	out := make([]webhookRuleset, 0, len(wh.Webhooks))
+	for _, w := range wh.Webhooks {
+		out = append(out, webhookRuleset{
+			configKind:        "ValidatingWebhookConfiguration",
+			configName:        wh.Name,
+			webhookName:       w.Name,
+			rules:             w.Rules,
+			namespaceSelector: w.NamespaceSelector,
+			objectSelector:    w.ObjectSelector,
+		})
+	}
+	return out
+}
+
+func mutatingRulesets(wh admissionregistrationv1.MutatingWebhookConfiguration) []webhookRuleset {
+	out := make([]webhookRuleset, 0, len(wh.Webhooks))
+	for _, w := range wh.Webhooks {
+		out = append(out, webhookRuleset{
+			configKind:        "MutatingWebhookConfiguration",
+			configName:        wh.Name,
+			webhookName:       w.Name,
+			rules:             w.Rules,
+			namespaceSelector: w.NamespaceSelector,
+			objectSelector:    w.ObjectSelector,
+		})
+	}
+	return out
+}
+
+func webhookRow(rs webhookRuleset, target ConstraintTarget, nsLabels map[string]string) (ConstraintRow, bool) {
+	matched, allResources := rulesMatchTarget(rs.rules, target.GVR)
+	if !matched {
+		return ConstraintRow{}, false
+	}
+	if !selectorMatches(rs.namespaceSelector, nsLabels) {
+		return ConstraintRow{}, false
+	}
+	if !selectorMatches(rs.objectSelector, target.Labels) {
+		return ConstraintRow{}, false
+	}
+	detail := rs.configName + "." + rs.webhookName
+	if allResources {
+		detail += ": all resources"
+	}
+	return ConstraintRow{
+		Source:   "Webhook",
+		Kind:     rs.configKind,
+		Name:     rs.configName,
+		Detail:   detail,
+		Blocking: true,
+	}, true
+}
+
+func rulesMatchTarget(rules []admissionregistrationv1.RuleWithOperations, gvr schema.GroupVersionResource) (matched, allResources bool) {
+	for _, rule := range rules {
+		if !operationsInclude(rule.Operations) {
+			continue
+		}
+		if !valueOrWildcard(rule.APIGroups, gvr.Group) || !valueOrWildcard(rule.APIVersions, gvr.Version) {
+			continue
+		}
+		if ok, wildcard := webhookResourceMatches(rule.Resources, gvr.Resource); ok {
+			return true, wildcard
+		}
+	}
+	return false, false
+}
+
+func operationsInclude(ops []admissionregistrationv1.OperationType) bool {
+	for _, op := range ops {
+		if op == admissionregistrationv1.OperationAll ||
+			op == admissionregistrationv1.Update ||
+			op == admissionregistrationv1.Delete {
+			return true
+		}
+	}
+	return false
+}
+
+func valueOrWildcard(values []string, want string) bool {
+	for _, v := range values {
+		if v == "*" || v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func webhookResourceMatches(resources []string, want string) (matched, wildcard bool) {
+	for _, r := range resources {
+		if r == "*" {
+			return true, true
+		}
+		if r == want {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+func selectorMatches(sel *metav1.LabelSelector, objLabels map[string]string) bool {
+	if sel == nil {
+		return true
+	}
+	selector, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return false
+	}
+	return selector.Matches(labels.Set(objLabels))
+}

--- a/internal/k8s/constraints_webhooks_test.go
+++ b/internal/k8s/constraints_webhooks_test.go
@@ -10,6 +10,106 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
+func TestRulesMatchTarget_Scope(t *testing.T) {
+	clusterScope := admissionregistrationv1.ClusterScope
+	namespacedScope := admissionregistrationv1.NamespacedScope
+	allScopes := admissionregistrationv1.AllScopes
+	deployments := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	rule := func(scope *admissionregistrationv1.ScopeType, resources ...string) []admissionregistrationv1.RuleWithOperations {
+		return []admissionregistrationv1.RuleWithOperations{{
+			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+			APIGroups:  []string{"*"}, APIVersions: []string{"*"}, Resources: resources, Scope: scope,
+		}}
+	}
+
+	tests := []struct {
+		name         string
+		rules        []admissionregistrationv1.RuleWithOperations
+		targetScope  admissionregistrationv1.ScopeType
+		wantMatch    bool
+		wantWildcard bool
+	}{
+		{"cluster rule against a namespaced target", rule(&clusterScope, "deployments"), namespacedScope, false, false},
+		{"namespaced rule against a cluster target", rule(&namespacedScope, "deployments"), clusterScope, false, false},
+		{"namespaced rule against a namespaced target", rule(&namespacedScope, "deployments"), namespacedScope, true, false},
+		{"unset scope places no restriction", rule(nil, "deployments"), clusterScope, true, false},
+		{"explicit all scopes", rule(&allScopes, "deployments"), clusterScope, true, false},
+		{"*/* matches every resource", rule(nil, "*/*"), namespacedScope, true, true},
+		{"resource/* matches the bare resource", rule(nil, "deployments/*"), namespacedScope, true, false},
+		{"other resource does not match", rule(nil, "statefulsets"), namespacedScope, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, wildcard := rulesMatchTarget(tt.rules, deployments, tt.targetScope)
+			if matched != tt.wantMatch || wildcard != tt.wantWildcard {
+				t.Errorf("rulesMatchTarget = (%v, %v), want (%v, %v)", matched, wildcard, tt.wantMatch, tt.wantWildcard)
+			}
+		})
+	}
+}
+
+func TestWebhookRows_NamespaceSelectorForClusterScopedTargets(t *testing.T) {
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	cfg := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		Name: "ns-scoped",
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name:        "ns-scoped.example.com",
+			SideEffects: &sideEffects,
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+				APIGroups:  []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"},
+			}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+		}},
+	}
+	client := newFakeClient(k8sfake.NewClientset(cfg), nil)
+
+	tests := []struct {
+		name     string
+		target   ConstraintTarget
+		wantRows int
+	}{
+		{
+			"Namespace object matches on its own labels",
+			ConstraintTarget{
+				Kind:   "Namespace",
+				Labels: map[string]string{"env": "prod"},
+				GVR:    schema.GroupVersionResource{Version: "v1", Resource: "namespaces"},
+			},
+			1,
+		},
+		{
+			"Namespace object with other labels is excluded",
+			ConstraintTarget{
+				Kind:   "Namespace",
+				Labels: map[string]string{"env": "staging"},
+				GVR:    schema.GroupVersionResource{Version: "v1", Resource: "namespaces"},
+			},
+			0,
+		},
+		{
+			"Node ignores namespaceSelector entirely",
+			ConstraintTarget{
+				Kind: "Node",
+				GVR:  schema.GroupVersionResource{Version: "v1", Resource: "nodes"},
+			},
+			1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := client.validatingWebhookConstraintRows(t.Context(), "", tt.target)
+			if err != nil {
+				t.Fatalf("validatingWebhookConstraintRows: %v", err)
+			}
+			if len(rows) != tt.wantRows {
+				t.Errorf("rows = %d, want %d: %+v", len(rows), tt.wantRows, rows)
+			}
+		})
+	}
+}
+
 func TestWebhookRows_OnlyMatchingConfigurations(t *testing.T) {
 	sideEffects := admissionregistrationv1.SideEffectClassNone
 	ns := &corev1.Namespace{
@@ -59,9 +159,9 @@ func TestWebhookRows_OnlyMatchingConfigurations(t *testing.T) {
 		GVR:       schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 	}
 
-	rows, err := client.webhookConstraintRows(t.Context(), "", target)
+	rows, err := client.validatingWebhookConstraintRows(t.Context(), "", target)
 	if err != nil {
-		t.Fatalf("webhookConstraintRows: %v", err)
+		t.Fatalf("validatingWebhookConstraintRows: %v", err)
 	}
 	if len(rows) != 1 {
 		t.Fatalf("expected exactly 1 row, got %d: %+v", len(rows), rows)

--- a/internal/k8s/constraints_webhooks_test.go
+++ b/internal/k8s/constraints_webhooks_test.go
@@ -36,7 +36,9 @@ func TestRulesMatchTarget_Scope(t *testing.T) {
 		{"unset scope places no restriction", rule(nil, "deployments"), clusterScope, true, false},
 		{"explicit all scopes", rule(&allScopes, "deployments"), clusterScope, true, false},
 		{"*/* matches every resource", rule(nil, "*/*"), namespacedScope, true, true},
-		{"resource/* matches the bare resource", rule(nil, "deployments/*"), namespacedScope, true, false},
+		{"* matches the bare resource", rule(nil, "*"), namespacedScope, true, true},
+		{"resource/* does not match the bare resource", rule(nil, "deployments/*"), namespacedScope, false, false},
+		{"exact resource matches", rule(nil, "deployments"), namespacedScope, true, false},
 		{"other resource does not match", rule(nil, "statefulsets"), namespacedScope, false, false},
 	}
 	for _, tt := range tests {

--- a/internal/k8s/constraints_webhooks_test.go
+++ b/internal/k8s/constraints_webhooks_test.go
@@ -1,0 +1,72 @@
+package k8s
+
+import (
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestWebhookRows_OnlyMatchingConfigurations(t *testing.T) {
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	ns := &corev1.Namespace{
+		Name: "default", Labels: map[string]string{"env": "prod"},
+	}
+
+	ruleMismatch := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		Name: "rule-mismatch",
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name:        "rule-mismatch.example.com",
+			SideEffects: &sideEffects,
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+				APIGroups:  []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"},
+			}},
+		}},
+	}
+	nsSelectorMismatch := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		Name: "ns-mismatch",
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name:        "ns-mismatch.example.com",
+			SideEffects: &sideEffects,
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Update},
+				APIGroups:  []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"},
+			}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}},
+		}},
+	}
+	fullMatch := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		Name: "full-match",
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name:        "full-match.example.com",
+			SideEffects: &sideEffects,
+			Rules: []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Update, admissionregistrationv1.Delete},
+				APIGroups:  []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"},
+			}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+		}},
+	}
+
+	client := newFakeClient(k8sfake.NewClientset(ns, ruleMismatch, nsSelectorMismatch, fullMatch), nil)
+
+	target := ConstraintTarget{
+		Namespace: "default",
+		GVR:       schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+	}
+
+	rows, err := client.webhookConstraintRows(t.Context(), "", target)
+	if err != nil {
+		t.Fatalf("webhookConstraintRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly 1 row, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].Name != "full-match" {
+		t.Errorf("Name = %q, want full-match", rows[0].Name)
+	}
+}

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -84,6 +84,10 @@ type Keybindings struct {
 	ToggleRare        string `json:"toggle_rare" yaml:"toggle_rare"`
 	OrphanOverlay     string `json:"orphan_overlay" yaml:"orphan_overlay"`
 	SessionManager    string `json:"session_manager" yaml:"session_manager"`
+	// Constraints opens the "what constrains this object" fullscreen view
+	// for the selected resource: quotas, limit ranges, PDBs, priority
+	// preemption, node scheduling terms, and admission webhooks.
+	Constraints string `json:"constraints" yaml:"constraints"`
 
 	// Actions
 	NamespaceSelector string `json:"namespace_selector" yaml:"namespace_selector"`
@@ -254,6 +258,7 @@ func DefaultKeybindings() Keybindings {
 		MetricsSparkCycle: "~",
 		OrphanOverlay:     "Z",
 		SessionManager:    "C",
+		Constraints:       "b",
 
 		// Actions
 		NamespaceSelector: "\\", AllNamespaces: "A", ActionMenu: "x",

--- a/internal/ui/config_keybindings_test.go
+++ b/internal/ui/config_keybindings_test.go
@@ -131,6 +131,31 @@ func TestEmittedNameForCtrlChord_FiresOnKnownDeadSpellings(t *testing.T) {
 	}
 }
 
+// TestConstraintsKeybindingDefaultIsFree checks the "b" default for Constraints
+// against every other keybinding default, so adding it did not silently shadow
+// an existing explorer-scope shortcut.
+func TestConstraintsKeybindingDefaultIsFree(t *testing.T) {
+	kb := DefaultKeybindings()
+	if kb.Constraints != "b" {
+		t.Fatalf("Constraints default = %q, want %q", kb.Constraints, "b")
+	}
+
+	v := reflect.ValueOf(kb)
+	for i := range v.NumField() {
+		name := v.Type().Field(i).Name
+		if name == "Constraints" {
+			continue
+		}
+		f := v.Field(i)
+		if f.Kind() != reflect.String {
+			continue
+		}
+		if f.String() == kb.Constraints {
+			t.Errorf("%s also defaults to %q, colliding with Constraints", name, kb.Constraints)
+		}
+	}
+}
+
 // TestLogKeybindingSwap verifies the log key layout: the details-pane live-log
 // toggle claims shift+l ("L") and the fullscreen log viewer uses ctrl+l
 // (reachable on macOS without Option-as-Meta, unlike an alt+letter binding).

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -439,6 +439,18 @@ func viewerHelpSections(kb Keybindings) []helpSection {
 			},
 		},
 		{
+			title: "Constraints View", context: "Constraints View",
+			bindings: []helpEntry{
+				{kb.WhichKeyLeader, "Which-key panel: hotkeys actionable now"},
+				{"j/k", "Navigate rows"},
+				{kb.JumpTop + "/" + kb.JumpBottom, "Jump to top / bottom"},
+				{"ctrl+d/ctrl+u", "Half page down / up"},
+				{"enter", "Jump to the row's object"},
+				{kb.Refresh, "Re-run the scan"},
+				{"q/esc", "Close constraints view"},
+			},
+		},
+		{
 			// Grouping and warnings-only used to be listed here. They are keys of
 			// the explorer's Events list (handleKeyExpandCollapse,
 			// handleExplorerActionKeySaveResource), not of the timeline, and are

--- a/internal/ui/help_sections.go
+++ b/internal/ui/help_sections.go
@@ -442,10 +442,10 @@ func viewerHelpSections(kb Keybindings) []helpSection {
 			title: "Constraints View", context: "Constraints View",
 			bindings: []helpEntry{
 				{kb.WhichKeyLeader, "Which-key panel: hotkeys actionable now"},
-				{"j/k", "Navigate rows"},
+				{kb.Down + "/" + kb.Up, "Navigate rows"},
 				{kb.JumpTop + "/" + kb.JumpBottom, "Jump to top / bottom"},
-				{"ctrl+d/ctrl+u", "Half page down / up"},
-				{"enter", "Jump to the row's object"},
+				{kb.PageDown + "/" + kb.PageUp, "Half page down / up"},
+				{kb.Enter, "Jump to the row's object"},
 				{kb.Refresh, "Re-run the scan"},
 				{"q/esc", "Close constraints view"},
 			},


### PR DESCRIPTION
## Summary
- New fullscreen constraints view on `b`. It lists the ResourceQuotas, PodDisruptionBudgets, PriorityClasses (with recent preemption events), node taints and selectors, and admission webhooks that apply to the selected object, with headroom where a quota is close to its limit.
- Sources the user cannot list are left out and named in a banner, split into denied (forbidden or unauthorized) and failed (any other error). The view only errors when every source fails.
- Lookups fan out with a bound of four in flight, are tied to the object they were requested for so a stale reply cannot land on a new selection, and cap the events list at 500.

## Test plan
- [x] Unit tests for each source (quota, PDB, priority, nodes, webhooks) and the fan-out detector, including partial denial and total failure
- [x] View tests for banner plus surviving rows, tab save and load, which-key and help registration
- [x] `go test -race ./...` and golangci-lint clean after rebase onto main
- [ ] Manual: open a Pod, press `b`, confirm quotas, PDB and webhooks appear; repeat with a user lacking `nodes` list rights and confirm the banner