### PR TITLE
test: restore PinnedTypes after the union pin group test

### DIFF
--- a/internal/app/pinned_cursor_test.go
+++ b/internal/app/pinned_cursor_test.go
@@ -26,6 +26,7 @@ func cursorIndexOfItem(m *Model, name string) int {
 func TestPinCursorFollowsToNextItem(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	defer func(orig []string) { model.PinnedTypes = orig }(model.PinnedTypes)
+	model.PinnedTypes = nil
 
 	m := baseModelWithFakeClient()
 	m.nav.Context = "prod"
@@ -63,6 +64,7 @@ func TestPinCursorFollowsToNextItem(t *testing.T) {
 func TestPinCursorFallsBackToPreviousWhenLast(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	defer func(orig []string) { model.PinnedTypes = orig }(model.PinnedTypes)
+	model.PinnedTypes = nil
 
 	m := baseModelWithFakeClient()
 	m.nav.Context = "prod"

--- a/internal/app/union_test.go
+++ b/internal/app/union_test.go
@@ -1634,6 +1634,7 @@ func TestUnionSentinelContextWideFeatures(t *testing.T) {
 func TestUnionSetPinGroupTogglesUnionSetPins(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func(orig []string) { model.PinnedTypes = orig }(model.PinnedTypes)
 
 	m := baseModelWithFakeClient()
 	m.unionMode = true


### PR DESCRIPTION
## Summary
- TestUnionSetPinGroupTogglesUnionSetPins pins a type through the real key handler and never restored `model.PinnedTypes`. Under `-shuffle` the leak reached TestPinCursorFollowsToNextItem, whose sidebar then carried an extra pinned entry and the cursor landed on the wrong item.
- The union test now restores the global with a defer, and both pin cursor tests start from an empty pin list so they hold regardless of order.

## Test plan
- [x] `go test -shuffle=1789026810112143000 -run 'TestUnionSetPinGroupTogglesUnionSetPins|TestPinCursorFollowsToNextItem' ./internal/app/` fails on main and passes here
- [x] `go test -shuffle=on ./internal/app/` ten times green
- [x] go vet and golangci-lint clean