### PR TITLE
fix: open the constraints view for workloads only and size its columns

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -85,7 +85,7 @@ chords, which all start with `g`; re-point the ones you use at the new prefix.
 | `O` | Object Explorer (browse the selected resource's live object as a drill-in tree) |
 | `U` | RBAC permissions browser (can-i) |
 | `Shift+Z` | Open the cluster-wide Orphan overview |
-| `b` | What constrains this object (quotas, PDBs, priority, node placement, webhooks - Pod/Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob only) |
+| `b` | What constrains this object (quotas, PDBs, priority, node placement, webhooks - Pod/Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob/ReplicationController only) |
 | `C` | Session manager (save/switch/delete named workspace sessions) |
 | `Ctrl+G` | Finalizer search and remove |
 | `!` | Error log |
@@ -531,7 +531,7 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 
 ## Constraints View
 
-Press `b` on a resource to see what constrains it: ResourceQuotas and LimitRanges against its container requests, PodDisruptionBudgets, its PriorityClass and any preemption events, node selector / affinity / taint mismatches, and admission webhooks that would intercept it. Available only for kinds that carry a pod template: Pod, Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, CronJob. A row that names no single object (a node selector or affinity mismatch) can't be jumped to; a row for a real object (quota, PDB, PriorityClass, node, webhook config) can. Sources denied by RBAC are named in a `skipped (denied: ...)` banner instead of being silently omitted. A source that broke for any other reason is named as `failed: ...` in the same banner, and the rows other sources found stay visible, so a short list means unread sources, not absent constraints.
+Press `b` on a resource to see what constrains it: ResourceQuotas and LimitRanges against its container requests, PodDisruptionBudgets, its PriorityClass and any preemption events, node selector / affinity / taint mismatches, and admission webhooks that would intercept it. Available only for kinds that carry a pod template: Pod, Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, CronJob, ReplicationController. A row that names no single object (a node selector or affinity mismatch) can't be jumped to; a row for a real object (quota, PDB, PriorityClass, node, webhook config) can. Sources denied by RBAC are named in a `skipped (denied: ...)` banner instead of being silently omitted. A source that broke for any other reason is named as `failed: ...` in the same banner, and the rows other sources found stay visible, so a short list means unread sources, not absent constraints.
 
 | Key | Action |
 |---|---|

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -85,7 +85,7 @@ chords, which all start with `g`; re-point the ones you use at the new prefix.
 | `O` | Object Explorer (browse the selected resource's live object as a drill-in tree) |
 | `U` | RBAC permissions browser (can-i) |
 | `Shift+Z` | Open the cluster-wide Orphan overview |
-| `b` | What constrains this object (quotas, PDBs, priority, node placement, webhooks) |
+| `b` | What constrains this object (quotas, PDBs, priority, node placement, webhooks - Pod/Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob only) |
 | `C` | Session manager (save/switch/delete named workspace sessions) |
 | `Ctrl+G` | Finalizer search and remove |
 | `!` | Error log |
@@ -531,7 +531,7 @@ Live refresh defaults to on; set `object_explorer.live: false` to start paused. 
 
 ## Constraints View
 
-Press `b` on a resource to see what constrains it: ResourceQuotas and LimitRanges against its container requests, PodDisruptionBudgets, its PriorityClass and any preemption events, node selector / affinity / taint mismatches, and admission webhooks that would intercept it. A row that names no single object (a node selector or affinity mismatch) can't be jumped to; a row for a real object (quota, PDB, PriorityClass, node, webhook config) can. Sources denied by RBAC are named in a `skipped (denied: ...)` banner instead of being silently omitted. A source that broke for any other reason is named as `failed: ...` in the same banner, and the rows other sources found stay visible, so a short list means unread sources, not absent constraints.
+Press `b` on a resource to see what constrains it: ResourceQuotas and LimitRanges against its container requests, PodDisruptionBudgets, its PriorityClass and any preemption events, node selector / affinity / taint mismatches, and admission webhooks that would intercept it. Available only for kinds that carry a pod template: Pod, Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, CronJob. A row that names no single object (a node selector or affinity mismatch) can't be jumped to; a row for a real object (quota, PDB, PriorityClass, node, webhook config) can. Sources denied by RBAC are named in a `skipped (denied: ...)` banner instead of being silently omitted. A source that broke for any other reason is named as `failed: ...` in the same banner, and the rows other sources found stay visible, so a short list means unread sources, not absent constraints.
 
 | Key | Action |
 |---|---|

--- a/internal/app/update_constraints.go
+++ b/internal/app/update_constraints.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"slices"
 
 	tea "charm.land/bubbletea/v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,6 +14,11 @@ import (
 
 const constraintsScrollOff = 3
 
+// constraintsWorkloadKinds are the kinds that carry, or generate, a pod
+// template — the shapes podSpecAndMetaFromRaw (internal/k8s) knows how to
+// read. Shared with the which-key Avail gate so the two lists never drift.
+var constraintsWorkloadKinds = []string{"Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob"}
+
 // openConstraintsView opens the "what constrains this object" fullscreen
 // view for the currently selected middle-column row.
 func (m Model) openConstraintsView() (tea.Model, tea.Cmd) {
@@ -23,6 +29,10 @@ func (m Model) openConstraintsView() (tea.Model, tea.Cmd) {
 	sel := m.selectedMiddleItem()
 	if sel == nil || sel.Raw == nil {
 		m.setStatusMessage("No resource data available", true)
+		return m, scheduleStatusClear()
+	}
+	if !slices.Contains(constraintsWorkloadKinds, sel.Kind) {
+		m.setStatusMessage("Constraints apply to workloads only", true)
 		return m, scheduleStatusClear()
 	}
 

--- a/internal/app/update_constraints.go
+++ b/internal/app/update_constraints.go
@@ -17,7 +17,9 @@ const constraintsScrollOff = 3
 // constraintsWorkloadKinds are the kinds that carry, or generate, a pod
 // template — the shapes podSpecAndMetaFromRaw (internal/k8s) knows how to
 // read. Shared with the which-key Avail gate so the two lists never drift.
-var constraintsWorkloadKinds = []string{"Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob"}
+var constraintsWorkloadKinds = []string{
+	"Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob", "ReplicationController",
+}
 
 // openConstraintsView opens the "what constrains this object" fullscreen
 // view for the currently selected middle-column row.
@@ -62,7 +64,7 @@ func (m Model) handleConstraintsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	kb := ui.ActiveKeybindings
 	rows := m.constraints.visibleRows()
 	maxIdx := len(rows) - 1
-	half := max(m.constraintsViewportHeight()/2, 1)
+	half := max(m.constraintsDataHeight()/2, 1)
 
 	// Cleared up front so no exit path leaves a half-typed gg armed for the
 	// explorer to complete after the view closes.
@@ -100,7 +102,7 @@ func (m Model) handleConstraintsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	m.constraints.scroll = ui.VimScrollOff(
 		m.constraints.scroll, m.constraints.cursor, len(rows),
-		m.constraintsViewportHeight(), constraintsScrollOff,
+		m.constraintsDataHeight(), constraintsScrollOff,
 		func(from, to int) int { return to - from },
 	)
 	return m, nil

--- a/internal/app/update_constraints_test.go
+++ b/internal/app/update_constraints_test.go
@@ -11,6 +11,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestOpenConstraintsView_RefusesKindWithoutPodTemplate(t *testing.T) {
+	m := basePush80Model()
+	m.setMiddleItems([]model.Item{{
+		Name: "cfg", Namespace: "default", Kind: "ConfigMap", Raw: map[string]any{"kind": "ConfigMap"},
+	}})
+	m.setCursor(0)
+
+	result, cmd := m.openConstraintsView()
+	updated, ok := result.(Model)
+	require.True(t, ok)
+
+	assert.Equal(t, modeExplorer, updated.mode, "must not open the constraints view for a kind with no pod template")
+	assert.True(t, updated.hasStatusMessage())
+	assert.Contains(t, updated.statusMessage, "Constraints apply to workloads only")
+	require.NotNil(t, cmd)
+}
+
+func TestOpenConstraintsView_OpensForEveryWorkloadKind(t *testing.T) {
+	for _, kind := range constraintsWorkloadKinds {
+		t.Run(kind, func(t *testing.T) {
+			m := basePush80Model()
+			m.setMiddleItems([]model.Item{{
+				Name: "obj", Namespace: "default", Kind: kind, Raw: map[string]any{"kind": kind},
+			}})
+			m.setCursor(0)
+
+			result, _ := m.openConstraintsView()
+			updated, ok := result.(Model)
+			require.True(t, ok)
+			assert.Equal(t, modeConstraints, updated.mode, "must open the constraints view for %s", kind)
+		})
+	}
+}
+
 func TestConstraintsView_EnterJumpsToRowObject(t *testing.T) {
 	m := basePush80Model()
 	m.mode = modeConstraints

--- a/internal/app/update_constraints_test.go
+++ b/internal/app/update_constraints_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -93,6 +95,28 @@ func TestConstraintsView_HiddenTargetLeavesNavigationUntouched(t *testing.T) {
 	assert.Equal(t, modeConstraints, updated.mode, "a failed jump must keep the view open")
 	assert.Equal(t, "default", updated.namespace, "a failed jump must not switch namespace")
 	assert.Empty(t, updated.jumpBackStack, "a failed jump must not record history")
+}
+
+func TestHandleConstraintsKey_CursorStaysVisibleWithBannerAndHeader(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.width = 120
+	m.height = 20
+	rows := make([]k8s.ConstraintRow, 30)
+	for i := range rows {
+		rows[i] = k8s.ConstraintRow{
+			Source: "Quota", Kind: "ResourceQuota", Namespace: "default", Name: fmt.Sprintf("quota-%02d", i),
+		}
+	}
+	m.constraints.report = k8s.ConstraintReport{Rows: rows, Skipped: []string{"poddisruptionbudgets"}}
+
+	result, _ := m.handleConstraintsKey(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	updated, ok := result.(Model)
+	require.True(t, ok)
+
+	out := strings.Join(updated.renderConstraintsRows(), "\n")
+	lastRow := rows[len(rows)-1]
+	assert.Contains(t, out, lastRow.Name, "the cursor row must render after jumping to the bottom")
 }
 
 func TestConstraintsView_QuitClearsPendingG(t *testing.T) {

--- a/internal/app/view_modes_constraints.go
+++ b/internal/app/view_modes_constraints.go
@@ -22,6 +22,13 @@ func (m Model) constraintsDataHeight() int {
 	return max(m.constraintsViewportHeight()-2, 1)
 }
 
+// constraintsContentWidth is the interior width content lines wrap to,
+// shared by the banner and the row/column sizing so both truncate to the
+// same box.
+func (m Model) constraintsContentWidth() int {
+	return max(m.width-4, 20)
+}
+
 func (m Model) viewConstraints() string {
 	title := ui.ViewTitle(m.width, m.constraints.title+" — what constrains this object")
 
@@ -31,7 +38,7 @@ func (m Model) viewConstraints() string {
 	} else if m.constraints.err != nil {
 		body = append(body, ui.ErrorStyle.Render("  "+ui.SanitizeTerminalText(m.constraints.err.Error())))
 	} else {
-		body = append(body, constraintsBanner(m.constraints.report.Skipped, m.constraints.report.Failed))
+		body = append(body, constraintsBanner(m.constraints.report.Skipped, m.constraints.report.Failed, m.constraintsContentWidth()))
 		body = append(body, m.renderConstraintsRows()...)
 	}
 
@@ -45,10 +52,10 @@ func (m Model) viewConstraints() string {
 	return lipgloss.JoinVertical(lipgloss.Left, title, content, m.constraintsHintBar())
 }
 
-// constraintsBanner names the sources the scan couldn't read — one line,
-// never a per-source row implying "absent". Denied and failed sources are
-// named separately so an RBAC gap doesn't read as a bug, or vice versa.
-func constraintsBanner(skipped, failed []string) string {
+// constraintsBanner names the sources the scan couldn't read, denied and
+// failed separately so an RBAC gap doesn't read as a bug, or vice versa.
+// Truncated to width: constraintsDataHeight reserves it exactly one line.
+func constraintsBanner(skipped, failed []string, width int) string {
 	if len(skipped) == 0 && len(failed) == 0 {
 		return ""
 	}
@@ -59,7 +66,8 @@ func constraintsBanner(skipped, failed []string) string {
 	if len(failed) > 0 {
 		parts = append(parts, "failed: "+strings.Join(sanitizedConstraintNames(failed), ", "))
 	}
-	return ui.StatusWarning.Render("  skipped (" + strings.Join(parts, "; ") + ")")
+	line := "  skipped (" + strings.Join(parts, "; ") + ")"
+	return ui.StatusWarning.Render(ui.Truncate(line, width))
 }
 
 func sanitizedConstraintNames(names []string) []string {
@@ -75,8 +83,7 @@ func sanitizedConstraintNames(names []string) []string {
 // which visibleRows and the cursor index without it.
 func (m Model) renderConstraintsRows() []string {
 	rows := m.constraints.visibleRows()
-	width := max(m.width-4, 20)
-	cols := constraintsColumns(width, rows)
+	cols := constraintsColumns(m.constraintsContentWidth(), rows)
 	header := constraintsHeaderLine(cols)
 
 	if len(rows) == 0 {

--- a/internal/app/view_modes_constraints.go
+++ b/internal/app/view_modes_constraints.go
@@ -65,18 +65,24 @@ func sanitizedConstraintNames(names []string) []string {
 	return out
 }
 
+// renderConstraintsRows renders the header line plus one line per visible
+// row. The header always leads and is never part of the scrolled range,
+// which visibleRows and the cursor index without it.
 func (m Model) renderConstraintsRows() []string {
 	rows := m.constraints.visibleRows()
-	if len(rows) == 0 {
-		return []string{ui.DimStyle.Render("  no constraints found")}
-	}
 	width := max(m.width-4, 20)
-	height := m.constraintsViewportHeight() - 1 // banner line
+	cols := constraintsColumns(width, rows)
+	header := constraintsHeaderLine(cols)
+
+	if len(rows) == 0 {
+		return []string{header, ui.DimStyle.Render("  no constraints found")}
+	}
+	height := m.constraintsViewportHeight() - 2 // banner + header lines
 	scroll := min(max(m.constraints.scroll, 0), max(len(rows)-1, 0))
 	end := min(scroll+height, len(rows))
 
-	cols := constraintsColumns(width)
-	out := make([]string, 0, max(end-scroll, 0))
+	out := make([]string, 0, max(end-scroll, 0)+1)
+	out = append(out, header)
 	for i := scroll; i < end; i++ {
 		out = append(out, formatConstraintRow(rows[i], i == m.constraints.cursor, cols))
 	}
@@ -89,14 +95,59 @@ type constraintColumns struct {
 	source, kind, name, headroom, detail, line int
 }
 
-// constraintsColumns hands cells back to the detail column, widest first,
-// until the row fits. Gaps between the five columns cost 5 cells.
-func constraintsColumns(width int) constraintColumns {
+const (
+	constraintHeaderSource   = "SOURCE"
+	constraintHeaderKind     = "KIND"
+	constraintHeaderName     = "NAME"
+	constraintHeaderHeadroom = "HEADROOM"
+	constraintHeaderDetail   = "DETAIL"
+)
+
+// constraintCells is one row's plain, sanitized cell text, shared between
+// column-width measurement and row rendering so they never disagree.
+type constraintCells struct {
+	source, kind, name, headroom, detail string
+}
+
+func constraintRowCells(row k8s.ConstraintRow) constraintCells {
+	nsName := ui.SanitizeTerminalText(row.Namespace)
+	if row.Name != "" {
+		if nsName != "" {
+			nsName += "/"
+		}
+		nsName += ui.SanitizeTerminalText(row.Name)
+	}
+	return constraintCells{
+		source:   row.Source,
+		kind:     ui.SanitizeTerminalText(row.Kind),
+		name:     nsName,
+		headroom: row.Headroom,
+		detail:   ui.SanitizeTerminalText(row.Detail),
+	}
+}
+
+// constraintsColumns sizes Source/Kind/Name/Headroom to their widest cell,
+// shrinks them toward their floors widest-first until Detail keeps at
+// least detailFloor cells, then hands Detail whatever remains.
+func constraintsColumns(width int, rows []k8s.ConstraintRow) constraintColumns {
 	const (
 		gaps        = 5
 		detailFloor = 10
 	)
-	cols := constraintColumns{source: 9, kind: 26, name: 28, headroom: 10, line: width - 1}
+	cols := constraintColumns{
+		source:   lipgloss.Width(constraintHeaderSource),
+		kind:     lipgloss.Width(constraintHeaderKind),
+		name:     lipgloss.Width(constraintHeaderName),
+		headroom: lipgloss.Width(constraintHeaderHeadroom),
+		line:     width - 1,
+	}
+	for _, row := range rows {
+		c := constraintRowCells(row)
+		cols.source = max(cols.source, lipgloss.Width(c.source))
+		cols.kind = max(cols.kind, lipgloss.Width(c.kind))
+		cols.name = max(cols.name, lipgloss.Width(c.name))
+		cols.headroom = max(cols.headroom, lipgloss.Width(c.headroom))
+	}
 
 	shrinkable := []*int{&cols.name, &cols.kind, &cols.headroom, &cols.source}
 	floors := []int{6, 6, 4, 4}
@@ -111,24 +162,30 @@ func constraintsColumns(width int) constraintColumns {
 	return cols
 }
 
+func constraintsHeaderLine(cols constraintColumns) string {
+	line := fmt.Sprintf("%-*s %-*s %-*s %-*s  %s",
+		cols.source, ui.Truncate(constraintHeaderSource, cols.source),
+		cols.kind, ui.Truncate(constraintHeaderKind, cols.kind),
+		cols.name, ui.Truncate(constraintHeaderName, cols.name),
+		cols.headroom, ui.Truncate(constraintHeaderHeadroom, cols.headroom),
+		ui.Truncate(constraintHeaderDetail, cols.detail),
+	)
+	line = ui.Truncate(line, cols.line)
+	return " " + ui.DimStyle.Bold(true).Render(line)
+}
+
 func formatConstraintRow(row k8s.ConstraintRow, isCursor bool, cols constraintColumns) string {
 	gutter := " "
 	if isCursor {
 		gutter = ui.YamlCursorIndicatorStyle.Render("▎")
 	}
-	nsName := ui.SanitizeTerminalText(row.Namespace)
-	if row.Name != "" {
-		if nsName != "" {
-			nsName += "/"
-		}
-		nsName += ui.SanitizeTerminalText(row.Name)
-	}
+	c := constraintRowCells(row)
 	line := fmt.Sprintf("%-*s %-*s %-*s %-*s  %s",
-		cols.source, ui.Truncate(row.Source, cols.source),
-		cols.kind, ui.Truncate(ui.SanitizeTerminalText(row.Kind), cols.kind),
-		cols.name, ui.Truncate(nsName, cols.name),
-		cols.headroom, ui.Truncate(row.Headroom, cols.headroom),
-		ui.Truncate(ui.SanitizeTerminalText(row.Detail), cols.detail),
+		cols.source, ui.Truncate(c.source, cols.source),
+		cols.kind, ui.Truncate(c.kind, cols.kind),
+		cols.name, ui.Truncate(c.name, cols.name),
+		cols.headroom, ui.Truncate(c.headroom, cols.headroom),
+		ui.Truncate(c.detail, cols.detail),
 	)
 	// The floors can still overrun a very narrow terminal, and a row wider
 	// than the box wraps into the border.

--- a/internal/app/view_modes_constraints.go
+++ b/internal/app/view_modes_constraints.go
@@ -10,11 +10,16 @@ import (
 	"github.com/janosmiko/lfk/internal/ui"
 )
 
-// constraintsViewportHeight is the number of table rows visible at once —
-// shared by the key handler (scroll math) and the renderer (page size) so
-// they agree on what "one page" means.
+// constraintsViewportHeight is the number of lines inside the fullscreen
+// box. constraintsDataHeight derives the actual row budget from it.
 func (m Model) constraintsViewportHeight() int {
 	return max(m.height-4, 3)
+}
+
+// constraintsDataHeight is the viewport minus the banner and header lines,
+// shared by the key handler and the renderer so both agree on one page.
+func (m Model) constraintsDataHeight() int {
+	return max(m.constraintsViewportHeight()-2, 1)
 }
 
 func (m Model) viewConstraints() string {
@@ -77,7 +82,7 @@ func (m Model) renderConstraintsRows() []string {
 	if len(rows) == 0 {
 		return []string{header, ui.DimStyle.Render("  no constraints found")}
 	}
-	height := m.constraintsViewportHeight() - 2 // banner + header lines
+	height := m.constraintsDataHeight()
 	scroll := min(max(m.constraints.scroll, 0), max(len(rows)-1, 0))
 	end := min(scroll+height, len(rows))
 

--- a/internal/app/view_modes_constraints_test.go
+++ b/internal/app/view_modes_constraints_test.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/janosmiko/lfk/internal/k8s"
 )
 
 func TestConstraintsBanner_DistinguishesDeniedFromFailed(t *testing.T) {
-	out := stripANSI(constraintsBanner([]string{"poddisruptionbudgets"}, []string{"nodes"}))
+	out := stripANSI(constraintsBanner([]string{"poddisruptionbudgets"}, []string{"nodes"}, 120))
 
 	if !strings.Contains(out, "denied") || !strings.Contains(out, "poddisruptionbudgets") {
 		t.Errorf("expected the denied group to name poddisruptionbudgets, got %q", out)
@@ -203,8 +204,57 @@ func TestViewConstraints_At80Columns_RowsFitWithinWidth(t *testing.T) {
 	}
 }
 
+func TestConstraintsBanner_TruncatesToOneLineSoDataRowsAreNotClipped(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.width = 60
+	m.height = 20
+	rows := make([]k8s.ConstraintRow, 30)
+	for i := range rows {
+		// Short, so the row survives column truncation at 60 columns — the
+		// assertion below is about the row being scrolled into view, not
+		// about its cell width (that's covered by the column-width tests).
+		rows[i] = k8s.ConstraintRow{Source: "Quota", Kind: "RQ", Name: fmt.Sprintf("q%02d", i)}
+	}
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: rows,
+		Skipped: []string{
+			"a-very-long-denied-resource-name-one",
+			"a-very-long-denied-resource-name-two",
+			"a-very-long-denied-resource-name-three",
+		},
+		Failed: []string{
+			"a-very-long-failed-resource-name-one",
+			"a-very-long-failed-resource-name-two",
+			"a-very-long-failed-resource-name-three",
+		},
+	}
+
+	result, _ := m.handleConstraintsKey(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	updated, ok := result.(Model)
+	if !ok {
+		t.Fatalf("expected Model, got %T", result)
+	}
+
+	content := stripANSI(updated.viewConstraints())
+	bannerLines := 0
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.Contains(line, "skipped (") {
+			bannerLines++
+		}
+	}
+	if bannerLines != 1 {
+		t.Errorf("banner rendered as %d lines, want exactly 1: %q", bannerLines, content)
+	}
+
+	lastRow := rows[len(rows)-1]
+	if !strings.Contains(content, lastRow.Name) {
+		t.Errorf("expected the cursor row %q to still render, got:\n%s", lastRow.Name, content)
+	}
+}
+
 func TestConstraintsBanner_EmptyWhenNothingSkippedOrFailed(t *testing.T) {
-	if out := constraintsBanner(nil, nil); out != "" {
+	if out := constraintsBanner(nil, nil, 120); out != "" {
 		t.Errorf("expected an empty banner, got %q", out)
 	}
 }

--- a/internal/app/view_modes_constraints_test.go
+++ b/internal/app/view_modes_constraints_test.go
@@ -33,11 +33,173 @@ func TestFormatConstraintRow_FitsTheAvailableWidth(t *testing.T) {
 
 	for _, width := range []int{20, 40, 60, 80, 120, 200} {
 		t.Run(fmt.Sprintf("width-%d", width), func(t *testing.T) {
-			line := stripANSI(formatConstraintRow(row, true, constraintsColumns(width)))
+			rows := []k8s.ConstraintRow{row}
+			line := stripANSI(formatConstraintRow(row, true, constraintsColumns(width, rows)))
 			if got := lipgloss.Width(line); got > width {
 				t.Errorf("row width = %d, want at most %d: %q", got, width, line)
 			}
 		})
+	}
+}
+
+// Reproduces the UAT screenshot: node names differing only past the old
+// fixed 28-char floor rendered identically until truncated.
+func TestConstraintsColumns_SizesToWidestCellAtWideWidth(t *testing.T) {
+	rows := []k8s.ConstraintRow{
+		{
+			Source: "Node", Kind: "Node", Name: "dev-envs-control-plane-fsn1-aaaaaa",
+			Headroom: "not tolerated",
+			Detail:   "taint node-role.kubernetes.io/control-plane=:NoSchedule not tolerated",
+		},
+		{
+			Source: "Node", Kind: "Node", Name: "dev-envs-control-plane-fsn1-bbbbbb",
+			Headroom: "not tolerated",
+			Detail:   "taint node-role.kubernetes.io/control-plane=:NoSchedule not tolerated",
+		},
+	}
+
+	cols := constraintsColumns(236, rows)
+
+	wantNameWidth := lipgloss.Width("dev-envs-control-plane-fsn1-aaaaaa")
+	if cols.name < wantNameWidth {
+		t.Errorf("name column width = %d, want at least %d so the full node name renders", cols.name, wantNameWidth)
+	}
+	wantHeadroomWidth := lipgloss.Width("not tolerated")
+	if cols.headroom < wantHeadroomWidth {
+		t.Errorf("headroom column width = %d, want at least %d", cols.headroom, wantHeadroomWidth)
+	}
+	if got := cols.source + cols.kind + cols.name + cols.headroom + cols.detail + 5; got > cols.line+1 {
+		t.Errorf("column sum = %d, want at most line width %d", got, cols.line+1)
+	}
+
+	for _, row := range rows {
+		line := stripANSI(formatConstraintRow(row, false, cols))
+		if !strings.Contains(line, row.Name) {
+			t.Errorf("at width 236, expected the full node name %q to render untruncated, got %q", row.Name, line)
+		}
+	}
+}
+
+// The other end: at 80 columns the row must still fit and Detail gives way first.
+func TestConstraintsColumns_NarrowWidthStillFitsAndTruncatesDetailLast(t *testing.T) {
+	row := k8s.ConstraintRow{
+		Source: "Webhook", Kind: "ValidatingWebhookConfiguration",
+		Namespace: "default", Name: "policy-check",
+		Headroom: "n/a",
+		Detail:   "rule create/update on pods matches, service policy-checker.default.svc:443, failurePolicy Fail",
+	}
+	cols := constraintsColumns(80, []k8s.ConstraintRow{row})
+	line := stripANSI(formatConstraintRow(row, false, cols))
+
+	if got := lipgloss.Width(line); got > 80 {
+		t.Errorf("row width = %d, want at most 80: %q", got, line)
+	}
+	if !strings.Contains(line, "Webhook") {
+		t.Errorf("expected the narrow Source column to still show its content, got %q", line)
+	}
+}
+
+func TestConstraintsHeaderLine_MatchesColumnWidthsAndIsNotSelectable(t *testing.T) {
+	rows := []k8s.ConstraintRow{
+		{Source: "Quota", Kind: "ResourceQuota", Namespace: "default", Name: "compute-quota", Headroom: "1", Detail: "requests 500m cpu"},
+	}
+	cols := constraintsColumns(120, rows)
+	header := stripANSI(constraintsHeaderLine(cols))
+
+	for _, label := range []string{"SOURCE", "KIND", "NAME", "HEADROOM", "DETAIL"} {
+		if !strings.Contains(header, label) {
+			t.Errorf("expected header to contain %q, got %q", label, header)
+		}
+	}
+	if got := lipgloss.Width(header); got > cols.line+1 {
+		t.Errorf("header width = %d, want at most %d", got, cols.line+1)
+	}
+}
+
+func TestRenderConstraintsRows_HeaderPrecedesRowsAndIsNotARow(t *testing.T) {
+	m := basePush80Model()
+	m.width = 120
+	m.height = 40
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: []k8s.ConstraintRow{
+			{Source: "Quota", Kind: "ResourceQuota", Namespace: "default", Name: "compute-quota", Headroom: "1", Detail: "requests 500m cpu"},
+			{Source: "PDB", Kind: "PodDisruptionBudget", Namespace: "default", Name: "web-pdb", Headroom: "0", Detail: "minAvailable 2"},
+		},
+	}
+
+	out := m.renderConstraintsRows()
+	if len(out) != len(m.constraints.report.Rows)+1 {
+		t.Fatalf("got %d lines, want %d (header + rows)", len(out), len(m.constraints.report.Rows)+1)
+	}
+	header := stripANSI(out[0])
+	if !strings.Contains(header, "SOURCE") {
+		t.Errorf("expected the first line to be the header, got %q", header)
+	}
+	if !strings.Contains(stripANSI(out[1]), "compute-quota") {
+		t.Errorf("expected the first row after the header, got %q", stripANSI(out[1]))
+	}
+
+	// The cursor indexes report.Rows, not the rendered lines, so it stays
+	// in range even though the header adds an extra line.
+	m.constraints.cursor = 1
+	out = m.renderConstraintsRows()
+	if !strings.Contains(stripANSI(out[2]), "web-pdb") {
+		t.Errorf("expected cursor row 1 to render web-pdb, got %q", stripANSI(out[2]))
+	}
+}
+
+func TestViewConstraints_At240Columns_DoesNotTruncateColumnsThatFit(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.width = 240
+	m.height = 40
+	m.constraints.title = "web-1"
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: []k8s.ConstraintRow{
+			{
+				Source: "Node", Kind: "Node", Name: "dev-envs-control-plane-fsn1-aaaaaaaaaa",
+				Headroom: "not tolerated",
+				Detail:   "taint node-role.kubernetes.io/control-plane=:NoSchedule not tolerated",
+			},
+			{
+				Source: "Node", Kind: "Node", Name: "dev-envs-control-plane-fsn1-bbbbbbbbbb",
+				Headroom: "not tolerated",
+				Detail:   "taint node-role.kubernetes.io/control-plane=:NoSchedule not tolerated",
+			},
+		},
+	}
+
+	out := stripANSI(m.View().Content)
+	for _, row := range m.constraints.report.Rows {
+		if !strings.Contains(out, row.Name) {
+			t.Errorf("expected full node name %q to render at 240 columns, got:\n%s", row.Name, out)
+		}
+		if !strings.Contains(out, row.Detail) {
+			t.Errorf("expected full detail %q to render at 240 columns, got:\n%s", row.Detail, out)
+		}
+	}
+}
+
+func TestViewConstraints_At80Columns_RowsFitWithinWidth(t *testing.T) {
+	m := basePush80Model()
+	m.mode = modeConstraints
+	m.width = 80
+	m.height = 30
+	m.constraints.title = "web-1"
+	m.constraints.report = k8s.ConstraintReport{
+		Rows: []k8s.ConstraintRow{{
+			Source: "Webhook", Kind: "ValidatingWebhookConfiguration",
+			Namespace: "default", Name: "policy-check",
+			Headroom: "n/a",
+			Detail:   "rule create/update on pods matches, service policy-checker.default.svc:443, failurePolicy Fail",
+		}},
+	}
+
+	out := stripANSI(m.View().Content)
+	for line := range strings.SplitSeq(out, "\n") {
+		if w := lipgloss.Width(line); w > 80 {
+			t.Errorf("line width = %d, want at most 80: %q", w, line)
+		}
 	}
 }
 

--- a/internal/app/whichkey_registry.go
+++ b/internal/app/whichkey_registry.go
@@ -526,7 +526,9 @@ var whichKeyExplorerActionList = []whichKeyAction{
 	{Key: func(kb ui.Keybindings) string { return kb.TogglePreviewLogs }, Label: "Live log preview", Group: wkViews, Avail: wkTogglePreviewLogsAvailable},
 	{Key: func(kb ui.Keybindings) string { return kb.ResourceMap }, Label: "Resource map", Group: wkViews, Avail: wkLevelResourcesUp},
 	{Key: func(kb ui.Keybindings) string { return kb.ObjectExplorer }, Label: "Object Explorer", Group: wkViews, Avail: func(c *wkCtx) bool { return wkOnRow(c) && c.sel.Raw != nil }},
-	{Key: func(kb ui.Keybindings) string { return kb.Constraints }, Label: "What constrains this object", Group: wkViews, Avail: func(c *wkCtx) bool { return wkOnRow(c) && c.sel.Raw != nil }},
+	{Key: func(kb ui.Keybindings) string { return kb.Constraints }, Label: "What constrains this object", Group: wkViews, Avail: func(c *wkCtx) bool {
+		return wkKindIn(constraintsWorkloadKinds...)(c) && c.sel.Raw != nil
+	}},
 	{Key: func(kb ui.Keybindings) string { return kb.APIExplorer }, Label: "API Explorer", Group: wkViews, Avail: wkAPIExplorerAvailable},
 	{Key: func(kb ui.Keybindings) string { return kb.RBACBrowser }, Label: "RBAC browser", Group: wkViews},
 	{Key: func(kb ui.Keybindings) string { return kb.OrphanOverlay }, Label: "Orphan overview", Group: wkViews, Avail: func(c *wkCtx) bool { return !c.unionSentinel }},

--- a/internal/app/whichkey_registry_test.go
+++ b/internal/app/whichkey_registry_test.go
@@ -84,6 +84,24 @@ func TestAvailableWhichKeyActions_SecretEditorOnlyForSecretAndConfigMap(t *testi
 	}
 }
 
+func TestAvailableWhichKeyActions_ConstraintsOnlyForWorkloadKinds(t *testing.T) {
+	restoreWhichKeyGlobals(t)
+	ui.ActiveKeybindings = ui.DefaultKeybindings()
+	m := whichKeyTestModel() // Pod
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "ConfigMap", APIVersion: "v1", Resource: "configmaps", Namespaced: true}
+	m.setMiddleItems([]model.Item{{Name: "cfg", Kind: "ConfigMap", Namespace: "default", Raw: map[string]any{}}})
+	m.setCursor(0)
+	if containsKey(whichKeyKeys(m), ui.ActiveKeybindings.Constraints) {
+		t.Fatal("constraints view must not be offered for a ConfigMap")
+	}
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true}
+	m.setMiddleItems([]model.Item{{Name: "p1", Kind: "Pod", Namespace: "default", Raw: map[string]any{}}})
+	m.setCursor(0)
+	if !containsKey(whichKeyKeys(m), ui.ActiveKeybindings.Constraints) {
+		t.Fatal("constraints view must be offered for a Pod")
+	}
+}
+
 func TestAvailableWhichKeyActions_RespectsRebind(t *testing.T) {
 	restoreWhichKeyGlobals(t)
 	kb := ui.DefaultKeybindings()
@@ -637,7 +655,9 @@ func wkLevelScopingCases() []wkLevelScopingCase {
 		{"Live log preview", "Pod", "", []model.Level{model.LevelResources, model.LevelOwned}},
 		{"Resource map", "", "", []model.Level{model.LevelResources, model.LevelOwned, model.LevelContainers}},
 		{"Object Explorer", "", "", []model.Level{model.LevelResources, model.LevelOwned, model.LevelContainers}},
-		{"What constrains this object", "", "", []model.Level{model.LevelResources, model.LevelOwned, model.LevelContainers}},
+		// LevelContainers is excluded: a container row's Kind is always
+		// "Container", never a workload kind (finding 1).
+		{"What constrains this object", "Pod", "", []model.Level{model.LevelResources, model.LevelOwned}},
 		{"API Explorer", "Pod", "", []model.Level{model.LevelResourceTypes, model.LevelResources, model.LevelOwned, model.LevelContainers}},
 		{"RBAC browser", "", "", allLevels},
 		{"Orphan overview", "", "", allLevels},

--- a/internal/k8s/constraints.go
+++ b/internal/k8s/constraints.go
@@ -104,8 +104,9 @@ func targetFromRaw(raw map[string]any) ConstraintTarget {
 	}
 }
 
-// podSpecAndMetaFromRaw picks the Pod spec/metadata for a bare Pod, or the
-// pod template's for anything else.
+// podSpecAndMetaFromRaw picks the Pod spec/metadata for a bare Pod, the
+// job template's pod template for a CronJob (spec.jobTemplate.spec.template),
+// or the pod template's for anything else (spec.template).
 func podSpecAndMetaFromRaw(raw map[string]any) (spec, meta map[string]any) {
 	kind, _ := raw["kind"].(string)
 	if kind == "Pod" {
@@ -114,7 +115,12 @@ func podSpecAndMetaFromRaw(raw map[string]any) (spec, meta map[string]any) {
 		return spec, meta
 	}
 	topSpec, _ := raw["spec"].(map[string]any)
-	tmpl, _ := topSpec["template"].(map[string]any)
+	tmplParent := topSpec
+	if kind == "CronJob" {
+		jobTemplate, _ := topSpec["jobTemplate"].(map[string]any)
+		tmplParent, _ = jobTemplate["spec"].(map[string]any)
+	}
+	tmpl, _ := tmplParent["template"].(map[string]any)
 	spec, _ = tmpl["spec"].(map[string]any)
 	meta, _ = tmpl["metadata"].(map[string]any)
 	return spec, meta

--- a/internal/k8s/constraints_test.go
+++ b/internal/k8s/constraints_test.go
@@ -35,6 +35,46 @@ func TestTargetFromRaw_DeploymentUsesPodTemplate(t *testing.T) {
 	assert.Equal(t, map[string]string{"disk": "nvme"}, target.NodeSelector)
 }
 
+func TestTargetFromRaw_CronJobUsesJobTemplatePodTemplate(t *testing.T) {
+	raw := map[string]any{
+		"kind": "CronJob",
+		"metadata": map[string]any{
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"jobTemplate": map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"labels": map[string]any{"app": "nightly"},
+						},
+						"spec": map[string]any{
+							"priorityClassName": "batch",
+							"nodeSelector":      map[string]any{"disk": "hdd"},
+							"containers": []any{
+								map[string]any{
+									"name":      "job",
+									"resources": map[string]any{"requests": map[string]any{"cpu": "1"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	target := targetFromRaw(raw)
+
+	assert.Equal(t, "default", target.Namespace)
+	assert.Equal(t, map[string]string{"app": "nightly"}, target.PodLabels)
+	assert.Equal(t, "batch", target.PriorityClassName)
+	assert.Equal(t, map[string]string{"disk": "hdd"}, target.NodeSelector)
+	if assert.Len(t, target.Containers, 1) {
+		assert.Equal(t, "job", target.Containers[0].Name)
+	}
+}
+
 func TestTargetFromRaw_KeepsRequiredAffinityMatchFields(t *testing.T) {
 	raw := map[string]any{
 		"kind": "Pod",


### PR DESCRIPTION
## Summary
- The constraints view (`b`) opens only for kinds with a pod template: Pod, Deployment, StatefulSet, DaemonSet, ReplicaSet, ReplicationController, Job, CronJob. Other kinds get a status message, and the which-key entry hides `b` there. CronJob templates are now read from `spec.jobTemplate`.
- The table has a header row, and columns size to their widest cell, so nothing is cut while the terminal has room. Only the detail column truncates when it does not.
- Scroll math and the renderer share one data-row height that subtracts the header and banner lines, so the cursor stays on screen.

## Test plan
- [x] Tests for the kind gate, the CronJob template path, header rendering, column widths at 80 and 240 columns, and cursor visibility with a banner
- [x] `go test -race ./...` and golangci-lint clean after rebase onto main
- [ ] Manual: `b` on a ConfigMap shows "Constraints apply to workloads only", `b` on a Pod shows a header and untruncated node names