### PR TITLE
fix: land owner jumps on the visible sidebar row

### DIFF
--- a/internal/app/jump_history.go
+++ b/internal/app/jump_history.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"maps"
 	"strings"
 
@@ -140,8 +141,28 @@ func (m Model) teleportToResourceType(rt model.ResourceTypeEntry, name string) (
 		m = ret.(Model)
 	}
 
-	// Find and select the target resource type in middle items.
-	for i, item := range m.middleItems {
+	// Reveal the target's accordion group: cursor positions are read
+	// against the collapsed visibleMiddleItems(), not this full slice
+	// (issue #748).
+	found := false
+	for _, item := range m.middleItems {
+		if item.Extra == rt.ResourceRef() {
+			found = true
+			if !m.allGroupsExpanded && item.Category != "" && item.Category != m.expandedGroup {
+				m.expandedGroup = item.Category
+			}
+			break
+		}
+	}
+	if !found {
+		m.setStatusMessage(
+			fmt.Sprintf("Cannot jump: %s not in sidebar (toggle rare resources with H?)", model.DisplayNameFor(rt)),
+			true)
+		return m, scheduleStatusClear()
+	}
+
+	// Find and select the target resource type in the now-visible middle items.
+	for i, item := range m.visibleMiddleItems() {
 		if item.Extra == rt.ResourceRef() {
 			m.setCursor(i)
 			break

--- a/internal/app/update_keys_jump_claim_test.go
+++ b/internal/app/update_keys_jump_claim_test.go
@@ -15,6 +15,7 @@ func claimJumpTestModel() Model {
 	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
 		{Kind: "ResourceClaim", APIGroup: "resource.k8s.io", APIVersion: "v1", Resource: "resourceclaims", Namespaced: true},
 	}
+	m.leftItems = model.BuildSidebarItems(m.discoveredResources["test-ctx"])
 	m.middleItems = []model.Item{
 		{
 			Name: "pod-1", Namespace: "default", Kind: "Pod", Status: "Running",

--- a/internal/app/update_keys_jump_owner_test.go
+++ b/internal/app/update_keys_jump_owner_test.go
@@ -1,0 +1,145 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/janosmiko/lfk/internal/model"
+)
+
+// jumpOwnerTestModel seeds discovery with Pod/ReplicaSet/Deployment/
+// StatefulSet so navigateToOwner can resolve every hop of a
+// Pod -> ReplicaSet -> Deployment chain, plus a sibling StatefulSet.
+func jumpOwnerTestModel() Model {
+	m := basePush80Model()
+	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
+		{Kind: "Pod", APIGroup: "", APIVersion: "v1", Resource: "pods", Namespaced: true},
+		{Kind: "ReplicaSet", APIGroup: "apps", APIVersion: "v1", Resource: "replicasets", Namespaced: true},
+		{Kind: "Deployment", APIGroup: "apps", APIVersion: "v1", Resource: "deployments", Namespaced: true},
+		{Kind: "StatefulSet", APIGroup: "apps", APIVersion: "v1", Resource: "statefulsets", Namespaced: true},
+	}
+	sidebar := model.BuildSidebarItems(m.discoveredResources["test-ctx"])
+	m.leftItemsHistory = [][]model.Item{{{Name: "test-ctx"}}}
+	m.leftItems = sidebar
+	// A collapsed accordion with a different group expanded reproduces
+	// issue #748: the fix must reveal ReplicaSet's own "Workloads" group
+	// rather than leaving the jump silently landing on the wrong row.
+	m.allGroupsExpanded = false
+	m.expandedGroup = "Dashboards"
+	return m
+}
+
+func TestActionKeyJumpOwnerPodToReplicaSet(t *testing.T) {
+	m := jumpOwnerTestModel()
+	m.middleItems = []model.Item{
+		{
+			Name: "myapp-7c9f9b6d8f-abcde", Namespace: "default", Kind: "Pod", Status: "Running",
+			Columns: []model.KeyValue{
+				{Key: "owner:0", Value: "apps/v1||ReplicaSet||myapp-7c9f9b6d8f"},
+			},
+		},
+	}
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpOwner()
+	assert.True(t, handled)
+	require.NotNil(t, cmd, "a collapsed accordion group must not silently swallow the jump")
+	rm := ret.(Model)
+	assert.False(t, rm.statusMessageErr, "status: %q", rm.statusMessage)
+	assert.Equal(t, model.LevelResources, rm.nav.Level)
+	assert.Equal(t, "ReplicaSet", rm.nav.ResourceType.Kind)
+	assert.Equal(t, "myapp-7c9f9b6d8f", rm.pendingTarget)
+	assert.Equal(t, "Workloads", rm.expandedGroup, "the target's own group must be revealed")
+}
+
+func TestActionKeyJumpOwnerReplicaSetToDeployment(t *testing.T) {
+	m := jumpOwnerTestModel()
+	m.nav.ResourceType = model.ResourceTypeEntry{Kind: "ReplicaSet", APIGroup: "apps", APIVersion: "v1", Resource: "replicasets", Namespaced: true}
+	m.middleItems = []model.Item{
+		{
+			Name: "myapp-7c9f9b6d8f", Namespace: "default", Kind: "ReplicaSet", Status: "1/1",
+			Columns: []model.KeyValue{
+				{Key: "owner:0", Value: "apps/v1||Deployment||myapp"},
+			},
+		},
+	}
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpOwner()
+	assert.True(t, handled)
+	require.NotNil(t, cmd)
+	rm := ret.(Model)
+	assert.False(t, rm.statusMessageErr, "status: %q", rm.statusMessage)
+	assert.Equal(t, model.LevelResources, rm.nav.Level)
+	assert.Equal(t, "Deployment", rm.nav.ResourceType.Kind)
+	assert.Equal(t, "myapp", rm.pendingTarget)
+}
+
+func TestActionKeyJumpOwnerStatefulSetStillWorksWithAccordionCollapsed(t *testing.T) {
+	m := jumpOwnerTestModel()
+	m.middleItems = []model.Item{
+		{
+			Name: "myapp-0", Namespace: "default", Kind: "Pod", Status: "Running",
+			Columns: []model.KeyValue{
+				{Key: "owner:0", Value: "apps/v1||StatefulSet||myapp"},
+			},
+		},
+	}
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpOwner()
+	assert.True(t, handled)
+	require.NotNil(t, cmd)
+	rm := ret.(Model)
+	assert.False(t, rm.statusMessageErr, "status: %q", rm.statusMessage)
+	assert.Equal(t, model.LevelResources, rm.nav.Level)
+	assert.Equal(t, "StatefulSet", rm.nav.ResourceType.Kind)
+}
+
+func TestActionKeyJumpOwnerHiddenTypeSetsStatusInsteadOfNoop(t *testing.T) {
+	defer func(orig []string) { model.HiddenTypes = orig }(model.HiddenTypes)
+	defer func(orig bool) { model.ShowRareResources = orig }(model.ShowRareResources)
+	model.ShowRareResources = false
+	model.HiddenTypes = []string{"apps/replicasets"}
+
+	m := jumpOwnerTestModel()
+	m.leftItems = model.BuildSidebarItems(m.discoveredResources["test-ctx"])
+	m.middleItems = []model.Item{
+		{
+			Name: "myapp-7c9f9b6d8f-abcde", Namespace: "default", Kind: "Pod", Status: "Running",
+			Columns: []model.KeyValue{
+				{Key: "owner:0", Value: "apps/v1||ReplicaSet||myapp-7c9f9b6d8f"},
+			},
+		},
+	}
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpOwner()
+	assert.True(t, handled)
+	require.NotNil(t, cmd)
+	rm := ret.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.NotEmpty(t, rm.statusMessage)
+}
+
+func TestActionKeyJumpOwnerUnknownKindNotInSidebarSetsStatus(t *testing.T) {
+	m := jumpOwnerTestModel()
+	m.middleItems = []model.Item{
+		{
+			Name: "orphan-pod", Namespace: "default", Kind: "Pod", Status: "Running",
+			Columns: []model.KeyValue{
+				{Key: "owner:0", Value: "custom.example.com/v1||WidgetController||my-widget"},
+			},
+		},
+	}
+	m.setCursor(0)
+
+	ret, cmd, handled := m.handleExplorerActionKeyJumpOwner()
+	assert.True(t, handled)
+	require.NotNil(t, cmd)
+	rm := ret.(Model)
+	assert.True(t, rm.statusMessageErr)
+	assert.NotEmpty(t, rm.statusMessage)
+}

--- a/internal/app/update_navigation_test.go
+++ b/internal/app/update_navigation_test.go
@@ -872,6 +872,7 @@ func TestNavigateChildResource_PodCertificateRequestJumpsToPod(t *testing.T) {
 	m.discoveredResources["test-ctx"] = []model.ResourceTypeEntry{
 		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
 	}
+	m.leftItems = model.BuildSidebarItems(m.discoveredResources["test-ctx"])
 
 	sel := &model.Item{
 		Name: "pcr-1", Namespace: "ns-a", Kind: "PodCertificateRequest",


### PR DESCRIPTION
## Summary
- `o` on a Pod owned by a ReplicaSet did nothing (#748). The jump set the sidebar cursor by index into the full resource list, but the cursor reads the accordion view, which collapses every category except the expanded one. When the owner's category was collapsed the index pointed past the visible rows and the jump was a silent no-op. This hit any owner kind, StatefulSet included, whenever its category was not the open one.
- The jump now expands the target's category and finds the row in the visible list. A target that is not in the sidebar at all sets a status message instead of nothing. The claim jump and blast-radius jumps share the same path and gain the fix.

Fixes #748

## Test plan
- [x] New tests: Pod to ReplicaSet, ReplicaSet to Deployment, StatefulSet with the accordion collapsed, hidden type and unknown kind set a status message
- [x] `go test -race ./internal/app/ ./internal/k8s/` and golangci-lint clean
- [ ] Manual: single replica Deployment, select its Pod, `o` lands on the ReplicaSet, `o` again on the Deployment