### PR TITLE
test: start the ui suite with NO_COLOR unset

### DIFF
--- a/internal/ui/main_test.go
+++ b/internal/ui/main_test.go
@@ -1,0 +1,14 @@
+package ui
+
+import (
+	"os"
+	"testing"
+)
+
+// A NO_COLOR set in the invoking shell is otherwise inherited by the whole
+// binary: LoadConfig (config_apply.go) forces ConfigNoColor on whenever it
+// sees the var, and that global then stays on for every later test.
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("NO_COLOR")
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary
- With `NO_COLOR` set in the shell, `go test ./internal/ui/` failed 20 tests. Any test that loaded a config saw the variable, turned the package-wide no-color theme on, and left it on for every later test. Reported by the author of #761.
- A `TestMain` now clears the variable once before the suite. The tests that cover `NO_COLOR` already set it with `t.Setenv`, so they still exercise the path.

## Test plan
- [x] `NO_COLOR=1 go test -race ./...` passes
- [x] `go test -race ./...` passes with it unset
- [x] Removing the theme switch in config_apply.go still fails TestLoadConfig_NoColor, so the guard is intact