### PR TITLE
fix: reset the explorer layout to normal on config reload

### DIFF
--- a/internal/ui/config_appearance_test.go
+++ b/internal/ui/config_appearance_test.go
@@ -144,6 +144,43 @@ func TestExplorerLayout_InvalidFallsBack(t *testing.T) {
 	assert.Equal(t, LayoutNormal, ConfigExplorerLayout, "invalid layout falls back to default")
 }
 
+// TestExplorerLayout_ResetsOnReload verifies a reload that no longer sets
+// appearance.layout returns to the compiled default instead of keeping the
+// previous load's value.
+func TestExplorerLayout_ResetsOnReload(t *testing.T) {
+	snapshotAppearanceGlobals(t)
+
+	path := writeConfigFile(t, "appearance:\n  layout: fullscreen\n")
+	LoadConfig(path)
+	assert.Equal(t, LayoutFullscreen, ConfigExplorerLayout, "first load applies fullscreen")
+
+	path = writeConfigFile(t, "appearance:\n  no_color: true\n")
+	LoadConfig(path)
+	assert.Equal(t, LayoutNormal, ConfigExplorerLayout, "reload without layout resets to default")
+}
+
+// TestExplorerLayout_ResetsOnReloadWithInvalidValue verifies a reload with an
+// invalid appearance.layout resets to the compiled default (rather than
+// keeping a previous load's value) and still warns.
+func TestExplorerLayout_ResetsOnReloadWithInvalidValue(t *testing.T) {
+	snapshotAppearanceGlobals(t)
+
+	path := writeConfigFile(t, "appearance:\n  layout: fullscreen\n")
+	LoadConfig(path)
+	assert.Equal(t, LayoutFullscreen, ConfigExplorerLayout, "first load applies fullscreen")
+
+	origLogger := logger.Logger
+	var buf bytes.Buffer
+	logger.Logger = slog.New(slog.NewTextHandler(&buf, nil))
+	t.Cleanup(func() { logger.Logger = origLogger })
+
+	path = writeConfigFile(t, "appearance:\n  layout: \"banana\"\n")
+	LoadConfig(path)
+
+	assert.Equal(t, LayoutNormal, ConfigExplorerLayout, "reload with invalid layout resets to default")
+	assert.Contains(t, buf.String(), "appearance.layout", "warning must name the offending key")
+}
+
 // TestExplorerLayout_FlatAlias applies the deprecated flat layout key.
 func TestExplorerLayout_FlatAlias(t *testing.T) {
 	snapshotAppearanceGlobals(t)

--- a/internal/ui/config_layout.go
+++ b/internal/ui/config_layout.go
@@ -8,17 +8,18 @@ import (
 	"github.com/janosmiko/lfk/internal/logger"
 )
 
-// applyExplorerLayout validates and applies the appearance.layout config value.
-// Empty keeps the compiled default. Unknown values warn and keep it too.
+// applyExplorerLayout validates and applies the appearance.layout config
+// value. Empty and unknown values both reset to LayoutNormal, not just leave
+// it, so a reload that drops the key doesn't keep a stale prior layout.
 func applyExplorerLayout(raw string) {
 	v := strings.ToLower(strings.TrimSpace(raw))
-	if v == "" {
-		return
-	}
 	switch v {
 	case LayoutNormal, LayoutSidebarHidden, LayoutFullscreen:
 		ConfigExplorerLayout = v
+	case "":
+		ConfigExplorerLayout = LayoutNormal
 	default:
+		ConfigExplorerLayout = LayoutNormal
 		logger.Warn("Invalid appearance.layout; using default",
 			"accepted", []string{LayoutNormal, LayoutSidebarHidden, LayoutFullscreen},
 			"default", LayoutNormal)


### PR DESCRIPTION
## Summary
- `appearance.layout` (from #757) only wrote the global on a valid value, so a reload with the key removed, empty, or misspelled kept the previous layout such as `fullscreen`. It now falls back to `normal` in both cases, the way `delete_propagation_policy` already does, and the invalid case still logs its warning.

## Test plan
- [x] TestExplorerLayout_ResetsOnReload and TestExplorerLayout_ResetsOnReloadWithInvalidValue, red before the fix
- [x] `go test -race ./internal/ui/` and golangci-lint clean