### PR TITLE
test: keep the copy feedback test off the real clipboard

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -149,6 +149,10 @@ func openInBrowser(url string) tea.Cmd {
 	}
 }
 
+// clipboardWriteAll is a seam over clipboard.WriteAll so tests can inject a
+// fake instead of hitting the real system clipboard.
+var clipboardWriteAll = clipboard.WriteAll
+
 // copyToSystemClipboard copies text to the system clipboard.
 //
 // Backed by atotto/clipboard so macOS (pbcopy), Linux X11 (xsel/xclip),
@@ -162,7 +166,7 @@ func openInBrowser(url string) tea.Cmd {
 // useful caller message — visible to the user as a flicker.
 func copyToSystemClipboard(text string) tea.Cmd {
 	return func() tea.Msg {
-		if err := clipboard.WriteAll(normalizeClipboardLineEndings(text, runtime.GOOS)); err != nil {
+		if err := clipboardWriteAll(normalizeClipboardLineEndings(text, runtime.GOOS)); err != nil {
 			return actionResultMsg{err: fmt.Errorf("clipboard: %w", err)}
 		}
 		return nil

--- a/internal/app/copy_feedback_test.go
+++ b/internal/app/copy_feedback_test.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Each fullscreen viewer's footer must surface a fresh status message in
@@ -332,29 +334,52 @@ func TestNormalizeClipboardLineEndings(t *testing.T) {
 	}
 }
 
+// stubClipboardWriteAll swaps clipboardWriteAll for fn and restores the
+// original on cleanup, so tests never touch the real system clipboard.
+func stubClipboardWriteAll(t *testing.T, fn func(string) error) *string {
+	t.Helper()
+	var got string
+	original := clipboardWriteAll
+	clipboardWriteAll = func(text string) error {
+		got = text
+		return fn(text)
+	}
+	t.Cleanup(func() { clipboardWriteAll = original })
+	return &got
+}
+
 // Regression guard: copyToSystemClipboard must not return a generic
 // "Copied to clipboard" message — every caller has already set a
 // context-specific status. Returning the generic one races back via
 // updateActionResult and overwrites the more useful caller message
 // (visible to the user as "Copied 1 line" → "Copied to clipboard").
 func TestCopyToSystemClipboardSuccessIsSilent(t *testing.T) {
+	got := stubClipboardWriteAll(t, func(string) error { return nil })
+
 	cmd := copyToSystemClipboard("anything")
 	if cmd == nil {
 		t.Fatal("copyToSystemClipboard returned nil cmd")
 	}
 	msg := cmd()
-	// On hosts where atotto/clipboard can't reach a clipboard (Linux CI
-	// without xsel/xclip/wl-copy installed, headless containers, etc.) an
-	// error is expected — only assert success-path silence when the write
-	// actually succeeded.
-	if msg == nil {
-		return
+
+	assert.Equal(t, "anything", *got, "clipboardWriteAll must receive the copied text")
+	assert.Nil(t, msg, "success must return nil so the caller's status message survives")
+}
+
+func TestCopyToSystemClipboardErrorReturnsActionResult(t *testing.T) {
+	writeErr := errors.New("write failed")
+	got := stubClipboardWriteAll(t, func(string) error { return writeErr })
+
+	cmd := copyToSystemClipboard("anything")
+	if cmd == nil {
+		t.Fatal("copyToSystemClipboard returned nil cmd")
 	}
+	msg := cmd()
+
+	assert.Equal(t, "anything", *got, "clipboardWriteAll must receive the copied text")
 	res, ok := msg.(actionResultMsg)
-	if !ok {
-		t.Fatalf("unexpected message type: %T", msg)
-	}
-	assert.NotEmpty(t, res.err, "non-nil success message would race and overwrite caller status")
+	require.True(t, ok, "unexpected message type: %T", msg)
+	assert.ErrorIs(t, res.err, writeErr)
 }
 
 // Regression guard: the status message must not be muted when a search


### PR DESCRIPTION
## Summary
- TestCopyToSystemClipboardSuccessIsSilent ran the real clipboard writer, so every `go test ./internal/app/` replaced the developer's clipboard with the word "anything".
- `copyToSystemClipboard` now calls a package-level `clipboardWriteAll` that defaults to `clipboard.WriteAll`. The test swaps in a fake that records the text, and a second test covers the error path through the same seam.

## Test plan
- [x] `pbcopy` a sentinel, run `go test ./internal/app/ -run Clipboard`, `pbpaste` still prints the sentinel
- [x] No `clipboard.WriteAll` left in any test file
- [x] `go test -race ./internal/app/` and golangci-lint clean