### PR TITLE
refactor: use go-colorful for the theme contrast math

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
+	github.com/lucasb-eyer/go-colorful v1.4.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
@@ -56,7 +57,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
 	github.com/mattn/go-runewidth v0.0.28 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/internal/ui/row_tint_test.go
+++ b/internal/ui/row_tint_test.go
@@ -463,12 +463,12 @@ func TestRenderTable_MultiSelectedTintedRowKeepsBg(t *testing.T) {
 	}
 }
 
-// TestBlendHexToward pins the blend helper: 0 returns the base, 1 returns the
+// TestBlendHex pins the blend helper: 0 returns the base, 1 returns the
 // tint, and midpoints move each channel linearly.
-func TestBlendHexToward(t *testing.T) {
-	assert.Equal(t, "#000000", blendHexToward("#000000", "#ffffff", 0))
-	assert.Equal(t, "#ffffff", blendHexToward("#000000", "#ffffff", 1))
-	assert.Equal(t, "#7f7f7f", blendHexToward("#000000", "#ffffff", 0.5))
+func TestBlendHex(t *testing.T) {
+	assert.Equal(t, "#000000", blendHex("#000000", "#ffffff", 0))
+	assert.Equal(t, "#ffffff", blendHex("#000000", "#ffffff", 1))
+	assert.Equal(t, "#7f7f7f", blendHex("#000000", "#ffffff", 0.5))
 	// Unparsable inputs fall back to the tint color unchanged.
-	assert.Equal(t, "#ff0000", blendHexToward("not-a-color", "#ff0000", 0.2))
+	assert.Equal(t, "#ff0000", blendHex("not-a-color", "#ff0000", 0.2))
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -123,15 +123,15 @@ var (
 	RowTintFailedFg      = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError))
 	RowTintProgressingFg = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary))
 	RowTintFailedBg      = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile)).
-				Background(lipgloss.Color(blendHexToward(defaultColorBase, defaultColorError, rowTintBgBlend)))
+				Background(lipgloss.Color(blendHex(defaultColorBase, defaultColorError, rowTintBgBlend)))
 	RowTintProgressingBg = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile)).
-				Background(lipgloss.Color(blendHexToward(defaultColorBase, defaultColorPrimary, rowTintBgBlend)))
+				Background(lipgloss.Color(blendHex(defaultColorBase, defaultColorPrimary, rowTintBgBlend)))
 	// Cursor row in background mode: the status background blended toward the
 	// selection color so the cursor stays visible on a tinted row (#540 UAT).
 	RowTintFailedCursorBg = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile)).Bold(true).
-				Background(lipgloss.Color(blendHexToward(blendHexToward(defaultColorBase, defaultColorError, rowTintBgBlend), defaultColorSelectedBg, rowTintCursorBlend)))
+				Background(lipgloss.Color(blendHex(blendHex(defaultColorBase, defaultColorError, rowTintBgBlend), defaultColorSelectedBg, rowTintCursorBlend)))
 	RowTintProgressingCursorBg = lipgloss.NewStyle().Foreground(lipgloss.Color(ColorFile)).Bold(true).
-					Background(lipgloss.Color(blendHexToward(blendHexToward(defaultColorBase, defaultColorPrimary, rowTintBgBlend), defaultColorSelectedBg, rowTintCursorBlend)))
+					Background(lipgloss.Color(blendHex(blendHex(defaultColorBase, defaultColorPrimary, rowTintBgBlend), defaultColorSelectedBg, rowTintCursorBlend)))
 
 	// Title bar (full-width background).
 	TitleBarStyle = lipgloss.NewStyle().

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -190,13 +190,13 @@ func ApplyTheme(t Theme) {
 	RowTintFailedFg = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Error)).Background(baseBg)
 	RowTintProgressingFg = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Primary)).Background(baseBg)
 	RowTintFailedBg = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text)).
-		Background(lipgloss.Color(blendHexToward(t.Base, t.Error, rowTintBgBlend)))
+		Background(lipgloss.Color(blendHex(t.Base, t.Error, rowTintBgBlend)))
 	RowTintProgressingBg = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text)).
-		Background(lipgloss.Color(blendHexToward(t.Base, t.Primary, rowTintBgBlend)))
+		Background(lipgloss.Color(blendHex(t.Base, t.Primary, rowTintBgBlend)))
 	RowTintFailedCursorBg = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text)).Bold(true).
-		Background(lipgloss.Color(blendHexToward(blendHexToward(t.Base, t.Error, rowTintBgBlend), t.SelectedBg, rowTintCursorBlend)))
+		Background(lipgloss.Color(blendHex(blendHex(t.Base, t.Error, rowTintBgBlend), t.SelectedBg, rowTintCursorBlend)))
 	RowTintProgressingCursorBg = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Text)).Bold(true).
-		Background(lipgloss.Color(blendHexToward(blendHexToward(t.Base, t.Primary, rowTintBgBlend), t.SelectedBg, rowTintCursorBlend)))
+		Background(lipgloss.Color(blendHex(blendHex(t.Base, t.Primary, rowTintBgBlend), t.SelectedBg, rowTintCursorBlend)))
 
 	var barBg color.Color = lipgloss.NoColor{}
 	if !ConfigTransparentBg {

--- a/internal/ui/theme_contrast.go
+++ b/internal/ui/theme_contrast.go
@@ -54,8 +54,10 @@ func blendHex(base, tint string, amount float64) string {
 }
 
 // derivedParentHighlightBg blends Border toward Base until bold Text over it
-// clears the WCAG AA large-text floor (3.0:1), for a near-white "bright
-// black" theme that would otherwise collapse the two to invisibility.
+// clears the WCAG AA large-text floor (3.0:1). Border skips fg-readability
+// enforcement because it also has a decorative role on column outlines, so
+// a near-white "bright black" theme could collapse Text-on-Border to
+// invisibility.
 func derivedParentHighlightBg(t Theme) string {
 	const target = 3.0
 
@@ -90,9 +92,10 @@ func derivedParentHighlightBg(t Theme) string {
 
 // EnforceMinContrast nudges fg's HSL lightness (hue and saturation kept) to
 // meet a WCAG contrast ratio against bg. value is the normalized knob in
-// [0, 1]: 0 is off, 0.175 is the AA threshold (4.5:1), 1.0 targets 21:1 via
-// wcagTarget = 1.0 + clamp(value, 0, 1) * 20.0. An unparsable fg or bg
-// returns fg unchanged.
+// [0, 1]: 0 is off, 0.175 is the AA threshold (4.5:1), 0.3 is the AAA
+// threshold (7.0:1), 1.0 targets 21:1 via wcagTarget = 1.0 + clamp(value, 0,
+// 1) * 20.0. At value=1.0 hue collapses to achromatic black or white, an
+// accepted tradeoff. An unparsable fg or bg returns fg unchanged.
 func EnforceMinContrast(fg, bg string, value float64) string {
 	if value <= 0 {
 		return fg

--- a/internal/ui/theme_contrast.go
+++ b/internal/ui/theme_contrast.go
@@ -3,56 +3,9 @@ package ui
 import (
 	"fmt"
 	"math"
-	"strconv"
+
+	"github.com/lucasb-eyer/go-colorful"
 )
-
-// parseHexColor parses a CSS hex color string ("#rrggbb" or "#rgb") and
-// returns the RGB components in [0, 1]. Returns ok=false for any unrecognised
-// input (named colors, malformed strings, wrong length) so callers can decide
-// to leave the original color unchanged rather than crash.
-func parseHexColor(s string) (r, g, b float64, ok bool) {
-	if len(s) == 0 || s[0] != '#' {
-		return 0, 0, 0, false
-	}
-	hex := s[1:]
-	switch len(hex) {
-	case 3:
-		// Expand #rgb -> #rrggbb
-		hex = string([]byte{hex[0], hex[0], hex[1], hex[1], hex[2], hex[2]})
-	case 6:
-		// Already the right length.
-	default:
-		return 0, 0, 0, false
-	}
-	ri, err := strconv.ParseInt(hex[0:2], 16, 32)
-	if err != nil {
-		return 0, 0, 0, false
-	}
-	gi, err := strconv.ParseInt(hex[2:4], 16, 32)
-	if err != nil {
-		return 0, 0, 0, false
-	}
-	bi, err := strconv.ParseInt(hex[4:6], 16, 32)
-	if err != nil {
-		return 0, 0, 0, false
-	}
-	return float64(ri) / 255.0, float64(gi) / 255.0, float64(bi) / 255.0, true
-}
-
-// formatHexColor converts RGB components in [0, 1] to a lowercase "#rrggbb"
-// CSS hex string. Values outside [0, 1] are clamped.
-func formatHexColor(r, g, b float64) string {
-	clamp := func(v float64) int {
-		if v < 0 {
-			return 0
-		}
-		if v > 1 {
-			return 255
-		}
-		return int(math.Round(v * 255))
-	}
-	return fmt.Sprintf("#%02x%02x%02x", clamp(r), clamp(g), clamp(b))
-}
 
 // linearize converts a single sRGB channel value in [0, 1] to linear light
 // using the WCAG-specified sRGB piecewise function.
@@ -78,129 +31,43 @@ func contrastRatio(l1, l2 float64) float64 {
 	return (lighter + 0.05) / (darker + 0.05)
 }
 
-// rgbToHSL converts an sRGB color (components in [0, 1]) to HSL where:
-//   - h is in [0, 1] representing degrees [0, 360)
-//   - s is in [0, 1]
-//   - l is in [0, 1]
-func rgbToHSL(r, g, b float64) (h, s, l float64) {
-	max := math.Max(r, math.Max(g, b))
-	min := math.Min(r, math.Min(g, b))
-	l = (max + min) / 2.0
-	if max == min {
-		// Achromatic.
-		return 0, 0, l
-	}
-	d := max - min
-	if l > 0.5 {
-		s = d / (2.0 - max - min)
-	} else {
-		s = d / (max + min)
-	}
-	switch max {
-	case r:
-		h = (g - b) / d
-		if g < b {
-			h += 6
-		}
-	case g:
-		h = (b-r)/d + 2
-	default: // b
-		h = (r-g)/d + 4
-	}
-	h /= 6
-	return h, s, l
-}
-
-// hslToRGB converts an HSL color (h in [0,1], s in [0,1], l in [0,1]) to sRGB.
-func hslToRGB(h, s, l float64) (r, g, b float64) {
-	if s == 0 {
-		// Achromatic.
-		return l, l, l
-	}
-	hue2rgb := func(p, q, t float64) float64 {
-		if t < 0 {
-			t += 1
-		}
-		if t > 1 {
-			t -= 1
-		}
-		switch {
-		case t < 1.0/6.0:
-			return p + (q-p)*6*t
-		case t < 1.0/2.0:
-			return q
-		case t < 2.0/3.0:
-			return p + (q-p)*(2.0/3.0-t)*6
-		default:
-			return p
-		}
-	}
-	var q float64
-	if l < 0.5 {
-		q = l * (1 + s)
-	} else {
-		q = l + s - l*s
-	}
-	p := 2*l - q
-	r = hue2rgb(p, q, h+1.0/3.0)
-	g = hue2rgb(p, q, h)
-	b = hue2rgb(p, q, h-1.0/3.0)
-	return r, g, b
-}
-
 // rowTintBgBlend is how far a row-tint background moves from the theme base
 // toward the severity color: strong enough to read as a tint, muted enough
 // that the selection highlight stays clearly distinct (issue #540).
 const rowTintBgBlend = 0.22
 
-// rowTintCursorBlend is how far the cursor row's background moves from the
-// status-tint background toward the selection background, so a selected tinted
-// row reads as both "failed" (status hue) and "cursor" (selection hue) instead
-// of losing the cursor highlight (issue #540 UAT).
+// rowTintCursorBlend keeps a selected tinted row reading as both "failed"
+// and "cursor" instead of losing the cursor highlight (issue #540 UAT).
 const rowTintCursorBlend = 0.5
 
-// blendHexToward linearly blends base toward tint by amount (0 = base,
-// 1 = tint), returning a hex color. Unparsable inputs return tint unchanged.
-func blendHexToward(base, tint string, amount float64) string {
-	br, bg, bb, okB := parseHexColor(base)
-	tr, tg, tb, okT := parseHexColor(tint)
-	if !okB || !okT {
+// blendHex blends base toward tint by amount (0 = base, 1 = tint).
+// Unparsable inputs return tint unchanged.
+func blendHex(base, tint string, amount float64) string {
+	baseCol, errBase := colorful.Hex(base)
+	tintCol, errTint := colorful.Hex(tint)
+	if errBase != nil || errTint != nil {
 		return tint
 	}
-	lerp := func(a, b float64) float64 { return a*(1-amount) + b*amount }
-	return fmt.Sprintf("#%02x%02x%02x", int(lerp(br, tr)*255), int(lerp(bg, tg)*255), int(lerp(bb, tb)*255))
+	c := baseCol.BlendRgb(tintCol, amount)
+	// Truncates rather than rounds so existing theme colors stay byte-identical.
+	return fmt.Sprintf("#%02x%02x%02x", uint8(c.R*255), uint8(c.G*255), uint8(c.B*255))
 }
 
-// derivedParentHighlightBg returns the background color to use for
-// ParentHighlightStyle (the LEFT pane's selected-row highlight, which
-// renders bold Text on top of the returned color).
-//
-// In most themes Border is a subtle mid-luminance color (terminal
-// "bright black"), giving Text-on-Border enough contrast to read. A
-// few themes (e.g. synthwave-everything) set their bright-black
-// palette entry to a near-white color, which collapses Text-on-Border
-// into invisibility. Border itself is intentionally not subject to
-// fg-readability enforcement because it has a decorative role on
-// column outlines — pushing it toward the foreground spectrum makes
-// other things unreadable. Instead we pick a substitute bg here:
-// blend Border toward Base via binary search until Text-on-bg meets
-// the WCAG AA large-text contrast floor (3.0:1).
-//
-// When Text-on-Border already clears the floor, Border is returned
-// unchanged so themes that work today keep their designer-chosen
-// highlight color.
+// derivedParentHighlightBg blends Border toward Base until bold Text over it
+// clears the WCAG AA large-text floor (3.0:1), for a near-white "bright
+// black" theme that would otherwise collapse the two to invisibility.
 func derivedParentHighlightBg(t Theme) string {
 	const target = 3.0
 
-	tr, tg, tb, okT := parseHexColor(t.Text)
-	br, bg, bb, okB := parseHexColor(t.Border)
-	baseR, baseG, baseB, okBase := parseHexColor(t.Base)
-	if !okT || !okB || !okBase {
+	textCol, errText := colorful.Hex(t.Text)
+	borderCol, errBorder := colorful.Hex(t.Border)
+	baseCol, errBase := colorful.Hex(t.Base)
+	if errText != nil || errBorder != nil || errBase != nil {
 		return t.Border
 	}
 
-	lText := relativeLuminance(tr, tg, tb)
-	if contrastRatio(lText, relativeLuminance(br, bg, bb)) >= target {
+	lText := relativeLuminance(textCol.R, textCol.G, textCol.B)
+	if contrastRatio(lText, relativeLuminance(borderCol.R, borderCol.G, borderCol.B)) >= target {
 		return t.Border
 	}
 
@@ -208,54 +75,35 @@ func derivedParentHighlightBg(t Theme) string {
 	// 30 iterations converges to far below 1/255 in each channel, more
 	// precision than hex-truncation can represent.
 	const iterations = 30
-	lerp := func(a, b, t float64) float64 { return a*(1-t) + b*t }
 	lo, hi := 0.0, 1.0
 	for range iterations {
 		mid := (lo + hi) / 2.0
-		r := lerp(br, baseR, mid)
-		g := lerp(bg, baseG, mid)
-		b := lerp(bb, baseB, mid)
-		if contrastRatio(lText, relativeLuminance(r, g, b)) >= target {
+		blended := borderCol.BlendRgb(baseCol, mid)
+		if contrastRatio(lText, relativeLuminance(blended.R, blended.G, blended.B)) >= target {
 			hi = mid
 		} else {
 			lo = mid
 		}
 	}
-	r := lerp(br, baseR, hi)
-	g := lerp(bg, baseG, hi)
-	b := lerp(bb, baseB, hi)
-	return formatHexColor(r, g, b)
+	return borderCol.BlendRgb(baseCol, hi).Hex()
 }
 
-// EnforceMinContrast nudges the fg hex color's HSL lightness so it meets a
-// minimum WCAG contrast ratio against the bg hex color. The value parameter is
-// the user-facing normalized knob in [0, 1]:
-//
-//   - 0.0  = off (no-op, returns fg unchanged)
-//   - 0.175 approx = WCAG AA threshold (4.5:1) for normal text
-//   - 0.3   approx = WCAG AAA threshold (7.0:1)
-//   - 1.0   = maximum (targets 21:1, forces fg toward pure black or white)
-//
-// The mapping is: wcagTarget = 1.0 + clamp(value, 0, 1) * 20.0
-//
-// Only the HSL lightness channel is adjusted. Hue and saturation are
-// preserved, so chromatic colors keep their identity at moderate values.
-// At value=1.0 the extremes (L=0 or L=1) are achromatic by definition —
-// hue collapse at max value is an acceptable and documented trade-off.
-//
-// If fg or bg fails parseHexColor (named color, malformed, empty) the
-// original fg is returned unchanged, never panicking.
+// EnforceMinContrast nudges fg's HSL lightness (hue and saturation kept) to
+// meet a WCAG contrast ratio against bg. value is the normalized knob in
+// [0, 1]: 0 is off, 0.175 is the AA threshold (4.5:1), 1.0 targets 21:1 via
+// wcagTarget = 1.0 + clamp(value, 0, 1) * 20.0. An unparsable fg or bg
+// returns fg unchanged.
 func EnforceMinContrast(fg, bg string, value float64) string {
 	if value <= 0 {
 		return fg
 	}
 
-	fgR, fgG, fgB, ok := parseHexColor(fg)
-	if !ok {
+	fgCol, err := colorful.Hex(fg)
+	if err != nil {
 		return fg
 	}
-	bgR, bgG, bgB, ok := parseHexColor(bg)
-	if !ok {
+	bgCol, err := colorful.Hex(bg)
+	if err != nil {
 		return fg
 	}
 
@@ -271,8 +119,8 @@ func EnforceMinContrast(fg, bg string, value float64) string {
 
 	target := 1.0 + clamp01(value)*20.0
 
-	lFg := relativeLuminance(fgR, fgG, fgB)
-	lBg := relativeLuminance(bgR, bgG, bgB)
+	lFg := relativeLuminance(fgCol.R, fgCol.G, fgCol.B)
+	lBg := relativeLuminance(bgCol.R, bgCol.G, bgCol.B)
 
 	if contrastRatio(lFg, lBg) >= target {
 		return fg
@@ -293,7 +141,7 @@ func EnforceMinContrast(fg, bg string, value float64) string {
 		goLighter = lBg < 0.179
 	}
 
-	h, s, l := rgbToHSL(fgR, fgG, fgB)
+	h, s, l := fgCol.Hsl()
 
 	// Binary search over lightness in [0, 1] for 40 iterations. This is more
 	// than enough for convergence to well under 0.001 precision in L.
@@ -305,11 +153,10 @@ func EnforceMinContrast(fg, bg string, value float64) string {
 		lo, hi = 0.0, l
 	}
 
-	for i := range iterations {
-		_ = i
+	for range iterations {
 		mid := (lo + hi) / 2.0
-		cr, cg, cb := hslToRGB(h, s, mid)
-		lMid := relativeLuminance(cr, cg, cb)
+		midCol := colorful.Hsl(h, s, mid)
+		lMid := relativeLuminance(midCol.R, midCol.G, midCol.B)
 		if contrastRatio(lMid, lBg) >= target {
 			if goLighter {
 				hi = mid // can go darker while still meeting target
@@ -335,6 +182,5 @@ func EnforceMinContrast(fg, bg string, value float64) string {
 		finalL = lo
 	}
 
-	nr, ng, nb := hslToRGB(h, s, finalL)
-	return formatHexColor(nr, ng, nb)
+	return colorful.Hsl(h, s, finalL).Hex()
 }

--- a/internal/ui/theme_contrast_test.go
+++ b/internal/ui/theme_contrast_test.go
@@ -6,73 +6,19 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/lucasb-eyer/go-colorful"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// ---- parseHexColor tests ----
-
-func TestParseHexColor(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		wantR  float64
-		wantG  float64
-		wantB  float64
-		wantOK bool
-	}{
-		{"black 6-digit", "#000000", 0, 0, 0, true},
-		{"white 6-digit", "#ffffff", 1, 1, 1, true},
-		{"white uppercase", "#FFFFFF", 1, 1, 1, true},
-		{"mixed case", "#FF0080", 1, 0, float64(0x80) / 255.0, true},
-		{"3-digit black", "#000", 0, 0, 0, true},
-		{"3-digit white", "#fff", 1, 1, 1, true},
-		{"3-digit mixed", "#f08", 1, 0, float64(0x88) / 255.0, true},
-		{"tokyonight primary", "#7aa2f7", float64(0x7a) / 255.0, float64(0xa2) / 255.0, float64(0xf7) / 255.0, true},
-		{"empty string", "", 0, 0, 0, false},
-		{"no hash", "ff0000", 0, 0, 0, false},
-		{"named color", "red", 0, 0, 0, false},
-		{"too short", "#ff00", 0, 0, 0, false},
-		{"too long", "#ff000000", 0, 0, 0, false},
-		{"invalid hex", "#gggggg", 0, 0, 0, false},
+// hexOK parses a hex color for test assertions, mirroring the (r, g, b, ok)
+// shape the deleted parseHexColor helper used.
+func hexOK(s string) (r, g, b float64, ok bool) {
+	c, err := colorful.Hex(s)
+	if err != nil {
+		return 0, 0, 0, false
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			r, g, b, ok := parseHexColor(tc.input)
-			assert.Equal(t, tc.wantOK, ok)
-			if tc.wantOK {
-				assert.InDelta(t, tc.wantR, r, 1e-10)
-				assert.InDelta(t, tc.wantG, g, 1e-10)
-				assert.InDelta(t, tc.wantB, b, 1e-10)
-			}
-		})
-	}
-}
-
-// ---- formatHexColor tests ----
-
-func TestFormatHexColor(t *testing.T) {
-	tests := []struct {
-		name    string
-		r, g, b float64
-		want    string
-	}{
-		{"black", 0, 0, 0, "#000000"},
-		{"white", 1, 1, 1, "#ffffff"},
-		{"red", 1, 0, 0, "#ff0000"},
-		{"green", 0, 1, 0, "#00ff00"},
-		{"blue", 0, 0, 1, "#0000ff"},
-		{"clamps below 0", -1, 0, 0, "#000000"},
-		{"clamps above 1", 2, 0, 0, "#ff0000"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := formatHexColor(tc.r, tc.g, tc.b)
-			assert.Equal(t, tc.want, got)
-		})
-	}
+	return c.R, c.G, c.B, true
 }
 
 // ---- relativeLuminance tests ----
@@ -122,9 +68,9 @@ func TestContrastRatio(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fgR, fgG, fgB, ok := parseHexColor(tc.fg)
+			fgR, fgG, fgB, ok := hexOK(tc.fg)
 			require.True(t, ok)
-			bgR, bgG, bgB, ok := parseHexColor(tc.bg)
+			bgR, bgG, bgB, ok := hexOK(tc.bg)
 			require.True(t, ok)
 			l1 := relativeLuminance(fgR, fgG, fgB)
 			l2 := relativeLuminance(bgR, bgG, bgB)
@@ -133,26 +79,6 @@ func TestContrastRatio(t *testing.T) {
 			// ratio must always be >= 1
 			assert.GreaterOrEqual(t, got, 1.0)
 		})
-	}
-}
-
-// ---- RGB/HSL roundtrip tests ----
-
-func TestRGBHSLRoundtrip(t *testing.T) {
-	// For chromatic colors the round-trip should be lossless.
-	testColors := []struct{ r, g, b float64 }{
-		{1, 0, 0},
-		{0, 1, 0},
-		{0, 0, 1},
-		{float64(0x7a) / 255.0, float64(0xa2) / 255.0, float64(0xf7) / 255.0}, // #7aa2f7
-		{float64(0xbb) / 255.0, float64(0x9a) / 255.0, float64(0xf7) / 255.0}, // #bb9af7
-	}
-	for _, c := range testColors {
-		h, s, l := rgbToHSL(c.r, c.g, c.b)
-		r2, g2, b2 := hslToRGB(h, s, l)
-		assert.InDelta(t, c.r, r2, 1e-9, "R roundtrip for (%g,%g,%g)", c.r, c.g, c.b)
-		assert.InDelta(t, c.g, g2, 1e-9, "G roundtrip for (%g,%g,%g)", c.r, c.g, c.b)
-		assert.InDelta(t, c.b, b2, 1e-9, "B roundtrip for (%g,%g,%g)", c.r, c.g, c.b)
 	}
 }
 
@@ -190,10 +116,10 @@ func TestEnforceMinContrastLightensAgainstDark(t *testing.T) {
 
 	require.NotEmpty(t, result)
 	// The result must be parseable.
-	rR, rG, rB, ok := parseHexColor(result)
+	rR, rG, rB, ok := hexOK(result)
 	require.True(t, ok, "result must be a valid hex color, got %q", result)
 
-	bgR, bgG, bgB, ok2 := parseHexColor(bg)
+	bgR, bgG, bgB, ok2 := hexOK(bg)
 	require.True(t, ok2)
 
 	lFg := relativeLuminance(rR, rG, rB)
@@ -203,7 +129,7 @@ func TestEnforceMinContrastLightensAgainstDark(t *testing.T) {
 	assert.GreaterOrEqual(t, ratio, target-0.1, "result contrast ratio %g should meet target %g", ratio, target)
 
 	// Verify fg moved lighter (higher luminance) compared to original.
-	origR, origG, origB, _ := parseHexColor(fg)
+	origR, origG, origB, _ := hexOK(fg)
 	origL := relativeLuminance(origR, origG, origB)
 	assert.GreaterOrEqual(t, lFg, origL, "fg should move to higher luminance (lighter) against dark bg")
 }
@@ -216,10 +142,10 @@ func TestEnforceMinContrastDarkensAgainstLight(t *testing.T) {
 	result := EnforceMinContrast(fg, bg, 0.175) // target ~4.5
 
 	require.NotEmpty(t, result)
-	rR, rG, rB, ok := parseHexColor(result)
+	rR, rG, rB, ok := hexOK(result)
 	require.True(t, ok, "result must be a valid hex color, got %q", result)
 
-	bgR, bgG, bgB, _ := parseHexColor(bg)
+	bgR, bgG, bgB, _ := hexOK(bg)
 	lFg := relativeLuminance(rR, rG, rB)
 	lBg := relativeLuminance(bgR, bgG, bgB)
 	ratio := contrastRatio(lFg, lBg)
@@ -227,7 +153,7 @@ func TestEnforceMinContrastDarkensAgainstLight(t *testing.T) {
 	assert.GreaterOrEqual(t, ratio, target-0.1, "result contrast ratio %g should meet target %g", ratio, target)
 
 	// Verify fg moved darker (lower luminance) compared to original.
-	origR, origG, origB, _ := parseHexColor(fg)
+	origR, origG, origB, _ := hexOK(fg)
 	origL := relativeLuminance(origR, origG, origB)
 	assert.LessOrEqual(t, lFg, origL, "fg should move to lower luminance (darker) against light bg")
 }
@@ -239,10 +165,10 @@ func TestEnforceMinContrastMaxValue(t *testing.T) {
 	result := EnforceMinContrast(fg, bg, 1.0)
 
 	require.NotEmpty(t, result)
-	rR, rG, rB, ok := parseHexColor(result)
+	rR, rG, rB, ok := hexOK(result)
 	require.True(t, ok, "result must be a valid hex color, got %q", result)
 
-	bgR, bgG, bgB, _ := parseHexColor(bg)
+	bgR, bgG, bgB, _ := hexOK(bg)
 	lFg := relativeLuminance(rR, rG, rB)
 	lBg := relativeLuminance(bgR, bgG, bgB)
 	ratio := contrastRatio(lFg, lBg)
@@ -261,8 +187,8 @@ func TestEnforceMinContrastPreservesHuePartial(t *testing.T) {
 	fg := "#2e3147" // very dark blue-ish, low contrast against dark base
 	bg := "#24283b" // dark base
 
-	origR, origG, origB, _ := parseHexColor(fg)
-	origH, _, _ := rgbToHSL(origR, origG, origB)
+	origCol, _ := colorful.Hex(fg)
+	origH, _, _ := origCol.Hsl()
 
 	result := EnforceMinContrast(fg, bg, 0.175) // AA nudge
 
@@ -270,12 +196,11 @@ func TestEnforceMinContrastPreservesHuePartial(t *testing.T) {
 		t.Skip("already meets target, hue preservation trivially holds")
 	}
 
-	rR, rG, rB, ok := parseHexColor(result)
-	require.True(t, ok)
-	newH, _, _ := rgbToHSL(rR, rG, rB)
+	resultCol, err := colorful.Hex(result)
+	require.NoError(t, err)
+	newH, _, _ := resultCol.Hsl()
 
-	// Compute angular difference in degrees (hue is in [0,1] mapped to [0,360]).
-	diff := math.Abs(origH-newH) * 360
+	diff := math.Abs(origH - newH)
 	if diff > 180 {
 		diff = 360 - diff
 	}
@@ -320,8 +245,8 @@ func TestApplyThemePreservesParentHighlightReadability(t *testing.T) {
 	ConfigMinContrastRatio = 0.5
 	ApplyTheme(DefaultTheme())
 
-	tr, tg, tb, okT := parseHexColor(ActiveTheme.Text)
-	br, bgG, bb, okB := parseHexColor(ActiveTheme.Border)
+	tr, tg, tb, okT := hexOK(ActiveTheme.Text)
+	br, bgG, bb, okB := hexOK(ActiveTheme.Border)
 	require.True(t, okT, "Text must remain a valid hex after enforcement")
 	require.True(t, okB, "Border must remain a valid hex after enforcement")
 
@@ -361,8 +286,8 @@ func TestDerivedParentHighlightBg_DimsWhenBorderTooCloseToText(t *testing.T) {
 
 	bg := derivedParentHighlightBg(theme)
 
-	tr, tg, tb, okT := parseHexColor(theme.Text)
-	br, bgG, bb, okB := parseHexColor(bg)
+	tr, tg, tb, okT := hexOK(theme.Text)
+	br, bgG, bb, okB := hexOK(bg)
 	require.True(t, okT, "Text must be a valid hex")
 	require.True(t, okB, "derived parent-highlight bg must be a valid hex (got %q)", bg)
 
@@ -405,15 +330,15 @@ func TestEnforceMinContrastPreservesFgBgRelationship(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fr, fg, fb, _ := parseHexColor(tc.fg)
-			br, bgGreen, bb, _ := parseHexColor(tc.bg)
+			fr, fg, fb, _ := hexOK(tc.fg)
+			br, bgGreen, bb, _ := hexOK(tc.bg)
 			lFgBefore := relativeLuminance(fr, fg, fb)
 			lBg := relativeLuminance(br, bgGreen, bb)
 			fgStartedDarker := lFgBefore < lBg
 
 			got := EnforceMinContrast(tc.fg, tc.bg, tc.value)
 
-			gr, gg, gb, ok := parseHexColor(got)
+			gr, gg, gb, ok := hexOK(got)
 			require.True(t, ok, "mutator must return a valid hex color")
 			lFgAfter := relativeLuminance(gr, gg, gb)
 
@@ -559,9 +484,9 @@ func TestApplyThemeHonoursContrastKnob(t *testing.T) {
 	assert.NotEqual(t, textWithoutKnob, textWithKnob, "text color should shift when contrast knob is active")
 
 	// Verify the new color actually meets the target ratio against Base.
-	tR, tG, tB, ok := parseHexColor(textWithKnob)
+	tR, tG, tB, ok := hexOK(textWithKnob)
 	require.True(t, ok, "shifted text color must be a valid hex")
-	bR, bG, bB, ok2 := parseHexColor(lowContrastTheme.Base)
+	bR, bG, bB, ok2 := hexOK(lowContrastTheme.Base)
 	require.True(t, ok2)
 
 	lFg := relativeLuminance(tR, tG, tB)


### PR DESCRIPTION
## Summary

theme_contrast.go now calls go-colorful for hex parsing, HSL conversion, and color blending instead of its own hand-rolled math. go-colorful was already pulled in through lipgloss and is now a direct dependency.

## Type of change

- [ ] feat: new user-facing feature
- [ ] fix: bug fix
- [x] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

N/A

## Changes

- Replace hand-rolled hex parsing and HSL conversion in theme_contrast.go with go-colorful
- Replace the blend math with go-colorful, keeping the hex output truncated on purpose (go-colorful rounds to nearest, which would shift some theme colors by one step, for example #7f7f7f to #808080)
- Add go-colorful as a direct module dependency

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

Contrast output for the built-in themes is byte-identical to before. The existing tests keep their expected hex values unchanged.

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

N/A, no UI change.
