### PR TITLE
refactor: deduplicate the k8s client helpers

### DIFF
--- a/internal/app/cursor.go
+++ b/internal/app/cursor.go
@@ -142,48 +142,50 @@ func carryOverMetricsColumnsFrom(oldItems, newItems []model.Item) {
 		"MEM": true, "MEM/R": true, "MEM/L": true,
 		"CPU%": true, "MEM%": true, "Uptime": true,
 	}
-	// Build lookup from old items. Carry over whatever metrics columns the
-	// item already had so the column set stays visually stable across watch
-	// ticks -- including "n/a" placeholders set by the node enrichment path
-	// when metrics-server returned nothing. The previous hasUsage gate
-	// dropped the carryover whenever every value was empty/zero, which made
-	// the metrics columns flicker out and back in on each refresh.
-	// The key includes the cluster: in union mode the same namespace+name can
-	// exist in several clusters and must not share carried columns.
+	// Prepend so carried metrics lead the raw request/limit columns
+	// (CPU Req, CPU Lim, Mem Req, Mem Lim) that podMetricsEnrichedMsg reads.
+	carryOverColumnsFrom(oldItems, newItems, metricsKeys, true)
+}
+
+// The cluster is part of the match key because in union mode the same
+// namespace+name can exist in several clusters and must not share columns.
+func carryOverColumnsFrom(oldItems, newItems []model.Item, keys map[string]bool, prependCarried bool) {
 	type itemKey struct{ cluster, ns, name string }
-	oldMetrics := make(map[itemKey][]model.KeyValue)
+	old := make(map[itemKey][]model.KeyValue)
 	for _, item := range oldItems {
 		var cols []model.KeyValue
 		for _, kv := range item.Columns {
-			if metricsKeys[kv.Key] {
+			if keys[kv.Key] {
 				cols = append(cols, kv)
 			}
 		}
 		if len(cols) > 0 {
-			oldMetrics[itemKey{item.ClusterName, item.Namespace, item.Name}] = cols
+			old[itemKey{item.ClusterName, item.Namespace, item.Name}] = cols
 		}
 	}
-	if len(oldMetrics) == 0 {
+	if len(old) == 0 {
 		return
 	}
-	// Apply to new items: prepend carried-over metrics columns while keeping
-	// the raw request/limit columns (CPU Req, CPU Lim, Mem Req, Mem Lim) so
-	// that podMetricsEnrichedMsg can still read them to compute percentages.
 	for i := range newItems {
 		key := itemKey{newItems[i].ClusterName, newItems[i].Namespace, newItems[i].Name}
-		cols, ok := oldMetrics[key]
+		cols, ok := old[key]
 		if !ok {
 			continue
 		}
 		var kept []model.KeyValue
 		for _, kv := range newItems[i].Columns {
-			if !metricsKeys[kv.Key] {
+			if !keys[kv.Key] {
 				kept = append(kept, kv)
 			}
 		}
 		merged := make([]model.KeyValue, 0, len(cols)+len(kept))
-		merged = append(merged, cols...)
-		merged = append(merged, kept...)
+		if prependCarried {
+			merged = append(merged, cols...)
+			merged = append(merged, kept...)
+		} else {
+			merged = append(merged, kept...)
+			merged = append(merged, cols...)
+		}
 		newItems[i].Columns = merged
 	}
 }
@@ -211,48 +213,13 @@ func (m *Model) carryOverServiceEndpointColumns(newItems []model.Item) {
 // carryOverServiceEndpointColumns, shared with the right-pane list preview
 // (see carryOverMetricsColumnsFrom).
 func carryOverServiceEndpointColumnsFrom(oldItems, newItems []model.Item) {
+	// The populator never writes these on the new item, so stripping them
+	// from newItems.Columns is a no-op today, kept for when it might.
 	endpointKeys := map[string]bool{
 		"Backing Endpoints": true,
 		"Endpoints":         true,
 	}
-	// Cluster-qualified key: see carryOverMetricsColumnsFrom.
-	type itemKey struct{ cluster, ns, name string }
-	old := make(map[itemKey][]model.KeyValue)
-	for _, item := range oldItems {
-		var cols []model.KeyValue
-		for _, kv := range item.Columns {
-			if endpointKeys[kv.Key] {
-				cols = append(cols, kv)
-			}
-		}
-		if len(cols) > 0 {
-			old[itemKey{item.ClusterName, item.Namespace, item.Name}] = cols
-		}
-	}
-	if len(old) == 0 {
-		return
-	}
-	for i := range newItems {
-		key := itemKey{newItems[i].ClusterName, newItems[i].Namespace, newItems[i].Name}
-		cols, ok := old[key]
-		if !ok {
-			continue
-		}
-		// Drop any rollup columns that arrived on the new item (the
-		// populator only writes "Type / Cluster IP / ..." for Services,
-		// so this loop is a no-op today — but keeping it makes the
-		// helper safe if the populator ever starts writing them too).
-		var kept []model.KeyValue
-		for _, kv := range newItems[i].Columns {
-			if !endpointKeys[kv.Key] {
-				kept = append(kept, kv)
-			}
-		}
-		merged := make([]model.KeyValue, 0, len(kept)+len(cols))
-		merged = append(merged, kept...)
-		merged = append(merged, cols...)
-		newItems[i].Columns = merged
-	}
+	carryOverColumnsFrom(oldItems, newItems, endpointKeys, false)
 }
 
 // clampAllCursors ensures all cursor positions are within bounds after resize.

--- a/internal/k8s/alerts.go
+++ b/internal/k8s/alerts.go
@@ -98,6 +98,29 @@ func probeAlerts(ctx context.Context, cs kubernetes.Interface, kubeCtx string,
 	return nil, fmt.Errorf("no Prometheus/Alertmanager service found in configured/default monitoring namespaces")
 }
 
+// resolveGrafanaURL tries common Grafana/dashboard URL annotation names.
+func resolveGrafanaURL(annotations map[string]string) string {
+	for _, key := range []string{"grafana_url", "dashboard_url", "runbook_url"} {
+		if url := annotations[key]; url != "" {
+			return url
+		}
+	}
+	return ""
+}
+
+func alertInfoFromPrometheus(a prometheusAlert) AlertInfo {
+	return AlertInfo{
+		Name:        a.Labels["alertname"],
+		State:       a.State,
+		Severity:    a.Labels["severity"],
+		Summary:     a.Annotations["summary"],
+		Description: a.Annotations["description"],
+		Since:       a.ActiveAt,
+		Labels:      a.Labels,
+		GrafanaURL:  resolveGrafanaURL(a.Annotations),
+	}
+}
+
 // parseAndFilterAlerts unmarshals the Prometheus alerts API response and filters
 // alerts relevant to the specified resource.
 func parseAndFilterAlerts(data []byte, resourceNs, resourceName, resourceKind string) ([]AlertInfo, error) {
@@ -116,23 +139,7 @@ func parseAndFilterAlerts(data []byte, resourceNs, resourceName, resourceKind st
 		if !alertMatchesResource(a.Labels, resourceNs, resourceName, kindLower) {
 			continue
 		}
-		info := AlertInfo{
-			Name:        a.Labels["alertname"],
-			State:       a.State,
-			Severity:    a.Labels["severity"],
-			Summary:     a.Annotations["summary"],
-			Description: a.Annotations["description"],
-			Since:       a.ActiveAt,
-			Labels:      a.Labels,
-		}
-		// Try common Grafana/dashboard URL annotation names.
-		for _, key := range []string{"grafana_url", "dashboard_url", "runbook_url"} {
-			if url := a.Annotations[key]; url != "" {
-				info.GrafanaURL = url
-				break
-			}
-		}
-		alerts = append(alerts, info)
+		alerts = append(alerts, alertInfoFromPrometheus(a))
 	}
 
 	return alerts, nil
@@ -173,22 +180,7 @@ func parseAllAlerts(data []byte, namespace string) ([]AlertInfo, error) {
 		if namespace != "" && a.Labels["namespace"] != "" && a.Labels["namespace"] != namespace {
 			continue
 		}
-		info := AlertInfo{
-			Name:        a.Labels["alertname"],
-			State:       a.State,
-			Severity:    a.Labels["severity"],
-			Summary:     a.Annotations["summary"],
-			Description: a.Annotations["description"],
-			Since:       a.ActiveAt,
-			Labels:      a.Labels,
-		}
-		for _, key := range []string{"grafana_url", "dashboard_url", "runbook_url"} {
-			if url := a.Annotations[key]; url != "" {
-				info.GrafanaURL = url
-				break
-			}
-		}
-		alerts = append(alerts, info)
+		alerts = append(alerts, alertInfoFromPrometheus(a))
 	}
 
 	return alerts, nil
@@ -202,6 +194,26 @@ type alertmanagerAlert struct {
 		State string `json:"state"` // "active", "suppressed", "unprocessed"
 	} `json:"status"`
 	StartsAt time.Time `json:"startsAt"`
+}
+
+func alertmanagerState(status string) string {
+	if status == "unprocessed" {
+		return "pending"
+	}
+	return "firing"
+}
+
+func alertInfoFromAlertmanager(a alertmanagerAlert) AlertInfo {
+	return AlertInfo{
+		Name:        a.Labels["alertname"],
+		State:       alertmanagerState(a.Status.State),
+		Severity:    a.Labels["severity"],
+		Summary:     a.Annotations["summary"],
+		Description: a.Annotations["description"],
+		Since:       a.StartsAt,
+		Labels:      a.Labels,
+		GrafanaURL:  resolveGrafanaURL(a.Annotations),
+	}
 }
 
 // parseAlertmanagerAlerts parses the Alertmanager v2 API response and returns alerts,
@@ -222,26 +234,7 @@ func parseAlertmanagerAlerts(data []byte, namespace string) ([]AlertInfo, error)
 		if namespace != "" && a.Labels["namespace"] != "" && a.Labels["namespace"] != namespace {
 			continue
 		}
-		state := "firing"
-		if a.Status.State == "unprocessed" {
-			state = "pending"
-		}
-		info := AlertInfo{
-			Name:        a.Labels["alertname"],
-			State:       state,
-			Severity:    a.Labels["severity"],
-			Summary:     a.Annotations["summary"],
-			Description: a.Annotations["description"],
-			Since:       a.StartsAt,
-			Labels:      a.Labels,
-		}
-		for _, key := range []string{"grafana_url", "dashboard_url", "runbook_url"} {
-			if url := a.Annotations[key]; url != "" {
-				info.GrafanaURL = url
-				break
-			}
-		}
-		alerts = append(alerts, info)
+		alerts = append(alerts, alertInfoFromAlertmanager(a))
 	}
 
 	return alerts, nil
@@ -263,26 +256,7 @@ func parseAndFilterAlertmanagerAlerts(data []byte, resourceNs, resourceName, res
 		if !alertMatchesResource(a.Labels, resourceNs, resourceName, kindLower) {
 			continue
 		}
-		state := "firing"
-		if a.Status.State == "unprocessed" {
-			state = "pending"
-		}
-		info := AlertInfo{
-			Name:        a.Labels["alertname"],
-			State:       state,
-			Severity:    a.Labels["severity"],
-			Summary:     a.Annotations["summary"],
-			Description: a.Annotations["description"],
-			Since:       a.StartsAt,
-			Labels:      a.Labels,
-		}
-		for _, key := range []string{"grafana_url", "dashboard_url", "runbook_url"} {
-			if url := a.Annotations[key]; url != "" {
-				info.GrafanaURL = url
-				break
-			}
-		}
-		alerts = append(alerts, info)
+		alerts = append(alerts, alertInfoFromAlertmanager(a))
 	}
 
 	return alerts, nil

--- a/internal/k8s/client_fakeclient_extra_test.go
+++ b/internal/k8s/client_fakeclient_extra_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"bytes"
+	"errors"
 	"log/slog"
 	"maps"
 	"testing"
@@ -468,6 +469,77 @@ func TestTerminateArgoWorkflow(t *testing.T) {
 
 	err := c.TerminateArgoWorkflow("", "default", "my-wf")
 	require.NoError(t, err)
+}
+
+func TestArgoWorkflowVerbs_PatchApplied(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "workflows"}
+	tests := []struct {
+		name  string
+		call  func(c *Client) error
+		field string
+		want  any
+	}{
+		{"suspend", func(c *Client) error { return c.SuspendArgoWorkflow("", "default", "my-wf") }, "suspend", true},
+		{"resume", func(c *Client) error { return c.ResumeArgoWorkflow("", "default", "my-wf") }, "suspend", false},
+		{"stop", func(c *Client) error { return c.StopArgoWorkflow("", "default", "my-wf") }, "shutdown", "Stop"},
+		{"terminate", func(c *Client) error { return c.TerminateArgoWorkflow("", "default", "my-wf") }, "shutdown", "Terminate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Workflow",
+					"metadata":   map[string]any{"name": "my-wf", "namespace": "default"},
+				},
+			}
+			dc := newFakeDynClient(wf)
+			c := newFakeClient(nil, dc)
+
+			require.NoError(t, tt.call(c))
+
+			got, err := dc.Resource(gvr).Namespace("default").Get(t.Context(), "my-wf", metav1.GetOptions{})
+			require.NoError(t, err)
+			spec, _ := got.Object["spec"].(map[string]any)
+			assert.Equal(t, tt.want, spec[tt.field])
+		})
+	}
+}
+
+func TestArgoWorkflowVerbs_PatchErrorWrapped(t *testing.T) {
+	tests := []struct {
+		name    string
+		call    func(c *Client) error
+		wantMsg string
+	}{
+		{"suspend", func(c *Client) error { return c.SuspendArgoWorkflow("", "default", "my-wf") }, "suspending workflow my-wf"},
+		{"resume", func(c *Client) error { return c.ResumeArgoWorkflow("", "default", "my-wf") }, "resuming workflow my-wf"},
+		{"stop", func(c *Client) error { return c.StopArgoWorkflow("", "default", "my-wf") }, "stopping workflow my-wf"},
+		{"terminate", func(c *Client) error { return c.TerminateArgoWorkflow("", "default", "my-wf") }, "terminating workflow my-wf"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Workflow",
+					"metadata":   map[string]any{"name": "my-wf", "namespace": "default"},
+				},
+			}
+			dc := newFakeDynClient(wf)
+			dc.PrependReactor("patch", "workflows", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("boom")
+			})
+			c := newFakeClient(nil, dc)
+
+			err := tt.call(c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+			assert.Contains(t, err.Error(), "boom")
+		})
+	}
 }
 
 func TestResubmitArgoWorkflow(t *testing.T) {

--- a/internal/k8s/client_populate_workloads.go
+++ b/internal/k8s/client_populate_workloads.go
@@ -28,10 +28,8 @@ func populatePodDetails(ti *model.Item, obj map[string]any, status, spec map[str
 		if ready, ok := csMap["ready"].(bool); ok && ready {
 			readyCount++
 		}
-		if rc, ok := csMap["restartCount"].(int64); ok {
+		if rc, ok := intFromMap(csMap, "restartCount"); ok {
 			restartCount += rc
-		} else if rcf, ok := csMap["restartCount"].(float64); ok {
-			restartCount += int64(rcf)
 		}
 	}
 	ti.Ready = fmt.Sprintf("%d/%d", readyCount, totalContainers)
@@ -186,17 +184,13 @@ func populateDeploymentDetails(ti *model.Item, obj, status, spec map[string]any)
 	if status == nil || spec == nil {
 		return
 	}
-	var specReplicas int64 = 1
-	if r, ok := spec["replicas"].(int64); ok {
+	specReplicas := int64(1)
+	if r, ok := intFromMap(spec, "replicas"); ok {
 		specReplicas = r
-	} else if r, ok := spec["replicas"].(float64); ok {
-		specReplicas = int64(r)
 	}
 	var readyReplicas int64
-	if r, ok := status["readyReplicas"].(int64); ok {
+	if r, ok := intFromMap(status, "readyReplicas"); ok {
 		readyReplicas = r
-	} else if r, ok := status["readyReplicas"].(float64); ok {
-		readyReplicas = int64(r)
 	}
 	ti.Ready = fmt.Sprintf("%d/%d", readyReplicas, specReplicas)
 	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Replicas", Value: fmt.Sprintf("%d", specReplicas)})
@@ -229,17 +223,13 @@ func populateStatefulSetDetails(ti *model.Item, obj, status, spec map[string]any
 	if status == nil || spec == nil {
 		return
 	}
-	var specReplicas int64 = 1
-	if r, ok := spec["replicas"].(int64); ok {
+	specReplicas := int64(1)
+	if r, ok := intFromMap(spec, "replicas"); ok {
 		specReplicas = r
-	} else if r, ok := spec["replicas"].(float64); ok {
-		specReplicas = int64(r)
 	}
 	var readyReplicas int64
-	if r, ok := status["readyReplicas"].(int64); ok {
+	if r, ok := intFromMap(status, "readyReplicas"); ok {
 		readyReplicas = r
-	} else if r, ok := status["readyReplicas"].(float64); ok {
-		readyReplicas = int64(r)
 	}
 	ti.Ready = fmt.Sprintf("%d/%d", readyReplicas, specReplicas)
 	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Replicas", Value: fmt.Sprintf("%d", specReplicas)})
@@ -273,15 +263,11 @@ func populateDaemonSetDetails(ti *model.Item, obj, status, spec map[string]any) 
 		return
 	}
 	var desired, ready int64
-	if d, ok := status["desiredNumberScheduled"].(int64); ok {
+	if d, ok := intFromMap(status, "desiredNumberScheduled"); ok {
 		desired = d
-	} else if d, ok := status["desiredNumberScheduled"].(float64); ok {
-		desired = int64(d)
 	}
-	if r, ok := status["numberReady"].(int64); ok {
+	if r, ok := intFromMap(status, "numberReady"); ok {
 		ready = r
-	} else if r, ok := status["numberReady"].(float64); ok {
-		ready = int64(r)
 	}
 	ti.Ready = fmt.Sprintf("%d/%d", ready, desired)
 	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Desired", Value: fmt.Sprintf("%d", desired)})
@@ -315,16 +301,12 @@ func populateReplicaSetDetails(ti *model.Item, obj, status, spec map[string]any)
 		return
 	}
 	var specReplicas int64
-	if r, ok := spec["replicas"].(int64); ok {
+	if r, ok := intFromMap(spec, "replicas"); ok {
 		specReplicas = r
-	} else if r, ok := spec["replicas"].(float64); ok {
-		specReplicas = int64(r)
 	}
 	var readyReplicas int64
-	if r, ok := status["readyReplicas"].(int64); ok {
+	if r, ok := intFromMap(status, "readyReplicas"); ok {
 		readyReplicas = r
-	} else if r, ok := status["readyReplicas"].(float64); ok {
-		readyReplicas = int64(r)
 	}
 	ti.Ready = fmt.Sprintf("%d/%d", readyReplicas, specReplicas)
 	ti.Columns = append(ti.Columns, model.KeyValue{Key: "Desired", Value: fmt.Sprintf("%d", specReplicas)})

--- a/internal/k8s/client_rightsizing.go
+++ b/internal/k8s/client_rightsizing.go
@@ -505,21 +505,27 @@ func layerVPAResource(rec *model.ResourceRec, rm map[string]any, resKey string, 
 // fails to parse (defensive — the VPA payload always parses, but
 // silent passthrough beats panicking on a future schema change).
 func scaleQuantityByHeadroom(q string, headroom float64) string {
-	if q == "" || headroom == 1 {
+	return scaleQuantityByFactor(q, headroom, isMemoryQuantity(q))
+}
+
+// scaleQuantityByFactor scales a Kubernetes quantity string by factor and
+// snaps it back to a canonical CPU or memory unit.
+func scaleQuantityByFactor(q string, factor float64, isMemory bool) string {
+	if q == "" || factor == 1 {
 		return q
 	}
 	parsed, err := resource.ParseQuantity(q)
 	if err != nil {
 		return q
 	}
-	if isMemoryQuantity(q) {
+	if isMemory {
 		// MilliValue() for memory returns bytes×1000. Convert back to
 		// bytes before scaling so SnapMemBytesToCanonical sees the right
 		// unit.
 		bytes := parsed.MilliValue() / 1000
-		return SnapMemBytesToCanonical(int64(float64(bytes) * headroom))
+		return SnapMemBytesToCanonical(int64(float64(bytes) * factor))
 	}
-	return SnapCPUMilliToCanonical(int64(float64(parsed.MilliValue()) * headroom))
+	return SnapCPUMilliToCanonical(int64(float64(parsed.MilliValue()) * factor))
 }
 
 // scaleLimitFromRatio returns the recommended limit that preserves

--- a/internal/k8s/client_rightsizing.go
+++ b/internal/k8s/client_rightsizing.go
@@ -519,11 +519,10 @@ func scaleQuantityByFactor(q string, factor float64, isMemory bool) string {
 		return q
 	}
 	if isMemory {
-		// MilliValue() for memory returns bytes×1000. Convert back to
-		// bytes before scaling so SnapMemBytesToCanonical sees the right
-		// unit.
-		bytes := parsed.MilliValue() / 1000
-		return SnapMemBytesToCanonical(int64(float64(bytes) * factor))
+		// Scale the milli value before dividing by 1000, or a sub-byte
+		// quantity truncates to 0 before factor is ever applied.
+		bytes := int64(float64(parsed.MilliValue()) * factor / 1000)
+		return SnapMemBytesToCanonical(bytes)
 	}
 	return SnapCPUMilliToCanonical(int64(float64(parsed.MilliValue()) * factor))
 }

--- a/internal/k8s/client_rightsizing_rescale.go
+++ b/internal/k8s/client_rightsizing_rescale.go
@@ -1,8 +1,6 @@
 package k8s
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/janosmiko/lfk/internal/model"
 )
 
@@ -93,19 +91,5 @@ func rescaleResourceRec(r model.ResourceRec, ratio float64, isMemory bool) model
 // caller already computed a new/old ratio and shouldn't have to fake
 // up a "headroom" parameter to reuse the existing helper.
 func scaleQuantityByRatio(q string, ratio float64, isMemory bool) string {
-	if q == "" || ratio == 1 {
-		return q
-	}
-	parsed, err := resource.ParseQuantity(q)
-	if err != nil {
-		return q
-	}
-	if isMemory {
-		// MilliValue() for memory returns bytes×1000. Convert back to
-		// bytes before scaling so SnapMemBytesToCanonical sees the right
-		// unit.
-		bytes := parsed.MilliValue() / 1000
-		return SnapMemBytesToCanonical(int64(float64(bytes) * ratio))
-	}
-	return SnapCPUMilliToCanonical(int64(float64(parsed.MilliValue()) * ratio))
+	return scaleQuantityByFactor(q, ratio, isMemory)
 }

--- a/internal/k8s/client_rightsizing_test.go
+++ b/internal/k8s/client_rightsizing_test.go
@@ -647,6 +647,7 @@ func TestScaleQuantityByHeadroom(t *testing.T) {
 		{name: "unparseable quantity returns input unchanged", q: "not-a-quantity", headroom: 2.0, want: "not-a-quantity"},
 		{name: "CPU quantity scales and snaps to milli suffix", q: "100m", headroom: 2.0, want: "200m"},
 		{name: "memory quantity scales and snaps to Mi suffix", q: "100Mi", headroom: 2.0, want: "200Mi"},
+		{name: "fractional-byte memory quantity scales before truncation", q: "0.0006Ki", headroom: 2.0, want: "1Mi"},
 	}
 
 	for _, tc := range cases {

--- a/internal/k8s/client_rightsizing_test.go
+++ b/internal/k8s/client_rightsizing_test.go
@@ -634,3 +634,24 @@ func TestAvailableRightsizingStrategies_DiscoveredPrometheus(t *testing.T) {
 		assert.Equal(t, []model.RightsizingStrategy{model.StrategySnapshot}, got)
 	})
 }
+
+func TestScaleQuantityByHeadroom(t *testing.T) {
+	cases := []struct {
+		name     string
+		q        string
+		headroom float64
+		want     string
+	}{
+		{name: "empty quantity returns empty", q: "", headroom: 2.0, want: ""},
+		{name: "headroom 1 returns input unchanged", q: "100m", headroom: 1, want: "100m"},
+		{name: "unparseable quantity returns input unchanged", q: "not-a-quantity", headroom: 2.0, want: "not-a-quantity"},
+		{name: "CPU quantity scales and snaps to milli suffix", q: "100m", headroom: 2.0, want: "200m"},
+		{name: "memory quantity scales and snaps to Mi suffix", q: "100Mi", headroom: 2.0, want: "200Mi"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, scaleQuantityByHeadroom(tc.q, tc.headroom))
+		})
+	}
+}

--- a/internal/k8s/gitops_workflow.go
+++ b/internal/k8s/gitops_workflow.go
@@ -14,77 +14,43 @@ import (
 )
 
 // SuspendArgoWorkflow sets spec.suspend=true on an Argo Workflow.
-func (c *Client) SuspendArgoWorkflow(contextName, namespace, name string) error {
+// patchWorkflow applies a merge patch to an ArgoWorkflow, wrapping any error
+// with the verb naming the caller's action (e.g. "suspending", "terminating").
+func patchWorkflow(c *Client, contextName, namespace, name string, patch []byte, verb string) error {
 	dynClient, err := c.dynamicForContext(contextName)
 	if err != nil {
 		return err
 	}
 
 	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "workflows"}
-	patch := []byte(`{"spec":{"suspend":true}}`)
 	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
 		context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{FieldManager: FieldManager()},
 	)
 	if err != nil {
-		return fmt.Errorf("suspending workflow %s: %w", name, err)
+		return fmt.Errorf("%s workflow %s: %w", verb, name, err)
 	}
 	return nil
 }
 
+func (c *Client) SuspendArgoWorkflow(contextName, namespace, name string) error {
+	return patchWorkflow(c, contextName, namespace, name, []byte(`{"spec":{"suspend":true}}`), "suspending")
+}
+
 // ResumeArgoWorkflow sets spec.suspend=false on an Argo Workflow.
 func (c *Client) ResumeArgoWorkflow(contextName, namespace, name string) error {
-	dynClient, err := c.dynamicForContext(contextName)
-	if err != nil {
-		return err
-	}
-
-	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "workflows"}
-	patch := []byte(`{"spec":{"suspend":false}}`)
-	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
-		context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{FieldManager: FieldManager()},
-	)
-	if err != nil {
-		return fmt.Errorf("resuming workflow %s: %w", name, err)
-	}
-	return nil
+	return patchWorkflow(c, contextName, namespace, name, []byte(`{"spec":{"suspend":false}}`), "resuming")
 }
 
 // StopArgoWorkflow sets spec.shutdown="Stop" on an Argo Workflow.
 // This stops new steps from running but allows exit handlers to execute.
 func (c *Client) StopArgoWorkflow(contextName, namespace, name string) error {
-	dynClient, err := c.dynamicForContext(contextName)
-	if err != nil {
-		return err
-	}
-
-	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "workflows"}
-	patch := []byte(`{"spec":{"shutdown":"Stop"}}`)
-	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
-		context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{FieldManager: FieldManager()},
-	)
-	if err != nil {
-		return fmt.Errorf("stopping workflow %s: %w", name, err)
-	}
-	return nil
+	return patchWorkflow(c, contextName, namespace, name, []byte(`{"spec":{"shutdown":"Stop"}}`), "stopping")
 }
 
 // TerminateArgoWorkflow sets spec.shutdown="Terminate" on an Argo Workflow.
 // This immediately terminates the workflow without running exit handlers.
 func (c *Client) TerminateArgoWorkflow(contextName, namespace, name string) error {
-	dynClient, err := c.dynamicForContext(contextName)
-	if err != nil {
-		return err
-	}
-
-	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "workflows"}
-	patch := []byte(`{"spec":{"shutdown":"Terminate"}}`)
-	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
-		context.Background(), name, k8stypes.MergePatchType, patch, metav1.PatchOptions{FieldManager: FieldManager()},
-	)
-	if err != nil {
-		return fmt.Errorf("terminating workflow %s: %w", name, err)
-	}
-	return nil
+	return patchWorkflow(c, contextName, namespace, name, []byte(`{"spec":{"shutdown":"Terminate"}}`), "terminating")
 }
 
 // ResubmitArgoWorkflow creates a new Workflow from an existing one's spec.

--- a/internal/k8s/resources_ports.go
+++ b/internal/k8s/resources_ports.go
@@ -4,8 +4,23 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func containerPortsFromContainers(containers []corev1.Container) []ContainerPort {
+	var ports []ContainerPort
+	for _, container := range containers {
+		for _, p := range container.Ports {
+			ports = append(ports, ContainerPort{
+				Name:          p.Name,
+				ContainerPort: p.ContainerPort,
+				Protocol:      string(p.Protocol),
+			})
+		}
+	}
+	return ports
+}
 
 func (c *Client) GetContainerPorts(ctx context.Context, contextName, namespace, podName string) ([]ContainerPort, error) {
 	cs, err := c.clientsetForContext(contextName)
@@ -18,17 +33,7 @@ func (c *Client) GetContainerPorts(ctx context.Context, contextName, namespace, 
 		return nil, fmt.Errorf("getting pod %s: %w", podName, err)
 	}
 
-	var ports []ContainerPort
-	for _, container := range pod.Spec.Containers {
-		for _, p := range container.Ports {
-			ports = append(ports, ContainerPort{
-				Name:          p.Name,
-				ContainerPort: p.ContainerPort,
-				Protocol:      string(p.Protocol),
-			})
-		}
-	}
-	return ports, nil
+	return containerPortsFromContainers(pod.Spec.Containers), nil
 }
 
 func (c *Client) GetServicePorts(ctx context.Context, contextName, namespace, svcName string) ([]ContainerPort, error) {
@@ -64,17 +69,7 @@ func (c *Client) GetDeploymentPorts(ctx context.Context, contextName, namespace,
 		return nil, fmt.Errorf("getting deployment %s: %w", name, err)
 	}
 
-	var ports []ContainerPort
-	for _, container := range dep.Spec.Template.Spec.Containers {
-		for _, p := range container.Ports {
-			ports = append(ports, ContainerPort{
-				Name:          p.Name,
-				ContainerPort: p.ContainerPort,
-				Protocol:      string(p.Protocol),
-			})
-		}
-	}
-	return ports, nil
+	return containerPortsFromContainers(dep.Spec.Template.Spec.Containers), nil
 }
 
 func (c *Client) GetStatefulSetPorts(ctx context.Context, contextName, namespace, name string) ([]ContainerPort, error) {
@@ -88,17 +83,7 @@ func (c *Client) GetStatefulSetPorts(ctx context.Context, contextName, namespace
 		return nil, fmt.Errorf("getting statefulset %s: %w", name, err)
 	}
 
-	var ports []ContainerPort
-	for _, container := range sts.Spec.Template.Spec.Containers {
-		for _, p := range container.Ports {
-			ports = append(ports, ContainerPort{
-				Name:          p.Name,
-				ContainerPort: p.ContainerPort,
-				Protocol:      string(p.Protocol),
-			})
-		}
-	}
-	return ports, nil
+	return containerPortsFromContainers(sts.Spec.Template.Spec.Containers), nil
 }
 
 func (c *Client) GetDaemonSetPorts(ctx context.Context, contextName, namespace, name string) ([]ContainerPort, error) {
@@ -112,15 +97,5 @@ func (c *Client) GetDaemonSetPorts(ctx context.Context, contextName, namespace, 
 		return nil, fmt.Errorf("getting daemonset %s: %w", name, err)
 	}
 
-	var ports []ContainerPort
-	for _, container := range ds.Spec.Template.Spec.Containers {
-		for _, p := range container.Ports {
-			ports = append(ports, ContainerPort{
-				Name:          p.Name,
-				ContainerPort: p.ContainerPort,
-				Protocol:      string(p.Protocol),
-			})
-		}
-	}
-	return ports, nil
+	return containerPortsFromContainers(ds.Spec.Template.Spec.Containers), nil
 }


### PR DESCRIPTION
## Summary

Deduplicates several repeated patterns in the k8s client: Argo workflow verbs, Prometheus/Alertmanager alert builders, container port listing, replica/restart count reads, VPA quantity scaling, and metrics/endpoint column carry-over. No behavior change intended.

## Type of change

- [x] refactor: code change that neither fixes a bug nor adds a feature

## Related issue

N/A

## Changes

- Share one patchWorkflow helper across suspend, resume, stop, and terminate
- Share one alert builder per source (Prometheus, Alertmanager) plus one Grafana URL lookup
- Share one container-port loop across Pod, Deployment, StatefulSet, and DaemonSet listing
- Route the nine replica/restart count reads through the existing intFromMap
- Share one quantity scaler between VPA headroom and rescale scaling
- Share one column carry-over function between metrics and endpoint columns

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings

N/A
