### PR TITLE
refactor: inline single-caller delegate wrappers and accessors

### DIFF
--- a/internal/app/update_diff.go
+++ b/internal/app/update_diff.go
@@ -584,7 +584,7 @@ func (m *Model) diffScrollToMatch(foldRegions []ui.DiffFoldRegion, viewportLines
 
 	// Move cursor column to the match position on the active side.
 	lineText := m.diffCurrentLineText(foldRegions)
-	col := ui.DiffSearchColumnInLine(lineText, m.diffView.searchQuery)
+	col := ui.FindColumnInLine(lineText, m.diffView.searchQuery)
 	if col >= 0 {
 		m.diffView.visualCurCol = col
 	}

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -279,7 +279,7 @@ func (m Model) handleKeyThemeSelector() Model {
 	m.schemeCursor = 0
 	m.schemeFilter.Clear()
 	m.schemeOriginalName = ui.ActiveSchemeName
-	ui.ResetOverlaySchemeScroll()
+	ui.OverlaySchemeScroll = 0
 	// Position cursor on the currently active scheme.
 	selectIdx := 0
 	for _, e := range m.schemeEntries {
@@ -407,7 +407,7 @@ func (m Model) namespaceSelectorItems(items []model.Item) []model.Item {
 func (m Model) openNamespaceSelectorForContext(contextName string) (tea.Model, tea.Cmd) {
 	m.overlay = overlayNamespace
 	m.overlayFilter.Clear()
-	ui.ResetOverlayNsScroll()
+	ui.OverlayNsScroll = 0
 	m.nsSelectionModified = false
 	// Snapshot the scope now, before Space/Tab/A editing mutates the live
 	// selection during the session. Commit (Enter) and the in-overlay quick

--- a/internal/app/update_mouse_overlay.go
+++ b/internal/app/update_mouse_overlay.go
@@ -144,7 +144,7 @@ func (m Model) activateOverlayItemAt(innerY int) (tea.Model, tea.Cmd, bool) {
 		if rowInItems < 0 || rowInItems >= visibleCount {
 			return m, nil, false
 		}
-		idx := ui.GetOverlayNsScroll() + rowInItems
+		idx := ui.OverlayNsScroll + rowInItems
 		if idx < 0 || idx >= len(items) {
 			return m, nil, false
 		}

--- a/internal/app/update_mouse_overlay_test.go
+++ b/internal/app/update_mouse_overlay_test.go
@@ -318,7 +318,7 @@ func TestCenteredOverlayBoxMatchesActualRenderAtNarrowHeights(t *testing.T) {
 				{Name: "staging"},
 			}
 			m.overlayCursor = 0
-			ui.ResetOverlayNsScroll()
+			ui.OverlayNsScroll = 0
 
 			box, ok := m.centeredOverlayBox()
 			assert.True(t, ok)
@@ -415,7 +415,7 @@ func TestOverlayMouseClickNamespaceItemSetsCursorAndApplies(t *testing.T) {
 		{Name: "monitoring"},
 	}
 	m.overlayCursor = 0
-	ui.ResetOverlayNsScroll()
+	ui.OverlayNsScroll = 0
 
 	// Namespace overlay layout (RenderNamespaceOverlay):
 	//   inner rows: 0=title, 1=title-pad, 2=filter, 3=blank,
@@ -441,7 +441,7 @@ func TestOverlayMouseClickNamespaceFilterRowIsNoOp(t *testing.T) {
 	m.overlay = overlayNamespace
 	m.overlayItems = []model.Item{{Name: "default"}}
 	m.overlayCursor = 0
-	ui.ResetOverlayNsScroll()
+	ui.OverlayNsScroll = 0
 
 	// Filter row is inner row 2, screen y = 9 + 2 + 2 = 13.
 	ret, _ := m.handleMouse(tea.MouseClickMsg{

--- a/internal/app/update_overlays_colorscheme.go
+++ b/internal/app/update_overlays_colorscheme.go
@@ -111,7 +111,7 @@ func (m Model) handleColorschemeNormalModeExtended(msg tea.KeyPressMsg, filtered
 	case "home":
 		m.pendingG = false
 		m.schemeCursor = 0
-		ui.ResetOverlaySchemeScroll()
+		ui.OverlaySchemeScroll = 0
 		m.previewSchemeAtCursor(filtered)
 		return m, nil
 
@@ -120,7 +120,7 @@ func (m Model) handleColorschemeNormalModeExtended(msg tea.KeyPressMsg, filtered
 		if selectableCount > 0 {
 			m.schemeCursor = selectableCount - 1
 		}
-		ui.ResetOverlaySchemeScroll()
+		ui.OverlaySchemeScroll = 0
 		m.previewSchemeAtCursor(filtered)
 		return m, nil
 
@@ -128,7 +128,7 @@ func (m Model) handleColorschemeNormalModeExtended(msg tea.KeyPressMsg, filtered
 		if m.pendingG {
 			m.pendingG = false
 			m.schemeCursor = 0
-			ui.ResetOverlaySchemeScroll()
+			ui.OverlaySchemeScroll = 0
 			m.previewSchemeAtCursor(filtered)
 			return m, nil
 		}
@@ -139,7 +139,7 @@ func (m Model) handleColorschemeNormalModeExtended(msg tea.KeyPressMsg, filtered
 		if selectableCount > 0 {
 			m.schemeCursor = selectableCount - 1
 		}
-		ui.ResetOverlaySchemeScroll()
+		ui.OverlaySchemeScroll = 0
 		m.previewSchemeAtCursor(filtered)
 		return m, nil
 
@@ -182,7 +182,7 @@ func (m Model) handleColorschemeFilterMode(msg tea.KeyPressMsg) (tea.Model, tea.
 		switch handlePastedText(&m.schemeFilter, []rune(msg.Text)) {
 		case filterContinue:
 			m.schemeCursor = 0
-			ui.ResetOverlaySchemeScroll()
+			ui.OverlaySchemeScroll = 0
 			m.previewSchemeAtCursor(m.filteredSchemeNames())
 			return m, nil
 		case filterPasteMultiline:
@@ -200,7 +200,7 @@ func (m Model) handleColorschemeFilterMode(msg tea.KeyPressMsg) (tea.Model, tea.
 		m.schemeFilterEntryName = ""
 		m.schemeFilter.Clear()
 		m.schemeCursor = 0
-		ui.ResetOverlaySchemeScroll()
+		ui.OverlaySchemeScroll = 0
 		if target != "" {
 			for i, n := range m.filteredSchemeNames() {
 				if n == target {
@@ -214,7 +214,7 @@ func (m Model) handleColorschemeFilterMode(msg tea.KeyPressMsg) (tea.Model, tea.
 	case filterAccept:
 		m.schemeFilterMode = false
 		m.schemeCursor = 0
-		ui.ResetOverlaySchemeScroll()
+		ui.OverlaySchemeScroll = 0
 		filtered := m.filteredSchemeNames()
 		// When the filter narrows to a single scheme, Enter is unambiguous:
 		// commit it and close. The live preview already applied the theme on
@@ -240,7 +240,7 @@ func (m Model) handleColorschemeFilterMode(msg tea.KeyPressMsg) (tea.Model, tea.
 		return m.closeTabOrQuit()
 	case filterContinue:
 		m.schemeCursor = 0
-		ui.ResetOverlaySchemeScroll()
+		ui.OverlaySchemeScroll = 0
 		m.previewSchemeAtCursor(m.filteredSchemeNames())
 		return m, nil
 	}
@@ -291,8 +291,8 @@ func (m *Model) filteredSchemeNames() []string {
 // item currently visible in the colorscheme overlay viewport.
 func (m *Model) schemeFirstVisibleSelectable() int {
 	items := m.schemeDisplayItems()
-	start := ui.GetOverlaySchemeScroll()
-	end := min(start+ui.GetOverlaySchemeVisible(), len(items))
+	start := ui.OverlaySchemeScroll
+	end := min(start+ui.OverlaySchemeVisible, len(items))
 	for i := start; i < end; i++ {
 		if items[i].selectIdx >= 0 {
 			return items[i].selectIdx
@@ -305,8 +305,8 @@ func (m *Model) schemeFirstVisibleSelectable() int {
 // item currently visible in the colorscheme overlay viewport.
 func (m *Model) schemeLastVisibleSelectable() int {
 	items := m.schemeDisplayItems()
-	start := ui.GetOverlaySchemeScroll()
-	end := min(start+ui.GetOverlaySchemeVisible(), len(items))
+	start := ui.OverlaySchemeScroll
+	end := min(start+ui.OverlaySchemeVisible, len(items))
 	for i := end - 1; i >= start; i-- {
 		if items[i].selectIdx >= 0 {
 			return items[i].selectIdx

--- a/internal/app/update_overlays_selectors_test.go
+++ b/internal/app/update_overlays_selectors_test.go
@@ -285,12 +285,12 @@ func TestCovSchemeFirstVisibleSelectable(t *testing.T) {
 	}
 	m.schemeFilter = TextInput{}
 	m.schemeCursor = 0
-	ui.ResetOverlaySchemeScroll()
-	oldVisible := ui.GetOverlaySchemeVisible()
-	t.Cleanup(func() { ui.SetOverlaySchemeVisible(oldVisible) })
+	ui.OverlaySchemeScroll = 0
+	oldVisible := ui.OverlaySchemeVisible
+	t.Cleanup(func() { ui.OverlaySchemeVisible = oldVisible })
 	// A sibling test's render can leave this at whatever viewport size it
 	// used, so pin it here rather than trust the ambient value.
-	ui.SetOverlaySchemeVisible(20)
+	ui.OverlaySchemeVisible = 20
 	idx := m.schemeFirstVisibleSelectable()
 	assert.Equal(t, 0, idx) // first selectable
 }
@@ -304,12 +304,12 @@ func TestCovSchemeLastVisibleSelectable(t *testing.T) {
 	}
 	m.schemeFilter = TextInput{}
 	m.schemeCursor = 0
-	ui.ResetOverlaySchemeScroll()
-	oldVisible := ui.GetOverlaySchemeVisible()
-	t.Cleanup(func() { ui.SetOverlaySchemeVisible(oldVisible) })
+	ui.OverlaySchemeScroll = 0
+	oldVisible := ui.OverlaySchemeVisible
+	t.Cleanup(func() { ui.OverlaySchemeVisible = oldVisible })
 	// A sibling test's render can leave this at whatever viewport size it
 	// used, so pin it here rather than trust the ambient value.
-	ui.SetOverlaySchemeVisible(20)
+	ui.OverlaySchemeVisible = 20
 	idx := m.schemeLastVisibleSelectable()
 	assert.Equal(t, 1, idx) // last selectable
 }

--- a/internal/app/view_overlay_lists.go
+++ b/internal/app/view_overlay_lists.go
@@ -309,9 +309,9 @@ func renderColumnToggleOverlay(m Model, entries []ui.ColumnToggleEntry, width, h
 // caller's `cursor` (selectable-index) is translated to the display index
 // inside the items slice so OverlayList can highlight the right row.
 //
-// Scroll lives in ui.overlaySchemeScroll so the mouse-click resolver in
-// update_overlays_selectors.go reads it via ui.GetOverlaySchemeScroll;
-// the helper updates it on every render via ui.SetOverlaySchemeScroll.
+// Scroll lives in ui.OverlaySchemeScroll so the mouse-click resolver in
+// update_overlays_selectors.go can read it. This helper updates it on
+// every render.
 func renderColorschemeOverlay(m Model, height int) string {
 	// contentH = total inner content the OverlayList block must fill
 	// (overlay box height minus lipgloss's 1+1 vertical padding).
@@ -319,7 +319,7 @@ func renderColorschemeOverlay(m Model, height int) string {
 	// the remainder is the items budget.
 	contentH := max(height-2, 1)
 	maxVisible := max(contentH-overlayListChromeFilterable(), 1)
-	ui.SetOverlaySchemeVisible(maxVisible)
+	ui.OverlaySchemeVisible = maxVisible
 
 	items, cursorDisplayIdx := buildColorschemeItems(m.schemeEntries, m.schemeFilter.Value, m.schemeCursor)
 	if len(items) == 0 {
@@ -333,10 +333,10 @@ func renderColorschemeOverlay(m Model, height int) string {
 		}, min(50, m.width-10)-4)
 	}
 
-	prev := ui.GetOverlaySchemeScroll()
+	prev := ui.OverlaySchemeScroll
 	identity := func(from, to int) int { return to - from }
 	scroll := ui.VimScrollOff(prev, cursorDisplayIdx, len(items), maxVisible, ui.ConfigScrollOff, identity)
-	ui.SetOverlaySchemeScroll(scroll)
+	ui.OverlaySchemeScroll = scroll
 
 	return ui.RenderOverlayList(items, ui.OverlayListConfig{
 		Title:            "Select Color Scheme",
@@ -674,21 +674,19 @@ func padRight(s string, width int) string {
 // collapses into a single ✓ — both signals "this row is in effect right
 // now" and the OverlayList active marker conveys the same information.
 //
-// Mouse-click resolution reads overlayNsScroll via ui.GetOverlayNsScroll();
-// the helper stores its computed scroll offset there before rendering so
-// the click handler keeps resolving rows correctly.
+// Mouse-click resolution reads ui.OverlayNsScroll. This helper stores its
+// computed scroll offset there before rendering so the click handler keeps
+// resolving rows correctly.
 func renderNamespaceOverlay(m Model, items []model.Item, height int) string {
 	contentH := max(height-2, 1)
 	maxVisible := min(max(contentH-overlayListChromeFilterable(), 1), max(len(items), 1))
-	// Namespace scroll lives in ui.overlayNsScroll so the mouse-click row
-	// resolver can read it. VimScrollOff gives sticky scrolloff behaviour;
-	// stateless cursor-only math pinned the cursor to viewport edges,
-	// which made scroll-up feel like the list was shifting instead of the
-	// cursor moving (issue reported during smoke testing).
-	prev := ui.GetOverlayNsScroll()
+	// VimScrollOff gives sticky scrolloff behaviour. Stateless cursor-only
+	// math pinned the cursor to viewport edges, making scroll-up look like
+	// the list was shifting instead of the cursor moving.
+	prev := ui.OverlayNsScroll
 	identity := func(from, to int) int { return to - from }
 	scroll := ui.VimScrollOff(prev, m.overlayCursor, len(items), maxVisible, ui.ConfigScrollOff, identity)
-	ui.SetOverlayNsScroll(scroll)
+	ui.OverlayNsScroll = scroll
 
 	listItems := make([]ui.OverlayListItem, len(items))
 	for i, it := range items {

--- a/internal/app/whichkey_diff.go
+++ b/internal/app/whichkey_diff.go
@@ -11,7 +11,7 @@ import (
 // the visual handler has no case for the toggles, the search key, the folds, or
 // q — pressing them there is a silent no-op, not a fallthrough.
 //
-// The diff itself is resolved once because ui.computeDiff builds an O(nxm) LCS
+// The diff itself is resolved once because ui.ComputeDiffLines builds an O(nxm) LCS
 // table (overlay_diff.go:20-50) and three entries need a different fact off the
 // same pass: the visible-line count handleDiffNormalCopy stops at, the fold
 // region under the cursor, and the text the yank would copy.
@@ -43,7 +43,7 @@ type wkDiffCtx struct {
 
 // newWKDiffCtx resolves the diff and the cursor's line once per availability
 // pass. Safe on a zero-value Model: the cache pointer is nil-safe and
-// computeDiff of two empty strings yields no lines, so every bound below is a
+// ComputeDiffLines of two empty strings yields no lines, so every bound below is a
 // length compare.
 //
 // The diff comes from the viewer's memo, not a fresh pass: this runs on every

--- a/internal/app/whichkey_diff_memo_test.go
+++ b/internal/app/whichkey_diff_memo_test.go
@@ -10,7 +10,7 @@ import (
 
 // wkDiffBenchModel is a diff viewer holding two manifests of a size the app
 // really opens (a ~400-line rendered Deployment against its live copy), with
-// enough unchanged runs to make folds real. computeDiff is O(nxm), so the cost
+// enough unchanged runs to make folds real. ComputeDiffLines is O(nxm), so the cost
 // this measures grows quadratically with the document — a 40-line fixture
 // would hide the whole finding.
 func wkDiffBenchModel() Model {

--- a/internal/logagg/detect.go
+++ b/internal/logagg/detect.go
@@ -9,19 +9,19 @@ func AllKinds() []ProfileKind {
 func ParserFor(kind ProfileKind) Parser {
 	switch kind {
 	case ProfileTraefikJSON:
-		return NewTraefikJSONParser()
+		return traefikParser{}
 	case ProfileIngressNginx:
-		return NewIngressNginxParser()
+		return ingressNginxParser{}
 	case ProfileNginx:
-		return NewNginxParser()
+		return nginxParser{}
 	case ProfileEnvoy:
-		return NewEnvoyParser()
+		return envoyParser{}
 	case ProfileLogfmt:
-		return NewLogfmtParser()
+		return logfmtParser{}
 	case ProfileJSON:
-		return NewJSONParser()
+		return jsonParser{}
 	default:
-		return NewJSONParser()
+		return jsonParser{}
 	}
 }
 

--- a/internal/logagg/detect_test.go
+++ b/internal/logagg/detect_test.go
@@ -49,17 +49,17 @@ func TestDetectKind_PrefersStructuredOverGeneric(t *testing.T) {
 }
 
 func TestParserFor(t *testing.T) {
-	if ParserFor(ProfileTraefikJSON).Kind() != ProfileTraefikJSON {
-		t.Error("ParserFor(traefik) returned wrong kind")
+	if _, ok := ParserFor(ProfileTraefikJSON).(traefikParser); !ok {
+		t.Error("ParserFor(traefik) returned wrong type")
 	}
-	if ParserFor("nonsense").Kind() != ProfileJSON {
+	if _, ok := ParserFor("nonsense").(jsonParser); !ok {
 		t.Error("ParserFor(unknown) should fall back to JSON")
 	}
-	if ParserFor(ProfileIngressNginx).Kind() != ProfileIngressNginx {
-		t.Error("ParserFor(ingress-nginx) returned wrong kind")
+	if _, ok := ParserFor(ProfileIngressNginx).(ingressNginxParser); !ok {
+		t.Error("ParserFor(ingress-nginx) returned wrong type")
 	}
-	if ParserFor(ProfileEnvoy).Kind() != ProfileEnvoy {
-		t.Error("ParserFor(envoy) returned wrong kind")
+	if _, ok := ParserFor(ProfileEnvoy).(envoyParser); !ok {
+		t.Error("ParserFor(envoy) returned wrong type")
 	}
 }
 

--- a/internal/logagg/fields.go
+++ b/internal/logagg/fields.go
@@ -30,6 +30,5 @@ const (
 
 // Parser turns a single log line into normalized Fields.
 type Parser interface {
-	Kind() ProfileKind
 	Parse(line string) (Fields, bool)
 }

--- a/internal/logagg/parse_envoy.go
+++ b/internal/logagg/parse_envoy.go
@@ -13,13 +13,9 @@ var envoyRe = regexp.MustCompile(`^\[[^\]]*\] "([A-Z]+) (\S+)[^"]*" (\d{3}) \S+ 
 // envoyQuotedRe captures all double-quoted tokens from a line.
 var envoyQuotedRe = regexp.MustCompile(`"([^"]*)"`)
 
-type envoyParser struct{}
-
-// NewEnvoyParser parses Envoy's default access log text format as used by
+// envoyParser parses Envoy's default access log text format as used by
 // Istio, Contour, Emissary, Gloo, and Gateway API.
-func NewEnvoyParser() Parser { return envoyParser{} }
-
-func (envoyParser) Kind() ProfileKind { return ProfileEnvoy }
+type envoyParser struct{}
 
 func (envoyParser) Parse(line string) (Fields, bool) {
 	m := envoyRe.FindStringSubmatch(line)

--- a/internal/logagg/parse_envoy_test.go
+++ b/internal/logagg/parse_envoy_test.go
@@ -46,7 +46,7 @@ func TestEnvoyParser_Parse(t *testing.T) {
 			wantOK: false,
 		},
 	}
-	p := NewEnvoyParser()
+	p := envoyParser{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := p.Parse(tt.line)
@@ -70,16 +70,10 @@ func TestEnvoyParser_Parse(t *testing.T) {
 	}
 }
 
-func TestEnvoyParser_Kind(t *testing.T) {
-	if NewEnvoyParser().Kind() != ProfileEnvoy {
-		t.Error("Kind() != ProfileEnvoy")
-	}
-}
-
 // TestEnvoyParser_TruncatedLine verifies that a truncated Envoy log line (fewer
 // than 5 quoted tokens) does not set host/service even when it parses successfully.
 func TestEnvoyParser_TruncatedLine(t *testing.T) {
-	p := NewEnvoyParser()
+	p := envoyParser{}
 
 	// Truncated line: only request-line quoted token (1 quoted token) — method/path/status still extracted.
 	truncLine := `[2023-10-10T13:55:36.000Z] "GET /api/health HTTP/1.1" 200 - 0 5 3 2`

--- a/internal/logagg/parse_ingress_nginx.go
+++ b/internal/logagg/parse_ingress_nginx.go
@@ -11,13 +11,9 @@ import (
 // Group 1 = request_time (seconds, float), group 2 = proxy_upstream_name.
 var ingressTailRe = regexp.MustCompile(`"\s+\d+\s+([\d.]+)\s+\[([^\]]*)\]`)
 
-type ingressNginxParser struct{}
-
-// NewIngressNginxParser parses the NGINX Ingress Controller default
+// ingressNginxParser parses the NGINX Ingress Controller default
 // log-format-upstream, which is CLF-core plus ingress-specific trailing fields.
-func NewIngressNginxParser() Parser { return ingressNginxParser{} }
-
-func (ingressNginxParser) Kind() ProfileKind { return ProfileIngressNginx }
+type ingressNginxParser struct{}
 
 func (ingressNginxParser) Parse(line string) (Fields, bool) {
 	m := nginxRe.FindStringSubmatch(line)

--- a/internal/logagg/parse_ingress_nginx_test.go
+++ b/internal/logagg/parse_ingress_nginx_test.go
@@ -40,7 +40,7 @@ func TestIngressNginxParser_Parse(t *testing.T) {
 			wantOK: false,
 		},
 	}
-	p := NewIngressNginxParser()
+	p := ingressNginxParser{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := p.Parse(tt.line)
@@ -61,11 +61,5 @@ func TestIngressNginxParser_Parse(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestIngressNginxParser_Kind(t *testing.T) {
-	if NewIngressNginxParser().Kind() != ProfileIngressNginx {
-		t.Error("Kind() != ProfileIngressNginx")
 	}
 }

--- a/internal/logagg/parse_json.go
+++ b/internal/logagg/parse_json.go
@@ -47,13 +47,9 @@ var jsonKeyAliases = map[string]string{
 	"upstream_host": FieldService, "upstream": FieldService, "proxy_upstream_name": FieldService,
 }
 
-type jsonParser struct{}
-
-// NewJSONParser parses single-line JSON objects, mapping common keys to
+// jsonParser parses single-line JSON objects, mapping common keys to
 // normalized fields and keeping all other scalar keys verbatim.
-func NewJSONParser() Parser { return jsonParser{} }
-
-func (jsonParser) Kind() ProfileKind { return ProfileJSON }
+type jsonParser struct{}
 
 func (jsonParser) Parse(line string) (Fields, bool) {
 	line = strings.TrimSpace(line)

--- a/internal/logagg/parse_json_test.go
+++ b/internal/logagg/parse_json_test.go
@@ -40,7 +40,7 @@ func TestJSONParser_Parse(t *testing.T) {
 			},
 		},
 	}
-	p := NewJSONParser()
+	p := jsonParser{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := p.Parse(tt.line)
@@ -112,7 +112,7 @@ func TestLogfmtParser_Parse(t *testing.T) {
 			},
 		},
 	}
-	p := NewLogfmtParser()
+	p := logfmtParser{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := p.Parse(tt.line)

--- a/internal/logagg/parse_logfmt.go
+++ b/internal/logagg/parse_logfmt.go
@@ -6,12 +6,8 @@ import (
 
 var logfmtPairRe = regexp.MustCompile(`(\w[\w.-]*)=("([^"]*)"|\S+)`)
 
+// logfmtParser parses key=value (logfmt) lines.
 type logfmtParser struct{}
-
-// NewLogfmtParser parses key=value (logfmt) lines.
-func NewLogfmtParser() Parser { return logfmtParser{} }
-
-func (logfmtParser) Kind() ProfileKind { return ProfileLogfmt }
 
 func (logfmtParser) Parse(line string) (Fields, bool) {
 	matches := logfmtPairRe.FindAllStringSubmatch(line, -1)

--- a/internal/logagg/parse_nginx.go
+++ b/internal/logagg/parse_nginx.go
@@ -25,13 +25,9 @@ var nginxDurRe = regexp.MustCompile(`(\d+)ms\s*$`)
 // by the expected downstream-url and duration fields.
 var nginxRouterRe = regexp.MustCompile(`\d+ "([^"]*@[^"]*)" "[^"]*"(?:\s+\d+ms)?\s*$`)
 
-type nginxParser struct{}
-
-// NewNginxParser parses NCSA Common/Combined Log Format access logs (nginx,
+// nginxParser parses NCSA Common/Combined Log Format access logs (nginx,
 // Apache, and Traefik's "common" access-log format).
-func NewNginxParser() Parser { return nginxParser{} }
-
-func (nginxParser) Kind() ProfileKind { return ProfileNginx }
+type nginxParser struct{}
 
 func (nginxParser) Parse(line string) (Fields, bool) {
 	m := nginxRe.FindStringSubmatch(line)

--- a/internal/logagg/parse_nginx_test.go
+++ b/internal/logagg/parse_nginx_test.go
@@ -38,7 +38,7 @@ func TestNginxParser_Parse(t *testing.T) {
 			wantOK: false,
 		},
 	}
-	p := NewNginxParser()
+	p := nginxParser{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := p.Parse(tt.line)
@@ -69,7 +69,7 @@ func TestNginxParser_Parse(t *testing.T) {
 
 // TestNginxParser_RouterExtraction tests Traefik router name extraction.
 func TestNginxParser_RouterExtraction(t *testing.T) {
-	p := NewNginxParser()
+	p := nginxParser{}
 
 	// Traefik CLF line with router name.
 	traefikLine := `10.42.2.19 - - [18/Jun/2026:15:18:46 +0000] "GET /api/health HTTP/1.1" 200 0 "-" "-" 100 "websecure-gitlab@kubernetes" "http://10.42.1.1:8080" 3ms`
@@ -95,7 +95,7 @@ func TestNginxParser_RouterExtraction(t *testing.T) {
 // TestNginxParser_AtInUserAgent verifies that an "@"-sign in the user-agent field
 // of a plain combined log line does NOT trigger router extraction.
 func TestNginxParser_AtInUserAgent(t *testing.T) {
-	p := NewNginxParser()
+	p := nginxParser{}
 
 	// Plain combined log line whose UA contains "@" — must NOT set router.
 	uaLine := `192.0.2.1 - - [10/Oct/2000:13:55:36 -0700] "GET /index.html HTTP/1.0" 200 2326 "-" "bot@example.com"`

--- a/internal/logagg/parse_traefik.go
+++ b/internal/logagg/parse_traefik.go
@@ -6,13 +6,9 @@ import (
 	"strings"
 )
 
-type traefikParser struct{}
-
-// NewTraefikJSONParser parses Traefik access logs in JSON format. Duration is
+// traefikParser parses Traefik access logs in JSON format. Duration is
 // reported in nanoseconds and converted to milliseconds.
-func NewTraefikJSONParser() Parser { return traefikParser{} }
-
-func (traefikParser) Kind() ProfileKind { return ProfileTraefikJSON }
+type traefikParser struct{}
 
 func (traefikParser) Parse(line string) (Fields, bool) {
 	line = strings.TrimSpace(line)

--- a/internal/logagg/parse_traefik_test.go
+++ b/internal/logagg/parse_traefik_test.go
@@ -44,7 +44,7 @@ func TestTraefikParser_Parse(t *testing.T) {
 			wantOK: false,
 		},
 	}
-	p := NewTraefikJSONParser()
+	p := traefikParser{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := p.Parse(tt.line)

--- a/internal/ui/cluster_color_overlay.go
+++ b/internal/ui/cluster_color_overlay.go
@@ -13,18 +13,8 @@ const ClusterColorNoneLabel = "None  (clear)"
 
 // ClusterColorSwatchN returns a width-cell coloured block for the given
 // color name, suitable for use as an OverlayListItem.Badge. Empty or
-// unknown names render as plain spaces so the "None" row stays aligned
-// without a visible swatch.
-func ClusterColorSwatchN(name string, width int) string {
-	return clusterColorSwatchBgN(name, width)
-}
-
-// clusterColorSwatchBgN returns a swatchW-cell coloured block rendered
-// as a background tint on whitespace. Empty / unknown name returns plain
-// spaces so the "None" row stays aligned with the colour rows without
-// adding a visible swatch. Routes through clusterColorBg so theme-mapped
-// names (red/yellow/green/blue) follow the active colorscheme.
-func clusterColorSwatchBgN(name string, swatchW int) string {
+// unknown names render as plain spaces so the "None" row stays aligned.
+func ClusterColorSwatchN(name string, swatchW int) string {
 	bg := clusterColorBg(name)
 	if bg == nil {
 		return strings.Repeat(" ", swatchW)

--- a/internal/ui/config_keybindings.go
+++ b/internal/ui/config_keybindings.go
@@ -473,7 +473,7 @@ func IsNamedKey(s string) bool { return namedKeys[s] }
 // as a word ("ctrl+p", "shift+tab", "pgup", "f12"). So the modifiers come off
 // first and the key under them must then be a single rune or a named key.
 //
-// splitModifierChord is deliberately not reused: it refuses the literal "+" key
+// SplitModifierChord is deliberately not reused: it refuses the literal "+" key
 // ("ctrl++") so the display path leaves such chords textual, but that is a real
 // keypress this predicate has to accept.
 func IsSingleKeypress(s string) bool {

--- a/internal/ui/diff_cache.go
+++ b/internal/ui/diff_cache.go
@@ -27,8 +27,8 @@ func (r *ResolvedDiff) LineText(visibleIdx, side int, unified bool) string {
 }
 
 // DiffCache memoizes the last ResolvedDiff so a caller that resolves the same
-// diff every frame pays computeDiff's O(nxm) LCS table once instead of once
-// per frame.
+// diff every frame pays ComputeDiffLines's O(nxm) LCS table once instead of
+// once per frame.
 //
 // Validity is checked against the INPUTS rather than tracked by a generation
 // counter the mutation sites would have to remember to bump: foldState is
@@ -53,7 +53,7 @@ func (c *DiffCache) Resolve(left, right string, foldState []bool) *ResolvedDiff 
 	if c != nil && c.resolved != nil && c.left == left && c.right == right && slices.Equal(c.foldState, foldState) {
 		return c.resolved
 	}
-	lines := computeDiff(left, right)
+	lines := ComputeDiffLines(left, right)
 	regions := ComputeDiffFoldRegionsFromLines(lines)
 	resolved := &ResolvedDiff{
 		lines:   lines,

--- a/internal/ui/diff_fold.go
+++ b/internal/ui/diff_fold.go
@@ -34,12 +34,12 @@ type VisibleDiffLine struct {
 // unchanged ('=') lines longer than 6 lines. Each such run is a foldable
 // region with 3 lines of context kept at each end.
 func ComputeDiffFoldRegions(left, right string) []DiffFoldRegion {
-	diffLines := computeDiff(left, right)
+	diffLines := ComputeDiffLines(left, right)
 	return ComputeDiffFoldRegionsFromLines(diffLines)
 }
 
 // ComputeDiffFoldRegionsFromLines is ComputeDiffFoldRegions for a caller that
-// already holds the diff. computeDiff builds an O(nxm) LCS table, so a caller
+// already holds the diff. ComputeDiffLines builds an O(nxm) LCS table, so a caller
 // needing both the regions and the raw lines must not pay for it twice.
 func ComputeDiffFoldRegionsFromLines(diffLines []diffLine) []DiffFoldRegion {
 	var regions []DiffFoldRegion

--- a/internal/ui/diff_fold_test.go
+++ b/internal/ui/diff_fold_test.go
@@ -65,7 +65,7 @@ func TestBuildVisibleDiffLines(t *testing.T) {
 		lines[i] = "line"
 	}
 	content := strings.Join(lines, "\n")
-	diffLines := computeDiff(content, content)
+	diffLines := ComputeDiffLines(content, content)
 	regions := ComputeDiffFoldRegionsFromLines(diffLines)
 
 	t.Run("no folds applied shows all lines", func(t *testing.T) {
@@ -208,10 +208,10 @@ func TestUpdateDiffSearchMatches(t *testing.T) {
 }
 
 func TestDiffSearchColumnInLine(t *testing.T) {
-	assert.Equal(t, 6, DiffSearchColumnInLine("name: test value", "test"))
-	assert.Equal(t, 0, DiffSearchColumnInLine("test at start", "test"))
-	assert.Equal(t, -1, DiffSearchColumnInLine("no match", "xyz"))
-	assert.Equal(t, -1, DiffSearchColumnInLine("", "test"))
+	assert.Equal(t, 6, FindColumnInLine("name: test value", "test"))
+	assert.Equal(t, 0, FindColumnInLine("test at start", "test"))
+	assert.Equal(t, -1, FindColumnInLine("no match", "xyz"))
+	assert.Equal(t, -1, FindColumnInLine("", "test"))
 }
 
 func TestDiffVisibleIndexForOriginal(t *testing.T) {

--- a/internal/ui/help_keys.go
+++ b/internal/ui/help_keys.go
@@ -121,7 +121,7 @@ func helpKeyDisplaySeparated(key string) string {
 
 // chordText is helpKeyDisplay's per-token worker.
 func chordText(tok string) string {
-	mods, last, ok := splitModifierChord(strings.ToLower(tok))
+	mods, last, ok := SplitModifierChord(strings.ToLower(tok))
 	if !ok {
 		return tok
 	}
@@ -160,7 +160,7 @@ func helpKeySymbols(key string) string {
 	bareKeyEligible := !strings.ContainsAny(key, " -")
 	symbols := mapChordTokens(key, func(tok string) string {
 		lower := strings.ToLower(tok)
-		if _, _, ok := splitModifierChord(lower); ok {
+		if _, _, ok := SplitModifierChord(lower); ok {
 			return KeyChordDisplay(lower)
 		}
 		if bareKeyEligible {

--- a/internal/ui/keysymbols.go
+++ b/internal/ui/keysymbols.go
@@ -99,11 +99,10 @@ func iconModeDrawsSymbols() bool {
 	return false
 }
 
-// splitModifierChord splits a modified chord into its modifier names and the
-// key they apply to. ok is false for anything that is not one — a plain binding,
-// a binding that merely contains "+" (the literal "+" key, "ctrl++"), or a
-// segment that is not a known modifier.
-func splitModifierChord(key string) (mods []string, last string, ok bool) {
+// SplitModifierChord splits a modified chord into its modifier names and the
+// key they apply to. ok is false for the literal "+" key ("ctrl++") and any
+// unmodified or unrecognized-modifier binding.
+func SplitModifierChord(key string) (mods []string, last string, ok bool) {
 	parts := strings.Split(key, "+")
 	if len(parts) < 2 {
 		return nil, "", false
@@ -118,14 +117,6 @@ func splitModifierChord(key string) (mods []string, last string, ok bool) {
 		return nil, "", false
 	}
 	return parts[:len(parts)-1], last, true
-}
-
-// SplitModifierChord exposes splitModifierChord to other packages that need
-// the raw modifier set behind a binding — e.g. the which-key panel's sort,
-// which groups entries by modifier tier and must not grow a second chord
-// parser next to this one.
-func SplitModifierChord(key string) (mods []string, last string, ok bool) {
-	return splitModifierChord(key)
 }
 
 // titleKeyName uppercases a chord's key rune-wise, so a multibyte key is never
@@ -159,7 +150,7 @@ func KeyChordDisplay(key string) string {
 		}
 		return key
 	}
-	chord, last, ok := splitModifierChord(key)
+	chord, last, ok := SplitModifierChord(key)
 	if !ok {
 		return key
 	}

--- a/internal/ui/listsummary.go
+++ b/internal/ui/listsummary.go
@@ -241,10 +241,13 @@ func BuildListSummary(kind string, items []model.Item) ListSummary {
 	return s
 }
 
+// Status values are cluster-controlled, so each one is sanitized before
+// bucketing: a hostile CRD status could embed escapes into this
+// always-visible dashboard band.
 func buildSummaryBar(dim summaryDimension, items []model.Item) SummaryBar {
 	counts := make(map[string]int)
 	for _, it := range items {
-		v := strings.TrimSpace(sanitizeSummaryValue(dim.valueOf(it)))
+		v := strings.TrimSpace(SanitizeTerminalText(dim.valueOf(it)))
 		if v == "" {
 			continue
 		}
@@ -268,19 +271,6 @@ func buildSummaryBar(dim summaryDimension, items []model.Item) SummaryBar {
 		return bi.Value < bj.Value
 	})
 	return bar
-}
-
-// sanitizeSummaryValue strips ASCII control characters (including ESC and
-// DEL) and the C1 control range (U+0080-U+009F, e.g. U+009B "CSI") from a
-// status value before it is bucketed and rendered. Status values
-// (.status.phase, condition types) come from cluster-controlled resources -
-// a hostile CRD status could embed cursor-movement or OSC-52 clipboard-write
-// escapes, and this is the single choke point every summary value passes
-// through on its way to the always-visible dashboard band. C1 controls are
-// UTF-8-encoded as two bytes but decode to a single rune >= 0x7f, so an
-// ASCII-only filter (r < 0x20 || r == 0x7f) lets them through as if printable.
-func sanitizeSummaryValue(s string) string {
-	return SanitizeTerminalText(s)
 }
 
 // SanitizeTerminalText strips control characters and bidi overrides from a

--- a/internal/ui/logpreview.go
+++ b/internal/ui/logpreview.go
@@ -705,7 +705,7 @@ func buildPreviewBody(parsed ParsedLogPreview, contentWidth int) []string {
 		return lines
 	}
 	for src := range strings.SplitSeq(body, "\n") {
-		lines = append(lines, wrapLine(sanitizeLogLine(src, ConfigLogRenderAnsi), contentWidth)...)
+		lines = append(lines, WrapLine(sanitizeLogLine(src, ConfigLogRenderAnsi), contentWidth)...)
 	}
 	return lines
 }
@@ -731,7 +731,7 @@ func renderPreviewFields(fields []LogPreviewField, width int) []string {
 		prefix := keyStyle.Render(key) + strings.Repeat(" ", keyWidth-lipgloss.Width(key)) + sepStyle.Render(" : ")
 		first := true
 		for line := range strings.SplitSeq(f.Value, "\n") {
-			chunks := wrapLine(sanitizeLogLine(line, ConfigLogRenderAnsi), availForValue)
+			chunks := WrapLine(sanitizeLogLine(line, ConfigLogRenderAnsi), availForValue)
 			if len(chunks) == 0 {
 				chunks = []string{""}
 			}

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -405,7 +405,7 @@ func renderWrappedLines(lines []string, scroll, height, width int, lineNumbers b
 	for i := scroll; i < end && len(result) < height; i++ {
 		line := lines[i]
 		isSelected := selStart >= 0 && i >= selStart && i <= selEnd
-		wrapped := wrapLine(line, availWidth)
+		wrapped := WrapLine(line, availWidth)
 		for j, wl := range wrapped {
 			if skipped < topSkip {
 				skipped++
@@ -472,19 +472,10 @@ func renderWrappedLines(lines []string, scroll, height, width int, lineNumbers b
 	return result, cursorRow, cursorCol
 }
 
-// WrapLine splits a line into chunks of at most width runes.
-// Exported for reuse in YAML, describe, and diff view wrapping.
+// WrapLine hard-wraps a line to width visual columns, for reuse in YAML,
+// describe, and diff view wrapping. Uses ansi.Hardwrap so embedded SGR
+// sequences survive the split instead of leaking "0m"/"[NNm" as literal text.
 func WrapLine(line string, width int) []string {
-	return wrapLine(line, width)
-}
-
-// wrapLine splits a line into chunks of at most width runes.
-// wrapLine hard-wraps a log line to width visual columns. Uses ansi.Hardwrap
-// so embedded SGR sequences (kyverno timestamps, klog level colors, etc.)
-// stay intact across the split — rune-slicing instead would split mid-CSI
-// and leak "0m"/"[NNm" as literal text or chop real content because escape
-// bytes are zero-width but consume rune budget.
-func wrapLine(line string, width int) []string {
 	if width <= 0 {
 		return []string{line}
 	}

--- a/internal/ui/logviewer_test.go
+++ b/internal/ui/logviewer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// --- wrapLine ---
+// --- WrapLine ---
 
 func TestWrapLine(t *testing.T) {
 	tests := []struct {
@@ -74,13 +74,13 @@ func TestWrapLine(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, wrapLine(tt.line, tt.width))
+			assert.Equal(t, tt.expected, WrapLine(tt.line, tt.width))
 		})
 	}
 }
 
 // Regression: producer-colored kyverno-style log rows in wrap mode lost
-// text mid-line. wrapLine rune-sliced the input, but ANSI escape sequences
+// text mid-line. WrapLine rune-sliced the input, but ANSI escape sequences
 // occupy several rune slots while contributing zero visual width. A wrap
 // at `width` runes regularly cut mid-SGR (e.g. between `\x1b[` and `90m`)
 // or chopped real text early because the rune budget was eaten by the
@@ -93,7 +93,7 @@ func TestWrapLine_PreservesANSIAndSplitsByVisualWidth(t *testing.T) {
 	// SGR runs around each field. ANSI bytes are zero-width and must not
 	// consume the wrap budget.
 	line := "\x1b[90mtimestamp\x1b[0m \x1b[34mlevel\x1b[0m message1"
-	parts := wrapLine(line, 16)
+	parts := WrapLine(line, 16)
 
 	// Stripped concatenation of the wrap parts must equal the stripped
 	// original (no characters lost mid-line).

--- a/internal/ui/overlay.go
+++ b/internal/ui/overlay.go
@@ -6,21 +6,10 @@ import (
 	"github.com/janosmiko/lfk/internal/tainted"
 )
 
-// overlayNsScroll is the persistent scroll position for the namespace overlay.
-var overlayNsScroll int
-
-// ResetOverlayNsScroll resets the namespace overlay scroll position (call when opening the overlay).
-func ResetOverlayNsScroll() { overlayNsScroll = 0 }
-
-// GetOverlayNsScroll returns the current scroll offset of the namespace
-// overlay. Used by mouse click resolution to translate a click row into
-// the correct item index in the underlying items slice.
-func GetOverlayNsScroll() int { return overlayNsScroll }
-
-// SetOverlayNsScroll updates the namespace-overlay scroll state. Called by
-// the namespace OverlayList helper on every render so mouse-click row
-// resolution stays in sync with the rendered scroll window.
-func SetOverlayNsScroll(s int) { overlayNsScroll = s }
+// OverlayNsScroll is the persistent scroll position for the namespace
+// overlay, read by mouse click resolution and written by the OverlayList
+// helper on every render.
+var OverlayNsScroll int
 
 // ErrorLogEntry stores a single application log entry with its timestamp and severity level.
 type ErrorLogEntry struct {

--- a/internal/ui/overlay_diff.go
+++ b/internal/ui/overlay_diff.go
@@ -15,9 +15,9 @@ type diffLine struct {
 	status byte   // '=' same, '<' only left, '>' only right, '~' both present but different
 }
 
-// computeDiff produces a line-by-line diff of two YAML texts using a simple
-// longest-common-subsequence algorithm, then pairs up the differences.
-func computeDiff(leftText, rightText string) []diffLine {
+// ComputeDiffLines produces a line-by-line diff of two YAML texts using a
+// simple longest-common-subsequence algorithm, then pairs up the differences.
+func ComputeDiffLines(leftText, rightText string) []diffLine {
 	leftLines := strings.Split(leftText, "\n")
 	rightLines := strings.Split(rightText, "\n")
 
@@ -82,7 +82,7 @@ const diffTabWidth = "    "
 
 // expandDiffTabs sizes width-based rendering (padRight, Truncate, WrapLine)
 // on tab-free text so a tab's terminal column advance isn't measured as
-// zero cells. Diffing, folding, and copy paths keep using computeDiff as-is.
+// zero cells. Diffing, folding, and copy paths keep using ComputeDiffLines as-is.
 func expandDiffTabs(lines []diffLine) []diffLine {
 	out := make([]diffLine, len(lines))
 	for i, dl := range lines {
@@ -93,16 +93,11 @@ func expandDiffTabs(lines []diffLine) []diffLine {
 	return out
 }
 
-// ComputeDiffLines is the exported wrapper for computeDiff.
-func ComputeDiffLines(left, right string) []diffLine {
-	return computeDiff(left, right)
-}
-
 // DiffViewTotalLines returns the total number of scrollable lines for a
 // side-by-side diff view after applying fold state. The header and separator
 // are rendered outside the scrollable area, so they are not counted here.
 func DiffViewTotalLines(left, right string, foldRegions []DiffFoldRegion, foldState []bool) int {
-	diffLines := computeDiff(left, right)
+	diffLines := ComputeDiffLines(left, right)
 	visLines := BuildVisibleDiffLines(diffLines, foldRegions, foldState)
 	return len(visLines)
 }
@@ -126,7 +121,7 @@ type DiffVisualParams struct {
 // currentMatchLine is the original diff line index of the current n/N match
 // (-1 means none). That line gets the distinct SelectedSearchHighlightStyle.
 func RenderDiffView(left, right, leftName, rightName string, scroll, width, height int, lineNumbers, wrap bool, searchQuery string, foldRegions []DiffFoldRegion, foldState []bool, searchMode bool, searchInput string, cursor, currentMatchLine int, vp DiffVisualParams, footerOverride string) string { //nolint:gocyclo // rendering function with inherent layout complexity
-	rawDiffLines := expandDiffTabs(computeDiff(left, right))
+	rawDiffLines := expandDiffTabs(ComputeDiffLines(left, right))
 	visLines := BuildVisibleDiffLines(rawDiffLines, foldRegions, foldState)
 
 	// Styles for diff highlighting.
@@ -266,7 +261,7 @@ func RenderDiffView(left, right, leftName, rightName string, scroll, width, heig
 // currentMatchLine is the original diff line index of the current n/N match
 // (-1 means none). That line gets the distinct SelectedSearchHighlightStyle.
 func RenderUnifiedDiffView(left, right, leftName, rightName string, scroll, width, height int, lineNumbers, wrap bool, searchQuery string, foldRegions []DiffFoldRegion, foldState []bool, searchMode bool, searchInput string, cursor, currentMatchLine int, vp DiffVisualParams, footerOverride string) string { //nolint:gocyclo // rendering function with inherent layout complexity
-	rawDiffLines := expandDiffTabs(computeDiff(left, right))
+	rawDiffLines := expandDiffTabs(ComputeDiffLines(left, right))
 	visLines := BuildVisibleDiffLines(rawDiffLines, foldRegions, foldState)
 
 	// Styles.
@@ -467,7 +462,7 @@ func RenderUnifiedDiffView(left, right, leftName, rightName string, scroll, widt
 // lines for a unified diff view after applying fold state. The --- and +++
 // header lines are always visible but not part of the cursor range.
 func UnifiedDiffViewTotalLines(left, right string, foldRegions []DiffFoldRegion, foldState []bool) int {
-	diffLines := computeDiff(left, right)
+	diffLines := ComputeDiffLines(left, right)
 	visLines := BuildVisibleDiffLines(diffLines, foldRegions, foldState)
 	return len(visLines)
 }
@@ -479,7 +474,7 @@ func UpdateDiffSearchMatches(left, right, query string, side int, unified bool) 
 	if query == "" {
 		return nil
 	}
-	diffLines := computeDiff(left, right)
+	diffLines := ComputeDiffLines(left, right)
 	var matches []int
 	for i, dl := range diffLines {
 		var text string
@@ -501,17 +496,10 @@ func UpdateDiffSearchMatches(left, right, query string, side int, unified bool) 
 	return matches
 }
 
-// DiffSearchColumnInLine returns the rune column of the first match of query
-// in the given diff line text, or -1 if not found.
-// Supports substring, regex, and fuzzy search modes.
-func DiffSearchColumnInLine(lineText, query string) int {
-	return FindColumnInLine(lineText, query)
-}
-
 // DiffVisibleIndexForOriginal finds the visible line index corresponding to
 // the given original diff line index, or -1 if hidden.
 func DiffVisibleIndexForOriginal(left, right string, foldRegions []DiffFoldRegion, foldState []bool, origIdx int) int {
-	diffLines := computeDiff(left, right)
+	diffLines := ComputeDiffLines(left, right)
 	visLines := BuildVisibleDiffLines(diffLines, foldRegions, foldState)
 	for i, vl := range visLines {
 		if vl.Original == origIdx {
@@ -526,13 +514,13 @@ func DiffVisibleIndexForOriginal(left, right string, foldRegions []DiffFoldRegio
 // For unified mode, it returns whichever side has content.
 // Returns empty string if the index is out of range or the line is a fold placeholder.
 func DiffLineTextAt(left, right string, foldRegions []DiffFoldRegion, foldState []bool, visibleIdx, side int, unified bool) string {
-	rawDiffLines := computeDiff(left, right)
+	rawDiffLines := ComputeDiffLines(left, right)
 	visLines := BuildVisibleDiffLines(rawDiffLines, foldRegions, foldState)
 	return DiffLineTextIn(rawDiffLines, visLines, visibleIdx, side, unified)
 }
 
 // DiffLineTextIn is DiffLineTextAt for a caller that already holds the computed
-// diff. computeDiff builds an O(nxm) LCS table, so a caller resolving several
+// diff. ComputeDiffLines builds an O(nxm) LCS table, so a caller resolving several
 // facts about the same diff (the which-key panel does: total lines, the fold
 // region at the cursor, the yank target) must reuse one pass rather than pay
 // for one per fact.

--- a/internal/ui/overlay_monitoring.go
+++ b/internal/ui/overlay_monitoring.go
@@ -9,37 +9,15 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// overlaySchemeScroll is the persistent scroll position for the colorscheme overlay.
-var overlaySchemeScroll int
+// OverlaySchemeScroll is the persistent scroll position for the colorscheme
+// overlay, written by renderColorschemeOverlay on every render and read by
+// mouse-click row resolution in update_overlays_selectors.go.
+var OverlaySchemeScroll int
 
-// ResetOverlaySchemeScroll resets the colorscheme overlay scroll to the top.
-func ResetOverlaySchemeScroll() { overlaySchemeScroll = 0 }
-
-// GetOverlaySchemeScroll returns the current colorscheme overlay scroll position.
-func GetOverlaySchemeScroll() int { return overlaySchemeScroll }
-
-// SetOverlaySchemeScroll updates the colorscheme-overlay scroll state. Called
-// by the renderColorschemeOverlay helper on every render so mouse-click row
-// resolution in update_overlays_selectors.go keeps resolving rows correctly.
-func SetOverlaySchemeScroll(s int) { overlaySchemeScroll = s }
-
-// overlaySchemeVisible mirrors the viewport size last used by the
-// colorscheme overlay renderer so the mouse-click / page-scroll
-// handlers can resolve hit rows against the correct viewport. The
-// renderer writes this on every render via SetOverlaySchemeVisible;
-// the default 20 matches the legacy constant for the brief window
-// before the first render.
-var overlaySchemeVisible = 20
-
-// GetOverlaySchemeVisible returns the current colorscheme overlay
-// viewport size (number of display lines, including any interleaved
-// section headers).
-func GetOverlaySchemeVisible() int { return overlaySchemeVisible }
-
-// SetOverlaySchemeVisible updates the viewport size to match what the
-// renderer is actually painting. Called from renderColorschemeOverlay
-// on every render.
-func SetOverlaySchemeVisible(n int) { overlaySchemeVisible = n }
+// OverlaySchemeVisible mirrors the colorscheme overlay's rendered viewport
+// size so mouse-click / page-scroll handlers resolve hit rows correctly.
+// The default 20 covers the brief window before the first render.
+var OverlaySchemeVisible = 20
 
 // ErrorLogVisualParams holds visual selection state for the error log overlay.
 type ErrorLogVisualParams struct {

--- a/internal/ui/overlay_network.go
+++ b/internal/ui/overlay_network.go
@@ -15,18 +15,12 @@ import (
 // of ingress/egress rules using box-drawing characters and arrows. A non-empty
 // query highlights matching text in the visible lines.
 func RenderNetworkPolicyOverlay(info NetworkPolicyEntry, scroll, width, height int, query string) string {
-	return renderScrollableLines(buildNetpolOverlayLines(info, width), scroll, width, height, query)
+	return renderScrollableLines(NetworkPolicyOverlayLines(info, width), scroll, width, height, query)
 }
 
 // NetworkPolicyOverlayLines returns the full (unscrolled) styled line list of
 // the single-policy view, for search/match scanning by the key handler.
 func NetworkPolicyOverlayLines(info NetworkPolicyEntry, width int) []string {
-	return buildNetpolOverlayLines(info, width)
-}
-
-// buildNetpolOverlayLines composes the full (unscrolled) line list for the
-// single-policy view.
-func buildNetpolOverlayLines(info NetworkPolicyEntry, width int) []string {
 	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Background(SurfaceBg)
 	arrowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Background(SurfaceBg)
 	boxBorderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorBorder)).Background(SurfaceBg)
@@ -56,7 +50,7 @@ func flattenRenderedLines(lines []string) []string {
 // NetworkPolicyOverlayLineCount returns the total line count of the
 // single-policy view at the given width, for scroll clamping.
 func NetworkPolicyOverlayLineCount(info NetworkPolicyEntry, width int) int {
-	return len(buildNetpolOverlayLines(info, width))
+	return len(NetworkPolicyOverlayLines(info, width))
 }
 
 // OverlayMaxScroll returns the bottom scroll position for a scrollable
@@ -143,16 +137,11 @@ func renderNetpolTargetLabel(info NetworkPolicyEntry) string {
 	return strings.Join(parts, "\n")
 }
 
-// hasPolicyType returns true if the policy types list contains the given type.
-func hasPolicyType(types []string, target string) bool {
-	return slices.Contains(types, target)
-}
-
 // renderNetpolDirectionRules renders ingress and egress rule sections.
 func renderNetpolDirectionRules(info NetworkPolicyEntry, targetLabel string, width int, sectionStyle, boxBorderStyle, arrowStyle, labelStyle, cidrStyle, greenStyle lipgloss.Style) []string {
 	var lines []string
-	hasIngress := hasPolicyType(info.PolicyTypes, "Ingress")
-	hasEgress := hasPolicyType(info.PolicyTypes, "Egress")
+	hasIngress := slices.Contains(info.PolicyTypes, "Ingress")
+	hasEgress := slices.Contains(info.PolicyTypes, "Egress")
 
 	if hasIngress || len(info.IngressRules) > 0 {
 		lines = append(lines, sectionStyle.Render("INGRESS RULES"))

--- a/internal/ui/overlay_network_multi.go
+++ b/internal/ui/overlay_network_multi.go
@@ -12,24 +12,12 @@ import (
 // stacked, with the same diagrams as the single-policy visualizer. A non-empty
 // query highlights matching text in the visible lines.
 func RenderNetworkPoliciesOverlay(info ResourceNetpolsEntry, scroll, width, height int, query string) string {
-	return renderScrollableLines(buildNetpolsOverlayLines(info, width), scroll, width, height, query)
+	return renderScrollableLines(NetworkPoliciesOverlayLines(info, width), scroll, width, height, query)
 }
 
 // NetworkPoliciesOverlayLines returns the full (unscrolled) styled line list
 // of the multi-policy view, for search/match scanning by the key handler.
 func NetworkPoliciesOverlayLines(info ResourceNetpolsEntry, width int) []string {
-	return buildNetpolsOverlayLines(info, width)
-}
-
-// NetworkPoliciesOverlayLineCount returns the total line count of the
-// multi-policy view at the given width, for scroll clamping.
-func NetworkPoliciesOverlayLineCount(info ResourceNetpolsEntry, width int) int {
-	return len(buildNetpolsOverlayLines(info, width))
-}
-
-// buildNetpolsOverlayLines composes the full (unscrolled) line list for the
-// multi-policy view.
-func buildNetpolsOverlayLines(info ResourceNetpolsEntry, width int) []string {
 	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary)).Background(SurfaceBg)
 	arrowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)).Bold(true).Background(SurfaceBg)
 	boxBorderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorBorder)).Background(SurfaceBg)
@@ -54,6 +42,12 @@ func buildNetpolsOverlayLines(info ResourceNetpolsEntry, width int) []string {
 	}
 	lines = append(lines, "")
 	return flattenRenderedLines(lines)
+}
+
+// NetworkPoliciesOverlayLineCount returns the total line count of the
+// multi-policy view at the given width, for scroll clamping.
+func NetworkPoliciesOverlayLineCount(info ResourceNetpolsEntry, width int) int {
+	return len(NetworkPoliciesOverlayLines(info, width))
 }
 
 // renderNetpolMultiBody renders the summary line and the stacked per-policy

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -921,7 +921,7 @@ func TestDiffViewTotalLines(t *testing.T) {
 
 func TestComputeDiff(t *testing.T) {
 	t.Run("identical lines", func(t *testing.T) {
-		lines := computeDiff("a\nb\nc", "a\nb\nc")
+		lines := ComputeDiffLines("a\nb\nc", "a\nb\nc")
 		assert.Len(t, lines, 3)
 		for _, l := range lines {
 			assert.Equal(t, byte('='), l.status)
@@ -929,7 +929,7 @@ func TestComputeDiff(t *testing.T) {
 	})
 
 	t.Run("left only lines", func(t *testing.T) {
-		lines := computeDiff("a\nb\nc", "a\nc")
+		lines := ComputeDiffLines("a\nb\nc", "a\nc")
 		// a is common, b is left-only, c is common.
 		assert.Len(t, lines, 3)
 		assert.Equal(t, byte('='), lines[0].status)
@@ -939,7 +939,7 @@ func TestComputeDiff(t *testing.T) {
 	})
 
 	t.Run("right only lines", func(t *testing.T) {
-		lines := computeDiff("a\nc", "a\nb\nc")
+		lines := ComputeDiffLines("a\nc", "a\nb\nc")
 		assert.Len(t, lines, 3)
 		assert.Equal(t, byte('='), lines[0].status)
 		assert.Equal(t, byte('>'), lines[1].status)
@@ -948,7 +948,7 @@ func TestComputeDiff(t *testing.T) {
 	})
 
 	t.Run("completely different", func(t *testing.T) {
-		lines := computeDiff("a\nb", "c\nd")
+		lines := ComputeDiffLines("a\nb", "c\nd")
 		// No common lines, so all are additions/removals.
 		assert.Len(t, lines, 4)
 		leftCount := 0
@@ -966,7 +966,7 @@ func TestComputeDiff(t *testing.T) {
 	})
 
 	t.Run("empty inputs", func(t *testing.T) {
-		lines := computeDiff("", "")
+		lines := ComputeDiffLines("", "")
 		assert.Len(t, lines, 0)
 	})
 }


### PR DESCRIPTION
## Summary

Removes internal/ui functions and internal/logagg constructors whose body only called another function, and replaces eight namespace/color-scheme scroll accessors with three exported variables. No behavior change.

## Type of change

- [ ] feat: new user-facing feature
- [ ] fix: bug fix
- [x] refactor: code change that neither fixes a bug nor adds a feature
- [ ] docs: documentation only
- [ ] test: add or update tests
- [ ] chore: maintenance (dependencies, tooling)
- [ ] perf: performance improvement
- [ ] ci: CI/CD configuration

## Related issue

## Changes

- Inline single-caller delegate wrappers in internal/ui (ComputeDiffLines, ClusterColorSwatchN, WrapLine, SplitModifierChord, NetworkPolicyOverlayLines, NetworkPoliciesOverlayLines) into their exported names
- Replace direct-call wrappers (FindColumnInLine, SanitizeTerminalText, slices.Contains) with the function callers already had access to
- Replace the eight Get/Set/Reset accessors for namespace and color scheme overlay scroll state with three exported variables, matching other exported UI state
- Drop the six New*Parser constructors in internal/logagg that only returned an empty struct; ParserFor now uses the struct literals directly
- Remove Parser.Kind(), read only by tests

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [ ] README / `docs/` updated when user-visible behavior or config changed
- [ ] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)

## Screenshots / recordings
