### PR TITLE
fix: offer prometheus rightsizing strategies when prometheus is discovered

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -64,7 +64,7 @@ The Hardware category lists ResourceClaims, ResourceClaimTemplates, ResourceSlic
 
 When Prometheus holds less history than the window, the header adds the real span, for example `over last 7d (data: 5h)`. A new workload therefore cannot pass for a week of evidence.
 
-The chip shows `snapshot` with no `[N/M]` counter when it is the only strategy available. To unlock the others, point lfk at Prometheus or VictoriaMetrics (see [config-reference.md](config-reference.md#monitoring)) or create a VPA in `Off` mode for the workload. Then cycle with `[` and `]`. Keys and headroom are in [keybindings.md](keybindings.md#right-sizing-advisor).
+The chip shows `snapshot` with no `[N/M]` counter when it is the only strategy available. lfk finds Prometheus or VictoriaMetrics in the cluster by its Service labels. If the chip still shows only `snapshot`, point lfk at it (see [config-reference.md](config-reference.md#monitoring)) or create a VPA in `Off` mode for the workload. Then cycle with `[` and `]`. Keys and headroom are in [keybindings.md](keybindings.md#right-sizing-advisor).
 
 ## Pod quarantine
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -994,7 +994,7 @@ Available strategies (priority order; unavailable ones are skipped):
    targets the workload. The recommender's target is multiplied by the active headroom
    (raw target at headroom = 1.0).
 2. **1d-max** — Prometheus `max_over_time` peak over the last 1 day × headroom.
-   Available when a Prometheus endpoint is configured for the cluster.
+   Available when lfk finds Prometheus in the cluster or a Prometheus endpoint is configured.
 3. **1d-avg** — Prometheus `avg_over_time` over the last 1 day × headroom.
 4. **7d-p95** — Prometheus `quantile_over_time(0.95, ...)` over the last 7 days × headroom.
 5. **snapshot** — current metrics-server usage × headroom (always available as the

--- a/internal/k8s/client_rightsizing.go
+++ b/internal/k8s/client_rightsizing.go
@@ -32,8 +32,8 @@ func effectiveHeadroom(h float64) float64 {
 // metrics-server fallback path that produced any number is the safety
 // net). VPA appears iff a VerticalPodAutoscaler with a matching
 // targetRef exists in the namespace. Prometheus strategies appear iff
-// model.ConfigMonitoring carries a Prometheus endpoint for this
-// context (or the "_global" fallback). The returned slice preserves
+// prometheusAvailable finds a usable endpoint for this context, from
+// config or label discovery. The returned slice preserves
 // the priority order from model.AllRightsizingStrategies so the caller
 // can pick the head as the default and walk the slice on </>.
 func (c *Client) AvailableRightsizingStrategies(ctx context.Context, contextName, namespace, kind, name string) []model.RightsizingStrategy {
@@ -44,7 +44,7 @@ func (c *Client) AvailableRightsizingStrategies(ctx context.Context, contextName
 		available[model.StrategyVPA] = true
 	}
 
-	if hasPrometheusConfigured(contextName) {
+	if c.prometheusAvailable(ctx, contextName) {
 		available[model.StrategyPromMax1D] = true
 		available[model.StrategyPromAvg1D] = true
 		available[model.StrategyPromP957D] = true
@@ -57,25 +57,6 @@ func (c *Client) AvailableRightsizingStrategies(ctx context.Context, contextName
 		}
 	}
 	return out
-}
-
-// hasPrometheusConfigured reports whether ConfigMonitoring carries a
-// usable Prometheus endpoint for the given context (or the "_global"
-// fallback). Centralised so the right-sizing strategy picker and the
-// Prometheus query path agree on what "configured" means.
-func hasPrometheusConfigured(contextName string) bool {
-	cfg := model.ConfigMonitoring
-	if cfg == nil {
-		return false
-	}
-	mc, ok := cfg[contextName]
-	if !ok {
-		mc, ok = cfg["_global"]
-	}
-	if !ok {
-		return false
-	}
-	return mc.Prometheus != nil
 }
 
 // GetRightsizing builds a per-container recommendation payload for

--- a/internal/k8s/client_rightsizing_test.go
+++ b/internal/k8s/client_rightsizing_test.go
@@ -590,3 +590,47 @@ func TestAvailableRightsizingStrategies(t *testing.T) {
 		})
 	}
 }
+
+// Covers #705: label-discovered Prometheus (no monitoring: config) must
+// also unlock the strategies, matching prometheusAvailable's rule.
+func TestAvailableRightsizingStrategies_DiscoveredPrometheus(t *testing.T) {
+	prevCfg := model.ConfigMonitoring
+	model.ConfigMonitoring = nil
+	t.Cleanup(func() { model.ConfigMonitoring = prevCfg })
+
+	pod := &corev1.Pod{
+		Name: "frontend-aaa", Namespace: "default",
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+
+	t.Run("discovered service, no config -> prom strategies present", func(t *testing.T) {
+		resetMonitoringDiscoveryCache()
+		cs := fake.NewSimpleClientset(pod, monitoringSvc("monitoring", "vmsingle-vmks", "vmsingle", port("http", 8428)))
+		dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+			vpaGVRForTest(): "VerticalPodAutoscalerList",
+			{Group: "autoscaling.k8s.io", Version: "v1beta2", Resource: "verticalpodautoscalers"}: "VerticalPodAutoscalerList",
+		})
+		c := NewTestClient(cs, dyn)
+
+		got := c.AvailableRightsizingStrategies(t.Context(), "test-ctx", "default", "Pod", "frontend-aaa")
+		assert.Equal(t, []model.RightsizingStrategy{
+			model.StrategyPromMax1D,
+			model.StrategyPromAvg1D,
+			model.StrategyPromP957D,
+			model.StrategySnapshot,
+		}, got)
+	})
+
+	t.Run("no config, no service -> no prom strategies", func(t *testing.T) {
+		resetMonitoringDiscoveryCache()
+		cs := fake.NewSimpleClientset(pod)
+		dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+			vpaGVRForTest(): "VerticalPodAutoscalerList",
+			{Group: "autoscaling.k8s.io", Version: "v1beta2", Resource: "verticalpodautoscalers"}: "VerticalPodAutoscalerList",
+		})
+		c := NewTestClient(cs, dyn)
+
+		got := c.AvailableRightsizingStrategies(t.Context(), "test-ctx", "default", "Pod", "frontend-aaa")
+		assert.Equal(t, []model.RightsizingStrategy{model.StrategySnapshot}, got)
+	})
+}


### PR DESCRIPTION
- Rightsizing offered the Prometheus strategies (`[`/`]`) only when `monitoring` config named Prometheus. Sparklines also use a Prometheus that label discovery finds, so users saw sparklines but no strategies.
- `AvailableRightsizingStrategies` now uses the same `prometheusAvailable` check as pod and node metrics.

Refs #705

## Test plan
- [x] Unit test: discovered Prometheus Service, no config, strategies listed
- [x] Unit test: no config, no Service, snapshot only
- [x] `go test -race ./...`, lint
- [ ] Manual: cluster with kube-prometheus-stack, no `monitoring` config, open rightsizing on a Deployment, `[`/`]` hint shows