### PR TITLE
refactor(app): drive orphan kind lookups from one table

### DIFF
--- a/internal/app/commandbar_orphans.go
+++ b/internal/app/commandbar_orphans.go
@@ -112,25 +112,10 @@ func findOrphanPreset(presets []FilterPreset, kind string) *FilterPreset {
 }
 
 // orphanPresetNameForKind returns the preset Name used by the orphan filter
-// preset for the given Kind. The names must match those defined in filters.go.
+// preset for the given Kind, from orphanKindTable in filters.go.
 func orphanPresetNameForKind(kind string) string {
-	switch kind {
-	case "Pod":
-		return "Orphans"
-	case "Service":
-		return "No Endpoints"
-	case "Secret", "ConfigMap":
-		return "Unmounted"
-	case "PersistentVolumeClaim":
-		return "Unused"
-	case "HorizontalPodAutoscaler",
-		"PodDisruptionBudget",
-		"NetworkPolicy",
-		"RoleBinding",
-		"ClusterRoleBinding":
-		return "Dangling"
-	case "Role", "ClusterRole":
-		return "Unbound"
+	if info, ok := orphanKindTable[kind]; ok {
+		return info.presetName
 	}
 	return "Unmounted"
 }

--- a/internal/app/filters.go
+++ b/internal/app/filters.go
@@ -416,40 +416,92 @@ func appendConfigPresets(presets []FilterPreset, kind string) []FilterPreset {
 	return presets
 }
 
+// orphanKindInfo is one row of orphanKindTable: everything the orphan
+// filter/detector feature needs for a given resource Kind.
+type orphanKindInfo struct {
+	pool        func(*k8s.OrphanReport) []k8s.OrphanItem
+	presetName  string
+	description string
+}
+
+// orphanKindTable drives orphanPoolForKind, orphanPresetsForKind,
+// needsOrphanCache and orphanPresetNameForKind (commandbar_orphans.go).
+var orphanKindTable = map[string]orphanKindInfo{
+	"Pod": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.Pods },
+		presetName:  "Orphans",
+		description: "No owner reference",
+	},
+	"Secret": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.Secrets },
+		presetName:  "Unmounted",
+		description: "No Pod / template / Ingress / SA refers to it",
+	},
+	"ConfigMap": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.ConfigMaps },
+		presetName:  "Unmounted",
+		description: "No Pod or workload template refers to it",
+	},
+	"Service": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.Services },
+		presetName:  "No Endpoints",
+		description: "Zero ready+notReady endpoints",
+	},
+	"PersistentVolumeClaim": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.PVCs },
+		presetName:  "Unused",
+		description: "Not mounted by any Pod or template",
+	},
+	"HorizontalPodAutoscaler": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.HPAs },
+		presetName:  "Dangling",
+		description: "scaleTargetRef points to a missing workload",
+	},
+	"PodDisruptionBudget": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.PDBs },
+		presetName:  "Dangling",
+		description: "Selector matches no live / templated pods",
+	},
+	"NetworkPolicy": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.NetworkPolicies },
+		presetName:  "Dangling",
+		description: "podSelector matches no live / templated pods",
+	},
+	"Role": {
+		// ClusterRoleBinding can only reference ClusterRoles, so a Role is
+		// "unbound" iff no RoleBinding refers to it.
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.Roles },
+		presetName:  "Unbound",
+		description: "No RoleBinding refers to it",
+	},
+	"ClusterRole": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.ClusterRoles },
+		presetName:  "Unbound",
+		description: "No RoleBinding / ClusterRoleBinding refers to it",
+	},
+	"RoleBinding": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.RoleBindings },
+		presetName:  "Dangling",
+		description: "Missing role or empty subjects",
+	},
+	"ClusterRoleBinding": {
+		pool:        func(r *k8s.OrphanReport) []k8s.OrphanItem { return r.ClusterRoleBindings },
+		presetName:  "Dangling",
+		description: "Missing role or empty subjects",
+	},
+}
+
 // orphanPoolForKind returns the OrphanItem slice on `report` matching
 // `kind`, or nil if the kind doesn't have a per-list orphan preset.
-// Centralised so orphanMatcher and any future caller stay in sync.
 func orphanPoolForKind(report *k8s.OrphanReport, kind string) []k8s.OrphanItem {
 	if report == nil {
 		return nil
 	}
-	switch kind {
-	case "Pod":
-		return report.Pods
-	case "Secret":
-		return report.Secrets
-	case "ConfigMap":
-		return report.ConfigMaps
-	case "Service":
-		return report.Services
-	case "PersistentVolumeClaim":
-		return report.PVCs
-	case "HorizontalPodAutoscaler":
-		return report.HPAs
-	case "PodDisruptionBudget":
-		return report.PDBs
-	case "NetworkPolicy":
-		return report.NetworkPolicies
-	case "Role":
-		return report.Roles
-	case "ClusterRole":
-		return report.ClusterRoles
-	case "RoleBinding":
-		return report.RoleBindings
-	case "ClusterRoleBinding":
-		return report.ClusterRoleBindings
+	info, ok := orphanKindTable[kind]
+	if !ok {
+		return nil
 	}
-	return nil
+	return info.pool(report)
 }
 
 // orphanLookupKey joins namespace and name with a NUL separator so a
@@ -499,93 +551,24 @@ func orphanMatcher(cache map[orphanCacheKey]*k8s.OrphanReport, key orphanCacheKe
 // user has one mnemonic to remember across the whole feature surface;
 // the per-kind preset Name still distinguishes the underlying check
 // (Orphans / Unmounted / Unused / No Endpoints / Dangling / Unbound).
-//
-// Descriptions are kept short (≈ ≤50 chars) so they fit within the
-// quick-filter overlay's 72-col content area without wrapping.
 func orphanPresetsForKind(kind string, cache map[orphanCacheKey]*k8s.OrphanReport, key orphanCacheKey) []FilterPreset {
-	const orphanKey = "O"
-	switch kind {
-	case "Pod":
-		return []FilterPreset{{
-			Name: "Orphans", Description: "No owner reference", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "Pod"),
-		}}
-	case "Secret":
-		return []FilterPreset{{
-			Name: "Unmounted", Description: "No Pod / template / Ingress / SA refers to it", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "Secret"),
-		}}
-	case "ConfigMap":
-		return []FilterPreset{{
-			Name: "Unmounted", Description: "No Pod or workload template refers to it", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "ConfigMap"),
-		}}
-	case "Service":
-		return []FilterPreset{{
-			Name: "No Endpoints", Description: "Zero ready+notReady endpoints", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "Service"),
-		}}
-	case "PersistentVolumeClaim":
-		return []FilterPreset{{
-			Name: "Unused", Description: "Not mounted by any Pod or template", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "PersistentVolumeClaim"),
-		}}
-	case "HorizontalPodAutoscaler":
-		return []FilterPreset{{
-			Name: "Dangling", Description: "scaleTargetRef points to a missing workload", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "HorizontalPodAutoscaler"),
-		}}
-	case "PodDisruptionBudget":
-		return []FilterPreset{{
-			Name: "Dangling", Description: "Selector matches no live / templated pods", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "PodDisruptionBudget"),
-		}}
-	case "NetworkPolicy":
-		return []FilterPreset{{
-			Name: "Dangling", Description: "podSelector matches no live / templated pods", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "NetworkPolicy"),
-		}}
-	case "Role":
-		return []FilterPreset{{
-			// ClusterRoleBinding can only reference ClusterRoles, so a
-			// Role is "unbound" iff no RoleBinding refers to it.
-			Name: "Unbound", Description: "No RoleBinding refers to it", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "Role"),
-		}}
-	case "ClusterRole":
-		return []FilterPreset{{
-			Name: "Unbound", Description: "No RoleBinding / ClusterRoleBinding refers to it", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "ClusterRole"),
-		}}
-	case "RoleBinding":
-		return []FilterPreset{{
-			Name: "Dangling", Description: "Missing role or empty subjects", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "RoleBinding"),
-		}}
-	case "ClusterRoleBinding":
-		return []FilterPreset{{
-			Name: "Dangling", Description: "Missing role or empty subjects", Key: orphanKey,
-			MatchFn: orphanMatcher(cache, key, "ClusterRoleBinding"),
-		}}
+	info, ok := orphanKindTable[kind]
+	if !ok {
+		return nil
 	}
-	return nil
+	return []FilterPreset{{
+		Name:        info.presetName,
+		Description: info.description,
+		Key:         "O",
+		MatchFn:     orphanMatcher(cache, key, kind),
+	}}
 }
 
 // needsOrphanCache reports whether opening the filter-preset overlay for this
-// kind should kick off a DetectOrphans scan. Every kind that has a preset in
-// orphanPresetsForKind also needs the cache; keep the two in sync.
+// kind should kick off a DetectOrphans scan.
 func needsOrphanCache(kind string) bool {
-	switch kind {
-	case "Pod", "Secret", "ConfigMap", "Service",
-		"PersistentVolumeClaim",
-		"HorizontalPodAutoscaler",
-		"PodDisruptionBudget",
-		"NetworkPolicy",
-		"Role", "ClusterRole",
-		"RoleBinding", "ClusterRoleBinding":
-		return true
-	}
-	return false
+	_, ok := orphanKindTable[kind]
+	return ok
 }
 
 // buildConfigMatchFn converts a ConfigFilterMatch into a MatchFn closure.

--- a/internal/app/filters_test.go
+++ b/internal/app/filters_test.go
@@ -610,6 +610,98 @@ func TestBuiltinFilterPresets_ServiceNoEndpoints(t *testing.T) {
 	require.NotNil(t, findPreset(presets, "LB No IP"), "existing Service preset must remain")
 }
 
+// Pins the per-kind behavior of the four orphan lookup functions before
+// they are collapsed into one table.
+func TestOrphanKindFunctions_Characterisation(t *testing.T) {
+	kinds := []string{
+		"Pod", "Secret", "ConfigMap", "Service",
+		"PersistentVolumeClaim", "HorizontalPodAutoscaler",
+		"PodDisruptionBudget", "NetworkPolicy",
+		"Role", "ClusterRole", "RoleBinding", "ClusterRoleBinding",
+	}
+	wantPresetName := map[string]string{
+		"Pod":                     "Orphans",
+		"Secret":                  "Unmounted",
+		"ConfigMap":               "Unmounted",
+		"Service":                 "No Endpoints",
+		"PersistentVolumeClaim":   "Unused",
+		"HorizontalPodAutoscaler": "Dangling",
+		"PodDisruptionBudget":     "Dangling",
+		"NetworkPolicy":           "Dangling",
+		"Role":                    "Unbound",
+		"ClusterRole":             "Unbound",
+		"RoleBinding":             "Dangling",
+		"ClusterRoleBinding":      "Dangling",
+	}
+	wantDescription := map[string]string{
+		"Pod":                     "No owner reference",
+		"Secret":                  "No Pod / template / Ingress / SA refers to it",
+		"ConfigMap":               "No Pod or workload template refers to it",
+		"Service":                 "Zero ready+notReady endpoints",
+		"PersistentVolumeClaim":   "Not mounted by any Pod or template",
+		"HorizontalPodAutoscaler": "scaleTargetRef points to a missing workload",
+		"PodDisruptionBudget":     "Selector matches no live / templated pods",
+		"NetworkPolicy":           "podSelector matches no live / templated pods",
+		"Role":                    "No RoleBinding refers to it",
+		"ClusterRole":             "No RoleBinding / ClusterRoleBinding refers to it",
+		"RoleBinding":             "Missing role or empty subjects",
+		"ClusterRoleBinding":      "Missing role or empty subjects",
+	}
+	wantPoolName := map[string]string{
+		"Pod":                     "pod-sentinel",
+		"Secret":                  "secret-sentinel",
+		"ConfigMap":               "configmap-sentinel",
+		"Service":                 "service-sentinel",
+		"PersistentVolumeClaim":   "pvc-sentinel",
+		"HorizontalPodAutoscaler": "hpa-sentinel",
+		"PodDisruptionBudget":     "pdb-sentinel",
+		"NetworkPolicy":           "netpol-sentinel",
+		"Role":                    "role-sentinel",
+		"ClusterRole":             "clusterrole-sentinel",
+		"RoleBinding":             "rolebinding-sentinel",
+		"ClusterRoleBinding":      "clusterrolebinding-sentinel",
+	}
+	report := &k8s.OrphanReport{
+		Pods:                []k8s.OrphanItem{{Name: "pod-sentinel"}},
+		Secrets:             []k8s.OrphanItem{{Name: "secret-sentinel"}},
+		ConfigMaps:          []k8s.OrphanItem{{Name: "configmap-sentinel"}},
+		Services:            []k8s.OrphanItem{{Name: "service-sentinel"}},
+		PVCs:                []k8s.OrphanItem{{Name: "pvc-sentinel"}},
+		HPAs:                []k8s.OrphanItem{{Name: "hpa-sentinel"}},
+		PDBs:                []k8s.OrphanItem{{Name: "pdb-sentinel"}},
+		NetworkPolicies:     []k8s.OrphanItem{{Name: "netpol-sentinel"}},
+		Roles:               []k8s.OrphanItem{{Name: "role-sentinel"}},
+		ClusterRoles:        []k8s.OrphanItem{{Name: "clusterrole-sentinel"}},
+		RoleBindings:        []k8s.OrphanItem{{Name: "rolebinding-sentinel"}},
+		ClusterRoleBindings: []k8s.OrphanItem{{Name: "clusterrolebinding-sentinel"}},
+	}
+
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			pool := orphanPoolForKind(report, kind)
+			require.Len(t, pool, 1)
+			assert.Equal(t, wantPoolName[kind], pool[0].Name)
+
+			assert.True(t, needsOrphanCache(kind))
+
+			presets := orphanPresetsForKind(kind, map[orphanCacheKey]*k8s.OrphanReport{}, orphanCacheKey{})
+			require.Len(t, presets, 1)
+			assert.Equal(t, wantPresetName[kind], presets[0].Name)
+			assert.Equal(t, wantDescription[kind], presets[0].Description)
+			assert.Equal(t, "O", presets[0].Key)
+
+			assert.Equal(t, wantPresetName[kind], orphanPresetNameForKind(kind))
+		})
+	}
+
+	t.Run("unknown kind", func(t *testing.T) {
+		assert.Nil(t, orphanPoolForKind(report, "Bogus"))
+		assert.False(t, needsOrphanCache("Bogus"))
+		assert.Nil(t, orphanPresetsForKind("Bogus", map[orphanCacheKey]*k8s.OrphanReport{}, orphanCacheKey{}))
+		assert.Equal(t, "Unmounted", orphanPresetNameForKind("Bogus"))
+	})
+}
+
 func TestNeedsOrphanCache_OrphanKinds(t *testing.T) {
 	for _, kind := range []string{"Pod", "Secret", "ConfigMap", "Service"} {
 		t.Run(kind, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Four orphan-lookup functions each switched over the same 12 kinds. They now read one shared `orphanKindTable`, so a kind's pool field, presets, cache need, and preset name live in a single row instead of four parallel switches.

## Type of change

- [x] refactor: code change that neither fixes a bug nor adds a feature

## Changes

- Add `orphanKindTable`, one row per kind (pool accessor, presets, preset name).
- Rewrite `orphanPoolForKind`, `orphanPresetsForKind`, `needsOrphanCache`, and `orphanPresetNameForKind` to read the table.
- Keep exact-kind lookups and the unknown-kind fallback unchanged.
- Add a characterisation test covering all four functions for every kind plus one unknown kind.

## Testing

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] Manually verified against a real cluster (when behavior changed)

## Checklist

- [x] Commits follow conventional commit style (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`)
- [x] README / `docs/` updated when user-visible behavior or config changed
- [x] `docs/keybindings.md` and the in-app help screen updated when keybindings changed
- [x] No secrets, tokens, or personal data included in diffs, logs, or screenshots
- [x] PR is opened from a feature branch on my fork (not from my fork's `main`)
